### PR TITLE
Ensure PrepareTempTablespaces() is called when using temp tablespaces

### DIFF
--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -419,15 +419,7 @@ sisc_lockname(char *p, int size, int share_id, const char* name)
 			 "gpcdb2.sisc_%d_%d_%d_%d_%s",
 			 GpIdentity.segindex, gp_session_id, gp_command_count, share_id, name);
 
-	/*
-	 * Ensure that temp tablespaces are set up to build temporary path.
-	 * Possibly the caller will have done this already, but it seems useful to
-	 * double-check here.  Failure to do this at all would result in the temp
-	 * files always getting placed in the default tablespace, which is a
-	 * pretty hard-to-detect bug.  Callers may prefer to do it earlier if they
-	 * want to be sure that any required catalog access is done in some other
-	 * resource context.
-	 */
+	/* Ensure that temp tablespaces are set up to build temporary path. */
 	PrepareTempTablespaces();
 	path = GetTempFilePath(filename, true);
 	if (strlen(path) >= size)

--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -419,6 +419,16 @@ sisc_lockname(char *p, int size, int share_id, const char* name)
 			 "gpcdb2.sisc_%d_%d_%d_%d_%s",
 			 GpIdentity.segindex, gp_session_id, gp_command_count, share_id, name);
 
+	/*
+	 * Ensure that temp tablespaces are set up to build temporary path.
+	 * Possibly the caller will have done this already, but it seems useful to
+	 * double-check here.  Failure to do this at all would result in the temp
+	 * files always getting placed in the default tablespace, which is a
+	 * pretty hard-to-detect bug.  Callers may prefer to do it earlier if they
+	 * want to be sure that any required catalog access is done in some other
+	 * resource context.
+	 */
+	PrepareTempTablespaces();
 	path = GetTempFilePath(filename, true);
 	if (strlen(path) >= size)
 		elog(ERROR, "path to temporary file too long: %s", path);

--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -63,6 +63,7 @@
 #include <zstd.h>
 #endif
 
+#include "commands/tablespace.h"
 #include "executor/instrument.h"
 #include "storage/fd.h"
 #include "storage/buffile.h"
@@ -238,6 +239,17 @@ BufFileCreateNamedTemp(const char *fileName, bool interXact, workfile_set *work_
 {
 	File		pfile;
 	BufFile	   *file;
+
+	/*
+	 * Ensure that temp tablespaces are set up for OpenTemporaryFile to use.
+	 * Possibly the caller will have done this already, but it seems useful to
+	 * double-check here.  Failure to do this at all would result in the temp
+	 * files always getting placed in the default tablespace, which is a
+	 * pretty hard-to-detect bug.  Callers may prefer to do it earlier if they
+	 * want to be sure that any required catalog access is done in some other
+	 * resource context.
+	 */
+	PrepareTempTablespaces();
 
 	pfile = OpenNamedTemporaryFile(fileName,
 								   true, /* create */

--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -202,6 +202,16 @@ BufFileCreateTempInSet(workfile_set *work_set, bool interXact)
 
 	snprintf(filePrefix, MAXPGPATH, "_%s_", work_set->prefix);
 
+	/*
+	 * Ensure that temp tablespaces are set up for OpenTemporaryFile to use.
+	 * Possibly the caller will have done this already, but it seems useful to
+	 * double-check here.  Failure to do this at all would result in the temp
+	 * files always getting placed in the default tablespace, which is a
+	 * pretty hard-to-detect bug.  Callers may prefer to do it earlier if they
+	 * want to be sure that any required catalog access is done in some other
+	 * resource context.
+	 */
+	PrepareTempTablespaces();
 	pfile = OpenTemporaryFile(interXact, filePrefix);
 	Assert(pfile >= 0);
 
@@ -241,7 +251,7 @@ BufFileCreateNamedTemp(const char *fileName, bool interXact, workfile_set *work_
 	BufFile	   *file;
 
 	/*
-	 * Ensure that temp tablespaces are set up for OpenTemporaryFile to use.
+	 * Ensure that temp tablespaces are set up for OpenNamedTemporaryFile to use.
 	 * Possibly the caller will have done this already, but it seems useful to
 	 * double-check here.  Failure to do this at all would result in the temp
 	 * files always getting placed in the default tablespace, which is a
@@ -280,6 +290,16 @@ BufFileOpenNamedTemp(const char *fileName, bool interXact)
 	File		pfile;
 	BufFile	   *file;
 
+	/*
+	 * Ensure that temp tablespaces are set up for OpenTemporaryFile to use.
+	 * Possibly the caller will have done this already, but it seems useful to
+	 * double-check here.  Failure to do this at all would result in the temp
+	 * files always getting placed in the default tablespace, which is a
+	 * pretty hard-to-detect bug.  Callers may prefer to do it earlier if they
+	 * want to be sure that any required catalog access is done in some other
+	 * resource context.
+	 */
+	PrepareTempTablespaces();
 	pfile = OpenNamedTemporaryFile(fileName,
 								   false,	/* create */
 								   false,	/* delOnClose */

--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -291,7 +291,7 @@ BufFileOpenNamedTemp(const char *fileName, bool interXact)
 	BufFile	   *file;
 
 	/*
-	 * Ensure that temp tablespaces are set up for OpenTemporaryFile to use.
+	 * Ensure that temp tablespaces are set up for OpenNamedTemporaryFile to use.
 	 * Possibly the caller will have done this already, but it seems useful to
 	 * double-check here.  Failure to do this at all would result in the temp
 	 * files always getting placed in the default tablespace, which is a

--- a/src/test/regress/input/temp_tablespaces.source
+++ b/src/test/regress/input/temp_tablespaces.source
@@ -171,11 +171,11 @@ select gp_tablespace_watch_log(gp_execution_dbid(), '[temp_tablespace]: separato
 
 set statement_mem='1MB';
 select count(*) from (select i, count(*) from tts_aggspill group by i,j,t having count(*) = 3) g;
--- supress too many output tuples, so sort(maybe merge sort) spills
-\o /dev/null
-select i1, count(distinct(i4)), count(1), count(distinct(i2)) , count(distinct(i3))
+--start_ignore
+-- ignore the output, we only need the following query to spill on Sort
+explain analyze select i1, count(distinct(i4)), count(1), count(distinct(i2)) , count(distinct(i3))
     from tts_testsiscm group by i1 order by 3,4,5 desc;
-\o
+--end_ignore
 
 set optimizer = off;
 set statement_mem='3MB';
@@ -248,10 +248,11 @@ select gp_tablespace_watch_log(gp_execution_dbid(), '[temp_tablespace]: separato
 set statement_mem='1MB';
 -- hash aggregate should spill on the default tablespace.
 select count(*) from (select i, count(*) from tts_aggspill group by i,j,t having count(*) = 3) g;
-\o /dev/null
-select i1, count(distinct(i4)), count(1), count(distinct(i2)) , count(distinct(i3))
+--start_ignore
+-- ignore the output, we only need the following query to spill on Sort
+explain analyze select i1, count(distinct(i4)), count(1), count(distinct(i2)) , count(distinct(i3))
     from tts_testsiscm group by i1 order by 3,4,5 desc;
-\o
+--end_ignore
 
 set optimizer = off;
 set statement_mem='3MB';

--- a/src/test/regress/input/temp_tablespaces.source
+++ b/src/test/regress/input/temp_tablespaces.source
@@ -111,7 +111,6 @@ CREATE TABLE tts_aggspill (i int, j int, t text) distributed by (i);
 CREATE TABLE tts_testsiscm (i1 int, i2 int, i3 int, i4 int) distributed by(i1);
 
 
-
 insert into tts_foo select i, i from generate_series(1,1000000)i;
 insert into tts_bar select i, i from generate_series(6000,120000)i;
 insert into tts_jazz select i, i from generate_series(4000,150000)i;
@@ -172,6 +171,11 @@ select gp_tablespace_watch_log(gp_execution_dbid(), '[temp_tablespace]: separato
 
 set statement_mem='1MB';
 select count(*) from (select i, count(*) from tts_aggspill group by i,j,t having count(*) = 3) g;
+-- supress too many output tuples, so sort(maybe merge sort) spills
+\o /dev/null
+select i1, count(distinct(i4)), count(1), count(distinct(i2)) , count(distinct(i3))
+    from tts_testsiscm group by i1 order by 3,4,5 desc;
+\o
 
 set optimizer = off;
 set statement_mem='3MB';
@@ -188,6 +192,8 @@ select gp_tablespace_watch_match(gp_execution_dbid(), 'temp', '_HashJoin') > 0 a
 
 select gp_tablespace_watch_match(gp_execution_dbid(), 'default', '_SIRW_') > 0 as "exist";
 select gp_tablespace_watch_match(gp_execution_dbid(), 'temp', '_SIRW_') > 0 as "exist";
+select gp_tablespace_watch_match(gp_execution_dbid(), 'default', '_Sort_') > 0 as "exist";
+select gp_tablespace_watch_match(gp_execution_dbid(), 'temp', '_Sort_') > 0 as "exist";
 
 -- temp files in hash aggregate should reside in the temp tablespace.
 select gp_tablespace_watch_match(gp_execution_dbid(), 'default', '_HashAggregate_') > 0 as "exist";
@@ -211,7 +217,6 @@ select count(*) from out11;
 set statement_mem = '1MB';
 -- hash aggregate should spill on the default tablespace.
 select count(*) from (select i, count(*) from tts_aggspill group by i,j,t having count(*) = 3) g;
-
 select gp_tablespace_watch_log(gp_execution_dbid(), '[RESET - use default temp tablespace]');
 
 set optimizer = off;
@@ -243,6 +248,10 @@ select gp_tablespace_watch_log(gp_execution_dbid(), '[temp_tablespace]: separato
 set statement_mem='1MB';
 -- hash aggregate should spill on the default tablespace.
 select count(*) from (select i, count(*) from tts_aggspill group by i,j,t having count(*) = 3) g;
+\o /dev/null
+select i1, count(distinct(i4)), count(1), count(distinct(i2)) , count(distinct(i3))
+    from tts_testsiscm group by i1 order by 3,4,5 desc;
+\o
 
 set optimizer = off;
 set statement_mem='3MB';
@@ -257,6 +266,7 @@ select gp_tablespace_watch_match(gp_execution_dbid(), 'default', '_HashJoin') > 
 select gp_tablespace_watch_match(gp_execution_dbid(), 'default', '_SIRW_') > 0 as "exist";
 -- temp files in hash aggregate should reside in the temp tablespace.
 select gp_tablespace_watch_match(gp_execution_dbid(), 'default', '_HashAggregate_') > 0 as "exist";
+select gp_tablespace_watch_match(gp_execution_dbid(), 'default', '_Sort_') > 0 as "exist";
 
 
 drop table tts_foo, tts_bar, tts_jazz, tts_aggspill, tts_testsiscm;

--- a/src/test/regress/output/temp_tablespaces.source
+++ b/src/test/regress/output/temp_tablespaces.source
@@ -217,6 +217,11 @@ select count(*) from (select i, count(*) from tts_aggspill group by i,j,t having
  10000
 (1 row)
 
+-- supress too many output tuples, so sort(maybe merge sort) spills
+\o /dev/null
+select i1, count(distinct(i4)), count(1), count(distinct(i2)) , count(distinct(i3))
+    from tts_testsiscm group by i1 order by 3,4,5 desc;
+\o
 set optimizer = off;
 set statement_mem='3MB';
 select count(*) from (with ctesisc as
@@ -262,6 +267,22 @@ select gp_tablespace_watch_match(gp_execution_dbid(), 'default', '_SIRW_') > 0 a
 (3 rows)
 
 select gp_tablespace_watch_match(gp_execution_dbid(), 'temp', '_SIRW_') > 0 as "exist";
+ exist 
+-------
+ t
+ t
+ t
+(3 rows)
+
+select gp_tablespace_watch_match(gp_execution_dbid(), 'default', '_Sort_') > 0 as "exist";
+ exist 
+-------
+ f
+ f
+ f
+(3 rows)
+
+select gp_tablespace_watch_match(gp_execution_dbid(), 'temp', '_Sort_') > 0 as "exist";
  exist 
 -------
  t
@@ -388,6 +409,10 @@ select count(*) from (select i, count(*) from tts_aggspill group by i,j,t having
  10000
 (1 row)
 
+\o /dev/null
+select i1, count(distinct(i4)), count(1), count(distinct(i2)) , count(distinct(i3))
+    from tts_testsiscm group by i1 order by 3,4,5 desc;
+\o
 set optimizer = off;
 set statement_mem='3MB';
 select count(*) from (with ctesisc as
@@ -426,6 +451,14 @@ select gp_tablespace_watch_match(gp_execution_dbid(), 'default', '_SIRW_') > 0 a
 
 -- temp files in hash aggregate should reside in the temp tablespace.
 select gp_tablespace_watch_match(gp_execution_dbid(), 'default', '_HashAggregate_') > 0 as "exist";
+ exist 
+-------
+ t
+ t
+ t
+(3 rows)
+
+select gp_tablespace_watch_match(gp_execution_dbid(), 'default', '_Sort_') > 0 as "exist";
  exist 
 -------
  t

--- a/src/test/regress/output/temp_tablespaces.source
+++ b/src/test/regress/output/temp_tablespaces.source
@@ -217,11 +217,9 @@ select count(*) from (select i, count(*) from tts_aggspill group by i,j,t having
  10000
 (1 row)
 
--- supress too many output tuples, so sort(maybe merge sort) spills
-\o /dev/null
-select i1, count(distinct(i4)), count(1), count(distinct(i2)) , count(distinct(i3))
-    from tts_testsiscm group by i1 order by 3,4,5 desc;
-\o
+--start_ignore
+-- ignore the output, we only need the following query to spill on Sort
+--end_ignore
 set optimizer = off;
 set statement_mem='3MB';
 select count(*) from (with ctesisc as
@@ -409,10 +407,9 @@ select count(*) from (select i, count(*) from tts_aggspill group by i,j,t having
  10000
 (1 row)
 
-\o /dev/null
-select i1, count(distinct(i4)), count(1), count(distinct(i2)) , count(distinct(i3))
-    from tts_testsiscm group by i1 order by 3,4,5 desc;
-\o
+--start_ignore
+-- ignore the output, we only need the following query to spill on Sort
+--end_ignore
 set optimizer = off;
 set statement_mem='3MB';
 select count(*) from (with ctesisc as


### PR DESCRIPTION
Backport the commit 93f03dad824f14f40519597e5e4a8fe7b6df858e
from upstream, to ensure that PrepareTempTablespaces() is always
called if needed.
```
Make BufFileCreateTemp() ensure that temp tablespaces are set up.

If PrepareTempTablespaces() has never been called in the current
transaction, OpenTemporaryFile() will fall back to using the default
tablespace, which is a bug if the user wanted temp files placed elsewhere.
gistInitBuildBuffers() appears to have this disease already, and it
seems like an easy trap for future coders to fall into.

We discussed other ways to close this gap, but none of them are prettier
or more reliable than just having BufFileCreateTemp do it.  In particular,
having fd.c do this creates layering issues that we could do without.

Per suggestion from Melanie Plageman.  Arguably this is a bug fix, but
nobody seems very excited about back-patching, so change in HEAD only.

Discussion: https://postgr.es/m/CAAKRu_YwzjuGAmmaw4-8XO=OVFGR1QhY_Pq-t3wjb9ribBJb_Q@mail.gmail.com
```
Also add a test case for sort node that ensure spilled temp files
are stored in a specific temp tablespaces in the GUC temp_tablespaces.
See PR #12437

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
