### PR TITLE
Fix potential nullptr dereference issue.

### DIFF
--- a/src/test/regress/expected/db_size_functions.out
+++ b/src/test/regress/expected/db_size_functions.out
@@ -311,6 +311,18 @@ select pg_total_relation_size('aocssizetest') = pg_table_size('aocssizetest');
  t
 (1 row)
 
+-- Test when the auxiliary relation of AO table is corrupted, the database will not PANIC.
+create table ao_with_malformed_visimaprelid (a int) with (appendonly=true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Set visimaprelid record in the pg_appendonly table to a malformed value.
+set allow_system_table_mods=true;
+update pg_appendonly
+  set visimaprelid=16383
+  where relid=(select oid from pg_class where relname='ao_with_malformed_visimaprelid');
+select pg_table_size('ao_with_malformed_visimaprelid');
+ERROR:  invalid auxiliary relation oid 16383 for appendonly relation 'ao_with_malformed_visimaprelid' (dbsize.c:610)
+drop table ao_with_malformed_visimaprelid;
 -- Also test pg_relation_size() in a query that selects from pg_class. It is a
 -- very typical way to use the functions, so make sure it works. (A
 -- plausible difference to the above scenarios would be that the function

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -132,4 +132,7 @@ s/.//gs
 m/HINT:  For non-partitioned tables, run analyze .+\. For partitioned tables, run analyze rootpartition .+\. See log for columns missing statistics\./
 s/.//gs
 
+m/\(dbsize\.c\:\d+\)/
+s/\(dbsize\.c:\d+\)/\(dbsize\.c:XXX\)/
+
 -- end_matchsubs

--- a/src/test/regress/sql/db_size_functions.sql
+++ b/src/test/regress/sql/db_size_functions.sql
@@ -96,6 +96,15 @@ select pg_table_size('aocssizetest') > pg_relation_size('aocssizetest');
 select pg_total_relation_size('aocssizetest') between 1500000 and 3000000; -- 1884456
 select pg_total_relation_size('aocssizetest') = pg_table_size('aocssizetest');
 
+-- Test when the auxiliary relation of AO table is corrupted, the database will not PANIC.
+create table ao_with_malformed_visimaprelid (a int) with (appendonly=true);
+-- Set visimaprelid record in the pg_appendonly table to a malformed value.
+set allow_system_table_mods=true;
+update pg_appendonly
+  set visimaprelid=16383
+  where relid=(select oid from pg_class where relname='ao_with_malformed_visimaprelid');
+select pg_table_size('ao_with_malformed_visimaprelid');
+drop table ao_with_malformed_visimaprelid;
 
 -- Also test pg_relation_size() in a query that selects from pg_class. It is a
 -- very typical way to use the functions, so make sure it works. (A


### PR DESCRIPTION
The returned relation 'auxRel' of 'try_relation_open()' is not checked.
Though it's safe to pass nullptr to 'calculate_total_relation_size()',
'relation_close()' needs a valid pointer.

Simple SQL to reproduce:

```sql
CREATE TABLE ao_with_malformed_visimaprelid (a int) WITH (appendonly=true);
-- Set visimaprelid record in the pg_appendonly table to a malformed value.
SET allow_system_table_mods=true;
UPDATE pg_appendonly
  SET visimaprelid=16383
  WHERE relid=(SELECT oid FROM pg_class WHERE relname='ao_with_malformed_visimaprelid');
SELECT pg_table_size('ao_with_malformed_visimaprelid');
```

This change is intuitive, do we need a test?

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
