### PR TITLE
Removing some invocation of DisconnectAndDestroyAllGangs that might PANIC.

### DIFF
--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -692,6 +692,11 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 		elog(LOG, "COPY signals FTS to probe segments");
 
 		SendPostmasterSignal(PMSIGNAL_WAKEN_FTS);
+		/*
+		 * Before error out, we need to reset the session. Gang will be cleaned up
+		 * when next transaction start, since it will find FTS version bump and
+		 * call cdbcomponent_updateCdbComponents().
+		 */
 		resetSessionForPrimaryGangLoss();
 
 		ereport(ERROR,

--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -441,6 +441,8 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 	List           *oidList = NIL;
 	int				nest_level;
 
+	SIMPLE_FAULT_INJECTOR("cdb_copy_end_internal_start");
+
 	initStringInfo(&io_err_msg);
 
 	/*
@@ -690,7 +692,7 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 		elog(LOG, "COPY signals FTS to probe segments");
 
 		SendPostmasterSignal(PMSIGNAL_WAKEN_FTS);
-		DisconnectAndDestroyAllGangs(true);
+		resetSessionForPrimaryGangLoss();
 
 		ereport(ERROR,
 				(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -73,8 +73,6 @@ CreateGangFunc pCreateGangFunc = cdbgang_createGang_async;
 static bool NeedResetSession = false;
 static Oid	OldTempNamespace = InvalidOid;
 
-static void resetSessionForPrimaryGangLoss(void);
-
 /*
  * cdbgang_createGang:
  *
@@ -689,6 +687,11 @@ getCdbProcessesForQD(int isPrimary)
 	return list;
 }
 
+/*
+ * This function should not be used in the context of named portals
+ * as it destroys the CdbComponentsContext, which is accessed later
+ * during named portal cleanup.
+ */
 void
 DisconnectAndDestroyAllGangs(bool resetSession)
 {
@@ -832,7 +835,7 @@ GpDropTempTables(void)
 	}
 }
 
-static void
+void
 resetSessionForPrimaryGangLoss(void)
 {
 	if (ProcCanSetMppSessionId())

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -81,8 +81,9 @@ cdbgang_createGang_async(List *segments, SegmentType segmentType)
 	/*
 	 * If we're in a global transaction, and there is some primary segment down,
 	 * we have to error out so that the current global transaction can be aborted.
-	 * Before error out, we need to clean up QEs, destroy the gang, and reset
-	 * the session.
+	 * Before error out, we need to reset the session. Gang will be cleaned up when next
+	 * transaction start, since it will find FTS version bump and call cdbcomponent_updateCdbComponents().
+	 *
 	 * We shouldn't error out in transaction abort state to avoid recursive abort.
 	 * In such case, the dispatcher would catch the error and then dtm does (retry)
 	 * abort.
@@ -93,7 +94,7 @@ cdbgang_createGang_async(List *segments, SegmentType segmentType)
 		{
 			if (FtsIsSegmentDown(newGangDefinition->db_descriptors[i]->segment_database_info))
 			{
-				DisconnectAndDestroyAllGangs(true);
+				resetSessionForPrimaryGangLoss();
 				elog(ERROR, "gang was lost due to cluster reconfiguration");
 			}
 		}

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -98,6 +98,8 @@ extern bool segment_failure_due_to_missing_writer(const char *error_message);
  */
 extern void cdbgang_parse_gpqeid_params(struct Port *port, const char *gpqeid_value);
 
+extern void resetSessionForPrimaryGangLoss(void);
+
 /*
  * MPP Worker Process information
  *

--- a/src/test/isolation2/expected/fts_errors.out
+++ b/src/test/isolation2/expected/fts_errors.out
@@ -134,7 +134,7 @@ END
 -- session 2: in transaction, gxid is dispatched to writer gang, cann't
 --            update cdb_component_dbs, following query should fail
 2:END;
-ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:97)
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:98)
 -- session 3: in transaction and has a cursor, cann't update
 --            cdb_component_dbs, following query should fail
 3:FETCH ALL FROM c1;
@@ -142,12 +142,12 @@ ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:97)
 ----+----
 (0 rows)
 3:END;
-ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:97)
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:98)
 -- session 4: not in transaction but has temp table, cann't update
 --            cdb_component_dbs, following query should fail and session
 --            is reset
 4:select * from tmp4;
-ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:97)
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:98)
 4:select * from tmp4;
 ERROR:  relation "tmp4" does not exist
 LINE 1: select * from tmp4;
@@ -155,7 +155,7 @@ LINE 1: select * from tmp4;
 -- session 5: has a subtransaction, cann't update cdb_component_dbs,
 --            following query should fail
 5:select * from tmp51;
-ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:97)
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:98)
 5:ROLLBACK TO SAVEPOINT s1;
 ERROR:  Could not rollback to savepoint (ROLLBACK TO SAVEPOINT s1)
 5:END;

--- a/src/test/isolation2/expected/fts_errors_1.out
+++ b/src/test/isolation2/expected/fts_errors_1.out
@@ -134,7 +134,7 @@ END
 -- session 2: in transaction, gxid is dispatched to writer gang, cann't
 --            update cdb_component_dbs, following query should fail
 2:END;
-ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:97)
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:98)
 -- session 3: in transaction and has a cursor, cann't update
 --            cdb_component_dbs, following query should fail
 3:FETCH ALL FROM c1;
@@ -142,14 +142,14 @@ ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:97)
 ----+----
 (0 rows)
 3:END;
-ERROR: server closed the connection unexpectedly
+ERROR:  Error on receive from seg1 slice1 127.0.1.1:7003 pid=31911: server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
 -- session 4: not in transaction but has temp table, cann't update
 --            cdb_component_dbs, following query should fail and session
 --            is reset
 4:select * from tmp4;
-ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:97)
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:98)
 4:select * from tmp4;
 ERROR:  relation "tmp4" does not exist
 LINE 1: select * from tmp4;
@@ -157,7 +157,7 @@ LINE 1: select * from tmp4;
 -- session 5: has a subtransaction, cann't update cdb_component_dbs,
 --            following query should fail
 5:select * from tmp51;
-ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:97)
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:98)
 5:ROLLBACK TO SAVEPOINT s1;
 ERROR:  Could not rollback to savepoint (ROLLBACK TO SAVEPOINT s1)
 5:END;

--- a/src/test/isolation2/expected/fts_session_reset.out
+++ b/src/test/isolation2/expected/fts_session_reset.out
@@ -44,7 +44,7 @@ INSERT 20
 -- the gang used by the previous insert is no longer valid. It must be destroyed
 -- and the transaction must be aborted.
 1:insert into test_fts_session_reset select * from generate_series(21,40);
-ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:97)
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:98)
 1:select count(*) from test_fts_session_reset;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 1:END;

--- a/src/test/isolation2/expected/gpdispatch.out
+++ b/src/test/isolation2/expected/gpdispatch.out
@@ -14,7 +14,7 @@ BEGIN
 
 -- session1 will be fatal.
 1: select count(*) > 0 from gp_dist_random('pg_class');
-FATAL:  could not allocate resources for segworker communication (cdbdisp_async.c:306)
+FATAL:  could not allocate resources for segworker communication (cdbdisp_async.c:319)
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
@@ -34,4 +34,122 @@ select gp_inject_fault('make_dispatch_result_error', 'reset', dbid) from gp_segm
  gp_inject_fault 
 -----------------
  Success:        
+(1 row)
+
+--
+-- Test for issue https://github.com/greenplum-db/gpdb/issues/12703
+--
+
+-- Case for cdbgang_createGang_async
+1: create table t_12703(a int);
+CREATE
+
+1:begin;
+BEGIN
+-- make a cursor so that we have a named portal
+1: declare cur12703 cursor for select * from t_12703;
+DECLARE
+
+2: select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=1), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+-- next sql will trigger FTS to mark seg1 as down
+2: select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- this will go to cdbgang_createGang_async's code path
+-- for some segments are DOWN. It should not PANIC even
+-- with a named portal existing.
+1: select * from t_12703;
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:98)
+1: abort;
+ABORT
+
+1q: ... <quitting>
+2q: ... <quitting>
+
+-- Case for cdbCopyEndInternal
+-- Provide some data to copy in
+insert into t_12703 select * from generate_series(1, 10)i;
+INSERT 10
+copy t_12703 to '/tmp/t_12703';
+COPY 10
+-- make copy in statement hang at the entry point of cdbCopyEndInternal
+select gp_inject_fault('cdb_copy_end_internal_start', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: copy t_12703 from '/tmp/t_12703';  <waiting ...>
+select gp_wait_until_triggered_fault('cdb_copy_end_internal_start', 1, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+-- make Gang connection is BAD
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=2), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+2: select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+2: begin;
+BEGIN
+select gp_inject_fault('cdb_copy_end_internal_start', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- continue copy it should not PANIC
+1<:  <... completed>
+ERROR:  MPP detected 1 segment failures, system is reconnected
+1q: ... <quitting>
+-- session 2 still alive (means not PANIC happens)
+2: select 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+2: end;
+END
+2q: ... <quitting>
+
+!\retcode gprecoverseg -aF --no-progress;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+-- loop while segments come in sync
+select wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+!\retcode gprecoverseg -ar;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+-- loop while segments come in sync
+select wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+-- verify no segment is down after recovery
+select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 0     
 (1 row)

--- a/src/test/isolation2/expected/gpdispatch_1.out
+++ b/src/test/isolation2/expected/gpdispatch_1.out
@@ -1,0 +1,322 @@
+-- Try to verify that a session fatal due to OOM should have no effect on other sessions.
+-- Report on https://github.com/greenplum-db/gpdb/issues/12399
+
+create extension if not exists gp_inject_fault;
+CREATE
+
+1: select gp_inject_fault('make_dispatch_result_error', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2: begin;
+BEGIN
+
+-- session1 will be fatal.
+1: select count(*) > 0 from gp_dist_random('pg_class');
+FATAL:  could not allocate resources for segworker communication (cdbdisp_async.c:319)
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+
+-- session2 should be ok.
+2: select count(*) > 0 from gp_dist_random('pg_class');
+ ?column? 
+----------
+ t        
+(1 row)
+2: commit;
+COMMIT
+1q: ... <quitting>
+2q: ... <quitting>
+
+select gp_inject_fault('make_dispatch_result_error', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+--
+-- Test for issue https://github.com/greenplum-db/gpdb/issues/12703
+--
+
+-- Case for cdbgang_createGang_async
+1: create table t_12703(a int);
+CREATE
+
+1:begin;
+BEGIN
+-- make a cursor so that we have a named portal
+1: declare cur12703 cursor for select * from t_12703;
+DECLARE
+
+2: select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=1), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+-- next sql will trigger FTS to mark seg1 as down
+2: select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- this will go to cdbgang_createGang_async's code path
+-- for some segments are DOWN. It should not PANIC even
+-- with a named portal existing.
+1: select * from t_12703;
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:98)
+ERROR:  Error on receive from seg1 slice1 127.0.1.1:7003 pid=58391: server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+1: abort;
+ABORT
+
+1q: ... <quitting>
+2q: ... <quitting>
+
+-- Case for cdbCopyEndInternal
+-- Provide some data to copy in
+insert into t_12703 select * from generate_series(1, 10)i;
+INSERT 10
+copy t_12703 to '/tmp/t_12703';
+COPY 10
+-- make copy in statement hang at the entry point of cdbCopyEndInternal
+select gp_inject_fault('cdb_copy_end_internal_start', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: copy t_12703 from '/tmp/t_12703';  <waiting ...>
+select gp_wait_until_triggered_fault('cdb_copy_end_internal_start', 1, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+-- make Gang connection is BAD
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=2), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+2: select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+2: begin;
+BEGIN
+select gp_inject_fault('cdb_copy_end_internal_start', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- continue copy it should not PANIC
+1<:  <... completed>
+ERROR:  MPP detected 1 segment failures, system is reconnected
+1q: ... <quitting>
+-- session 2 still alive (means not PANIC happens)
+2: select 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+2: end;
+END
+2q: ... <quitting>
+
+!\retcode gprecoverseg -aF --no-progress;
+-- start_ignore
+20211101:14:57:13:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-Starting gprecoverseg with args: -aF --no-progress
+20211101:14:57:13:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.14950.gaf07f2a6fe build dev'
+20211101:14:57:13:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-coordinator Greenplum Version: 'PostgreSQL 12beta2 (Greenplum Database 7.0.0-alpha.0+dev.14950.gaf07f2a6fe build dev) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0, 64-bit compiled on Nov  1 2021 11:23:12 (with assert checking)'
+20211101:14:57:13:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-Obtaining Segment details from coordinator...
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-Heap checksum setting is consistent between coordinator and the segments that are candidates for recoverseg
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-Greenplum instance recovery parameters
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-Recovery type              = Standard
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-Recovery 1 of 2
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-   Synchronization mode                 = Full
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance host                 = zlyu
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance address              = zlyu
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance directory            = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast2/demoDataDir1
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance port                 = 7003
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance host        = zlyu
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance address     = zlyu
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance directory   = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror2/demoDataDir1
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance port        = 7006
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Target                      = in-place
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-Recovery 2 of 2
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-   Synchronization mode                 = Full
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance host                 = zlyu
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance address              = zlyu
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance directory            = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast3/demoDataDir2
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance port                 = 7004
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance host        = zlyu
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance address     = zlyu
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance directory   = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror3/demoDataDir2
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance port        = 7007
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Target                      = in-place
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211101:14:57:14:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-Starting to create new pg_hba.conf on primary segments
+20211101:14:57:15:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-Successfully modified pg_hba.conf on primary segments to allow replication connections
+20211101:14:57:15:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-2 segment(s) to recover
+20211101:14:57:15:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-Ensuring 2 failed segment(s) are stopped
+20211101:14:57:17:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-Validating remote directories
+20211101:14:57:18:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-Configuring new segments
+.
+20211101:14:57:20:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-Updating configuration with new mirrors
+20211101:14:57:20:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-Updating mirrors
+20211101:14:57:20:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-Starting mirrors
+20211101:14:57:20:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-era is fbb165f204b577b2_211101145214
+20211101:14:57:20:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-Commencing parallel segment instance startup, please wait...
+20211101:14:57:21:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-Process results...
+20211101:14:57:21:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-
+20211101:14:57:21:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-Triggering FTS probe
+20211101:14:57:21:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-********************************
+20211101:14:57:21:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-Segments successfully recovered.
+20211101:14:57:21:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-********************************
+20211101:14:57:21:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-Recovered mirror segments need to sync WAL with primary segments.
+20211101:14:57:21:101597 gprecoverseg:zlyu:gpadmin-[INFO]:-Use 'gpstate -e' to check progress of WAL sync remaining bytes
+
+-- end_ignore
+(exited with code 0)
+
+-- loop while segments come in sync
+select wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+!\retcode gprecoverseg -ar;
+-- start_ignore
+20211101:14:57:21:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Starting gprecoverseg with args: -ar
+20211101:14:57:21:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.14950.gaf07f2a6fe build dev'
+20211101:14:57:21:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-coordinator Greenplum Version: 'PostgreSQL 12beta2 (Greenplum Database 7.0.0-alpha.0+dev.14950.gaf07f2a6fe build dev) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0, 64-bit compiled on Nov  1 2021 11:23:12 (with assert checking)'
+20211101:14:57:21:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Obtaining Segment details from coordinator...
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Greenplum instance recovery parameters
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Recovery type              = Rebalance
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Unbalanced segment 1 of 4
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance host        = zlyu
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance address     = zlyu
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance directory   = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror2/demoDataDir1
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance port        = 7006
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Balanced role                   = Mirror
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Current role                    = Primary
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Unbalanced segment 2 of 4
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance host        = zlyu
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance address     = zlyu
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance directory   = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast2/demoDataDir1
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance port        = 7003
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Balanced role                   = Primary
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Current role                    = Mirror
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Unbalanced segment 3 of 4
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance host        = zlyu
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance address     = zlyu
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance directory   = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror3/demoDataDir2
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance port        = 7007
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Balanced role                   = Mirror
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Current role                    = Primary
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Unbalanced segment 4 of 4
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance host        = zlyu
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance address     = zlyu
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance directory   = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast3/demoDataDir2
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance port        = 7004
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Balanced role                   = Primary
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Current role                    = Mirror
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Determining primary and mirror segment pairs to rebalance
+20211101:14:57:22:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Stopping unbalanced primary segments...
+20211101:14:57:23:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Triggering segment reconfiguration
+20211101:14:57:28:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Starting segment synchronization
+20211101:14:57:28:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-=============================START ANOTHER RECOVER=========================================
+20211101:14:57:28:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.14950.gaf07f2a6fe build dev'
+20211101:14:57:28:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-coordinator Greenplum Version: 'PostgreSQL 12beta2 (Greenplum Database 7.0.0-alpha.0+dev.14950.gaf07f2a6fe build dev) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0, 64-bit compiled on Nov  1 2021 11:23:12 (with assert checking)'
+20211101:14:57:28:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Obtaining Segment details from coordinator...
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Heap checksum setting is consistent between coordinator and the segments that are candidates for recoverseg
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Greenplum instance recovery parameters
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Recovery type              = Standard
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Recovery 1 of 2
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Synchronization mode                 = Incremental
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance host                 = zlyu
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance address              = zlyu
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance directory            = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror2/demoDataDir1
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance port                 = 7006
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance host        = zlyu
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance address     = zlyu
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance directory   = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast2/demoDataDir1
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance port        = 7003
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Target                      = in-place
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Recovery 2 of 2
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Synchronization mode                 = Incremental
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance host                 = zlyu
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance address              = zlyu
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance directory            = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror3/demoDataDir2
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance port                 = 7007
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance host        = zlyu
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance address     = zlyu
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance directory   = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast3/demoDataDir2
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance port        = 7004
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Target                      = in-place
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211101:14:57:29:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Starting to create new pg_hba.conf on primary segments
+20211101:14:57:30:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Successfully modified pg_hba.conf on primary segments to allow replication connections
+20211101:14:57:30:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-2 segment(s) to recover
+20211101:14:57:30:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Ensuring 2 failed segment(s) are stopped
+20211101:14:57:32:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Updating configuration with new mirrors
+20211101:14:57:32:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Updating mirrors
+20211101:14:57:32:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Running pg_rewind on failed segments
+zlyu (dbid 6): pg_rewind: no rewind required
+zlyu (dbid 7): pg_rewind: no rewind required
+20211101:14:57:36:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Starting mirrors
+20211101:14:57:36:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-era is fbb165f204b577b2_211101145214
+20211101:14:57:36:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Commencing parallel segment instance startup, please wait...
+20211101:14:57:36:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Process results...
+20211101:14:57:36:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-
+20211101:14:57:36:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Triggering FTS probe
+20211101:14:57:36:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-********************************
+20211101:14:57:36:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Segments successfully recovered.
+20211101:14:57:36:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-********************************
+20211101:14:57:36:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Recovered mirror segments need to sync WAL with primary segments.
+20211101:14:57:36:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-Use 'gpstate -e' to check progress of WAL sync remaining bytes
+20211101:14:57:36:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-==============================END ANOTHER RECOVER==========================================
+20211101:14:57:36:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-******************************************************************
+20211101:14:57:36:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-The rebalance operation has completed successfully.
+20211101:14:57:36:103065 gprecoverseg:zlyu:gpadmin-[INFO]:-******************************************************************
+
+-- end_ignore
+(exited with code 0)
+
+-- loop while segments come in sync
+select wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+-- verify no segment is down after recovery
+select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 0     
+(1 row)

--- a/src/test/isolation2/init_file_isolation2
+++ b/src/test/isolation2/init_file_isolation2
@@ -7,6 +7,10 @@ s/\s+\(entry db(.*)+\spid=\d+\)//
 m/^\d+.*gpconfig.*-\[INFO\]:-/
 s/^\d+.*gpconfig.*-\[INFO\]:-//
 
+# line number in error message
+m/\(cdbgang_async\.c\:\d+\)/
+s/\(cdbgang_async\.c:\d+\)/\(cdbgang_async\.c:LINE_NUM\)/
+
 # ignore OID and file/line number diffs for invalid toast indexes
 m/^ERROR:  no valid index found for toast relation/
 s/with Oid \d+ \(.*\)/with Oid OID/

--- a/src/test/isolation2/sql/gpdispatch.sql
+++ b/src/test/isolation2/sql/gpdispatch.sql
@@ -16,3 +16,61 @@ create extension if not exists gp_inject_fault;
 2q:
 
 select gp_inject_fault('make_dispatch_result_error', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+--
+-- Test for issue https://github.com/greenplum-db/gpdb/issues/12703
+--
+
+-- Case for cdbgang_createGang_async
+1: create table t_12703(a int);
+
+1:begin;
+-- make a cursor so that we have a named portal
+1: declare cur12703 cursor for select * from t_12703;
+
+2: select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=1), 'stop');
+-- next sql will trigger FTS to mark seg1 as down
+2: select gp_request_fts_probe_scan();
+
+-- this will go to cdbgang_createGang_async's code path
+-- for some segments are DOWN. It should not PANIC even
+-- with a named portal existing.
+1: select * from t_12703;
+1: abort;
+
+1q:
+2q:
+
+-- Case for cdbCopyEndInternal
+-- Provide some data to copy in
+insert into t_12703 select * from generate_series(1, 10)i;
+copy t_12703 to '/tmp/t_12703';
+-- make copy in statement hang at the entry point of cdbCopyEndInternal
+select gp_inject_fault('cdb_copy_end_internal_start', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+1&: copy t_12703 from '/tmp/t_12703';
+select gp_wait_until_triggered_fault('cdb_copy_end_internal_start', 1, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+-- make Gang connection is BAD
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=2), 'stop');
+2: select gp_request_fts_probe_scan();
+2: begin;
+select gp_inject_fault('cdb_copy_end_internal_start', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+-- continue copy it should not PANIC
+1<:
+1q:
+-- session 2 still alive (means not PANIC happens)
+2: select 1;
+2: end;
+2q:
+
+!\retcode gprecoverseg -aF --no-progress;
+
+-- loop while segments come in sync
+select wait_until_all_segments_synchronized();
+
+!\retcode gprecoverseg -ar;
+
+-- loop while segments come in sync
+select wait_until_all_segments_synchronized();
+
+-- verify no segment is down after recovery
+select count(*) from gp_segment_configuration where status = 'd';


### PR DESCRIPTION
DisconnectAndDestroyAllGangs will destroy the memory context CdbComponentsContext.
But if we have named portal exists (cursors), later when we clean up
those portals during transaction-abort, it will PANIC due to null pointer
reference to the destroyed CdbComponentsContext.

So it is safe to call this function:
  1. call it after all portals are cleaned up
  2. call it when there cannot be any named portals

In this commit, I remove the invocation of DisconnectAndDestroyAllGangs in:
  * cdbgang_createGang_async
  * cdbCopyEndInternal

When the above two places hit error we can just leave the cleanup progress
when aborting transaction.

For details, please refer to Github Issue 12703. This commit fixes it.