### PR TITLE
Fix cannot drop table after creating extension failure with normal user for 6X.

### DIFF
--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -816,27 +816,6 @@ execute_extension_script(Node *stmt,
 			(nodeTag(stmt) == T_CreateExtensionStmt || nodeTag(stmt) == T_AlterExtensionStmt) &&
 			is_begin_state(stmt));
 
-	/*
-	 * Enforce superuser-ness if appropriate.  We postpone this check until
-	 * here so that the flag is correctly associated with the right script(s)
-	 * if it's set in secondary control files.
-	 */
-	if (control->superuser && !superuser())
-	{
-		if (from_version == NULL)
-			ereport(ERROR,
-					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-					 errmsg("permission denied to create extension \"%s\"",
-							control->name),
-					 errhint("Must be superuser to create this extension.")));
-		else
-			ereport(ERROR,
-					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-					 errmsg("permission denied to update extension \"%s\"",
-							control->name),
-					 errhint("Must be superuser to update this extension.")));
-	}
-
 	filename = get_extension_script_filename(control, from_version, version);
 
 	/*
@@ -849,41 +828,6 @@ execute_extension_script(Node *stmt,
 	 * takes care of undoing the setting on error.
 	 */
 	save_nestlevel = NewGUCNestLevel();
-
-	if (client_min_messages < WARNING)
-		(void) set_config_option("client_min_messages", "warning",
-								 PGC_USERSET, PGC_S_SESSION,
-								 GUC_ACTION_SAVE, true, 0);
-	if (log_min_messages < WARNING)
-		(void) set_config_option("log_min_messages", "warning",
-								 PGC_SUSET, PGC_S_SESSION,
-								 GUC_ACTION_SAVE, true, 0);
-
-	/*
-	 * Set up the search path to contain the target schema, then the schemas
-	 * of any prerequisite extensions, and nothing else.  In particular this
-	 * makes the target schema be the default creation target namespace.
-	 *
-	 * Note: it might look tempting to use PushOverrideSearchPath for this,
-	 * but we cannot do that.  We have to actually set the search_path GUC in
-	 * case the extension script examines or changes it.  In any case, the
-	 * GUC_ACTION_SAVE method is just as convenient.
-	 */
-	initStringInfo(&pathbuf);
-	appendStringInfoString(&pathbuf, quote_identifier(schemaName));
-	foreach(lc, requiredSchemas)
-	{
-		Oid			reqschema = lfirst_oid(lc);
-		char	   *reqname = get_namespace_name(reqschema);
-
-		if (reqname)
-			appendStringInfo(&pathbuf, ", %s", quote_identifier(reqname));
-	}
-
-	(void) set_config_option("search_path", pathbuf.data,
-							 PGC_USERSET, PGC_S_SESSION,
-							 GUC_ACTION_SAVE, true, 0);
-
 	/*
 	 * Set creating_extension and related variables so that
 	 * recordDependencyOnCurrentExtension and other functions do the right
@@ -893,6 +837,66 @@ execute_extension_script(Node *stmt,
 	CurrentExtensionObject = extensionOid;
 	PG_TRY();
 	{
+		/*
+		 * Enforce superuser-ness if appropriate.  We postpone this check until
+		 * here so that the flag is correctly associated with the right script(s)
+		 * if it's set in secondary control files.
+		 */
+		/* issue:12713
+		 * The errport below should be included in the try{}catch block, otherwise
+		 * it will cause the creating_extension in QE be true and false in QD which
+		 * may cause the table created by the QEs cannot be removed later.	*/
+		if (control->superuser && !superuser())
+		{
+			if (from_version == NULL)
+				ereport(ERROR,
+						(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+						 errmsg("permission denied to create extension \"%s\"",
+								control->name),
+						 errhint("Must be superuser to create this extension.")));
+			else
+				ereport(ERROR,
+						(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+						 errmsg("permission denied to update extension \"%s\"",
+								control->name),
+						 errhint("Must be superuser to update this extension.")));
+		}
+
+
+		if (client_min_messages < WARNING)
+			(void) set_config_option("client_min_messages", "warning",
+									 PGC_USERSET, PGC_S_SESSION,
+									 GUC_ACTION_SAVE, true, 0);
+		if (log_min_messages < WARNING)
+			(void) set_config_option("log_min_messages", "warning",
+									 PGC_SUSET, PGC_S_SESSION,
+									 GUC_ACTION_SAVE, true, 0);
+
+		/*
+		 * Set up the search path to contain the target schema, then the schemas
+		 * of any prerequisite extensions, and nothing else.  In particular this
+		 * makes the target schema be the default creation target namespace.
+		 *
+		 * Note: it might look tempting to use PushOverrideSearchPath for this,
+		 * but we cannot do that.  We have to actually set the search_path GUC in
+		 * case the extension script examines or changes it.  In any case, the
+		 * GUC_ACTION_SAVE method is just as convenient.
+		 */
+		initStringInfo(&pathbuf);
+		appendStringInfoString(&pathbuf, quote_identifier(schemaName));
+		foreach(lc, requiredSchemas)
+		{
+			Oid			reqschema = lfirst_oid(lc);
+			char	   *reqname = get_namespace_name(reqschema);
+
+			if (reqname)
+				appendStringInfo(&pathbuf, ", %s", quote_identifier(reqname));
+		}
+
+		(void) set_config_option("search_path", pathbuf.data,
+								 PGC_USERSET, PGC_S_SESSION,
+								 GUC_ACTION_SAVE, true, 0);
+
 		char	   *c_sql = read_extension_script_file(control, filename);
 		Datum		t_sql;
 

--- a/src/test/regress/expected/create_extension_gp_debug_segments.out
+++ b/src/test/regress/expected/create_extension_gp_debug_segments.out
@@ -21,3 +21,30 @@ select gp_inject_fault('create_function_fail', 'reset', 2);
  Success:
 (1 row)
 
+--
+-- Tests for cannot drop table after create extension with normal user
+-- The issue: https://github.com/greenplum-db/gpdb/issues/12713
+--
+--1. use normal user to create extension
+--2. create a table
+--3. quit psql
+--4. reconnect
+--5. try to drop the table
+--start_ignore
+drop table if exists t_12713;
+NOTICE:  table "t_12713" does not exist, skipping
+drop user if exists normal_user_12713;
+NOTICE:  role "normal_user_12713" does not exist, skipping
+create user normal_user_12713;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+--end_ignore
+set role normal_user_12713;
+create extension postgres_fdw;
+ERROR:  permission denied to create extension "postgres_fdw"
+HINT:  Must be superuser to create this extension.
+create table t_12713(name text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'name' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+\c
+drop table t_12713;
+drop user normal_user_12713;

--- a/src/test/regress/expected/create_extension_gp_debug_segments.out
+++ b/src/test/regress/expected/create_extension_gp_debug_segments.out
@@ -31,6 +31,8 @@ select gp_inject_fault('create_function_fail', 'reset', 2);
 --4. reconnect
 --5. try to drop the table
 --start_ignore
+drop extension if exists postgres_fdw;
+NOTICE:  extension "postgres_fdw" does not exist, skipping
 drop table if exists t_12713;
 NOTICE:  table "t_12713" does not exist, skipping
 drop user if exists normal_user_12713;

--- a/src/test/regress/sql/create_extension_gp_debug_segments.sql
+++ b/src/test/regress/sql/create_extension_gp_debug_segments.sql
@@ -24,6 +24,7 @@ select gp_inject_fault('create_function_fail', 'reset', 2);
 --5. try to drop the table
 
 --start_ignore
+drop extension if exists postgres_fdw;
 drop table if exists t_12713;
 drop user if exists normal_user_12713;
 create user normal_user_12713;

--- a/src/test/regress/sql/create_extension_gp_debug_segments.sql
+++ b/src/test/regress/sql/create_extension_gp_debug_segments.sql
@@ -13,3 +13,25 @@ create extension gp_debug_numsegments;
 
 select gp_inject_fault('create_function_fail', 'reset', 2);
 
+--
+-- Tests for cannot drop table after create extension with normal user
+-- The issue: https://github.com/greenplum-db/gpdb/issues/12713
+--
+--1. use normal user to create extension
+--2. create a table
+--3. quit psql
+--4. reconnect
+--5. try to drop the table
+
+--start_ignore
+drop table if exists t_12713;
+drop user if exists normal_user_12713;
+create user normal_user_12713;
+--end_ignore
+
+set role normal_user_12713;
+create extension postgres_fdw;
+create table t_12713(name text);
+\c
+drop table t_12713;
+drop user normal_user_12713;


### PR DESCRIPTION
Issue: https://github.com/greenplum-db/gpdb/issues/12713

The problem is first found in gpload. And after multiple retries one reproduce prodedure was found:
1. First use a normal user (not super user) to create extension and hit an error
with "permission denied"
2. Then create a table within the same psql connection.
3. Then quit the psql connection and start a new one and try to drop the table
created in step 2.
```
gpadmin=# set role test;
SET
gpadmin=> create extension gp_inject_fault ;
ERROR:  permission denied to create extension "gp_inject_fault"
HINT:  Must be superuser to create this extension.
gpadmin=> create table t(a int);
CREATE TABLE
gpadmin=> quit;
gpadmin@zlv-ubuntu:~/gpdb$ psql
psql (12beta2)
Type "help" for help.

gpadmin=# set role test;
SET
gpadmin=> drop table t;
ERROR:  cache lookup failed for extension 16415 (objectaddress.c:3570)  (seg1 127.0.1.1:7003 pid=16991) (objectaddress.c:3570)
```
The reason for this is that the user acl judgement code in "execute_extension_script" fails to catch the error throw
inside the user acl judgement which makes the QD fails to call CdbDispatchUtilityStatement to QEs to set the "creating_extension" to false:
(a. Before the QD runs at the user acl judgement, the QD has call CdbDispatchUtilityStatement to start createextension.
b. Then QE executes the "CreateExtension" function in "CREATE_EXTENSION_BEGIN" switch branch, and set the "creating_extension" to true in QEs.
c. If everything goes fine, the QD will call CdbDispatchUtilityStatement at end of the function "execute_extension_script"
d. Then QEs will execute "CREATE_EXTENSION_BEGIN" again and set the  "creating_extension" to false.)
But in this issue, the value of "creating_extension" in QD is false, and in QEs to be true.

In later session of creating table will call the function "recordDependencyOnCurrentExtension" and will add
dependance of the failed extension which will make the catalogs in QEs and QD incompatible.

The fix is quite straight forward:
Move the user acl judgement code into the try{...}catch{} block.

Take a look at issue:12713 to see more details.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
