### PR TITLE
Do not drop DISTINCT ON clause and ORDER BY clause in `pull_up_sublinks`

### DIFF
--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -1432,9 +1432,6 @@ convert_ANY_sublink_to_join(PlannerInfo *root, SubLink *sublink,
 	Assert(sublink->subLinkType == ANY_SUBLINK);
 	Assert(IsA(subselect, Query));
 
-	cdbsubselect_drop_orderby(subselect);
-	cdbsubselect_drop_distinct(subselect);
-
 	/*
 	 * If deeply correlated, then don't pull it up
 	 */

--- a/src/include/cdb/cdbsubselect.h
+++ b/src/include/cdb/cdbsubselect.h
@@ -19,8 +19,6 @@ struct Node;                            /* #include "nodes/nodes.h" */
 struct PlannerInfo;                     /* #include "nodes/relation.h" */
 
 extern JoinExpr *convert_EXPR_to_join(PlannerInfo *root, OpExpr *opexp);
-extern void cdbsubselect_drop_orderby(Query *subselect);
-extern void cdbsubselect_drop_distinct(Query *subselect);
 extern bool has_correlation_in_funcexpr_rte(List *rtable);
 extern bool is_simple_subquery(PlannerInfo *root, Query *subquery, RangeTblEntry *rte,
 							   JoinExpr *lowest_outer_join);

--- a/src/test/regress/expected/notin.out
+++ b/src/test/regress/expected/notin.out
@@ -409,17 +409,21 @@ explain select x,y from l1 where (x,y) not in
          ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000001.07..10000000002.34 rows=1 width=8)
                Join Filter: ((l1.x = "NotIn_SUBQUERY".y) AND (l1.y = "NotIn_SUBQUERY".sum))
                ->  Seq Scan on l1  (cost=0.00..1.03 rows=3 width=8)
-               ->  Materialize  (cost=1.07..1.14 rows=3 width=12)
-                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=1.07..1.13 rows=3 width=12)
-                           ->  Subquery Scan on "NotIn_SUBQUERY"  (cost=1.07..1.09 rows=1 width=12)
-                                 ->  HashAggregate  (cost=1.07..1.08 rows=1 width=16)
-                                       Group Key: l1_1.y
-                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1.06 rows=1 width=8)
-                                             Hash Key: l1_1.y
-                                             ->  Seq Scan on l1 l1_1  (cost=0.00..1.04 rows=1 width=8)
-                                                   Filter: (y < 4)
+               ->  Materialize  (cost=1.09..1.16 rows=3 width=12)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=1.09..1.15 rows=3 width=12)
+                           ->  Subquery Scan on "NotIn_SUBQUERY"  (cost=1.09..1.11 rows=1 width=12)
+                                 ->  Unique  (cost=1.09..1.10 rows=1 width=16)
+                                       Group Key: l1_1.y, (sum(l1_1.x))
+                                       ->  Sort  (cost=1.09..1.09 rows=1 width=16)
+                                             Sort Key: l1_1.y, (sum(l1_1.x))
+                                             ->  HashAggregate  (cost=1.07..1.08 rows=1 width=16)
+                                                   Group Key: l1_1.y
+                                                   ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1.06 rows=1 width=8)
+                                                         Hash Key: l1_1.y
+                                                         ->  Seq Scan on l1 l1_1  (cost=0.00..1.04 rows=1 width=8)
+                                                               Filter: (y < 4)
  Optimizer: Postgres query optimizer
-(17 rows)
+(21 rows)
 
 select x,y from l1 where (x,y) not in
 	(select distinct y, sum(x) from l1 group by y having y < 4 order by y) order by 1,2;

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -416,17 +416,21 @@ explain select x,y from l1 where (x,y) not in
          ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000001.07..10000000002.34 rows=1 width=8)
                Join Filter: ((l1.x = "NotIn_SUBQUERY".y) AND (l1.y = "NotIn_SUBQUERY".sum))
                ->  Seq Scan on l1  (cost=0.00..1.03 rows=3 width=8)
-               ->  Materialize  (cost=1.07..1.14 rows=3 width=12)
-                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=1.07..1.13 rows=3 width=12)
-                           ->  Subquery Scan on "NotIn_SUBQUERY"  (cost=1.07..1.09 rows=1 width=12)
-                                 ->  HashAggregate  (cost=1.07..1.08 rows=1 width=16)
-                                       Group Key: l1_1.y
-                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1.06 rows=1 width=8)
-                                             Hash Key: l1_1.y
-                                             ->  Seq Scan on l1 l1_1  (cost=0.00..1.04 rows=1 width=8)
-                                                   Filter: (y < 4)
+               ->  Materialize  (cost=1.09..1.16 rows=3 width=12)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=1.09..1.15 rows=3 width=12)
+                           ->  Subquery Scan on "NotIn_SUBQUERY"  (cost=1.09..1.11 rows=1 width=12)
+                                 ->  Unique  (cost=1.09..1.10 rows=1 width=16)
+                                       Group Key: l1_1.y, (sum(l1_1.x))
+                                       ->  Sort  (cost=1.09..1.09 rows=1 width=16)
+                                             Sort Key: l1_1.y, (sum(l1_1.x))
+                                             ->  HashAggregate  (cost=1.07..1.08 rows=1 width=16)
+                                                   Group Key: l1_1.y
+                                                   ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1.06 rows=1 width=8)
+                                                         Hash Key: l1_1.y
+                                                         ->  Seq Scan on l1 l1_1  (cost=0.00..1.04 rows=1 width=8)
+                                                               Filter: (y < 4)
  Optimizer: Postgres query optimizer
-(19 rows)
+(21 rows)
 
 select x,y from l1 where (x,y) not in
 	(select distinct y, sum(x) from l1 group by y having y < 4 order by y) order by 1,2;

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -981,10 +981,16 @@ select * from int4_tbl o where (f1, f1) in
                            Output: i.f1, ((generate_series(1, 50)) / 10)
                            ->  ProjectSet
                                  Output: generate_series(1, 50), i.f1
-                                 ->  Seq Scan on public.int4_tbl i
+                                 ->  GroupAggregate
                                        Output: i.f1
+                                       Group Key: i.f1
+                                       ->  Sort
+                                             Output: i.f1
+                                             Sort Key: i.f1
+                                             ->  Seq Scan on public.int4_tbl i
+                                                   Output: i.f1
  Optimizer: Postgres query optimizer
-(19 rows)
+(25 rows)
 
 select * from int4_tbl o where (f1, f1) in
   (select f1, generate_series(1,50) / 10 g from int4_tbl i group by f1);

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1692,9 +1692,11 @@ EXPLAIN select count(*) from
                                  Group Key: b.hundred
                                  ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..389.00 rows=3334 width=4)
                                        Hash Key: b.hundred
-                                       ->  Seq Scan on tenk1 b  (cost=0.00..189.00 rows=3334 width=4)
+                                       ->  HashAggregate  (cost=70.67..71.67 rows=100 width=4)
+                                             Group Key: b.hundred
+                                             ->  Seq Scan on tenk1 b  (cost=0.00..62.33 rows=3333 width=4)
  Optimizer: Postgres query optimizer
-(13 rows)
+(15 rows)
 
 EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a
@@ -1718,7 +1720,9 @@ EXPLAIN select count(distinct ss.ten) from
                                                    Group Key: b.hundred
                                                    ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..389.00 rows=3334 width=4)
                                                          Hash Key: b.hundred
-                                                         ->  Seq Scan on tenk1 b  (cost=0.00..189.00 rows=3334 width=4)
+                                                         ->  HashAggregate  (cost=70.67..71.67 rows=100 width=4)
+                                                               Group Key: b.hundred
+                                                               ->  Seq Scan on tenk1 b  (cost=0.00..62.33 rows=3333 width=4)
  Optimizer: Postgres query optimizer
 (19 rows)
 
@@ -2878,4 +2882,112 @@ where dt < '2010-01-01'::date;
                Output: extra_flow_dist1.a, extra_flow_dist1.b
  Optimizer: Postgres query optimizer
 (44 rows)
+
+-- Check DISTINCT ON clause and ORDER BY clause in SubLink, See https://github.com/greenplum-db/gpdb/issues/12656.
+-- For EXISTS SubLink, we don’t need to care about the data deduplication problem, we can delete DISTINCT ON clause and
+-- ORDER BY clause with confidence, because we only care about whether the data exists.
+-- But for ANY SubLink, wo can't do this, because we not only care about the existence of data, but also the content of
+-- the data.
+create table issue_12656 (
+    i int,
+    j int
+) distributed by (i);
+insert into issue_12656 values (1, 10001), (1, 10002);
+-- case 1, check basic DISTINCT ON
+explain (costs off, verbose)
+select * from issue_12656 where (i, j) in (select distinct on (i) i, j from issue_12656);
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: issue_12656.i, issue_12656.j
+   ->  Hash Join
+         Output: issue_12656.i, issue_12656.j
+         Inner Unique: true
+         Hash Cond: ((issue_12656.i = issue_12656_1.i) AND (issue_12656.j = issue_12656_1.j))
+         ->  Seq Scan on subselect_gp.issue_12656
+               Output: issue_12656.i, issue_12656.j
+         ->  Hash
+               Output: issue_12656_1.i, issue_12656_1.j
+               ->  Unique
+                     Output: issue_12656_1.i, issue_12656_1.j
+                     Group Key: issue_12656_1.i
+                     ->  Sort
+                           Output: issue_12656_1.i, issue_12656_1.j
+                           Sort Key: issue_12656_1.i
+                           ->  Seq Scan on subselect_gp.issue_12656 issue_12656_1
+                                 Output: issue_12656_1.i, issue_12656_1.j
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(20 rows)
+
+select * from issue_12656 where (i, j) in (select distinct on (i) i, j from issue_12656);
+ i |   j   
+---+-------
+ 1 | 10001
+(1 row)
+
+-- case 2, check DISTINCT ON and ORDER BY
+explain (costs off, verbose)
+select * from issue_12656 where (i, j) in (select distinct on (i) i, j from issue_12656 order by i, j asc);
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: issue_12656.i, issue_12656.j
+   ->  Hash Join
+         Output: issue_12656.i, issue_12656.j
+         Inner Unique: true
+         Hash Cond: ((issue_12656.i = issue_12656_1.i) AND (issue_12656.j = issue_12656_1.j))
+         ->  Seq Scan on subselect_gp.issue_12656
+               Output: issue_12656.i, issue_12656.j
+         ->  Hash
+               Output: issue_12656_1.i, issue_12656_1.j
+               ->  Unique
+                     Output: issue_12656_1.i, issue_12656_1.j
+                     Group Key: issue_12656_1.i
+                     ->  Sort
+                           Output: issue_12656_1.i, issue_12656_1.j
+                           Sort Key: issue_12656_1.i, issue_12656_1.j
+                           ->  Seq Scan on subselect_gp.issue_12656 issue_12656_1
+                                 Output: issue_12656_1.i, issue_12656_1.j
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(20 rows)
+
+select * from issue_12656 where (i, j) in (select distinct on (i) i, j from issue_12656 order by i, j asc);
+ i |   j   
+---+-------
+ 1 | 10001
+(1 row)
+
+explain (costs off, verbose)
+select * from issue_12656 where (i, j) in (select distinct on (i) i, j from issue_12656 order by i, j desc);
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: issue_12656.i, issue_12656.j
+   ->  Hash Join
+         Output: issue_12656.i, issue_12656.j
+         Inner Unique: true
+         Hash Cond: ((issue_12656.i = issue_12656_1.i) AND (issue_12656.j = issue_12656_1.j))
+         ->  Seq Scan on subselect_gp.issue_12656
+               Output: issue_12656.i, issue_12656.j
+         ->  Hash
+               Output: issue_12656_1.i, issue_12656_1.j
+               ->  Unique
+                     Output: issue_12656_1.i, issue_12656_1.j
+                     Group Key: issue_12656_1.i
+                     ->  Sort
+                           Output: issue_12656_1.i, issue_12656_1.j
+                           Sort Key: issue_12656_1.i, issue_12656_1.j DESC
+                           ->  Seq Scan on subselect_gp.issue_12656 issue_12656_1
+                                 Output: issue_12656_1.i, issue_12656_1.j
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(20 rows)
+
+select * from issue_12656 where (i, j) in (select distinct on (i) i, j from issue_12656 order by i, j desc);
+ i |   j   
+---+-------
+ 1 | 10002
+(1 row)
 

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -2968,3 +2968,111 @@ where dt < '2010-01-01'::date;
  Optimizer: Pivotal Optimizer (GPORCA)
 (62 rows)
 
+-- Check DISTINCT ON clause and ORDER BY clause in SubLink, See https://github.com/greenplum-db/gpdb/issues/12656.
+-- For EXISTS SubLink, we don’t need to care about the data deduplication problem, we can delete DISTINCT ON clause and
+-- ORDER BY clause with confidence, because we only care about whether the data exists.
+-- But for ANY SubLink, wo can't do this, because we not only care about the existence of data, but also the content of
+-- the data.
+create table issue_12656 (
+    i int,
+    j int
+) distributed by (i);
+insert into issue_12656 values (1, 10001), (1, 10002);
+-- case 1, check basic DISTINCT ON
+explain (costs off, verbose)
+select * from issue_12656 where (i, j) in (select distinct on (i) i, j from issue_12656);
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: issue_12656.i, issue_12656.j
+   ->  Hash Join
+         Output: issue_12656.i, issue_12656.j
+         Inner Unique: true
+         Hash Cond: ((issue_12656.i = issue_12656_1.i) AND (issue_12656.j = issue_12656_1.j))
+         ->  Seq Scan on subselect_gp.issue_12656
+               Output: issue_12656.i, issue_12656.j
+         ->  Hash
+               Output: issue_12656_1.i, issue_12656_1.j
+               ->  Unique
+                     Output: issue_12656_1.i, issue_12656_1.j
+                     Group Key: issue_12656_1.i
+                     ->  Sort
+                           Output: issue_12656_1.i, issue_12656_1.j
+                           Sort Key: issue_12656_1.i
+                           ->  Seq Scan on subselect_gp.issue_12656 issue_12656_1
+                                 Output: issue_12656_1.i, issue_12656_1.j
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=on
+(20 rows)
+
+select * from issue_12656 where (i, j) in (select distinct on (i) i, j from issue_12656);
+ i |   j   
+---+-------
+ 1 | 10001
+(1 row)
+
+-- case 2, check DISTINCT ON and ORDER BY
+explain (costs off, verbose)
+select * from issue_12656 where (i, j) in (select distinct on (i) i, j from issue_12656 order by i, j asc);
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: issue_12656.i, issue_12656.j
+   ->  Hash Join
+         Output: issue_12656.i, issue_12656.j
+         Inner Unique: true
+         Hash Cond: ((issue_12656.i = issue_12656_1.i) AND (issue_12656.j = issue_12656_1.j))
+         ->  Seq Scan on subselect_gp.issue_12656
+               Output: issue_12656.i, issue_12656.j
+         ->  Hash
+               Output: issue_12656_1.i, issue_12656_1.j
+               ->  Unique
+                     Output: issue_12656_1.i, issue_12656_1.j
+                     Group Key: issue_12656_1.i
+                     ->  Sort
+                           Output: issue_12656_1.i, issue_12656_1.j
+                           Sort Key: issue_12656_1.i, issue_12656_1.j
+                           ->  Seq Scan on subselect_gp.issue_12656 issue_12656_1
+                                 Output: issue_12656_1.i, issue_12656_1.j
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=on
+(20 rows)
+
+select * from issue_12656 where (i, j) in (select distinct on (i) i, j from issue_12656 order by i, j asc);
+ i |   j   
+---+-------
+ 1 | 10001
+(1 row)
+
+explain (costs off, verbose)
+select * from issue_12656 where (i, j) in (select distinct on (i) i, j from issue_12656 order by i, j desc);
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: issue_12656.i, issue_12656.j
+   ->  Hash Join
+         Output: issue_12656.i, issue_12656.j
+         Inner Unique: true
+         Hash Cond: ((issue_12656.i = issue_12656_1.i) AND (issue_12656.j = issue_12656_1.j))
+         ->  Seq Scan on subselect_gp.issue_12656
+               Output: issue_12656.i, issue_12656.j
+         ->  Hash
+               Output: issue_12656_1.i, issue_12656_1.j
+               ->  Unique
+                     Output: issue_12656_1.i, issue_12656_1.j
+                     Group Key: issue_12656_1.i
+                     ->  Sort
+                           Output: issue_12656_1.i, issue_12656_1.j
+                           Sort Key: issue_12656_1.i, issue_12656_1.j DESC
+                           ->  Seq Scan on subselect_gp.issue_12656 issue_12656_1
+                                 Output: issue_12656_1.i, issue_12656_1.j
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=on
+(20 rows)
+
+select * from issue_12656 where (i, j) in (select distinct on (i) i, j from issue_12656 order by i, j desc);
+ i |   j   
+---+-------
+ 1 | 10002
+(1 row)
+

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -1006,8 +1006,14 @@ select * from int4_tbl o where (f1, f1) in
                            Output: i.f1, ((generate_series(1, 50)) / 10)
                            ->  ProjectSet
                                  Output: generate_series(1, 50), i.f1
-                                 ->  Seq Scan on public.int4_tbl i
+                                 ->  GroupAggregate
                                        Output: i.f1
+                                       Group Key: i.f1
+                                       ->  Sort
+                                             Output: i.f1
+                                             Sort Key: i.f1
+                                             ->  Seq Scan on public.int4_tbl i
+                                                   Output: i.f1
  Optimizer: Postgres query optimizer
 (19 rows)
 


### PR DESCRIPTION
For fix the issue #12656 we need to keep DISTINCT ON clause and ORDER BY clause in SubQuery when pulling up sublinks of ANY type, to ensure that the planner can de-duplicate according to the correct logic.

Not only for DISTINCT ON, the ORDER BY clause should be reserved too, the following example illustrates why we need to keep the ORDER BY clause:

```
postgres=# select version();
                                               version                                                
------------------------------------------------------------------------------------------------------
 PostgreSQL 12.8 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0, 64-bit
(1 row)

postgres=# create table test_table(i int, tz timestamptz);
postgres=# insert into test_table values (1, '2021-01-01'), (1, '2021-02-01');

postgres=# select * from test_table where (i, tz) in 
(select distinct on (i) i, tz from test_table order by i, tz desc);
 i |           tz
---+------------------------
 1 | 2021-02-01 00:00:00+00
(1 row)

postgres=# select * from test_table where (i, tz) in 
(select distinct on (i) i, tz from test_table order by i, tz asc);
 i |           tz
---+------------------------
 1 | 2021-01-01 00:00:00+00
(1 row)
```

Sorting in different order will lead to different output, so we can't simply delete ORDER BY clause when pulling up SubLink.

And after running the performance tests with tpc-ds 1TB data, there's no obvious difference in runtime efficiency



## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
