### PR TITLE
Fix clang++-13 compile error

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
@@ -185,6 +185,8 @@ private:
 		{
 		}
 		SGroupAndExpression(const SGroupAndExpression &other) = default;
+		SGroupAndExpression &operator=(const SGroupAndExpression &other) =
+			default;
 		SExpressionInfo *
 		GetExprInfo() const
 		{

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h
@@ -184,9 +184,6 @@ private:
 			: m_group_info(g), m_expr_index(ix)
 		{
 		}
-		SGroupAndExpression(const SGroupAndExpression &other) = default;
-		SGroupAndExpression &operator=(const SGroupAndExpression &other) =
-			default;
 		SExpressionInfo *
 		GetExprInfo() const
 		{


### PR DESCRIPTION
Explicitly defefault copy assignment operator for SGroupAndExpression.
Without this, we would get below compile error with Clang++-13 and above
with -std=c++14.

```
In file included from CJoinOrderDPv2.cpp:12:
../../../../../../src/backend/gporca/libgpopt/include/gpopt/xforms/CJoinOrderDPv2.h:187:3: error: definition of implicit copy assignment operator for 'SGroupAndExpression' is deprecated because it has a user-declared copy constructor [-Werror,-Wdeprecated-copy]
                SGroupAndExpression(const SGroupAndExpression &other) = default;
                ^
CJoinOrderDPv2.cpp:1083:24: note: in implicit copy assignment operator for 'gpopt::CJoinOrderDPv2::SGroupAndExpression' first required here
                left_child_expr_info = GetBestExprForProperties(
                                     ^
1 error generated.
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
