### PR TITLE
[6X backport] ORCA: avoid returning output of a CTE producer

### DIFF
--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -68,7 +68,7 @@ static void
 init_tuplestore_state(ShareInputScanState *node)
 {
 	Assert(node->ts_state == NULL);
-	
+
 	EState *estate = node->ss.ps.state;
 	ShareInputScan *sisc = (ShareInputScan *)node->ss.ps.plan;
 	ShareNodeEntry *snEntry = ExecGetShareNodeEntry(estate, sisc->share_id, false);
@@ -82,7 +82,7 @@ init_tuplestore_state(ShareInputScanState *node)
 		{
 			ExecProcNode(snState);
 		}
-		
+
 		else
 		{
 			Assert(share_type == SHARE_MATERIAL_XSLICE || share_type == SHARE_SORT_XSLICE);
@@ -123,7 +123,7 @@ init_tuplestore_state(ShareInputScanState *node)
 		tuplesort_begin_pos(node->ts_state->sortstore, (TuplesortPos **)(&node->ts_pos));
 		tuplesort_rescan_pos(node->ts_state->sortstore, (TuplesortPos *)node->ts_pos);
 	}
-	else 
+	else
 	{
 		Assert(sisc->share_type == SHARE_SORT);
 		Assert(snState != NULL);
@@ -156,7 +156,7 @@ ExecShareInputScan(ShareInputScanState *node)
 
 	ShareType share_type = sisc->share_type;
 
-	/* 
+	/*
 	 * get state info from node
 	 */
 	estate = node->ss.ps.state;
@@ -172,13 +172,22 @@ ExecShareInputScan(ShareInputScanState *node)
 		init_tuplestore_state(node);
 	}
 
+	/*
+	 * Return NULL when necessary.
+	 * This could help improve performance, especially when tuplestore is huge, because ShareInputScan
+	 * do not need to read tuple from tuplestore when discard_output is true, which means current
+	 * ShareInputScan is one but not the last one of Sequence's subplans.
+	 */
+    if (sisc->discard_output)
+        return NULL;
+
 	slot = node->ss.ps.ps_ResultTupleSlot;
 
 	while(1)
 	{
 		bool gotOK = false;
 
-		if(share_type == SHARE_MATERIAL || share_type == SHARE_MATERIAL_XSLICE) 
+		if(share_type == SHARE_MATERIAL || share_type == SHARE_MATERIAL_XSLICE)
 		{
 			ntuplestore_acc_advance((NTupleStoreAccessor *) node->ts_pos, forward ? 1 : -1);
 			gotOK = ntuplestore_acc_current_tupleslot((NTupleStoreAccessor *) node->ts_pos, slot);
@@ -201,7 +210,7 @@ ExecShareInputScan(ShareInputScanState *node)
 }
 
 /*  ------------------------------------------------------------------
- * 	ExecInitShareInputScan 
+ * 	ExecInitShareInputScan
  * ------------------------------------------------------------------
  */
 ShareInputScanState *
@@ -212,12 +221,12 @@ ExecInitShareInputScan(ShareInputScan *node, EState *estate, int eflags)
 	TupleDesc tupDesc;
 
 	Assert(innerPlan(node) == NULL);
-	
+
 	/* create state data structure */
 	sisstate = makeNode(ShareInputScanState);
 	sisstate->ss.ps.plan = (Plan *) node;
 	sisstate->ss.ps.state = estate;
-	
+
 	sisstate->ts_state = NULL;
 	sisstate->ts_pos = NULL;
 	sisstate->ts_markpos = NULL;
@@ -231,15 +240,15 @@ ExecInitShareInputScan(ShareInputScan *node, EState *estate, int eflags)
 		sisstate->share_lk_ctxt = shareinput_init_lk_ctxt(node->share_id);
 	}
 
-	/* 
-	 * init child node.  
-	 * if outerPlan is NULL, this is no-op (so that the ShareInput node will be 
+	/*
+	 * init child node.
+	 * if outerPlan is NULL, this is no-op (so that the ShareInput node will be
 	 * only init-ed once).
 	 */
 	outerPlan = outerPlan(node);
 	outerPlanState(sisstate) = ExecInitNode(outerPlan, estate, eflags);
 
-	sisstate->ss.ps.targetlist = (List *) 
+	sisstate->ss.ps.targetlist = (List *)
 		ExecInitExpr((Expr *) node->scan.plan.targetlist, (PlanState *) sisstate);
 	Assert(node->scan.plan.qual == NULL);
 	sisstate->ss.ps.qual = NULL;
@@ -254,7 +263,7 @@ ExecInitShareInputScan(ShareInputScan *node, EState *estate, int eflags)
 	ExecInitResultTupleSlot(estate, &sisstate->ss.ps);
 	sisstate->ss.ss_ScanTupleSlot = ExecInitExtraTupleSlot(estate);
 
-	/* 
+	/*
 	 * init tuple type.
 	 */
 	ExecAssignResultTypeFromTL(&sisstate->ss.ps);
@@ -266,7 +275,7 @@ ExecInitShareInputScan(ShareInputScan *node, EState *estate, int eflags)
 
 		tupDesc = ExecTypeFromTL(node->scan.plan.targetlist, hasoid);
 	}
-		
+
 	ExecAssignScanType(&sisstate->ss, tupDesc);
 
 	sisstate->ss.ps.ps_ProjInfo = NULL;
@@ -290,13 +299,13 @@ ExecInitShareInputScan(ShareInputScan *node, EState *estate, int eflags)
 	 * ExecSliceDependencyShareInputScan() which is called at the begining of ExecutePlan().
 	 * The shareinput-writer will open/create the named pipe file when data is ready.
 	 * The READER and the WRITER share the pipe file for communication, so the pipe file
-	 * must be in the same tablespace. 
+	 * must be in the same tablespace.
 	 *
 	 * We can't call PrepareTempTablespaces() under ExecShareInputScan()/ExecProcNode()
 	 * like other callers, because it's too late for the READER.
 	 */
 	PrepareTempTablespaces();
-	
+
 	return sisstate;
 }
 
@@ -333,7 +342,7 @@ void ExecEndShareInputScan(ShareInputScanState *node)
 
 	ExecEagerFreeShareInputScan(node);
 
-	/* 
+	/*
 	 * shutdown subplan.  First scanner of underlying share input will
 	 * do the shutdown, all other scanners are no-op because outerPlanState
 	 * is NULL
@@ -378,7 +387,7 @@ ExecReScanShareInputScan(ShareInputScanState *node)
 }
 
 /*************************************************************************
- * XXX 
+ * XXX
  * we need some IPC mechanism for shareinput_read_wait/writer_notify.  Semaphore is
  * the first thing come to mind but it turns out postgres is very picky about
  * how to use semaphore and we do not want to mess up with it.
@@ -393,12 +402,12 @@ ExecReScanShareInputScan(ShareInputScanState *node)
  * At first, I used postgres File to manage the FIFO.  It turns out this is not
  * correct because when postgres run out of file descriptors, it will try to close
  * some file descriptors using an LRU algorithm.  Later when the File is used again,
- * postgres will reopen it. The FIFO here is used for synchronization so it is simply 
+ * postgres will reopen it. The FIFO here is used for synchronization so it is simply
  * wrong.  Here we use the file descriptor directly, and use a XCallBack to cleanup
  * the resource at the end of transaction (commit or abort).
- * 
+ *
  * XXX However, it is always better to have this kind of stuff abstracted out
- * by the system.  
+ * by the system.
  **************************************************************************/
 
 #include "fcntl.h"
@@ -413,7 +422,7 @@ char *shareinput_create_bufname_prefix(int share_id)
 	return psprintf("SIRW_%d_%d_%d", gp_session_id, gp_command_count, share_id);
 }
 
-/* Here we use the absolute path name as the lock name.  See fd.c 
+/* Here we use the absolute path name as the lock name.  See fd.c
  * for how the name is created (GP_TEMP_FILE_DIR and make_database_relative).
  */
 static void
@@ -499,7 +508,7 @@ static void shareinput_clean_lk_ctxt(ShareInput_Lk_Context *lk_ctxt)
 
 static void XCallBack_ShareInput_FIFO(XactEvent ev, void* vp)
 {
-	ShareInput_Lk_Context *lk_ctxt = (ShareInput_Lk_Context *) vp; 
+	ShareInput_Lk_Context *lk_ctxt = (ShareInput_Lk_Context *) vp;
 	shareinput_clean_lk_ctxt(lk_ctxt);
 }
 
@@ -515,7 +524,7 @@ create_tmp_fifo(const char *fifoname)
 #endif
 }
 
-/* 
+/*
  * As all other read/write in postgres, we may be interrupted so retry is needed.
  */
 static int retry_read(int fd, char *buf, int rsize)
@@ -587,7 +596,7 @@ static void fi_close_created_fds(int *fds, char *file_prefix, int num)
 }
 #endif
 
-/* 
+/*
  * Readiness (a) synchronization.
  *
  * For readiness, the shared node will write xslice of 'a' into the pipe.
@@ -595,15 +604,15 @@ static void fi_close_created_fds(int *fds, char *file_prefix, int num)
  * it need to write all xslice copies of 'a', even if we are interrupted, that
  * is, we should not call CHECK_FOR_INTERRUPTS.
  *
- * For sharer, it need to check for ready to read (using select), because read 
+ * For sharer, it need to check for ready to read (using select), because read
  * is blocking.  Otherwise if shared is cancelled before write, then we will be
  * blocked here forever.  Once shared has write at least one 'a', it will write
  * all xslice of 'a', so once select succeed, read will eventually succeed.  Once
  * sharer got 'a', it write 'b' back to shared.
  *
  * Done (b and z) synchronization.
- * For done, the shared is the only reader.  sharer will not block for writing, 
- * but shared may block for read, therefore, we much call select before shared 
+ * For done, the shared is the only reader.  sharer will not block for writing,
+ * but shared may block for read, therefore, we much call select before shared
  * calling read.  Because there is only one shared, nobody can steal char from
  * the pipe, therefore, if select succeed, read will not block forever.
  *
@@ -653,7 +662,7 @@ shareinput_reader_waitready(void *ctxt, int share_id, PlanGenerator planGen)
 #endif
 
 	create_tmp_fifo(pctxt->lkname_ready);
-	pctxt->readyfd = open(pctxt->lkname_ready, O_RDWR, 0600); 
+	pctxt->readyfd = open(pctxt->lkname_ready, O_RDWR, 0600);
 	if(pctxt->readyfd < 0)
 		elog(ERROR, "could not open fifo \"%s\": %m", pctxt->lkname_ready);
 
@@ -741,7 +750,7 @@ shareinput_writer_notifyready(void *ctxt, int share_id, int xslice, PlanGenerato
 
 	create_tmp_fifo(pctxt->lkname_ready);
 	pctxt->del_ready = true;
-	pctxt->readyfd = open(pctxt->lkname_ready, O_RDWR, 0600); 
+	pctxt->readyfd = open(pctxt->lkname_ready, O_RDWR, 0600);
 	if(pctxt->readyfd < 0)
 		elog(ERROR, "could not open fifo \"%s\": %m", pctxt->lkname_ready);
 
@@ -761,7 +770,7 @@ shareinput_writer_notifyready(void *ctxt, int share_id, int xslice, PlanGenerato
 	}
 	elog(DEBUG1, "SISC WRITER (shareid=%d, slice=%d): wrote notify_ready to %d xslice readers",
 						share_id, currentSliceId, xslice);
-	
+
 	if (planGen == PLANGEN_PLANNER)
 	{
 		/* For planner-generated plans, we wait for acks from all the readers */
@@ -910,7 +919,7 @@ shareinput_writer_waitdone(void *ctxt, int share_id, int nsharer_xslice)
 			elog(DEBUG1, "SISC WRITER (shareid=%d, slice=%d): wait done timeout once",
 					share_id, currentSliceId);
 		}
-		else 
+		else
 		{
 			int save_errno = errno;
 			elog(LOG, "SISC WRITER (shareid=%d, slice=%d): wait done time out once, errno %d",
@@ -973,11 +982,11 @@ ExecEagerFreeShareInputScan(ShareInputScanState *node)
 		}
 	}
 
-	/* 
+	/*
 	 * Reset our copy of the pointer to the ts_state. The tuplestore can still be accessed by
 	 * the other consumers, but we don't have a pointer to it anymore
-	 */ 
-	node->ts_state = NULL; 
+	 */
+	node->ts_state = NULL;
 	node->ts_pos = NULL;
 	node->ts_markpos = NULL;
 

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -3535,6 +3535,7 @@ CTranslatorDXLToPlStmt::TranslateDXLCTEProducerToSharedScan(
 	// create the shared input scan representing the CTE Producer
 	ShareInputScan *shared_input_scan = MakeNode(ShareInputScan);
 	shared_input_scan->share_id = cte_id;
+	shared_input_scan->discard_output = true;
 	Plan *plan = &(shared_input_scan->scan.plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
@@ -3747,6 +3748,7 @@ CTranslatorDXLToPlStmt::TranslateDXLCTEConsumerToSharedScan(
 
 	ShareInputScan *share_input_scan_cte_consumer = MakeNode(ShareInputScan);
 	share_input_scan_cte_consumer->share_id = cte_id;
+	share_input_scan_cte_consumer->discard_output = false;
 
 	Plan *plan = &(share_input_scan_cte_consumer->scan.plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();

--- a/src/backend/optimizer/plan/planshare.c
+++ b/src/backend/optimizer/plan/planshare.c
@@ -27,7 +27,7 @@ int get_plan_share_id(Plan *p)
 {
 	if(IsA(p, Material))
 		return ((Material *) p)->share_id;
-	
+
 	if(IsA(p, Sort))
 		return ((Sort *) p)->share_id;
 
@@ -52,7 +52,7 @@ ShareType get_plan_share_type(Plan *p)
 {
 	if(IsA(p, Material))
 		return ((Material *) p)->share_type;
-	
+
 	if(IsA(p, Sort))
 		return ((Sort *) p)->share_type ;
 
@@ -127,7 +127,7 @@ void incr_plan_nsharer_xslice(Plan *p)
 	}
 }
 
-static ShareInputScan *make_shareinputscan(PlannerInfo *root, Plan *inputplan) 
+static ShareInputScan *make_shareinputscan(PlannerInfo *root, Plan *inputplan)
 {
 	ShareInputScan *sisc = NULL;
 	Path sipath;
@@ -153,6 +153,7 @@ static ShareInputScan *make_shareinputscan(PlannerInfo *root, Plan *inputplan)
 	set_plan_share_type((Plan *) sisc, get_plan_share_type(inputplan));
 	set_plan_share_id((Plan *) sisc, get_plan_share_id(inputplan));
 	sisc->driver_slice = -1;
+    sisc->discard_output = false;
 
 	sisc->scan.plan.qual = NIL;
 	sisc->scan.plan.righttree = NULL;
@@ -185,7 +186,7 @@ prepare_plan_for_sharing(PlannerInfo *root, Plan *common)
 	{
 		shared = common->lefttree;
 	}
-	
+
 	else if(IsA(common, Material))
 	{
 		Material *m = (Material *) common;
@@ -220,7 +221,7 @@ prepare_plan_for_sharing(PlannerInfo *root, Plan *common)
 		shared->plan_rows = common->plan_rows;
 		shared->plan_width = common->plan_width;
 		shared->dispatch = common->dispatch;
-		shared->flow = copyObject(common->flow); 
+		shared->flow = copyObject(common->flow);
 		shared->extParam = bms_copy(common->extParam);
 		shared->allParam = bms_copy(common->allParam);
 
@@ -275,7 +276,7 @@ share_plan(PlannerInfo *root, Plan *common, int numpartners)
 /*
  * Return the total cost of sharing common numpartner times.
  * If the planner need to make a decision whether the common subplan should be shared
- * or should be duplicated, planner should compare the cost returned by this function 
+ * or should be duplicated, planner should compare the cost returned by this function
  * against common->total_cost * numpartners.
  */
 Cost cost_share_plan(Plan *common, PlannerInfo *root, int numpartners)

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -979,6 +979,9 @@ typedef struct ShareInputScan
 	ShareType 	share_type;
 	int 		share_id;
 	int 		driver_slice;   	/* slice id that will execute the underlying material/sort */
+
+    /* Discard the scan output? True for ORCA CTE producer, false otherwise. */
+    bool        discard_output;
 } ShareInputScan;
 
 /* ----------------


### PR DESCRIPTION
When dealing with queries which have CTE and result set being used
more than once, ORCA produces a plan with Sequence Node and
ShareInputScan Node. Here is an example:

explain (costs off) with tmp_t as (select id from test) select a.id from tmp_t a join tmp_t b on a.id = b.id;
```
                          QUERY PLAN
 ------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   ->  Sequence
         ->  Shared Scan (share slice:id 1:0)
               ->  Seq Scan on test
         ->  Hash Join
               Hash Cond: (share0_ref3.id = share0_ref2.id)
               ->  Shared Scan (share slice:id 1:0)
               ->  Hash
                     ->  Shared Scan (share slice:id 1:0)
 Optimizer: Pivotal Optimizer (GPORCA)
(10 rows)
```

This plan has three ShareInputScan nodes: one producer and two
consumers, all of them read from the tuplestore and return tuples to
upper node.  However, the CTE producer does not need to do so, because
the Sequence Node only receives the last subplan's output tuples.

When tuplestore is small, the extra read from the CTE producer is at
low cost, but when tuplestore is huge, this read is heavy and would
cause bad performance of the entire query.

This commit adds a flag discard_output in ShareInputScan plan node to
indicate when a ShareInputScan can avoid reading from tuplestore and
return early. The flag is set to true by ORCA when translating CTE producer,
and set to false elsewhere.

Fixes #12710

Co-authored-by: wuyuhao28 <wuyuhao28@github.com>
Co-authored-by: Alexandra Wang <walexandra@vmware.com>
Reviewed-by: Zhenghua Lyu <kainwen@gmail.com>
Reviewed-by: Shreedhar Hardikar <shardikar@vmware.com>
(cherry picked from commit 1b5be8cc5be9bf9e55d381b239cc9037c81eb340)

