### PR TITLE
6X: Backport FDW features to support Greenplum FDW

### DIFF
--- a/src/backend/cdb/motion/cdbmotion.c
+++ b/src/backend/cdb/motion/cdbmotion.c
@@ -722,7 +722,7 @@ EndMotionLayerNode(MotionLayerState *mlStates, int16 motNodeID, bool flushCommLa
 	 */
 	if (pMNEntry->preserve_order && pMNEntry->ready_tuple_lists != NULL)
 	{
-		for (i = 0; i < getgpsegmentCount(); i++)
+		for (i = 0; i < pMNEntry->num_senders; i++)
 		{
 			pCSEntry = &pMNEntry->ready_tuple_lists[i];
 
@@ -875,7 +875,7 @@ getChunkSorterEntry(MotionLayerState *mlStates,
 	AssertArg(motNodeEntry != NULL);
 
 	Assert(srcRoute >= 0);
-	Assert(srcRoute < getgpsegmentCount());
+	Assert(srcRoute < motNodeEntry->num_senders);
 
 	/* Do we have a sorter initialized ? */
 	if (motNodeEntry->ready_tuple_lists != NULL)
@@ -888,7 +888,7 @@ getChunkSorterEntry(MotionLayerState *mlStates,
 	oldCtxt = MemoryContextSwitchTo(mlStates->motion_layer_mctx);
 
 	if (motNodeEntry->ready_tuple_lists == NULL)
-		motNodeEntry->ready_tuple_lists = (ChunkSorterEntry *) palloc0(getgpsegmentCount() * sizeof(ChunkSorterEntry));
+		motNodeEntry->ready_tuple_lists = (ChunkSorterEntry *) palloc0(motNodeEntry->num_senders * sizeof(ChunkSorterEntry));
 
 	chunkSorterEntry = &motNodeEntry->ready_tuple_lists[srcRoute];
 

--- a/src/backend/commands/foreigncmds.c
+++ b/src/backend/commands/foreigncmds.c
@@ -173,11 +173,13 @@ transformGenericOptions(Oid catalogId,
 	result = optionListToArray(resultOptions);
 
 	/*
-	 * Check and separate out the mpp_execute option, fdwvalidator doesn't have
-	 * to handle it. USER MAPPING doesn't have the mpp_execute option.
+	 * Check and separate out the extra options, fdwvalidator doesn't have
+	 * to handle it. USER MAPPING doesn't have these options.
 	 */
 	if (catalogId != UserMappingRelationId)
+	{
 		SeparateOutMppExecute(&resultOptions);
+	}
 
 	if (OidIsValid(fdwvalidator))
 	{

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -4799,7 +4799,7 @@ FillSliceGangInfo(Slice *slice, int numsegments)
 				slice->gangSize = numsegments;
 				slice->segments = NIL;
 				for (i = 0; i < numsegments; i++)
-					slice->segments = lappend_int(slice->segments, i);
+					slice->segments = lappend_int(slice->segments, i % getgpsegmentCount());
 			}
 			break;
 		case GANGTYPE_ENTRYDB_READER:

--- a/src/backend/foreign/foreign.c
+++ b/src/backend/foreign/foreign.c
@@ -18,6 +18,7 @@
 #include "catalog/pg_foreign_server.h"
 #include "catalog/pg_foreign_table.h"
 #include "catalog/pg_user_mapping.h"
+#include "cdb/cdbutil.h"
 #include "commands/defrem.h"
 #include "foreign/fdwapi.h"
 #include "foreign/foreign.h"
@@ -70,6 +71,41 @@ SeparateOutMppExecute(List **options)
 	}
 
 	return exec_location;
+}
+
+/* Get and separate out the num_segments option */
+int32
+SeparateOutNumSegments(List **options)
+{
+	ListCell *lc = NULL;
+	ListCell *prev = NULL;
+	char *num_segments_str = NULL;
+	int32 num_segments = 0;
+
+	foreach(lc, *options)
+	{
+		DefElem    *def = (DefElem *) lfirst(lc);
+
+		if (strcmp(def->defname, "num_segments") == 0)
+		{
+			num_segments_str = defGetString(def);
+			num_segments = pg_atoi(num_segments_str, sizeof(int32), 0);
+
+			if (num_segments <= 0)
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_SYNTAX_ERROR),
+						 errmsg("\"%d\" is not a valid num_segments value",
+								num_segments)));
+			}
+
+			*options = list_delete_cell(*options, lc, prev);
+			break;
+		}
+
+		prev = lc;
+	}
+	return num_segments;
 }
 
 /*
@@ -188,6 +224,12 @@ GetForeignServer(Oid serverid)
 	{
 		ForeignDataWrapper *fdw = GetForeignDataWrapper(server->fdwid);
 		server->exec_location = fdw->exec_location;
+	}
+
+	server->num_segments = SeparateOutNumSegments(&server->options);
+	if (server->num_segments <= 0)
+	{
+		server->num_segments = getgpsegmentCount();
 	}
 
 	ReleaseSysCache(tp);

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -3067,7 +3067,10 @@ create_foreignscan_path(PlannerInfo *root, RelOptInfo *rel,
 			CdbPathLocus_MakeGeneral(&(pathnode->path.locus), getgpsegmentCount());
 			break;
 		case FTEXECLOCATION_ALL_SEGMENTS:
-			CdbPathLocus_MakeStrewn(&(pathnode->path.locus), getgpsegmentCount());
+			if (rel->ftEntry && rel->ftEntry->num_segments > 0)
+				CdbPathLocus_MakeStrewn(&(pathnode->path.locus), rel->ftEntry->num_segments);
+			else
+				CdbPathLocus_MakeStrewn(&(pathnode->path.locus), getgpsegmentCount());
 			break;
 		case FTEXECLOCATION_MASTER:
 			CdbPathLocus_MakeEntry(&(pathnode->path.locus));

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -3067,8 +3067,11 @@ create_foreignscan_path(PlannerInfo *root, RelOptInfo *rel,
 			CdbPathLocus_MakeGeneral(&(pathnode->path.locus), getgpsegmentCount());
 			break;
 		case FTEXECLOCATION_ALL_SEGMENTS:
-			if (rel->ftEntry && rel->ftEntry->num_segments > 0)
-				CdbPathLocus_MakeStrewn(&(pathnode->path.locus), rel->ftEntry->num_segments);
+			if (rel->ftEntry)
+			{
+				ForeignServer *server = GetForeignServer(rel->ftEntry->serverid);
+				CdbPathLocus_MakeStrewn(&(pathnode->path.locus), server->num_segments);
+			}
 			else
 				CdbPathLocus_MakeStrewn(&(pathnode->path.locus), getgpsegmentCount());
 			break;

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -412,9 +412,14 @@ get_relation_info(PlannerInfo *root, Oid relationObjectId, bool inhparent,
 
 	/* Grab the fdwroutine info using the relcache, while we have it */
 	if (relation->rd_rel->relkind == RELKIND_FOREIGN_TABLE)
+	{
 		rel->fdwroutine = GetFdwRoutineForRelation(relation, true);
+		rel->ftEntry->exec_location = GetForeignTable(RelationGetRelid(relation))->exec_location;
+	}
 	else
+	{
 		rel->fdwroutine = NULL;
+	}
 
 	heap_close(relation, NoLock);
 

--- a/src/include/foreign/foreign.h
+++ b/src/include/foreign/foreign.h
@@ -53,6 +53,7 @@ typedef struct ForeignServer
 	char	   *serverversion;	/* server version, optional */
 	List	   *options;		/* srvoptions as DefElem list */
 	char		exec_location;  /* execute on MASTER, ANY or ALL SEGMENTS, Greenplum MPP specific */
+	int32		num_segments;	/* the number of segments of the foreign cluster */
 } ForeignServer;
 
 typedef struct UserMapping
@@ -72,6 +73,7 @@ typedef struct ForeignTable
 
 
 extern char SeparateOutMppExecute(List **options);
+extern int32 SeparateOutNumSegments(List **options);
 extern ForeignServer *GetForeignServer(Oid serverid);
 extern ForeignServer *GetForeignServerByName(const char *name, bool missing_ok);
 extern UserMapping *GetUserMapping(Oid userid, Oid serverid);

--- a/src/test/regress/expected/gp_foreign_data.out
+++ b/src/test/regress/expected/gp_foreign_data.out
@@ -26,3 +26,12 @@ CREATE FOREIGN TABLE ft3 (
 CREATE FOREIGN TABLE ft4 (
 	c1 int
 ) SERVER s0 OPTIONS (delimiter ',', mpp_execute 'all segments');
+-- CREATE FOREIGN SERVER WITH num_segments
+CREATE SERVER s1 FOREIGN DATA WRAPPER dummy OPTIONS (num_segments '5');
+-- CHECK FOREIGN SERVER's OPTIONS
+SELECT srvoptions FROM pg_foreign_server WHERE srvname = 's1';
+    srvoptions    
+------------------
+ {num_segments=5}
+(1 row)
+

--- a/src/test/regress/sql/gp_foreign_data.sql
+++ b/src/test/regress/sql/gp_foreign_data.sql
@@ -3,6 +3,8 @@
 --
 
 -- start_ignore
+DROP SERVER s0 CASCADE;
+DROP SERVER s1 CASCADE;
 DROP FOREIGN DATA WRAPPER dummy CASCADE;
 -- end_ignore
 
@@ -24,3 +26,9 @@ CREATE FOREIGN TABLE ft3 (
 CREATE FOREIGN TABLE ft4 (
 	c1 int
 ) SERVER s0 OPTIONS (delimiter ',', mpp_execute 'all segments');
+
+-- CREATE FOREIGN SERVER WITH num_segments
+CREATE SERVER s1 FOREIGN DATA WRAPPER dummy OPTIONS (num_segments '5');
+
+-- CHECK FOREIGN SERVER's OPTIONS
+SELECT srvoptions FROM pg_foreign_server WHERE srvname = 's1';


### PR DESCRIPTION
This PR contains two features needed by Greenplum FDW.

1, Support creating a Gang with QEs more than the segment count 

Scenarios like FDW could have more QEs than the segment count to query
the foreign clusters.

2, Support num_segments option for foreign servers

Support specifying the num_segments option for foreign servers,
Greenplum will create that amount of QEs if the `mpp_execute`
option's value is 'all segments'.

```
CREATE SERVER s1 FOREIGN DATA WRAPPER dummy OPTIONS (num_segments '42');
```