### PR TITLE
Restore redo functions for AO smgr on standby

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -12312,15 +12312,13 @@ IsStandbyMode(void)
 }
 
 /*
- * True if we are running crash recovery.
- * False if we are running standby continious recovery or not in recovery at all
- * This only works in the startup process as the ArchiveRecoveryRequested and
- * StandbyModeRequested flags are not in shared memory.
+ * True if we are currently performing crash recovery.
+ * False if we are running standby-mode continuous or archive recovery.
  */
 bool
 IsCrashRecoveryOnly(void)
 {
-	return ArchiveRecoveryRequested == false && StandbyModeRequested == false;
+	return !ArchiveRecoveryRequested && !StandbyModeRequested;
 }
 
 /*

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -12312,6 +12312,18 @@ IsStandbyMode(void)
 }
 
 /*
+ * True if we are running crash recovery.
+ * False if we are running standby continious recovery or not in recovery at all
+ * This only works in the startup process as the ArchiveRecoveryRequested and
+ * StandbyModeRequested flags are not in shared memory.
+ */
+bool
+IsCrashRecoveryOnly(void)
+{
+	return ArchiveRecoveryRequested == false && StandbyModeRequested == false;
+}
+
+/*
  * Report the last WAL replay location
  */
 XLogRecPtr

--- a/src/backend/cdb/cdbappendonlyxlog.c
+++ b/src/backend/cdb/cdbappendonlyxlog.c
@@ -203,14 +203,6 @@ appendonly_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record)
 	uint8         xl_info = record->xl_info;
 	uint8         info = xl_info & ~XLR_INFO_MASK;
 
-	/*
-	 * Perform redo of AO XLOG records only for standby mode. We do
-	 * not need to replay AO XLOG records in normal mode because fsync
-	 * is performed on file close.
-	 */
-	if (!IsStandbyMode())
-		return;
-
 	switch (info)
 	{
 		case XLOG_APPENDONLY_INSERT:

--- a/src/backend/cdb/cdbappendonlyxlog.c
+++ b/src/backend/cdb/cdbappendonlyxlog.c
@@ -203,6 +203,14 @@ appendonly_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record)
 	uint8         xl_info = record->xl_info;
 	uint8         info = xl_info & ~XLR_INFO_MASK;
 
+	/*
+	 * Do not perform redo of AO XLOG records for crash recovery mode. We do
+	 * not need to replay AO XLOG records in this case because fsync
+	 * is performed on file close.
+	 */
+	if (IsCrashRecoveryOnly())
+		return;
+
 	switch (info)
 	{
 		case XLOG_APPENDONLY_INSERT:

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -379,6 +379,7 @@ extern void do_pg_abort_backup(void);
 /* Greenplum additions */
 extern List *XLogReadTimeLineHistory(TimeLineID targetTLI);
 extern bool IsStandbyMode(void);
+extern bool IsCrashRecoveryOnly(void);
 extern DBState GetCurrentDBState(void);
 extern XLogRecPtr last_xlog_replay_location(void);
 extern void wait_for_mirror(void);

--- a/src/test/recovery/t/101_non_standby_recovery.pl
+++ b/src/test/recovery/t/101_non_standby_recovery.pl
@@ -2,19 +2,33 @@ use strict;
 use warnings;
 use PostgresNode;
 use TestLib;
-use Test::More tests => 1;
+use Test::More tests => 3;
 
 my $node = get_new_node('master');
 
 # Create a data directory with initdb
-$node->init;
+$node->init(has_archiving    => 1);
 
 # Start the PostgreSQL server
 $node->start;
 
-# Take a backup of a stopped server
+# Take a backup of a running server
+$node->backup_fs_hot('testbackup');
+
+# Create a couple of tables: heap, append-optimized, columnar append-optimized
+# Restored cluster should replay these actions later
+$node->safe_psql(
+	'postgres', "
+	BEGIN;
+	CREATE TABLE heap AS SELECT a FROM generate_series(1,10) AS a;
+	CREATE TABLE ao(a int, b int) WITH (appendoptimized = true) DISTRIBUTED BY (a);
+	CREATE TABLE co(a int, b int) WITH (appendoptimized = true, orientation = column) DISTRIBUTED BY (a);
+	INSERT INTO ao select i, i FROM generate_series(1,10)i;
+	INSERT INTO co select i, i FROM generate_series(1,10)i;
+	COMMIT;");
+
+# Stop the PostgreSQL server
 $node->stop;
-my $ret = $node->backup_fs_cold('testbackup');
 
 # Restore it to create a new independent node
 my $restored_node = get_new_node('restored_node');
@@ -31,4 +45,7 @@ standby_mode=off
 $restored_node->start;
 
 # Make sure that the server is up and running
-is($restored_node->safe_psql('postgres', 'SELECT 1'), '1', 'Server start sanity check');
+is($restored_node->safe_psql('postgres', 'SELECT count(*) from ao'), '10', 'AO table read check');
+is($restored_node->safe_psql('postgres', 'SELECT count(*) from co'), '10', 'AOCS table read check');
+is($restored_node->safe_psql('postgres', 'SELECT count(*) from heap'), '10', 'Heap table read check');
+


### PR DESCRIPTION
Currently PITR is not restoring AO files properly, because it's redo
functions are disabled. This was done because redo seemed unnecesary for
recovery : AO files were fsynced before xlogging. But for PITR we still
need to redo xlog, even if not in standby mode.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
