### PR TITLE
(6x) Removing some invocation of DisconnectAndDestroyAllGangs that might P…

### DIFF
--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -448,6 +448,10 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 	bool		io_errors = false;
 	StringInfoData io_err_msg;
 
+#ifdef FAULT_INJECTOR
+	SIMPLE_FAULT_INJECTOR("hang_at_cdb_copy_end_internal");
+#endif
+
 	initStringInfo(&io_err_msg);
 
 	/*
@@ -696,7 +700,6 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 		elog(LOG, "COPY signals FTS to probe segments");
 
 		SendPostmasterSignal(PMSIGNAL_WAKEN_FTS);
-		DisconnectAndDestroyAllGangs(true);
 
 		ereport(ERROR,
 				(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -688,6 +688,12 @@ getCdbProcessesForQD(int isPrimary)
 	return list;
 }
 
+/*
+ * Be very careful to use this function when having named Portal exists.
+ * This function will destroy the MemoryContexr CdbComponentsContext, if
+ * named portal exists, later when we clean up named portal it might ref
+ * a null pointer (the memorycontext) and lead to PANIC.
+ */
 void
 DisconnectAndDestroyAllGangs(bool resetSession)
 {

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -90,7 +90,6 @@ cdbgang_createGang_async(List *segments, SegmentType segmentType)
 		{
 			if (FtsIsSegmentDown(newGangDefinition->db_descriptors[i]->segment_database_info))
 			{
-				DisconnectAndDestroyAllGangs(true);
 				elog(ERROR, "gang was lost due to cluster reconfiguration");
 			}
 		}

--- a/src/test/isolation2/expected/fts_errors.out
+++ b/src/test/isolation2/expected/fts_errors.out
@@ -139,7 +139,7 @@ END
 -- session 2: in transaction, gxid is dispatched to writer gang, cann't
 --            update cdb_component_dbs, following query should fail
 2:END;
-ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:94)
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:93)
 -- session 3: in transaction and has a cursor, cann't update
 --            cdb_component_dbs, following query should fail
 3:FETCH ALL FROM c1;
@@ -147,14 +147,12 @@ ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:94)
 ----+----
 (0 rows)
 3:END;
-ERROR: server closed the connection unexpectedly
-	This probably means the server terminated abnormally
-	before or while processing the request.
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:93)
 -- session 4: not in transaction but has temp table, cann't update
 --            cdb_component_dbs, following query should fail and session
 --            is reset
 4:select * from tmp4;
-ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:94)
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:93)
 4:select * from tmp4;
 ERROR:  relation "tmp4" does not exist
 LINE 1: select * from tmp4;
@@ -162,7 +160,7 @@ LINE 1: select * from tmp4;
 -- session 5: has a subtransaction, cann't update cdb_component_dbs,
 --            following query should fail
 5:select * from tmp51;
-ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:94)
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:93)
 5:ROLLBACK TO SAVEPOINT s1;
 ERROR:  Could not rollback to savepoint (ROLLBACK TO SAVEPOINT s1)
 5:END;

--- a/src/test/isolation2/expected/fts_errors_1.out
+++ b/src/test/isolation2/expected/fts_errors_1.out
@@ -139,7 +139,7 @@ END
 -- session 2: in transaction, gxid is dispatched to writer gang, cann't
 --            update cdb_component_dbs, following query should fail
 2:END;
-ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:94)
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:93)
 -- session 3: in transaction and has a cursor, cann't update
 --            cdb_component_dbs, following query should fail
 3:FETCH ALL FROM c1;
@@ -147,12 +147,14 @@ ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:94)
 ----+----
 (0 rows)
 3:END;
-ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:94)
+ERROR:  Error on receive from seg1 slice1 127.0.1.1:6003 pid=215565: server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
 -- session 4: not in transaction but has temp table, cann't update
 --            cdb_component_dbs, following query should fail and session
 --            is reset
 4:select * from tmp4;
-ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:94)
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:93)
 4:select * from tmp4;
 ERROR:  relation "tmp4" does not exist
 LINE 1: select * from tmp4;
@@ -160,7 +162,7 @@ LINE 1: select * from tmp4;
 -- session 5: has a subtransaction, cann't update cdb_component_dbs,
 --            following query should fail
 5:select * from tmp51;
-ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:94)
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:93)
 5:ROLLBACK TO SAVEPOINT s1;
 ERROR:  Could not rollback to savepoint (ROLLBACK TO SAVEPOINT s1)
 5:END;

--- a/src/test/isolation2/expected/fts_session_reset.out
+++ b/src/test/isolation2/expected/fts_session_reset.out
@@ -46,7 +46,11 @@ INSERT 20
 -- the gang used by the previous insert is no longer valid. It must be destroyed
 -- and the transaction must be aborted.
 1:insert into test_fts_session_reset select * from generate_series(21,40);
+<<<<<<< HEAD
 ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:94)
+=======
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:96)
+>>>>>>> 4ee557d2eb... Removing some invocation of DisconnectAndDestroyAllGangs that might PANIC.
 1:select count(*) from test_fts_session_reset;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 1:END;

--- a/src/test/isolation2/expected/gpdispatch.out
+++ b/src/test/isolation2/expected/gpdispatch.out
@@ -4,6 +4,9 @@
 create extension if not exists gp_inject_fault;
 CREATE
 
+include: helpers/server_helpers.sql;
+CREATE
+
 1: set gp_debug_linger = '1s';
 SET
 1: select gp_inject_fault('make_dispatch_result_error', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = -1;
@@ -38,4 +41,122 @@ select gp_inject_fault('make_dispatch_result_error', 'reset', dbid) from gp_segm
  gp_inject_fault 
 -----------------
  Success:        
+(1 row)
+
+--
+-- Test for issue https://github.com/greenplum-db/gpdb/issues/12703
+--
+
+-- Case for cdbgang_createGang_async
+1: create table t_12703(a int);
+CREATE
+
+1:begin;
+BEGIN
+-- make a cursor so that we have a named portal
+1: declare cur12703 cursor for select * from t_12703;
+DECLARE
+
+2: select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=1), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+-- next sql will trigger FTS to mark seg1 as down
+2: select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- this will go to cdbgang_createGang_async's code path
+-- for some segments are DOWN. It should not PANIC even
+-- with a named portal existing.
+1: select * from t_12703;
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:93)
+1: abort;
+ABORT
+
+1q: ... <quitting>
+2q: ... <quitting>
+
+-- Case for cdbCopyEndInternal
+-- Provide some data to copy in
+insert into t_12703 select * from generate_series(1, 10)i;
+INSERT 10
+copy t_12703 to '/tmp/t_12703';
+COPY 10
+-- make copy in statement hang at the entry point of cdbCopyEndInternal
+select gp_inject_fault('hang_at_cdb_copy_end_internal', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: copy t_12703 from '/tmp/t_12703';  <waiting ...>
+select gp_wait_until_triggered_fault('hang_at_cdb_copy_end_internal', 1, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+-- make Gang connection is BAD
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=2), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+2: select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+2: begin;
+BEGIN
+select gp_inject_fault('hang_at_cdb_copy_end_internal', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- continue copy it should not PANIC
+1<:  <... completed>
+ERROR:  MPP detected 1 segment failures, system is reconnected
+1q: ... <quitting>
+-- session 2 still alive (means not PANIC happens)
+2: select 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+2: end;
+END
+2q: ... <quitting>
+
+!\retcode gprecoverseg -aF --no-progress;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+-- loop while segments come in sync
+select wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+!\retcode gprecoverseg -ar;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+-- loop while segments come in sync
+select wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+-- verify no segment is down after recovery
+select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 0     
 (1 row)

--- a/src/test/isolation2/expected/gpdispatch_1.out
+++ b/src/test/isolation2/expected/gpdispatch_1.out
@@ -2,23 +2,46 @@
 -- Report on https://github.com/greenplum-db/gpdb/issues/12399
 
 create extension if not exists gp_inject_fault;
+CREATE
 
 include: helpers/server_helpers.sql;
+CREATE
 
 1: set gp_debug_linger = '1s';
+SET
 1: select gp_inject_fault('make_dispatch_result_error', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
 2: begin;
+BEGIN
 
 -- session1 will fatal
 1: select count(*) > 0 from gp_dist_random('pg_class');
+FATAL:  could not allocate resources for segworker communication (cdbdisp_async.c:301)
+HINT:  Process 211119 will wait for gp_debug_linger=1 seconds before termination.
+Note that its locks and other resources will not be released until then.
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
 
 -- session 2 should be ok
 2: select count(*) > 0 from gp_dist_random('pg_class');
+ ?column? 
+----------
+ t        
+(1 row)
 2: commit;
-1q:
-2q:
+COMMIT
+1q: ... <quitting>
+2q: ... <quitting>
 
 select gp_inject_fault('make_dispatch_result_error', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
 
 --
 -- Test for issue https://github.com/greenplum-db/gpdb/issues/12703
@@ -26,54 +49,117 @@ select gp_inject_fault('make_dispatch_result_error', 'reset', dbid) from gp_segm
 
 -- Case for cdbgang_createGang_async
 1: create table t_12703(a int);
+CREATE
 
 1:begin;
+BEGIN
 -- make a cursor so that we have a named portal
 1: declare cur12703 cursor for select * from t_12703;
+DECLARE
 
 2: select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=1), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
 -- next sql will trigger FTS to mark seg1 as down
 2: select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
 
 -- this will go to cdbgang_createGang_async's code path
 -- for some segments are DOWN. It should not PANIC even
 -- with a named portal existing.
 1: select * from t_12703;
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:93)
+ERROR:  Error on receive from seg1 slice1 127.0.1.1:6003 pid=211136: server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
 1: abort;
+ABORT
 
-1q:
-2q:
+1q: ... <quitting>
+2q: ... <quitting>
 
 -- Case for cdbCopyEndInternal
 -- Provide some data to copy in
 insert into t_12703 select * from generate_series(1, 10)i;
+INSERT 10
 copy t_12703 to '/tmp/t_12703';
+COPY 10
 -- make copy in statement hang at the entry point of cdbCopyEndInternal
 select gp_inject_fault('hang_at_cdb_copy_end_internal', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = -1;
-1&: copy t_12703 from '/tmp/t_12703';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: copy t_12703 from '/tmp/t_12703';  <waiting ...>
 select gp_wait_until_triggered_fault('hang_at_cdb_copy_end_internal', 1, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
 -- make Gang connection is BAD
 select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=2), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
 2: select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
 2: begin;
+BEGIN
 select gp_inject_fault('hang_at_cdb_copy_end_internal', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
 -- continue copy it should not PANIC
-1<:
-1q:
+1<:  <... completed>
+ERROR:  MPP detected 1 segment failures, system is reconnected
+1q: ... <quitting>
 -- session 2 still alive (means not PANIC happens)
 2: select 1;
+ ?column? 
+----------
+ 1        
+(1 row)
 2: end;
-2q:
+END
+2q: ... <quitting>
 
 !\retcode gprecoverseg -aF --no-progress;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
 
 -- loop while segments come in sync
 select wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
 
 !\retcode gprecoverseg -ar;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
 
 -- loop while segments come in sync
 select wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
 
 -- verify no segment is down after recovery
 select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 0     
+(1 row)


### PR DESCRIPTION
…ANIC.

DisconnectAndDestroyAllGangs will destroy the memory context CdbComponentsContext.
But if we have named portal exists (cursors), later when we clean up
those portals during transaction-abort, it will PANIC due to null pointer
reference to the destroyed CdbComponentsContext.

So it is safe to call this function:
  1. call it after all portals are cleaned up
  2. call it when there cannot be any named portals

In this commit, I remove the invocation of DisconnectAndDestroyAllGangs in:
  * cdbgang_createGang_async
  * cdbCopyEndInternal

When the above two places hit error we can just leave the cleanup progress
when aborting transaction.

For details, please refer to Issue https://github.com/greenplum-db/gpdb/issues/12703.
This commit fixes it.

-----

master branch pr: https://github.com/greenplum-db/gpdb/pull/12766
this is backport.
