### PR TITLE
ORCA: Improve cardinality estimation for Dynamic Table Scan under SPE

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexProbeMergeFilters.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexProbeMergeFilters.mdp
@@ -754,7 +754,7 @@ EXPLAIN SELECT * FROM table_with_two_indices_ao WHERE b = 15 AND c BETWEEN 10000
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.061257" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.061296" Rows="1.766098" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -771,7 +771,7 @@ EXPLAIN SELECT * FROM table_with_two_indices_ao WHERE b = 15 AND c BETWEEN 10000
         <dxl:SortingColumnList/>
         <dxl:Append IsTarget="false" IsZapped="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.061212" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.061218" Rows="1.766098" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -787,7 +787,7 @@ EXPLAIN SELECT * FROM table_with_two_indices_ao WHERE b = 15 AND c BETWEEN 10000
           <dxl:Filter/>
           <dxl:BitmapTableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.061212" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.061218" Rows="1.766098" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="6" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectRange.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectRange.mdp
@@ -1038,7 +1038,7 @@
     <dxl:Plan Id="1" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.000413" Rows="1.000012" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="6.000413" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -1052,7 +1052,7 @@
         <dxl:SortingColumnList/>
         <dxl:Append IsTarget="false" IsZapped="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="6.000377" Rows="1.000012" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="6.000377" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -1065,7 +1065,7 @@
           <dxl:Filter/>
           <dxl:IndexScan IndexScanDirection="Forward">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6.000377" Rows="1.000012" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.000377" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="a">
@@ -1110,7 +1110,7 @@
           </dxl:IndexScan>
           <dxl:IndexScan IndexScanDirection="Forward">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6.000377" Rows="1.000012" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.000377" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="18" Alias="a">
@@ -1155,7 +1155,7 @@
           </dxl:IndexScan>
           <dxl:IndexScan IndexScanDirection="Forward">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6.000377" Rows="1.000012" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.000377" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="27" Alias="a">
@@ -1200,7 +1200,7 @@
           </dxl:IndexScan>
           <dxl:IndexScan IndexScanDirection="Forward">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6.000377" Rows="1.000012" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.000377" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="36" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/JoinOrderDPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinOrderDPE.mdp
@@ -3147,7 +3147,7 @@
     <dxl:Plan Id="0" SpaceSize="84">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1301.264890" Rows="95315.069401" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="1301.264895" Rows="95315.069401" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -3179,7 +3179,7 @@
         </dxl:HashCondList>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.025532" Rows="156.000136" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.025537" Rows="156.000136" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -3199,7 +3199,7 @@
           <dxl:SortingColumnList/>
           <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.016230" Rows="156.000136" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.016235" Rows="156.000136" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -3284,7 +3284,7 @@
             </dxl:Append>
             <dxl:PartitionSelector RelationMdid="0.245931.1.0" SelectorId="11" ScanId="3" Partitions="3">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000166" Rows="3.000003" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000171" Rows="3.000003" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -3302,7 +3302,7 @@
               </dxl:PartFilterExpr>
               <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000166" Rows="3.000003" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000171" Rows="3.000003" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -3316,7 +3316,7 @@
                 <dxl:SortingColumnList/>
                 <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="1" SelectorIds="">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000001" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000001" Width="8"/>
                   </dxl:Properties>
                   <dxl:TableDescriptor Mdid="0.245961.1.0" TableName="foo" LockMode="1">
                     <dxl:Columns>
@@ -3342,7 +3342,7 @@
                   <dxl:Filter/>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000001" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000001" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="36" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/NLJ-Broadcast-DPE-Outer-Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NLJ-Broadcast-DPE-Outer-Child.mdp
@@ -560,7 +560,7 @@ select * from bmao_part as t1 join bmao_part as t2 on t1.a < t2.a where t1.a < 5
     <dxl:Plan Id="0" SpaceSize="6">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1463.285198" Rows="799200.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1463.290572" Rows="799200.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -580,7 +580,7 @@ select * from bmao_part as t1 join bmao_part as t2 on t1.a < t2.a where t1.a < 5
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1405.870670" Rows="799200.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1405.876044" Rows="799200.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -605,7 +605,7 @@ select * from bmao_part as t1 join bmao_part as t2 on t1.a < t2.a where t1.a < 5
           </dxl:JoinFilter>
           <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.194797" Rows="1598.400000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.200172" Rows="1598.400000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -619,7 +619,7 @@ select * from bmao_part as t1 join bmao_part as t2 on t1.a < t2.a where t1.a < 5
             <dxl:SortingColumnList/>
             <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="1" SelectorIds="">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.027445" Rows="799.200000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.032819" Rows="799.200000" Width="8"/>
               </dxl:Properties>
               <dxl:TableDescriptor Mdid="0.37336903.1.1" TableName="bmao_part">
                 <dxl:Columns>
@@ -645,7 +645,7 @@ select * from bmao_part as t1 join bmao_part as t2 on t1.a < t2.a where t1.a < 5
               <dxl:Filter/>
               <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.027445" Rows="799.200000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.032819" Rows="799.200000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="18" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverGbAgg-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverGbAgg-2.mdp
@@ -1612,7 +1612,7 @@
     <dxl:Plan Id="0" SpaceSize="14">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.027662" Rows="101.010101" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.027897" Rows="101.010101" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -1635,7 +1635,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.016777" Rows="101.010101" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.017013" Rows="101.010101" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -1850,7 +1850,7 @@
           </dxl:Append>
           <dxl:PartitionSelector RelationMdid="0.325693.1.1" SelectorId="0" ScanId="1" Partitions="0,1,2,3,4">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000710" Rows="2.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000945" Rows="2.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="10" Alias="a">
@@ -1868,7 +1868,7 @@
             </dxl:PartFilterExpr>
             <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000710" Rows="2.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000945" Rows="2.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="a">
@@ -1882,7 +1882,7 @@
               <dxl:SortingColumnList/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000082" Rows="1.000000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000317" Rows="1.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="10" Alias="a">
@@ -1896,7 +1896,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000082" Rows="1.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000317" Rows="1.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="10"/>
@@ -1919,7 +1919,7 @@
                   <dxl:Filter/>
                   <dxl:Sort SortDiscardDuplicates="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000306" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="10" Alias="a">
@@ -1937,7 +1937,7 @@
                     <dxl:LimitOffset/>
                     <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="2" SelectorIds="">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000306" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:TableDescriptor Mdid="0.325915.1.1" TableName="p2">
                         <dxl:Columns>
@@ -1963,7 +1963,7 @@
                       <dxl:Filter/>
                       <dxl:TableScan>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000306" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="72" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
@@ -4768,7 +4768,7 @@
     <dxl:Plan Id="0" SpaceSize="16648">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1749361.680098" Rows="321694266.492042" Width="355"/>
+          <dxl:Cost StartupCost="0" TotalCost="1749361.683589" Rows="321694266.492042" Width="355"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="cs_sold_date_sk">
@@ -5000,7 +5000,7 @@
         </dxl:HashCondList>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1339481.821919" Rows="467986.685065" Width="339"/>
+            <dxl:Cost StartupCost="0" TotalCost="1339481.825410" Rows="467986.685065" Width="339"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="cs_sold_date_sk">
@@ -5209,7 +5209,7 @@
           <dxl:SortingColumnList/>
           <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1338769.494706" Rows="467986.685065" Width="339"/>
+              <dxl:Cost StartupCost="0" TotalCost="1338769.498197" Rows="467986.685065" Width="339"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="cs_sold_date_sk">
@@ -6554,7 +6554,7 @@
             </dxl:HashJoin>
             <dxl:PartitionSelector RelationMdid="0.802597.1.1" SelectorId="0" ScanId="1" Partitions="0,1,2,3,4">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="432.238603" Rows="838.491452" Width="107"/>
+                <dxl:Cost StartupCost="0" TotalCost="432.242094" Rows="838.491452" Width="107"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="64" Alias="d_date_sk">
@@ -6650,7 +6650,7 @@
               </dxl:PartFilterExpr>
               <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="432.238603" Rows="838.491452" Width="107"/>
+                  <dxl:Cost StartupCost="0" TotalCost="432.242094" Rows="838.491452" Width="107"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="64" Alias="d_date_sk">
@@ -6742,7 +6742,7 @@
                 <dxl:SortingColumnList/>
                 <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="3" SelectorIds="">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.064411" Rows="419.245726" Width="107"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.067902" Rows="419.245726" Width="107"/>
                   </dxl:Properties>
                   <dxl:TableDescriptor Mdid="0.802906.1.1" TableName="date_dim">
                     <dxl:Columns>
@@ -6872,7 +6872,7 @@
                   <dxl:Filter/>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.064411" Rows="419.245726" Width="107"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.067902" Rows="419.245726" Width="107"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="304" Alias="d_date_sk">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-List-Cost1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-List-Cost1.mdp
@@ -1,0 +1,1484 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:Comment><![CDATA[
+	Objective: We should derive statistics of a Dynamic Table Scan with SPE
+	using the disjunctive constraints of the selected child partitions. In this
+	case, one partition is selected after SPE, cost of CPhysicalDynamicTableScan
+	in physical plan should be around 615 with ~100000 rows.
+
+	create table bar (a int, b int, c varchar(10000)) partition by list (b) (values (1, 3, 5, 7, 9), values (0, 2, 4, 6, 8), values (10), values(NULL), default partition extra);
+	insert into bar select i, i % 10, repeat('a',10000) from generate_series(1, 200000)i;
+	insert into bar select i, 10, repeat('a',10000) from generate_series(1, 100000)i;
+	insert into bar select i, NULL, repeat('a',10000) from generate_series(1, 100000)i;
+	insert into bar select i, i, repeat('a',10000) from generate_series(11, 100010)i;
+	analyze bar;
+
+	explain analyze select * from bar where b = 0;
+
+        Physical plan:
+        +--CPhysicalMotionGather(master)   rows:20030   width:10042  rebinds:1   cost:1487.892640   origin: [Grp:4, GrpExpr:2]
+           +--CPhysicalFilter   rows:20030   width:10042  rebinds:1   cost:740.538117   origin: [Grp:4, GrpExpr:1]
+              |--CPhysicalDynamicTableScan "bar" ("bar"), Columns: ["a" (0), "b" (1), "c" (2), "ctid" (3), "xmin" (4), "cmin" (5), "xmax" (6), "cmax" (7), "tableoid" (8), "gp_segment_id" (9)] Scan Id: 1   rows:100001   width:10042  rebinds:1   cost:615.105177   origin: [Grp:0, GrpExpr:1]
+              +--CScalarCmp (=)   origin: [Grp:3, GrpExpr:0]
+                 |--CScalarIdent "b" (1)   origin: [Grp:1, GrpExpr:0]
+                 +--CScalarConst (0)   origin: [Grp:2, GrpExpr:0]
+
+                                                      QUERY PLAN
+        ---------------------------------------------------------------------------------------
+         Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1487.89 rows=20031 width=10012)
+           ->  Append  (cost=0.00..740.54 rows=6677 width=10012)
+                 ->  Seq Scan on bar_1_prt_3  (cost=0.00..740.54 rows=6677 width=10012)
+                       Filter: (b = 0)
+         Optimizer: Pivotal Optimizer (GPORCA)
+        (5 rows)
+
+  ]]>
+    </dxl:Comment>
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Relation Mdid="0.49410.1.0" Name="bar_1_prt_5" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:IsNull>
+            <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:IsNull>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.518.1.0" Name="&lt;&gt;" ComparisonType="NEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.144.1.0"/>
+        <dxl:Commutator Mdid="0.518.1.0"/>
+        <dxl:InverseOp Mdid="0.96.1.0"/>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.49383.1.0.1" Name="b" Width="4.000000" NullFreq="0.200000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.040060" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039667" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039760" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040020" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040287" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039660" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040020" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040513" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039873" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040140" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.200000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="994"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="994"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1918"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1918"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2981"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2981"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3983"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3983"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4926"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4926"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6927"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6927"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7854"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7854"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8877"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8877"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9789"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9789"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10802"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10802"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11825"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11825"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12766"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12766"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13774"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13774"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14711"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14711"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15739"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15739"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16730"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17774"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17774"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18807"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18807"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20755"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20755"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21708"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21708"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22677"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22677"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23759"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23759"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24854"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24854"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25866"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25866"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26896"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26896"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27830"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27830"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28879"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28879"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29809"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29809"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30793"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30793"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31803"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31803"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32763"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32763"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33725"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33725"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34649"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34649"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35606"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36687"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36687"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37760"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37760"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38772"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38772"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39804"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39804"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40851"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40851"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41817"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41817"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42806"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42806"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43739"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43739"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44776"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44776"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45746"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45746"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46757"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46757"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47760"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47760"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48730"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49654"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49654"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50606"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51554"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51554"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="52597"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52597"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53650"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53650"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54555"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54555"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55607"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55607"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56562"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56562"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57542"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57542"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="58455"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58455"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59401"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59401"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60447"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60447"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61518"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61518"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62512"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62512"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63470"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64485"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64485"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65429"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65429"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66409"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66409"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67430"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67430"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68489"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68489"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69550"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69550"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70568"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70568"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71594"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71594"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72682"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72682"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73751"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73751"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74821"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74821"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75844"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75844"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77756"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77756"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78796"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78796"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79782"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79782"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80804"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80804"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81740"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81740"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="82714"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82714"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83765"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83765"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84766"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84766"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85864"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85864"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86848"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86848"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87863"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87863"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88965"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88965"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89959"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89959"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90958"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90958"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91933"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91933"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="92972"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92972"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93987"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93987"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94963"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94963"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96005"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96005"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96964"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96964"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97983"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97983"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99046"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99046"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="100008"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.49383.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1918"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1918"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2981"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2981"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4089"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4089"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5892"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5892"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6889"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6889"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8039"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8039"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9090"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9090"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10169"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10169"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11825"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11825"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12831"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12831"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14128"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14128"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15739"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15739"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16730"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17908"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17908"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18953"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18953"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20378"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20378"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21834"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21834"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22892"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22892"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23987"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23987"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25866"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25866"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26896"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26896"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28049"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28049"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29015"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29015"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30244"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30244"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31871"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31871"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32920"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32920"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34078"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34078"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35606"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36687"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36687"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38010"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38010"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39132"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39132"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40158"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40158"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41940"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41940"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43002"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43002"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44048"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44048"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45746"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45746"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46757"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46757"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48037"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48037"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49149"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49149"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50198"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50198"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51806"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51806"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53074"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53074"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54058"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54058"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55607"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55607"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56562"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56562"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57943"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57943"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59048"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59048"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60081"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60081"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61783"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61783"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62878"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62878"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63890"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63890"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65429"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65429"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66409"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66409"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67820"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67820"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68916"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68916"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69945"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69945"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71594"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71594"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72791"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72791"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73986"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73986"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75496"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75496"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77756"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77756"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79019"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79019"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80106"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80106"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81778"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81778"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83013"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83013"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84035"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84035"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85860"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86848"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86848"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87863"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87863"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89025"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89025"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90058"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90058"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91881"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91881"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93056"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93056"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94045"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94045"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95771"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95771"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96964"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96964"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98007"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98007"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99056"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99056"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="100228"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="100228"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="105937"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="105937"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="110218"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="110218"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="116117"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="116117"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="120207"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="120207"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="126290"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="126290"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="130345"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="130345"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="136380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="136380"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="140427"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="140427"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="146168"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="146168"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="150601"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="150601"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="156004"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="156004"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="160609"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="160609"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="166076"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="166076"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="170425"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="170425"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="176002"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="176002"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="180231"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="180231"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="185806"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="185806"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="190088"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="190088"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="195755"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="195755"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="200000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1043.1.0" Name="varchar" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1015.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.49383.1.0" Name="bar" Rows="500000.000000" RelPages="0" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Relation Mdid="0.49383.1.0" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,9,3" PartitionColumns="1" PartitionTypes="l" NumberLeafPartitions="5">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:Partitions>
+          <dxl:Partition Mdid="0.49398.1.0"/>
+          <dxl:Partition Mdid="0.49392.1.0"/>
+          <dxl:Partition Mdid="0.49404.1.0"/>
+          <dxl:Partition Mdid="0.49410.1.0"/>
+          <dxl:Partition Mdid="0.49386.1.0"/>
+        </dxl:Partitions>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.49386.1.0" Name="bar_1_prt_extra" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:Not>
+            <dxl:Or>
+              <dxl:IsNull>
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:IsNull>
+              <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="6"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="7"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="8"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="9"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                </dxl:Array>
+              </dxl:ArrayComp>
+            </dxl:Or>
+          </dxl:Not>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.49398.1.0" Name="bar_1_prt_3" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="6"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="8"/>
+              </dxl:Array>
+            </dxl:ArrayComp>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.49392.1.0" Name="bar_1_prt_2" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="7"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="9"/>
+              </dxl:Array>
+            </dxl:ArrayComp>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.49404.1.0" Name="bar_1_prt_4" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+          <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+          <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+        </dxl:Comparison>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.49383.1.0" TableName="bar" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+              <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1487.892667" Rows="20030.200300" Width="10012"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="2" Alias="c">
+            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="1" SelectorIds="">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="740.538119" Rows="20030.200300" Width="10012"/>
+          </dxl:Properties>
+          <dxl:TableDescriptor Mdid="0.49383.1.0" TableName="bar" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="c">
+              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="740.538119" Rows="20030.200300" Width="10012"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="10" Alias="a">
+                <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="11" Alias="b">
+                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="12" Alias="c">
+                <dxl:Ident ColId="12" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+              </dxl:Comparison>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.49398.1.0" TableName="bar_1_prt_3" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="12" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:Append>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-List-Cost2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-List-Cost2.mdp
@@ -1,0 +1,1488 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:Comment><![CDATA[
+	Objective: We should derive statistics of a Dynamic Table Scan with SPE
+	using the disjunctive constraints of the selected child partitions. In this
+	case, two partitions including the default partition are selected after SPE,
+	CPhysicalDynamicTableScan in physical plan should cost around 799 with ~200000 rows.
+
+	create table bar (a int, b int, c varchar(10000)) partition by list (b) (values (1, 3, 5, 7, 9), values (0, 2, 4, 6, 8), values (10), values(NULL), default partition extra);
+	insert into bar select i, i % 10, repeat('a',10000) from generate_series(1, 200000)i;
+	insert into bar select i, 10, repeat('a',10000) from generate_series(1, 100000)i;
+	insert into bar select i, NULL, repeat('a',10000) from generate_series(1, 100000)i;
+	insert into bar select i, i, repeat('a',10000) from generate_series(11, 100010)i;
+	analyze bar;
+
+	explain analyze select * from bar where b = 0 or b = 11;
+
+        Physical plan:
+        +--CPhysicalMotionGather(master)   rows:20030   width:10042  rebinds:1   cost:1673.125582   origin: [Grp:7, GrpExpr:2]
+           +--CPhysicalFilter   rows:20030   width:10042  rebinds:1   cost:925.741222   origin: [Grp:7, GrpExpr:1]
+              |--CPhysicalDynamicTableScan "bar" ("bar"), Columns: ["a" (0), "b" (1), "c" (2), "ctid" (3), "xmin" (4), "cmin" (5), "xmax" (6), "cmax" (7), "tableoid" (8), "gp_segment_id" (9)] Scan Id: 1   rows:199999   width:10042  rebinds:1   cost:799.206662   origin: [Grp:0, GrpExpr:1]
+              +--CScalarBoolOp (EboolopOr)   origin: [Grp:6, GrpExpr:0]
+                 |--CScalarCmp (=)   origin: [Grp:3, GrpExpr:0]
+                 |  |--CScalarIdent "b" (1)   origin: [Grp:1, GrpExpr:0]
+                 |  +--CScalarConst (0)   origin: [Grp:2, GrpExpr:0]
+                 +--CScalarCmp (=)   origin: [Grp:5, GrpExpr:0]
+                    |--CScalarIdent "b" (1)   origin: [Grp:1, GrpExpr:0]
+                    +--CScalarConst (11)   origin: [Grp:4, GrpExpr:0]
+
+                                                      QUERY PLAN
+        ---------------------------------------------------------------------------------------
+         Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1487.89 rows=20031 width=10012)
+           ->  Append  (cost=0.00..740.54 rows=6677 width=10012)
+                 ->  Seq Scan on bar_1_prt_3  (cost=0.00..740.54 rows=6677 width=10012)
+                       Filter: (b = 0)
+         Optimizer: Pivotal Optimizer (GPORCA)
+        (5 rows)
+
+  ]]>
+    </dxl:Comment>
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Relation Mdid="0.49410.1.0" Name="bar_1_prt_5" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:IsNull>
+            <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:IsNull>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.518.1.0" Name="&lt;&gt;" ComparisonType="NEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.144.1.0"/>
+        <dxl:Commutator Mdid="0.518.1.0"/>
+        <dxl:InverseOp Mdid="0.96.1.0"/>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.49383.1.0.1" Name="b" Width="4.000000" NullFreq="0.200000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.040060" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039667" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039760" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040020" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040287" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039660" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040020" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040513" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039873" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040140" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.200000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="994"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="994"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1918"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1918"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2981"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2981"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3983"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3983"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4926"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4926"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6927"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6927"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7854"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7854"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8877"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8877"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9789"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9789"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10802"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10802"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11825"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11825"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12766"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12766"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13774"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13774"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14711"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14711"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15739"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15739"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16730"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17774"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17774"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18807"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18807"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20755"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20755"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21708"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21708"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22677"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22677"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23759"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23759"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24854"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24854"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25866"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25866"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26896"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26896"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27830"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27830"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28879"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28879"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29809"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29809"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30793"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30793"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31803"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31803"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32763"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32763"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33725"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33725"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34649"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34649"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35606"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36687"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36687"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37760"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37760"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38772"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38772"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39804"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39804"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40851"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40851"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41817"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41817"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42806"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42806"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43739"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43739"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44776"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44776"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45746"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45746"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46757"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46757"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47760"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47760"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48730"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49654"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49654"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50606"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51554"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51554"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="52597"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52597"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53650"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53650"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54555"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54555"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55607"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55607"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56562"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56562"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57542"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57542"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="58455"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58455"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59401"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59401"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60447"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60447"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61518"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61518"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62512"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62512"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63470"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64485"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64485"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65429"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65429"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66409"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66409"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67430"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67430"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68489"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68489"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69550"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69550"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70568"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70568"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71594"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71594"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72682"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72682"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73751"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73751"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74821"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74821"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75844"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75844"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77756"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77756"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78796"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78796"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79782"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79782"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80804"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80804"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81740"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81740"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="82714"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82714"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83765"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83765"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84766"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84766"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85864"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85864"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86848"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86848"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87863"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87863"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88965"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88965"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89959"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89959"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90958"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90958"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91933"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91933"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="92972"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92972"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93987"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93987"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94963"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94963"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96005"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96005"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96964"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96964"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97983"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97983"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99046"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99046"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="100008"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.49383.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1918"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1918"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2981"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2981"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4089"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4089"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5892"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5892"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6889"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6889"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8039"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8039"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9090"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9090"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10169"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10169"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11825"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11825"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12831"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12831"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14128"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14128"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15739"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15739"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16730"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17908"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17908"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18953"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18953"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20378"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20378"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21834"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21834"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22892"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22892"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23987"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23987"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25866"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25866"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26896"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26896"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28049"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28049"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29015"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29015"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30244"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30244"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31871"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31871"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32920"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32920"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34078"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34078"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35606"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36687"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36687"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38010"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38010"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39132"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39132"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40158"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40158"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41940"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41940"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43002"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43002"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44048"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44048"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45746"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45746"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46757"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46757"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48037"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48037"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49149"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49149"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50198"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50198"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51806"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51806"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53074"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53074"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54058"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54058"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55607"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55607"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56562"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56562"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57943"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57943"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59048"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59048"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60081"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60081"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61783"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61783"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62878"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62878"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63890"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63890"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65429"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65429"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66409"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66409"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67820"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67820"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68916"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68916"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69945"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69945"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71594"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71594"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72791"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72791"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73986"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73986"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75496"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75496"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77756"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77756"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79019"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79019"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80106"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80106"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81778"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81778"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83013"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83013"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84035"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84035"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85860"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86848"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86848"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87863"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87863"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89025"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89025"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90058"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90058"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91881"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91881"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93056"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93056"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94045"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94045"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95771"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95771"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96964"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96964"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98007"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98007"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99056"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99056"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="100228"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="100228"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="105937"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="105937"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="110218"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="110218"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="116117"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="116117"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="120207"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="120207"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="126290"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="126290"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="130345"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="130345"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="136380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="136380"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="140427"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="140427"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="146168"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="146168"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="150601"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="150601"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="156004"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="156004"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="160609"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="160609"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="166076"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="166076"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="170425"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="170425"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="176002"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="176002"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="180231"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="180231"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="185806"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="185806"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="190088"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="190088"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="195755"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="195755"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="200000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1043.1.0" Name="varchar" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1015.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.49383.1.0" Name="bar" Rows="500000.000000" RelPages="0" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Relation Mdid="0.49383.1.0" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,9,3" PartitionColumns="1" PartitionTypes="l" NumberLeafPartitions="5">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:Partitions>
+          <dxl:Partition Mdid="0.49398.1.0"/>
+          <dxl:Partition Mdid="0.49392.1.0"/>
+          <dxl:Partition Mdid="0.49404.1.0"/>
+          <dxl:Partition Mdid="0.49410.1.0"/>
+          <dxl:Partition Mdid="0.49386.1.0"/>
+        </dxl:Partitions>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.49386.1.0" Name="bar_1_prt_extra" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:Not>
+            <dxl:Or>
+              <dxl:IsNull>
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:IsNull>
+              <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="6"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="7"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="8"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="9"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                </dxl:Array>
+              </dxl:ArrayComp>
+            </dxl:Or>
+          </dxl:Not>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.49398.1.0" Name="bar_1_prt_3" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="6"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="8"/>
+              </dxl:Array>
+            </dxl:ArrayComp>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.49392.1.0" Name="bar_1_prt_2" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="7"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="9"/>
+              </dxl:Array>
+            </dxl:ArrayComp>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.49404.1.0" Name="bar_1_prt_4" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+          <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+          <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+        </dxl:Comparison>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.49383.1.0" TableName="bar" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+              <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1487.892667" Rows="20030.200300" Width="10012"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="2" Alias="c">
+            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="1" SelectorIds="">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="740.538119" Rows="20030.200300" Width="10012"/>
+          </dxl:Properties>
+          <dxl:TableDescriptor Mdid="0.49383.1.0" TableName="bar" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="c">
+              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="740.538119" Rows="20030.200300" Width="10012"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="10" Alias="a">
+                <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="11" Alias="b">
+                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="12" Alias="c">
+                <dxl:Ident ColId="12" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+              </dxl:Comparison>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.49398.1.0" TableName="bar_1_prt_3" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="12" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:Append>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-List-Cost3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-List-Cost3.mdp
@@ -1,0 +1,1540 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:Comment><![CDATA[
+	Objective: We should derive statistics of a Dynamic Table Scan with SPE
+	using the disjunctive constraints of the selected child partitions. In this
+	case, two partitions are selected after SPE, CPhysicalDynamicTableScan in
+	physical plan should cost around 799 with ~200000 rows.
+
+	create table bar (a int, b int, c varchar(10000)) partition by list (b) (values (1, 3, 5, 7, 9), values (0, 2, 4, 6, 8), values (10), values(NULL), default partition extra);
+	insert into bar select i, i % 10, repeat('a',10000) from generate_series(1, 200000)i;
+	insert into bar select i, 10, repeat('a',10000) from generate_series(1, 100000)i;
+	insert into bar select i, NULL, repeat('a',10000) from generate_series(1, 100000)i;
+	insert into bar select i, i, repeat('a',10000) from generate_series(11, 100010)i;
+	analyze bar;
+
+	explain select * from bar where b = 0 or b is null;
+
+        Physical plan:
+        +--CPhysicalMotionGather(master)   rows:120031   width:10042  rebinds:1   cost:6025.046863   origin: [Grp:6, GrpExpr:2]
+           +--CPhysicalFilter   rows:120031   width:10042  rebinds:1   cost:1546.493914   origin: [Grp:6, GrpExpr:1]
+              |--CPhysicalDynamicTableScan "bar" ("bar"), Columns: ["a" (0), "b" (1), "c" (2), "ctid" (3), "xmin" (4), "cmin" (5), "xmax" (6), "cmax" (7), "tableoid" (8), "gp_segment_id" (9)] Scan Id: 1   rows:200002   width:10042  rebinds:1   cost:799.210354   origin: [Grp:0, GrpExpr:1]
+              +--CScalarBoolOp (EboolopOr)   origin: [Grp:5, GrpExpr:0]
+                 |--CScalarCmp (=)   origin: [Grp:3, GrpExpr:0]
+                 |  |--CScalarIdent "b" (1)   origin: [Grp:1, GrpExpr:0]
+                 |  +--CScalarConst (0)   origin: [Grp:2, GrpExpr:0]
+                 +--CScalarNullTest   origin: [Grp:4, GrpExpr:0]
+                    +--CScalarIdent "b" (1)   origin: [Grp:1, GrpExpr:0]
+
+                                                       QUERY PLAN
+        ----------------------------------------------------------------------------------------
+         Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6025.05 rows=120032 width=10012)
+           ->  Append  (cost=0.00..1546.49 rows=40011 width=10012)
+                 ->  Seq Scan on bar_1_prt_3  (cost=0.00..1546.49 rows=40011 width=10012)
+                       Filter: ((b = 0) OR (b IS NULL))
+                 ->  Seq Scan on bar_1_prt_5  (cost=0.00..1546.49 rows=40011 width=10012)
+                       Filter: ((b = 0) OR (b IS NULL))
+         Optimizer: Pivotal Optimizer (GPORCA)
+        (7 rows)
+
+  ]]>
+    </dxl:Comment>
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Relation Mdid="0.49410.1.0" Name="bar_1_prt_5" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:IsNull>
+            <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:IsNull>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.518.1.0" Name="&lt;&gt;" ComparisonType="NEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.144.1.0"/>
+        <dxl:Commutator Mdid="0.518.1.0"/>
+        <dxl:InverseOp Mdid="0.96.1.0"/>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.49383.1.0.1" Name="b" Width="4.000000" NullFreq="0.200000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.040060" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039667" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039760" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040020" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040287" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039660" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040020" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040513" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039873" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040140" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.200000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="994"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="994"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1918"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1918"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2981"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2981"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3983"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3983"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4926"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4926"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6927"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6927"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7854"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7854"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8877"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8877"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9789"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9789"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10802"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10802"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11825"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11825"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12766"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12766"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13774"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13774"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14711"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14711"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15739"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15739"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16730"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17774"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17774"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18807"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18807"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20755"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20755"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21708"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21708"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22677"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22677"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23759"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23759"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24854"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24854"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25866"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25866"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26896"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26896"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27830"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27830"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28879"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28879"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29809"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29809"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30793"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30793"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31803"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31803"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32763"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32763"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33725"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33725"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34649"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34649"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35606"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36687"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36687"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37760"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37760"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38772"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38772"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39804"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39804"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40851"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40851"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41817"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41817"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42806"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42806"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43739"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43739"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44776"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44776"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45746"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45746"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46757"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46757"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47760"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47760"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48730"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49654"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49654"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50606"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51554"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51554"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="52597"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52597"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53650"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53650"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54555"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54555"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55607"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55607"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56562"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56562"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57542"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57542"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="58455"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58455"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59401"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59401"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60447"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60447"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61518"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61518"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62512"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62512"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63470"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64485"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64485"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65429"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65429"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66409"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66409"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67430"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67430"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68489"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68489"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69550"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69550"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70568"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70568"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71594"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71594"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72682"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72682"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73751"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73751"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74821"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74821"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75844"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75844"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77756"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77756"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78796"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78796"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79782"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79782"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80804"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80804"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81740"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81740"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="82714"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82714"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83765"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83765"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84766"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84766"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85864"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85864"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86848"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86848"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87863"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87863"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88965"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88965"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89959"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89959"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90958"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90958"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91933"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91933"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="92972"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92972"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93987"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93987"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94963"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94963"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96005"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96005"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96964"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96964"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97983"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97983"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99046"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99046"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="100008"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.49383.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1918"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1918"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2981"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2981"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4089"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4089"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5892"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5892"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6889"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6889"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8039"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8039"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9090"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9090"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10169"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10169"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11825"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11825"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12831"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12831"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14128"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14128"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15739"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15739"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16730"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17908"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17908"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18953"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18953"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20378"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20378"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21834"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21834"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22892"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22892"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23987"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23987"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25866"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25866"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26896"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26896"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28049"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28049"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29015"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29015"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30244"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30244"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31871"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31871"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32920"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32920"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34078"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34078"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35606"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36687"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36687"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38010"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38010"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39132"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39132"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40158"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40158"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41940"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41940"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43002"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43002"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44048"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44048"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45746"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45746"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46757"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46757"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48037"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48037"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49149"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49149"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50198"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50198"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51806"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51806"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53074"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53074"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54058"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54058"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55607"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55607"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56562"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56562"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57943"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57943"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59048"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59048"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60081"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60081"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61783"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61783"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62878"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62878"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63890"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63890"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65429"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65429"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66409"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66409"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67820"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67820"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68916"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68916"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69945"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69945"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71594"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71594"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72791"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72791"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73986"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73986"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75496"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75496"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77756"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77756"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79019"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79019"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80106"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80106"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81778"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81778"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83013"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83013"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84035"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84035"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85860"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86848"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86848"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87863"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87863"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89025"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89025"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90058"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90058"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91881"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91881"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93056"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93056"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94045"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94045"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95771"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95771"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96964"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96964"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98007"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98007"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99056"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99056"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="100228"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="100228"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="105937"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="105937"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="110218"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="110218"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="116117"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="116117"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="120207"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="120207"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="126290"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="126290"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="130345"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="130345"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="136380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="136380"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="140427"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="140427"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="146168"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="146168"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="150601"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="150601"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="156004"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="156004"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="160609"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="160609"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="166076"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="166076"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="170425"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="170425"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="176002"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="176002"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="180231"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="180231"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="185806"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="185806"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="190088"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="190088"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="195755"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="195755"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="200000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1043.1.0" Name="varchar" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1015.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.49383.1.0" Name="bar" Rows="500000.000000" RelPages="0" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Relation Mdid="0.49383.1.0" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,9,3" PartitionColumns="1" PartitionTypes="l" NumberLeafPartitions="5">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:Partitions>
+          <dxl:Partition Mdid="0.49398.1.0"/>
+          <dxl:Partition Mdid="0.49392.1.0"/>
+          <dxl:Partition Mdid="0.49404.1.0"/>
+          <dxl:Partition Mdid="0.49410.1.0"/>
+          <dxl:Partition Mdid="0.49386.1.0"/>
+        </dxl:Partitions>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.49386.1.0" Name="bar_1_prt_extra" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:Not>
+            <dxl:Or>
+              <dxl:IsNull>
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:IsNull>
+              <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="6"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="7"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="8"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="9"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                </dxl:Array>
+              </dxl:ArrayComp>
+            </dxl:Or>
+          </dxl:Not>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.49398.1.0" Name="bar_1_prt_3" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="6"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="8"/>
+              </dxl:Array>
+            </dxl:ArrayComp>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.49392.1.0" Name="bar_1_prt_2" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="7"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="9"/>
+              </dxl:Array>
+            </dxl:ArrayComp>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.49404.1.0" Name="bar_1_prt_4" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Or>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+          </dxl:Comparison>
+          <dxl:IsNull>
+            <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:IsNull>
+        </dxl:Or>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.49383.1.0" TableName="bar" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+              <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="6025.046822" Rows="120031.800448" Width="10012"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="2" Alias="c">
+            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="1" SelectorIds="">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1546.493903" Rows="120031.800448" Width="10012"/>
+          </dxl:Properties>
+          <dxl:TableDescriptor Mdid="0.49383.1.0" TableName="bar" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="c">
+              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1546.493903" Rows="120031.800448" Width="10012"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="10" Alias="a">
+                <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="11" Alias="b">
+                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="12" Alias="c">
+                <dxl:Ident ColId="12" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Or>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                </dxl:Comparison>
+                <dxl:IsNull>
+                  <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:IsNull>
+              </dxl:Or>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.49398.1.0" TableName="bar_1_prt_3" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="12" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1546.493903" Rows="120031.800448" Width="10012"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="20" Alias="a">
+                <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="21" Alias="b">
+                <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="22" Alias="c">
+                <dxl:Ident ColId="22" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Or>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                </dxl:Comparison>
+                <dxl:IsNull>
+                  <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:IsNull>
+              </dxl:Or>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.49410.1.0" TableName="bar_1_prt_5" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="20" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="21" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="22" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="24" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="25" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="26" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="27" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="28" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="29" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:Append>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-List-Cost4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-List-Cost4.mdp
@@ -1,0 +1,1635 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:Comment><![CDATA[
+	Objective: We should derive statistics of a Dynamic Table Scan with SPE
+	using the disjunctive constraints of the selected child partitions. In this
+	case, 4 partitions including the default partition are selected after SPE,
+	CPhysicalDynamicTableScan in physical plan should cost around 1167 with ~400000 rows.
+
+	create table bar (a int, b int, c varchar(10000)) partition by list (b) (values (1, 3, 5, 7, 9), values (0, 2, 4, 6, 8), values (10), values(NULL), default partition extra);
+	insert into bar select i, i % 10, repeat('a',10000) from generate_series(1, 200000)i;
+	insert into bar select i, 10, repeat('a',10000) from generate_series(1, 100000)i;
+	insert into bar select i, NULL, repeat('a',10000) from generate_series(1, 100000)i;
+	insert into bar select i, i, repeat('a',10000) from generate_series(11, 100010)i;
+	analyze bar;
+
+	explain select * from bar where b = 0 or b is not null;
+
+        Physical plan:
+        +--CPhysicalMotionGather(master)   rows:399999   width:10042  rebinds:1   cost:18579.330599   origin: [Grp:7, GrpExpr:2]
+           +--CPhysicalFilter   rows:399999   width:10042  rebinds:1   cost:3654.775988   origin: [Grp:7, GrpExpr:1]
+              |--CPhysicalDynamicTableScan "bar" ("bar"), Columns: ["a" (0), "b" (1), "c" (2), "ctid" (3), "xmin" (4), "cmin" (5), "xmax" (6), "cmax" (7), "tableoid" (8), "gp_segment_id" (9)] Scan Id: 1   rows:399999   width:10042  rebinds:1   cost:1167.413331   origin: [Grp:0, GrpExpr:1]
+              +--CScalarBoolOp (EboolopOr)   origin: [Grp:6, GrpExpr:0]
+                 |--CScalarCmp (=)   origin: [Grp:3, GrpExpr:0]
+                 |  |--CScalarIdent "b" (1)   origin: [Grp:1, GrpExpr:0]
+                 |  +--CScalarConst (0)   origin: [Grp:2, GrpExpr:0]
+                 +--CScalarBoolOp (EboolopNot)   origin: [Grp:5, GrpExpr:0]
+                    +--CScalarNullTest   origin: [Grp:4, GrpExpr:0]
+                       +--CScalarIdent "b" (1)   origin: [Grp:1, GrpExpr:0]
+
+                                                       QUERY PLAN
+        -----------------------------------------------------------------------------------------
+         Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..18579.33 rows=400000 width=10012)
+           ->  Append  (cost=0.00..3654.78 rows=133334 width=10012)
+                 ->  Seq Scan on bar_1_prt_3  (cost=0.00..3654.78 rows=133334 width=10012)
+                       Filter: ((b = 0) OR (NOT (b IS NULL)))
+                 ->  Seq Scan on bar_1_prt_2  (cost=0.00..3654.78 rows=133334 width=10012)
+                       Filter: ((b = 0) OR (NOT (b IS NULL)))
+                 ->  Seq Scan on bar_1_prt_4  (cost=0.00..3654.78 rows=133334 width=10012)
+                       Filter: ((b = 0) OR (NOT (b IS NULL)))
+                 ->  Seq Scan on bar_1_prt_extra  (cost=0.00..3654.78 rows=133334 width=10012)
+                       Filter: ((b = 0) OR (NOT (b IS NULL)))
+         Optimizer: Pivotal Optimizer (GPORCA)
+        (11 rows)
+
+  ]]>
+    </dxl:Comment>
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Relation Mdid="0.49410.1.0" Name="bar_1_prt_5" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:IsNull>
+            <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:IsNull>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.518.1.0" Name="&lt;&gt;" ComparisonType="NEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.144.1.0"/>
+        <dxl:Commutator Mdid="0.518.1.0"/>
+        <dxl:InverseOp Mdid="0.96.1.0"/>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.49383.1.0.1" Name="b" Width="4.000000" NullFreq="0.200000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.040060" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039667" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039760" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040020" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040287" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039660" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040020" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040513" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039873" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040140" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.200000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="994"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="994"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1918"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1918"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2981"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2981"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3983"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3983"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4926"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4926"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6927"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6927"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7854"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7854"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8877"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8877"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9789"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9789"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10802"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10802"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11825"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11825"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12766"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12766"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13774"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13774"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14711"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14711"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15739"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15739"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16730"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17774"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17774"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18807"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18807"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20755"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20755"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21708"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21708"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22677"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22677"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23759"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23759"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24854"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24854"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25866"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25866"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26896"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26896"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27830"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27830"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28879"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28879"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29809"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29809"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30793"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30793"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31803"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31803"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32763"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32763"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33725"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33725"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34649"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34649"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35606"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36687"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36687"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37760"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37760"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38772"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38772"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39804"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39804"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40851"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40851"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41817"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41817"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42806"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42806"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43739"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43739"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44776"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44776"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45746"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45746"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46757"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46757"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47760"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47760"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48730"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49654"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49654"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50606"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51554"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51554"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="52597"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52597"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53650"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53650"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54555"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54555"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55607"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55607"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56562"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56562"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57542"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57542"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="58455"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58455"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59401"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59401"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60447"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60447"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61518"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61518"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62512"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62512"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63470"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64485"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64485"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65429"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65429"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66409"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66409"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67430"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67430"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68489"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68489"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69550"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69550"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70568"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70568"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71594"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71594"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72682"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72682"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73751"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73751"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74821"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74821"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75844"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75844"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77756"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77756"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78796"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78796"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79782"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79782"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80804"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80804"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81740"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81740"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="82714"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82714"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83765"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83765"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84766"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84766"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85864"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85864"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86848"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86848"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87863"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87863"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88965"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88965"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89959"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89959"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90958"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90958"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91933"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91933"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="92972"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92972"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93987"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93987"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94963"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94963"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96005"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96005"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96964"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96964"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97983"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97983"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99046"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99046"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="100008"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.49383.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1918"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1918"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2981"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2981"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4089"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4089"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5892"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5892"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6889"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6889"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8039"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8039"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9090"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9090"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10169"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10169"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11825"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11825"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12831"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12831"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14128"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14128"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15739"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15739"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16730"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17908"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17908"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18953"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18953"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20378"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20378"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21834"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21834"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22892"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22892"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23987"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23987"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25866"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25866"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26896"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26896"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28049"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28049"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29015"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29015"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30244"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30244"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31871"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31871"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32920"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32920"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34078"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34078"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35606"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36687"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36687"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38010"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38010"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39132"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39132"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40158"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40158"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41940"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41940"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43002"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43002"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44048"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44048"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45746"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45746"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46757"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46757"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48037"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48037"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49149"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49149"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50198"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50198"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51806"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51806"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53074"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53074"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54058"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54058"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55607"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55607"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56562"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56562"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57943"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57943"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59048"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59048"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60081"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60081"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61783"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61783"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62878"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62878"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63890"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63890"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65429"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65429"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66409"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66409"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67820"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67820"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68916"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68916"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69945"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69945"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71594"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71594"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72791"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72791"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73986"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73986"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75496"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75496"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77756"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77756"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79019"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79019"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80106"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80106"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81778"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81778"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83013"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83013"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84035"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84035"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85860"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86848"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86848"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87863"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87863"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89025"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89025"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90058"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90058"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91881"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91881"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93056"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93056"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94045"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94045"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95771"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95771"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96964"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96964"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98007"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98007"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99056"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99056"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="100228"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="100228"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="105937"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="105937"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="110218"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="110218"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="116117"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="116117"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="120207"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="120207"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="126290"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="126290"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="130345"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="130345"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="136380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="136380"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="140427"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="140427"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="146168"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="146168"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="150601"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="150601"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="156004"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="156004"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="160609"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="160609"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="166076"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="166076"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="170425"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="170425"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="176002"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="176002"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="180231"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="180231"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="185806"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="185806"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="190088"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="190088"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="195755"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="195755"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="200000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1043.1.0" Name="varchar" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1015.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.49383.1.0" Name="bar" Rows="500000.000000" RelPages="0" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Relation Mdid="0.49383.1.0" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,9,3" PartitionColumns="1" PartitionTypes="l" NumberLeafPartitions="5">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:Partitions>
+          <dxl:Partition Mdid="0.49398.1.0"/>
+          <dxl:Partition Mdid="0.49392.1.0"/>
+          <dxl:Partition Mdid="0.49404.1.0"/>
+          <dxl:Partition Mdid="0.49410.1.0"/>
+          <dxl:Partition Mdid="0.49386.1.0"/>
+        </dxl:Partitions>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.49386.1.0" Name="bar_1_prt_extra" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:Not>
+            <dxl:Or>
+              <dxl:IsNull>
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:IsNull>
+              <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="6"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="7"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="8"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="9"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                </dxl:Array>
+              </dxl:ArrayComp>
+            </dxl:Or>
+          </dxl:Not>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.49398.1.0" Name="bar_1_prt_3" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="6"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="8"/>
+              </dxl:Array>
+            </dxl:ArrayComp>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.49392.1.0" Name="bar_1_prt_2" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="7"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="9"/>
+              </dxl:Array>
+            </dxl:ArrayComp>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.49404.1.0" Name="bar_1_prt_4" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Or>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+          </dxl:Comparison>
+          <dxl:IsNotNull>
+            <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:IsNotNull>
+        </dxl:Or>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.49383.1.0" TableName="bar" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+              <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="18579.330667" Rows="400000.000000" Width="10012"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="2" Alias="c">
+            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="1" SelectorIds="">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="3654.776000" Rows="400000.000000" Width="10012"/>
+          </dxl:Properties>
+          <dxl:TableDescriptor Mdid="0.49383.1.0" TableName="bar" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="c">
+              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="3654.776000" Rows="400000.000000" Width="10012"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="10" Alias="a">
+                <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="11" Alias="b">
+                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="12" Alias="c">
+                <dxl:Ident ColId="12" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Or>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                </dxl:Comparison>
+                <dxl:Not>
+                  <dxl:IsNull>
+                    <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:IsNull>
+                </dxl:Not>
+              </dxl:Or>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.49398.1.0" TableName="bar_1_prt_3" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="12" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="3654.776000" Rows="400000.000000" Width="10012"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="20" Alias="a">
+                <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="21" Alias="b">
+                <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="22" Alias="c">
+                <dxl:Ident ColId="22" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Or>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                </dxl:Comparison>
+                <dxl:Not>
+                  <dxl:IsNull>
+                    <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:IsNull>
+                </dxl:Not>
+              </dxl:Or>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.49392.1.0" TableName="bar_1_prt_2" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="20" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="21" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="22" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="24" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="25" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="26" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="27" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="28" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="29" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="3654.776000" Rows="400000.000000" Width="10012"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="30" Alias="a">
+                <dxl:Ident ColId="30" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="31" Alias="b">
+                <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="32" Alias="c">
+                <dxl:Ident ColId="32" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Or>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                </dxl:Comparison>
+                <dxl:Not>
+                  <dxl:IsNull>
+                    <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:IsNull>
+                </dxl:Not>
+              </dxl:Or>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.49404.1.0" TableName="bar_1_prt_4" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="30" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="31" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="32" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="33" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="34" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="35" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="36" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="37" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="38" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="39" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="3654.776000" Rows="400000.000000" Width="10012"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="40" Alias="a">
+                <dxl:Ident ColId="40" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="41" Alias="b">
+                <dxl:Ident ColId="41" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="42" Alias="c">
+                <dxl:Ident ColId="42" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Or>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="41" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                </dxl:Comparison>
+                <dxl:Not>
+                  <dxl:IsNull>
+                    <dxl:Ident ColId="41" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:IsNull>
+                </dxl:Not>
+              </dxl:Or>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.49386.1.0" TableName="bar_1_prt_extra" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="40" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="41" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="42" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="43" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="44" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="45" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="46" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="47" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="48" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="49" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:Append>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-List-Cost5.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-List-Cost5.mdp
@@ -1,0 +1,1539 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:Comment><![CDATA[
+	Objective: We should derive statistics of a Dynamic Table Scan with SPE
+	using the disjunctive constraints of the selected child partitions. In this
+	case, two partitions are selected after SPE, CPhysicalDynamicTableScan in
+	physical plan should cost around 799 with ~200000 rows.
+
+	create table bar (a int, b int, c varchar(10000)) partition by list (b) (values (1, 3, 5, 7, 9), values (0, 2, 4, 6, 8), values (10), values(NULL), default partition extra);
+	insert into bar select i, i % 10, repeat('a',10000) from generate_series(1, 200000)i;
+	insert into bar select i, 10, repeat('a',10000) from generate_series(1, 100000)i;
+	insert into bar select i, NULL, repeat('a',10000) from generate_series(1, 100000)i;
+	insert into bar select i, i, repeat('a',10000) from generate_series(11, 100010)i;
+	analyze bar;
+
+	explain select * from bar where b is null or b = 11;
+
+        Physical plan:
+        +--CPhysicalMotionGather(master)   rows:100001   width:10042  rebinds:1   cost:5153.349797   origin: [Grp:6, GrpExpr:2]
+           +--CPhysicalFilter   rows:100001   width:10042  rebinds:1   cost:1422.155163   origin: [Grp:6, GrpExpr:1]
+              |--CPhysicalDynamicTableScan "bar" ("bar"), Columns: ["a" (0), "b" (1), "c" (2), "ctid" (3), "xmin" (4), "cmin" (5), "xmax" (6), "cmax" (7), "tableoid" (8), "gp_segment_id" (9)] Scan Id: 1   rows:200001   width:10042  rebinds:1   cost:799.208508   origin: [Grp:0, GrpExpr:1]
+              +--CScalarBoolOp (EboolopOr)   origin: [Grp:5, GrpExpr:0]
+                 |--CScalarNullTest   origin: [Grp:2, GrpExpr:0]
+                 |  +--CScalarIdent "b" (1)   origin: [Grp:1, GrpExpr:0]
+                 +--CScalarCmp (=)   origin: [Grp:4, GrpExpr:0]
+                    |--CScalarIdent "b" (1)   origin: [Grp:1, GrpExpr:0]
+                    +--CScalarConst (11)   origin: [Grp:3, GrpExpr:0]
+
+                                                       QUERY PLAN
+        ----------------------------------------------------------------------------------------
+         Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..5153.35 rows=100002 width=10012)
+           ->  Append  (cost=0.00..1422.16 rows=33334 width=10012)
+                 ->  Seq Scan on bar_1_prt_5  (cost=0.00..1422.16 rows=33334 width=10012)
+                       Filter: ((b IS NULL) OR (b = 11))
+                 ->  Seq Scan on bar_1_prt_extra  (cost=0.00..1422.16 rows=33334 width=10012)
+                       Filter: ((b IS NULL) OR (b = 11))
+         Optimizer: Pivotal Optimizer (GPORCA)
+        (7 rows)
+  ]]>
+    </dxl:Comment>
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Relation Mdid="0.49410.1.0" Name="bar_1_prt_5" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:IsNull>
+            <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:IsNull>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.518.1.0" Name="&lt;&gt;" ComparisonType="NEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.144.1.0"/>
+        <dxl:Commutator Mdid="0.518.1.0"/>
+        <dxl:InverseOp Mdid="0.96.1.0"/>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.49383.1.0.1" Name="b" Width="4.000000" NullFreq="0.200000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.040060" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039667" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039760" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040020" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040287" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039660" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040020" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040513" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039873" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040140" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.200000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="994"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="994"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1918"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1918"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2981"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2981"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3983"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3983"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4926"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4926"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6927"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6927"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7854"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7854"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8877"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8877"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9789"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9789"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10802"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10802"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11825"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11825"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12766"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12766"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13774"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13774"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14711"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14711"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15739"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15739"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16730"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17774"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17774"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18807"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18807"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20755"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20755"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21708"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21708"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22677"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22677"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23759"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23759"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24854"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24854"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25866"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25866"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26896"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26896"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27830"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27830"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28879"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28879"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29809"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29809"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30793"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30793"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31803"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31803"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32763"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32763"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33725"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33725"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34649"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34649"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35606"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36687"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36687"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37760"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37760"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38772"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38772"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39804"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39804"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40851"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40851"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41817"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41817"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42806"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42806"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43739"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43739"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44776"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44776"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45746"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45746"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46757"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46757"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47760"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47760"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48730"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49654"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49654"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50606"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51554"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51554"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="52597"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52597"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53650"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53650"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54555"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54555"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55607"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55607"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56562"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56562"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57542"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57542"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="58455"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58455"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59401"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59401"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60447"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60447"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61518"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61518"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62512"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62512"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63470"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64485"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64485"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65429"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65429"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66409"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66409"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67430"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67430"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68489"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68489"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69550"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69550"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70568"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70568"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71594"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71594"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72682"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72682"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73751"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73751"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74821"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74821"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75844"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75844"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77756"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77756"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78796"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78796"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79782"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79782"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80804"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80804"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81740"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81740"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="82714"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82714"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83765"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83765"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84766"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84766"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85864"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85864"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86848"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86848"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87863"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87863"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88965"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88965"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89959"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89959"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90958"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90958"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91933"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91933"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="92972"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92972"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93987"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93987"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94963"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94963"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96005"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96005"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96964"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96964"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97983"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97983"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99046"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="370.900000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99046"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="100008"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.49383.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1918"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1918"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2981"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2981"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4089"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4089"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5892"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5892"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6889"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6889"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8039"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8039"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9090"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9090"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10169"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10169"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11825"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11825"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12831"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12831"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14128"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14128"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15739"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15739"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16730"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17908"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17908"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18953"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18953"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20378"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20378"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21834"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21834"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22892"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22892"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23987"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23987"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25866"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25866"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26896"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26896"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28049"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28049"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29015"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29015"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30244"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30244"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31871"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31871"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32920"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32920"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34078"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34078"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35606"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36687"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36687"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38010"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38010"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39132"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39132"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40158"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40158"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41940"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41940"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43002"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43002"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44048"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44048"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45746"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45746"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46757"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46757"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48037"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48037"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49149"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49149"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50198"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50198"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51806"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51806"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53074"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53074"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54058"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54058"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55607"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55607"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56562"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56562"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57943"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57943"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59048"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59048"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60081"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60081"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61783"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61783"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62878"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62878"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63890"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63890"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65429"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65429"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66409"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66409"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67820"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67820"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68916"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68916"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69945"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69945"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71594"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71594"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72791"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72791"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73986"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73986"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75496"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75496"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77756"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77756"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79019"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79019"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80106"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80106"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81778"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81778"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83013"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83013"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84035"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84035"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85860"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86848"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86848"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87863"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87863"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89025"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89025"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90058"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90058"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91881"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91881"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93056"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93056"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94045"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94045"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95771"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95771"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96964"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96964"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98007"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98007"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99056"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99056"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="100228"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="100228"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="105937"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="105937"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="110218"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="110218"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="116117"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="116117"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="120207"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="120207"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="126290"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="126290"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="130345"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="130345"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="136380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="136380"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="140427"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="140427"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="146168"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="146168"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="150601"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="150601"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="156004"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="156004"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="160609"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="160609"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="166076"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="166076"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="170425"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="170425"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="176002"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="176002"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="180231"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="180231"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="185806"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="185806"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="190088"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="190088"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="195755"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1551.760000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="195755"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="200000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1043.1.0" Name="varchar" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1015.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.49383.1.0" Name="bar" Rows="500000.000000" RelPages="0" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Relation Mdid="0.49383.1.0" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,9,3" PartitionColumns="1" PartitionTypes="l" NumberLeafPartitions="5">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:Partitions>
+          <dxl:Partition Mdid="0.49398.1.0"/>
+          <dxl:Partition Mdid="0.49392.1.0"/>
+          <dxl:Partition Mdid="0.49404.1.0"/>
+          <dxl:Partition Mdid="0.49410.1.0"/>
+          <dxl:Partition Mdid="0.49386.1.0"/>
+        </dxl:Partitions>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.49386.1.0" Name="bar_1_prt_extra" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:Not>
+            <dxl:Or>
+              <dxl:IsNull>
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:IsNull>
+              <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="6"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="7"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="8"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="9"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                </dxl:Array>
+              </dxl:ArrayComp>
+            </dxl:Or>
+          </dxl:Not>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.49398.1.0" Name="bar_1_prt_3" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="6"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="8"/>
+              </dxl:Array>
+            </dxl:ArrayComp>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.49392.1.0" Name="bar_1_prt_2" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="7"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="9"/>
+              </dxl:Array>
+            </dxl:ArrayComp>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.49404.1.0" Name="bar_1_prt_4" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Or>
+          <dxl:IsNull>
+            <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:IsNull>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="11"/>
+          </dxl:Comparison>
+        </dxl:Or>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.49383.1.0" TableName="bar" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+              <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="5153.349797" Rows="100001.500000" Width="10012"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="2" Alias="c">
+            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="1" SelectorIds="">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1422.155163" Rows="100001.500000" Width="10012"/>
+          </dxl:Properties>
+          <dxl:TableDescriptor Mdid="0.49383.1.0" TableName="bar" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="c">
+              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1422.155163" Rows="100001.500000" Width="10012"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="10" Alias="a">
+                <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="11" Alias="b">
+                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="12" Alias="c">
+                <dxl:Ident ColId="12" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Or>
+                <dxl:IsNull>
+                  <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:IsNull>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="11"/>
+                </dxl:Comparison>
+              </dxl:Or>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.49410.1.0" TableName="bar_1_prt_5" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="12" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1422.155163" Rows="100001.500000" Width="10012"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="20" Alias="a">
+                <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="21" Alias="b">
+                <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="22" Alias="c">
+                <dxl:Ident ColId="22" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Or>
+                <dxl:IsNull>
+                  <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:IsNull>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="11"/>
+                </dxl:Comparison>
+              </dxl:Or>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.49386.1.0" TableName="bar_1_prt_extra" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="20" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="21" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="22" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="24" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="25" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="26" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="27" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="28" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="29" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:Append>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-Range-Cost1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-Range-Cost1.mdp
@@ -1,0 +1,1899 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:Comment><![CDATA[
+	Objective: We should derive statistics of a Dynamic Table Scan with SPE
+	using the disjunctive constraints of the selected child partitions. In this
+	case, one partition is selected after SPE, CPhysicalDynamicTableScan in
+	physical plan should cost around 615 with ~100000 rows.
+
+	create table foo (a int, b int, c varchar(10000)) partition by range (b) (start (1) end (1000001) every (100000), default partition extra);
+	insert into foo select i, i, repeat('a',10000) from generate_series(1, 1100000)i;
+	insert into foo select i, 1, repeat('a',10000) from generate_series(1, 1000)i;
+	analyze foo;
+
+	explain analyze select * from foo where b = 2;
+
+        Physical plan:
+        +--CPhysicalMotionGather(master)   rows:1   width:10041  rebinds:1   cost:616.234478   origin: [Grp:4, GrpExpr:2]
+           +--CPhysicalFilter   rows:1   width:10041  rebinds:1   cost:616.197170   origin: [Grp:4, GrpExpr:1]
+              |--CPhysicalDynamicTableScan "foo" ("foo"), Columns: ["a" (0), "b" (1), "c" (2), "ctid" (3), "xmin" (4), "cmin" (5), "xmax" (6), "cmax" (7), "tableoid" (8), "gp_segment_id" (9)] Scan Id: 1   rows:100005   width:10041  rebinds:1   cost:615.094242   origin: [Grp:0, GrpExpr:1]
+              +--CScalarCmp (=)   origin: [Grp:3, GrpExpr:0]
+                 |--CScalarIdent "b" (1)   origin: [Grp:1, GrpExpr:0]
+                 +--CScalarConst (2)   origin: [Grp:2, GrpExpr:0]
+        ",
+
+                                                                         QUERY PLAN
+        ----------------------------------------------------------------------------------------------------------------------------
+         Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..616.23 rows=1 width=10011) (actual time=4.789..5.271 rows=1 loops=1)
+           ->  Append  (cost=0.00..616.20 rows=1 width=10011) (actual time=0.024..4.475 rows=1 loops=1)
+                 ->  Seq Scan on foo_1_prt_2  (cost=0.00..616.20 rows=1 width=10011) (actual time=0.024..4.474 rows=1 loops=1)
+                       Filter: (b = 2)
+                       Rows Removed by Filter: 33799
+         Planning Time: 16.457 ms
+           (slice0)    Executor memory: 38K bytes.
+           (slice1)    Executor memory: 38K bytes avg x 3 workers, 38K bytes max (seg0).
+         Memory used:  128000kB
+         Optimizer: Pivotal Optimizer (GPORCA)
+         Execution Time: 5.741 ms
+        (11 rows)
+
+  ]]>
+    </dxl:Comment>
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.32768.1.0" Name="foo" Rows="1101000.000000" RelPages="0" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.32768.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,9,3" PartitionColumns="1" PartitionTypes="r" NumberLeafPartitions="11">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10003">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:Partitions>
+          <dxl:Partition Mdid="0.32777.1.0"/>
+          <dxl:Partition Mdid="0.32783.1.0"/>
+          <dxl:Partition Mdid="0.32789.1.0"/>
+          <dxl:Partition Mdid="0.32795.1.0"/>
+          <dxl:Partition Mdid="0.32801.1.0"/>
+          <dxl:Partition Mdid="0.32807.1.0"/>
+          <dxl:Partition Mdid="0.32813.1.0"/>
+          <dxl:Partition Mdid="0.32819.1.0"/>
+          <dxl:Partition Mdid="0.32825.1.0"/>
+          <dxl:Partition Mdid="0.32831.1.0"/>
+          <dxl:Partition Mdid="0.32771.1.0"/>
+        </dxl:Partitions>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32771.1.0" Name="foo_1_prt_extra" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:Not>
+            <dxl:And>
+              <dxl:IsNotNull>
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:IsNotNull>
+              <dxl:Or>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="100001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="100001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="200001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="200001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="300001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="300001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="400001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="400001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="500001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="500001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="600001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="600001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="700001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="700001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="800001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="800001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="900001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="900001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1000001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+              </dxl:Or>
+            </dxl:And>
+          </dxl:Not>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32783.1.0" Name="foo_1_prt_3" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="100001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="200001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.525.1.0" Name="&gt;=" ComparisonType="GEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.150.1.0"/>
+        <dxl:Commutator Mdid="0.523.1.0"/>
+        <dxl:InverseOp Mdid="0.97.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Relation Mdid="0.32777.1.0" Name="foo_1_prt_2" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="100001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Relation Mdid="0.32789.1.0" Name="foo_1_prt_4" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="200001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="300001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.1043.1.0" Name="varchar" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1015.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Relation Mdid="0.32795.1.0" Name="foo_1_prt_5" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="300001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="400001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32807.1.0" Name="foo_1_prt_7" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="500001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="600001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32801.1.0" Name="foo_1_prt_6" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="400001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="500001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32813.1.0" Name="foo_1_prt_8" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="600001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="700001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.32768.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.000911" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11992"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11992"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22804"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22804"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33722"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33722"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45057"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45057"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56102"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56102"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67027"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67027"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77849"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77849"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88885"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88885"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99999"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99999"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="110742"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="110742"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="121864"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="121864"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="132859"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="132859"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="143836"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="143836"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="154779"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="154779"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="165734"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="165734"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="176710"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="176710"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="188050"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="188050"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="198929"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="198929"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="210202"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="210202"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="221188"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="221188"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="231981"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="231981"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="243102"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="243102"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="254017"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="254017"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="265178"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="265178"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="276014"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="276014"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="287044"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="287044"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="297991"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="297991"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="308872"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="308872"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="319751"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="319751"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="330967"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="330967"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="342212"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="342212"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="353020"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="353020"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="364173"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="364173"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="375049"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="375049"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="386275"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="386275"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="396875"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="396875"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="407767"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="407767"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="418864"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="418864"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="429762"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="429762"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="440642"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="440642"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="451837"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="451837"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="462947"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="462947"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="473985"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="473985"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="484774"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="484774"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="496057"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="496057"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="506874"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="506874"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="518089"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="518089"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="529071"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="529071"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="539998"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="539998"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="550931"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="550931"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="562086"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="562086"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="573088"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="573088"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="583927"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="583927"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="594844"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="594844"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="606033"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="606033"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="617177"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="617177"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="628196"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="628196"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="639045"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="639045"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="649916"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="649916"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="660877"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="660877"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="671825"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="671825"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="682777"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="682777"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="693869"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="693869"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="704895"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="704895"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="715905"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="715905"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="726981"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="726981"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="738122"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="738122"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="749084"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="749084"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="759982"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="759982"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="771078"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="771078"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="782085"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="782085"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="793212"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="793212"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="803899"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="803899"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="814952"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="814952"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="825999"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="825999"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="837227"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="837227"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="848259"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="848259"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="859103"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="859103"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="870142"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="870142"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="881133"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="881133"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="892084"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="892084"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="902989"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="902989"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="913733"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="913733"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="924938"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="924938"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="936003"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="936003"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="946680"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="946680"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="957712"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="957712"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="968810"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="968810"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="979906"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="979906"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="991106"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="991106"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1002077"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1002077"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1013349"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1013349"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1024114"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1024114"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1035226"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1035226"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1046195"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1046195"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1056912"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1056912"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1068004"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1068004"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1079015"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1079015"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1089888"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1089888"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1099999"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.32768.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10055"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10055"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21075"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21075"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32057"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32057"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43421"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43421"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54677"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54677"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65728"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65728"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76575"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76575"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99039"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99039"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="109751"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="109751"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="120880"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="120880"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="131802"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="131802"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="142828"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="142828"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="153721"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="153721"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="164603"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="164603"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="175752"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="175752"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="187030"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="187030"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="197944"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="197944"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="209176"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="209176"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="220200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="220200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="231040"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="231040"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="242070"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="242070"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="253025"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="253025"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="264172"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="264172"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="275041"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="275041"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="286072"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="286072"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="296963"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="296963"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="307917"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="307917"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="318726"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="318726"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="329996"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="329996"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="341168"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="341168"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="352018"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="352018"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="363072"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="363072"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="373978"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="373978"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="385346"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="385346"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="395876"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="395876"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="406813"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="406813"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="417837"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="417837"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="428803"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="428803"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="439681"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="439681"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="450731"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="450731"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="461902"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="461902"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="472965"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="472965"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="483821"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="483821"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="494999"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="494999"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="505878"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="505878"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="517065"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="517065"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="528044"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="528044"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="538988"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="538988"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="549987"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="549987"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="561041"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="561041"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="572057"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="572057"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="582997"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="582997"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="593900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="593900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="604988"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="604988"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="616154"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="616154"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="627222"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="627222"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="638100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="638100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="648994"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="648994"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="659887"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="659887"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="670749"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="670749"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="681825"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="681825"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="692800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="692800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="703950"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="703950"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="714936"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="714936"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="725923"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="725923"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="737094"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="737094"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="748143"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="748143"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="759023"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="759023"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="770115"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="770115"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="781003"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="781003"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="792239"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="792239"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="802936"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="802936"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="813952"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="813952"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="824938"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="824938"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="836154"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="836154"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="847229"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="847229"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="858185"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="858185"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="869078"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="869078"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="880063"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="880063"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="891043"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="891043"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="901997"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="901997"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="912754"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="912754"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="923968"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="923968"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="935024"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="935024"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="945720"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="945720"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="956788"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="956788"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="967802"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="967802"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="978854"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="978854"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="990100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="990100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1001014"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1001014"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1012309"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1012309"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1023171"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1023171"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1034115"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1034115"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1045147"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1045147"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1056007"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1056007"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1067040"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1067040"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1078029"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1078029"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1088878"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1088878"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1099999"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Relation Mdid="0.32819.1.0" Name="foo_1_prt_9" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="700001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="800001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32831.1.0" Name="foo_1_prt_11" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="900001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1000001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32825.1.0" Name="foo_1_prt_10" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="800001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="900001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+          <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+          <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:Comparison>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.32768.1.0" TableName="foo" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10003"/>
+              <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="616.236066" Rows="1.000000" Width="10011"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="2" Alias="c">
+            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="1" SelectorIds="">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="616.198758" Rows="1.000000" Width="10011"/>
+          </dxl:Properties>
+          <dxl:TableDescriptor Mdid="0.32768.1.0" TableName="foo" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10003"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="c">
+              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="616.198758" Rows="1.000000" Width="10011"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="10" Alias="a">
+                <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="11" Alias="b">
+                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="12" Alias="c">
+                <dxl:Ident ColId="12" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+              </dxl:Comparison>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.32777.1.0" TableName="foo_1_prt_2" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="12" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:Append>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-Range-Cost2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-Range-Cost2.mdp
@@ -1,0 +1,1955 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:Comment><![CDATA[
+	Objective: We should derive statistics of a Dynamic Table Scan with SPE
+	using the disjunctive constraints of the selected child partitions. In this
+	case, two partitions are selected after SPE, CPhysicalDynamicTableScan in
+	physical plan should cost around 799 with ~200000 rows.
+
+	create table foo (a int, b int, c varchar(10000)) partition by range (b) (start (1) end (1000001) every (100000), default partition extra);
+	insert into foo select i, i, repeat('a',10000) from generate_series(1, 1100000)i;
+	insert into foo select i, 1, repeat('a',10000) from generate_series(1, 1000)i;
+	analyze foo;
+
+	explain analyze select * from foo where b >= 100000 and b <= 100002;
+
+        Physical plan:
+        +--CPhysicalMotionGather(master)   rows:3   width:10041  rebinds:1   cost:801.587210   origin: [Grp:7, GrpExpr:2]
+           +--CPhysicalFilter   rows:3   width:10041  rebinds:1   cost:801.472610   origin: [Grp:7, GrpExpr:1]
+              |--CPhysicalDynamicTableScan "foo" ("foo"), Columns: ["a" (0), "b" (1), "c" (2), "ctid" (3), "xmin" (4), "cmin" (5), "xmax" (6), "cmax" (7), "tableoid" (8), "gp_segment_id" (9)] Scan Id: 1   rows:200048   width:10041  rebinds:1   cost:799.259676   origin: [Grp:0, GrpExpr:1]
+              +--CScalarBoolOp (EboolopAnd)   origin: [Grp:6, GrpExpr:0]
+                 |--CScalarCmp (>=)   origin: [Grp:3, GrpExpr:0]
+                 |  |--CScalarIdent "b" (1)   origin: [Grp:1, GrpExpr:0]
+                 |  +--CScalarConst (100000)   origin: [Grp:2, GrpExpr:0]
+                 +--CScalarCmp (<=)   origin: [Grp:5, GrpExpr:0]
+                    |--CScalarIdent "b" (1)   origin: [Grp:1, GrpExpr:0]
+                    +--CScalarConst (100002)   origin: [Grp:4, GrpExpr:0]
+
+                                                                          QUERY PLAN
+        ------------------------------------------------------------------------------------------------------------------------------
+         Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..801.59 rows=4 width=10011) (actual time=10.056..11.184 rows=3 loops=1)
+           ->  Append  (cost=0.00..801.47 rows=2 width=10011) (actual time=5.036..10.231 rows=2 loops=1)
+                 ->  Seq Scan on foo_1_prt_2  (cost=0.00..801.47 rows=2 width=10011) (actual time=5.036..5.079 rows=1 loops=1)
+                       Filter: ((b >= 100000) AND (b <= 100002))
+                       Rows Removed by Filter: 33550
+                 ->  Seq Scan on foo_1_prt_3  (cost=0.00..801.47 rows=2 width=10011) (actual time=0.019..4.981 rows=1 loops=1)
+                       Filter: ((b >= 100000) AND (b <= 100002))
+                       Rows Removed by Filter: 33190
+         Planning Time: 17.818 ms
+           (slice0)    Executor memory: 41K bytes.
+           (slice1)    Executor memory: 41K bytes avg x 3 workers, 41K bytes max (seg0).
+         Memory used:  128000kB
+         Optimizer: Pivotal Optimizer (GPORCA)
+         Execution Time: 11.618 ms
+        (14 rows)
+
+  ]]>
+    </dxl:Comment>
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.32768.1.0" Name="foo" Rows="1101000.000000" RelPages="0" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.32768.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,9,3" PartitionColumns="1" PartitionTypes="r" NumberLeafPartitions="11">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10003">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:Partitions>
+          <dxl:Partition Mdid="0.32777.1.0"/>
+          <dxl:Partition Mdid="0.32783.1.0"/>
+          <dxl:Partition Mdid="0.32789.1.0"/>
+          <dxl:Partition Mdid="0.32795.1.0"/>
+          <dxl:Partition Mdid="0.32801.1.0"/>
+          <dxl:Partition Mdid="0.32807.1.0"/>
+          <dxl:Partition Mdid="0.32813.1.0"/>
+          <dxl:Partition Mdid="0.32819.1.0"/>
+          <dxl:Partition Mdid="0.32825.1.0"/>
+          <dxl:Partition Mdid="0.32831.1.0"/>
+          <dxl:Partition Mdid="0.32771.1.0"/>
+        </dxl:Partitions>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32771.1.0" Name="foo_1_prt_extra" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:Not>
+            <dxl:And>
+              <dxl:IsNotNull>
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:IsNotNull>
+              <dxl:Or>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="100001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="100001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="200001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="200001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="300001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="300001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="400001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="400001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="500001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="500001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="600001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="600001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="700001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="700001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="800001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="800001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="900001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="900001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1000001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+              </dxl:Or>
+            </dxl:And>
+          </dxl:Not>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.523.1.0" Name="&lt;=" ComparisonType="LEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.149.1.0"/>
+        <dxl:Commutator Mdid="0.525.1.0"/>
+        <dxl:InverseOp Mdid="0.521.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Relation Mdid="0.32783.1.0" Name="foo_1_prt_3" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="100001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="200001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.525.1.0" Name="&gt;=" ComparisonType="GEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.150.1.0"/>
+        <dxl:Commutator Mdid="0.523.1.0"/>
+        <dxl:InverseOp Mdid="0.97.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Relation Mdid="0.32777.1.0" Name="foo_1_prt_2" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="100001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Relation Mdid="0.32789.1.0" Name="foo_1_prt_4" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="200001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="300001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.1043.1.0" Name="varchar" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1015.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Relation Mdid="0.32795.1.0" Name="foo_1_prt_5" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="300001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="400001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32807.1.0" Name="foo_1_prt_7" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="500001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="600001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32801.1.0" Name="foo_1_prt_6" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="400001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="500001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32813.1.0" Name="foo_1_prt_8" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="600001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="700001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.32768.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.000911" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11992"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11992"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22804"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22804"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33722"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33722"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45057"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45057"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56102"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56102"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67027"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67027"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77849"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77849"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88885"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88885"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99999"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99999"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="110742"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="110742"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="121864"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="121864"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="132859"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="132859"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="143836"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="143836"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="154779"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="154779"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="165734"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="165734"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="176710"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="176710"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="188050"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="188050"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="198929"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="198929"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="210202"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="210202"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="221188"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="221188"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="231981"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="231981"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="243102"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="243102"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="254017"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="254017"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="265178"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="265178"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="276014"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="276014"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="287044"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="287044"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="297991"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="297991"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="308872"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="308872"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="319751"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="319751"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="330967"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="330967"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="342212"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="342212"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="353020"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="353020"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="364173"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="364173"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="375049"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="375049"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="386275"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="386275"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="396875"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="396875"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="407767"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="407767"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="418864"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="418864"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="429762"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="429762"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="440642"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="440642"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="451837"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="451837"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="462947"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="462947"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="473985"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="473985"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="484774"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="484774"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="496057"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="496057"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="506874"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="506874"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="518089"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="518089"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="529071"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="529071"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="539998"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="539998"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="550931"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="550931"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="562086"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="562086"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="573088"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="573088"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="583927"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="583927"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="594844"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="594844"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="606033"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="606033"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="617177"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="617177"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="628196"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="628196"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="639045"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="639045"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="649916"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="649916"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="660877"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="660877"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="671825"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="671825"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="682777"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="682777"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="693869"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="693869"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="704895"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="704895"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="715905"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="715905"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="726981"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="726981"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="738122"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="738122"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="749084"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="749084"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="759982"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="759982"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="771078"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="771078"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="782085"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="782085"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="793212"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="793212"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="803899"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="803899"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="814952"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="814952"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="825999"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="825999"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="837227"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="837227"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="848259"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="848259"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="859103"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="859103"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="870142"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="870142"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="881133"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="881133"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="892084"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="892084"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="902989"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="902989"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="913733"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="913733"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="924938"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="924938"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="936003"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="936003"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="946680"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="946680"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="957712"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="957712"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="968810"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="968810"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="979906"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="979906"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="991106"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="991106"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1002077"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1002077"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1013349"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1013349"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1024114"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1024114"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1035226"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1035226"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1046195"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1046195"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1056912"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1056912"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1068004"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1068004"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1079015"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1079015"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1089888"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009991" DistinctValues="10330.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1089888"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1099999"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.32768.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10055"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10055"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21075"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21075"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32057"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32057"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43421"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43421"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54677"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54677"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65728"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65728"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76575"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76575"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99039"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99039"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="109751"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="109751"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="120880"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="120880"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="131802"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="131802"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="142828"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="142828"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="153721"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="153721"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="164603"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="164603"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="175752"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="175752"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="187030"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="187030"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="197944"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="197944"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="209176"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="209176"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="220200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="220200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="231040"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="231040"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="242070"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="242070"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="253025"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="253025"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="264172"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="264172"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="275041"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="275041"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="286072"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="286072"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="296963"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="296963"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="307917"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="307917"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="318726"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="318726"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="329996"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="329996"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="341168"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="341168"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="352018"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="352018"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="363072"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="363072"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="373978"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="373978"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="385346"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="385346"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="395876"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="395876"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="406813"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="406813"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="417837"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="417837"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="428803"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="428803"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="439681"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="439681"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="450731"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="450731"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="461902"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="461902"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="472965"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="472965"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="483821"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="483821"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="494999"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="494999"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="505878"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="505878"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="517065"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="517065"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="528044"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="528044"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="538988"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="538988"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="549987"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="549987"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="561041"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="561041"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="572057"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="572057"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="582997"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="582997"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="593900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="593900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="604988"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="604988"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="616154"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="616154"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="627222"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="627222"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="638100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="638100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="648994"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="648994"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="659887"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="659887"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="670749"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="670749"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="681825"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="681825"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="692800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="692800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="703950"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="703950"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="714936"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="714936"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="725923"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="725923"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="737094"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="737094"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="748143"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="748143"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="759023"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="759023"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="770115"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="770115"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="781003"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="781003"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="792239"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="792239"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="802936"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="802936"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="813952"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="813952"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="824938"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="824938"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="836154"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="836154"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="847229"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="847229"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="858185"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="858185"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="869078"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="869078"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="880063"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="880063"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="891043"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="891043"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="901997"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="901997"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="912754"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="912754"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="923968"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="923968"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="935024"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="935024"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="945720"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="945720"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="956788"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="956788"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="967802"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="967802"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="978854"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="978854"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="990100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="990100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1001014"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1001014"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1012309"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1012309"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1023171"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1023171"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1034115"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1034115"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1045147"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1045147"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1056007"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1056007"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1067040"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1067040"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1078029"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1078029"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1088878"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10330.020000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1088878"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1099999"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Relation Mdid="0.32819.1.0" Name="foo_1_prt_9" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="700001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="800001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32831.1.0" Name="foo_1_prt_11" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="900001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1000001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32825.1.0" Name="foo_1_prt_10" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="800001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="900001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:And>
+          <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+            <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="100000"/>
+          </dxl:Comparison>
+          <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+            <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="100002"/>
+          </dxl:Comparison>
+        </dxl:And>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.32768.1.0" TableName="foo" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10003"/>
+              <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="801.590882" Rows="3.071793" Width="10011"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="2" Alias="c">
+            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="1" SelectorIds="">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="801.476281" Rows="3.071793" Width="10011"/>
+          </dxl:Properties>
+          <dxl:TableDescriptor Mdid="0.32768.1.0" TableName="foo" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10003"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="c">
+              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="801.476281" Rows="3.071793" Width="10011"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="10" Alias="a">
+                <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="11" Alias="b">
+                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="12" Alias="c">
+                <dxl:Ident ColId="12" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:And>
+                <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                  <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="100000"/>
+                </dxl:Comparison>
+                <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                  <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="100002"/>
+                </dxl:Comparison>
+              </dxl:And>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.32777.1.0" TableName="foo_1_prt_2" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="12" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="801.476281" Rows="3.071793" Width="10011"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="20" Alias="a">
+                <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="21" Alias="b">
+                <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="22" Alias="c">
+                <dxl:Ident ColId="22" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:And>
+                <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                  <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="100000"/>
+                </dxl:Comparison>
+                <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                  <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="100002"/>
+                </dxl:Comparison>
+              </dxl:And>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.32783.1.0" TableName="foo_1_prt_3" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="20" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="21" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="22" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="24" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="25" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="26" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="27" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="28" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="29" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:Append>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-Range-Cost3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-Range-Cost3.mdp
@@ -1,0 +1,2172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:Comment><![CDATA[
+	Objective: We should derive statistics of a Dynamic Table Scan with SPE
+	using the disjunctive constraints of the selected child partitions. In this
+	case, 6 partitions are selected after SPE, cost of CPhysicalDynamicTableScan
+	in physical plan should be around 1536 with about 600000 rows.
+
+	create table foo (a int, b int, c varchar(10000)) partition by range (b) (start (1) end (1000001) every (100000), default partition extra);
+	insert into foo select i, i, repeat('a',10000) from generate_series(1, 1100000)i;
+	insert into foo select i, 1, repeat('a',10000) from generate_series(1, 1000)i;
+	analyze foo;
+
+	explain analyze select * from foo where b IN (1, 100001, 200001, 300001, 400001, 10000000000);
+
+        Physical plan:
+        +--CPhysicalMotionGather(master)   rows:5   width:10041  rebinds:1   cost:1543.624697   origin: [Grp:4, GrpExpr:2]
+           +--CPhysicalFilter   rows:5   width:10041  rebinds:1   cost:1543.438159   origin: [Grp:4, GrpExpr:1]
+              |--CPhysicalDynamicTableScan "foo" ("foo"), Columns: ["a" (0), "b" (1), "c" (2), "ctid" (3), "xmin" (4), "cmin" (5), "xmax" (6), "cmax" (7), "tableoid" (8), "gp_segment_id" (9)] Scan Id: 1   rows:600711   width:10041  rebinds:1   cost:1536.819324   origin: [Grp:0, GrpExpr:1]
+              +--CScalarArrayCmp Any (=)   origin: [Grp:3, GrpExpr:0]
+                 |--CScalarIdent "b" (1)   origin: [Grp:1, GrpExpr:0]
+                 +--CScalarArray: {eleMDId: (20,1.0), arrayMDId: (1016,1.0) CScalarConst (1) CScalarConst (100001) CScalarConst (200001) CScalarConst (300001) CScalarConst (400001) CScalarConst (10000000000)}   origin: [Grp:2, GrpExpr:0]
+
+
+                                                                           QUERY PLAN
+        ---------------------------------------------------------------------------------------------------------------------------------
+         Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1543.62 rows=6 width=10011) (actual time=9.451..71.891 rows=1005 loops=1)
+           ->  Append  (cost=0.00..1543.44 rows=2 width=10011) (actual time=8.241..70.389 rows=341 loops=1)
+                 ->  Seq Scan on foo_1_prt_2  (cost=0.00..1543.44 rows=2 width=10011) (actual time=8.239..8.362 rows=340 loops=1)
+                       Filter: (b = ANY ('{1,100001,200001,300001,400001,10000000000}'::bigint[]))
+                       Rows Removed by Filter: 33211
+                 ->  Seq Scan on foo_1_prt_3  (cost=0.00..1543.44 rows=2 width=10011) (actual time=0.019..7.868 rows=1 loops=1)
+                       Filter: (b = ANY ('{1,100001,200001,300001,400001,10000000000}'::bigint[]))
+                       Rows Removed by Filter: 33190
+                 ->  Seq Scan on foo_1_prt_4  (cost=0.00..1543.44 rows=2 width=10011) (actual time=0.025..7.729 rows=1 loops=1)
+                       Filter: (b = ANY ('{1,100001,200001,300001,400001,10000000000}'::bigint[]))
+                       Rows Removed by Filter: 33460
+                 ->  Seq Scan on foo_1_prt_5  (cost=0.00..1543.44 rows=2 width=10011) (actual time=0.019..7.480 rows=1 loops=1)
+                       Filter: (b = ANY ('{1,100001,200001,300001,400001,10000000000}'::bigint[]))
+                       Rows Removed by Filter: 33329
+                 ->  Seq Scan on foo_1_prt_6  (cost=0.00..1543.44 rows=2 width=10011) (actual time=0.016..14.258 rows=1 loops=1)
+                       Filter: (b = ANY ('{1,100001,200001,300001,400001,10000000000}'::bigint[]))
+                       Rows Removed by Filter: 33265
+                 ->  Seq Scan on foo_1_prt_extra  (cost=0.00..1543.44 rows=2 width=10011) (never executed)
+                       Filter: (b = ANY ('{1,100001,200001,300001,400001,10000000000}'::bigint[]))
+         Planning Time: 15.486 ms
+           (slice0)    Executor memory: 53K bytes.
+           (slice1)    Executor memory: 62K bytes avg x 3 workers, 62K bytes max (seg0).
+         Memory used:  128000kB
+         Optimizer: Pivotal Optimizer (GPORCA)
+         Execution Time: 72.526 ms
+        (25 rows)
+
+  ]]>
+    </dxl:Comment>
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.32768.1.0" Name="foo" Rows="1101000.000000" RelPages="0" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.32768.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,9,3" PartitionColumns="1" PartitionTypes="r" NumberLeafPartitions="11">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10003">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:Partitions>
+          <dxl:Partition Mdid="0.32777.1.0"/>
+          <dxl:Partition Mdid="0.32783.1.0"/>
+          <dxl:Partition Mdid="0.32789.1.0"/>
+          <dxl:Partition Mdid="0.32795.1.0"/>
+          <dxl:Partition Mdid="0.32801.1.0"/>
+          <dxl:Partition Mdid="0.32807.1.0"/>
+          <dxl:Partition Mdid="0.32813.1.0"/>
+          <dxl:Partition Mdid="0.32819.1.0"/>
+          <dxl:Partition Mdid="0.32825.1.0"/>
+          <dxl:Partition Mdid="0.32831.1.0"/>
+          <dxl:Partition Mdid="0.32771.1.0"/>
+        </dxl:Partitions>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32771.1.0" Name="foo_1_prt_extra" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:Not>
+            <dxl:And>
+              <dxl:IsNotNull>
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:IsNotNull>
+              <dxl:Or>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="100001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="100001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="200001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="200001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="300001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="300001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="400001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="400001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="500001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="500001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="600001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="600001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="700001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="700001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="800001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="800001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="900001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="900001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1000001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+              </dxl:Or>
+            </dxl:And>
+          </dxl:Not>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32783.1.0" Name="foo_1_prt_3" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="100001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="200001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.525.1.0" Name="&gt;=" ComparisonType="GEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.150.1.0"/>
+        <dxl:Commutator Mdid="0.523.1.0"/>
+        <dxl:InverseOp Mdid="0.97.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Relation Mdid="0.32777.1.0" Name="foo_1_prt_2" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="100001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.15.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.20.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.852.1.0"/>
+        <dxl:Commutator Mdid="0.416.1.0"/>
+        <dxl:InverseOp Mdid="0.36.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Relation Mdid="0.32789.1.0" Name="foo_1_prt_4" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="200001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="300001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.1043.1.0" Name="varchar" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1015.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Relation Mdid="0.32795.1.0" Name="foo_1_prt_5" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="300001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="400001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32807.1.0" Name="foo_1_prt_7" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="500001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="600001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32801.1.0" Name="foo_1_prt_6" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="400001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="500001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32813.1.0" Name="foo_1_prt_8" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="600001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="700001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.32768.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11896"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11896"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22891"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22891"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33888"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33888"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44766"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44766"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55778"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55778"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66951"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66951"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78024"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78024"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89026"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89026"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99998"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99998"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="110794"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="110794"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="121750"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="121750"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="132884"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="132884"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="143665"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="143665"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="154643"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="154643"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="165919"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="165919"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="176907"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="176907"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="187868"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="187868"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="198986"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="198986"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="210298"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="210298"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="221207"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="221207"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="232306"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="232306"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="243325"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="243325"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="254293"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="254293"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="265338"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="265338"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="276194"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="276194"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="287113"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="287113"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="297964"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="297964"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="309042"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="309042"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="320051"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="320051"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="331012"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="331012"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="342094"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="342094"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="353163"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="353163"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="364179"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="364179"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="375217"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="375217"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="386117"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="386117"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="397063"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="397063"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="407946"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="407946"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="418908"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="418908"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="429852"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="429852"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="440714"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="440714"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="452094"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="452094"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="462964"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="462964"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="474008"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="474008"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="484787"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="484787"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="495950"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="495950"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="506793"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="506793"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="517767"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="517767"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="528517"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="528517"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="539337"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="539337"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="550476"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="550476"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="561661"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="561661"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="572750"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="572750"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="583928"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="583928"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="594972"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="594972"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="606025"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="606025"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="617067"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="617067"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="627980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="627980"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="639223"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="639223"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="650197"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="650197"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="661151"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="661151"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="672159"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="672159"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="682937"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="682937"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="693860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="693860"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="705097"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="705097"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="715970"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="715970"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="726857"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="726857"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="737936"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="737936"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="748960"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="748960"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="760080"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="760080"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="770984"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="770984"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="781784"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="781784"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="793059"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="793059"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="804070"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="804070"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="815237"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="815237"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="826165"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="826165"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="837047"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="837047"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="847823"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="847823"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="858741"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="858741"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="869736"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="869736"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="880867"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="880867"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="891918"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="891918"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="902986"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="902986"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="913935"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="913935"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="924839"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="924839"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="935708"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="935708"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="946774"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="946774"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="958051"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="958051"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="969149"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="969149"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="980086"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="980086"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="991130"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="991130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1002039"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1002039"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1013072"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1013072"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1024124"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1024124"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1035235"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1035235"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1045973"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1045973"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1057292"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1057292"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1068302"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1068302"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1078934"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1078934"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1089811"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1089811"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1099999"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.32768.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9960"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9960"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21116"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21116"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32201"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32201"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43268"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43268"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54268"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54268"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65637"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65637"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76826"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76826"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87860"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98985"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98985"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="109793"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="109793"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="120737"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="120737"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="131927"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="131927"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="142693"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="142693"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="153619"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="153619"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="165011"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="165011"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="175900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="175900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="186884"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="186884"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="198012"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="198012"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="209284"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="209284"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="220217"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="220217"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="231290"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="231290"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="242308"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="242308"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="253369"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="253369"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="264377"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="264377"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="275152"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="275152"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="286158"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="286158"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="296990"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="296990"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="308041"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="308041"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="319021"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="319021"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="330105"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="330105"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="341099"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="341099"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="352066"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="352066"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="363157"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="363157"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="374197"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="374197"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="385131"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="385131"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="396081"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="396081"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="407000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="407000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="417976"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="417976"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="428792"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="428792"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="439670"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="439670"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="451020"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="451020"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="462001"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="462001"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="472988"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="472988"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="483807"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="483807"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="494998"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="494998"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="505837"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="505837"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="516763"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="516763"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="527518"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="527518"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="538320"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="538320"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="549456"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="549456"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="560576"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="560576"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="571734"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="571734"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="582851"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="582851"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="594011"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="594011"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="604991"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="604991"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="616062"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="616062"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="627013"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="627013"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="638176"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="638176"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="649196"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="649196"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="660165"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="660165"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="671203"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="671203"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="681964"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="681964"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="692783"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="692783"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="704064"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="704064"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="715037"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="715037"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="725910"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="725910"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="736942"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="736942"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="747955"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="747955"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="759160"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="759160"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="770003"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="770003"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="780813"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="780813"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="791962"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="791962"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="803060"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="803060"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="814235"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="814235"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="825202"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="825202"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="836113"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="836113"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="846842"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="846842"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="857698"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="857698"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="868789"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="868789"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="879832"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="879832"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="890918"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="890918"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="901914"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="901914"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="912948"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="912948"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="923861"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="923861"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="934741"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="934741"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="945801"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="945801"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="957072"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="957072"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="968121"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="968121"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="979138"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="979138"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="990155"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="990155"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1000981"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1000981"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1012104"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1012104"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1023163"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1023163"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1034207"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1034207"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1045009"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1045009"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1056256"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1056256"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1067320"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1067320"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1077968"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1077968"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1088838"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1088838"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1099999"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Relation Mdid="0.32819.1.0" Name="foo_1_prt_9" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="700001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="800001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32831.1.0" Name="foo_1_prt_11" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="900001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1000001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32825.1.0" Name="foo_1_prt_10" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="800001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="900001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:ArrayComp OperatorName="=" OperatorMdid="0.15.1.0" OperatorType="Any">
+          <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+          <dxl:Array ArrayType="0.1016.1.0" ElementType="0.20.1.0" MultiDimensional="false">
+            <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+            <dxl:ConstValue TypeMdid="0.20.1.0" Value="100001"/>
+            <dxl:ConstValue TypeMdid="0.20.1.0" Value="200001"/>
+            <dxl:ConstValue TypeMdid="0.20.1.0" Value="300001"/>
+            <dxl:ConstValue TypeMdid="0.20.1.0" Value="400001"/>
+            <dxl:ConstValue TypeMdid="0.20.1.0" Value="10000000000"/>
+          </dxl:Array>
+        </dxl:ArrayComp>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.32768.1.0" TableName="foo" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10003"/>
+              <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1543.624697" Rows="5.000007" Width="10011"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="2" Alias="c">
+            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="1" SelectorIds="">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1543.438159" Rows="5.000007" Width="10011"/>
+          </dxl:Properties>
+          <dxl:TableDescriptor Mdid="0.32768.1.0" TableName="foo" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10003"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="c">
+              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1543.438159" Rows="5.000007" Width="10011"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="10" Alias="a">
+                <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="11" Alias="b">
+                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="12" Alias="c">
+                <dxl:Ident ColId="12" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:ArrayComp OperatorName="=" OperatorMdid="0.15.1.0" OperatorType="Any">
+                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Array ArrayType="0.1016.1.0" ElementType="0.20.1.0" MultiDimensional="false">
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="100001"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="200001"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="300001"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="400001"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="10000000000"/>
+                </dxl:Array>
+              </dxl:ArrayComp>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.32777.1.0" TableName="foo_1_prt_2" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="12" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1543.438159" Rows="5.000007" Width="10011"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="20" Alias="a">
+                <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="21" Alias="b">
+                <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="22" Alias="c">
+                <dxl:Ident ColId="22" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:ArrayComp OperatorName="=" OperatorMdid="0.15.1.0" OperatorType="Any">
+                <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Array ArrayType="0.1016.1.0" ElementType="0.20.1.0" MultiDimensional="false">
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="100001"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="200001"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="300001"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="400001"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="10000000000"/>
+                </dxl:Array>
+              </dxl:ArrayComp>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.32783.1.0" TableName="foo_1_prt_3" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="20" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="21" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="22" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="24" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="25" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="26" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="27" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="28" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="29" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1543.438159" Rows="5.000007" Width="10011"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="30" Alias="a">
+                <dxl:Ident ColId="30" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="31" Alias="b">
+                <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="32" Alias="c">
+                <dxl:Ident ColId="32" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:ArrayComp OperatorName="=" OperatorMdid="0.15.1.0" OperatorType="Any">
+                <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Array ArrayType="0.1016.1.0" ElementType="0.20.1.0" MultiDimensional="false">
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="100001"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="200001"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="300001"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="400001"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="10000000000"/>
+                </dxl:Array>
+              </dxl:ArrayComp>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.32789.1.0" TableName="foo_1_prt_4" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="30" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="31" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="32" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="33" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="34" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="35" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="36" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="37" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="38" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="39" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1543.438159" Rows="5.000007" Width="10011"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="40" Alias="a">
+                <dxl:Ident ColId="40" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="41" Alias="b">
+                <dxl:Ident ColId="41" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="42" Alias="c">
+                <dxl:Ident ColId="42" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:ArrayComp OperatorName="=" OperatorMdid="0.15.1.0" OperatorType="Any">
+                <dxl:Ident ColId="41" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Array ArrayType="0.1016.1.0" ElementType="0.20.1.0" MultiDimensional="false">
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="100001"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="200001"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="300001"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="400001"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="10000000000"/>
+                </dxl:Array>
+              </dxl:ArrayComp>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.32795.1.0" TableName="foo_1_prt_5" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="40" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="41" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="42" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="43" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="44" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="45" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="46" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="47" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="48" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="49" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1543.438159" Rows="5.000007" Width="10011"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="50" Alias="a">
+                <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="51" Alias="b">
+                <dxl:Ident ColId="51" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="52" Alias="c">
+                <dxl:Ident ColId="52" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:ArrayComp OperatorName="=" OperatorMdid="0.15.1.0" OperatorType="Any">
+                <dxl:Ident ColId="51" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Array ArrayType="0.1016.1.0" ElementType="0.20.1.0" MultiDimensional="false">
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="100001"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="200001"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="300001"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="400001"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="10000000000"/>
+                </dxl:Array>
+              </dxl:ArrayComp>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.32801.1.0" TableName="foo_1_prt_6" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="50" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="51" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="52" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="53" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="54" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="55" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="56" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="57" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="58" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="59" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1543.438159" Rows="5.000007" Width="10011"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="60" Alias="a">
+                <dxl:Ident ColId="60" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="61" Alias="b">
+                <dxl:Ident ColId="61" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="62" Alias="c">
+                <dxl:Ident ColId="62" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:ArrayComp OperatorName="=" OperatorMdid="0.15.1.0" OperatorType="Any">
+                <dxl:Ident ColId="61" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Array ArrayType="0.1016.1.0" ElementType="0.20.1.0" MultiDimensional="false">
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="100001"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="200001"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="300001"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="400001"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="10000000000"/>
+                </dxl:Array>
+              </dxl:ArrayComp>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.32771.1.0" TableName="foo_1_prt_extra" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="60" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="61" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="62" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="63" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="64" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="65" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="66" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="67" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="68" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="69" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:Append>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-Range-Cost4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-Range-Cost4.mdp
@@ -1,0 +1,1191 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:Comment><![CDATA[
+	Objective: We should derive statistics of a Dynamic Table Scan with SPE
+	using the disjunctive constraints of the selected child partitions. In this
+	case, default partition is the one and only child partition, cost of
+	CPhysicalDynamicTableScan in physical plan should be around 615 with ~100000 rows.
+
+	create table default_part_only (a int, b int, c varchar(10000)) partition by range (b)(default partition d);
+	insert into default_part_only select i, i, repeat('a',10000) from generate_series(1, 100000)i;
+	analyze default_part_only;
+
+	select * from default_part_only where b = 1;
+
+        Physical plan:
+        +--CPhysicalMotionGather(master)   rows:1   width:10042  rebinds:1   cost:616.244767   origin: [Grp:4, GrpExpr:2]
+           +--CPhysicalFilter   rows:1   width:10042  rebinds:1   cost:616.206386   origin: [Grp:4, GrpExpr:1]
+              |--CPhysicalDynamicTableScan "default_part_only" ("default_part_only"), Columns: ["a" (0), "b" (1), "c" (2), "ctid" (3), "xmin" (4), "cmin" (5), "xmax" (6), "cmax" (7), "tableoid" (8), "gp_segment_id" (9)] Scan Id: 1   rows:100000   width:10042  rebinds:1   cost:615.103333   origin: [Grp:0, GrpExpr:1]
+              +--CScalarCmp (=)   origin: [Grp:3, GrpExpr:0]
+                 |--CScalarIdent "b" (1)   origin: [Grp:1, GrpExpr:0]
+                 +--CScalarConst (1)   origin: [Grp:2, GrpExpr:0]
+
+
+                                                        QUERY PLAN
+        -------------------------------------------------------------------------------------------
+         Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..616.24 rows=2 width=10012)
+           ->  Append  (cost=0.00..616.21 rows=1 width=10012)
+                 ->  Seq Scan on default_part_only_1_prt_d  (cost=0.00..616.21 rows=1 width=10012)
+                       Filter: (b = 1)
+         Optimizer: Pivotal Optimizer (GPORCA)
+        (5 rows)
+
+  ]]>
+    </dxl:Comment>
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1043.1.0" Name="varchar" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1015.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.74798.1.0" Name="default_part_only" Rows="100000.000000" RelPages="0" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.74798.1.0" Name="default_part_only" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,9,3" PartitionColumns="1" PartitionTypes="r" NumberLeafPartitions="1">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:Partitions>
+          <dxl:Partition Mdid="0.74801.1.0"/>
+        </dxl:Partitions>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.74801.1.0" Name="default_part_only_1_prt_d" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.74798.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="935"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="935"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1947"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1947"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2927"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2927"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3995"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3995"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5005"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5005"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6080"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6080"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7142"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7142"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8195"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8195"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9190"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9190"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10233"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10233"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11262"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11262"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12334"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12334"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13363"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13363"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14323"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14323"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15304"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15304"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16333"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16333"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17196"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17196"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18143"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18143"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19146"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19146"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20120"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20120"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21116"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21116"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22156"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22156"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23218"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23218"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24267"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24267"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25213"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25213"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26258"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26258"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27257"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27257"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28186"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28186"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29212"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29212"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30328"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30328"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31325"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31325"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32343"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32343"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33335"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33335"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34256"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34256"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35255"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35255"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36235"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36235"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37146"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37146"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38176"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38176"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39207"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39207"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40217"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40217"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41131"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41131"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42142"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42142"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43175"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43175"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44214"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44214"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45127"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45127"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46150"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46150"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47233"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47233"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48185"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48185"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49196"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49196"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50247"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50247"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51229"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51229"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="52183"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52183"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53150"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53150"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54186"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54186"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55207"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55207"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56207"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56207"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57280"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57280"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="58351"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58351"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59306"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59306"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60265"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60265"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61262"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61262"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62329"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62329"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63435"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63435"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64440"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64440"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65354"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65354"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66377"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66377"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67420"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67420"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68495"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68495"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69494"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69494"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70538"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70538"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71496"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71496"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72389"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72389"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73367"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73367"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75389"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75389"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76330"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76330"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77356"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77356"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78370"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78370"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79370"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79370"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80235"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80235"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81243"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81243"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="82203"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82203"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83173"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83173"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84164"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84164"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85222"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85222"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86134"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86134"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87104"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87104"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88069"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88069"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89117"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89117"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90116"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90116"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91116"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91116"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="92114"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92114"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93086"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93086"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94052"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94052"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95040"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95040"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96006"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96006"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97003"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97003"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98006"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98006"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98995"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98995"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="100000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.74798.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="935"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="935"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1947"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1947"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2927"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2927"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3995"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3995"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5005"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5005"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6080"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6080"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7142"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7142"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8195"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8195"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9190"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9190"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10233"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10233"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11262"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11262"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12334"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12334"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13363"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13363"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14323"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14323"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15304"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15304"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16333"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16333"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17196"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17196"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18143"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18143"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19146"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19146"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20120"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20120"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21116"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21116"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22156"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22156"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23218"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23218"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24267"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24267"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25213"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25213"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26258"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26258"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27257"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27257"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28186"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28186"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29212"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29212"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30328"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30328"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31325"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31325"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32343"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32343"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33335"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33335"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34256"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34256"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35255"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35255"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36235"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36235"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37146"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37146"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38176"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38176"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39207"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39207"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40217"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40217"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41131"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41131"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42142"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42142"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43175"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43175"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44214"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44214"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45127"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45127"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46150"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46150"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47233"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47233"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48185"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48185"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49196"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49196"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50247"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50247"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51229"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51229"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="52183"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52183"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53150"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53150"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54186"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54186"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55207"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55207"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56207"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56207"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57280"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57280"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="58351"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58351"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59306"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59306"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60265"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60265"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61262"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61262"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62329"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62329"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63435"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63435"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64440"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64440"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65354"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65354"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66377"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66377"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67420"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67420"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68495"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68495"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69494"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69494"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70538"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70538"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71496"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71496"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72389"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72389"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73367"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73367"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75389"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75389"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76330"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76330"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77356"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77356"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78370"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78370"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79370"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79370"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80235"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80235"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81243"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81243"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="82203"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82203"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83173"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83173"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84164"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84164"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85222"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85222"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86134"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86134"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87104"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87104"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88069"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88069"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89117"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89117"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90116"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90116"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91116"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91116"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="92114"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92114"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93086"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93086"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94052"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94052"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95040"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95040"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96006"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96006"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97003"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97003"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98006"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98006"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98995"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98995"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="100000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+          <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:Comparison>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.74798.1.0" TableName="default_part_only" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+              <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="616.243519" Rows="1.000000" Width="10012"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="2" Alias="c">
+            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="1" SelectorIds="">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="616.206207" Rows="1.000000" Width="10012"/>
+          </dxl:Properties>
+          <dxl:TableDescriptor Mdid="0.74798.1.0" TableName="default_part_only" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="c">
+              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="616.206207" Rows="1.000000" Width="10012"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="10" Alias="a">
+                <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="11" Alias="b">
+                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="12" Alias="c">
+                <dxl:Ident ColId="12" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+              </dxl:Comparison>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.74801.1.0" TableName="default_part_only_1_prt_d" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="12" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:Append>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-Range-Cost5.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SPE-DynamicTableScan-Range-Cost5.mdp
@@ -1,0 +1,2314 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:Comment><![CDATA[
+	Objective: We should derive statistics of a Dynamic Table Scan with SPE
+	using the disjunctive constraints of the selected child partitions. In this
+	case, all partitions are selected because the filter predicate is
+	unsupported, CPhysicalDynamicTableScan in physical plan should cost arround
+	2456 with all 1101000 rows.
+
+	create table foo (a int, b int, c varchar(10000)) partition by range (b) (start (1) end (1000001) every (100000), default partition extra);
+	insert into foo select i, i, repeat('a',10000) from generate_series(1, 1100000)i;
+	insert into foo select i, 1, repeat('a',10000) from generate_series(1, 1000)i;
+	analyze foo;
+
+	select * from foo where b + 1 = 2;
+
+        Physical plan:
+        +--CPhysicalMotionGather(master)   rows:440400   width:10041  rebinds:1   cost:21633.627142   origin: [Grp:6, GrpExpr:2]
+           +--CPhysicalFilter   rows:440400   width:10041  rebinds:1   cost:5203.333678   origin: [Grp:6, GrpExpr:1]
+              |--CPhysicalDynamicTableScan "foo" ("foo"), Columns: ["a" (0), "b" (1), "c" (2), "ctid" (3), "xmin" (4), "cmin" (5), "xmax" (6), "cmax" (7), "tableoid" (8), "gp_segment_id" (9)] Scan Id: 1   rows:1101000   width:10041  rebinds:1   cost:2457.775850   origin: [Grp:0, GrpExpr:1]
+              +--CScalarCmp (=)   origin: [Grp:5, GrpExpr:0]
+                 |--CScalarOp (+)   origin: [Grp:3, GrpExpr:0]
+                 |  |--CScalarIdent "b" (1)   origin: [Grp:1, GrpExpr:0]
+                 |  +--CScalarConst (1)   origin: [Grp:2, GrpExpr:0]
+                 +--CScalarConst (2)   origin: [Grp:4, GrpExpr:0]
+
+                                                       QUERY PLAN
+        -----------------------------------------------------------------------------------------
+         Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..21633.63 rows=440400 width=10011)
+           ->  Append  (cost=0.00..5203.33 rows=146800 width=10011)
+                 ->  Seq Scan on foo_1_prt_2  (cost=0.00..5203.33 rows=146800 width=10011)
+                       Filter: ((b + 1) = 2)
+                 ->  Seq Scan on foo_1_prt_3  (cost=0.00..5203.33 rows=146800 width=10011)
+                       Filter: ((b + 1) = 2)
+                 ->  Seq Scan on foo_1_prt_4  (cost=0.00..5203.33 rows=146800 width=10011)
+                       Filter: ((b + 1) = 2)
+                 ->  Seq Scan on foo_1_prt_5  (cost=0.00..5203.33 rows=146800 width=10011)
+                       Filter: ((b + 1) = 2)
+                 ->  Seq Scan on foo_1_prt_6  (cost=0.00..5203.33 rows=146800 width=10011)
+                       Filter: ((b + 1) = 2)
+                 ->  Seq Scan on foo_1_prt_7  (cost=0.00..5203.33 rows=146800 width=10011)
+                       Filter: ((b + 1) = 2)
+                 ->  Seq Scan on foo_1_prt_8  (cost=0.00..5203.33 rows=146800 width=10011)
+                       Filter: ((b + 1) = 2)
+                 ->  Seq Scan on foo_1_prt_9  (cost=0.00..5203.33 rows=146800 width=10011)
+                       Filter: ((b + 1) = 2)
+                 ->  Seq Scan on foo_1_prt_10  (cost=0.00..5203.33 rows=146800 width=10011)
+                       Filter: ((b + 1) = 2)
+                 ->  Seq Scan on foo_1_prt_11  (cost=0.00..5203.33 rows=146800 width=10011)
+                       Filter: ((b + 1) = 2)
+                 ->  Seq Scan on foo_1_prt_extra  (cost=0.00..5203.33 rows=146800 width=10011)
+                       Filter: ((b + 1) = 2)
+         Optimizer: Pivotal Optimizer (GPORCA)
+        (25 rows)
+
+  ]]>
+    </dxl:Comment>
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.32768.1.0" Name="foo" Rows="1101000.000000" RelPages="0" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.32768.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,9,3" PartitionColumns="1" PartitionTypes="r" NumberLeafPartitions="11">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10003">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:Partitions>
+          <dxl:Partition Mdid="0.32777.1.0"/>
+          <dxl:Partition Mdid="0.32783.1.0"/>
+          <dxl:Partition Mdid="0.32789.1.0"/>
+          <dxl:Partition Mdid="0.32795.1.0"/>
+          <dxl:Partition Mdid="0.32801.1.0"/>
+          <dxl:Partition Mdid="0.32807.1.0"/>
+          <dxl:Partition Mdid="0.32813.1.0"/>
+          <dxl:Partition Mdid="0.32819.1.0"/>
+          <dxl:Partition Mdid="0.32825.1.0"/>
+          <dxl:Partition Mdid="0.32831.1.0"/>
+          <dxl:Partition Mdid="0.32771.1.0"/>
+        </dxl:Partitions>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32771.1.0" Name="foo_1_prt_extra" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:Not>
+            <dxl:And>
+              <dxl:IsNotNull>
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:IsNotNull>
+              <dxl:Or>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="100001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="100001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="200001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="200001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="300001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="300001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="400001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="400001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="500001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="500001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="600001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="600001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="700001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="700001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="800001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="800001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="900001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="900001"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1000001"/>
+                  </dxl:Comparison>
+                </dxl:And>
+              </dxl:Or>
+            </dxl:And>
+          </dxl:Not>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32783.1.0" Name="foo_1_prt_3" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="100001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="200001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32777.1.0" Name="foo_1_prt_2" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="100001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.525.1.0" Name="&gt;=" ComparisonType="GEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.150.1.0"/>
+        <dxl:Commutator Mdid="0.523.1.0"/>
+        <dxl:InverseOp Mdid="0.97.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Relation Mdid="0.32789.1.0" Name="foo_1_prt_4" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="200001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="300001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1043.1.0" Name="varchar" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1015.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Relation Mdid="0.32795.1.0" Name="foo_1_prt_5" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="300001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="400001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32807.1.0" Name="foo_1_prt_7" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="500001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="600001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32801.1.0" Name="foo_1_prt_6" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="400001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="500001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.551.1.0" Name="+" ComparisonType="Other" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.23.1.0"/>
+        <dxl:OpFunc Mdid="0.177.1.0"/>
+        <dxl:Commutator Mdid="0.551.1.0"/>
+      </dxl:GPDBScalarOp>
+      <dxl:Relation Mdid="0.32813.1.0" Name="foo_1_prt_8" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="600001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="700001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.32768.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11896"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11896"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22891"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22891"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33888"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33888"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44766"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44766"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55778"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55778"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66951"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66951"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78024"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78024"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89026"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89026"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99998"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99998"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="110794"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="110794"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="121750"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="121750"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="132884"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="132884"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="143665"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="143665"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="154643"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="154643"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="165919"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="165919"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="176907"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="176907"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="187868"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="187868"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="198986"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="198986"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="210298"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="210298"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="221207"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="221207"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="232306"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="232306"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="243325"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="243325"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="254293"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="254293"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="265338"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="265338"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="276194"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="276194"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="287113"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="287113"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="297964"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="297964"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="309042"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="309042"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="320051"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="320051"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="331012"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="331012"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="342094"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="342094"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="353163"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="353163"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="364179"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="364179"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="375217"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="375217"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="386117"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="386117"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="397063"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="397063"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="407946"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="407946"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="418908"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="418908"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="429852"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="429852"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="440714"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="440714"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="452094"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="452094"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="462964"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="462964"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="474008"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="474008"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="484787"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="484787"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="495950"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="495950"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="506793"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="506793"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="517767"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="517767"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="528517"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="528517"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="539337"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="539337"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="550476"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="550476"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="561661"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="561661"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="572750"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="572750"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="583928"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="583928"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="594972"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="594972"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="606025"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="606025"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="617067"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="617067"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="627980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="627980"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="639223"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="639223"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="650197"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="650197"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="661151"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="661151"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="672159"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="672159"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="682937"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="682937"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="693860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="693860"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="705097"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="705097"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="715970"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="715970"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="726857"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="726857"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="737936"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="737936"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="748960"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="748960"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="760080"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="760080"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="770984"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="770984"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="781784"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="781784"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="793059"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="793059"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="804070"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="804070"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="815237"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="815237"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="826165"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="826165"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="837047"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="837047"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="847823"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="847823"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="858741"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="858741"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="869736"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="869736"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="880867"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="880867"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="891918"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="891918"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="902986"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="902986"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="913935"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="913935"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="924839"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="924839"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="935708"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="935708"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="946774"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="946774"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="958051"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="958051"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="969149"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="969149"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="980086"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="980086"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="991130"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="991130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1002039"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1002039"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1013072"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1013072"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1024124"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1024124"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1035235"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1035235"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1045973"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1045973"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1057292"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1057292"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1068302"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1068302"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1078934"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1078934"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1089811"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1089811"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1099999"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.32768.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9960"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9960"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21116"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21116"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32201"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32201"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43268"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43268"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54268"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54268"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65637"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65637"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76826"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76826"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87860"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98985"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98985"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="109793"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="109793"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="120737"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="120737"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="131927"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="131927"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="142693"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="142693"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="153619"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="153619"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="165011"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="165011"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="175900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="175900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="186884"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="186884"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="198012"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="198012"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="209284"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="209284"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="220217"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="220217"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="231290"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="231290"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="242308"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="242308"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="253369"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="253369"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="264377"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="264377"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="275152"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="275152"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="286158"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="286158"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="296990"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="296990"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="308041"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="308041"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="319021"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="319021"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="330105"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="330105"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="341099"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="341099"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="352066"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="352066"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="363157"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="363157"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="374197"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="374197"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="385131"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="385131"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="396081"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="396081"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="407000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="407000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="417976"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="417976"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="428792"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="428792"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="439670"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="439670"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="451020"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="451020"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="462001"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="462001"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="472988"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="472988"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="483807"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="483807"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="494998"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="494998"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="505837"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="505837"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="516763"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="516763"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="527518"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="527518"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="538320"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="538320"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="549456"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="549456"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="560576"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="560576"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="571734"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="571734"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="582851"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="582851"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="594011"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="594011"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="604991"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="604991"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="616062"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="616062"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="627013"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="627013"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="638176"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="638176"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="649196"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="649196"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="660165"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="660165"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="671203"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="671203"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="681964"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="681964"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="692783"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="692783"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="704064"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="704064"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="715037"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="715037"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="725910"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="725910"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="736942"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="736942"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="747955"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="747955"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="759160"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="759160"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="770003"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="770003"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="780813"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="780813"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="791962"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="791962"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="803060"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="803060"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="814235"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="814235"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="825202"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="825202"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="836113"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="836113"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="846842"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="846842"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="857698"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="857698"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="868789"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="868789"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="879832"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="879832"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="890918"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="890918"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="901914"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="901914"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="912948"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="912948"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="923861"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="923861"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="934741"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="934741"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="945801"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="945801"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="957072"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="957072"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="968121"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="968121"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="979138"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="979138"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="990155"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="990155"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1000981"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1000981"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1012104"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1012104"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1023163"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1023163"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1034207"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1034207"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1045009"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1045009"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1056256"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1056256"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1067320"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1067320"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1077968"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1077968"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1088838"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="11010.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1088838"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1099999"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Relation Mdid="0.32819.1.0" Name="foo_1_prt_9" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="700001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="800001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32831.1.0" Name="foo_1_prt_11" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="900001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1000001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.32825.1.0" Name="foo_1_prt_10" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" TypeModifier="10004" Nullable="true" ColWidth="10004">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="800001"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="900001"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+          <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+            <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+          </dxl:OpExpr>
+          <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:Comparison>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.32768.1.0" TableName="foo" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10003"/>
+              <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="21633.627142" Rows="440400.000000" Width="10011"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="2" Alias="c">
+            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="1" SelectorIds="">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="5203.333678" Rows="440400.000000" Width="10011"/>
+          </dxl:Properties>
+          <dxl:TableDescriptor Mdid="0.32768.1.0" TableName="foo" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10003"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="c">
+              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="5203.333678" Rows="440400.000000" Width="10011"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="10" Alias="a">
+                <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="11" Alias="b">
+                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="12" Alias="c">
+                <dxl:Ident ColId="12" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                  <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:OpExpr>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+              </dxl:Comparison>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.32777.1.0" TableName="foo_1_prt_2" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="12" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="5203.333678" Rows="440400.000000" Width="10011"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="20" Alias="a">
+                <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="21" Alias="b">
+                <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="22" Alias="c">
+                <dxl:Ident ColId="22" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                  <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:OpExpr>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+              </dxl:Comparison>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.32783.1.0" TableName="foo_1_prt_3" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="20" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="21" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="22" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="24" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="25" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="26" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="27" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="28" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="29" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="5203.333678" Rows="440400.000000" Width="10011"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="30" Alias="a">
+                <dxl:Ident ColId="30" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="31" Alias="b">
+                <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="32" Alias="c">
+                <dxl:Ident ColId="32" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                  <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:OpExpr>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+              </dxl:Comparison>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.32789.1.0" TableName="foo_1_prt_4" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="30" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="31" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="32" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="33" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="34" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="35" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="36" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="37" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="38" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="39" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="5203.333678" Rows="440400.000000" Width="10011"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="40" Alias="a">
+                <dxl:Ident ColId="40" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="41" Alias="b">
+                <dxl:Ident ColId="41" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="42" Alias="c">
+                <dxl:Ident ColId="42" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                  <dxl:Ident ColId="41" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:OpExpr>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+              </dxl:Comparison>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.32795.1.0" TableName="foo_1_prt_5" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="40" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="41" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="42" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="43" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="44" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="45" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="46" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="47" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="48" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="49" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="5203.333678" Rows="440400.000000" Width="10011"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="50" Alias="a">
+                <dxl:Ident ColId="50" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="51" Alias="b">
+                <dxl:Ident ColId="51" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="52" Alias="c">
+                <dxl:Ident ColId="52" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                  <dxl:Ident ColId="51" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:OpExpr>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+              </dxl:Comparison>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.32801.1.0" TableName="foo_1_prt_6" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="50" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="51" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="52" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="53" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="54" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="55" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="56" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="57" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="58" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="59" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="5203.333678" Rows="440400.000000" Width="10011"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="60" Alias="a">
+                <dxl:Ident ColId="60" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="61" Alias="b">
+                <dxl:Ident ColId="61" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="62" Alias="c">
+                <dxl:Ident ColId="62" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                  <dxl:Ident ColId="61" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:OpExpr>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+              </dxl:Comparison>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.32807.1.0" TableName="foo_1_prt_7" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="60" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="61" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="62" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="63" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="64" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="65" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="66" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="67" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="68" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="69" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="5203.333678" Rows="440400.000000" Width="10011"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="70" Alias="a">
+                <dxl:Ident ColId="70" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="71" Alias="b">
+                <dxl:Ident ColId="71" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="72" Alias="c">
+                <dxl:Ident ColId="72" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                  <dxl:Ident ColId="71" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:OpExpr>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+              </dxl:Comparison>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.32813.1.0" TableName="foo_1_prt_8" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="70" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="71" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="72" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="73" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="74" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="75" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="76" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="77" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="78" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="79" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="5203.333678" Rows="440400.000000" Width="10011"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="80" Alias="a">
+                <dxl:Ident ColId="80" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="81" Alias="b">
+                <dxl:Ident ColId="81" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="82" Alias="c">
+                <dxl:Ident ColId="82" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                  <dxl:Ident ColId="81" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:OpExpr>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+              </dxl:Comparison>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.32819.1.0" TableName="foo_1_prt_9" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="80" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="81" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="82" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="83" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="84" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="85" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="86" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="87" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="88" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="89" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="5203.333678" Rows="440400.000000" Width="10011"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="90" Alias="a">
+                <dxl:Ident ColId="90" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="91" Alias="b">
+                <dxl:Ident ColId="91" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="92" Alias="c">
+                <dxl:Ident ColId="92" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                  <dxl:Ident ColId="91" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:OpExpr>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+              </dxl:Comparison>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.32825.1.0" TableName="foo_1_prt_10" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="90" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="91" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="92" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="93" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="94" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="95" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="96" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="97" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="98" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="99" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="5203.333678" Rows="440400.000000" Width="10011"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="100" Alias="a">
+                <dxl:Ident ColId="100" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="101" Alias="b">
+                <dxl:Ident ColId="101" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="102" Alias="c">
+                <dxl:Ident ColId="102" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                  <dxl:Ident ColId="101" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:OpExpr>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+              </dxl:Comparison>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.32831.1.0" TableName="foo_1_prt_11" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="100" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="101" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="102" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="103" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="104" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="105" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="106" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="107" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="108" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="109" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="5203.333678" Rows="440400.000000" Width="10011"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="110" Alias="a">
+                <dxl:Ident ColId="110" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="111" Alias="b">
+                <dxl:Ident ColId="111" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="112" Alias="c">
+                <dxl:Ident ColId="112" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                  <dxl:Ident ColId="111" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:OpExpr>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+              </dxl:Comparison>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.32771.1.0" TableName="foo_1_prt_extra" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="110" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="111" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="112" Attno="3" ColName="c" TypeMdid="0.1043.1.0" TypeModifier="10004" ColWidth="10004"/>
+                <dxl:Column ColId="113" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="114" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="115" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="116" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="117" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="118" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="119" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:Append>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDynamicGetBase.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDynamicGetBase.h
@@ -59,10 +59,6 @@ protected:
 							ULongPtrArray *colids,
 							ULongPtrArray *pdrgpulPos) const;
 
-	// derive stats from base table using filters on partition and/or index columns
-	IStatistics *PstatsDeriveFilter(CMemoryPool *mp, CExpressionHandle &exprhdl,
-									CExpression *pexprFilter) const;
-
 	// Child partitions
 	IMdIdArray *m_partition_mdids = nullptr;
 	// Map of Root colref -> col index in child tabledesc

--- a/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
@@ -1181,7 +1181,6 @@ CLogical::PstatsBaseTable(
 	return stats;
 }
 
-
 //---------------------------------------------------------------------------
 //	@function:
 //		CLogical::PstatsDeriveDummy

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -223,6 +223,13 @@ NLJ-Broadcast-DPE-Outer-Child PartTbl-MultiWayJoinWithDPE PartTbl-MultiWayJoinWi
 PartTbl-LeftOuterHashJoin-DPE-IsNull PartTbl-LeftOuterNLJoin-DPE-IsNull
 PartTbl-List-DPE-Int-Predicates JoinOrderDPE;
 
+CPartTblSPETest:
+PartTbl-SPE-DynamicTableScan-Range-Cost1 PartTbl-SPE-DynamicTableScan-Range-Cost2
+PartTbl-SPE-DynamicTableScan-Range-Cost3 PartTbl-SPE-DynamicTableScan-Range-Cost4
+PartTbl-SPE-DynamicTableScan-Range-Cost5 PartTbl-SPE-DynamicTableScan-List-Cost1
+PartTbl-SPE-DynamicTableScan-List-Cost2 PartTbl-SPE-DynamicTableScan-List-Cost3
+PartTbl-SPE-DynamicTableScan-List-Cost4 PartTbl-SPE-DynamicTableScan-List-Cost5;
+
 CSetop1Test:
 ValueScanWithDuplicateAndSelfComparison PushGbBelowNaryUnionAll
 PushGbBelowNaryUnion-1 PushGbBelowNaryUnion-2 MS-UnionAll-1


### PR DESCRIPTION
ORCA: Improve cardinality estimation for Dynamic Table Scan under SPE

Previously, Orca always generates cardinality estimation for the
CLogicalDynamicGetBase operator by applying the query predicate stats
on top of the root table stats.  This makes sense for Dynamic Bitmap
Heap Scan and Dynamic Index Scan because the input rows for those
dynamic scans are filtered exactly by the query predicate.  However,
Dynamic Table Scan (CLogicalDynamicGet) is slightly different.
Although the query predicate helps partition pruning, we scan every
tuple of the selected partitions regardless the selectivity of the
query predicate within a leaf partition.  Therefore, for static
partition elimination, we should use the combined statistics of the
selected leaf partitions to estimate cardinality of
CLogicalDynamicGet.

To achieve the above goal there are two options:

Option 1: When deriving stats of CLogicalDynamicGet, use the selected
partitions' disjunctive constraints as the stats filter for the root
table.

Option 2: When deriving stats of CLogicalDynamicGet, retrieve and
combine stats of each selected leaf partition.

This patch went with option 1. The disjunctive constraints can be
easily recorded as part of static partition elimination.  The downside
of option 2 is a) more I/Os of the MD accessor to retrieve leaf
partition statistics if a lot of leaf partitions are selected and b)
complicate code a little bit for column matching when retrieving and
merging statistics.