### PR TITLE
Fix compilation warning for gp_dispatch_keepalives GUC

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4060,7 +4060,6 @@ struct config_int ConfigureNamesInt_gp[] =
 			gettext_noop("This controls the number of consecutive keepalive retransmits that can be "
 						 "lost before a QD/QE connection is considered dead. A value of 0 uses the "
 						 "system default."),
-			NULL,
 			GUC_NOT_IN_SAMPLE
 		},
 		&gp_dispatch_keepalives_count,


### PR DESCRIPTION
This is the warning:
guc_gp.c:4063:4: warning: initialization of 'int' from 'void *'
makes integer from pointer without a cast [-Wint-conversion]
 4063 |    NULL,
      |    ^~~~

That happens because there was an extra field in the struct that
described gp_dispatch_keepalives_count GUC (introduced in
https://github.com/greenplum-db/gpdb/commit/d673b309ce571932fbf887ae25182d28dac913b7).
