### PR TITLE
Replace MemoryContextContains() with a more robust version

### DIFF
--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -1180,7 +1180,7 @@ finalize_aggregate(AggState *aggstate,
 	 * If result is pass-by-ref, make sure it is in the right context.
 	 */
 	if (!peragg->resulttypeByVal && !*resultIsNull &&
-		!MemoryContextContains(CurrentMemoryContext,
+		!MemoryContextContainsGenericAllocation(CurrentMemoryContext,
 							   DatumGetPointer(*resultVal)))
 		*resultVal = datumCopy(*resultVal,
 							   peragg->resulttypeByVal,
@@ -1241,7 +1241,7 @@ finalize_partialaggregate(AggState *aggstate,
 
 	/* If result is pass-by-ref, make sure it is in the right context. */
 	if (!peragg->resulttypeByVal && !*resultIsNull &&
-		!MemoryContextContains(CurrentMemoryContext,
+		!MemoryContextContainsGenericAllocation(CurrentMemoryContext,
 							   DatumGetPointer(*resultVal)))
 		*resultVal = datumCopy(*resultVal,
 							   peragg->resulttypeByVal,

--- a/src/backend/executor/nodeWindowAgg.c
+++ b/src/backend/executor/nodeWindowAgg.c
@@ -813,7 +813,7 @@ finalize_windowaggregate(WindowAggState *winstate,
 	 * If result is pass-by-ref, make sure it is in the right context.
 	 */
 	if (!peraggstate->resulttypeByVal && !*isnull &&
-		!MemoryContextContains(CurrentMemoryContext,
+		!MemoryContextContainsGenericAllocation(CurrentMemoryContext,
 							   DatumGetPointer(*result)))
 		*result = datumCopy(*result,
 							peraggstate->resulttypeByVal,
@@ -1296,13 +1296,8 @@ eval_windowfunction(WindowAggState *winstate, WindowStatePerFunc perfuncstate,
 	 * need this in case the function returns a pointer into some short-lived
 	 * tuple, as is entirely possible.)
 	 */
-	// GPDB_84_MERGE_FIXME: In upstream, we know that the allocation
-	// was palloc in some memory context, but in GPDB, that is not true.
-	// This is not actually 100% safe, there is a small chance
-	// MemoryContextContains() incorrectly says that the chunk is in the context,
-	// which could lead to a crash. nodeAgg.c has the same problem.
 	if (!perfuncstate->resulttypeByVal && !fcinfo->isnull &&
-		!MemoryContextContains(CurrentMemoryContext,
+		!MemoryContextContainsGenericAllocation(CurrentMemoryContext,
 							   DatumGetPointer(*result))
 		)
 		*result = datumCopy(*result,

--- a/src/backend/utils/mmgr/aset.c
+++ b/src/backend/utils/mmgr/aset.c
@@ -1247,6 +1247,33 @@ AllocSetFree(MemoryContext context, void *pointer)
 }
 
 /*
+ * AllocSetContains
+ *		Detects whether a generic memory pointer belongs to a given context or not.
+ *		Note, the "generic" means it will be ready to handle pointers to any memory region,
+ *		whether allocated using palloc or not, and regardless of their alignment.  This will
+ *		return true if the pointer points to any data structure within a block managed by the
+ *		given memory context.
+ *
+ *		This should be used in place of MemoryContextContains if there is any uncertainty
+ *		about whether the pointer has maximal alignment and points to the beginning of a chunk
+ *		allocated by some MemoryContext
+ */
+bool
+AllocSetContains(MemoryContext context, void *pointer)
+{
+	Assert(context->type == T_AllocSetContext);
+
+	AllocSet set = (AllocSet) context;
+
+	for (AllocBlock block = set->blocks; block != NULL; block = (AllocBlock) block->next)
+	{
+		if (pointer >= (void *)block && pointer < (void *)block->endptr)
+			return true;
+	}
+	return false;
+}
+
+/*
  * AllocSetRealloc
  *		Returns new pointer to allocated memory of given size or NULL if
  *		request could not be completed; this memory is added to the set.

--- a/src/backend/utils/mmgr/test/Makefile
+++ b/src/backend/utils/mmgr/test/Makefile
@@ -2,7 +2,7 @@ subdir=src/backend/utils/mmgr
 top_builddir=../../../../..
 include $(top_builddir)/src/Makefile.global
 
-TARGETS=vmem_tracker redzone_handler runaway_cleaner idle_tracker event_version memprot
+TARGETS=vmem_tracker redzone_handler runaway_cleaner idle_tracker event_version memprot mcxt
 
 include $(top_srcdir)/src/backend/mock.mk
 
@@ -59,4 +59,7 @@ idle_tracker.t: \
 
 event_version.t: $(MOCK_DIR)/backend/storage/ipc/shmem_mock.o\
 	$(MOCK_DIR)/backend/access/hash/hash_mock.o\
+	$(MOCK_DIR)/backend/utils/fmgr/fmgr_mock.o
+
+mcxt.t: $(MOCK_DIR)/backend/access/hash/hashpage_mock.o \
 	$(MOCK_DIR)/backend/utils/fmgr/fmgr_mock.o

--- a/src/backend/utils/mmgr/test/mcxt_test.c
+++ b/src/backend/utils/mmgr/test/mcxt_test.c
@@ -83,10 +83,10 @@ test__MemoryContextContainsGenericAllocation_FalsePositive(void **state)
 	contains = MemoryContextContainsGenericAllocation(mcxt, pointer);
 	assert_false(contains);
 
-	*(MemoryContext *) (((char *) pointer) - sizeof(void *)) = another_mcxt;
+	*(MemoryContext *) (((char *) pointer) - sizeof(void *)) = mcxt;
 
-	// check for a rare case of a false negative when memory just before 
-	// pointer happens to contain the address of the mcxt it's looking for
+	// check for false positive when memory just before pointer happens
+	// to contain the address it's looking for
 	contains = MemoryContextContainsGenericAllocation(mcxt, pointer);
 	assert_false(contains);
 }
@@ -110,8 +110,8 @@ test__MemoryContextContainsGenericAllocation_FalseNegative(void **state)
 
 	*(MemoryContext *) (((char *) pointer) - sizeof(void *)) = another_mcxt;
 
-	// check for a rare case of a false negative when memory just before 
-	// pointer happens to contain the address of the mcxt it's looking for
+	// check for a false negative when memory just before pointer contains
+	// an address it's not looking for
 	bool contains = MemoryContextContainsGenericAllocation(mcxt, pointer);
 	assert_true(contains);
 }

--- a/src/backend/utils/mmgr/test/mcxt_test.c
+++ b/src/backend/utils/mmgr/test/mcxt_test.c
@@ -1,0 +1,162 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#include "../mcxt.c"
+
+static void
+test__MemoryContextContainsGenericAllocation_DoesContain(void **state)
+{
+	MemoryContext mcxt = AllocSetContextCreate(ErrorContext,
+													 "TestContext",
+													 ALLOCSET_DEFAULT_MINSIZE,
+													 ALLOCSET_DEFAULT_INITSIZE,
+													 ALLOCSET_DEFAULT_MAXSIZE);
+	MemoryContextSwitchTo(mcxt);
+
+	// Most common case, where pointer points to beginning of a chunk allocated
+	//  in the correct context  (true positive)
+	char *pointer = palloc(500);
+	bool contains = MemoryContextContainsGenericAllocation(mcxt, pointer);
+	assert_true(contains);
+
+	// Make sure this also works for pointers into an offset of a chunk from
+	//   the right context, and misaligned
+	contains = MemoryContextContainsGenericAllocation(mcxt, pointer + 499);
+	assert_true(contains);
+}
+
+static void
+test__MemoryContextContainsGenericAllocation_DoesNotContainAllocationFromAnotherMemoryContext(void **state)
+{
+	MemoryContext mcxt = AllocSetContextCreate(ErrorContext,
+													 "A memory context",
+													 ALLOCSET_DEFAULT_MINSIZE,
+													 ALLOCSET_DEFAULT_INITSIZE,
+													 ALLOCSET_DEFAULT_MAXSIZE);
+	MemoryContext another_mcxt = AllocSetContextCreate(ErrorContext,
+													 "Another memory context",
+													 ALLOCSET_DEFAULT_MINSIZE,
+													 ALLOCSET_DEFAULT_INITSIZE,
+													 ALLOCSET_DEFAULT_MAXSIZE);
+
+	MemoryContextSwitchTo(mcxt);
+
+	bool contains;
+	void *pointer = palloc(sizeof(char));
+
+	contains = MemoryContextContainsGenericAllocation(another_mcxt, pointer);
+	assert_false(contains);
+}
+
+static void
+test__MemoryContextContainsGenericAllocation_FalsePositive(void **state)
+{
+	MemoryContext mcxt = AllocSetContextCreate(ErrorContext,
+													 "A memory context",
+													 ALLOCSET_DEFAULT_MINSIZE,
+													 ALLOCSET_DEFAULT_INITSIZE,
+													 ALLOCSET_DEFAULT_MAXSIZE);
+	MemoryContext another_mcxt = AllocSetContextCreate(ErrorContext,
+													 "Another memory context",
+													 ALLOCSET_DEFAULT_MINSIZE,
+													 ALLOCSET_DEFAULT_INITSIZE,
+													 ALLOCSET_DEFAULT_MAXSIZE);
+
+	MemoryContextSwitchTo(another_mcxt);
+	char *pointer = palloc(500);
+	bool contains;
+
+	//  With the previous MemoryContextContains() function, you could get a
+	//  false positive here if the pointer points into the middle of a palloc'd
+	//  region (which does happen in some window functions, such as LAG()
+	//  where the pointer can point to columns within previously allocated memtuples)
+	//  instead of the beginning, where the memory just before the pointer happens
+	//  to match the address of the memory context.  This is rare in gpdb7, but
+	//  we were seeing it happen in gpdb6 when the preceeding memory was all 0's
+	pointer += 200;
+
+	*(MemoryContext *) (((char *) pointer) - sizeof(void *)) = NULL;
+	// check for false positive when memory just before pointer contains
+	// a null pointer -- this was happening with LAG() function in gpdb6 before
+	contains = MemoryContextContainsGenericAllocation(mcxt, pointer);
+	assert_false(contains);
+
+	*(MemoryContext *) (((char *) pointer) - sizeof(void *)) = another_mcxt;
+
+	// check for a rare case of a false negative when memory just before 
+	// pointer happens to contain the address of the mcxt it's looking for
+	contains = MemoryContextContainsGenericAllocation(mcxt, pointer);
+	assert_false(contains);
+}
+
+static void
+test__MemoryContextContainsGenericAllocation_FalseNegative(void **state)
+{
+	MemoryContext mcxt = AllocSetContextCreate(ErrorContext,
+													 "A memory context",
+													 ALLOCSET_DEFAULT_MINSIZE,
+													 ALLOCSET_DEFAULT_INITSIZE,
+													 ALLOCSET_DEFAULT_MAXSIZE);
+	MemoryContext another_mcxt = AllocSetContextCreate(ErrorContext,
+													 "Another memory context",
+													 ALLOCSET_DEFAULT_MINSIZE,
+													 ALLOCSET_DEFAULT_INITSIZE,
+													 ALLOCSET_DEFAULT_MAXSIZE);
+	MemoryContextSwitchTo(mcxt);
+	char *pointer = palloc(500);
+	pointer += 200;
+
+	*(MemoryContext *) (((char *) pointer) - sizeof(void *)) = another_mcxt;
+
+	// check for a rare case of a false negative when memory just before 
+	// pointer happens to contain the address of the mcxt it's looking for
+	bool contains = MemoryContextContainsGenericAllocation(mcxt, pointer);
+	assert_true(contains);
+}
+
+static void
+test__MemoryContextContainsGenericAllocation_MultipleAllocations(void **state) {
+	MemoryContext mcxt = AllocSetContextCreate(ErrorContext,
+													 "A memory context",
+													 ALLOCSET_DEFAULT_MINSIZE,
+													 ALLOCSET_DEFAULT_INITSIZE,
+													 ALLOCSET_DEFAULT_MAXSIZE);
+
+	MemoryContextSwitchTo(mcxt);
+
+	for (Size s = 1; s < 5 * ALLOCSET_DEFAULT_INITSIZE; s *= 16) {
+		assert_true(MemoryContextContainsGenericAllocation(mcxt, palloc(s)));
+	}
+}
+
+static void
+test__MemoryContextContainsGenericAllocation_DoesNotContainNullPointer(void **state)
+{
+	MemoryContext mcxt = AllocSetContextCreate(ErrorContext,
+													 "TestContext",
+													 ALLOCSET_DEFAULT_MINSIZE,
+													 ALLOCSET_DEFAULT_INITSIZE,
+													 ALLOCSET_DEFAULT_MAXSIZE);
+	bool contains = MemoryContextContainsGenericAllocation(mcxt, NULL);
+	assert_false(contains);
+}
+
+int
+main(int argc, char* argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+
+	const UnitTest tests[] = {
+		unit_test(test__MemoryContextContainsGenericAllocation_DoesContain),
+		unit_test(test__MemoryContextContainsGenericAllocation_DoesNotContainAllocationFromAnotherMemoryContext),
+		unit_test(test__MemoryContextContainsGenericAllocation_MultipleAllocations),
+		unit_test(test__MemoryContextContainsGenericAllocation_FalsePositive),
+		unit_test(test__MemoryContextContainsGenericAllocation_FalseNegative),
+		unit_test(test__MemoryContextContainsGenericAllocation_DoesNotContainNullPointer)
+	};
+
+	return run_tests(tests);
+}
+

--- a/src/include/utils/memutils.h
+++ b/src/include/utils/memutils.h
@@ -134,6 +134,7 @@ extern void MemoryContextAllowInCriticalSection(MemoryContext context,
 extern void MemoryContextCheck(MemoryContext context);
 #endif
 extern bool MemoryContextContains(MemoryContext context, void *pointer);
+extern bool MemoryContextContainsGenericAllocation(MemoryContext context, void *pointer);
 
 extern void MemoryContextError(int errorcode, MemoryContext context,
                                const char *sfile, int sline,
@@ -218,6 +219,8 @@ extern MemoryContext AllocSetContextCreateInternal(MemoryContext parent,
 #define AllocSetContextCreate \
 	AllocSetContextCreateInternal
 #endif
+
+extern bool AllocSetContains(MemoryContext context, void *pointer);
 
 /* slab.c */
 extern MemoryContext SlabContextCreate(MemoryContext parent,


### PR DESCRIPTION
The existing version of MemoryContextContains(context, pointer) reads the 8 bytes in memory preceding the pointer passed to it, and returns true or false based on whether it matches the address of context.

This method works well for pointers which point to the beginning of a memory chunk allocated by palloc(), but is not safe to call when the pointer points to an offset into a chunk of memory.  In that case, it will likely return false, but has the potential to return true (a "false positive" result) if the bytes in memory immediately preceding pointer happen to match this address.

In postgres, the pointers passed to it point to the beginning of a chunk.  But in gpdb, that's often not the case... so this function can cause cause a crash if these unlikely circumstances occur.  It's a bit more likely in gpdb6, where we can consistently reproduce the crash but still possible in gpdb7.

Since there is no current case(*) in gpdb where we can guarantee that the pointer passed to it is pointing to the beginning of a chunk, we've disabled it entirely with Assert(false).  This commit replaces it with a different implementation, which is safe to call with any valid pointer.  This method traverses the block list at a lower level, so is specific to AllocSet.  AllocSet is the only type of MemoryContext used in gpdb.  AllocSlab and AllocGenerate were both merged in from upstream, but are currently unused in gpdb--for now, we just return an error if this is called on anything but an AllocSet.  (In the future, if we use one or both of those for something, we can extend this to include implementation for those cases.)

(*) A typical scenario for how this is called:
- Input tuples are spooled into memory in a tmpcontext, while output tuples from window functions are allocated in a more permanent memory context, exprcontext.
- Window functions might allocate their own memory, but it's also common for them to return pointers to data which has already been allocated previously... often in the temporary input context rather than the output context.  For example, the function LAG() will return a pointer to a single column (attr) within a MemTuple representing its value in a previous row.  If this is not the first column in the tuple, then the pointer will not point to the beginning of the memory chunk which stores an array of values, one for each attr.
- If MemoryContexContains() return false, then the memory pointed to is copied over to the more permanent context, but not copied if it returns true.  We could just always copy, but if the data is large then this would incur extra performance cost, which is why it's important to be able to decide accurately which context the pointer was actually allocated in.  A false positive can cause a crash later, after the tmpcontext gets reset and reused for something else.