### PR TITLE
Docs: improved gpmt home page

### DIFF
--- a/gpdb-doc/dita/utility_guide/ref/gpmt.xml
+++ b/gpdb-doc/dita/utility_guide/ref/gpmt.xml
@@ -8,12 +8,15 @@
       required by VMware Support.</p>
     <section>
       <title>Synopsis</title>
-      <codeblock><b>gpmt</b> tool [<varname>tool_options</varname> ...] 
-[<varname>-hostfile FILE</varname>] [<varname>-help</varname>] [<varname>-verbose</varname>]
+      <codeblock><b>gpmt </b> <varname>tool</varname> [<varname>tool_options</varname> ...] 
+<b>gpmt -hostfile</b> <varname>FILE</varname>
+<b>gpmt -help</b>
+<b>gpmt -verbose</b>
 </codeblock>
     </section>
     <section>
       <title>Tools</title>
+      <sectiondiv><b>Greenplum</b></sectiondiv>
       <parml>
         <plentry>
           <pt><xref href="gpmt-analyze_session.xml" type="topic" format="dita">analyze_session</xref></pt>
@@ -55,9 +58,7 @@
             RCA.</pd>
         </plentry>
       </parml>
-    </section>
-    <section>
-      <title>Options</title>
+      <sectiondiv><b>Miscellaneous</b></sectiondiv>
       <parml>
         <plentry>
           <pt><varname>hostfile</varname></pt>
@@ -76,6 +77,11 @@
           <pt><varname>version</varname></pt>
           <pd>Display the GPMT version.</pd>
         </plentry>
+      </parml>
+    </section>
+    <section>
+      <title>Global Options</title>
+      <parml>
         <plentry>
           <pt><varname>-hostfile</varname></pt>
           <pd>Limit the hosts where the tool will be run.</pd>
@@ -89,6 +95,15 @@
           <pd>Print verbose log messages.</pd>
         </plentry>
       </parml>
+    </section>
+    <section>
+      <title>Examples</title>
+      <p><b>Display gpmt version</b></p>
+      <codeblock>gpmt version</codeblock>
+      <p><b>Collect a core file</b></p>
+      <codeblock>gpmt packcore -cmd collect -core core.1234</codeblock>
+      <p><b>Show help for a specific tool</b></p>
+      <codeblock>gpmt gp_log_collector -help</codeblock>
     </section>
   </body>
 </topic>

--- a/gpdb-doc/dita/utility_guide/ref/gpmt.xml
+++ b/gpdb-doc/dita/utility_guide/ref/gpmt.xml
@@ -9,8 +9,11 @@
     <section>
       <title>Synopsis</title>
       <codeblock><b>gpmt </b> <varname>tool</varname> [<varname>tool_options</varname> ...] 
+
 <b>gpmt -hostfile</b> <varname>FILE</varname>
+
 <b>gpmt -help</b>
+
 <b>gpmt -verbose</b>
 </codeblock>
     </section>


### PR DESCRIPTION
Modified GPMT home page:

- Under synopsis, Separate the help, verbose and version option.
- Give only global options - same as in online help
- Divide tools into GPDB and MISC as in online help
- Add examples same as from online help

Preview site:
https://mireia-gpmt.sc2-04-pcf1-apps.oc.vmware.com/7-0/utility_guide/ref/gpmt.html