### PR TITLE
fix 6x gpload cannot process multipul input files

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -1764,7 +1764,9 @@ class gpload:
                 # MPP-13617
                 if ':' in l:
                     l = '[' + l + ']'
-                self.locations.append('%s://%s:%d%s%s%s' % (protocol, l, port, sep, '%20'.join(file), fragment))
+                for f in file:
+                    self.locations.append('%s://%s:%d%s%s%s' % (protocol, l, port, sep, f, fragment))
+
         if not found_source:
             self.control_file_error("configuration file must contain source definition")
 

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_base.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_base.py
@@ -538,6 +538,17 @@ def ModifyOutFile(file,old_str,new_str):
             f2.write(line)
     os.remove(file)
     os.rename("%s.bak" % file, file)
+    if file == 'query65.out':
+        print file
+        print 'in file 65'
+        # case 65 is unstable, which file not found is random, 
+        # so we need to pre-process it here
+        with open('query65.out', 'r') as f1,open("query65.bak", "w") as f2:
+            for line in f1:
+                line = re.sub(':pathto\/data_file[0-9]*\.txt',':pathto/data_file_not_exist.txt',line)
+                f2.write(line)
+        os.remove('query65.out')
+        os.rename("query65.bak" , 'query65.out')
 
 Modify_Output_Case = [44,46,51,57,65,219]
 

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_input_column.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_input_column.py
@@ -8,6 +8,7 @@ import pytest
 @prepare_before_test(num=64, times=1)
 def test_64_gpload_multi_input_file():
     "64 gpload with multiple input file"
+    runfile(mkpath('setup.sql'))
     copy_data('external_file_01.txt','data_file.txt')
     copy_data('external_file_01.txt','data_file1.txt')
     write_config_file(format='text',file=['data_file.txt','data_file1.txt'],table='texttable')
@@ -16,6 +17,7 @@ def test_64_gpload_multi_input_file():
 @prepare_before_test(num=65, times=1)
 def test_65_gpload_multi_input_file_with_a_notexist():
     "65 gpload with multiple input files including a not exist one"
+    runfile(mkpath('setup.sql'))
     copy_data('external_file_01.txt','data_file.txt')
     copy_data('external_file_01.txt','data_file1.txt')
     write_config_file(format='text',file=['data_file.txt','data_file1.txt','data_file99.txt'],table='texttable')

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_input_column.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_input_column.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from TEST_local_base import write_config_file, psql_run, mkpath
+from TEST_local_base import get_ip, write_config_file, psql_run, mkpath
 from TEST_local_base import prepare_before_test, drop_tables, runfile
 from TEST_local_base import runfile, copy_data, run, hostNameAddrs, masterPort
 import pytest
@@ -227,3 +227,11 @@ def test_78_gpload_merge_upper_case():
         write_config_file(mode='insert',file='data_file.txt',config='config/config_file'+str(i),reuse_tables=True, fast_match=True, table='testheaderreuse',columns=columns[i], delimiter="','")
         f.write("\\! gpload -f "+mkpath('config/config_file'+str(i))+"\n")
     f.close()
+
+@pytest.mark.order(79)
+@prepare_before_test(num=79)
+def test_79_gpload_multi_input_hostname():
+    """79 test gpload has a input source with multiple hostname"""
+    runfile(mkpath('setup.sql'))
+    copy_data('external_file_01.txt','data_file.txt')
+    write_config_file(format='text',file=['data_file.txt'],table='texttable',local_host=['127.0.0.1','localhost'])

--- a/gpMgmt/bin/gpload_test/gpload2/query65.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query65.ans
@@ -1,10 +1,10 @@
-2021-11-08 11:36:19|INFO|gpload session started 2021-11-08 11:36:19
-2021-11-08 11:36:19|INFO|setting schema 'public' for table 'texttable'
-2021-11-08 11:36:19|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt pathto/data_file1.txt pathto/data_file99.txt" -t 30
-2021-11-08 11:36:19|INFO|did not find an external table to reuse. creating ext_gpload_table
-2021-11-08 11:36:20|ERROR|ERROR:  http response code 404 from gpfdist (gpfdist://*:pathto/data_file.txt): HTTP/1.0 404 file not found  (seg0 slice1 *:6002 pid=7393)
+2021-11-09 13:55:16|INFO|gpload session started 2021-11-09 13:55:16
+2021-11-09 13:55:16|INFO|setting schema 'public' for table 'texttable'
+2021-11-09 13:55:16|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt pathto/data_file1.txt pathto/data_file99.txt" -t 30
+2021-11-09 13:55:16|INFO|did not find an external table to reuse. creating ext_gpload_table
+2021-11-09 13:55:17|ERROR|ERROR:  http response code 404 from gpfdist (gpfdist://*:pathto/data_file_not_exist.txt): HTTP/1.0 404 file not found  (seg0 slice1 *:6002 pid=27699)
  encountered while running INSERT INTO public."texttable" ("s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7") SELECT "s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7" FROM ext_gpload_table
-2021-11-08 11:36:20|INFO|rows Inserted          = 0
-2021-11-08 11:36:20|INFO|rows Updated           = 0
-2021-11-08 11:36:20|INFO|data formatting errors = 0
-2021-11-08 11:36:20|INFO|gpload failed
+2021-11-09 13:55:17|INFO|rows Inserted          = 0
+2021-11-09 13:55:17|INFO|rows Updated           = 0
+2021-11-09 13:55:17|INFO|data formatting errors = 0
+2021-11-09 13:55:17|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query65.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query65.ans
@@ -1,10 +1,10 @@
-2021-06-21 17:05:42|INFO|gpload session started 2021-06-21 17:05:42
-2021-06-21 17:05:42|INFO|setting schema 'public' for table 'texttable'
-2021-06-21 17:05:42|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt pathto/data_file1.txt pathto/data_file99.txt" -t 30
-2021-06-21 17:05:42|INFO|did not find an external table to reuse. creating ext_gpload_table
-2021-06-21 17:05:43|ERROR|ERROR:  http response code 404 from gpfdist (gpfdist://*:pathto/data_file.txt%pathto/data_file1.txt%pathto/data_file99.txt): HTTP/1.0 404 file not found  (seg1 slice1 *:6003 pid=26025)
+2021-11-08 11:36:19|INFO|gpload session started 2021-11-08 11:36:19
+2021-11-08 11:36:19|INFO|setting schema 'public' for table 'texttable'
+2021-11-08 11:36:19|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt pathto/data_file1.txt pathto/data_file99.txt" -t 30
+2021-11-08 11:36:19|INFO|did not find an external table to reuse. creating ext_gpload_table
+2021-11-08 11:36:20|ERROR|ERROR:  http response code 404 from gpfdist (gpfdist://*:pathto/data_file.txt): HTTP/1.0 404 file not found  (seg0 slice1 *:6002 pid=7393)
  encountered while running INSERT INTO public."texttable" ("s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7") SELECT "s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7" FROM ext_gpload_table
-2021-06-21 17:05:43|INFO|rows Inserted          = 0
-2021-06-21 17:05:43|INFO|rows Updated           = 0
-2021-06-21 17:05:43|INFO|data formatting errors = 0
-2021-06-21 17:05:43|INFO|gpload failed
+2021-11-08 11:36:20|INFO|rows Inserted          = 0
+2021-11-08 11:36:20|INFO|rows Updated           = 0
+2021-11-08 11:36:20|INFO|data formatting errors = 0
+2021-11-08 11:36:20|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query79.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query79.ans
@@ -1,0 +1,18 @@
+2021-11-09 14:03:11|INFO|gpload session started 2021-11-09 14:03:11
+2021-11-09 14:03:11|INFO|setting schema 'public' for table 'texttable'
+2021-11-09 14:03:11|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-11-09 14:03:11|INFO|did not find an external table to reuse. creating ext_gpload_reusable_b7f68444_4122_11ec_bf52_0050569ea4ff
+2021-11-09 14:03:11|INFO|running time: 0.07 seconds
+2021-11-09 14:03:11|INFO|rows Inserted          = 16
+2021-11-09 14:03:11|INFO|rows Updated           = 0
+2021-11-09 14:03:11|INFO|data formatting errors = 0
+2021-11-09 14:03:11|INFO|gpload succeeded
+2021-11-09 14:03:11|INFO|gpload session started 2021-11-09 14:03:11
+2021-11-09 14:03:11|INFO|setting schema 'public' for table 'texttable'
+2021-11-09 14:03:11|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-11-09 14:03:11|INFO|reusing external table ext_gpload_reusable_b7f68444_4122_11ec_bf52_0050569ea4ff
+2021-11-09 14:03:11|INFO|running time: 0.04 seconds
+2021-11-09 14:03:11|INFO|rows Inserted          = 16
+2021-11-09 14:03:11|INFO|rows Updated           = 0
+2021-11-09 14:03:11|INFO|data formatting errors = 0
+2021-11-09 14:03:11|INFO|gpload succeeded


### PR DESCRIPTION
* fix gpload cannot process multiple input files
gpload can process multiple files in one input source.
We need the file location when creating or finding reuse external tables. 
The original location string is wrong. We make it write in the right way.

* add test case for multiple hostname in one input source

the input yaml config is like :
```
GPLOAD:
   INPUT:
     - SOURCE:
         LOCAL_HOSTNAME:
           - 10.117.190.113
           - 10.117.190.51
         PORT: 8081
         FILE: 
           - /home/gpadmin/workspace/test.txt
           - /home/gpadmin/workspace/test1.txt
```
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
