### PR TITLE
docs - update correlation statistic support

### DIFF
--- a/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
+++ b/gpdb-doc/dita/admin_guide/intro/about_statistics.xml
@@ -309,7 +309,10 @@
             </dlentry>
             <dlentry>
               <dt>correlation</dt>
-              <dd>Greenplum Database does not calculate the correlation statistic. </dd>
+              <dd>Greenplum Database computes correlation statistics for heap tables. These
+               statistics are used by the Postgres Planner. Greenplum does not compute
+               correlation statistics for AO and AOCO tables; the value in this column for
+               these table types is undefined.</dd>
             </dlentry>
             <dlentry>
               <dt>most_common_elems</dt>


### PR DESCRIPTION
greenplum 6 computes correlation statistics for heap tables.

this PR is against 6X_STABLE.

question about support on master - does greenplum also compute the stats for AO and AOCO tables?  (will submit a separate PR.)