### PR TITLE
(6x only) Fix wrong plan of dedup semi join.

### DIFF
--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -829,11 +829,15 @@ cdb_add_join_path(PlannerInfo *root, RelOptInfo *parent_rel, JoinType orig_joint
 			return;
 
 		if (!root->disallow_unique_rowid_path)
+		{
 			path = (Path *) create_unique_rowid_path(root,
 													 parent_rel,
 													 (Path *) new_path,
 													 new_path->outerjoinpath->parent->relids,
 													 required_outer);
+		}
+		else
+			return;
 	}
 	else if (orig_jointype == JOIN_DEDUP_SEMI_REVERSE)
 	{
@@ -844,11 +848,15 @@ cdb_add_join_path(PlannerInfo *root, RelOptInfo *parent_rel, JoinType orig_joint
 			return;
 
 		if (!root->disallow_unique_rowid_path)
+		{
 			path = (Path *) create_unique_rowid_path(root,
 													 parent_rel,
 													 (Path *) new_path,
 													 new_path->innerjoinpath->parent->relids,
 													 required_outer);
+		}
+		else
+			return;
 	}
 
 	add_path(parent_rel, path);

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1408,3 +1408,88 @@ select t1.relname, ss.x from
 drop table rep_tbl;
 drop table dis_tbl;
 reset enable_seqscan;
+-- test for indexonly scan with dedup semi join
+create table t1_dedupsemi_indexonly(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t2_dedupsemi_indexonly(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t1_dedupsemi_indexonly select i,i from generate_series(1, 100)i;
+insert into t2_dedupsemi_indexonly select i,i from generate_series(1, 4)i;
+insert into t2_dedupsemi_indexonly select i,i from generate_series(1, 4)i;
+create unique index idx on t1_dedupsemi_indexonly(a);
+analyze t1_dedupsemi_indexonly;
+analyze t2_dedupsemi_indexonly;
+-- if ever seen indexonly scan path, planner will not to use
+-- unique rowid path method to implement the SEMI join. The
+-- following case will lead to a SEMI join plan to give the
+-- correct answer.
+explain (costs off)
+select * from
+(
+  select a from t1_dedupsemi_indexonly where a < 3 -- index only scan
+) x (a)
+where x.a + 1 in (select distinct b from t2_dedupsemi_indexonly);
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: ((t1_dedupsemi_indexonly.a + 1) = t2_dedupsemi_indexonly.b)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: (t1_dedupsemi_indexonly.a + 1)
+               ->  Seq Scan on t1_dedupsemi_indexonly
+                     Filter: (a < 3)
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: t2_dedupsemi_indexonly.b
+                     ->  Seq Scan on t2_dedupsemi_indexonly
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+select * from
+(
+  select a from t1_dedupsemi_indexonly where a < 3 -- index only scan
+) x (a)
+where x.a + 1 in (select distinct b from t2_dedupsemi_indexonly);
+ a 
+---
+ 1
+ 2
+(2 rows)
+
+explain (costs off)
+select * from
+(
+  select a from t1_dedupsemi_indexonly where a < 3 -- index only scan
+) x (a)
+where x.a + 1 in (select b from t2_dedupsemi_indexonly);
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: ((t1_dedupsemi_indexonly.a + 1) = t2_dedupsemi_indexonly.b)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: (t1_dedupsemi_indexonly.a + 1)
+               ->  Seq Scan on t1_dedupsemi_indexonly
+                     Filter: (a < 3)
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: t2_dedupsemi_indexonly.b
+                     ->  Seq Scan on t2_dedupsemi_indexonly
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+select * from
+(
+  select a from t1_dedupsemi_indexonly where a < 3 -- index only scan
+) x (a)
+where x.a + 1 in (select b from t2_dedupsemi_indexonly);
+ a 
+---
+ 2
+ 1
+(2 rows)
+
+drop table t1_dedupsemi_indexonly;
+drop table t2_dedupsemi_indexonly;

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1424,3 +1424,92 @@ select t1.relname, ss.x from
 drop table rep_tbl;
 drop table dis_tbl;
 reset enable_seqscan;
+-- test for indexonly scan with dedup semi join
+create table t1_dedupsemi_indexonly(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t2_dedupsemi_indexonly(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t1_dedupsemi_indexonly select i,i from generate_series(1, 100)i;
+insert into t2_dedupsemi_indexonly select i,i from generate_series(1, 4)i;
+insert into t2_dedupsemi_indexonly select i,i from generate_series(1, 4)i;
+create unique index idx on t1_dedupsemi_indexonly(a);
+analyze t1_dedupsemi_indexonly;
+analyze t2_dedupsemi_indexonly;
+-- if ever seen indexonly scan path, planner will not to use
+-- unique rowid path method to implement the SEMI join. The
+-- following case will lead to a SEMI join plan to give the
+-- correct answer.
+explain (costs off)
+select * from
+(
+  select a from t1_dedupsemi_indexonly where a < 3 -- index only scan
+) x (a)
+where x.a + 1 in (select distinct b from t2_dedupsemi_indexonly);
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: ((t1_dedupsemi_indexonly.a + 1) = t2_dedupsemi_indexonly.b)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: (t1_dedupsemi_indexonly.a + 1)
+               ->  Index Scan using idx on t1_dedupsemi_indexonly
+                     Index Cond: (a < 3)
+         ->  Hash
+               ->  GroupAggregate
+                     Group Key: t2_dedupsemi_indexonly.b
+                     ->  Sort
+                           Sort Key: t2_dedupsemi_indexonly.b
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Hash Key: t2_dedupsemi_indexonly.b
+                                 ->  Seq Scan on t2_dedupsemi_indexonly
+ Optimizer: Pivotal Optimizer (GPORCA)
+(16 rows)
+
+select * from
+(
+  select a from t1_dedupsemi_indexonly where a < 3 -- index only scan
+) x (a)
+where x.a + 1 in (select distinct b from t2_dedupsemi_indexonly);
+ a 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from
+(
+  select a from t1_dedupsemi_indexonly where a < 3 -- index only scan
+) x (a)
+where x.a + 1 in (select b from t2_dedupsemi_indexonly);
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: ((t1_dedupsemi_indexonly.a + 1) = t2_dedupsemi_indexonly.b)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: (t1_dedupsemi_indexonly.a + 1)
+               ->  Index Scan using idx on t1_dedupsemi_indexonly
+                     Index Cond: (a < 3)
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: t2_dedupsemi_indexonly.b
+                     ->  Seq Scan on t2_dedupsemi_indexonly
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
+select * from
+(
+  select a from t1_dedupsemi_indexonly where a < 3 -- index only scan
+) x (a)
+where x.a + 1 in (select b from t2_dedupsemi_indexonly);
+ a 
+---
+ 2
+ 1
+(2 rows)
+
+drop table t1_dedupsemi_indexonly;
+drop table t2_dedupsemi_indexonly;


### PR DESCRIPTION
I introduced this bug in commit dc92cc92 by forgetting the
else-clause to let to code fall through. This might lead to
a wrong plan that choose inner join instead of semi join.

The following case is an example:

```
create table t1(a int, b int);
create table t2(a int, b int);
insert into t1 select i,i from generate_series(1, 100)i;
insert into t2 select i,i from generate_series(1, 4)i;
insert into t2 select i,i from generate_series(1, 4)i;
create unique index idx on t1(a);
analyze;

explain
select * from
(
  select a from t1 where a < 3 -- index only scan
) x (a)
where x.a + 1 in (select distinct b from t2);

select * from
(
  select a from t1 where a < 3 -- index only scan
) x (a)
where x.a + 1 in (select distinct b from t2);
```

Let's take a deep look at the above case:
  - first, the distinct clause in the sublink is dropped by
    gpdb during parse-analyze stage, we have PR #12756 to
    change this behavior. Dropping distinct clause will lead
    to missing a unique operation in the subquery of the sublink.
  - second, we see index only scan in the subquery of scan t1,
    so we do not try gpdb's specific unique rowid path, but
    because of the bug (missing else-clause in cdb_add_join_path),
    we will create a inner join instead of semi join and wrong
    results.
  - if we do not have index, we will not see index only scan and
    we might choose gpdb's specific unique rowid method and give
    the correct result.

Besides, if we have the PR #12756 in and with distinct clause
in the sublink, it will force a unique path of the subquery
of the sublink's plan thus lead to correct answer also.
