### PR TITLE
Reduce search space size for InnerJoins

### DIFF
--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -285,6 +285,11 @@ CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elements[] = {
 	 false,	 // m_negate_param
 	 GPOS_WSZ_LIT(
 		 "Enable plan alternatives where NLJ's inner child is redistributed")},
+	{EopttraceForceComprehensiveJoinImplementation,
+	 &optimizer_force_comprehensive_join_implementation,
+	 false,	 // m_negate_param
+	 GPOS_WSZ_LIT(
+		 "Explore a nested loop join even if a hash join is possible")},
 
 };
 

--- a/src/backend/gporca/data/dxl/minidump/CTE-4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-4.mdp
@@ -271,7 +271,7 @@
         </dxl:LogicalCTEAnchor>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="48">
+    <dxl:Plan Id="0" SpaceSize="25">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.003882" Rows="10.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/CTE-5.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-5.mdp
@@ -454,7 +454,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1820">
+    <dxl:Plan Id="0" SpaceSize="240">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="10344.016560" Rows="3.333333" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/CTE-NoPushProperties.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-NoPushProperties.mdp
@@ -1726,7 +1726,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="42">
+    <dxl:Plan Id="0" SpaceSize="24">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.483722" Rows="1000.000000" Width="26"/>

--- a/src/backend/gporca/data/dxl/minidump/CTE-PushProperties.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-PushProperties.mdp
@@ -1755,7 +1755,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="80">
+    <dxl:Plan Id="0" SpaceSize="62">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.388623" Rows="400.000000" Width="26"/>

--- a/src/backend/gporca/data/dxl/minidump/CTE-volatile.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-volatile.mdp
@@ -410,7 +410,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="60">
+    <dxl:Plan Id="0" SpaceSize="32">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.050688" Rows="100.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/CTG-Join.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTG-Join.mdp
@@ -92,7 +92,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="32">
+    <dxl:Plan Id="0" SpaceSize="20">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="0.000534" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/CapGbCardToSelectCard.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CapGbCardToSelectCard.mdp
@@ -10888,7 +10888,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
         </dxl:LogicalJoin>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="188">
+    <dxl:Plan Id="0" SpaceSize="98">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="102938.691528" Rows="13.696907" Width="127"/>

--- a/src/backend/gporca/data/dxl/minidump/Coalesce-With-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Coalesce-With-Subquery.mdp
@@ -852,7 +852,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="5302">
+    <dxl:Plan Id="0" SpaceSize="2856">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="38915.797885" Rows="4.000000" Width="269"/>

--- a/src/backend/gporca/data/dxl/minidump/CoerceToDomain.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CoerceToDomain.mdp
@@ -1931,7 +1931,7 @@ SELECT * FROM information_schema.tables;
         </dxl:LogicalJoin>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="36">
+    <dxl:Plan Id="0" SpaceSize="24">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.080500" Rows="2.800000" Width="96"/>

--- a/src/backend/gporca/data/dxl/minidump/DPE-IN.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPE-IN.mdp
@@ -971,7 +971,7 @@ select * from P,X where P.a=X.a  and X.a  in (1,2);
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="11">
+    <dxl:Plan Id="0" SpaceSize="7">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.284504" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/DPE-NOT-IN.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPE-NOT-IN.mdp
@@ -963,7 +963,7 @@ select * from P,X where P.a=X.a  and X.a not in (1,2);
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="11">
+    <dxl:Plan Id="0" SpaceSize="7">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="863.294061" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/DPE-with-unsupported-pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPE-with-unsupported-pred.mdp
@@ -2371,7 +2371,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="137">
+    <dxl:Plan Id="0" SpaceSize="75">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324807.970884" Rows="2844.444444" Width="28"/>

--- a/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin.mdp
@@ -530,7 +530,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="16">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="907.643201" Rows="20.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin2.mdp
@@ -11330,7 +11330,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="42">
+    <dxl:Plan Id="0" SpaceSize="22">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="865.875352" Rows="3866.533707" Width="116"/>

--- a/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin3.mdp
@@ -13863,7 +13863,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="3209.039368" Rows="716144.000000" Width="402"/>

--- a/src/backend/gporca/data/dxl/minidump/EffectsOfJoinFilter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EffectsOfJoinFilter.mdp
@@ -442,7 +442,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="16">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="925.946009" Rows="99.352229" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/EqualityJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EqualityJoin.mdp
@@ -418,7 +418,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="16">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="969.461920" Rows="200.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/Equiv-HashedDistr-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Equiv-HashedDistr-2.mdp
@@ -1936,7 +1936,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="484">
+    <dxl:Plan Id="0" SpaceSize="264">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="34974.557438" Rows="9548.818729" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/EquivClassesAndOr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EquivClassesAndOr.mdp
@@ -344,7 +344,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="837">
+    <dxl:Plan Id="0" SpaceSize="300">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.002536" Rows="1.000000" Width="60"/>

--- a/src/backend/gporca/data/dxl/minidump/EquivClassesIntersect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EquivClassesIntersect.mdp
@@ -295,7 +295,7 @@
         </dxl:LogicalSelect>
       </dxl:Intersect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="80">
+    <dxl:Plan Id="0" SpaceSize="32">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000787" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/ExpandJoinOrder.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExpandJoinOrder.mdp
@@ -865,7 +865,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3866">
+    <dxl:Plan Id="0" SpaceSize="2316">
       <dxl:Limit>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="31120.116045" Rows="100.000000" Width="128"/>

--- a/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisj.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisj.mdp
@@ -15774,7 +15774,7 @@ WHERE ((sale_type = 's'::text AND dyear = 2001 AND year_total &gt; 0::numeric) O
         </dxl:LogicalProject>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="7020">
+    <dxl:Plan Id="0" SpaceSize="2692">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="5944.261371" Rows="20169.272000" Width="76"/>

--- a/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisjWithComputedColumns.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisjWithComputedColumns.mdp
@@ -454,7 +454,7 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="7695">
+    <dxl:Plan Id="0" SpaceSize="3190">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.002852" Rows="1.000000" Width="64"/>

--- a/src/backend/gporca/data/dxl/minidump/Factorized-Preds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Factorized-Preds.mdp
@@ -275,7 +275,7 @@
         </dxl:Or>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="16">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000890" Rows="1.000000" Width="28"/>

--- a/src/backend/gporca/data/dxl/minidump/GroupByOuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GroupByOuterRef.mdp
@@ -320,7 +320,7 @@ where t.a in (select count(s.i) from s);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="24">
+    <dxl:Plan Id="0" SpaceSize="18">
       <dxl:HashJoin JoinType="In">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000729" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/HJN-DPE-Bitmap-Outer-Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HJN-DPE-Bitmap-Outer-Child.mdp
@@ -1917,7 +1917,7 @@ select * from dbs_target, dbs_helper where dbs_target.c1 = dbs_helper.c1 and dbs
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="28">
+    <dxl:Plan Id="0" SpaceSize="20">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="829.034339" Rows="35.148716" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/HJN-DeeperOuter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HJN-DeeperOuter.mdp
@@ -356,7 +356,7 @@ SELECT z.*,x.* FROM x,y,z WHERE x.i=y.i AND x.i=z.i;
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1219">
+    <dxl:Plan Id="0" SpaceSize="354">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.001398" Rows="1.000000" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/HJN-Redistribute-One-Side.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HJN-Redistribute-One-Side.mdp
@@ -4551,7 +4551,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="40">
+    <dxl:Plan Id="0" SpaceSize="32">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="11941.357050" Rows="1.000000" Width="275"/>

--- a/src/backend/gporca/data/dxl/minidump/HashJoinOnRelabeledColumns.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HashJoinOnRelabeledColumns.mdp
@@ -265,7 +265,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="16">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000640" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondDisjointWithHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondDisjointWithHashedDistr.mdp
@@ -824,7 +824,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="21">
+    <dxl:Plan Id="0" SpaceSize="13">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="863.431632" Rows="1000.888592" Width="20"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondIntersectWithHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondIntersectWithHashedDistr.mdp
@@ -830,7 +830,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="31">
+    <dxl:Plan Id="0" SpaceSize="23">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="864.151759" Rows="1000.000000" Width="20"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondMatchHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondMatchHashedDistr.mdp
@@ -802,7 +802,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="17">
+    <dxl:Plan Id="0" SpaceSize="9">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.992066" Rows="100.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondSubsetOfHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondSubsetOfHashedDistr.mdp
@@ -824,7 +824,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="21">
+    <dxl:Plan Id="0" SpaceSize="13">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="863.431632" Rows="1000.888592" Width="20"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondSupersetOfHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondSupersetOfHashedDistr.mdp
@@ -816,7 +816,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="25">
+    <dxl:Plan Id="0" SpaceSize="17">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="863.780122" Rows="100.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-PartTable2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-PartTable2.mdp
@@ -489,7 +489,7 @@ select * from bar, (select * from foo where foo.a in (select h.a from bar h, bar
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="22893">
+    <dxl:Plan Id="0" SpaceSize="9648">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324469.354209" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-Redistribute-Const-Table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-Redistribute-Const-Table.mdp
@@ -388,7 +388,7 @@ Table X (int i, int j) is distributed by i, column i has index
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="39">
+    <dxl:Plan Id="0" SpaceSize="22">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="6.000265" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexGet-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexGet-OuterRefs.mdp
@@ -260,7 +260,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="40">
+    <dxl:Plan Id="0" SpaceSize="24">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="437.001095" Rows="1.000000" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexedNLJBitmap.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexedNLJBitmap.mdp
@@ -531,7 +531,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="828.966775" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicates.mdp
@@ -460,7 +460,7 @@ explain select 1+row_number() over(partition by foo.c) from foo, bar where foo.a
         </dxl:LogicalWindow>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="24">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000549" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesForPartSQ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesForPartSQ.mdp
@@ -507,7 +507,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="235">
+    <dxl:Plan Id="0" SpaceSize="173">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000970" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesInnerOfLOJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesInnerOfLOJ.mdp
@@ -816,7 +816,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="257">
+    <dxl:Plan Id="0" SpaceSize="238">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.000804" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/Intersect-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Intersect-OuterRefs.mdp
@@ -1413,7 +1413,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="13920">
+    <dxl:Plan Id="0" SpaceSize="4060">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.065290" Rows="77.229878" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/Intersect-Volatile-Func.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Intersect-Volatile-Func.mdp
@@ -109,7 +109,7 @@
         </dxl:LogicalProject>
       </dxl:Intersect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="935">
+    <dxl:Plan Id="0" SpaceSize="476">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="0.000404" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/JOIN-Pred-Cast-Int4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JOIN-Pred-Cast-Int4.mdp
@@ -453,7 +453,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.022378" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/JOIN-Pred-Cast-Varchar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JOIN-Pred-Cast-Varchar.mdp
@@ -649,7 +649,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="20">
+    <dxl:Plan Id="0" SpaceSize="12">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.566515" Rows="10000.000000" Width="14"/>

--- a/src/backend/gporca/data/dxl/minidump/JOIN-cast2text-int4-Eq-cast2text-double.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JOIN-cast2text-int4-Eq-cast2text-double.mdp
@@ -474,7 +474,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="20">
+    <dxl:Plan Id="0" SpaceSize="12">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.031867" Rows="100.000000" Width="13"/>

--- a/src/backend/gporca/data/dxl/minidump/JOIN-int4-Eq-double.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JOIN-int4-Eq-double.mdp
@@ -453,7 +453,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.030459" Rows="100.000000" Width="13"/>

--- a/src/backend/gporca/data/dxl/minidump/JOIN-int4-Eq-int2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JOIN-int4-Eq-int2.mdp
@@ -352,7 +352,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.022512" Rows="100.000000" Width="6"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-Disj-Subqs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-Disj-Subqs.mdp
@@ -985,7 +985,7 @@ OR
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="375168">
+    <dxl:Plan Id="0" SpaceSize="269692">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="9921.832259" Rows="521.833333" Width="246"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-INDF.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-INDF.mdp
@@ -344,7 +344,7 @@ select * from foo, foo2 where foo.a is not distinct from foo2.a;
         </dxl:Not>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="16">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.003542" Rows="9.999994" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
@@ -4044,7 +4044,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="323272">
+    <dxl:Plan Id="0" SpaceSize="78194">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="3422679.529071" Rows="19136.250000" Width="31"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinColWithOnlyNDV.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinColWithOnlyNDV.mdp
@@ -11699,10 +11699,10 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="88162.264340" Rows="4424643.209483" Width="856"/>
+          <dxl:Cost StartupCost="0" TotalCost="97948.947313" Rows="4424643.209483" Width="856"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="ws_sold_date_sk">
@@ -11888,9 +11888,9 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+        <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="71156.413643" Rows="4424643.209483" Width="856"/>
+            <dxl:Cost StartupCost="0" TotalCost="80943.096616" Rows="4424643.209483" Width="856"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="ws_sold_date_sk">
@@ -12075,12 +12075,168 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:JoinFilter>
+          <dxl:JoinFilter/>
+          <dxl:HashCondList>
             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
               <dxl:Ident ColId="13" ColName="ws_web_site_sk" TypeMdid="0.23.1.0"/>
               <dxl:Ident ColId="41" ColName="web_site_sk" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
-          </dxl:JoinFilter>
+          </dxl:HashCondList>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="12138.403400" Rows="184296000.000000" Width="201"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="ws_sold_date_sk">
+                <dxl:Ident ColId="0" ColName="ws_sold_date_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="ws_sold_time_sk">
+                <dxl:Ident ColId="1" ColName="ws_sold_time_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="2" Alias="ws_ship_date_sk">
+                <dxl:Ident ColId="2" ColName="ws_ship_date_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="3" Alias="ws_item_sk">
+                <dxl:Ident ColId="3" ColName="ws_item_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="4" Alias="ws_bill_customer_sk">
+                <dxl:Ident ColId="4" ColName="ws_bill_customer_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="5" Alias="ws_bill_cdemo_sk">
+                <dxl:Ident ColId="5" ColName="ws_bill_cdemo_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="6" Alias="ws_bill_hdemo_sk">
+                <dxl:Ident ColId="6" ColName="ws_bill_hdemo_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="7" Alias="ws_bill_addr_sk">
+                <dxl:Ident ColId="7" ColName="ws_bill_addr_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="8" Alias="ws_ship_customer_sk">
+                <dxl:Ident ColId="8" ColName="ws_ship_customer_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="9" Alias="ws_ship_cdemo_sk">
+                <dxl:Ident ColId="9" ColName="ws_ship_cdemo_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="10" Alias="ws_ship_hdemo_sk">
+                <dxl:Ident ColId="10" ColName="ws_ship_hdemo_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="11" Alias="ws_ship_addr_sk">
+                <dxl:Ident ColId="11" ColName="ws_ship_addr_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="12" Alias="ws_web_page_sk">
+                <dxl:Ident ColId="12" ColName="ws_web_page_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="13" Alias="ws_web_site_sk">
+                <dxl:Ident ColId="13" ColName="ws_web_site_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="14" Alias="ws_ship_mode_sk">
+                <dxl:Ident ColId="14" ColName="ws_ship_mode_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="15" Alias="ws_warehouse_sk">
+                <dxl:Ident ColId="15" ColName="ws_warehouse_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="16" Alias="ws_promo_sk">
+                <dxl:Ident ColId="16" ColName="ws_promo_sk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="17" Alias="ws_order_number">
+                <dxl:Ident ColId="17" ColName="ws_order_number" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="18" Alias="ws_quantity">
+                <dxl:Ident ColId="18" ColName="ws_quantity" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="19" Alias="ws_wholesale_cost">
+                <dxl:Ident ColId="19" ColName="ws_wholesale_cost" TypeMdid="0.1700.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="20" Alias="ws_list_price">
+                <dxl:Ident ColId="20" ColName="ws_list_price" TypeMdid="0.1700.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="21" Alias="ws_sales_price">
+                <dxl:Ident ColId="21" ColName="ws_sales_price" TypeMdid="0.1700.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="22" Alias="ws_ext_discount_amt">
+                <dxl:Ident ColId="22" ColName="ws_ext_discount_amt" TypeMdid="0.1700.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="23" Alias="ws_ext_sales_price">
+                <dxl:Ident ColId="23" ColName="ws_ext_sales_price" TypeMdid="0.1700.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="24" Alias="ws_ext_wholesale_cost">
+                <dxl:Ident ColId="24" ColName="ws_ext_wholesale_cost" TypeMdid="0.1700.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="25" Alias="ws_ext_list_price">
+                <dxl:Ident ColId="25" ColName="ws_ext_list_price" TypeMdid="0.1700.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="26" Alias="ws_ext_tax">
+                <dxl:Ident ColId="26" ColName="ws_ext_tax" TypeMdid="0.1700.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="27" Alias="ws_coupon_amt">
+                <dxl:Ident ColId="27" ColName="ws_coupon_amt" TypeMdid="0.1700.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="28" Alias="ws_ext_ship_cost">
+                <dxl:Ident ColId="28" ColName="ws_ext_ship_cost" TypeMdid="0.1700.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="29" Alias="ws_net_paid">
+                <dxl:Ident ColId="29" ColName="ws_net_paid" TypeMdid="0.1700.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="30" Alias="ws_net_paid_inc_tax">
+                <dxl:Ident ColId="30" ColName="ws_net_paid_inc_tax" TypeMdid="0.1700.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="31" Alias="ws_net_paid_inc_ship">
+                <dxl:Ident ColId="31" ColName="ws_net_paid_inc_ship" TypeMdid="0.1700.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="32" Alias="ws_net_paid_inc_ship_tax">
+                <dxl:Ident ColId="32" ColName="ws_net_paid_inc_ship_tax" TypeMdid="0.1700.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="33" Alias="ws_net_profit">
+                <dxl:Ident ColId="33" ColName="ws_net_profit" TypeMdid="0.1700.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="0.641613.1.1" TableName="web_sales">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="ws_sold_date_sk" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="1" Attno="2" ColName="ws_sold_time_sk" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="2" Attno="3" ColName="ws_ship_date_sk" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="3" Attno="4" ColName="ws_item_sk" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="4" Attno="5" ColName="ws_bill_customer_sk" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="5" Attno="6" ColName="ws_bill_cdemo_sk" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="6" Attno="7" ColName="ws_bill_hdemo_sk" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="7" Attno="8" ColName="ws_bill_addr_sk" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="8" Attno="9" ColName="ws_ship_customer_sk" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="9" Attno="10" ColName="ws_ship_cdemo_sk" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="10" Attno="11" ColName="ws_ship_hdemo_sk" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="11" Attno="12" ColName="ws_ship_addr_sk" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="12" Attno="13" ColName="ws_web_page_sk" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="13" Attno="14" ColName="ws_web_site_sk" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="14" Attno="15" ColName="ws_ship_mode_sk" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="15" Attno="16" ColName="ws_warehouse_sk" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="16" Attno="17" ColName="ws_promo_sk" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="17" Attno="18" ColName="ws_order_number" TypeMdid="0.20.1.0"/>
+                <dxl:Column ColId="18" Attno="19" ColName="ws_quantity" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="19" Attno="20" ColName="ws_wholesale_cost" TypeMdid="0.1700.1.0"/>
+                <dxl:Column ColId="20" Attno="21" ColName="ws_list_price" TypeMdid="0.1700.1.0"/>
+                <dxl:Column ColId="21" Attno="22" ColName="ws_sales_price" TypeMdid="0.1700.1.0"/>
+                <dxl:Column ColId="22" Attno="23" ColName="ws_ext_discount_amt" TypeMdid="0.1700.1.0"/>
+                <dxl:Column ColId="23" Attno="24" ColName="ws_ext_sales_price" TypeMdid="0.1700.1.0"/>
+                <dxl:Column ColId="24" Attno="25" ColName="ws_ext_wholesale_cost" TypeMdid="0.1700.1.0"/>
+                <dxl:Column ColId="25" Attno="26" ColName="ws_ext_list_price" TypeMdid="0.1700.1.0"/>
+                <dxl:Column ColId="26" Attno="27" ColName="ws_ext_tax" TypeMdid="0.1700.1.0"/>
+                <dxl:Column ColId="27" Attno="28" ColName="ws_coupon_amt" TypeMdid="0.1700.1.0"/>
+                <dxl:Column ColId="28" Attno="29" ColName="ws_ext_ship_cost" TypeMdid="0.1700.1.0"/>
+                <dxl:Column ColId="29" Attno="30" ColName="ws_net_paid" TypeMdid="0.1700.1.0"/>
+                <dxl:Column ColId="30" Attno="31" ColName="ws_net_paid_inc_tax" TypeMdid="0.1700.1.0"/>
+                <dxl:Column ColId="31" Attno="32" ColName="ws_net_paid_inc_ship" TypeMdid="0.1700.1.0"/>
+                <dxl:Column ColId="32" Attno="33" ColName="ws_net_paid_inc_ship_tax" TypeMdid="0.1700.1.0"/>
+                <dxl:Column ColId="33" Attno="34" ColName="ws_net_profit" TypeMdid="0.1700.1.0"/>
+                <dxl:Column ColId="34" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="35" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="36" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="37" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="38" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="39" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="40" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
           <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.044508" Rows="2.000000" Width="655"/>
@@ -12296,162 +12452,7 @@
               </dxl:TableDescriptor>
             </dxl:TableScan>
           </dxl:BroadcastMotion>
-          <dxl:TableScan>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="12138.403400" Rows="184296000.000000" Width="201"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="ws_sold_date_sk">
-                <dxl:Ident ColId="0" ColName="ws_sold_date_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="ws_sold_time_sk">
-                <dxl:Ident ColId="1" ColName="ws_sold_time_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="2" Alias="ws_ship_date_sk">
-                <dxl:Ident ColId="2" ColName="ws_ship_date_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="3" Alias="ws_item_sk">
-                <dxl:Ident ColId="3" ColName="ws_item_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="4" Alias="ws_bill_customer_sk">
-                <dxl:Ident ColId="4" ColName="ws_bill_customer_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="5" Alias="ws_bill_cdemo_sk">
-                <dxl:Ident ColId="5" ColName="ws_bill_cdemo_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="6" Alias="ws_bill_hdemo_sk">
-                <dxl:Ident ColId="6" ColName="ws_bill_hdemo_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="7" Alias="ws_bill_addr_sk">
-                <dxl:Ident ColId="7" ColName="ws_bill_addr_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="8" Alias="ws_ship_customer_sk">
-                <dxl:Ident ColId="8" ColName="ws_ship_customer_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="9" Alias="ws_ship_cdemo_sk">
-                <dxl:Ident ColId="9" ColName="ws_ship_cdemo_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="10" Alias="ws_ship_hdemo_sk">
-                <dxl:Ident ColId="10" ColName="ws_ship_hdemo_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="11" Alias="ws_ship_addr_sk">
-                <dxl:Ident ColId="11" ColName="ws_ship_addr_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="12" Alias="ws_web_page_sk">
-                <dxl:Ident ColId="12" ColName="ws_web_page_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="13" Alias="ws_web_site_sk">
-                <dxl:Ident ColId="13" ColName="ws_web_site_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="14" Alias="ws_ship_mode_sk">
-                <dxl:Ident ColId="14" ColName="ws_ship_mode_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="15" Alias="ws_warehouse_sk">
-                <dxl:Ident ColId="15" ColName="ws_warehouse_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="16" Alias="ws_promo_sk">
-                <dxl:Ident ColId="16" ColName="ws_promo_sk" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="17" Alias="ws_order_number">
-                <dxl:Ident ColId="17" ColName="ws_order_number" TypeMdid="0.20.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="18" Alias="ws_quantity">
-                <dxl:Ident ColId="18" ColName="ws_quantity" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="19" Alias="ws_wholesale_cost">
-                <dxl:Ident ColId="19" ColName="ws_wholesale_cost" TypeMdid="0.1700.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="20" Alias="ws_list_price">
-                <dxl:Ident ColId="20" ColName="ws_list_price" TypeMdid="0.1700.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="21" Alias="ws_sales_price">
-                <dxl:Ident ColId="21" ColName="ws_sales_price" TypeMdid="0.1700.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="22" Alias="ws_ext_discount_amt">
-                <dxl:Ident ColId="22" ColName="ws_ext_discount_amt" TypeMdid="0.1700.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="23" Alias="ws_ext_sales_price">
-                <dxl:Ident ColId="23" ColName="ws_ext_sales_price" TypeMdid="0.1700.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="24" Alias="ws_ext_wholesale_cost">
-                <dxl:Ident ColId="24" ColName="ws_ext_wholesale_cost" TypeMdid="0.1700.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="25" Alias="ws_ext_list_price">
-                <dxl:Ident ColId="25" ColName="ws_ext_list_price" TypeMdid="0.1700.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="26" Alias="ws_ext_tax">
-                <dxl:Ident ColId="26" ColName="ws_ext_tax" TypeMdid="0.1700.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="27" Alias="ws_coupon_amt">
-                <dxl:Ident ColId="27" ColName="ws_coupon_amt" TypeMdid="0.1700.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="28" Alias="ws_ext_ship_cost">
-                <dxl:Ident ColId="28" ColName="ws_ext_ship_cost" TypeMdid="0.1700.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="29" Alias="ws_net_paid">
-                <dxl:Ident ColId="29" ColName="ws_net_paid" TypeMdid="0.1700.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="30" Alias="ws_net_paid_inc_tax">
-                <dxl:Ident ColId="30" ColName="ws_net_paid_inc_tax" TypeMdid="0.1700.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="31" Alias="ws_net_paid_inc_ship">
-                <dxl:Ident ColId="31" ColName="ws_net_paid_inc_ship" TypeMdid="0.1700.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="32" Alias="ws_net_paid_inc_ship_tax">
-                <dxl:Ident ColId="32" ColName="ws_net_paid_inc_ship_tax" TypeMdid="0.1700.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="33" Alias="ws_net_profit">
-                <dxl:Ident ColId="33" ColName="ws_net_profit" TypeMdid="0.1700.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="0.641613.1.1" TableName="web_sales">
-              <dxl:Columns>
-                <dxl:Column ColId="0" Attno="1" ColName="ws_sold_date_sk" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="1" Attno="2" ColName="ws_sold_time_sk" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="2" Attno="3" ColName="ws_ship_date_sk" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="3" Attno="4" ColName="ws_item_sk" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="4" Attno="5" ColName="ws_bill_customer_sk" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="5" Attno="6" ColName="ws_bill_cdemo_sk" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="6" Attno="7" ColName="ws_bill_hdemo_sk" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="7" Attno="8" ColName="ws_bill_addr_sk" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="8" Attno="9" ColName="ws_ship_customer_sk" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="9" Attno="10" ColName="ws_ship_cdemo_sk" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="10" Attno="11" ColName="ws_ship_hdemo_sk" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="11" Attno="12" ColName="ws_ship_addr_sk" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="12" Attno="13" ColName="ws_web_page_sk" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="13" Attno="14" ColName="ws_web_site_sk" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="14" Attno="15" ColName="ws_ship_mode_sk" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="15" Attno="16" ColName="ws_warehouse_sk" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="16" Attno="17" ColName="ws_promo_sk" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="17" Attno="18" ColName="ws_order_number" TypeMdid="0.20.1.0"/>
-                <dxl:Column ColId="18" Attno="19" ColName="ws_quantity" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="19" Attno="20" ColName="ws_wholesale_cost" TypeMdid="0.1700.1.0"/>
-                <dxl:Column ColId="20" Attno="21" ColName="ws_list_price" TypeMdid="0.1700.1.0"/>
-                <dxl:Column ColId="21" Attno="22" ColName="ws_sales_price" TypeMdid="0.1700.1.0"/>
-                <dxl:Column ColId="22" Attno="23" ColName="ws_ext_discount_amt" TypeMdid="0.1700.1.0"/>
-                <dxl:Column ColId="23" Attno="24" ColName="ws_ext_sales_price" TypeMdid="0.1700.1.0"/>
-                <dxl:Column ColId="24" Attno="25" ColName="ws_ext_wholesale_cost" TypeMdid="0.1700.1.0"/>
-                <dxl:Column ColId="25" Attno="26" ColName="ws_ext_list_price" TypeMdid="0.1700.1.0"/>
-                <dxl:Column ColId="26" Attno="27" ColName="ws_ext_tax" TypeMdid="0.1700.1.0"/>
-                <dxl:Column ColId="27" Attno="28" ColName="ws_coupon_amt" TypeMdid="0.1700.1.0"/>
-                <dxl:Column ColId="28" Attno="29" ColName="ws_ext_ship_cost" TypeMdid="0.1700.1.0"/>
-                <dxl:Column ColId="29" Attno="30" ColName="ws_net_paid" TypeMdid="0.1700.1.0"/>
-                <dxl:Column ColId="30" Attno="31" ColName="ws_net_paid_inc_tax" TypeMdid="0.1700.1.0"/>
-                <dxl:Column ColId="31" Attno="32" ColName="ws_net_paid_inc_ship" TypeMdid="0.1700.1.0"/>
-                <dxl:Column ColId="32" Attno="33" ColName="ws_net_paid_inc_ship_tax" TypeMdid="0.1700.1.0"/>
-                <dxl:Column ColId="33" Attno="34" ColName="ws_net_profit" TypeMdid="0.1700.1.0"/>
-                <dxl:Column ColId="34" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                <dxl:Column ColId="35" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="36" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="37" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="38" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="39" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                <dxl:Column ColId="40" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:Columns>
-            </dxl:TableDescriptor>
-          </dxl:TableScan>
-        </dxl:NestedLoopJoin>
+        </dxl:HashJoin>
       </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/JoinOrderDPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinOrderDPE.mdp
@@ -3144,7 +3144,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="644">
+    <dxl:Plan Id="0" SpaceSize="84">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1301.264890" Rows="95315.069401" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin-Tpcds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin-Tpcds.mdp
@@ -11631,7 +11631,7 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
         </dxl:LogicalCTEAnchor>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="176674">
+    <dxl:Plan Id="0" SpaceSize="87522">
       <dxl:Limit>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="5904.512295" Rows="5.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin.mdp
@@ -301,7 +301,7 @@ and ei.entity_id  = i.ad_id;
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="5008">
+    <dxl:Plan Id="0" SpaceSize="3148">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2586.003103" Rows="2.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/MultiLevel-IN-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultiLevel-IN-Subquery.mdp
@@ -686,7 +686,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4866">
+    <dxl:Plan Id="0" SpaceSize="950">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1294.489763" Rows="999.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/Nested-Setops-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Nested-Setops-2.mdp
@@ -597,7 +597,7 @@
         </dxl:LogicalProject>
       </dxl:Difference>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1423008000">
+    <dxl:Plan Id="0" SpaceSize="177876000">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2592.974241" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/NoBroadcastUnderGatherForWindowFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NoBroadcastUnderGatherForWindowFunction.mdp
@@ -433,7 +433,7 @@ WHERE buyer_name = 'ABC'
         </dxl:LogicalWindow>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6">
+    <dxl:Plan Id="0" SpaceSize="4">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.008986" Rows="1.000000" Width="25"/>

--- a/src/backend/gporca/data/dxl/minidump/Non-Hashjoinable-Pred-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Non-Hashjoinable-Pred-2.mdp
@@ -256,7 +256,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="16">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.001222" Rows="1.000000" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/PartSelectorOnJoinSide.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartSelectorOnJoinSide.mdp
@@ -2264,7 +2264,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="13">
+    <dxl:Plan Id="0" SpaceSize="9">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="898.322204" Rows="73705.404960" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/PartSelectorOnJoinSide2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartSelectorOnJoinSide2.mdp
@@ -2919,7 +2919,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="14">
+    <dxl:Plan Id="0" SpaceSize="6">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2157.192890" Rows="1479264.726597" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-AvoidRangePred-DPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-AvoidRangePred-DPE.mdp
@@ -1926,7 +1926,7 @@ FROM abuela JOIN bar ON a = c AND b BETWEEN d - 1 AND d + 4
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="415">
+    <dxl:Plan Id="0" SpaceSize="202">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.013245" Rows="3.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-GroupBy.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-GroupBy.mdp
@@ -828,7 +828,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1118">
+    <dxl:Plan Id="0" SpaceSize="701">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.020922" Rows="100.000000" Width="14"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-Limit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-Limit.mdp
@@ -782,7 +782,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="64">
+    <dxl:Plan Id="0" SpaceSize="32">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.043086" Rows="100.000000" Width="46"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DisablePartSelectionJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DisablePartSelectionJoin.mdp
@@ -845,7 +845,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.108395" Rows="1.000000" Width="20"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-HJ3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-HJ3.mdp
@@ -468,7 +468,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="16">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000831" Rows="1.000000" Width="28"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-HJ4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-HJ4.mdp
@@ -744,7 +744,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="12">
+    <dxl:Plan Id="0" SpaceSize="4">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000635" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverExcept.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverExcept.mdp
@@ -1788,7 +1788,7 @@ select * from (select * from p1 except select * from p2) as p, tt where p.b=tt.b
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="196">
+    <dxl:Plan Id="0" SpaceSize="103">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1298.385913" Rows="4000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverGbAgg-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverGbAgg-2.mdp
@@ -1604,7 +1604,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="31">
+    <dxl:Plan Id="0" SpaceSize="14">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.027662" Rows="101.010101" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverGbAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverGbAgg.mdp
@@ -799,7 +799,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="32">
+    <dxl:Plan Id="0" SpaceSize="12">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.001263" Rows="1.000000" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverIntersect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverIntersect.mdp
@@ -1788,7 +1788,7 @@ select * from (select * from p1 intersect select * from p2) as p, tt where p.b=t
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2124">
+    <dxl:Plan Id="0" SpaceSize="680">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1301.575209" Rows="10000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-1.mdp
@@ -1788,7 +1788,7 @@ select * from (select * from p1 union all select * from p2) as p, tt where p.b=t
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18">
+    <dxl:Plan Id="0" SpaceSize="9">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1297.273809" Rows="20000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-2.mdp
@@ -1137,7 +1137,7 @@ select * from (select * from tt union all select * from p2) as p, tt where p.b=t
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="17">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1294.717330" Rows="5431.276543" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoin.mdp
@@ -513,7 +513,7 @@ explain select count(*) from r_p, s c, s d, s e where r_p.a = c.c and r_p.a = d.
         </dxl:LogicalJoin>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="820798">
+    <dxl:Plan Id="0" SpaceSize="520621">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.012321" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE-2.mdp
@@ -2566,7 +2566,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1077">
+    <dxl:Plan Id="0" SpaceSize="261">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="23515.903551" Rows="12277684.984863" Width="246"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
@@ -4765,10 +4765,10 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="53564">
+    <dxl:Plan Id="0" SpaceSize="16648">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1548186.589494" Rows="321694266.492042" Width="355"/>
+          <dxl:Cost StartupCost="0" TotalCost="1749361.680098" Rows="321694266.492042" Width="355"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="cs_sold_date_sk">
@@ -5000,7 +5000,7 @@
         </dxl:HashCondList>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1138306.731315" Rows="467986.685065" Width="339"/>
+            <dxl:Cost StartupCost="0" TotalCost="1339481.821919" Rows="467986.685065" Width="339"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="cs_sold_date_sk">
@@ -5209,7 +5209,7 @@
           <dxl:SortingColumnList/>
           <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1137594.404102" Rows="467986.685065" Width="339"/>
+              <dxl:Cost StartupCost="0" TotalCost="1338769.494706" Rows="467986.685065" Width="339"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="cs_sold_date_sk">
@@ -5422,9 +5422,9 @@
                 <dxl:Ident ColId="64" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
               </dxl:Comparison>
             </dxl:HashCondList>
-            <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+            <dxl:HashJoin JoinType="Inner">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1136809.698814" Rows="467986.685065" Width="232"/>
+                <dxl:Cost StartupCost="0" TotalCost="1337984.789418" Rows="467986.685065" Width="232"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="cs_sold_date_sk">
@@ -5546,80 +5546,13 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:JoinFilter>
+              <dxl:JoinFilter/>
+              <dxl:HashCondList>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                   <dxl:Ident ColId="5" ColName="cs_bill_hdemo_sk" TypeMdid="0.23.1.0"/>
                   <dxl:Ident ColId="52" ColName="hd_demo_sk" TypeMdid="0.23.1.0"/>
                 </dxl:Comparison>
-              </dxl:JoinFilter>
-              <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.240955" Rows="2.000000" Width="32"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="52" Alias="hd_demo_sk">
-                    <dxl:Ident ColId="52" ColName="hd_demo_sk" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="53" Alias="hd_income_band_sk">
-                    <dxl:Ident ColId="53" ColName="hd_income_band_sk" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="54" Alias="hd_buy_potential">
-                    <dxl:Ident ColId="54" ColName="hd_buy_potential" TypeMdid="0.1042.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="55" Alias="hd_dep_count">
-                    <dxl:Ident ColId="55" ColName="hd_dep_count" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="56" Alias="hd_vehicle_count">
-                    <dxl:Ident ColId="56" ColName="hd_vehicle_count" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.239280" Rows="1.000000" Width="32"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="52" Alias="hd_demo_sk">
-                      <dxl:Ident ColId="52" ColName="hd_demo_sk" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="53" Alias="hd_income_band_sk">
-                      <dxl:Ident ColId="53" ColName="hd_income_band_sk" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="54" Alias="hd_buy_potential">
-                      <dxl:Ident ColId="54" ColName="hd_buy_potential" TypeMdid="0.1042.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="55" Alias="hd_dep_count">
-                      <dxl:Ident ColId="55" ColName="hd_dep_count" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="56" Alias="hd_vehicle_count">
-                      <dxl:Ident ColId="56" ColName="hd_vehicle_count" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
-                      <dxl:Ident ColId="54" ColName="hd_buy_potential" TypeMdid="0.1042.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAACj4xMDAwMA==" LintValue="266732324"/>
-                    </dxl:Comparison>
-                  </dxl:Filter>
-                  <dxl:TableDescriptor Mdid="0.810130.1.1" TableName="household_demographics">
-                    <dxl:Columns>
-                      <dxl:Column ColId="52" Attno="1" ColName="hd_demo_sk" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="53" Attno="2" ColName="hd_income_band_sk" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="54" Attno="3" ColName="hd_buy_potential" TypeMdid="0.1042.1.0" ColWidth="15"/>
-                      <dxl:Column ColId="55" Attno="4" ColName="hd_dep_count" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="56" Attno="5" ColName="hd_vehicle_count" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="57" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="58" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="59" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="60" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="61" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="62" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="63" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:BroadcastMotion>
+              </dxl:HashCondList>
               <dxl:Append IsTarget="false" IsZapped="false" PartIndexId="1" SelectorIds="0">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="213404.135560" Rows="3367164198.571393" Width="200"/>
@@ -6550,7 +6483,75 @@
                   </dxl:TableDescriptor>
                 </dxl:TableScan>
               </dxl:Append>
-            </dxl:NestedLoopJoin>
+              <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.240955" Rows="2.000000" Width="32"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="52" Alias="hd_demo_sk">
+                    <dxl:Ident ColId="52" ColName="hd_demo_sk" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="53" Alias="hd_income_band_sk">
+                    <dxl:Ident ColId="53" ColName="hd_income_band_sk" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="54" Alias="hd_buy_potential">
+                    <dxl:Ident ColId="54" ColName="hd_buy_potential" TypeMdid="0.1042.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="55" Alias="hd_dep_count">
+                    <dxl:Ident ColId="55" ColName="hd_dep_count" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="56" Alias="hd_vehicle_count">
+                    <dxl:Ident ColId="56" ColName="hd_vehicle_count" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.239280" Rows="1.000000" Width="32"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="52" Alias="hd_demo_sk">
+                      <dxl:Ident ColId="52" ColName="hd_demo_sk" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="53" Alias="hd_income_band_sk">
+                      <dxl:Ident ColId="53" ColName="hd_income_band_sk" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="54" Alias="hd_buy_potential">
+                      <dxl:Ident ColId="54" ColName="hd_buy_potential" TypeMdid="0.1042.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="55" Alias="hd_dep_count">
+                      <dxl:Ident ColId="55" ColName="hd_dep_count" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="56" Alias="hd_vehicle_count">
+                      <dxl:Ident ColId="56" ColName="hd_vehicle_count" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+                      <dxl:Ident ColId="54" ColName="hd_buy_potential" TypeMdid="0.1042.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAACj4xMDAwMA==" LintValue="266732324"/>
+                    </dxl:Comparison>
+                  </dxl:Filter>
+                  <dxl:TableDescriptor Mdid="0.810130.1.1" TableName="household_demographics">
+                    <dxl:Columns>
+                      <dxl:Column ColId="52" Attno="1" ColName="hd_demo_sk" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="53" Attno="2" ColName="hd_income_band_sk" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="54" Attno="3" ColName="hd_buy_potential" TypeMdid="0.1042.1.0" ColWidth="15"/>
+                      <dxl:Column ColId="55" Attno="4" ColName="hd_dep_count" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="56" Attno="5" ColName="hd_vehicle_count" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="57" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="58" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="59" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="60" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="61" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="62" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="63" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:BroadcastMotion>
+            </dxl:HashJoin>
             <dxl:PartitionSelector RelationMdid="0.802597.1.1" SelectorId="0" ScanId="1" Partitions="0,1,2,3,4">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="432.238603" Rows="838.491452" Width="107"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SQExists.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SQExists.mdp
@@ -729,7 +729,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="63">
+    <dxl:Plan Id="0" SpaceSize="41">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000656" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SQScalar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SQScalar.mdp
@@ -734,7 +734,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="48">
+    <dxl:Plan Id="0" SpaceSize="28">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000898" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFunction.mdp
@@ -883,7 +883,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6">
+    <dxl:Plan Id="0" SpaceSize="4">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="952.936690" Rows="10000.000000" Width="20"/>

--- a/src/backend/gporca/data/dxl/minidump/PushGbBelowJoin-NegativeCase.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushGbBelowJoin-NegativeCase.mdp
@@ -386,7 +386,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18240">
+    <dxl:Plan Id="0" SpaceSize="12480">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="3017.002573" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/PushSelectDownUnionAllOfCTG.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushSelectDownUnionAllOfCTG.mdp
@@ -209,7 +209,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="988020">
+    <dxl:Plan Id="0" SpaceSize="283008">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="0.001436" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedJoinPartitionedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedJoinPartitionedTable.mdp
@@ -916,7 +916,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="11">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.005845" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/Select-Over-CTEAnchor.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Select-Over-CTEAnchor.mdp
@@ -460,7 +460,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1820">
+    <dxl:Plan Id="0" SpaceSize="240">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="10344.016560" Rows="3.333333" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/Select-Proj-OuterJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Select-Proj-OuterJoin.mdp
@@ -889,7 +889,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="72144">
+    <dxl:Plan Id="0" SpaceSize="16660">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="891.087839" Rows="3009.000000" Width="64"/>

--- a/src/backend/gporca/data/dxl/minidump/SemiJoin2InnerJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SemiJoin2InnerJoin.mdp
@@ -528,7 +528,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="69">
+    <dxl:Plan Id="0" SpaceSize="33">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="863.943229" Rows="4.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/Subq-JoinWithOuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq-JoinWithOuterRef.mdp
@@ -417,7 +417,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="117">
+    <dxl:Plan Id="0" SpaceSize="53">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.000818" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/Subq-On-OuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq-On-OuterRef.mdp
@@ -262,7 +262,7 @@
         </dxl:SubqueryAny>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="16">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000632" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqExists-With-External-Corrs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqExists-With-External-Corrs.mdp
@@ -456,7 +456,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="62302">
+    <dxl:Plan Id="0" SpaceSize="22026">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.001472" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqExists-Without-External-Corrs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqExists-Without-External-Corrs.mdp
@@ -431,7 +431,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="384581">
+    <dxl:Plan Id="0" SpaceSize="150026">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="12930.008073" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/TPCDS-39-InnerJoin-JoinEstimate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TPCDS-39-InnerJoin-JoinEstimate.mdp
@@ -2648,7 +2648,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="9093.176214" Rows="11530621.000000" Width="123"/>

--- a/src/backend/gporca/data/dxl/minidump/TPCH-Partitioned-256GB.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TPCH-Partitioned-256GB.mdp
@@ -4043,7 +4043,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="225448">
+    <dxl:Plan Id="0" SpaceSize="57782">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2343319.893955" Rows="10325183.250315" Width="697"/>

--- a/src/backend/gporca/data/dxl/minidump/UnionAll.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnionAll.mdp
@@ -8890,7 +8890,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="25">
+    <dxl:Plan Id="0" SpaceSize="12">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1773.052304" Rows="2163263.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/UnionAllWithTruncatedOutput.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnionAllWithTruncatedOutput.mdp
@@ -321,7 +321,7 @@
         </dxl:LogicalJoin>
       </dxl:UnionAll>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="72">
+    <dxl:Plan Id="0" SpaceSize="24">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2155.001254" Rows="3.333333" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/UnionWithOuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnionWithOuterRefs.mdp
@@ -729,7 +729,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1958">
+    <dxl:Plan Id="0" SpaceSize="1120">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="929.941015" Rows="14282.594514" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/UnnestSQJoins.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnnestSQJoins.mdp
@@ -1277,7 +1277,7 @@ WHERE
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="128412">
+    <dxl:Plan Id="0" SpaceSize="52727">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1306.824501" Rows="199.680000" Width="148"/>

--- a/src/backend/gporca/data/dxl/minidump/UpdateCardinalityAssert.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateCardinalityAssert.mdp
@@ -274,7 +274,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalUpdate>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="16">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:DMLUpdate Columns="0,1" ActionCol="18" OidCol="19" CtidCol="2" SegmentIdCol="8" InputSorted="false" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.102559" Rows="1.000000" Width="1"/>

--- a/src/backend/gporca/data/dxl/minidump/UpdateDistrKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateDistrKey.mdp
@@ -269,7 +269,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalUpdate>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="36">
+    <dxl:Plan Id="0" SpaceSize="20">
       <dxl:DMLUpdate Columns="0,1" ActionCol="18" OidCol="19" CtidCol="2" SegmentIdCol="8" InputSorted="false" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1880.351554" Rows="10000.000000" Width="1"/>

--- a/src/backend/gporca/data/dxl/minidump/UpdateNotNullCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateNotNullCols.mdp
@@ -327,7 +327,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalUpdate>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="28">
+    <dxl:Plan Id="0" SpaceSize="12">
       <dxl:DMLUpdate Columns="0,1" ActionCol="19" OidCol="20" CtidCol="2" SegmentIdCol="8" InputSorted="false" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.815480" Rows="8.000000" Width="1"/>

--- a/src/backend/gporca/data/dxl/minidump/UpdateUniqueConstraint-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateUniqueConstraint-2.mdp
@@ -764,7 +764,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalUpdate>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="88">
+    <dxl:Plan Id="0" SpaceSize="40">
       <dxl:DMLUpdate Columns="0,1" ActionCol="23" OidCol="24" CtidCol="2" SegmentIdCol="8" InputSorted="false" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="872.289027" Rows="100.000000" Width="1"/>

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXform.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXform.h
@@ -222,6 +222,7 @@ public:
 		ExfExpandDynamicGetWithExternalPartitions____removed,
 		ExfLeftJoin2RightJoin,
 		ExfRightOuterJoin2HashJoin,
+		ExfImplementInnerJoin,
 		ExfInvalid,
 		ExfSentinel = ExfInvalid
 	};

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformImplementInnerJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformImplementInnerJoin.h
@@ -3,13 +3,13 @@
 //	Copyright (C) 2011 EMC Corp.
 //
 //	@filename:
-//		CXformInnerJoin2HashJoin.h
+//		CXformImplementInnerJoin.h
 //
 //	@doc:
-//		Transform inner join to inner Hash Join
+//		Transform inner join to inner Hash/NLJ Join
 //---------------------------------------------------------------------------
-#ifndef GPOPT_CXformInnerJoin2HashJoin_H
-#define GPOPT_CXformInnerJoin2HashJoin_H
+#ifndef GPOPT_CXformImplementInnerJoin_H
+#define GPOPT_CXformImplementInnerJoin_H
 
 #include "gpos/base.h"
 
@@ -21,37 +21,37 @@ using namespace gpos;
 
 //---------------------------------------------------------------------------
 //	@class:
-//		CXformInnerJoin2HashJoin
+//		CXformImplementInnerJoin
 //
 //	@doc:
-//		Transform inner join to inner Hash Join
-//		Deprecated in favor of CXformImplementInnerJoin.
+//		Transform inner join to inner Hash Join or Inner Nested Loop Join
+//		(if a Hash Join is not possible)
 //
 //---------------------------------------------------------------------------
-class CXformInnerJoin2HashJoin : public CXformImplementation
+class CXformImplementInnerJoin : public CXformImplementation
 {
 private:
 public:
-	CXformInnerJoin2HashJoin(const CXformInnerJoin2HashJoin &) = delete;
+	CXformImplementInnerJoin(const CXformImplementInnerJoin &) = delete;
 
 	// ctor
-	explicit CXformInnerJoin2HashJoin(CMemoryPool *mp);
+	explicit CXformImplementInnerJoin(CMemoryPool *mp);
 
 	// dtor
-	~CXformInnerJoin2HashJoin() override = default;
+	~CXformImplementInnerJoin() override = default;
 
 	// ident accessors
 	EXformId
 	Exfid() const override
 	{
-		return ExfInnerJoin2HashJoin;
+		return ExfImplementInnerJoin;
 	}
 
 	// return a string for xform name
 	const CHAR *
 	SzId() const override
 	{
-		return "CXformInnerJoin2HashJoin";
+		return "CXformImplementInnerJoin";
 	}
 
 	// compute xform promise for a given expression handle
@@ -61,11 +61,11 @@ public:
 	void Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 				   CExpression *pexpr) const override;
 
-};	// class CXformInnerJoin2HashJoin
+};	// class CXformImplementInnerJoin
 
 }  // namespace gpopt
 
 
-#endif	// !GPOPT_CXformInnerJoin2HashJoin_H
+#endif	// !GPOPT_CXformImplementInnerJoin_H
 
 // EOF

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformInnerJoin2NLJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformInnerJoin2NLJoin.h
@@ -25,6 +25,7 @@ using namespace gpos;
 //
 //	@doc:
 //		Transform inner join to inner NLJ
+//		Deprecated in favor of CXformImplementInnerJoin.
 //
 //---------------------------------------------------------------------------
 class CXformInnerJoin2NLJoin : public CXformImplementation

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformResult.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformResult.h
@@ -61,6 +61,12 @@ public:
 	// print function
 	IOstream &OsPrint(IOstream &os) const;
 
+	ULONG
+	Size() const
+	{
+		return m_pdrgpexpr->Size();
+	}
+
 };	// class CXformResult
 
 // shorthand for printing

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/xforms.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/xforms.h
@@ -57,6 +57,7 @@
 #include "gpopt/xforms/CXformImplementFullOuterMergeJoin.h"
 #include "gpopt/xforms/CXformImplementIndexApply.h"
 #include "gpopt/xforms/CXformImplementInnerCorrelatedApply.h"
+#include "gpopt/xforms/CXformImplementInnerJoin.h"
 #include "gpopt/xforms/CXformImplementLeftAntiSemiCorrelatedApply.h"
 #include "gpopt/xforms/CXformImplementLeftAntiSemiCorrelatedApplyNotIn.h"
 #include "gpopt/xforms/CXformImplementLeftOuterCorrelatedApply.h"

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalInnerJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalInnerJoin.cpp
@@ -68,8 +68,7 @@ CLogicalInnerJoin::PxfsCandidates(CMemoryPool *mp) const
 {
 	CXformSet *xform_set = GPOS_NEW(mp) CXformSet(mp);
 
-	(void) xform_set->ExchangeSet(CXform::ExfInnerJoin2NLJoin);
-	(void) xform_set->ExchangeSet(CXform::ExfInnerJoin2HashJoin);
+	(void) xform_set->ExchangeSet(CXform::ExfImplementInnerJoin);
 	(void) xform_set->ExchangeSet(CXform::ExfSubqJoin2Apply);
 	(void) xform_set->ExchangeSet(CXform::ExfJoin2BitmapIndexGetApply);
 	(void) xform_set->ExchangeSet(CXform::ExfJoin2IndexGetApply);

--- a/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
@@ -289,6 +289,7 @@ CXformFactory::Instantiate()
 	SkipUnused(2);
 	Add(GPOS_NEW(m_mp) CXformLeftJoin2RightJoin(m_mp));
 	Add(GPOS_NEW(m_mp) CXformRightOuterJoin2HashJoin(m_mp));
+	Add(GPOS_NEW(m_mp) CXformImplementInnerJoin(m_mp));
 
 	GPOS_ASSERT(nullptr != m_rgpxf[CXform::ExfSentinel - 1] &&
 				"Not all xforms have been instantiated");

--- a/src/backend/gporca/libgpopt/src/xforms/CXformInnerJoin2NLJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformInnerJoin2NLJoin.cpp
@@ -54,9 +54,9 @@ CXformInnerJoin2NLJoin::CXformInnerJoin2NLJoin(CMemoryPool *mp)
 //
 //---------------------------------------------------------------------------
 CXform::EXformPromise
-CXformInnerJoin2NLJoin::Exfp(CExpressionHandle &exprhdl) const
+CXformInnerJoin2NLJoin::Exfp(CExpressionHandle &) const
 {
-	return CXformUtils::ExfpLogicalJoin2PhysicalJoin(exprhdl);
+	return CXform::ExfpNone;
 }
 
 
@@ -66,17 +66,13 @@ CXformInnerJoin2NLJoin::Exfp(CExpressionHandle &exprhdl) const
 //
 //	@doc:
 //		actual transformation
+//		Deprecated in favor of CXformImplementInnerJoin.
 //
 //---------------------------------------------------------------------------
 void
-CXformInnerJoin2NLJoin::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
-								  CExpression *pexpr) const
+CXformInnerJoin2NLJoin::Transform(CXformContext *, CXformResult *,
+								  CExpression *) const
 {
-	GPOS_ASSERT(nullptr != pxfctxt);
-	GPOS_ASSERT(FPromising(pxfctxt->Pmp(), this, pexpr));
-	GPOS_ASSERT(FCheckPattern(pexpr));
-
-	CXformUtils::ImplementNLJoin<CPhysicalInnerNLJoin>(pxfctxt, pxfres, pexpr);
 }
 
 

--- a/src/backend/gporca/libgpopt/src/xforms/Makefile
+++ b/src/backend/gporca/libgpopt/src/xforms/Makefile
@@ -72,6 +72,7 @@ OBJS        = CDecorrelator.o \
               CXformInnerApplyWithOuterKey2InnerJoin.o \
               CXformInnerJoin2HashJoin.o \
               CXformInnerJoin2NLJoin.o \
+              CXformImplementInnerJoin.o \
               CXformInsert2DML.o \
               CXformIntersect2Join.o \
               CXformIntersectAll2LeftSemiJoin.o \

--- a/src/backend/gporca/libnaucrates/include/naucrates/traceflags/traceflags.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/traceflags/traceflags.h
@@ -213,6 +213,8 @@ enum EOptTraceFlag
 	// enable NL Left Join plan alternatives where inner child is redistributed if possible
 	EopttraceEnableRedistributeNLLOJInnerChild = 103040,
 
+	EopttraceForceComprehensiveJoinImplementation = 103041,
+
 	///////////////////////////////////////////////////////
 	///////////////////// statistics flags ////////////////
 	//////////////////////////////////////////////////////

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -331,6 +331,7 @@ bool		optimizer_expand_fulljoin;
 bool		optimizer_enable_mergejoin;
 bool		optimizer_prune_unused_columns;
 bool		optimizer_enable_redistribute_nestloop_loj_inner_child;
+bool		optimizer_force_comprehensive_join_implementation;
 
 
 /* Optimizer plan enumeration related GUCs */
@@ -2840,7 +2841,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 		 &optimizer_enable_redistribute_nestloop_loj_inner_child,
 		 true,
 		 NULL, NULL, NULL
+	},
+	{
+		{"optimizer_force_comprehensive_join_implementation", PGC_USERSET, QUERY_TUNING_METHOD,
+		 gettext_noop("Explore a nested loop join even if a hash join is possible"),
+		 NULL,
+		 GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		 },
+		 &optimizer_force_comprehensive_join_implementation,
+		 false,
+		 NULL, NULL, NULL
+	},
 
 	/* End-of-list marker */
 	{

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -515,6 +515,7 @@ extern bool optimizer_enable_groupagg;
 extern bool optimizer_enable_mergejoin;
 extern bool optimizer_prune_unused_columns;
 extern bool optimizer_enable_redistribute_nestloop_loj_inner_child;
+extern bool optimizer_force_comprehensive_join_implementation;
 
 /* Optimizer plan enumeration related GUCs */
 extern bool optimizer_enumerate_plans;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -401,6 +401,7 @@
 		"optimizer_enable_streaming_material",
 		"optimizer_enable_tablescan",
 		"optimizer_enable_redistribute_nestloop_loj_inner_child",
+		"optimizer_force_comprehensive_join_implementation",
 		"optimizer_enforce_subplans",
 		"optimizer_enumerate_plans",
 		"optimizer_expand_fulljoin",


### PR DESCRIPTION
This PR introduces a new xform (CXformImplementInnerJoin) that uses 
existing traceflags to generate a InnerNLJ *only* if a InnerHJ
cannot be generated. Disables existing CXformInnerJoin2HashJoin and
CXformInnerJoin2NLJoin implementations, by making them defunct.

It also introduces a new GUC (optimizer_force_comprehensive_join_implementation)
that enables this space size improvement when set to false (default in 7X).

Optimization time improves for certain characteristic queries:
* North star query opt. time: 374s (down from 1038s)
* Benchmark opt. time: 78s (down from 163s)

Most MDP changes are plan size changes. 2 MDPs had plan changes which
were due to the fact that they did not penalize NLJs. Thus, I believe the new
(higher costed) HJ plans are better.

Question to reviewers:
1. I have left the original xforms around because that way I don't have to add additional traceflags for NLJ/HJ, and the xform ids can be used as before. I'm open to alternative implementation ideas.
2. The logic is fairly straightforward in the code, so I haven't added many comments. Please highlight anything that you think could benefit from more comments.