### PR TITLE
Add throttle logic to slow down WAL writes in CATCHUP phase. 

### DIFF
--- a/src/backend/replication/gp_replication.c
+++ b/src/backend/replication/gp_replication.c
@@ -581,6 +581,27 @@ GetMirrorStatus(FtsResponse *response, bool *ready_for_syncrep)
 }
 
 /*
+ * Is the mirror catching up?
+ */
+bool
+gp_is_mirror_catching_up(void)
+{
+	int			i;
+	uint32		stval;
+
+	for (i = 0; i < max_wal_senders; i++)
+	{
+		volatile WalSnd *walsender = &WalSndCtl->walsnds[i];
+
+		stval = pg_atomic_read_u32(&walsender->state_value);
+		if (stval == (uint32)WALSNDSTATE_CATCHUP)
+			return true;
+	}
+
+	return false;
+}
+
+/*
  * Set WalSndCtl->sync_standbys_defined to true to enable synchronous segment
  * WAL replication and insert synchronous_standby_names="*" into the
  * gp_replication.conf to persist this state in case of segment crash.

--- a/src/backend/storage/lmgr/lwlocknames.txt
+++ b/src/backend/storage/lmgr/lwlocknames.txt
@@ -66,3 +66,4 @@ ShareInputScanLock				56
 FTSReplicationStatusLock			57
 GxidBumpLock						58
 ParallelCursorEndpointLock			59
+WalCatchupThrottleLock              60

--- a/src/include/replication/gp_replication.h
+++ b/src/include/replication/gp_replication.h
@@ -74,6 +74,7 @@ extern void FTSReplicationStatusMarkDisconnectForReplication(const char *app_nam
 extern pg_time_t FTSGetReplicationDisconnectTime(const char *app_name);
 
 extern void GetMirrorStatus(FtsResponse *response, bool *ready_for_syncrep);
+extern bool gp_is_mirror_catching_up(void);
 extern void SetSyncStandbysDefined(void);
 extern void UnsetSyncStandbysDefined(void);
 

--- a/src/include/replication/walsender_private.h
+++ b/src/include/replication/walsender_private.h
@@ -12,6 +12,7 @@
 #ifndef _WALSENDER_PRIVATE_H
 #define _WALSENDER_PRIVATE_H
 
+#include "port/atomics.h"
 #include "access/xlog.h"
 #include "nodes/nodes.h"
 #include "replication/syncrep.h"
@@ -106,6 +107,12 @@ typedef struct WalSnd
 	 * mirror in streaming mode
 	 */
 	bool 		is_for_gp_walreceiver;
+
+	/*
+	 * An atomic variable to combine walsender state with other indicators
+	 * to identify some state-aware situation.
+	 */
+	pg_atomic_uint32	state_value;
 } WalSnd;
 
 extern WalSnd *MyWalSnd;

--- a/src/test/isolation2/expected/segwalrep/xact_throttle_when_catchup.out
+++ b/src/test/isolation2/expected/segwalrep/xact_throttle_when_catchup.out
@@ -1,0 +1,178 @@
+--
+-- Test: transaction commits should be throttled when mirror is in
+-- catchup state due to a big lag.
+-- Throttle test is difficult to automate, this is trying to represent
+-- whether transactions being throttled or not by showing a single
+-- transaction blocking/unblocking result. The theory is that:
+-- generating a bulk inserts to enlarge the WAL lag between primary
+-- and mirror;
+-- having mirror stay CATCHUP state with syncrep off by suspending
+-- 'wal_sender_after_caughtup_within_range' injection point;
+-- creating insert transaction with different record size to verify
+-- the position of blocking among transaction statements.
+--
+-- setup
+!\retcode gpconfig -c wait_for_replication_threshold -v 1 --skipvalidation;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -u;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+
+CREATE TABLE xact_throttle_tbl (a int, b int, c text) DISTRIBUTED BY (a);
+CREATE
+CHECKPOINT;
+CHECKPOINT
+
+1: SELECT gp_inject_fault_infinite('wal_sender_after_caughtup_within_range', 'suspend', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- stop the mirror
+1: SELECT pg_ctl((SELECT datadir FROM gp_segment_configuration c WHERE c.role='m' AND c.content=0), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+1: SELECT gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- insert records to the primary, '2' will be distributed to content 0,
+1: BEGIN;
+BEGIN
+1: INSERT INTO xact_throttle_tbl VALUES(2, 0, 'a');
+INSERT 1
+-- stuck at executing COMMIT since syncrep hasn't been turned off yet
+1: COMMIT;
+COMMIT
+
+-- generate a large WAL lag which will create several WAL segment files
+1: INSERT INTO xact_throttle_tbl SELECT 2, generate_series(1, 3000000), 'a';
+INSERT 3000000
+
+-- make sure mirror is in catchup state
+0U&: SELECT wait_until_standby_in_state('catchup');  <waiting ...>
+
+-- bring the mirror back up, make sure it is in catchup state
+1: SELECT pg_ctl_start(datadir, port) FROM gp_segment_configuration WHERE role = 'm' AND content = 0;
+ pg_ctl_start                                     
+--------------------------------------------------
+ waiting for server to start done
+server started
+ 
+(1 row)
+
+-- show catchup state
+0U<:  <... completed>
+ wait_until_standby_in_state 
+-----------------------------
+ catchup                     
+(1 row)
+
+1: SELECT gp_wait_until_triggered_fault('wal_sender_after_caughtup_within_range', 1, dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- make sure syncrep is off
+0U: show synchronous_standby_names;
+ synchronous_standby_names 
+---------------------------
+                           
+(1 row)
+
+-- now mirror stays at CATCHUP state, and syncrep stays at off
+
+-- a) insert transactions with small WAL bytes written should not be blocked,
+-- this also indicates slow and small inserts would not be blocked or throttled
+1: BEGIN;
+BEGIN
+1: INSERT INTO xact_throttle_tbl VALUES(2, 0, 'a');
+INSERT 1
+1: COMMIT;
+COMMIT
+
+-- b) insert transactions with large WAL bytes written should be throttled
+-- make sure the replication threshold is 1024, then insert a longer record
+-- e.g. 1025 like below to generate a "large" WAL record
+0U: show wait_for_replication_threshold;
+ wait_for_replication_threshold 
+--------------------------------
+ 1kB                            
+(1 row)
+
+2: BEGIN;
+BEGIN
+-- stuck before executing COMMIT due to throttle
+2&: INSERT INTO xact_throttle_tbl VALUES(2, 2, repeat('a', 1025));  <waiting ...>
+
+-- c) bulk inserts may enlarge WAL bytes written size, resulting throttle
+-- Actually, this case is mutually exclusive with the above one since the system
+-- is already pending on writing above WAL record, new queries could not be proceeded
+-- any more. Put it here as a comment for creating large WAL record in this way.
+-- 3&: INSERT INTO xact_throttle_tbl SELECT 2, generate_series(4000000, 5000000), 'aa';
+
+-- wait for a moment to ensure the insert transaction is still running
+1: SELECT pg_sleep(5);
+ pg_sleep 
+----------
+          
+(1 row)
+-- check the current query in pg_stat_activity after waiting, the state should be still 'active'
+1: SELECT application_name,state,query,backend_type FROM pg_stat_activity WHERE query LIKE 'INSERT INTO xact_throttle_tbl%';
+ application_name | state  | query                                                          | backend_type   
+------------------+--------+----------------------------------------------------------------+----------------
+ pg_regress       | active | INSERT INTO xact_throttle_tbl VALUES(2, 2, repeat('a', 1025)); | client backend 
+(1 row)
+
+-- reset fault on primary as well as mirror
+1: SELECT gp_inject_fault('wal_sender_after_caughtup_within_range', 'reset', dbid) FROM gp_segment_configuration WHERE content=0;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+(2 rows)
+
+-- after this, system continue to proceed
+
+2<:  <... completed>
+INSERT 1
+2: COMMIT;
+COMMIT
+
+SELECT wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+-- make sure syncrep is on
+0U: show synchronous_standby_names;
+ synchronous_standby_names 
+---------------------------
+ *                         
+(1 row)
+
+-- cleanup
+DROP TABLE xact_throttle_tbl;
+DROP
+!\retcode gpconfig -r wait_for_replication_threshold --skipvalidation;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -u;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -239,6 +239,7 @@ test: segwalrep/dtm_recovery_on_standby
 test: segwalrep/commit_blocking_on_standby
 test: segwalrep/dtx_recovery_wait_lsn
 test: segwalrep/select_throttle
+test: segwalrep/xact_throttle_when_catchup
 test: fts_manual_probe
 test: fts_session_reset
 test: fts_segment_reset

--- a/src/test/isolation2/sql/segwalrep/xact_throttle_when_catchup.sql
+++ b/src/test/isolation2/sql/segwalrep/xact_throttle_when_catchup.sql
@@ -1,0 +1,97 @@
+--
+-- Test: transaction commits should be throttled when mirror is in
+-- catchup state due to a big lag.
+-- Throttle test is difficult to automate, this is trying to represent
+-- whether transactions being throttled or not by showing a single
+-- transaction blocking/unblocking result. The theory is that:
+-- generating a bulk inserts to enlarge the WAL lag between primary
+-- and mirror;
+-- having mirror stay CATCHUP state with syncrep off by suspending
+-- 'wal_sender_after_caughtup_within_range' injection point;
+-- creating insert transaction with different record size to verify
+-- the position of blocking among transaction statements.
+--
+-- setup
+!\retcode gpconfig -c wait_for_replication_threshold -v 1 --skipvalidation;
+!\retcode gpstop -u;
+
+CREATE TABLE xact_throttle_tbl (a int, b int, c text) DISTRIBUTED BY (a);
+CHECKPOINT;
+
+1: SELECT gp_inject_fault_infinite('wal_sender_after_caughtup_within_range', 'suspend', dbid)
+    FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+
+-- stop the mirror
+1: SELECT pg_ctl((SELECT datadir FROM gp_segment_configuration c WHERE c.role='m' AND c.content=0), 'stop');
+1: SELECT gp_request_fts_probe_scan();
+
+-- insert records to the primary, '2' will be distributed to content 0,
+1: BEGIN;
+1: INSERT INTO xact_throttle_tbl VALUES(2, 0, 'a');
+-- stuck at executing COMMIT since syncrep hasn't been turned off yet
+1: COMMIT;
+
+-- generate a large WAL lag which will create several WAL segment files
+1: INSERT INTO xact_throttle_tbl SELECT 2, generate_series(1, 3000000), 'a';
+
+-- make sure mirror is in catchup state
+0U&: SELECT wait_until_standby_in_state('catchup');
+
+-- bring the mirror back up, make sure it is in catchup state
+1: SELECT pg_ctl_start(datadir, port) FROM gp_segment_configuration WHERE role = 'm' AND content = 0;
+
+-- show catchup state
+0U<:
+
+1: SELECT gp_wait_until_triggered_fault('wal_sender_after_caughtup_within_range', 1, dbid)
+    FROM gp_segment_configuration WHERE content=0 AND role='p';
+
+-- make sure syncrep is off
+0U: show synchronous_standby_names;
+
+-- now mirror stays at CATCHUP state, and syncrep stays at off
+
+-- a) insert transactions with small WAL bytes written should not be blocked,
+-- this also indicates slow and small inserts would not be blocked or throttled
+1: BEGIN;
+1: INSERT INTO xact_throttle_tbl VALUES(2, 0, 'a');
+1: COMMIT;
+
+-- b) insert transactions with large WAL bytes written should be throttled
+-- make sure the replication threshold is 1024, then insert a longer record
+-- e.g. 1025 like below to generate a "large" WAL record
+0U: show wait_for_replication_threshold;
+
+2: BEGIN;
+-- stuck before executing COMMIT due to throttle
+2&: INSERT INTO xact_throttle_tbl VALUES(2, 2, repeat('a', 1025));
+
+-- c) bulk inserts may enlarge WAL bytes written size, resulting throttle
+-- Actually, this case is mutually exclusive with the above one since the system
+-- is already pending on writing above WAL record, new queries could not be proceeded
+-- any more. Put it here as a comment for creating large WAL record in this way.
+-- 3&: INSERT INTO xact_throttle_tbl SELECT 2, generate_series(4000000, 5000000), 'aa';
+
+-- wait for a moment to ensure the insert transaction is still running
+1: SELECT pg_sleep(5);
+-- check the current query in pg_stat_activity after waiting, the state should be still 'active'
+1: SELECT application_name,state,query,backend_type FROM pg_stat_activity WHERE query LIKE 'INSERT INTO xact_throttle_tbl%';
+
+-- reset fault on primary as well as mirror
+1: SELECT gp_inject_fault('wal_sender_after_caughtup_within_range', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content=0;
+
+-- after this, system continue to proceed
+
+2<:
+2: COMMIT;
+
+SELECT wait_until_all_segments_synchronized();
+
+-- make sure syncrep is on
+0U: show synchronous_standby_names;
+
+-- cleanup
+DROP TABLE xact_throttle_tbl;
+!\retcode gpconfig -r wait_for_replication_threshold --skipvalidation;
+!\retcode gpstop -u;


### PR DESCRIPTION
There was a guc repl_catchup_within_range that "Sets the maximum number of xlog
segments allowed to lag when the backends can start blocking despite the WAL
sender being in catchup phase." It was for the coordinator only. Now we could
use it on segments also, but this mechanism is not sufficient if the new wal is
generated faster - wal catchup would need more time and the primary is at the
risk of data loss during the period due to syncrep off. So we do further
throttle in large wal write function to slow down those transactions a bit and
leave more resources to wal catchup.

xlog lag is calculated using GetFlushRecPtr() -
XLogGetReplicationSlotMinimumLSN(), but note XLogGetReplicationSlotMinimumLSN()
is not updated very frequently - I created a thead about this in pgsql-hackers
mail list but this does not affect our patch much. (just slows down the write
query further during wal catchup).

Co-authored-by: Haolin Wang <whaolin@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
