### PR TITLE
Fix data redistributed between segs in copy (query) on segment

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -503,26 +503,6 @@ apply_motion(PlannerInfo *root, Plan *plan, Query *query)
 						targetPolicy = createHashPartitionedPolicy(policykeys,
 																   policyopclasses,
 																   GP_POLICY_DEFAULT_NUMSEGMENTS());
-
-						if (query->parentStmtType == PARENTSTMTTYPE_COPY)
-						{
-							/* TODO
-							if (glob_cstate->on_segment && glob_cstate->rel == NULL)
-							{
-								ereport(WARNING
-										// (errcode(ERRCODE_SUCCESSFUL_COMPLETION),
-										 errmsg("Results are redistributed between segments, please note.")
-										);
-							}
-							*/
-
-							/* redistributed results in 'copy (query) on segment',
-							 * so need to give user a warning.
-							 */
-							ereport(NOTICE,
-									 (errmsg("Results are redistributed between segments, please note."))
-									);
-						}
 					}
 
 					/* If we deduced the policy from the query, give a NOTICE */

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -456,6 +456,13 @@ apply_motion(PlannerInfo *root, Plan *plan, Query *query)
 				}
 				else
 				{
+					/*
+					 *	wenlin: skip get targetPolicy for copy (select ...)
+					 *										*/
+					if (query->parentStmtType == PARENTSTMTTYPE_COPY)
+					{
+						break;
+					}
 					/* First try to deduce the distribution from the query */
 					targetPolicy = get_partitioned_policy_from_flow(plan);
 

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -503,6 +503,26 @@ apply_motion(PlannerInfo *root, Plan *plan, Query *query)
 						targetPolicy = createHashPartitionedPolicy(policykeys,
 																   policyopclasses,
 																   GP_POLICY_DEFAULT_NUMSEGMENTS());
+
+						if (query->parentStmtType == PARENTSTMTTYPE_COPY)
+						{
+							/* TODO
+							if (glob_cstate->on_segment && glob_cstate->rel == NULL)
+							{
+								ereport(WARNING
+										// (errcode(ERRCODE_SUCCESSFUL_COMPLETION),
+										 errmsg("Results are redistributed between segments, please note.")
+										);
+							}
+							*/
+
+							/* redistributed results in 'copy (query) on segment',
+							 * so need to give user a warning.
+							 */
+							ereport(NOTICE,
+									 (errmsg("Results are redistributed between segments, please note."))
+									);
+						}
 					}
 
 					/* If we deduced the policy from the query, give a NOTICE */

--- a/src/backend/cdb/cdbpullup.c
+++ b/src/backend/cdb/cdbpullup.c
@@ -23,7 +23,6 @@
 #include "nodes/nodeFuncs.h"	/* exprType() and exprTypmod() */
 #include "parser/parsetree.h"	/* get_tle_by_resno() */
 #include "utils/lsyscache.h"	/* get_opfamily_member() */
-#include "cdb/cdbhash.h"        /* cdb_eqop_in_hash_opfamily() */
 
 #include "cdb/cdbpullup.h"		/* me */
 
@@ -306,20 +305,10 @@ cdbpullup_findEclassInTargetList(EquivalenceClass *eclass, List *targetlist,
 		Expr	   *key = (Expr *) em->em_expr;
 		ListCell *lc_tle;
 
-		if (OidIsValid(hashOpFamily))
-		{
-			PG_TRY();
-			{
-				if (!cdb_eqop_in_hash_opfamily(hashOpFamily, em->em_datatype))
-					continue;
-			}
-			PG_CATCH();
-			{
-				/* not found */
-				continue;
-			}
-			PG_END_TRY();
-		}
+		if (OidIsValid(hashOpFamily) &&
+			!get_opfamily_member(hashOpFamily, em->em_datatype, em->em_datatype,
+								 HTEqualStrategyNumber))
+			continue;
 
 		/* A constant is OK regardless of the target list */
 		if (em->em_is_const)

--- a/src/backend/cdb/cdbpullup.c
+++ b/src/backend/cdb/cdbpullup.c
@@ -23,6 +23,7 @@
 #include "nodes/nodeFuncs.h"	/* exprType() and exprTypmod() */
 #include "parser/parsetree.h"	/* get_tle_by_resno() */
 #include "utils/lsyscache.h"	/* get_opfamily_member() */
+#include "cdb/cdbhash.h"        /* cdb_eqop_in_hash_opfamily() */
 
 #include "cdb/cdbpullup.h"		/* me */
 
@@ -305,10 +306,20 @@ cdbpullup_findEclassInTargetList(EquivalenceClass *eclass, List *targetlist,
 		Expr	   *key = (Expr *) em->em_expr;
 		ListCell *lc_tle;
 
-		if (OidIsValid(hashOpFamily) &&
-			!get_opfamily_member(hashOpFamily, em->em_datatype, em->em_datatype,
-								 HTEqualStrategyNumber))
-			continue;
+		if (OidIsValid(hashOpFamily))
+		{
+			PG_TRY();
+			{
+				if (!cdb_eqop_in_hash_opfamily(hashOpFamily, em->em_datatype))
+					continue;
+			}
+			PG_CATCH();
+			{
+				/* not found */
+				continue;
+			}
+			PG_END_TRY();
+		}
 
 		/* A constant is OK regardless of the target list */
 		if (em->em_is_const)

--- a/src/test/regress/expected/copyselect.out
+++ b/src/test/regress/expected/copyselect.out
@@ -153,3 +153,37 @@ select * from test3;
 (2 rows)
 
 drop table test3;
+-- copy (query) to ... on segment
+-- https://github.com/greenplum-db/gpdb/issues/12700
+-- a partition table distributed by a varchar distkey
+CREATE TABLE part_table (high varchar(32), id int, code char(1))
+DISTRIBUTED BY (high)
+PARTITION BY RANGE (code)
+( PARTITION p1 start('a') end ('c'),
+  PARTITION p2 start('c') end ('e'),
+  PARTITION p3 start('e') end ('g'),
+  DEFAULT PARTITION others
+);
+NOTICE:  CREATE TABLE will create partition "part_table_1_prt_others" for table "part_table"
+NOTICE:  CREATE TABLE will create partition "part_table_1_prt_p1" for table "part_table"
+NOTICE:  CREATE TABLE will create partition "part_table_1_prt_p2" for table "part_table"
+NOTICE:  CREATE TABLE will create partition "part_table_1_prt_p3" for table "part_table"
+insert into part_table select g::varchar(32), g, chr( (ascii('a') + g%10) ) from generate_series(1,1000) as g;
+-- execute copy (query) on segment
+\set QUIET off
+COPY (select gp_segment_id, high from part_table where code < 'c' and gp_segment_id=0) TO '/tmp/copy_out_varchar_<SEGID>.csv' ON SEGMENT csv delimiter '|' quote '"';
+COPY 63
+COPY (select gp_segment_id, high from part_table where code < 'c' and gp_segment_id=1) TO '/tmp/copy_out_varchar_<SEGID>.csv' ON SEGMENT csv delimiter '|' quote '"';
+COPY 64
+COPY (select gp_segment_id, high from part_table where code < 'c' and gp_segment_id=2) TO '/tmp/copy_out_varchar_<SEGID>.csv' ON SEGMENT csv delimiter '|' quote '"';
+COPY 73
+\set QUIET on
+-- rows should be same as copy above
+select gp_segment_id,count(*) from part_table where code < 'c' group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+             1 |    64
+             2 |    73
+             0 |    63
+(3 rows)
+


### PR DESCRIPTION
This PR fix https://github.com/greenplum-db/gpdb/issues/12700.

Current logic:
https://github.com/greenplum-db/gpdb/blob/1242aadf0137d3b26ee42c80e579e78bd7a805c7/src/backend/cdb/cdbmutate.c#L438-L441
This logic is used for CTAS, no for Copy. 
Apply this logic will cause results redistributed again (please see repro steps in the issue) in some scenes, so cause 'copy (quey) on segment' gets error outputs.

To avoid this issue, just skip this logic for copy, the same as master branch does (doesn't have this issue):
https://github.com/greenplum-db/gpdb/blob/b57bf4a2a3da9d7dc0fb21c69aea074d22e5098a/src/backend/cdb/cdbllize.c#L406
https://github.com/greenplum-db/gpdb/blob/b57bf4a2a3da9d7dc0fb21c69aea074d22e5098a/src/backend/cdb/cdbllize.c#L581


## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
