### PR TITLE
gpload: Add INPUT configuration NEWLINE support.

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -119,6 +119,7 @@ valid_tokens = {
     "delimiter": {'parse_children': True, 'parent': "input"},
     "escape": {'parse_children': True, 'parent': "input"},
     "null_as": {'parse_children': True, 'parent': "input"},
+    "newline": {'parse_children': True, 'parent': "input"},
     "quote": {'parse_children': True, 'parent': "input"},
     "encoding": {'parse_children': True, 'parent': "input"},
     "force_not_null": {'parse_children': False, 'parent': "input"},
@@ -378,6 +379,7 @@ keywords = {
 	"natural": True,
 	"nchar": True,
 	"new": True,
+	"newline": True,
 	"next": True,
 	"no": True,
 	"nocreatedb": True,
@@ -2374,7 +2376,6 @@ class gpload:
         else:
             self.formatOpts += "null %s " % quote_no_slash("\\N")
 
-
         esc = self.getconfig('gpload:input:escape', None, None)
         if esc:
             if type(esc) != str and type(esc) != str:
@@ -2393,6 +2394,11 @@ class gpload:
 
         if formatType=='csv':
             self.get_external_table_formatOpts('quote')
+
+        newline = self.getconfig('gpload:input:newline', str, False)
+        self.log(self.DEBUG, "newline " + str(newline))
+        if newline != False: # could be empty string
+            self.formatOpts += "newline %s " % quote_no_slash(newline)
 
         if self.getconfig('gpload:input:header',bool,False):
             self.formatOpts += "header "

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_base.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_base.py
@@ -164,7 +164,7 @@ coordinatorPort = getPortCoordinatorOnly()
 def write_config_file(version='1.0.0.1', database='reuse_gptest', user=os.environ.get('USER'), host=hostNameAddrs, port=coordinatorPort, config='config/config_file', local_host=[hostNameAddrs], file='data/external_file_01.txt', input_port='8081', port_range=None,
     ssl=None,columns=None, format='text', force_not_null=[], log_errors=None, error_limit=None, delimiter="'|'", encoding=None, escape=None, null_as=None, fill_missing_fields=None, quote=None, header=None, transform=None, transform_config=None, max_line_length=None, 
     table='texttable', mode='insert', update_columns=['n2'], update_condition=None, match_columns=['n1','s1','s2'], staging_table=None, mapping=None, externalSchema=None, preload=True, truncate=False, reuse_tables=True, fast_match=None,
-    sql=False, before=None, after=None, error_table=None):
+    sql=False, before=None, after=None, error_table=None, newline=None):
 
     f = open(config,'w', encoding="utf-8")
     f.write("VERSION: "+version)
@@ -206,7 +206,10 @@ def write_config_file(version='1.0.0.1', database='reuse_gptest', user=os.enviro
         f.write("\n    - ERROR_LIMIT: "+str(error_limit))
     if error_table:
         f.write("\n    - ERROR_TABLE: "+error_table)
-    f.write("\n    - DELIMITER: "+delimiter)
+    if delimiter:
+        f.write("\n    - DELIMITER: "+delimiter)
+    if newline:
+        f.write("\n    - NEWLINE: "+str(newline))
     if encoding:
         f.write("\n    - ENCODING: "+encoding)
     if escape:

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_data_format.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_data_format.py
@@ -287,3 +287,103 @@ def test_252_gpload_eol_LF_in_quote_csv():
     runfile(file)
     copy_data('external_file_252.csv','data_file.csv')
     write_config_file(reuse_tables=True,format='csv',file='data_file.csv',table='texttable2')
+
+@prepare_before_test(num=253)
+def test_253_gpload_eol_CRLF_txt():
+    "253 gpload loads text file with CR and LF in data and CRLF as end of line"
+    file = mkpath('setup.sql')
+    runfile(file)
+    copy_data('external_file_253.txt','data_file.txt')
+    write_config_file(reuse_tables=True,
+                      format='text',
+                      file='data_file.txt',
+                      table='texttable2',
+                      newline='CRLF')
+
+@prepare_before_test(num=254)
+def test_254_gpload_eol_CRLF_csv():
+    "254 gpload loads csv file with CR and LF in data and CRLF as end of line"
+    file = mkpath('setup.sql')
+    runfile(file)
+    copy_data('external_file_254.csv','data_file.csv')
+    write_config_file(reuse_tables=True,
+                      format='csv',
+                      file='data_file.csv',
+                      table='texttable2',
+                      delimiter=None,
+                      newline='CRLF')
+
+@prepare_before_test(num=255)
+def test_255_gpload_eol_LF_txt():
+    "255 gpload loads text file with CR in data and LF as end of line"
+    file = mkpath('setup.sql')
+    runfile(file)
+    copy_data('external_file_255.txt','data_file.txt')
+    write_config_file(reuse_tables=True,
+                      format='text',
+                      file='data_file.txt',
+                      table='texttable2',
+                      newline='LF')
+
+@prepare_before_test(num=256)
+def test_256_gpload_eol_LF_csv():
+    "256 gpload loads csv file with CR in data and LF as end of line"
+    file = mkpath('setup.sql')
+    runfile(file)
+    copy_data('external_file_256.csv','data_file.csv')
+    write_config_file(reuse_tables=True,
+                      format='csv',
+                      file='data_file.csv',
+                      table='texttable2',
+                      delimiter=None,
+                      newline='LF')
+
+@prepare_before_test(num=257)
+def test_257_gpload_eol_CR_txt():
+    "257 gpload loads text file with CR as end of line"
+    file = mkpath('setup.sql')
+    runfile(file)
+    copy_data('external_file_257.txt','data_file.txt')
+    write_config_file(reuse_tables=True,
+                      format='text',
+                      file='data_file.txt',
+                      table='texttable2',
+                      newline='CR')
+
+@prepare_before_test(num=258)
+def test_258_gpload_eol_CR_csv():
+    "258 gpload loads csv file with CR as end of line"
+    file = mkpath('setup.sql')
+    runfile(file)
+    copy_data('external_file_258.csv','data_file.csv')
+    write_config_file(reuse_tables=True,
+                      format='csv',
+                      file='data_file.csv',
+                      table='texttable2',
+                      delimiter=None,
+                      newline='CR')
+
+@prepare_before_test(num=259,times=1)
+def test_259_gpload_eol_CRLF_txt():
+    "259 gpload text file load error with invalid NEWLINE value"
+    file = mkpath('setup.sql')
+    runfile(file)
+    copy_data('external_file_259.txt','data_file.txt')
+    write_config_file(reuse_tables=True,
+                      format='text',
+                      file='data_file.txt',
+                      table='texttable2',
+                      newline='LFCR')
+
+@prepare_before_test(num=260,times=1)
+def test_260_gpload_eol_CRLF_csv():
+    "259 gpload csv file load error with invalid NEWLINE value"
+    file = mkpath('setup.sql')
+    runfile(file)
+    copy_data('external_file_260.csv','data_file.csv')
+    write_config_file(reuse_tables=True,
+                      format='csv',
+                      file='data_file.csv',
+                      table='texttable2',
+                      delimiter=None,
+                      newline='LFCR')

--- a/gpMgmt/bin/gpload_test/gpload2/data/external_file_253.txt
+++ b/gpMgmt/bin/gpload_test/gpload2/data/external_file_253.txt
@@ -1,0 +1,6 @@
+line1 with CR|eol_CRLF
+line2|eol_CRLF
+line3 with LF
+|eol_CRLF
+line4|eol_CRLF
+line5|eol_CRLF

--- a/gpMgmt/bin/gpload_test/gpload2/data/external_file_254.csv
+++ b/gpMgmt/bin/gpload_test/gpload2/data/external_file_254.csv
@@ -1,0 +1,6 @@
+line1 with CR,eol_CRLF
+line2,eol_CRLF
+line3 with LF
+,eol_CRLF
+line4,eol_CRLF
+line5,eol_CRLF

--- a/gpMgmt/bin/gpload_test/gpload2/data/external_file_255.txt
+++ b/gpMgmt/bin/gpload_test/gpload2/data/external_file_255.txt
@@ -1,0 +1,5 @@
+line1 with CR|eol_LF
+line2|eol_LF
+line3|eol_LF
+line4|eol_LF
+line5|eol_LF

--- a/gpMgmt/bin/gpload_test/gpload2/data/external_file_256.csv
+++ b/gpMgmt/bin/gpload_test/gpload2/data/external_file_256.csv
@@ -1,0 +1,5 @@
+line1 with CR,eol_LF
+line2,eol_LF
+line3,eol_LF
+line4,eol_LF
+line5,eol_LF

--- a/gpMgmt/bin/gpload_test/gpload2/data/external_file_257.txt
+++ b/gpMgmt/bin/gpload_test/gpload2/data/external_file_257.txt
@@ -1,0 +1,1 @@
+line1|eol_CRline2|eol_CRline3|eol_CRline4|eol_CRline5|eol_CR

--- a/gpMgmt/bin/gpload_test/gpload2/data/external_file_258.csv
+++ b/gpMgmt/bin/gpload_test/gpload2/data/external_file_258.csv
@@ -1,0 +1,1 @@
+line1,eol_CRline2,eol_CRline3,eol_CRline4,eol_CRline5,eol_CR

--- a/gpMgmt/bin/gpload_test/gpload2/data/external_file_259.txt
+++ b/gpMgmt/bin/gpload_test/gpload2/data/external_file_259.txt
@@ -1,0 +1,6 @@
+line1 with CR|eol_CRLF
+line2|eol_CRLF
+line3 with LF
+|eol_CRLF
+line4|eol_CRLF
+line5|eol_CRLF

--- a/gpMgmt/bin/gpload_test/gpload2/data/external_file_260.csv
+++ b/gpMgmt/bin/gpload_test/gpload2/data/external_file_260.csv
@@ -1,0 +1,6 @@
+line1 with CR,eol_CRLF
+line2,eol_CRLF
+line3 with LF
+,eol_CRLF
+line4,eol_CRLF
+line5,eol_CRLF

--- a/gpMgmt/bin/gpload_test/gpload2/query253.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query253.ans
@@ -1,0 +1,18 @@
+2021-01-06 15:26:17|INFO|gpload session started 2021-01-06 15:26:17
+2021-01-06 15:26:17|INFO|setting schema 'public' for table 'texttable2'
+2021-01-06 15:26:17|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2021-01-06 15:26:17|INFO|did not find an external table to reuse. creating ext_gpload_reusable_7723d6fc_4ff0_11eb_bbcd_00505698d059
+2021-01-06 15:26:17|INFO|running time: 0.08 seconds
+2021-01-06 15:26:17|INFO|rows Inserted          = 5
+2021-01-06 15:26:17|INFO|rows Updated           = 0
+2021-01-06 15:26:17|INFO|data formatting errors = 0
+2021-01-06 15:26:17|INFO|gpload succeeded
+2021-01-06 15:26:17|INFO|gpload session started 2021-01-06 15:26:17
+2021-01-06 15:26:17|INFO|setting schema 'public' for table 'texttable2'
+2021-01-06 15:26:17|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2021-01-06 15:26:17|INFO|reusing external table ext_gpload_reusable_7723d6fc_4ff0_11eb_bbcd_00505698d059
+2021-01-06 15:26:17|INFO|running time: 0.06 seconds
+2021-01-06 15:26:17|INFO|rows Inserted          = 5
+2021-01-06 15:26:17|INFO|rows Updated           = 0
+2021-01-06 15:26:17|INFO|data formatting errors = 0
+2021-01-06 15:26:17|INFO|gpload succeeded

--- a/gpMgmt/bin/gpload_test/gpload2/query254.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query254.ans
@@ -1,0 +1,18 @@
+2021-01-06 15:26:17|INFO|gpload session started 2021-01-06 15:26:17
+2021-01-06 15:26:17|INFO|setting schema 'public' for table 'texttable2'
+2021-01-06 15:26:17|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2021-01-06 15:26:17|INFO|did not find an external table to reuse. creating ext_gpload_reusable_7723d6fc_4ff0_11eb_bbcd_00505698d059
+2021-01-06 15:26:17|INFO|running time: 0.08 seconds
+2021-01-06 15:26:17|INFO|rows Inserted          = 5
+2021-01-06 15:26:17|INFO|rows Updated           = 0
+2021-01-06 15:26:17|INFO|data formatting errors = 0
+2021-01-06 15:26:17|INFO|gpload succeeded
+2021-01-06 15:26:17|INFO|gpload session started 2021-01-06 15:26:17
+2021-01-06 15:26:17|INFO|setting schema 'public' for table 'texttable2'
+2021-01-06 15:26:17|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2021-01-06 15:26:17|INFO|reusing external table ext_gpload_reusable_7723d6fc_4ff0_11eb_bbcd_00505698d059
+2021-01-06 15:26:17|INFO|running time: 0.06 seconds
+2021-01-06 15:26:17|INFO|rows Inserted          = 5
+2021-01-06 15:26:17|INFO|rows Updated           = 0
+2021-01-06 15:26:17|INFO|data formatting errors = 0
+2021-01-06 15:26:17|INFO|gpload succeeded

--- a/gpMgmt/bin/gpload_test/gpload2/query255.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query255.ans
@@ -1,0 +1,18 @@
+2021-01-06 15:26:17|INFO|gpload session started 2021-01-06 15:26:17
+2021-01-06 15:26:17|INFO|setting schema 'public' for table 'texttable2'
+2021-01-06 15:26:17|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2021-01-06 15:26:17|INFO|did not find an external table to reuse. creating ext_gpload_reusable_7723d6fc_4ff0_11eb_bbcd_00505698d059
+2021-01-06 15:26:17|INFO|running time: 0.08 seconds
+2021-01-06 15:26:17|INFO|rows Inserted          = 5
+2021-01-06 15:26:17|INFO|rows Updated           = 0
+2021-01-06 15:26:17|INFO|data formatting errors = 0
+2021-01-06 15:26:17|INFO|gpload succeeded
+2021-01-06 15:26:17|INFO|gpload session started 2021-01-06 15:26:17
+2021-01-06 15:26:17|INFO|setting schema 'public' for table 'texttable2'
+2021-01-06 15:26:17|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2021-01-06 15:26:17|INFO|reusing external table ext_gpload_reusable_7723d6fc_4ff0_11eb_bbcd_00505698d059
+2021-01-06 15:26:17|INFO|running time: 0.06 seconds
+2021-01-06 15:26:17|INFO|rows Inserted          = 5
+2021-01-06 15:26:17|INFO|rows Updated           = 0
+2021-01-06 15:26:17|INFO|data formatting errors = 0
+2021-01-06 15:26:17|INFO|gpload succeeded

--- a/gpMgmt/bin/gpload_test/gpload2/query256.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query256.ans
@@ -1,0 +1,18 @@
+2021-01-06 15:26:17|INFO|gpload session started 2021-01-06 15:26:17
+2021-01-06 15:26:17|INFO|setting schema 'public' for table 'texttable2'
+2021-01-06 15:26:17|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2021-01-06 15:26:17|INFO|did not find an external table to reuse. creating ext_gpload_reusable_7723d6fc_4ff0_11eb_bbcd_00505698d059
+2021-01-06 15:26:17|INFO|running time: 0.08 seconds
+2021-01-06 15:26:17|INFO|rows Inserted          = 5
+2021-01-06 15:26:17|INFO|rows Updated           = 0
+2021-01-06 15:26:17|INFO|data formatting errors = 0
+2021-01-06 15:26:17|INFO|gpload succeeded
+2021-01-06 15:26:17|INFO|gpload session started 2021-01-06 15:26:17
+2021-01-06 15:26:17|INFO|setting schema 'public' for table 'texttable2'
+2021-01-06 15:26:17|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2021-01-06 15:26:17|INFO|reusing external table ext_gpload_reusable_7723d6fc_4ff0_11eb_bbcd_00505698d059
+2021-01-06 15:26:17|INFO|running time: 0.06 seconds
+2021-01-06 15:26:17|INFO|rows Inserted          = 5
+2021-01-06 15:26:17|INFO|rows Updated           = 0
+2021-01-06 15:26:17|INFO|data formatting errors = 0
+2021-01-06 15:26:17|INFO|gpload succeeded

--- a/gpMgmt/bin/gpload_test/gpload2/query257.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query257.ans
@@ -1,0 +1,18 @@
+2021-01-06 15:26:17|INFO|gpload session started 2021-01-06 15:26:17
+2021-01-06 15:26:17|INFO|setting schema 'public' for table 'texttable2'
+2021-01-06 15:26:17|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2021-01-06 15:26:17|INFO|did not find an external table to reuse. creating ext_gpload_reusable_7723d6fc_4ff0_11eb_bbcd_00505698d059
+2021-01-06 15:26:17|INFO|running time: 0.08 seconds
+2021-01-06 15:26:17|INFO|rows Inserted          = 5
+2021-01-06 15:26:17|INFO|rows Updated           = 0
+2021-01-06 15:26:17|INFO|data formatting errors = 0
+2021-01-06 15:26:17|INFO|gpload succeeded
+2021-01-06 15:26:17|INFO|gpload session started 2021-01-06 15:26:17
+2021-01-06 15:26:17|INFO|setting schema 'public' for table 'texttable2'
+2021-01-06 15:26:17|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2021-01-06 15:26:17|INFO|reusing external table ext_gpload_reusable_7723d6fc_4ff0_11eb_bbcd_00505698d059
+2021-01-06 15:26:17|INFO|running time: 0.06 seconds
+2021-01-06 15:26:17|INFO|rows Inserted          = 5
+2021-01-06 15:26:17|INFO|rows Updated           = 0
+2021-01-06 15:26:17|INFO|data formatting errors = 0
+2021-01-06 15:26:17|INFO|gpload succeeded

--- a/gpMgmt/bin/gpload_test/gpload2/query258.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query258.ans
@@ -1,0 +1,18 @@
+2021-01-06 15:26:17|INFO|gpload session started 2021-01-06 15:26:17
+2021-01-06 15:26:17|INFO|setting schema 'public' for table 'texttable2'
+2021-01-06 15:26:17|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2021-01-06 15:26:17|INFO|did not find an external table to reuse. creating ext_gpload_reusable_7723d6fc_4ff0_11eb_bbcd_00505698d059
+2021-01-06 15:26:17|INFO|running time: 0.08 seconds
+2021-01-06 15:26:17|INFO|rows Inserted          = 5
+2021-01-06 15:26:17|INFO|rows Updated           = 0
+2021-01-06 15:26:17|INFO|data formatting errors = 0
+2021-01-06 15:26:17|INFO|gpload succeeded
+2021-01-06 15:26:17|INFO|gpload session started 2021-01-06 15:26:17
+2021-01-06 15:26:17|INFO|setting schema 'public' for table 'texttable2'
+2021-01-06 15:26:17|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2021-01-06 15:26:17|INFO|reusing external table ext_gpload_reusable_7723d6fc_4ff0_11eb_bbcd_00505698d059
+2021-01-06 15:26:17|INFO|running time: 0.06 seconds
+2021-01-06 15:26:17|INFO|rows Inserted          = 5
+2021-01-06 15:26:17|INFO|rows Updated           = 0
+2021-01-06 15:26:17|INFO|data formatting errors = 0
+2021-01-06 15:26:17|INFO|gpload succeeded

--- a/gpMgmt/bin/gpload_test/gpload2/query259.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query259.ans
@@ -1,0 +1,9 @@
+2021-10-25 07:07:31|INFO|gpload session started 2021-10-25 07:07:31
+2021-10-25 07:07:31|INFO|setting schema 'public' for table 'texttable2'
+2021-10-25 07:07:31|INFO|started gpfdist -p 8081 -P 8082 -f "/tmp/build/e18b2f02/gpdb_src/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-10-25 07:07:31|INFO|did not find an external table to reuse. creating ext_gpload_reusable_38cea190_3562_11ec_9d95_92812239cffc
+2021-10-25 07:07:31|ERROR|unexpected error -- backtrace written to log file
+2021-10-25 07:07:31|INFO|rows Inserted          = 0
+2021-10-25 07:07:31|INFO|rows Updated           = 0
+2021-10-25 07:07:31|INFO|data formatting errors = 0
+2021-10-25 07:07:31|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query260.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query260.ans
@@ -1,0 +1,9 @@
+2021-10-25 07:07:31|INFO|gpload session started 2021-10-25 07:07:31
+2021-10-25 07:07:31|INFO|setting schema 'public' for table 'texttable2'
+2021-10-25 07:07:31|INFO|started gpfdist -p 8081 -P 8082 -f "/tmp/build/e18b2f02/gpdb_src/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-10-25 07:07:31|INFO|did not find an external table to reuse. creating ext_gpload_reusable_38cea190_3562_11ec_9d95_92812239cffc
+2021-10-25 07:07:31|ERROR|unexpected error -- backtrace written to log file
+2021-10-25 07:07:31|INFO|rows Inserted          = 0
+2021-10-25 07:07:31|INFO|rows Updated           = 0
+2021-10-25 07:07:31|INFO|data formatting errors = 0
+2021-10-25 07:07:31|INFO|gpload failed

--- a/gpMgmt/doc/gpload_help
+++ b/gpMgmt/doc/gpload_help
@@ -213,6 +213,8 @@ GPLOAD:
     - ERROR_LIMIT: <integer>
     - ERROR_TABLE: <schema>.<table_name>
     - LOG_ERRORS: true | false
+    - NEWLINE: 'LF' | 'CR' | 'CRLF'
+    
    EXTERNAL:
     - SCHEMA: <schema> | '%'
    OUTPUT:
@@ -366,6 +368,13 @@ DELIMITER - Optional. Specifies a single ASCII character that separates columns
             "\u001B". The escape string syntax, E'<character-code>', is also
             supported for non-printable characters. The ASCII or unicode character
             must be enclosed in single quotes. For example: E'\x1B' or E'\u001B'. 
+
+NEWLINE - Optional. Specifies the newline used in your data files – LF
+          (Line feed, 0x0A), CR (Carriage return, 0x0D), or CRLF
+          (Carriage return plus line feed, 0x0D 0x0A). If not
+          specified, a Greenplum Database segment will detect the
+          newline type by looking at the first row of data it receives
+          and using the first newline type encountered.
 
 ESCAPE - Specifies the single character that is used for C escape sequences
         (such as \n,\t,\100, and so on) and for escaping data characters 


### PR DESCRIPTION
Introduce an optional NEWLINE gpload INPUT configuration. This
configuration will in turn be passed to the create external table
FORMAT configuration.

An example of this usage is for the handling of DOS formatted
files (CRLF terminated lines). If used, instead of erroring out, we
can now load data with embedded CR or LF characters in text fields. To
allow this, an optional line termination NEWLINE field ('CR', 'LF',
'CRLF') has been introduced into the gpload INPUT configuration.

The gplaod REUSE_TABLES option is also supported.

The change validates with CSV and TXT file formats.

The change validates an error is received when using an unsupported
NEWLINE value.

The change adds the ability to specify "None" for the 'delimiter' test
configuration. This allows a CSV testing to generate a config file
without a DELIMITER value thus using the default "," value.

Additionally, here are the recommended GP doc gpload utility reference
updates:

CONFIG FILE FORMAT

```
GPLOAD:
   INPUT:

    - NEWLINE: 'LF' | 'CR' | 'CRLF'
```

GPLOAD
  INPUT
```
    NEWLINE

      Specifies the newline used in your data files – LF (Line feed,
      0x0A), CR (Carriage return, 0x0D), or CRLF (Carriage return plus
      line feed, 0x0D 0x0A). If not specified, a Greenplum Database
      segment will detect the newline type by looking at the first row
      of data it receives and using the first newline type
      encountered.
```

**_Special thanks to Don Brown for the fix._**

**Notes**
- In addition to tests added to support gpload NEWLINE configuration, all existing gpload regression tests included with installcheck-world pass.
- The usage of the literal `CR`, `LF` & `CRLF` is similar to how the `CREATE EXTERNAL TABLE` specifies its NEWLINE optional FORMAT configuration - Please refer to the following for its usage: https://gpdb.docs.pivotal.io/6-18/ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.html