### PR TITLE
[6X] disable cte sharing in subplan

### DIFF
--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -11371,53 +11371,66 @@ INSERT INTO onetimefilter1 SELECT i, i FROM generate_series(1,10)i;
 INSERT INTO onetimefilter2 SELECT i, i FROM generate_series(1,10)i;
 ANALYZE onetimefilter1;
 ANALYZE onetimefilter2;
-EXPLAIN WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilter1, onetimefilter2 WHERE onetimefilter1.a=onetimefilter2.a) SELECT (SELECT 1 FROM abc WHERE f1.b = f2.b LIMIT 1), COALESCE((SELECT 2 FROM abc WHERE f1.a=random() AND f1.a=2), 0), (SELECT b FROM abc WHERE b=f1.b) FROM onetimefilter1 f1, onetimefilter2 f2 WHERE f1.b = f2.b;
-                                                               QUERY PLAN                                                               
-----------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice6; segments: 3)  (cost=3.43..12.31 rows=10 width=12)
-   ->  Hash Join  (cost=3.43..12.31 rows=4 width=12)
+EXPLAIN (COSTS OFF) WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilter1, onetimefilter2 WHERE onetimefilter1.a=onetimefilter2.a) SELECT (SELECT 1 FROM abc WHERE f1.b = f2.b LIMIT 1), COALESCE((SELECT 2 FROM abc WHERE f1.a=random() AND f1.a=2), 0), (SELECT b FROM abc WHERE b=f1.b) FROM onetimefilter1 f1, onetimefilter2 f2 WHERE f1.b = f2.b;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice9; segments: 3)
+   ->  Hash Join
          Hash Cond: (f1.b = f2.b)
-         ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..3.30 rows=4 width=8)
+         ->  Redistribute Motion 3:3  (slice7; segments: 3)
                Hash Key: f1.b
-               ->  Seq Scan on onetimefilter1 f1  (cost=0.00..3.10 rows=4 width=8)
-         ->  Hash  (cost=3.30..3.30 rows=4 width=4)
-               ->  Redistribute Motion 3:3  (slice5; segments: 3)  (cost=0.00..3.30 rows=4 width=4)
+               ->  Seq Scan on onetimefilter1 f1
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice8; segments: 3)
                      Hash Key: f2.b
-                     ->  Seq Scan on onetimefilter2 f2  (cost=0.00..3.10 rows=4 width=4)
-         SubPlan 1  (slice6; segments: 3)
-           ->  Limit  (cost=0.00..0.04 rows=1 width=0)
-                 ->  Limit  (cost=0.00..0.02 rows=1 width=0)
-                       ->  Result  (cost=0.00..0.20 rows=4 width=0)
+                     ->  Seq Scan on onetimefilter2 f2
+         SubPlan 1  (slice9; segments: 3)
+           ->  Limit
+                 ->  Limit
+                       ->  Result
                              One-Time Filter: (f1.b = f2.b)
-                             ->  Result  (cost=6.51..6.77 rows=4 width=8)
-                                   ->  Materialize  (cost=6.51..6.77 rows=4 width=8)
-                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=6.51..6.72 rows=4 width=8)
-                                               ->  Shared Scan (share slice:id 1:0)  (cost=6.51..6.72 rows=4 width=8)
-                                                     ->  Materialize  (cost=3.23..6.51 rows=4 width=8)
-                                                           ->  Hash Join  (cost=3.23..6.46 rows=4 width=8)
-                                                                 Hash Cond: (onetimefilter1.a = onetimefilter2.a)
-                                                                 ->  Seq Scan on onetimefilter1  (cost=0.00..3.10 rows=4 width=8)
-                                                                 ->  Hash  (cost=3.10..3.10 rows=4 width=4)
-                                                                       ->  Seq Scan on onetimefilter2  (cost=0.00..3.10 rows=4 width=4)
-         SubPlan 2  (slice6; segments: 3)
-           ->  Result  (cost=0.00..0.28 rows=1 width=0)
+                             ->  Hash Join
+                                   Hash Cond: (onetimefilter1.a = onetimefilter2.a)
+                                   ->  Result
+                                         ->  Materialize
+                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                                     ->  Seq Scan on onetimefilter1
+                                   ->  Hash
+                                         ->  Result
+                                               ->  Materialize
+                                                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                                           ->  Seq Scan on onetimefilter2
+         SubPlan 2  (slice9; segments: 3)
+           ->  Result
                  One-Time Filter: (f1.a = 2)
-                 ->  Subquery Scan on abc  (cost=0.00..0.28 rows=1 width=0)
-                       Filter: ((f1.a)::double precision = random())
-                       ->  Result  (cost=6.51..6.77 rows=4 width=8)
-                             ->  Materialize  (cost=6.51..6.77 rows=4 width=8)
-                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=6.51..6.72 rows=4 width=8)
-                                         ->  Shared Scan (share slice:id 2:0)  (cost=6.51..6.72 rows=4 width=8)
-         SubPlan 3  (slice6; segments: 3)
-           ->  Subquery Scan on abc_1  (cost=0.00..0.22 rows=1 width=4)
-                 Filter: (abc_1.b = f1.b)
-                 ->  Result  (cost=6.51..6.77 rows=4 width=8)
-                       ->  Materialize  (cost=6.51..6.77 rows=4 width=8)
-                             ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=6.51..6.72 rows=4 width=8)
-                                   ->  Shared Scan (share slice:id 3:0)  (cost=6.51..6.72 rows=4 width=8)
- Planning time: 0.276 ms
+                 ->  Hash Join
+                       Hash Cond: (onetimefilter1_1.a = onetimefilter2_1.a)
+                       Join Filter: ((f1.a)::double precision = random())
+                       ->  Result
+                             ->  Materialize
+                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                         ->  Seq Scan on onetimefilter1 onetimefilter1_1
+                       ->  Hash
+                             ->  Result
+                                   ->  Materialize
+                                         ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                               ->  Seq Scan on onetimefilter2 onetimefilter2_1
+         SubPlan 3  (slice9; segments: 3)
+           ->  Subquery Scan on abc
+                 ->  Hash Join
+                       Hash Cond: (onetimefilter2_2.a = onetimefilter1_2.a)
+                       ->  Result
+                             ->  Materialize
+                                   ->  Broadcast Motion 3:3  (slice5; segments: 3)
+                                         ->  Seq Scan on onetimefilter2 onetimefilter2_2
+                       ->  Hash
+                             ->  Result
+                                   Filter: (onetimefilter1_2.b = f1.b)
+                                   ->  Materialize
+                                         ->  Broadcast Motion 3:3  (slice6; segments: 3)
+                                               ->  Seq Scan on onetimefilter1 onetimefilter1_2
  Optimizer: Postgres query optimizer
-(43 rows)
+(56 rows)
 
 WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilter1, onetimefilter2 WHERE onetimefilter1.a=onetimefilter2.a) SELECT (SELECT 1 FROM abc WHERE f1.b = f2.b LIMIT 1), COALESCE((SELECT 2 FROM abc WHERE f1.a=random() AND f1.a=2), 0), (SELECT b FROM abc WHERE b=f1.b) FROM onetimefilter1 f1, onetimefilter2 f2 WHERE f1.b = f2.b;
  ?column? | coalesce | b  
@@ -13445,35 +13458,32 @@ select first_id
 from material_test2
 where first_id in (select first_id from mat_w)
 and first_id in (select first_id from mat_w);
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.36..5.01 rows=39 width=4)
    Output: material_test2.first_id
    ->  Seq Scan on orca.material_test2  (cost=0.36..5.01 rows=13 width=4)
          Output: material_test2.first_id
          Filter: ((hashed SubPlan 1) AND (hashed SubPlan 2))
          SubPlan 1  (slice3; segments: 3)
-           ->  Materialize  (cost=4.69..4.94 rows=3 width=4)
-                 Output: share0_ref1.first_id
-                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=4.69..4.90 rows=3 width=4)
-                       Output: share0_ref1.first_id
-                       ->  Shared Scan (share slice:id 1:0)  (cost=4.69..4.90 rows=3 width=4)
-                             Output: share0_ref1.first_id
-                             ->  Materialize  (cost=0.00..4.69 rows=3 width=4)
-                                   Output: material_test.first_id
-                                   ->  Seq Scan on orca.material_test  (cost=0.00..4.65 rows=3 width=4)
-                                         Output: material_test.first_id
-                                         Filter: (material_test.second_id = ANY ('{1,2,3,4}'::integer[]))
+           ->  Materialize  (cost=0.00..4.69 rows=3 width=4)
+                 Output: material_test.first_id
+                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..4.65 rows=3 width=4)
+                       Output: material_test.first_id
+                       ->  Seq Scan on orca.material_test  (cost=0.00..4.65 rows=3 width=4)
+                             Output: material_test.first_id
+                             Filter: (material_test.second_id = ANY ('{1,2,3,4}'::integer[]))
          SubPlan 2  (slice3; segments: 3)
-           ->  Materialize  (cost=4.69..4.94 rows=3 width=4)
-                 Output: share0_ref2.first_id
-                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=4.69..4.90 rows=3 width=4)
-                       Output: share0_ref2.first_id
-                       ->  Shared Scan (share slice:id 2:0)  (cost=4.69..4.90 rows=3 width=4)
-                             Output: share0_ref2.first_id
+           ->  Materialize  (cost=0.00..4.69 rows=3 width=4)
+                 Output: material_test_1.first_id
+                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..4.65 rows=3 width=4)
+                       Output: material_test_1.first_id
+                       ->  Seq Scan on orca.material_test material_test_1  (cost=0.00..4.65 rows=3 width=4)
+                             Output: material_test_1.first_id
+                             Filter: (material_test_1.second_id = ANY ('{1,2,3,4}'::integer[]))
  Optimizer: Postgres query optimizer
  Settings: enable_seqscan=on, optimizer=off
-(26 rows)
+(23 rows)
 
 with mat_w as (
 select first_id

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -11503,56 +11503,55 @@ INSERT INTO onetimefilter1 SELECT i, i FROM generate_series(1,10)i;
 INSERT INTO onetimefilter2 SELECT i, i FROM generate_series(1,10)i;
 ANALYZE onetimefilter1;
 ANALYZE onetimefilter2;
-EXPLAIN WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilter1, onetimefilter2 WHERE onetimefilter1.a=onetimefilter2.a) SELECT (SELECT 1 FROM abc WHERE f1.b = f2.b LIMIT 1), COALESCE((SELECT 2 FROM abc WHERE f1.a=random() AND f1.a=2), 0), (SELECT b FROM abc WHERE b=f1.b) FROM onetimefilter1 f1, onetimefilter2 f2 WHERE f1.b = f2.b;
-                                                          QUERY PLAN                                                          
-------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1852062876647.47 rows=11 width=12)
-   ->  Sequence  (cost=0.00..1852062876647.47 rows=4 width=12)
-         ->  Shared Scan (share slice:id 6:0)  (cost=0.00..862.00 rows=4 width=1)
-               ->  Materialize  (cost=0.00..862.00 rows=4 width=1)
-                     ->  Hash Join  (cost=0.00..862.00 rows=4 width=8)
+EXPLAIN (COSTS OFF) WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilter1, onetimefilter2 WHERE onetimefilter1.a=onetimefilter2.a) SELECT (SELECT 1 FROM abc WHERE f1.b = f2.b LIMIT 1), COALESCE((SELECT 2 FROM abc WHERE f1.a=random() AND f1.a=2), 0), (SELECT b FROM abc WHERE b=f1.b) FROM onetimefilter1 f1, onetimefilter2 f2 WHERE f1.b = f2.b;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice6; segments: 2)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 6:0)
+               ->  Materialize
+                     ->  Hash Join
                            Hash Cond: (onetimefilter1_1.a = onetimefilter2_1.a)
-                           ->  Seq Scan on onetimefilter1 onetimefilter1_1  (cost=0.00..431.00 rows=4 width=8)
-                           ->  Hash  (cost=431.00..431.00 rows=4 width=4)
-                                 ->  Seq Scan on onetimefilter2 onetimefilter2_1  (cost=0.00..431.00 rows=4 width=4)
-         ->  Result  (cost=0.00..1852062875785.47 rows=4 width=12)
-               ->  Hash Join  (cost=0.00..862.00 rows=4 width=12)
+                           ->  Seq Scan on onetimefilter1 onetimefilter1_1
+                           ->  Hash
+                                 ->  Seq Scan on onetimefilter2 onetimefilter2_1
+         ->  Result
+               ->  Hash Join
                      Hash Cond: (onetimefilter1.b = onetimefilter2.b)
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=4 width=8)
+                     ->  Redistribute Motion 2:2  (slice1; segments: 2)
                            Hash Key: onetimefilter1.b
-                           ->  Seq Scan on onetimefilter1  (cost=0.00..431.00 rows=4 width=8)
-                     ->  Hash  (cost=431.00..431.00 rows=4 width=4)
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
+                           ->  Seq Scan on onetimefilter1
+                     ->  Hash
+                           ->  Redistribute Motion 2:2  (slice2; segments: 2)
                                  Hash Key: onetimefilter2.b
-                                 ->  Seq Scan on onetimefilter2  (cost=0.00..431.00 rows=4 width=4)
-               SubPlan 1  (slice6; segments: 3)
-                 ->  Result  (cost=0.00..431.01 rows=1 width=4)
-                       ->  Limit  (cost=0.00..431.01 rows=1 width=1)
-                             ->  Result  (cost=0.00..431.01 rows=5 width=1)
+                                 ->  Seq Scan on onetimefilter2
+               SubPlan 1  (slice6; segments: 2)
+                 ->  Result
+                       ->  Limit
+                             ->  Result
                                    One-Time Filter: (onetimefilter1.b = onetimefilter2.b)
-                                   ->  Materialize  (cost=0.00..431.00 rows=11 width=1)
-                                         ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=11 width=1)
-                                               ->  Result  (cost=0.00..431.00 rows=4 width=1)
-                                                     ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=4 width=1)
-               SubPlan 2  (slice6; segments: 3)
-                 ->  Result  (cost=0.00..431.33 rows=3 width=4)
-                       ->  Result  (cost=0.00..431.33 rows=3 width=1)
+                                   ->  Materialize
+                                         ->  Broadcast Motion 2:2  (slice3; segments: 2)
+                                               ->  Result
+                                                     ->  Shared Scan (share slice:id 3:0)
+               SubPlan 2  (slice6; segments: 2)
+                 ->  Result
+                       ->  Result
                              One-Time Filter: (onetimefilter1.a = 2)
                              Filter: ((onetimefilter1.a)::double precision = random())
-                             ->  Materialize  (cost=0.00..431.00 rows=11 width=1)
-                                   ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=11 width=1)
-                                         ->  Result  (cost=0.00..431.00 rows=4 width=1)
-                                               ->  Shared Scan (share slice:id 4:0)  (cost=0.00..431.00 rows=4 width=1)
-               SubPlan 3  (slice6; segments: 3)
-                 ->  Result  (cost=0.00..431.66 rows=1 width=4)
+                             ->  Materialize
+                                   ->  Broadcast Motion 2:2  (slice4; segments: 2)
+                                         ->  Result
+                                               ->  Shared Scan (share slice:id 4:0)
+               SubPlan 3  (slice6; segments: 2)
+                 ->  Result
                        Filter: (share0_ref3.b = onetimefilter1.b)
-                       ->  Materialize  (cost=0.00..431.00 rows=11 width=4)
-                             ->  Broadcast Motion 3:3  (slice5; segments: 3)  (cost=0.00..431.00 rows=11 width=4)
-                                   ->  Result  (cost=0.00..431.00 rows=4 width=4)
-                                         ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=4 width=4)
- Planning time: 65.338 ms
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
-(46 rows)
+                       ->  Materialize
+                             ->  Broadcast Motion 2:2  (slice5; segments: 2)
+                                   ->  Result
+                                         ->  Shared Scan (share slice:id 5:0)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(45 rows)
 
 WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilter1, onetimefilter2 WHERE onetimefilter1.a=onetimefilter2.a) SELECT (SELECT 1 FROM abc WHERE f1.b = f2.b LIMIT 1), COALESCE((SELECT 2 FROM abc WHERE f1.a=random() AND f1.a=2), 0), (SELECT b FROM abc WHERE b=f1.b) FROM onetimefilter1 f1, onetimefilter2 f2 WHERE f1.b = f2.b;
  ?column? | coalesce | b  

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -11506,7 +11506,7 @@ ANALYZE onetimefilter2;
 EXPLAIN (COSTS OFF) WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilter1, onetimefilter2 WHERE onetimefilter1.a=onetimefilter2.a) SELECT (SELECT 1 FROM abc WHERE f1.b = f2.b LIMIT 1), COALESCE((SELECT 2 FROM abc WHERE f1.a=random() AND f1.a=2), 0), (SELECT b FROM abc WHERE b=f1.b) FROM onetimefilter1 f1, onetimefilter2 f2 WHERE f1.b = f2.b;
                                         QUERY PLAN                                        
 ------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice6; segments: 2)
+ Gather Motion 3:1  (slice6; segments: 3)
    ->  Sequence
          ->  Shared Scan (share slice:id 6:0)
                ->  Materialize
@@ -11518,36 +11518,36 @@ EXPLAIN (COSTS OFF) WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM 
          ->  Result
                ->  Hash Join
                      Hash Cond: (onetimefilter1.b = onetimefilter2.b)
-                     ->  Redistribute Motion 2:2  (slice1; segments: 2)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
                            Hash Key: onetimefilter1.b
                            ->  Seq Scan on onetimefilter1
                      ->  Hash
-                           ->  Redistribute Motion 2:2  (slice2; segments: 2)
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                  Hash Key: onetimefilter2.b
                                  ->  Seq Scan on onetimefilter2
-               SubPlan 1  (slice6; segments: 2)
+               SubPlan 1  (slice6; segments: 3)
                  ->  Result
                        ->  Limit
                              ->  Result
                                    One-Time Filter: (onetimefilter1.b = onetimefilter2.b)
                                    ->  Materialize
-                                         ->  Broadcast Motion 2:2  (slice3; segments: 2)
+                                         ->  Broadcast Motion 3:3  (slice3; segments: 3)
                                                ->  Result
                                                      ->  Shared Scan (share slice:id 3:0)
-               SubPlan 2  (slice6; segments: 2)
+               SubPlan 2  (slice6; segments: 3)
                  ->  Result
                        ->  Result
                              One-Time Filter: (onetimefilter1.a = 2)
                              Filter: ((onetimefilter1.a)::double precision = random())
                              ->  Materialize
-                                   ->  Broadcast Motion 2:2  (slice4; segments: 2)
+                                   ->  Broadcast Motion 3:3  (slice4; segments: 3)
                                          ->  Result
                                                ->  Shared Scan (share slice:id 4:0)
-               SubPlan 3  (slice6; segments: 2)
+               SubPlan 3  (slice6; segments: 3)
                  ->  Result
                        Filter: (share0_ref3.b = onetimefilter1.b)
                        ->  Materialize
-                             ->  Broadcast Motion 2:2  (slice5; segments: 2)
+                             ->  Broadcast Motion 3:3  (slice5; segments: 3)
                                    ->  Result
                                          ->  Shared Scan (share slice:id 5:0)
  Optimizer: Pivotal Optimizer (GPORCA)

--- a/src/test/regress/expected/shared_scan.out
+++ b/src/test/regress/expected/shared_scan.out
@@ -70,13 +70,18 @@ SET statement_timeout = '15s';
 (2 rows)
 
 RESET statement_timeout;
-SELECT *,
+SELECT COUNT(*)
+FROM (SELECT *,
         (
         WITH cte AS (SELECT * FROM jazz WHERE jazz.e = bar.c)
         SELECT 1 FROM cte c1, cte c2
         )
-        FROM bar;
-ERROR:  shareinputscan with outer refs is not supported by GPDB
+      FROM bar) as s;
+ count 
+-------
+   100
+(1 row)
+
 CREATE TABLE t1 (a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -160,3 +165,85 @@ SELECT col_mismatch_func2();
 ERROR:  structure of query does not match function result type
 DETAIL:  Number of returned columns (3) does not match expected column count (2).
 CONTEXT:  PL/pgSQL function col_mismatch_func2() line 6 at RETURN QUERY
+-- https://github.com/greenplum-db/gpdb/issues/12701
+-- Disable cte sharing in subquery
+drop table if exists pk_list;
+NOTICE:  table "pk_list" does not exist, skipping
+create table pk_list (id int, schema_name varchar, table_name varchar) distributed by (id);
+drop table if exists calender;
+NOTICE:  table "calender" does not exist, skipping
+create table calender (id int, data_hour timestamp) distributed by (id);
+explain (costs off)
+with
+	tbls as (select distinct schema_name, table_name as table_nm from pk_list),
+	tbls_daily_report_23 as (select unnest(string_to_array('mart_cm.card' ,',')) as table_nm_23),
+	tbls_w_onl_actl_data as (select unnest(string_to_array('mart_cm.cont_resp,mart_cm.card', ',')) as table_nm_onl_act)
+select  data_hour, stat.schema_name as schema_nm, dt.table_nm
+from (
+	select * from calender c
+	cross join tbls
+) dt
+inner join (
+	select tbls.schema_name, tbls.table_nm as table_name
+	from tbls tbls
+) stat on dt.table_nm = stat.table_name
+where
+	(data_hour = date_trunc('day',data_hour) and stat.schema_name || '.' ||stat.table_name not in (select table_nm_23 from tbls_daily_report_23))
+	and (stat.schema_name || '.' ||stat.table_name not in (select table_nm_onl_act from tbls_w_onl_actl_data))
+	or (stat.schema_name || '.' ||stat.table_name in (select table_nm_onl_act from tbls_w_onl_actl_data));
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice11; segments: 3)
+   ->  Hash Join
+         Hash Cond: ((dt.table_nm)::text = (stat.table_name)::text)
+         Join Filter: (((dt.data_hour = date_trunc('day'::text, dt.data_hour)) AND (NOT (hashed SubPlan 1)) AND (NOT (hashed SubPlan 2))) OR (hashed SubPlan 3))
+         ->  Subquery Scan on dt
+               ->  Nested Loop
+                     ->  Seq Scan on calender c
+                     ->  Materialize
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                 ->  HashAggregate
+                                       Group Key: pk_list.schema_name, pk_list.table_name
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                             Hash Key: pk_list.schema_name, pk_list.table_name
+                                             ->  HashAggregate
+                                                   Group Key: pk_list.schema_name, pk_list.table_name
+                                                   ->  Seq Scan on pk_list
+         ->  Hash
+               ->  Broadcast Motion 3:3  (slice7; segments: 3)
+                     ->  Subquery Scan on stat
+                           Filter: (((NOT (hashed SubPlan 1)) AND (NOT (hashed SubPlan 2))) OR (hashed SubPlan 3))
+                           ->  HashAggregate
+                                 Group Key: pk_list_1.schema_name, pk_list_1.table_name
+                                 ->  Redistribute Motion 3:3  (slice6; segments: 3)
+                                       Hash Key: pk_list_1.schema_name, pk_list_1.table_name
+                                       ->  HashAggregate
+                                             Group Key: pk_list_1.schema_name, pk_list_1.table_name
+                                             ->  Seq Scan on pk_list pk_list_1
+                           SubPlan 1  (slice7; segments: 3)
+                             ->  Materialize
+                                   ->  Broadcast Motion 1:3  (slice3; segments: 1)
+                                         ->  Result
+                           SubPlan 2  (slice7; segments: 3)
+                             ->  Materialize
+                                   ->  Broadcast Motion 1:3  (slice4; segments: 1)
+                                         ->  Result
+                           SubPlan 3  (slice7; segments: 3)
+                             ->  Materialize
+                                   ->  Broadcast Motion 1:3  (slice5; segments: 1)
+                                         ->  Result
+         SubPlan 1  (slice11; segments: 3)
+           ->  Materialize
+                 ->  Broadcast Motion 1:3  (slice8; segments: 1)
+                       ->  Result
+         SubPlan 2  (slice11; segments: 3)
+           ->  Materialize
+                 ->  Broadcast Motion 1:3  (slice9; segments: 1)
+                       ->  Result
+         SubPlan 3  (slice11; segments: 3)
+           ->  Materialize
+                 ->  Broadcast Motion 1:3  (slice10; segments: 1)
+                       ->  Result
+ Optimizer: Postgres query optimizer
+(52 rows)
+

--- a/src/test/regress/expected/shared_scan_optimizer.out
+++ b/src/test/regress/expected/shared_scan_optimizer.out
@@ -73,13 +73,18 @@ SET statement_timeout = '15s';
 (2 rows)
 
 RESET statement_timeout;
-SELECT *,
+SELECT COUNT(*)
+FROM (SELECT *,
         (
         WITH cte AS (SELECT * FROM jazz WHERE jazz.e = bar.c)
         SELECT 1 FROM cte c1, cte c2
         )
-        FROM bar;
-ERROR:  shareinputscan with outer refs is not supported by GPDB
+      FROM bar) as s;
+ count 
+-------
+   100
+(1 row)
+
 CREATE TABLE t1 (a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -173,3 +178,85 @@ NOTICE:  An ERROR must have happened. Stopping a Shared Scan.
 ERROR:  structure of query does not match function result type
 DETAIL:  Number of returned columns (3) does not match expected column count (2).
 CONTEXT:  PL/pgSQL function col_mismatch_func2() line 6 at RETURN QUERY
+-- https://github.com/greenplum-db/gpdb/issues/12701
+-- Disable cte sharing in subquery
+drop table if exists pk_list;
+NOTICE:  table "pk_list" does not exist, skipping
+create table pk_list (id int, schema_name varchar, table_name varchar) distributed by (id);
+drop table if exists calender;
+NOTICE:  table "calender" does not exist, skipping
+create table calender (id int, data_hour timestamp) distributed by (id);
+explain (costs off)
+with
+	tbls as (select distinct schema_name, table_name as table_nm from pk_list),
+	tbls_daily_report_23 as (select unnest(string_to_array('mart_cm.card' ,',')) as table_nm_23),
+	tbls_w_onl_actl_data as (select unnest(string_to_array('mart_cm.cont_resp,mart_cm.card', ',')) as table_nm_onl_act)
+select  data_hour, stat.schema_name as schema_nm, dt.table_nm
+from (
+	select * from calender c
+	cross join tbls
+) dt
+inner join (
+	select tbls.schema_name, tbls.table_nm as table_name
+	from tbls tbls
+) stat on dt.table_nm = stat.table_name
+where
+	(data_hour = date_trunc('day',data_hour) and stat.schema_name || '.' ||stat.table_name not in (select table_nm_23 from tbls_daily_report_23))
+	and (stat.schema_name || '.' ||stat.table_name not in (select table_nm_onl_act from tbls_w_onl_actl_data))
+	or (stat.schema_name || '.' ||stat.table_name in (select table_nm_onl_act from tbls_w_onl_actl_data));
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice11; segments: 3)
+   ->  Hash Join
+         Hash Cond: ((dt.table_nm)::text = (stat.table_name)::text)
+         Join Filter: (((dt.data_hour = date_trunc('day'::text, dt.data_hour)) AND (NOT (hashed SubPlan 1)) AND (NOT (hashed SubPlan 2))) OR (hashed SubPlan 3))
+         ->  Subquery Scan on dt
+               ->  Nested Loop
+                     ->  Seq Scan on calender c
+                     ->  Materialize
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                 ->  HashAggregate
+                                       Group Key: pk_list.schema_name, pk_list.table_name
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                             Hash Key: pk_list.schema_name, pk_list.table_name
+                                             ->  HashAggregate
+                                                   Group Key: pk_list.schema_name, pk_list.table_name
+                                                   ->  Seq Scan on pk_list
+         ->  Hash
+               ->  Broadcast Motion 3:3  (slice7; segments: 3)
+                     ->  Subquery Scan on stat
+                           Filter: (((NOT (hashed SubPlan 1)) AND (NOT (hashed SubPlan 2))) OR (hashed SubPlan 3))
+                           ->  HashAggregate
+                                 Group Key: pk_list_1.schema_name, pk_list_1.table_name
+                                 ->  Redistribute Motion 3:3  (slice6; segments: 3)
+                                       Hash Key: pk_list_1.schema_name, pk_list_1.table_name
+                                       ->  HashAggregate
+                                             Group Key: pk_list_1.schema_name, pk_list_1.table_name
+                                             ->  Seq Scan on pk_list pk_list_1
+                           SubPlan 1  (slice7; segments: 3)
+                             ->  Materialize
+                                   ->  Broadcast Motion 1:3  (slice3; segments: 1)
+                                         ->  Result
+                           SubPlan 2  (slice7; segments: 3)
+                             ->  Materialize
+                                   ->  Broadcast Motion 1:3  (slice4; segments: 1)
+                                         ->  Result
+                           SubPlan 3  (slice7; segments: 3)
+                             ->  Materialize
+                                   ->  Broadcast Motion 1:3  (slice5; segments: 1)
+                                         ->  Result
+         SubPlan 1  (slice11; segments: 3)
+           ->  Materialize
+                 ->  Broadcast Motion 1:3  (slice8; segments: 1)
+                       ->  Result
+         SubPlan 2  (slice11; segments: 3)
+           ->  Materialize
+                 ->  Broadcast Motion 1:3  (slice9; segments: 1)
+                       ->  Result
+         SubPlan 3  (slice11; segments: 3)
+           ->  Materialize
+                 ->  Broadcast Motion 1:3  (slice10; segments: 1)
+                       ->  Result
+ Optimizer: Postgres query optimizer
+(52 rows)
+

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -2216,7 +2216,7 @@ INSERT INTO onetimefilter1 SELECT i, i FROM generate_series(1,10)i;
 INSERT INTO onetimefilter2 SELECT i, i FROM generate_series(1,10)i;
 ANALYZE onetimefilter1;
 ANALYZE onetimefilter2;
-EXPLAIN WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilter1, onetimefilter2 WHERE onetimefilter1.a=onetimefilter2.a) SELECT (SELECT 1 FROM abc WHERE f1.b = f2.b LIMIT 1), COALESCE((SELECT 2 FROM abc WHERE f1.a=random() AND f1.a=2), 0), (SELECT b FROM abc WHERE b=f1.b) FROM onetimefilter1 f1, onetimefilter2 f2 WHERE f1.b = f2.b;
+EXPLAIN (COSTS OFF) WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilter1, onetimefilter2 WHERE onetimefilter1.a=onetimefilter2.a) SELECT (SELECT 1 FROM abc WHERE f1.b = f2.b LIMIT 1), COALESCE((SELECT 2 FROM abc WHERE f1.a=random() AND f1.a=2), 0), (SELECT b FROM abc WHERE b=f1.b) FROM onetimefilter1 f1, onetimefilter2 f2 WHERE f1.b = f2.b;
 WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilter1, onetimefilter2 WHERE onetimefilter1.a=onetimefilter2.a) SELECT (SELECT 1 FROM abc WHERE f1.b = f2.b LIMIT 1), COALESCE((SELECT 2 FROM abc WHERE f1.a=random() AND f1.a=2), 0), (SELECT b FROM abc WHERE b=f1.b) FROM onetimefilter1 f1, onetimefilter2 f2 WHERE f1.b = f2.b;
 
 

--- a/src/test/regress/sql/shared_scan.sql
+++ b/src/test/regress/sql/shared_scan.sql
@@ -48,12 +48,13 @@ SET statement_timeout = '15s';
 
 RESET statement_timeout;
 
-SELECT *,
+SELECT COUNT(*)
+FROM (SELECT *,
         (
         WITH cte AS (SELECT * FROM jazz WHERE jazz.e = bar.c)
         SELECT 1 FROM cte c1, cte c2
         )
-        FROM bar;
+      FROM bar) as s;
 
 CREATE TABLE t1 (a int, b int);
 CREATE TABLE t2 (a int);
@@ -93,3 +94,30 @@ $$;
 
 -- This should only ERROR and should not SIGSEGV
 SELECT col_mismatch_func2();
+
+-- https://github.com/greenplum-db/gpdb/issues/12701
+-- Disable cte sharing in subquery
+drop table if exists pk_list;
+create table pk_list (id int, schema_name varchar, table_name varchar) distributed by (id);
+drop table if exists calender;
+create table calender (id int, data_hour timestamp) distributed by (id);
+
+explain (costs off)
+with
+	tbls as (select distinct schema_name, table_name as table_nm from pk_list),
+	tbls_daily_report_23 as (select unnest(string_to_array('mart_cm.card' ,',')) as table_nm_23),
+	tbls_w_onl_actl_data as (select unnest(string_to_array('mart_cm.cont_resp,mart_cm.card', ',')) as table_nm_onl_act)
+select  data_hour, stat.schema_name as schema_nm, dt.table_nm
+from (
+	select * from calender c
+	cross join tbls
+) dt
+inner join (
+	select tbls.schema_name, tbls.table_nm as table_name
+	from tbls tbls
+) stat on dt.table_nm = stat.table_name
+where
+	(data_hour = date_trunc('day',data_hour) and stat.schema_name || '.' ||stat.table_name not in (select table_nm_23 from tbls_daily_report_23))
+	and (stat.schema_name || '.' ||stat.table_name not in (select table_nm_onl_act from tbls_w_onl_actl_data))
+	or (stat.schema_name || '.' ||stat.table_name in (select table_nm_onl_act from tbls_w_onl_actl_data));
+


### PR DESCRIPTION
This PR fix #12701 .

Current code logic is trying to enable CTE sharing in subplan automatically (but ignores the gp_cte_sharing GUC, maybe it's also a bug).
https://github.com/greenplum-db/gpdb/blob/baa0c336b43f7d907ee6d3ca3758898e8495eea9/src/backend/optimizer/plan/subselect.c#L604-L611

It is fixup_subplans() that copy subplan and leads to mismatch of the length of subplans and subroot. And apply_shareinput_xslice() cannot make it correct when shared plan is in subplan, then an assert of panic happened (please see the repro of issue).

Trying to keep the length consistent (todo something in copy subplan and root) is a bit complicated. Considering the gp_cte_sharing GUC is off in default, so I think disable all CTE sharings in subquery is an acceptable workaround.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
