### PR TITLE
Add S3 external table getting parameters from http/https server function for master.

### DIFF
--- a/concourse/scripts/regression_tests_gpcloud.bash
+++ b/concourse/scripts/regression_tests_gpcloud.bash
@@ -3,12 +3,12 @@
 set -exo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-GPDB_INSTALL_DIR="/usr/local/gpdb"
+GPDB_INSTALL_DIR="/usr/local/greenplum-db-devel"
 
 function gen_local_regression_script(){
 cat > /home/gpadmin/run_regression_test.sh <<-EOF
 set -exo pipefail
-INSTALL_DIR=/usr/local/gpdb
+INSTALL_DIR=/usr/local/greenplum-db-devel
 GPDB_SRC_DIR=\${1}/gpdb_src
 
 source \$INSTALL_DIR/greenplum_path.sh
@@ -37,7 +37,7 @@ function setup_gpadmin_user() {
 }
 
 function make_cluster() {
-  PYTHONPATH=${SCRIPT_DIR}:${PYTHONPATH} python2 -c "from builds.GpBuild import GpBuild; GpBuild(\"planner\").create_demo_cluster(install_dir='/usr/local/gpdb')"
+  PYTHONPATH=${SCRIPT_DIR}:${PYTHONPATH} python2 -c "from builds.GpBuild import GpBuild; GpBuild(\"planner\").create_demo_cluster(install_dir='/usr/local/greenplum-db-devel')"
 }
 
 function configure_with_planner() {

--- a/gpcontrib/gpcloud/bin/dummyHTTPServer.py
+++ b/gpcontrib/gpcloud/bin/dummyHTTPServer.py
@@ -14,7 +14,21 @@ Send a POST request::
 
 from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 import SocketServer
+import getopt
+import sys
+import os
+import ssl
 
+help_msg = '''./dummyHTTPServer.py 
+[-h] | [-p (--port=) <port>][-f (--filename=) <filename>][-s][-t(--type=)<S|PARAM_S>]
+Options:
+    -h : print this help info
+    -p --port=: http listen port
+    -f --filename=: content filename path
+    -t --type=: PARAM_S server or Common Server
+    -s: use ssl connection
+    '''
+filename = "data/s3httptest.conf"
 class S(BaseHTTPRequestHandler):
 
     def _set_headers(self,length = 0):
@@ -57,17 +71,79 @@ class S(BaseHTTPRequestHandler):
         self._set_headers(length)
         self.wfile.write("")
 
-def run(server_class=HTTPServer, handler_class=S, port=8553):
-	server_address = ('', port)
-	handler_class.protocol_version = 'HTTP/1.1'
-	httpd = server_class(server_address, handler_class)
-	print 'Starting http server...'
-	httpd.serve_forever()
+class PARAM_S(BaseHTTPRequestHandler):
+    def _set_headers(self,length = 0):
+        self.send_response(200)
+        self.send_header('Content-type', 'text/plain')
+        self.send_header('Content-Length', length)
+        self.end_headers()
+
+    def _getcontent(self):
+        content = ""
+        if filename != "":
+            try:
+                with open(filename, 'r') as f:
+                    content = f.read()
+            except Exception:
+                print "Can not open file:%s" % filename
+        return content
+
+    def do_GET(self):
+        try:
+            if self.headers['S3_Param_Req']:
+                content = self._getcontent()
+                self._set_headers(len(content))
+                self.wfile.write(content)
+            else:
+                self._set_headers(0)
+        except KeyError:
+            print "Header missing S3_Param_Req"
+            self._set_headers(0)
+
+def run(server_class=HTTPServer, handler_class=S, port=8553, https=False):
+    server_address = ('', port)
+    handler_class.protocol_version = 'HTTP/1.1'
+    httpd = server_class(server_address, handler_class)
+    if https:
+        datadir = os.getcwd()
+        curdir = "./"
+        while(curdir != "gpdb_src" and curdir != "gpdb"):
+            datadir, curdir = os.path.split(datadir)
+        datadir = os.path.join(datadir, curdir)
+        datadir = os.path.join(datadir, "gpAux/gpdemo/datadirs/qddir/demoDataDir-1/")
+        datadir += "/gpfdists/"
+        keyfile = datadir + "server.key"
+        certfile = datadir + "server.crt"
+        httpd.socket = ssl.wrap_socket (httpd.socket,
+            keyfile=keyfile,
+            certfile=certfile, server_side=True)
+    print 'Starting http server...'
+    httpd.serve_forever()
 
 if __name__ == "__main__":
     from sys import argv
-
-    if len(argv) == 2:
-        run(port=int(argv[1]))
+    port = 8553
+    servertype = "S"
+    use_ssl = False
+    try:
+        opts, args = getopt.getopt(argv[1:],"hsp:f:t:",["--port=","--filename=", "--type="])
+    except getopt.GetoptError:
+        print help_msg
+        sys.exit(2)
+    for opt, arg in opts:
+        if opt == '-h':
+            print help_msg
+            sys.exit(0)
+        elif opt == '-s':
+            use_ssl = True
+        elif opt in ("-p", "--port"):
+            port = int(arg)
+        elif opt in ("-f", "--filename"):
+            filename = arg
+        elif opt in ("-t", "--type"):
+            servertype = arg
+    if servertype == "S":
+        run(handler_class=S, port=port)
     else:
-        run()
+        run(handler_class=PARAM_S, port=port, https=use_ssl)
+

--- a/gpcontrib/gpcloud/bin/dummyHTTPServer.py
+++ b/gpcontrib/gpcloud/bin/dummyHTTPServer.py
@@ -25,7 +25,7 @@ Options:
     -h : print this help info
     -p --port=: http listen port
     -f --filename=: content filename path
-    -t --type=: PARAM_S server or Common Server
+    -t --type=: Parameter_Server server or Common_Server
     -s: use ssl connection
     '''
 filename = "data/s3httptest.conf"
@@ -142,7 +142,7 @@ if __name__ == "__main__":
             filename = arg
         elif opt in ("-t", "--type"):
             servertype = arg
-    if servertype == "S":
+    if servertype == "Common_Server":
         run(handler_class=S, port=port)
     else:
         run(handler_class=PARAM_S, port=port, https=use_ssl)

--- a/gpcontrib/gpcloud/include/s3utils.h
+++ b/gpcontrib/gpcloud/include/s3utils.h
@@ -48,6 +48,7 @@ class MD5Calc {
 
 class Config {
    public:
+    Config(const string& filename, const string& url, const char *datadir);
     Config(const string& filename);
     ~Config();
     bool SectionExist(const string& sec);

--- a/gpcontrib/gpcloud/lib/ini.cpp
+++ b/gpcontrib/gpcloud/lib/ini.cpp
@@ -178,16 +178,13 @@ static CURL *create_curl_from_url(const char *url, const char *datadir) {
     INICURL_EASY_SETOPT(curl, CURLOPT_URL, url);
     // Add https support
     if (strncmp(url, "https", 5) == 0) {
-        memset(extssl_cer_full, 0, S3MAXPGPATH);
         snprintf(extssl_cer_full, S3MAXPGPATH, "%s/%s", datadir, extssl_cert);
         /* set the cert for client authentication */
         INICURL_EASY_SETOPT(curl, CURLOPT_SSLCERT, extssl_cer_full);
         INICURL_EASY_SETOPT(curl, CURLOPT_SSLKEYTYPE,"PEM");
-        memset(extssl_key_full, 0, S3MAXPGPATH);
         snprintf(extssl_key_full, S3MAXPGPATH, "%s/%s", datadir, extssl_key);
         /* set the private key (file or ID in engine) */
         INICURL_EASY_SETOPT(curl, CURLOPT_SSLKEY, extssl_key_full);
-        memset(extssl_cas_full, 0, S3MAXPGPATH);
         snprintf(extssl_cas_full, S3MAXPGPATH, "%s/%s", datadir, extssl_ca);
         /* set the file with the CA certificates, for validating the server */
         INICURL_EASY_SETOPT(curl, CURLOPT_CAINFO, extssl_cas_full);
@@ -215,7 +212,7 @@ get_s3_param(char *buffer, size_t size, size_t nitems, void *userp)
 
     return nbytes;
 }
-ini_t* ini_load_4url(const char *url, const char *datadir) {
+ini_t* ini_load_from_url(const char *url, const char *datadir) {
     ini_t *ini = NULL;
     CURL *curl = NULL;
     curl_slist *headers = NULL;

--- a/gpcontrib/gpcloud/lib/ini.cpp
+++ b/gpcontrib/gpcloud/lib/ini.cpp
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <curl/curl.h>
 
 #include "ini.h"
 
@@ -151,6 +152,114 @@ static void split_data(ini_t *ini) {
         break;
     }
   }
+}
+
+#define S3MAXPGPATH 1024
+const static int extssl_protocol  = CURL_SSLVERSION_TLSv1;
+static const char* extssl_cert = "gpfdists/client.crt";
+static const char* extssl_key = "gpfdists/client.key";
+static const char* extssl_ca = "gpfdists/root.crt";
+#define INICURL_EASY_SETOPT(h, opt, val) \
+    do { \
+        int			e; \
+        if ((e = curl_easy_setopt(h, opt, val)) != CURLE_OK){  \
+            curl_easy_cleanup(curl);  \
+            return NULL; \
+        } \
+    } while(0)
+
+static CURL *create_curl_from_url(const char *url, const char *datadir) {
+    char extssl_key_full[S3MAXPGPATH] = {0};
+    char extssl_cer_full[S3MAXPGPATH] = {0};
+    char extssl_cas_full[S3MAXPGPATH] = {0};
+    CURL *curl = NULL;
+
+    curl = curl_easy_init();
+    INICURL_EASY_SETOPT(curl, CURLOPT_URL, url);
+    // Add https support
+    if (strncmp(url, "https", 5) == 0) {
+        memset(extssl_cer_full, 0, S3MAXPGPATH);
+        snprintf(extssl_cer_full, S3MAXPGPATH, "%s/%s", datadir, extssl_cert);
+        /* set the cert for client authentication */
+        INICURL_EASY_SETOPT(curl, CURLOPT_SSLCERT, extssl_cer_full);
+        INICURL_EASY_SETOPT(curl, CURLOPT_SSLKEYTYPE,"PEM");
+        memset(extssl_key_full, 0, S3MAXPGPATH);
+        snprintf(extssl_key_full, S3MAXPGPATH, "%s/%s", datadir, extssl_key);
+        /* set the private key (file or ID in engine) */
+        INICURL_EASY_SETOPT(curl, CURLOPT_SSLKEY, extssl_key_full);
+        memset(extssl_cas_full, 0, S3MAXPGPATH);
+        snprintf(extssl_cas_full, S3MAXPGPATH, "%s/%s", datadir, extssl_ca);
+        /* set the file with the CA certificates, for validating the server */
+        INICURL_EASY_SETOPT(curl, CURLOPT_CAINFO, extssl_cas_full);
+        /* set cert verification */
+        INICURL_EASY_SETOPT(curl, CURLOPT_SSL_VERIFYPEER, 1);
+        /* set host verification */
+        INICURL_EASY_SETOPT(curl, CURLOPT_SSL_VERIFYHOST, 2);
+        /* set protocol */
+        INICURL_EASY_SETOPT(curl, CURLOPT_SSLVERSION, extssl_protocol);
+    }
+    return curl;
+}
+static size_t
+get_s3_param(char *buffer, size_t size, size_t nitems, void *userp)
+{
+    ini_t *ini = (ini_t *)userp;
+    int nbytes = size * nitems;
+    ini->data = (char*) malloc(nbytes+1);
+    if (ini->data == NULL) {
+        return 0;
+    }
+    ini->data[nbytes] = '\0';
+    ini->end = ini->data  + nbytes;
+    memcpy(ini->data, buffer, nbytes);
+
+    return nbytes;
+}
+ini_t* ini_load_4url(const char *url, const char *datadir) {
+    ini_t *ini = NULL;
+    CURL *curl = NULL;
+    curl_slist *headers = NULL;
+    CURLcode e;
+
+    curl_global_init(CURL_GLOBAL_ALL);
+    /* Init ini struct */
+    ini = (ini_t*) malloc(sizeof(*ini));
+    if (!ini) {
+        goto fail;
+    }
+    memset(ini, 0, sizeof(*ini));
+    /* Curl param */
+    curl = create_curl_from_url(url, datadir);
+    if (curl == NULL) {
+        goto fail;
+    }
+    // Add header "S3_Param_Req"
+    headers = curl_slist_append(NULL, "S3_Param_Req: true");
+    if (headers == NULL) {
+        goto fail;
+    }
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, get_s3_param);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, ini);
+    /* Load file content into memory, null terminate, init end var */
+    e = curl_easy_perform(curl);
+    if (e != CURLE_OK) {
+        goto fail;
+    }
+    /* Prepare data */
+    split_data(ini);
+    /* Clean up and return */
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
+    curl_global_cleanup();
+    return ini;
+
+fail:
+    if (ini) ini_free(ini);
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
+    curl_global_cleanup();
+    return NULL;
 }
 
 ini_t* ini_load(const char *filename) {

--- a/gpcontrib/gpcloud/lib/ini.h
+++ b/gpcontrib/gpcloud/lib/ini.h
@@ -12,7 +12,7 @@
 
 typedef struct ini_t ini_t;
 
-ini_t*      ini_load_4url(const char *url, const char *datadir);
+ini_t*      ini_load_from_url(const char *url, const char *datadir);
 ini_t*      ini_load(const char *filename);
 void        ini_free(ini_t *ini);
 bool        ini_section_exist(ini_t *ini, const char* section);

--- a/gpcontrib/gpcloud/lib/ini.h
+++ b/gpcontrib/gpcloud/lib/ini.h
@@ -12,6 +12,7 @@
 
 typedef struct ini_t ini_t;
 
+ini_t*      ini_load_4url(const char *url, const char *datadir);
 ini_t*      ini_load(const char *filename);
 void        ini_free(ini_t *ini);
 bool        ini_section_exist(ini_t *ini, const char* section);

--- a/gpcontrib/gpcloud/regress/Makefile
+++ b/gpcontrib/gpcloud/regress/Makefile
@@ -12,6 +12,7 @@ installcheck:
 	@echo "The sub-directory for this test instance is: $(write_prefix)"
 	@rm -rf source_replaced
 	@mkdir -p source_replaced
+	@cp ../bin/dummyHTTPServer.py source_replaced/
 	@cp -rf input source_replaced/input
 	@cp -rf output source_replaced/output
 	@./generate_config_file.sh $(config_file)

--- a/gpcontrib/gpcloud/regress/input/1_09_partition.source
+++ b/gpcontrib/gpcloud/regress/input/1_09_partition.source
@@ -1,3 +1,4 @@
+SET client_min_messages TO 'warning';
 CREATE TABLE stock (date text, time text, open float, high float, low float, volume int) DISTRIBUTED BY (date) PARTITION BY RANGE (volume)
 (
   PARTITION stock10000 START (10000) INCLUSIVE,
@@ -33,3 +34,4 @@ DROP TABLE ext_stock000;
 DROP TABLE ext_stock001;
 DROP TABLE ext_stock002;
 DROP TABLE stock;
+RESET client_min_messages;

--- a/gpcontrib/gpcloud/regress/input/1_16_multiple_files_with_header_line.source
+++ b/gpcontrib/gpcloud/regress/input/1_16_multiple_files_with_header_line.source
@@ -1,5 +1,6 @@
 --- test set 1: multiple files with header and different EOLs ---
 -- with line terminator '\n' (LF)
+SET client_min_messages TO 'warning';
 CREATE READABLE EXTERNAL TABLE s3regress_multiple_files_with_header_line_lf(date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-us-west-2.amazonaws.com/@read_prefix@/csv_with_header/ config=@config_file@') FORMAT 'csv' (HEADER NEWLINE 'LF');
 
@@ -30,3 +31,4 @@ SELECT count(*) FROM s3regress_multiple_files_with_header_line_crlf whcrlf, s3re
 DROP EXTERNAL TABLE s3regress_multiple_files_with_header_line_lf;
 DROP EXTERNAL TABLE s3regress_multiple_files_without_header_line_lf;
 DROP EXTERNAL TABLE s3regress_multiple_files_with_header_line_crlf;
+RESET client_min_messages;

--- a/gpcontrib/gpcloud/regress/input/3_05_insert_to_wet_from_ret.source
+++ b/gpcontrib/gpcloud/regress/input/3_05_insert_to_wet_from_ret.source
@@ -1,3 +1,4 @@
+SET client_min_messages TO 'warning';
 CREATE READABLE EXTERNAL TABLE s3write_ret2wet_read (date text, time text, status bool, sample1 float, sample2 float,
         volume int) LOCATION('s3://s3-us-west-2.amazonaws.com/@write_prefix@/ret2wet/ config=@config_file@') FORMAT 'csv';
 
@@ -24,3 +25,4 @@ DROP EXTERNAL TABLE IF EXISTS s3write_ret2wet_read;
 DROP EXTERNAL TABLE IF EXISTS s3write_ret2wet_write;
 DROP EXTERNAL TABLE IF EXISTS s3write_ret2wet_read_new;
 DROP EXTERNAL TABLE IF EXISTS s3write_ret2wet_write_new;
+RESET client_min_messages;

--- a/gpcontrib/gpcloud/regress/input/3_06_special_characters.source
+++ b/gpcontrib/gpcloud/regress/input/3_06_special_characters.source
@@ -1,3 +1,4 @@
+SET client_min_messages TO 'warning';
 CREATE READABLE EXTERNAL TABLE s3write_special_characters_read (date text, time text, status bool, sample1 float, sample2 float,
         volume int) LOCATION('s3://s3-us-west-2.amazonaws.com/@write_prefix@/?:&=+/ config=@config_file@') FORMAT 'csv';
 
@@ -24,3 +25,4 @@ DROP EXTERNAL TABLE IF EXISTS s3write_special_characters_read;
 DROP EXTERNAL TABLE IF EXISTS s3write_special_characters_write;
 DROP EXTERNAL TABLE IF EXISTS s3write_special_characters_read_new;
 DROP EXTERNAL TABLE IF EXISTS s3write_special_characters_write_new;
+RESET client_min_messages;

--- a/gpcontrib/gpcloud/regress/input/5_01_normal_http_param.source
+++ b/gpcontrib/gpcloud/regress/input/5_01_normal_http_param.source
@@ -1,3 +1,4 @@
+SET client_min_messages TO 'warning';
 CREATE EXTERNAL WEB TABLE dummyHttpServerstart (x text)
 execute E'((python @abs_srcdir@/dummyHTTPServer.py -p 8553 -f @config_file@ -t PARAM_S >/dev/null 2>&1 &);for i in `seq 1 30`; do curl http://127.0.0.1:8553 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
 on SEGMENT 0
@@ -35,4 +36,4 @@ select * from dummyHttpServerstop;
 drop external table dummyHttpServerstop;
 drop external table dummyHttpServerstart;
 -- end_ignore
-
+RESET client_min_messages;

--- a/gpcontrib/gpcloud/regress/input/5_01_normal_http_param.source
+++ b/gpcontrib/gpcloud/regress/input/5_01_normal_http_param.source
@@ -1,6 +1,6 @@
 SET client_min_messages TO 'warning';
 CREATE EXTERNAL WEB TABLE dummyHttpServerstart (x text)
-execute E'((python @abs_srcdir@/dummyHTTPServer.py -p 8553 -f @config_file@ -t PARAM_S >/dev/null 2>&1 &);for i in `seq 1 30`; do curl http://127.0.0.1:8553 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+execute E'((python @abs_srcdir@/dummyHTTPServer.py -p 8553 -f @config_file@ -t Parameter_Server >/dev/null 2>&1 &);for i in `seq 1 30`; do curl http://127.0.0.1:8553 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 
@@ -17,7 +17,7 @@ select * from dummyHttpServerstart;
 -- test http protocol: get config from http server
 drop external table if exists s3regress_normal1;
 CREATE READABLE EXTERNAL TABLE s3regress_normal1 (date text, time text, open float, high float,
-        low float, volume int) LOCATION('s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 server=http://127.0.0.1:8553') FORMAT 'csv';
+        low float, volume int) LOCATION('s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 config_server=http://127.0.0.1:8553') FORMAT 'csv';
 
 SELECT count(*) FROM s3regress_normal1;
 
@@ -25,7 +25,7 @@ DROP EXTERNAL TABLE s3regress_normal1;
 
 drop external table if exists s3regress_normal_onmaster1;
 CREATE READABLE EXTERNAL TABLE s3regress_normal_onmaster1 (date text, time text, open float, high float,
-        low float, volume int) LOCATION('s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 server=http://127.0.0.1:8553') ON MASTER FORMAT 'csv';
+        low float, volume int) LOCATION('s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 config_server=http://127.0.0.1:8553') ON MASTER FORMAT 'csv';
 
 SELECT count(*) FROM s3regress_normal_onmaster1;
 

--- a/gpcontrib/gpcloud/regress/input/5_01_normal_http_param.source
+++ b/gpcontrib/gpcloud/regress/input/5_01_normal_http_param.source
@@ -1,0 +1,38 @@
+CREATE EXTERNAL WEB TABLE dummyHttpServerstart (x text)
+execute E'((python @abs_srcdir@/dummyHTTPServer.py -p 8553 -f @config_file@ -t PARAM_S >/dev/null 2>&1 &);for i in `seq 1 30`; do curl http://127.0.0.1:8553 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+
+CREATE EXTERNAL WEB TABLE dummyHttpServerstop (x text)
+execute E'(ps aux | grep dummyHTTPServer | grep -v grep |  awk \'{print $2;}\' | xargs kill) > /dev/null 2>&1; echo "stopping..."'
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+
+-- start_ignore
+select * from dummyHttpServerstop;
+select * from dummyHttpServerstart;
+-- end_ignore
+
+-- test http protocol: get config from http server
+drop external table if exists s3regress_normal1;
+CREATE READABLE EXTERNAL TABLE s3regress_normal1 (date text, time text, open float, high float,
+        low float, volume int) LOCATION('s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 server=http://127.0.0.1:8553') FORMAT 'csv';
+
+SELECT count(*) FROM s3regress_normal1;
+
+DROP EXTERNAL TABLE s3regress_normal1;
+
+drop external table if exists s3regress_normal_onmaster1;
+CREATE READABLE EXTERNAL TABLE s3regress_normal_onmaster1 (date text, time text, open float, high float,
+        low float, volume int) LOCATION('s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 server=http://127.0.0.1:8553') ON MASTER FORMAT 'csv';
+
+SELECT count(*) FROM s3regress_normal_onmaster1;
+
+DROP EXTERNAL TABLE s3regress_normal_onmaster1;
+
+-- start_ignore
+select * from dummyHttpServerstop;
+drop external table dummyHttpServerstop;
+drop external table dummyHttpServerstart;
+-- end_ignore
+

--- a/gpcontrib/gpcloud/regress/input/5_02_normal_https_param.source
+++ b/gpcontrib/gpcloud/regress/input/5_02_normal_https_param.source
@@ -1,0 +1,38 @@
+CREATE EXTERNAL WEB TABLE dummyHttpsServerstart (x text)
+execute E'((python @abs_srcdir@/dummyHTTPServer.py -p 8553 -f @config_file@ -t PARAM_S -s >/dev/null 2>&1 &);for i in `seq 1 30`; do curl http://127.0.0.1:8553 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+
+CREATE EXTERNAL WEB TABLE dummyHttpsServerstop (x text)
+execute E'(ps aux | grep dummyHTTPServer | grep -v grep |  awk \'{print $2;}\' | xargs kill) > /dev/null 2>&1; echo "stopping..."'
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+
+-- start_ignore
+select * from dummyHttpsServerstop;
+select * from dummyHttpsServerstart;
+-- end_ignore
+
+-- test http protocol: get config from http server
+drop external table if exists s3regress_normal1;
+CREATE READABLE EXTERNAL TABLE s3regress_normal1 (date text, time text, open float, high float,
+        low float, volume int) LOCATION('s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 server=https://127.0.0.1:8553') FORMAT 'csv';
+
+SELECT count(*) FROM s3regress_normal1;
+
+DROP EXTERNAL TABLE s3regress_normal1;
+
+drop external table if exists s3regress_normal_onmaster1;
+CREATE READABLE EXTERNAL TABLE s3regress_normal_onmaster1 (date text, time text, open float, high float,
+        low float, volume int) LOCATION('s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 server=https://127.0.0.1:8553') ON MASTER FORMAT 'csv';
+
+SELECT count(*) FROM s3regress_normal_onmaster1;
+
+DROP EXTERNAL TABLE s3regress_normal_onmaster1;
+
+-- start_ignore
+select * from dummyHttpsServerstop;
+drop external table dummyHttpsServerstop;
+drop external table dummyHttpsServerstart;
+-- end_ignore
+

--- a/gpcontrib/gpcloud/regress/input/5_02_normal_https_param.source
+++ b/gpcontrib/gpcloud/regress/input/5_02_normal_https_param.source
@@ -1,5 +1,5 @@
 CREATE EXTERNAL WEB TABLE dummyHttpsServerstart (x text)
-execute E'((python @abs_srcdir@/dummyHTTPServer.py -p 8553 -f @config_file@ -t PARAM_S -s >/dev/null 2>&1 &);for i in `seq 1 30`; do curl http://127.0.0.1:8553 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+execute E'((python @abs_srcdir@/dummyHTTPServer.py -p 8553 -f @config_file@ -t Parameter_Server -s >/dev/null 2>&1 &);for i in `seq 1 30`; do curl http://127.0.0.1:8553 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 
@@ -16,7 +16,7 @@ select * from dummyHttpsServerstart;
 -- test http protocol: get config from http server
 drop external table if exists s3regress_normal1;
 CREATE READABLE EXTERNAL TABLE s3regress_normal1 (date text, time text, open float, high float,
-        low float, volume int) LOCATION('s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 server=https://127.0.0.1:8553') FORMAT 'csv';
+        low float, volume int) LOCATION('s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 config_server=https://127.0.0.1:8553') FORMAT 'csv';
 
 SELECT count(*) FROM s3regress_normal1;
 
@@ -24,7 +24,7 @@ DROP EXTERNAL TABLE s3regress_normal1;
 
 drop external table if exists s3regress_normal_onmaster1;
 CREATE READABLE EXTERNAL TABLE s3regress_normal_onmaster1 (date text, time text, open float, high float,
-        low float, volume int) LOCATION('s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 server=https://127.0.0.1:8553') ON MASTER FORMAT 'csv';
+        low float, volume int) LOCATION('s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 config_server=https://127.0.0.1:8553') ON MASTER FORMAT 'csv';
 
 SELECT count(*) FROM s3regress_normal_onmaster1;
 

--- a/gpcontrib/gpcloud/regress/output/1_09_partition.source
+++ b/gpcontrib/gpcloud/regress/output/1_09_partition.source
@@ -1,3 +1,4 @@
+SET client_min_messages TO 'warning';
 CREATE TABLE stock (date text, time text, open float, high float, low float, volume int) DISTRIBUTED BY (date) PARTITION BY RANGE (volume)
 (
   PARTITION stock10000 START (10000) INCLUSIVE,
@@ -47,3 +48,4 @@ DROP TABLE ext_stock000;
 DROP TABLE ext_stock001;
 DROP TABLE ext_stock002;
 DROP TABLE stock;
+RESET client_min_messages;

--- a/gpcontrib/gpcloud/regress/output/1_10_all_regions.source
+++ b/gpcontrib/gpcloud/regress/output/1_10_all_regions.source
@@ -1,22 +1,16 @@
 CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-us-east-1.amazonaws.com/us-east-1.@read_prefix@/small17/data0000 config=@config_file@') FORMAT 'csv';
 \d s3regress_all_regions
-External table "public.s3regress_all_regions"
- Column |       Type       | Modifiers 
---------+------------------+-----------
- date   | text             | 
- time   | text             | 
- open   | double precision | 
- high   | double precision | 
- low    | double precision | 
- volume | integer          | 
-Type: readable
-Encoding: UTF8
-Format type: csv
-Format options: delimiter ',' null '' escape '"' quote '"'
-External options: {}
-External location: "s3://s3-us-east-1.amazonaws.com/us-east-1.@read_prefix@/small17/data0000 config=@config_file@"
-Execute on: all segments
+               Foreign table "public.s3regress_all_regions"
+ Column |       Type       | Collation | Nullable | Default | FDW options 
+--------+------------------+-----------+----------+---------+-------------
+ date   | text             |           |          |         | 
+ time   | text             |           |          |         | 
+ open   | double precision |           |          |         | 
+ high   | double precision |           |          |         | 
+ low    | double precision |           |          |         | 
+ volume | integer          |           |          |         | 
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-us-east-1.amazonaws.com/us-east-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -28,22 +22,16 @@ DROP EXTERNAL TABLE s3regress_all_regions;
 CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 config=@config_file@') FORMAT 'csv';
 \d s3regress_all_regions
-External table "public.s3regress_all_regions"
- Column |       Type       | Modifiers 
---------+------------------+-----------
- date   | text             | 
- time   | text             | 
- open   | double precision | 
- high   | double precision | 
- low    | double precision | 
- volume | integer          | 
-Type: readable
-Encoding: UTF8
-Format type: csv
-Format options: delimiter ',' null '' escape '"' quote '"'
-External options: {}
-External location: "s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 config=@config_file@"
-Execute on: all segments
+               Foreign table "public.s3regress_all_regions"
+ Column |       Type       | Collation | Nullable | Default | FDW options 
+--------+------------------+-----------+----------+---------+-------------
+ date   | text             |           |          |         | 
+ time   | text             |           |          |         | 
+ open   | double precision |           |          |         | 
+ high   | double precision |           |          |         | 
+ low    | double precision |           |          |         | 
+ volume | integer          |           |          |         | 
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-us-east-2.amazonaws.com/us-east-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -55,22 +43,16 @@ DROP EXTERNAL TABLE s3regress_all_regions;
 CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-us-west-1.amazonaws.com/us-west-1.@read_prefix@/small17/data0000 config=@config_file@') FORMAT 'csv';
 \d s3regress_all_regions
-External table "public.s3regress_all_regions"
- Column |       Type       | Modifiers 
---------+------------------+-----------
- date   | text             | 
- time   | text             | 
- open   | double precision | 
- high   | double precision | 
- low    | double precision | 
- volume | integer          | 
-Type: readable
-Encoding: UTF8
-Format type: csv
-Format options: delimiter ',' null '' escape '"' quote '"'
-External options: {}
-External location: "s3://s3-us-west-1.amazonaws.com/us-west-1.@read_prefix@/small17/data0000 config=@config_file@"
-Execute on: all segments
+               Foreign table "public.s3regress_all_regions"
+ Column |       Type       | Collation | Nullable | Default | FDW options 
+--------+------------------+-----------+----------+---------+-------------
+ date   | text             |           |          |         | 
+ time   | text             |           |          |         | 
+ open   | double precision |           |          |         | 
+ high   | double precision |           |          |         | 
+ low    | double precision |           |          |         | 
+ volume | integer          |           |          |         | 
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-us-west-1.amazonaws.com/us-west-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -82,22 +64,16 @@ DROP EXTERNAL TABLE s3regress_all_regions;
 CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-ap-south-1.amazonaws.com/ap-south-1.@read_prefix@/small17/data0000 config=@config_file@') FORMAT 'csv';
 \d s3regress_all_regions
-External table "public.s3regress_all_regions"
- Column |       Type       | Modifiers 
---------+------------------+-----------
- date   | text             | 
- time   | text             | 
- open   | double precision | 
- high   | double precision | 
- low    | double precision | 
- volume | integer          | 
-Type: readable
-Encoding: UTF8
-Format type: csv
-Format options: delimiter ',' null '' escape '"' quote '"'
-External options: {}
-External location: "s3://s3-ap-south-1.amazonaws.com/ap-south-1.@read_prefix@/small17/data0000 config=@config_file@"
-Execute on: all segments
+               Foreign table "public.s3regress_all_regions"
+ Column |       Type       | Collation | Nullable | Default | FDW options 
+--------+------------------+-----------+----------+---------+-------------
+ date   | text             |           |          |         | 
+ time   | text             |           |          |         | 
+ open   | double precision |           |          |         | 
+ high   | double precision |           |          |         | 
+ low    | double precision |           |          |         | 
+ volume | integer          |           |          |         | 
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-ap-south-1.amazonaws.com/ap-south-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -109,22 +85,16 @@ DROP EXTERNAL TABLE s3regress_all_regions;
 CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-ap-northeast-2.amazonaws.com/ap-northeast-2.@read_prefix@/small17/data0000 config=@config_file@') FORMAT 'csv';
 \d s3regress_all_regions
-External table "public.s3regress_all_regions"
- Column |       Type       | Modifiers 
---------+------------------+-----------
- date   | text             | 
- time   | text             | 
- open   | double precision | 
- high   | double precision | 
- low    | double precision | 
- volume | integer          | 
-Type: readable
-Encoding: UTF8
-Format type: csv
-Format options: delimiter ',' null '' escape '"' quote '"'
-External options: {}
-External location: "s3://s3-ap-northeast-2.amazonaws.com/ap-northeast-2.@read_prefix@/small17/data0000 config=@config_file@"
-Execute on: all segments
+               Foreign table "public.s3regress_all_regions"
+ Column |       Type       | Collation | Nullable | Default | FDW options 
+--------+------------------+-----------+----------+---------+-------------
+ date   | text             |           |          |         | 
+ time   | text             |           |          |         | 
+ open   | double precision |           |          |         | 
+ high   | double precision |           |          |         | 
+ low    | double precision |           |          |         | 
+ volume | integer          |           |          |         | 
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-ap-northeast-2.amazonaws.com/ap-northeast-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -136,22 +106,16 @@ DROP EXTERNAL TABLE s3regress_all_regions;
 CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-ap-southeast-1.amazonaws.com/ap-southeast-1.@read_prefix@/small17/data0000 config=@config_file@') FORMAT 'csv';
 \d s3regress_all_regions
-External table "public.s3regress_all_regions"
- Column |       Type       | Modifiers 
---------+------------------+-----------
- date   | text             | 
- time   | text             | 
- open   | double precision | 
- high   | double precision | 
- low    | double precision | 
- volume | integer          | 
-Type: readable
-Encoding: UTF8
-Format type: csv
-Format options: delimiter ',' null '' escape '"' quote '"'
-External options: {}
-External location: "s3://s3-ap-southeast-1.amazonaws.com/ap-southeast-1.@read_prefix@/small17/data0000 config=@config_file@"
-Execute on: all segments
+               Foreign table "public.s3regress_all_regions"
+ Column |       Type       | Collation | Nullable | Default | FDW options 
+--------+------------------+-----------+----------+---------+-------------
+ date   | text             |           |          |         | 
+ time   | text             |           |          |         | 
+ open   | double precision |           |          |         | 
+ high   | double precision |           |          |         | 
+ low    | double precision |           |          |         | 
+ volume | integer          |           |          |         | 
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-ap-southeast-1.amazonaws.com/ap-southeast-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -163,22 +127,16 @@ DROP EXTERNAL TABLE s3regress_all_regions;
 CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-ap-southeast-2.amazonaws.com/ap-southeast-2.@read_prefix@/small17/data0000 config=@config_file@') FORMAT 'csv';
 \d s3regress_all_regions
-External table "public.s3regress_all_regions"
- Column |       Type       | Modifiers 
---------+------------------+-----------
- date   | text             | 
- time   | text             | 
- open   | double precision | 
- high   | double precision | 
- low    | double precision | 
- volume | integer          | 
-Type: readable
-Encoding: UTF8
-Format type: csv
-Format options: delimiter ',' null '' escape '"' quote '"'
-External options: {}
-External location: "s3://s3-ap-southeast-2.amazonaws.com/ap-southeast-2.@read_prefix@/small17/data0000 config=@config_file@"
-Execute on: all segments
+               Foreign table "public.s3regress_all_regions"
+ Column |       Type       | Collation | Nullable | Default | FDW options 
+--------+------------------+-----------+----------+---------+-------------
+ date   | text             |           |          |         | 
+ time   | text             |           |          |         | 
+ open   | double precision |           |          |         | 
+ high   | double precision |           |          |         | 
+ low    | double precision |           |          |         | 
+ volume | integer          |           |          |         | 
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-ap-southeast-2.amazonaws.com/ap-southeast-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -190,22 +148,16 @@ DROP EXTERNAL TABLE s3regress_all_regions;
 CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-ap-northeast-1.amazonaws.com/ap-northeast-1.@read_prefix@/small17/data0000 config=@config_file@') FORMAT 'csv';
 \d s3regress_all_regions
-External table "public.s3regress_all_regions"
- Column |       Type       | Modifiers 
---------+------------------+-----------
- date   | text             | 
- time   | text             | 
- open   | double precision | 
- high   | double precision | 
- low    | double precision | 
- volume | integer          | 
-Type: readable
-Encoding: UTF8
-Format type: csv
-Format options: delimiter ',' null '' escape '"' quote '"'
-External options: {}
-External location: "s3://s3-ap-northeast-1.amazonaws.com/ap-northeast-1.@read_prefix@/small17/data0000 config=@config_file@"
-Execute on: all segments
+               Foreign table "public.s3regress_all_regions"
+ Column |       Type       | Collation | Nullable | Default | FDW options 
+--------+------------------+-----------+----------+---------+-------------
+ date   | text             |           |          |         | 
+ time   | text             |           |          |         | 
+ open   | double precision |           |          |         | 
+ high   | double precision |           |          |         | 
+ low    | double precision |           |          |         | 
+ volume | integer          |           |          |         | 
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-ap-northeast-1.amazonaws.com/ap-northeast-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -217,22 +169,16 @@ DROP EXTERNAL TABLE s3regress_all_regions;
 CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-eu-central-1.amazonaws.com/eu-central-1.@read_prefix@/small17/data0000 config=@config_file@') FORMAT 'csv';
 \d s3regress_all_regions
-External table "public.s3regress_all_regions"
- Column |       Type       | Modifiers 
---------+------------------+-----------
- date   | text             | 
- time   | text             | 
- open   | double precision | 
- high   | double precision | 
- low    | double precision | 
- volume | integer          | 
-Type: readable
-Encoding: UTF8
-Format type: csv
-Format options: delimiter ',' null '' escape '"' quote '"'
-External options: {}
-External location: "s3://s3-eu-central-1.amazonaws.com/eu-central-1.@read_prefix@/small17/data0000 config=@config_file@"
-Execute on: all segments
+               Foreign table "public.s3regress_all_regions"
+ Column |       Type       | Collation | Nullable | Default | FDW options 
+--------+------------------+-----------+----------+---------+-------------
+ date   | text             |           |          |         | 
+ time   | text             |           |          |         | 
+ open   | double precision |           |          |         | 
+ high   | double precision |           |          |         | 
+ low    | double precision |           |          |         | 
+ volume | integer          |           |          |         | 
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-eu-central-1.amazonaws.com/eu-central-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -244,22 +190,16 @@ DROP EXTERNAL TABLE s3regress_all_regions;
 CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-eu-west-1.amazonaws.com/eu-west-1.@read_prefix@/small17/data0000 config=@config_file@') FORMAT 'csv';
 \d s3regress_all_regions
-External table "public.s3regress_all_regions"
- Column |       Type       | Modifiers 
---------+------------------+-----------
- date   | text             | 
- time   | text             | 
- open   | double precision | 
- high   | double precision | 
- low    | double precision | 
- volume | integer          | 
-Type: readable
-Encoding: UTF8
-Format type: csv
-Format options: delimiter ',' null '' escape '"' quote '"'
-External options: {}
-External location: "s3://s3-eu-west-1.amazonaws.com/eu-west-1.@read_prefix@/small17/data0000 config=@config_file@"
-Execute on: all segments
+               Foreign table "public.s3regress_all_regions"
+ Column |       Type       | Collation | Nullable | Default | FDW options 
+--------+------------------+-----------+----------+---------+-------------
+ date   | text             |           |          |         | 
+ time   | text             |           |          |         | 
+ open   | double precision |           |          |         | 
+ high   | double precision |           |          |         | 
+ low    | double precision |           |          |         | 
+ volume | integer          |           |          |         | 
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-eu-west-1.amazonaws.com/eu-west-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  
@@ -271,22 +211,16 @@ DROP EXTERNAL TABLE s3regress_all_regions;
 CREATE READABLE EXTERNAL TABLE s3regress_all_regions (date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-sa-east-1.amazonaws.com/sa-east-1.@read_prefix@/small17/data0000 config=@config_file@') FORMAT 'csv';
 \d s3regress_all_regions
-External table "public.s3regress_all_regions"
- Column |       Type       | Modifiers 
---------+------------------+-----------
- date   | text             | 
- time   | text             | 
- open   | double precision | 
- high   | double precision | 
- low    | double precision | 
- volume | integer          | 
-Type: readable
-Encoding: UTF8
-Format type: csv
-Format options: delimiter ',' null '' escape '"' quote '"'
-External options: {}
-External location: "s3://s3-sa-east-1.amazonaws.com/sa-east-1.@read_prefix@/small17/data0000 config=@config_file@"
-Execute on: all segments
+               Foreign table "public.s3regress_all_regions"
+ Column |       Type       | Collation | Nullable | Default | FDW options 
+--------+------------------+-----------+----------+---------+-------------
+ date   | text             |           |          |         | 
+ time   | text             |           |          |         | 
+ open   | double precision |           |          |         | 
+ high   | double precision |           |          |         | 
+ low    | double precision |           |          |         | 
+ volume | integer          |           |          |         | 
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-sa-east-1.amazonaws.com/sa-east-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions;
   round  

--- a/gpcontrib/gpcloud/regress/output/1_16_multiple_files_with_header_line.source
+++ b/gpcontrib/gpcloud/regress/output/1_16_multiple_files_with_header_line.source
@@ -1,8 +1,8 @@
 --- test set 1: multiple files with header and different EOLs ---
 -- with line terminator '\n' (LF)
+SET client_min_messages TO 'warning';
 CREATE READABLE EXTERNAL TABLE s3regress_multiple_files_with_header_line_lf(date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-us-west-2.amazonaws.com/@read_prefix@/csv_with_header/ config=@config_file@') FORMAT 'csv' (HEADER NEWLINE 'LF');
-NOTICE:  HEADER means that each one of the data files has a header row
 SELECT count(*) FROM s3regress_multiple_files_with_header_line_lf;
  count 
 -------
@@ -12,7 +12,6 @@ SELECT count(*) FROM s3regress_multiple_files_with_header_line_lf;
 -- with line terminator '\r\n' (CRLF)
 CREATE READABLE EXTERNAL TABLE s3regress_multiple_files_with_header_line_crlf(date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-us-west-2.amazonaws.com/@read_prefix@/csv_with_header_crlf/ config=@config_file@') FORMAT 'csv' (HEADER NEWLINE 'CRLF');
-NOTICE:  HEADER means that each one of the data files has a header row
 SELECT count(*) FROM s3regress_multiple_files_with_header_line_crlf;
  count 
 -------
@@ -47,3 +46,4 @@ SELECT count(*) FROM s3regress_multiple_files_with_header_line_crlf whcrlf, s3re
 DROP EXTERNAL TABLE s3regress_multiple_files_with_header_line_lf;
 DROP EXTERNAL TABLE s3regress_multiple_files_without_header_line_lf;
 DROP EXTERNAL TABLE s3regress_multiple_files_with_header_line_crlf;
+RESET client_min_messages;

--- a/gpcontrib/gpcloud/regress/output/1_16_multiple_files_with_header_line.source
+++ b/gpcontrib/gpcloud/regress/output/1_16_multiple_files_with_header_line.source
@@ -33,14 +33,14 @@ SELECT count(*) FROM s3regress_multiple_files_with_header_line_crlf crlf, s3regr
 SELECT count(*) FROM s3regress_multiple_files_with_header_line_lf wh, s3regress_multiple_files_without_header_line_lf nh where wh.volume = nh.volume;
  count 
 -------
-    17
+     3
 (1 row)
 
 -- join query between a table without header + LF and the other table with header + CRLF.
 SELECT count(*) FROM s3regress_multiple_files_with_header_line_crlf whcrlf, s3regress_multiple_files_without_header_line_lf nhlf where whcrlf.volume = nhlf.volume;
  count 
 -------
-    17
+     3
 (1 row)
 
 DROP EXTERNAL TABLE s3regress_multiple_files_with_header_line_lf;

--- a/gpcontrib/gpcloud/regress/output/1_18_all_regions_version2.source
+++ b/gpcontrib/gpcloud/regress/output/1_18_all_regions_version2.source
@@ -1,22 +1,16 @@
 CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3.amazonaws.com/us-east-1.@read_prefix@/small17/data0000 config=@config_file@ section=default region=us-east-1') FORMAT 'csv';
 \d s3regress_all_regions_version2
-External table "public.s3regress_all_regions_version2"
- Column |       Type       | Modifiers 
---------+------------------+-----------
- date   | text             | 
- time   | text             | 
- open   | double precision | 
- high   | double precision | 
- low    | double precision | 
- volume | integer          | 
-Type: readable
-Encoding: UTF8
-Format type: csv
-Format options: delimiter ',' null '' escape '"' quote '"'
-External options: {}
-External location: "s3://s3.amazonaws.com/us-east-1.@read_prefix@/small17/data0000 config=@config_file@ section=default region=us-east-1"
-Execute on: all segments
+          Foreign table "public.s3regress_all_regions_version2"
+ Column |       Type       | Collation | Nullable | Default | FDW options 
+--------+------------------+-----------+----------+---------+-------------
+ date   | text             |           |          |         | 
+ high   | double precision |           |          |         | 
+ low    | double precision |           |          |         | 
+ open   | double precision |           |          |         | 
+ time   | text             |           |          |         | 
+ volume | integer          |           |          |         | 
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3.amazonaws.com/us-east-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=us-east-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -28,22 +22,16 @@ DROP EXTERNAL TABLE s3regress_all_regions_version2;
 CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 config=@config_file@ section=default region=us-east-2') FORMAT 'csv';
 \d s3regress_all_regions_version2
-External table "public.s3regress_all_regions_version2"
- Column |       Type       | Modifiers 
---------+------------------+-----------
- date   | text             | 
- time   | text             | 
- open   | double precision | 
- high   | double precision | 
- low    | double precision | 
- volume | integer          | 
-Type: readable
-Encoding: UTF8
-Format type: csv
-Format options: delimiter ',' null '' escape '"' quote '"'
-External options: {}
-External location: "s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 config=@config_file@ section=default region=us-east-2"
-Execute on: all segments
+          Foreign table "public.s3regress_all_regions_version2"
+ Column |       Type       | Collation | Nullable | Default | FDW options 
+--------+------------------+-----------+----------+---------+-------------
+ date   | text             |           |          |         | 
+ high   | double precision |           |          |         | 
+ low    | double precision |           |          |         | 
+ open   | double precision |           |          |         | 
+ time   | text             |           |          |         | 
+ volume | integer          |           |          |         | 
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-us-east-2.amazonaws.com/us-east-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=us-east-2', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -55,22 +43,16 @@ DROP EXTERNAL TABLE s3regress_all_regions_version2;
 CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-us-west-1.amazonaws.com/us-west-1.@read_prefix@/small17/data0000 config=@config_file@ section=default region=us-west-1') FORMAT 'csv';
 \d s3regress_all_regions_version2
-External table "public.s3regress_all_regions_version2"
- Column |       Type       | Modifiers 
---------+------------------+-----------
- date   | text             | 
- time   | text             | 
- open   | double precision | 
- high   | double precision | 
- low    | double precision | 
- volume | integer          | 
-Type: readable
-Encoding: UTF8
-Format type: csv
-Format options: delimiter ',' null '' escape '"' quote '"'
-External options: {}
-External location: "s3://s3-us-west-1.amazonaws.com/us-west-1.@read_prefix@/small17/data0000 config=@config_file@ section=default region=us-west-1"
-Execute on: all segments
+          Foreign table "public.s3regress_all_regions_version2"
+ Column |       Type       | Collation | Nullable | Default | FDW options 
+--------+------------------+-----------+----------+---------+-------------
+ date   | text             |           |          |         | 
+ high   | double precision |           |          |         | 
+ low    | double precision |           |          |         | 
+ open   | double precision |           |          |         | 
+ time   | text             |           |          |         | 
+ volume | integer          |           |          |         | 
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-us-west-1.amazonaws.com/us-west-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=us-west-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -82,22 +64,16 @@ DROP EXTERNAL TABLE s3regress_all_regions_version2;
 CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-ap-south-1.amazonaws.com/ap-south-1.@read_prefix@/small17/data0000 config=@config_file@ section=default region=ap-south-1') FORMAT 'csv';
 \d s3regress_all_regions_version2
-External table "public.s3regress_all_regions_version2"
- Column |       Type       | Modifiers 
---------+------------------+-----------
- date   | text             | 
- time   | text             | 
- open   | double precision | 
- high   | double precision | 
- low    | double precision | 
- volume | integer          | 
-Type: readable
-Encoding: UTF8
-Format type: csv
-Format options: delimiter ',' null '' escape '"' quote '"'
-External options: {}
-External location: "s3://s3-ap-south-1.amazonaws.com/ap-south-1.@read_prefix@/small17/data0000 config=@config_file@ section=default region=ap-south-1"
-Execute on: all segments
+          Foreign table "public.s3regress_all_regions_version2"
+ Column |       Type       | Collation | Nullable | Default | FDW options 
+--------+------------------+-----------+----------+---------+-------------
+ date   | text             |           |          |         | 
+ high   | double precision |           |          |         | 
+ low    | double precision |           |          |         | 
+ open   | double precision |           |          |         | 
+ time   | text             |           |          |         | 
+ volume | integer          |           |          |         | 
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-ap-south-1.amazonaws.com/ap-south-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=ap-south-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -109,22 +85,16 @@ DROP EXTERNAL TABLE s3regress_all_regions_version2;
 CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-ap-northeast-2.amazonaws.com/ap-northeast-2.@read_prefix@/small17/data0000 config=@config_file@ section=default region=ap-northeast-2') FORMAT 'csv';
 \d s3regress_all_regions_version2
-External table "public.s3regress_all_regions_version2"
- Column |       Type       | Modifiers 
---------+------------------+-----------
- date   | text             | 
- time   | text             | 
- open   | double precision | 
- high   | double precision | 
- low    | double precision | 
- volume | integer          | 
-Type: readable
-Encoding: UTF8
-Format type: csv
-Format options: delimiter ',' null '' escape '"' quote '"'
-External options: {}
-External location: "s3://s3-ap-northeast-2.amazonaws.com/ap-northeast-2.@read_prefix@/small17/data0000 config=@config_file@ section=default region=ap-northeast-2"
-Execute on: all segments
+          Foreign table "public.s3regress_all_regions_version2"
+ Column |       Type       | Collation | Nullable | Default | FDW options 
+--------+------------------+-----------+----------+---------+-------------
+ date   | text             |           |          |         | 
+ high   | double precision |           |          |         | 
+ low    | double precision |           |          |         | 
+ open   | double precision |           |          |         | 
+ time   | text             |           |          |         | 
+ volume | integer          |           |          |         | 
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-ap-northeast-2.amazonaws.com/ap-northeast-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=ap-northeast-2', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -136,22 +106,16 @@ DROP EXTERNAL TABLE s3regress_all_regions_version2;
 CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-ap-southeast-1.amazonaws.com/ap-southeast-1.@read_prefix@/small17/data0000 config=@config_file@ section=default region=ap-southeast-1') FORMAT 'csv';
 \d s3regress_all_regions_version2
-External table "public.s3regress_all_regions_version2"
- Column |       Type       | Modifiers 
---------+------------------+-----------
- date   | text             | 
- time   | text             | 
- open   | double precision | 
- high   | double precision | 
- low    | double precision | 
- volume | integer          | 
-Type: readable
-Encoding: UTF8
-Format type: csv
-Format options: delimiter ',' null '' escape '"' quote '"'
-External options: {}
-External location: "s3://s3-ap-southeast-1.amazonaws.com/ap-southeast-1.@read_prefix@/small17/data0000 config=@config_file@ section=default region=ap-southeast-1"
-Execute on: all segments
+          Foreign table "public.s3regress_all_regions_version2"
+ Column |       Type       | Collation | Nullable | Default | FDW options 
+--------+------------------+-----------+----------+---------+-------------
+ date   | text             |           |          |         | 
+ high   | double precision |           |          |         | 
+ low    | double precision |           |          |         | 
+ open   | double precision |           |          |         | 
+ time   | text             |           |          |         | 
+ volume | integer          |           |          |         | 
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-ap-southeast-1.amazonaws.com/ap-southeast-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=ap-southeast-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -163,22 +127,16 @@ DROP EXTERNAL TABLE s3regress_all_regions_version2;
 CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-ap-southeast-2.amazonaws.com/ap-southeast-2.@read_prefix@/small17/data0000 config=@config_file@ section=default region=ap-southeast-2') FORMAT 'csv';
 \d s3regress_all_regions_version2
-External table "public.s3regress_all_regions_version2"
- Column |       Type       | Modifiers 
---------+------------------+-----------
- date   | text             | 
- time   | text             | 
- open   | double precision | 
- high   | double precision | 
- low    | double precision | 
- volume | integer          | 
-Type: readable
-Encoding: UTF8
-Format type: csv
-Format options: delimiter ',' null '' escape '"' quote '"'
-External options: {}
-External location: "s3://s3-ap-southeast-2.amazonaws.com/ap-southeast-2.@read_prefix@/small17/data0000 config=@config_file@ section=default region=ap-southeast-2"
-Execute on: all segments
+          Foreign table "public.s3regress_all_regions_version2"
+ Column |       Type       | Collation | Nullable | Default | FDW options 
+--------+------------------+-----------+----------+---------+-------------
+ date   | text             |           |          |         | 
+ high   | double precision |           |          |         | 
+ low    | double precision |           |          |         | 
+ open   | double precision |           |          |         | 
+ time   | text             |           |          |         | 
+ volume | integer          |           |          |         | 
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-ap-southeast-2.amazonaws.com/ap-southeast-2.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=ap-southeast-2', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -190,22 +148,16 @@ DROP EXTERNAL TABLE s3regress_all_regions_version2;
 CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-ap-northeast-1.amazonaws.com/ap-northeast-1.@read_prefix@/small17/data0000 config=@config_file@ section=default region=ap-northeast-1') FORMAT 'csv';
 \d s3regress_all_regions_version2
-External table "public.s3regress_all_regions_version2"
- Column |       Type       | Modifiers 
---------+------------------+-----------
- date   | text             | 
- time   | text             | 
- open   | double precision | 
- high   | double precision | 
- low    | double precision | 
- volume | integer          | 
-Type: readable
-Encoding: UTF8
-Format type: csv
-Format options: delimiter ',' null '' escape '"' quote '"'
-External options: {}
-External location: "s3://s3-ap-northeast-1.amazonaws.com/ap-northeast-1.@read_prefix@/small17/data0000 config=@config_file@ section=default region=ap-northeast-1"
-Execute on: all segments
+          Foreign table "public.s3regress_all_regions_version2"
+ Column |       Type       | Collation | Nullable | Default | FDW options 
+--------+------------------+-----------+----------+---------+-------------
+ date   | text             |           |          |         | 
+ high   | double precision |           |          |         | 
+ low    | double precision |           |          |         | 
+ open   | double precision |           |          |         | 
+ time   | text             |           |          |         | 
+ volume | integer          |           |          |         | 
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-ap-northeast-1.amazonaws.com/ap-northeast-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=ap-northeast-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -217,22 +169,16 @@ DROP EXTERNAL TABLE s3regress_all_regions_version2;
 CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-eu-central-1.amazonaws.com/eu-central-1.@read_prefix@/small17/data0000 config=@config_file@ section=default region=eu-central-1') FORMAT 'csv';
 \d s3regress_all_regions_version2
-External table "public.s3regress_all_regions_version2"
- Column |       Type       | Modifiers 
---------+------------------+-----------
- date   | text             | 
- time   | text             | 
- open   | double precision | 
- high   | double precision | 
- low    | double precision | 
- volume | integer          | 
-Type: readable
-Encoding: UTF8
-Format type: csv
-Format options: delimiter ',' null '' escape '"' quote '"'
-External options: {}
-External location: "s3://s3-eu-central-1.amazonaws.com/eu-central-1.@read_prefix@/small17/data0000 config=@config_file@ section=default region=eu-central-1"
-Execute on: all segments
+          Foreign table "public.s3regress_all_regions_version2"
+ Column |       Type       | Collation | Nullable | Default | FDW options 
+--------+------------------+-----------+----------+---------+-------------
+ date   | text             |           |          |         | 
+ high   | double precision |           |          |         | 
+ low    | double precision |           |          |         | 
+ open   | double precision |           |          |         | 
+ time   | text             |           |          |         | 
+ volume | integer          |           |          |         | 
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-eu-central-1.amazonaws.com/eu-central-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=eu-central-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -244,22 +190,16 @@ DROP EXTERNAL TABLE s3regress_all_regions_version2;
 CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-eu-west-1.amazonaws.com/eu-west-1.@read_prefix@/small17/data0000 config=@config_file@ section=default region=eu-west-1') FORMAT 'csv';
 \d s3regress_all_regions_version2
-External table "public.s3regress_all_regions_version2"
- Column |       Type       | Modifiers 
---------+------------------+-----------
- date   | text             | 
- time   | text             | 
- open   | double precision | 
- high   | double precision | 
- low    | double precision | 
- volume | integer          | 
-Type: readable
-Encoding: UTF8
-Format type: csv
-Format options: delimiter ',' null '' escape '"' quote '"'
-External options: {}
-External location: "s3://s3-eu-west-1.amazonaws.com/eu-west-1.@read_prefix@/small17/data0000 config=@config_file@ section=default region=eu-west-1"
-Execute on: all segments
+          Foreign table "public.s3regress_all_regions_version2"
+ Column |       Type       | Collation | Nullable | Default | FDW options 
+--------+------------------+-----------+----------+---------+-------------
+ date   | text             |           |          |         | 
+ high   | double precision |           |          |         | 
+ low    | double precision |           |          |         | 
+ open   | double precision |           |          |         | 
+ time   | text             |           |          |         | 
+ volume | integer          |           |          |         | 
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-eu-west-1.amazonaws.com/eu-west-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=eu-west-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  
@@ -271,22 +211,16 @@ DROP EXTERNAL TABLE s3regress_all_regions_version2;
 CREATE READABLE EXTERNAL TABLE s3regress_all_regions_version2 (date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-sa-east-1.amazonaws.com/sa-east-1.@read_prefix@/small17/data0000 config=@config_file@ section=default region=sa-east-1') FORMAT 'csv';
 \d s3regress_all_regions_version2
-External table "public.s3regress_all_regions_version2"
- Column |       Type       | Modifiers 
---------+------------------+-----------
- date   | text             | 
- time   | text             | 
- open   | double precision | 
- high   | double precision | 
- low    | double precision | 
- volume | integer          | 
-Type: readable
-Encoding: UTF8
-Format type: csv
-Format options: delimiter ',' null '' escape '"' quote '"'
-External options: {}
-External location: "s3://s3-sa-east-1.amazonaws.com/sa-east-1.@read_prefix@/small17/data0000 config=@config_file@ section=default region=sa-east-1"
-Execute on: all segments
+          Foreign table "public.s3regress_all_regions_version2"
+ Column |       Type       | Collation | Nullable | Default | FDW options 
+--------+------------------+-----------+----------+---------+-------------
+ date   | text             |           |          |         | 
+ high   | double precision |           |          |         | 
+ low    | double precision |           |          |         | 
+ open   | double precision |           |          |         | 
+ time   | text             |           |          |         | 
+ volume | integer          |           |          |         | 
+FDW options: (format 'csv', delimiter ',', "null" '', escape '"', quote '"', format_type 'c', location_uris 's3://s3-sa-east-1.amazonaws.com/sa-east-1.s3test.pivotal.io/regress/small17/data0000 config=/home/gpadmin/s3.conf section=default region=sa-east-1', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
 
 SELECT round(sum(open)) FROM s3regress_all_regions_version2;
   round  

--- a/gpcontrib/gpcloud/regress/output/3_05_insert_to_wet_from_ret.source
+++ b/gpcontrib/gpcloud/regress/output/3_05_insert_to_wet_from_ret.source
@@ -1,3 +1,4 @@
+SET client_min_messages TO 'warning';
 CREATE READABLE EXTERNAL TABLE s3write_ret2wet_read (date text, time text, status bool, sample1 float, sample2 float,
         volume int) LOCATION('s3://s3-us-west-2.amazonaws.com/@write_prefix@/ret2wet/ config=@config_file@') FORMAT 'csv';
 CREATE WRITABLE EXTERNAL TABLE s3write_ret2wet_write (date text, time text, status bool, sample1 float, sample2 float,
@@ -24,3 +25,4 @@ DROP EXTERNAL TABLE IF EXISTS s3write_ret2wet_read;
 DROP EXTERNAL TABLE IF EXISTS s3write_ret2wet_write;
 DROP EXTERNAL TABLE IF EXISTS s3write_ret2wet_read_new;
 DROP EXTERNAL TABLE IF EXISTS s3write_ret2wet_write_new;
+RESET client_min_messages;

--- a/gpcontrib/gpcloud/regress/output/3_06_special_characters.source
+++ b/gpcontrib/gpcloud/regress/output/3_06_special_characters.source
@@ -1,3 +1,4 @@
+SET client_min_messages TO 'warning';
 CREATE READABLE EXTERNAL TABLE s3write_special_characters_read (date text, time text, status bool, sample1 float, sample2 float,
         volume int) LOCATION('s3://s3-us-west-2.amazonaws.com/@write_prefix@/?:&=+/ config=@config_file@') FORMAT 'csv';
 CREATE WRITABLE EXTERNAL TABLE s3write_special_characters_write (date text, time text, status bool, sample1 float, sample2 float,
@@ -24,3 +25,4 @@ DROP EXTERNAL TABLE IF EXISTS s3write_special_characters_read;
 DROP EXTERNAL TABLE IF EXISTS s3write_special_characters_write;
 DROP EXTERNAL TABLE IF EXISTS s3write_special_characters_read_new;
 DROP EXTERNAL TABLE IF EXISTS s3write_special_characters_write_new;
+RESET client_min_messages;

--- a/gpcontrib/gpcloud/regress/output/4_01_create_invalid_wet.source
+++ b/gpcontrib/gpcloud/regress/output/4_01_create_invalid_wet.source
@@ -4,4 +4,4 @@ ERROR:  syntax error at or near "FORMAT"
 LINE 2:         low float, volume int) FORMAT 'csv';
                                        ^
 DROP EXTERNAL TABLE s3regress_create_invalid_wet;
-ERROR:  table "s3regress_create_invalid_wet" does not exist
+ERROR:  foreign table "s3regress_create_invalid_wet" does not exist

--- a/gpcontrib/gpcloud/regress/output/5_01_normal_http_param.source
+++ b/gpcontrib/gpcloud/regress/output/5_01_normal_http_param.source
@@ -1,6 +1,6 @@
 SET client_min_messages TO 'warning';
 CREATE EXTERNAL WEB TABLE dummyHttpServerstart (x text)
-execute E'((python @abs_srcdir@/dummyHTTPServer.py -p 8553 -f @config_file@ -t PARAM_S >/dev/null 2>&1 &);for i in `seq 1 30`; do curl http://127.0.0.1:8553 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+execute E'((python @abs_srcdir@/dummyHTTPServer.py -p 8553 -f @config_file@ -t Parameter_Server >/dev/null 2>&1 &);for i in `seq 1 30`; do curl http://127.0.0.1:8553 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 CREATE EXTERNAL WEB TABLE dummyHttpServerstop (x text)
@@ -24,7 +24,7 @@ select * from dummyHttpServerstart;
 -- test http protocol: get config from http server
 drop external table if exists s3regress_normal1;
 CREATE READABLE EXTERNAL TABLE s3regress_normal1 (date text, time text, open float, high float,
-        low float, volume int) LOCATION('s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 server=http://127.0.0.1:8553') FORMAT 'csv';
+        low float, volume int) LOCATION('s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 config_server=http://127.0.0.1:8553') FORMAT 'csv';
 SELECT count(*) FROM s3regress_normal1;
  count  
 --------
@@ -34,7 +34,7 @@ SELECT count(*) FROM s3regress_normal1;
 DROP EXTERNAL TABLE s3regress_normal1;
 drop external table if exists s3regress_normal_onmaster1;
 CREATE READABLE EXTERNAL TABLE s3regress_normal_onmaster1 (date text, time text, open float, high float,
-        low float, volume int) LOCATION('s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 server=http://127.0.0.1:8553') ON MASTER FORMAT 'csv';
+        low float, volume int) LOCATION('s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 config_server=http://127.0.0.1:8553') ON MASTER FORMAT 'csv';
 SELECT count(*) FROM s3regress_normal_onmaster1;
  count  
 --------

--- a/gpcontrib/gpcloud/regress/output/5_01_normal_http_param.source
+++ b/gpcontrib/gpcloud/regress/output/5_01_normal_http_param.source
@@ -1,3 +1,4 @@
+SET client_min_messages TO 'warning';
 CREATE EXTERNAL WEB TABLE dummyHttpServerstart (x text)
 execute E'((python @abs_srcdir@/dummyHTTPServer.py -p 8553 -f @config_file@ -t PARAM_S >/dev/null 2>&1 &);for i in `seq 1 30`; do curl http://127.0.0.1:8553 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
 on SEGMENT 0
@@ -51,3 +52,4 @@ select * from dummyHttpServerstop;
 drop external table dummyHttpServerstop;
 drop external table dummyHttpServerstart;
 -- end_ignore
+RESET client_min_messages;

--- a/gpcontrib/gpcloud/regress/output/5_01_normal_http_param.source
+++ b/gpcontrib/gpcloud/regress/output/5_01_normal_http_param.source
@@ -1,0 +1,53 @@
+CREATE EXTERNAL WEB TABLE dummyHttpServerstart (x text)
+execute E'((python @abs_srcdir@/dummyHTTPServer.py -p 8553 -f @config_file@ -t PARAM_S >/dev/null 2>&1 &);for i in `seq 1 30`; do curl http://127.0.0.1:8553 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+CREATE EXTERNAL WEB TABLE dummyHttpServerstop (x text)
+execute E'(ps aux | grep dummyHTTPServer | grep -v grep |  awk \'{print $2;}\' | xargs kill) > /dev/null 2>&1; echo "stopping..."'
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+-- start_ignore
+select * from dummyHttpServerstop;
+      x      
+-------------
+ stopping...
+(1 row)
+
+select * from dummyHttpServerstart;
+      x      
+-------------
+ starting...
+(1 row)
+
+-- end_ignore
+-- test http protocol: get config from http server
+drop external table if exists s3regress_normal1;
+CREATE READABLE EXTERNAL TABLE s3regress_normal1 (date text, time text, open float, high float,
+        low float, volume int) LOCATION('s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 server=http://127.0.0.1:8553') FORMAT 'csv';
+SELECT count(*) FROM s3regress_normal1;
+ count  
+--------
+ 117446
+(1 row)
+
+DROP EXTERNAL TABLE s3regress_normal1;
+drop external table if exists s3regress_normal_onmaster1;
+CREATE READABLE EXTERNAL TABLE s3regress_normal_onmaster1 (date text, time text, open float, high float,
+        low float, volume int) LOCATION('s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 server=http://127.0.0.1:8553') ON MASTER FORMAT 'csv';
+SELECT count(*) FROM s3regress_normal_onmaster1;
+ count  
+--------
+ 117446
+(1 row)
+
+DROP EXTERNAL TABLE s3regress_normal_onmaster1;
+-- start_ignore
+select * from dummyHttpServerstop;
+      x      
+-------------
+ stopping...
+(1 row)
+
+drop external table dummyHttpServerstop;
+drop external table dummyHttpServerstart;
+-- end_ignore

--- a/gpcontrib/gpcloud/regress/output/5_02_normal_https_param.source
+++ b/gpcontrib/gpcloud/regress/output/5_02_normal_https_param.source
@@ -1,0 +1,53 @@
+CREATE EXTERNAL WEB TABLE dummyHttpsServerstart (x text)
+execute E'((python @abs_srcdir@/dummyHTTPServer.py -p 8553 -f @config_file@ -t PARAM_S -s >/dev/null 2>&1 &);for i in `seq 1 30`; do curl http://127.0.0.1:8553 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+CREATE EXTERNAL WEB TABLE dummyHttpsServerstop (x text)
+execute E'(ps aux | grep dummyHTTPServer | grep -v grep |  awk \'{print $2;}\' | xargs kill) > /dev/null 2>&1; echo "stopping..."'
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+-- start_ignore
+select * from dummyHttpsServerstop;
+      x      
+-------------
+ stopping...
+(1 row)
+
+select * from dummyHttpsServerstart;
+      x      
+-------------
+ starting...
+(1 row)
+
+-- end_ignore
+-- test http protocol: get config from http server
+drop external table if exists s3regress_normal1;
+CREATE READABLE EXTERNAL TABLE s3regress_normal1 (date text, time text, open float, high float,
+        low float, volume int) LOCATION('s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 server=https://127.0.0.1:8553') FORMAT 'csv';
+SELECT count(*) FROM s3regress_normal1;
+ count  
+--------
+ 117446
+(1 row)
+
+DROP EXTERNAL TABLE s3regress_normal1;
+drop external table if exists s3regress_normal_onmaster1;
+CREATE READABLE EXTERNAL TABLE s3regress_normal_onmaster1 (date text, time text, open float, high float,
+        low float, volume int) LOCATION('s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 server=https://127.0.0.1:8553') ON MASTER FORMAT 'csv';
+SELECT count(*) FROM s3regress_normal_onmaster1;
+ count  
+--------
+ 117446
+(1 row)
+
+DROP EXTERNAL TABLE s3regress_normal_onmaster1;
+-- start_ignore
+select * from dummyHttpsServerstop;
+      x      
+-------------
+ stopping...
+(1 row)
+
+drop external table dummyHttpsServerstop;
+drop external table dummyHttpsServerstart;
+-- end_ignore

--- a/gpcontrib/gpcloud/regress/output/5_02_normal_https_param.source
+++ b/gpcontrib/gpcloud/regress/output/5_02_normal_https_param.source
@@ -1,5 +1,5 @@
 CREATE EXTERNAL WEB TABLE dummyHttpsServerstart (x text)
-execute E'((python @abs_srcdir@/dummyHTTPServer.py -p 8553 -f @config_file@ -t PARAM_S -s >/dev/null 2>&1 &);for i in `seq 1 30`; do curl http://127.0.0.1:8553 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+execute E'((python @abs_srcdir@/dummyHTTPServer.py -p 8553 -f @config_file@ -t Parameter_Server -s >/dev/null 2>&1 &);for i in `seq 1 30`; do curl http://127.0.0.1:8553 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 CREATE EXTERNAL WEB TABLE dummyHttpsServerstop (x text)
@@ -23,7 +23,7 @@ select * from dummyHttpsServerstart;
 -- test http protocol: get config from http server
 drop external table if exists s3regress_normal1;
 CREATE READABLE EXTERNAL TABLE s3regress_normal1 (date text, time text, open float, high float,
-        low float, volume int) LOCATION('s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 server=https://127.0.0.1:8553') FORMAT 'csv';
+        low float, volume int) LOCATION('s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 config_server=https://127.0.0.1:8553') FORMAT 'csv';
 SELECT count(*) FROM s3regress_normal1;
  count  
 --------
@@ -33,7 +33,7 @@ SELECT count(*) FROM s3regress_normal1;
 DROP EXTERNAL TABLE s3regress_normal1;
 drop external table if exists s3regress_normal_onmaster1;
 CREATE READABLE EXTERNAL TABLE s3regress_normal_onmaster1 (date text, time text, open float, high float,
-        low float, volume int) LOCATION('s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 server=https://127.0.0.1:8553') ON MASTER FORMAT 'csv';
+        low float, volume int) LOCATION('s3://s3-us-east-2.amazonaws.com/us-east-2.@read_prefix@/small17/data0000 config_server=https://127.0.0.1:8553') ON MASTER FORMAT 'csv';
 SELECT count(*) FROM s3regress_normal_onmaster1;
  count  
 --------

--- a/gpcontrib/gpcloud/regress/regress_schedule
+++ b/gpcontrib/gpcloud/regress/regress_schedule
@@ -2,6 +2,7 @@ test: 0_00_prepare_protocols
 
 # ~ 1s
 test: 1_03_bad_data 1_04_empty_prefix 1_05_one_line 1_06_1correct_1wrong 2_02_invalid_region 2_03_invalid_config 2_04_invalid_header 2_05_limit_zero 3_01_create_wet 3_02_quick_shoot_wet 3_11_write_with_encryption 4_01_create_invalid_wet 2_06_invalid_sub_query 1_17_no_eol_at_eof 2_07_wrong_proxy
+test: 5_01_normal_http_param
 
 # tens of seconds
 test: 1_01_normal 1_02_log_error 1_10_all_regions 1_11_gzipped_data 1_12_no_prefix 1_13_parallel1 1_13_parallel2 1_09_partition 3_09_write_big_row 3_10_write_mixed_length_rows 1_15_normal_sub_query 1_16_multiple_files_with_header_line 1_18_all_regions_version2 1_20_deflate_data

--- a/gpcontrib/gpcloud/src/s3conf.cpp
+++ b/gpcontrib/gpcloud/src/s3conf.cpp
@@ -16,6 +16,7 @@ extern "C" {
 #include "c.h"
 #include "cdb/cdbvars.h"
 extern int getgpsegmentCount(void);
+extern char *DataDir;
 }
 #endif
 
@@ -47,6 +48,7 @@ S3Params InitConfig(const string& urlWithOptions) {
     string sourceUrl = TruncateOptions(urlWithOptions);
     S3_CHECK_OR_DIE(!sourceUrl.empty(), S3RuntimeError, "URL not found from location string");
 
+    string httpUrl = GetOptS3(urlWithOptions, "server");
     string configPath = GetOptS3(urlWithOptions, "config");
     if (configPath.empty()) {
         S3WARN("The 'config' parameter is not provided, use default value 's3/s3.conf'.");
@@ -62,10 +64,18 @@ S3Params InitConfig(const string& urlWithOptions) {
     string urlRegion = GetOptS3(urlWithOptions, "region");
 
     // read configurations from file
+
+#if !defined(S3_STANDALONE)
+    Config s3Cfg(configPath, httpUrl, DataDir);
+#elif defined(S3_UNITTEST)
+    /* Define this for gtest:HttpParam, otherwise the http cannot be tested. */
+    Config s3Cfg(configPath, httpUrl, "../../../gpAux/gpdemo/datadirs/qddir/demoDataDir-1/");
+#else
     Config s3Cfg(configPath);
+#endif
 
     S3_CHECK_OR_DIE(s3Cfg.Handle() != NULL, S3RuntimeError,
-                    "Failed to parse config file '" + configPath + "', or it doesn't exist");
+                    "Failed to parse config file '" + configPath + "', or it doesn't exist(or http failed)");
 
     S3_CHECK_OR_DIE(s3Cfg.SectionExist(configSection), S3ConfigError,
                     "Selected section '" + configSection +

--- a/gpcontrib/gpcloud/src/s3conf.cpp
+++ b/gpcontrib/gpcloud/src/s3conf.cpp
@@ -48,7 +48,7 @@ S3Params InitConfig(const string& urlWithOptions) {
     string sourceUrl = TruncateOptions(urlWithOptions);
     S3_CHECK_OR_DIE(!sourceUrl.empty(), S3RuntimeError, "URL not found from location string");
 
-    string httpUrl = GetOptS3(urlWithOptions, "server");
+    string httpUrl = GetOptS3(urlWithOptions, "config_server");
     string configPath = GetOptS3(urlWithOptions, "config");
     if (configPath.empty()) {
         S3WARN("The 'config' parameter is not provided, use default value 's3/s3.conf'.");
@@ -67,9 +67,6 @@ S3Params InitConfig(const string& urlWithOptions) {
 
 #if !defined(S3_STANDALONE)
     Config s3Cfg(configPath, httpUrl, DataDir);
-#elif defined(S3_UNITTEST)
-    /* Define this for gtest:HttpParam, otherwise the http cannot be tested. */
-    Config s3Cfg(configPath, httpUrl, "../../../gpAux/gpdemo/datadirs/qddir/demoDataDir-1/");
 #else
     Config s3Cfg(configPath);
 #endif

--- a/gpcontrib/gpcloud/src/s3utils.cpp
+++ b/gpcontrib/gpcloud/src/s3utils.cpp
@@ -126,6 +126,20 @@ const char *MD5Calc::Get() {
     return this->result.c_str();
 }
 
+Config::Config(const string &filename, const string &url, const char *datadir) : _conf(NULL) {
+    if (!url.empty()) {
+        this->_conf = ini_load_4url(url.c_str(), datadir);
+    } else {
+        this->_conf = ini_load(filename.c_str());
+    }
+    if (this->_conf == NULL) {
+#ifndef S3_STANDALONE
+        write_log("Failed to load config file:'%s', url is '%s'\n", filename.c_str(), url.c_str());
+#else
+        S3ERROR("Failed to load config file:'%s'", filename.c_str());
+#endif
+    }
+}
 Config::Config(const string &filename) : _conf(NULL) {
     if (!filename.empty()) this->_conf = ini_load(filename.c_str());
     if (this->_conf == NULL) {

--- a/gpcontrib/gpcloud/src/s3utils.cpp
+++ b/gpcontrib/gpcloud/src/s3utils.cpp
@@ -128,7 +128,7 @@ const char *MD5Calc::Get() {
 
 Config::Config(const string &filename, const string &url, const char *datadir) : _conf(NULL) {
     if (!url.empty()) {
-        this->_conf = ini_load_4url(url.c_str(), datadir);
+        this->_conf = ini_load_from_url(url.c_str(), datadir);
     } else {
         this->_conf = ini_load(filename.c_str());
     }

--- a/gpcontrib/gpcloud/test/Makefile
+++ b/gpcontrib/gpcloud/test/Makefile
@@ -8,7 +8,7 @@ ARCH = $(shell uname -s)
 CPP = g++
 INCLUDES = -I../src -I../include -I../lib
 LDFLAGS = $(COMMON_LINK_OPTIONS)
-CPPFLAGS = $(COMMON_CPP_FLAGS) -g3 -DS3_STANDALONE -fprofile-arcs -ftest-coverage
+CPPFLAGS = $(COMMON_CPP_FLAGS) -g3 -DS3_STANDALONE -fprofile-arcs -ftest-coverage -DS3_UNITTEST
 
 ifeq "$(ARCH)" "Darwin"
 	LDFLAGS += -coverage

--- a/gpcontrib/gpcloud/test/Makefile
+++ b/gpcontrib/gpcloud/test/Makefile
@@ -8,7 +8,7 @@ ARCH = $(shell uname -s)
 CPP = g++
 INCLUDES = -I../src -I../include -I../lib
 LDFLAGS = $(COMMON_LINK_OPTIONS)
-CPPFLAGS = $(COMMON_CPP_FLAGS) -g3 -DS3_STANDALONE -fprofile-arcs -ftest-coverage -DS3_UNITTEST
+CPPFLAGS = $(COMMON_CPP_FLAGS) -g3 -DS3_STANDALONE -fprofile-arcs -ftest-coverage
 
 ifeq "$(ARCH)" "Darwin"
 	LDFLAGS += -coverage

--- a/gpcontrib/gpcloud/test/data/s3httptest.conf
+++ b/gpcontrib/gpcloud/test/data/s3httptest.conf
@@ -1,0 +1,19 @@
+[hello]
+version = 1
+accessid = 123
+secret = 456
+token = 789
+chunksize = 4096
+threadnum = 4
+gpcheckcloud_newline = "\n"
+autocompress = false
+loglevel = debug
+logtype = internal
+logserverhost = 127.0.0.1
+logserverport = 9999
+encryption = false
+proxy = S5://xxxx
+verifycert = false
+server_side_encryption = fake
+low_speed_limit = 1
+low_speed_time = 2

--- a/gpcontrib/gpcloud/test/s3conf_test.cpp
+++ b/gpcontrib/gpcloud/test/s3conf_test.cpp
@@ -121,3 +121,35 @@ TEST(Config, Gpcheckcloud_eol) {
         InitConfig("s3://abc/a config=data/s3test.conf section=gpcheckcloud_newline_error"),
         S3ConfigError);
 }
+/* Run './bin/dummyHTTPServer.py -f data/s3httptest.conf -t PARAM_S' before enabling this test */
+TEST(HttpParam, DISABLED_InitConfigWithHttpOK) {
+    S3Params params = InitConfig("s3://abc/a server=http://127.0.0.1:8553 section=hello");
+    EXPECT_EQ("\n", params.getGpcheckcloud_newline());
+    S3Credential cred{"123","456","789"};
+    EXPECT_EQ(cred, params.getCred());
+    EXPECT_EQ(8388608, params.getChunkSize());
+    EXPECT_EQ(4, params.getNumOfChunks());
+    EXPECT_EQ(0, params.getKeySize());
+    EXPECT_EQ(1, params.getLowSpeedLimit());
+    EXPECT_EQ(2, params.getLowSpeedTime());
+    EXPECT_EQ(false, params.isAutoCompress());
+    EXPECT_EQ(false, params.isVerifyCert());
+    EXPECT_EQ(SSE_NONE, params.getSSEType());
+    EXPECT_EQ("S5://xxxx", params.getProxy());
+}
+/* Run './bin/dummyHTTPServer.py -f data/s3httptest.conf -t PARAM_S -s' before enabling this test */
+TEST(HttpParam, DISABLED_InitConfigWithHttpsOK) {
+    S3Params params = InitConfig("s3://abc/a server=https://127.0.0.1:8553 section=hello");
+    EXPECT_EQ("\n", params.getGpcheckcloud_newline());
+    S3Credential cred{"123","456","789"};
+    EXPECT_EQ(cred, params.getCred());
+    EXPECT_EQ(8388608, params.getChunkSize());
+    EXPECT_EQ(4, params.getNumOfChunks());
+    EXPECT_EQ(0, params.getKeySize());
+    EXPECT_EQ(1, params.getLowSpeedLimit());
+    EXPECT_EQ(2, params.getLowSpeedTime());
+    EXPECT_EQ(false, params.isAutoCompress());
+    EXPECT_EQ(false, params.isVerifyCert());
+    EXPECT_EQ(SSE_NONE, params.getSSEType());
+    EXPECT_EQ("S5://xxxx", params.getProxy());
+}

--- a/gpcontrib/gpcloud/test/s3conf_test.cpp
+++ b/gpcontrib/gpcloud/test/s3conf_test.cpp
@@ -121,9 +121,22 @@ TEST(Config, Gpcheckcloud_eol) {
         InitConfig("s3://abc/a config=data/s3test.conf section=gpcheckcloud_newline_error"),
         S3ConfigError);
 }
-/* Run './bin/dummyHTTPServer.py -f data/s3httptest.conf -t PARAM_S' before enabling this test */
+/* HttpParam test: because the unittest is compiled with S3_STANDLONE, so if we want to test
+ * this case, we need change the code of s3conf.cpp line 67 like this:
+ #if !defined(S3_STANDALONE)
+      Config s3Cfg(configPath, httpUrl, DataDir);
+ #elif defined(S3_UNITTEST)
+      Config s3Cfg(configPath, httpUrl, "../../../gpAux/gpdemo/datadirs/qddir/demoDataDir-1/");
+ #else
+      Config s3Cfg(configPath);
+ #endif
+Alse add -DS3_UNITTEST in test/Makefile
+Then recompile and then start dummyServer as the following test case and remove the DISABLED_
+before each test case.
+*/
+/* Run './bin/dummyHTTPServer.py -f data/s3httptest.conf -t Parameter_Server' before enabling this test */
 TEST(HttpParam, DISABLED_InitConfigWithHttpOK) {
-    S3Params params = InitConfig("s3://abc/a server=http://127.0.0.1:8553 section=hello");
+    S3Params params = InitConfig("s3://abc/a config_server=http://127.0.0.1:8553 section=hello");
     EXPECT_EQ("\n", params.getGpcheckcloud_newline());
     S3Credential cred{"123","456","789"};
     EXPECT_EQ(cred, params.getCred());
@@ -137,9 +150,9 @@ TEST(HttpParam, DISABLED_InitConfigWithHttpOK) {
     EXPECT_EQ(SSE_NONE, params.getSSEType());
     EXPECT_EQ("S5://xxxx", params.getProxy());
 }
-/* Run './bin/dummyHTTPServer.py -f data/s3httptest.conf -t PARAM_S -s' before enabling this test */
+/* Run './bin/dummyHTTPServer.py -f data/s3httptest.conf -t Parameter_Server -s' before enabling this test */
 TEST(HttpParam, DISABLED_InitConfigWithHttpsOK) {
-    S3Params params = InitConfig("s3://abc/a server=https://127.0.0.1:8553 section=hello");
+    S3Params params = InitConfig("s3://abc/a config_server=https://127.0.0.1:8553 section=hello");
     EXPECT_EQ("\n", params.getGpcheckcloud_newline());
     S3Credential cred{"123","456","789"};
     EXPECT_EQ(cred, params.getCred());


### PR DESCRIPTION
Enable S3 external table get S3 parameters from http/https server.
    
    Now the s3 external table get params from local files in the location file
    path after "config=" which relies on the file exists on each segment
    locally. But for cloud users, the users cannot settle each config file on
     each segment.
    
    So this pr provides a way for each s3 external table QE get params from
     http/https server whose address is configured after the "server=" string.
    So if you are using the "server=" string in the location, you need to
    start the http/https server by yourself. In this way, the s3 accessid
    and secret key will not have to be written into configfile on the segment
     locally which is safer than before.
    
    If you set both "config=filepath" and "server=httpaddress" at the same
    time, it will only try to get params from http server. If it fails, the
    s3 segments will fail to get params without trying the filepath way.

    For gpdb7 is on the run, backport from pr "https://github.com/greenplum-db/gpdb/pull/12779"
    for future upgrade.
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
