### PR TITLE
Replace MemoryContextContainsGenericAllocation() with a more robust version

### DIFF
--- a/src/backend/executor/nodeWindowAgg.c
+++ b/src/backend/executor/nodeWindowAgg.c
@@ -1256,10 +1256,7 @@ eval_windowfunction(WindowAggState *winstate, WindowStatePerFunc perfuncstate,
 	// GPDB_84_MERGE_FIXME: In upstream, we know that the allocation
 	// was palloc in some memory context, but in GPDB, that is not true.
 	// So we have to use MemoryContextContainsGenericAllocation instead of
-	// plain MemoryContextContains(). This is not actually 100% safe, there is
-	// a small chance MemoryContextContainsGenericAllocation() incorrectly
-	// says that the chunk is in the context, which could lead to a crash.
-	// nodeAgg.c has the same problem.
+	// plain MemoryContextContains().
 	if (!perfuncstate->resulttypeByVal && !fcinfo.isnull &&
 		!MemoryContextContainsGenericAllocation(CurrentMemoryContext,
 							   DatumGetPointer(*result))

--- a/src/backend/utils/mmgr/test/Makefile
+++ b/src/backend/utils/mmgr/test/Makefile
@@ -2,7 +2,7 @@ subdir=src/backend/utils/mmgr
 top_builddir=../../../../..
 include $(top_builddir)/src/Makefile.global
 
-TARGETS=aset memaccounting vmem_tracker redzone_handler runaway_cleaner idle_tracker event_version memprot
+TARGETS=aset memaccounting vmem_tracker redzone_handler runaway_cleaner idle_tracker event_version memprot mcxt
 
 include $(top_builddir)/src/backend/mock.mk
 

--- a/src/backend/utils/mmgr/test/mcxt_test.c
+++ b/src/backend/utils/mmgr/test/mcxt_test.c
@@ -1,0 +1,163 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#include "../mcxt.c"
+
+static void
+test__MemoryContextContainsGenericAllocation_DoesContain(void **state)
+{
+	MemoryContext mcxt = AllocSetContextCreate(ErrorContext,
+													 "TestContext",
+													 ALLOCSET_DEFAULT_MINSIZE,
+													 ALLOCSET_DEFAULT_INITSIZE,
+													 ALLOCSET_DEFAULT_MAXSIZE);
+	MemoryContextSwitchTo(mcxt);
+
+	// Most common case, where pointer points to beginning of a chunk allocated
+	//  in the correct context  (true positive)
+	char *pointer = palloc(500);
+	bool contains = MemoryContextContainsGenericAllocation(mcxt, pointer);
+	assert_true(contains);
+
+	// Make sure this also works for pointers into an offset of a chunk from
+	//   the right context, and misaligned
+	contains = MemoryContextContainsGenericAllocation(mcxt, pointer + 499);
+	assert_true(contains);
+}
+
+static void
+test__MemoryContextContainsGenericAllocation_DoesNotContainAllocationFromAnotherMemoryContext(void **state)
+{
+	MemoryContext mcxt = AllocSetContextCreate(ErrorContext,
+													 "A memory context",
+													 ALLOCSET_DEFAULT_MINSIZE,
+													 ALLOCSET_DEFAULT_INITSIZE,
+													 ALLOCSET_DEFAULT_MAXSIZE);
+	MemoryContext another_mcxt = AllocSetContextCreate(ErrorContext,
+													 "Another memory context",
+													 ALLOCSET_DEFAULT_MINSIZE,
+													 ALLOCSET_DEFAULT_INITSIZE,
+													 ALLOCSET_DEFAULT_MAXSIZE);
+
+	MemoryContextSwitchTo(mcxt);
+
+	bool contains;
+	void *pointer = palloc(sizeof(char));
+
+	contains = MemoryContextContainsGenericAllocation(another_mcxt, pointer);
+	assert_false(contains);
+}
+
+static void
+test__MemoryContextContainsGenericAllocation_FalsePositive(void **state)
+{
+	MemoryContext mcxt = AllocSetContextCreate(ErrorContext,
+													 "A memory context",
+													 ALLOCSET_DEFAULT_MINSIZE,
+													 ALLOCSET_DEFAULT_INITSIZE,
+													 ALLOCSET_DEFAULT_MAXSIZE);
+	MemoryContext another_mcxt = AllocSetContextCreate(ErrorContext,
+													 "Another memory context",
+													 ALLOCSET_DEFAULT_MINSIZE,
+													 ALLOCSET_DEFAULT_INITSIZE,
+													 ALLOCSET_DEFAULT_MAXSIZE);
+
+	MemoryContextSwitchTo(another_mcxt);
+	char *pointer = palloc(500);
+	bool contains;
+
+	//  With the previous MemoryContextContains() function, you could get a
+	//  false positive here if the pointer points into the middle of a palloc'd
+	//  region (which does happen in some window functions, such as LAG()
+	//  where the pointer can point to columns within previously allocated memtuples)
+	//  instead of the beginning, where the memory just before the pointer happens
+	//  to match the address of the memory context.  This is rare in gpdb7, but
+	//  we were seeing it happen in gpdb6 when the preceeding memory was all 0's
+	pointer += 200;
+
+	(((StandardChunkHeader *) pointer) - 1)->sharedHeader = NULL;
+
+	// check for false positive when memory just before pointer contains
+	// a null pointer -- this was happening with LAG() function in gpdb6 before
+	contains = MemoryContextContainsGenericAllocation(mcxt, pointer);
+	assert_false(contains);
+
+	(((StandardChunkHeader *) pointer) - 1)->sharedHeader = another_mcxt;
+
+	// check for a rare case of a false negative when memory just before 
+	// pointer happens to contain the address of the mcxt it's looking for
+	contains = MemoryContextContainsGenericAllocation(mcxt, pointer);
+	assert_false(contains);
+}
+
+static void
+test__MemoryContextContainsGenericAllocation_FalseNegative(void **state)
+{
+	MemoryContext mcxt = AllocSetContextCreate(ErrorContext,
+													 "A memory context",
+													 ALLOCSET_DEFAULT_MINSIZE,
+													 ALLOCSET_DEFAULT_INITSIZE,
+													 ALLOCSET_DEFAULT_MAXSIZE);
+	MemoryContext another_mcxt = AllocSetContextCreate(ErrorContext,
+													 "Another memory context",
+													 ALLOCSET_DEFAULT_MINSIZE,
+													 ALLOCSET_DEFAULT_INITSIZE,
+													 ALLOCSET_DEFAULT_MAXSIZE);
+	MemoryContextSwitchTo(mcxt);
+	char *pointer = palloc(500);
+	pointer += 200;
+
+	(((StandardChunkHeader *) pointer) - 1)->sharedHeader = another_mcxt;
+
+	// check for a rare case of a false negative when memory just before 
+	// pointer happens to contain the address of the mcxt it's looking for
+	bool contains = MemoryContextContainsGenericAllocation(mcxt, pointer);
+	assert_true(contains);
+}
+
+static void
+test__MemoryContextContainsGenericAllocation_MultipleAllocations(void **state) {
+	MemoryContext mcxt = AllocSetContextCreate(ErrorContext,
+													 "A memory context",
+													 ALLOCSET_DEFAULT_MINSIZE,
+													 ALLOCSET_DEFAULT_INITSIZE,
+													 ALLOCSET_DEFAULT_MAXSIZE);
+
+	MemoryContextSwitchTo(mcxt);
+
+	for (Size s = 1; s < 5 * ALLOCSET_DEFAULT_INITSIZE; s *= 16) {
+		assert_true(MemoryContextContainsGenericAllocation(mcxt, palloc(s)));
+	}
+}
+
+static void
+test__MemoryContextContainsGenericAllocation_DoesNotContainNullPointer(void **state)
+{
+	MemoryContext mcxt = AllocSetContextCreate(ErrorContext,
+													 "TestContext",
+													 ALLOCSET_DEFAULT_MINSIZE,
+													 ALLOCSET_DEFAULT_INITSIZE,
+													 ALLOCSET_DEFAULT_MAXSIZE);
+	bool contains = MemoryContextContainsGenericAllocation(mcxt, NULL);
+	assert_false(contains);
+}
+
+int
+main(int argc, char* argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+
+	const UnitTest tests[] = {
+		unit_test(test__MemoryContextContainsGenericAllocation_DoesContain),
+		unit_test(test__MemoryContextContainsGenericAllocation_DoesNotContainAllocationFromAnotherMemoryContext),
+		unit_test(test__MemoryContextContainsGenericAllocation_MultipleAllocations),
+		unit_test(test__MemoryContextContainsGenericAllocation_FalsePositive),
+		unit_test(test__MemoryContextContainsGenericAllocation_FalseNegative),
+		unit_test(test__MemoryContextContainsGenericAllocation_DoesNotContainNullPointer)
+	};
+
+	return run_tests(tests);
+}
+

--- a/src/include/utils/memutils.h
+++ b/src/include/utils/memutils.h
@@ -226,7 +226,6 @@ extern void dump_memory_allocation_ctxt(FILE * ofile, void *ctxt);
 #ifdef MEMORY_CONTEXT_CHECKING
 extern void MemoryContextCheck(MemoryContext context);
 #endif
-extern bool MemoryContextContains(MemoryContext context, void *pointer);
 extern bool MemoryContextContainsGenericAllocation(MemoryContext context, void *pointer);
 
 /* Functions called only by context-type-specific memory managers... */
@@ -262,6 +261,8 @@ extern MemoryContext AllocSetContextCreate(MemoryContext parent,
 					  Size minContextSize,
 					  Size initBlockSize,
 					  Size maxBlockSize);
+
+extern bool AllocSetContains(MemoryContext context, void *pointer);
 
 /* mpool.c */
 typedef struct MPool MPool;


### PR DESCRIPTION
The existing version of MemoryContextContainsGeneric(context, pointer) reads the 24 bytes of memory preceding the pointer passed to it, casts it to a StandardChunkHeader, and returns true or false based on whether the address stored at header->sharedHeader matches any of the addresses in the context->sharedHeaderList.

This was an improvement  over MemoryContextContains(context, pointer), which dereferences header->sharedHeader causing an immediate crash if header->sharedHeader is not a valid pointer (which is the case, whenever it points to a memory structure not aligned with the beginning of a chunk allocated with palloc()).  But several problems with it remained.

As with MemoryContextContains(), the present version of MemoryContextContainsGenericAllocation works fine for pointers which point to the beginning of a memory chunk allocated by palloc().  But is still not safe to call when the pointer points to an offset into a chunk of memory.  It won't crash immediately, but if the memory at header->sharedHeader happens to be all 0's, then it will be interpreted as a NULL pointer which always matches the end of the linked list, which terminates with NULL.  This was causing crashes reported by existing users of gpdb.  A less likely way in which  the same crash can happen is if the bytes at that address happen to match anything in the linked list.

In postgres, the pointers passed to it point to the beginning of a chunk. But in gpdb, that's often not the case... so this function can cause cause a crash if the above circumstances occur.  (This is less of an issue in gpdb7, where a NULL will not match, but the less likely version can still happen.)

Since there is no current case(*) in gpdb where we can guarantee that the pointer passed to it is pointing to the beginning of a chunk, we've disabled MemoryContextContains() entirely with Assert(false), and replaced MemoryContextGenericAllocation() with a different implementation, fully safe to call on any valid pointer. The new method traverses the block list at a lower level, so it's specific to AllocSet.  AllocSet is the only type of MemoryContext in gpdb6, but in more recent versions of postgres and gpdb, there are others defined, so we just throw an error if it's not an AllocSet.

(*) A typical scenario for how this is called:

Input tuples are spooled into memory in a tmpcontext, while output tuples from window functions are allocated in a more permanent memory context, exprcontext.
Window functions might allocate their own memory, but it's also common for them to return pointers to data which has already been allocated previously... often in the temporary input context rather than the output context. For example, the function LAG() will return a pointer to a single column (attr) within a MemTuple representing its value in a previous row. If this is not the first column in the tuple, then the pointer will not point to the beginning of the memory chunk which stores an array of values, one for each attr.
If MemoryContexContainsGenericAllocation() return false, then the memory pointed to is copied over to the more permanent context, but not copied if it returns true. We could just always copy, but if the data is large then this would incur extra performance cost, which is why it's important to be able to decide accurately which context the pointer was actually allocated in. A false positive can cause a crash later, after the tmpcontext gets reset and reused for something else.