### PR TITLE
Remove NI_NUMERICHOST and NI_NUMERICSERV checks in getnameinfo()

### DIFF
--- a/src/backend/libpq/ip.c
+++ b/src/backend/libpq/ip.c
@@ -361,11 +361,6 @@ getnameinfo_unix(const struct sockaddr_un * sa, int salen,
 		(node == NULL && service == NULL))
 		return EAI_FAIL;
 
-	/* We don't support those. */
-	if ((node && !(flags & NI_NUMERICHOST))
-		|| (service && !(flags & NI_NUMERICSERV)))
-		return EAI_FAIL;
-
 	if (node)
 	{
 		ret = snprintf(node, nodelen, "%s", "[local]");

--- a/src/backend/libpq/test/Makefile
+++ b/src/backend/libpq/test/Makefile
@@ -2,7 +2,7 @@ subdir=src/backend/libpq
 top_builddir=../../../..
 include $(top_builddir)/src/Makefile.global
 
-TARGETS=pqcomm auth
+TARGETS=pqcomm auth ip
 
 include $(top_builddir)/src/backend/mock.mk
 
@@ -16,3 +16,5 @@ auth.t: \
 	$(MOCK_DIR)/backend/libpq/hba_mock.o \
 	$(MOCK_DIR)/backend/utils/adt/timestamp_mock.o \
 	$(MOCK_DIR)/backend/utils/fmgr/fmgr_mock.o
+
+ip.t:

--- a/src/backend/libpq/test/ip_test.c
+++ b/src/backend/libpq/test/ip_test.c
@@ -1,0 +1,60 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#include "../ip.c"
+
+test_pg_get_nameinfo_all_unix(bool log_hostname)
+{
+	int result = -1;
+	char remote_host[NI_MAXHOST] = {'\0'};
+	char remote_port[NI_MAXSERV] = {'\0'};
+	struct sockaddr_storage *addr = (struct sockaddr_storage *) malloc(sizeof(struct sockaddr_storage));
+	int salen = sizeof(struct sockaddr_storage);
+
+	/* initialize UNIX socket parameters */
+	addr->ss_family = AF_UNIX;
+#if defined(__darwin__)
+	strcpy(addr->__ss_pad1, "mock");
+#else
+	strcpy(addr->__ss_padding, "mock");
+#endif
+
+	/* This code is pretty much duplicated from postmaster.c:BackendInitialize() */
+	result = pg_getnameinfo_all(addr, salen,
+				    remote_host, sizeof(remote_host),
+				    remote_port, sizeof(remote_port),
+				    (log_hostname ? 0 : NI_NUMERICHOST) | NI_NUMERICSERV);
+
+	assert_true(result != EAI_FAIL);
+	assert_string_equal(remote_host, "[local]");
+	assert_string_equal(remote_port, "mock");
+}
+
+void
+test_pg_get_nameinfo_all_unix_log_hostname_false(void **state)
+{
+	test_pg_get_nameinfo_all_unix(false);
+}
+
+void
+test_pg_get_nameinfo_all_unix_log_hostname_true(void **state)
+{
+	test_pg_get_nameinfo_all_unix(true);
+}
+
+int
+main(int argc, char* argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+
+	const UnitTest tests[] = {
+		unit_test(test_pg_get_nameinfo_all_unix_log_hostname_false),
+		unit_test(test_pg_get_nameinfo_all_unix_log_hostname_true)
+	};
+
+	MemoryContextInit();
+
+	return run_tests(tests);
+}

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -6562,12 +6562,10 @@ BackendInitialize(Port *port)
 	if ((ret = pg_getnameinfo_all(&port->raddr.addr, port->raddr.salen,
 						   remote_host, sizeof(remote_host),
 						   remote_port, sizeof(remote_port),
-					   (log_hostname ? 0 : NI_NUMERICHOST) | NI_NUMERICSERV)) != 0)
-	{
-			ereport(WARNING,
-					(errmsg_internal("pg_getnameinfo_all() failed: %s",
-									 gai_strerror(ret))));
-	}
+				  (log_hostname ? 0 : NI_NUMERICHOST) | NI_NUMERICSERV)) != 0)
+		ereport(WARNING,
+				(errmsg_internal("pg_getnameinfo_all() failed: %s",
+								 gai_strerror(ret))));
 	if (remote_port[0] == '\0')
 		snprintf(remote_ps_data, sizeof(remote_ps_data), "%s", remote_host);
 	else

--- a/src/port/getaddrinfo.c
+++ b/src/port/getaddrinfo.c
@@ -376,11 +376,6 @@ getnameinfo(const struct sockaddr * sa, int salen,
 	if (sa == NULL || (node == NULL && service == NULL))
 		return EAI_FAIL;
 
-	/* We don't support those. */
-	if ((node && !(flags & NI_NUMERICHOST))
-		|| (service && !(flags & NI_NUMERICSERV)))
-		return EAI_FAIL;
-
 #ifdef	HAVE_IPV6
 	if (sa->sa_family == AF_INET6)
 		return EAI_FAMILY;


### PR DESCRIPTION
This PR backports two upstream Postgres commits:
https://github.com/postgres/postgres/commit/c424d0d1052cb4053c8712ac44123f9b9a9aa3f2
https://github.com/postgres/postgres/commit/1997f34db4687e671690ed054c8f30bb501b1168

The above two patches were missed in a previous backport commit:
https://github.com/greenplum-db/gpdb/commit/a9768e32a0a310bd7e7a45c089898542670bf2c2

Due to the incomplete backport, we see invalid WARNING logs whenever connecting to the coordinator segment using a UNIX socket (e.g. `psql postgres vs. psql -h cdw postgres`) when the `log_hostname` GUC was enabled on the coordinator segment.  Example warning message in the logs: `"WARNING","01000","pg_getnameinfo_all() failed: Non-recoverable failure in name resolution",,,,,,,0,,"postmaster.c",6569`.  The WARNING is harmless but this is a bug in 5X_STABLE that does not exist in any other GPDB version except 5X_STABLE which can cause unnecessary user concerns on the GPDB or OS networking layer.