### PR TITLE
Modify change tracking disabled assertion to work with gpaddmirrors

### DIFF
--- a/src/backend/cdb/cdbresynchronizechangetracking.c
+++ b/src/backend/cdb/cdbresynchronizechangetracking.c
@@ -2319,7 +2319,10 @@ ChangeTracking_MarkFullResyncLockAcquired(void)
 	FileRep_SetSegmentState(SegmentStateChangeTrackingDisabled, FaultTypeNotInitialized);
 
 	getFileRepRoleAndState(&fileRepRole, &segmentState, &dataState, NULL, NULL);
-	Assert(segmentState == SegmentStateChangeTrackingDisabled);
+	Assert(segmentState == SegmentStateChangeTrackingDisabled /* common scenario */ ||
+		(fileRepRole == FileRepNoRoleConfigured &&
+		 segmentState == SegmentStateNotInitialized &&
+		 dataState == DataStateNotInitialized) /* PMModeMirrorlessSegment doing gpaddmirrors */);
 }
 
 /*


### PR DESCRIPTION
The assertion was added back in 2017 to make sure that change tracking
was disabled when change tracking logs get partially written or
corrupted (mostly due to disk full or other disk issues). However, it
was not noticed that gpaddmirrors goes through the same code path with
mode PMModeMirrorlessSegment (mostly because our gpaddmirrors
automated tests used to run on non-assert builds). The assertion would
always fail when running gpaddmirrors because getFileRepRoleAndState()
only returns valid values for PMModePrimarySegment and
PMModeMirrorSegment. Modify the assertion to make an exception for
gpaddmirrors.

GPDB commit reference:
https://github.com/greenplum-db/gpdb/commit/a0cc23d497a001c82b6cff07d5143be6f2e322b1

This PR fixes the gpaddmirrors job in the 5X_STABLE_with_asserts pipeline that was recently created this past summer.