### PR TITLE
[6X] Fix index corruption when invalid snapshot used with AO tables.

### DIFF
--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -2457,11 +2457,13 @@ IndexBuildScan(Relation parentRelation,
 	 * concurrent build, or during bootstrap, we take a regular MVCC snapshot
 	 * and index whatever's live according to that.
 	 *
-	 * If the relation is an append-only table, we also use a regular MVCC
-	 * snapshot.
+	 * Like for heap tables, if the relation is an append-only table, we use
+	 * SnapshotAny to access data. RECENTLY_DEAD tuples, used, for example, by
+	 * "repeatable read" transaction, should be indexed to avoid inconsistent
+	 * results caused by index access. We use another snapshot to access
+	 * metadata - see AO-specific scan functions implementation below.
 	 */
-	if (IsBootstrapProcessingMode() || indexInfo->ii_Concurrent ||
-			 RelationIsAppendOptimized(parentRelation))
+	if (IsBootstrapProcessingMode() || indexInfo->ii_Concurrent)
 	{
 		snapshot = RegisterSnapshot(GetTransactionSnapshot());
 		registered_snapshot = true;
@@ -2470,8 +2472,13 @@ IndexBuildScan(Relation parentRelation,
 	else
 	{
 		snapshot = SnapshotAny;
-		/* okay to ignore lazy VACUUMs here */
-		OldestXmin = GetOldestXmin(parentRelation, true);
+		/*
+		 * TODO: add support to cut off definitely dead rows using OldestXmin
+		 * for AO tables
+		 */
+		if (!RelationIsAppendOptimized(parentRelation))
+			/* okay to ignore lazy VACUUMs here */
+			OldestXmin = GetOldestXmin(parentRelation, true);
 	}
 
 	if (RelationIsHeap(parentRelation))
@@ -2927,9 +2934,16 @@ IndexBuildAppendOnlyRowScan(Relation parentRelation,
 	predicate = (List *)
 		ExecPrepareExpr((Expr *)indexInfo->ii_Predicate, estate);
 	
+	/*
+	 * Regular MVCC snapshot, which may be taken in IndexBuildScan function,
+	 * can hide newly globally inserted tuples from global index build process,
+	 * because it's outdated in such case (see dispatching part of DefineIndex
+	 * for more). Since this, we need to use SnapshotSelf to get the actual
+	 * metadata (pg_aoseg, in particular)".
+	 */
 	aoscan = appendonly_beginscan(parentRelation,
 								  snapshot,
-								  snapshot,
+								  SnapshotSelf,
 								  0,
 								  NULL);
 
@@ -3069,7 +3083,18 @@ IndexBuildAppendOnlyColScan(Relation parentRelation,
 			proj[attno] = true;
 	}
 	
-	aocsscan = aocs_beginscan(parentRelation, snapshot, snapshot, NULL /* relationTupleDesc */, proj);
+	/*
+	 * Regular MVCC snapshot, which may be taken in IndexBuildScan function,
+	 * can hide newly globally inserted tuples from global index build process,
+	 * because it's outdated in such case (see dispatching part of DefineIndex
+	 * for more). Since this, we need to use SnapshotSelf to get the actual
+	 * metadata (pg_aoseg, in particular).
+	 */
+	aocsscan = aocs_beginscan(parentRelation,
+							  snapshot,
+							  SnapshotSelf,
+							  NULL /* relationTupleDesc */,
+							  proj);
 
 	if (!OidIsValid(blkdirrelid) || !OidIsValid(blkdiridxid))
 	{

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -843,6 +843,11 @@ DefineIndex(Oid relationId,
 		/* make sure the QE uses the same index name that we chose */
 		stmt->idxname = indexRelationName;
 		stmt->oldNode = InvalidOid;
+		/*
+		 * Please note, top snapshot dispatched here was taken before lock
+		 * acquiring, but it's OK since with don't use it - see IndexBuildScan
+		 * for used snapshots and more.
+		 */
 		CdbDispatchUtilityStatement((Node *) stmt,
 									DF_CANCEL_ON_ERROR |
 									DF_WITH_SNAPSHOT |

--- a/src/test/isolation2/input/uao/snapshot_index_corruption.source
+++ b/src/test/isolation2/input/uao/snapshot_index_corruption.source
@@ -1,0 +1,34 @@
+-- @Description Test index corruption when invalid snapshot used.
+--
+-- Create AO table, insert few rows on it.
+drop table if exists test_ao;
+create table test_ao(i bigint) with (appendonly=true, orientation=@orientation@) distributed by (i);
+insert into test_ao select generate_series(1,100);
+-- Test 1
+-- Begin single-insert transaction.
+1: begin;
+1: insert into test_ao values(101);
+-- Try to create index, it should hold on lock before commit below.
+2&: create index test_ao_idx on test_ao(i);
+-- Commit single-insert transaction, so index continues creation.
+1: commit;
+-- Force index usage and check row is here (false before fix).
+2<:
+2: set optimizer=off;
+2: set enable_seqscan=off;
+2: explain (costs off) select i from test_ao where i = 101;
+2: select i from test_ao where i = 101;
+
+-- Test 2
+-- Drop incomplete index
+1: drop index test_ao_idx;
+-- Start repeatable read transaction and check row is here.
+2: begin;
+2: set transaction isolation level repeatable read;
+2: select i from test_ao where i = 100;
+-- Update row selected above and create new index
+1: update test_ao set i = 200 where i = 100;
+1: create index test_ao_idx on test_ao(i);
+-- For the repeatable read isolation level row still there (false before fix).
+2: explain (costs off) select i from test_ao where i = 100;
+2: select i from test_ao where i = 100;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -136,6 +136,7 @@ test: uao/selectinsert_while_vacuum_row
 test: uao/selectinsertupdate_while_vacuum_row
 test: uao/selectupdate_while_vacuum_row
 test: uao/snapshot_eof_row
+test: uao/snapshot_index_corruption_row
 test: uao/update_while_vacuum_row
 test: uao/vacuum_self_serializable_row
 test: uao/vacuum_self_serializable2_row
@@ -187,6 +188,7 @@ test: uao/selectinsert_while_vacuum_column
 test: uao/selectinsertupdate_while_vacuum_column
 test: uao/selectupdate_while_vacuum_column
 test: uao/snapshot_eof_column
+test: uao/snapshot_index_corruption_column
 test: uao/update_while_vacuum_column
 test: uao/vacuum_self_serializable_column
 test: uao/vacuum_self_serializable2_column

--- a/src/test/isolation2/output/uao/snapshot_index_corruption.source
+++ b/src/test/isolation2/output/uao/snapshot_index_corruption.source
@@ -1,0 +1,78 @@
+-- @Description Test index corruption when invalid snapshot used.
+--
+-- Create AO table, insert few rows on it.
+drop table if exists test_ao;
+DROP
+create table test_ao(i bigint) with (appendonly=true, orientation=@orientation@) distributed by (i);
+CREATE
+insert into test_ao select generate_series(1,100);
+INSERT 100
+-- Test 1
+-- Begin single-insert transaction.
+1: begin;
+BEGIN
+1: insert into test_ao values(101);
+INSERT 1
+-- Try to create index, it should hold on lock before commit below.
+2&: create index test_ao_idx on test_ao(i);  <waiting ...>
+-- Commit single-insert transaction, so index continues creation.
+1: commit;
+COMMIT
+-- Force index usage and check row is here (false before fix).
+2<:  <... completed>
+CREATE
+2: set optimizer=off;
+SET
+2: set enable_seqscan=off;
+SET
+2: explain (costs off) select i from test_ao where i = 101;
+ QUERY PLAN                                   
+----------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)     
+   ->  Bitmap Heap Scan on test_ao            
+         Recheck Cond: (i = 101)              
+         ->  Bitmap Index Scan on test_ao_idx 
+               Index Cond: (i = 101)          
+ Optimizer: Postgres query optimizer          
+(6 rows)
+2: select i from test_ao where i = 101;
+ i   
+-----
+ 101 
+(1 row)
+
+-- Test 2
+-- Drop incomplete index
+1: drop index test_ao_idx;
+DROP
+-- Start repeatable read transaction and check row is here.
+2: begin;
+BEGIN
+2: set transaction isolation level repeatable read;
+SET
+2: select i from test_ao where i = 100;
+ i   
+-----
+ 100 
+(1 row)
+-- Update row selected above and create new index
+1: update test_ao set i = 200 where i = 100;
+UPDATE 1
+1: create index test_ao_idx on test_ao(i);
+CREATE
+-- For the repeatable read isolation level row still there (false before fix).
+2: explain (costs off) select i from test_ao where i = 100;
+ QUERY PLAN                                   
+----------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)     
+   ->  Bitmap Heap Scan on test_ao            
+         Recheck Cond: (i = 100)              
+         ->  Bitmap Index Scan on test_ao_idx 
+               Index Cond: (i = 100)          
+ Optimizer: Postgres query optimizer          
+(6 rows)
+2: select i from test_ao where i = 100;
+ i   
+-----
+ 100 
+(1 row)


### PR DESCRIPTION
Using of regular MVCC snapshot to access AO-tables metadata may cause index building (performed globally) inconsistency, because tuples inserted (the same globally) at another opened transactions are not visible. Using the same MVCC snapshot to access AO-tables data ignore RECENTLY_DEAD tuples, used, for example, by "repeatable read" transactions, which again leads to inconsistent results caused by index access.

Commit fixes such behavior using SnapshotSelf for metadata access and SnapshotAny for data access. Additional isolation tests shows how to reproduce the bug before the fix.

_______________
When building an index, the MVCC snapshot [taken](https://github.com/arenadata/gpdb/blob/18d86c55845cecb9325a338c2f8cc389b877544e/src/backend/tcop/pquery.c#L1371) before [acquiring](https://github.com/arenadata/gpdb/blob/18d86c55845cecb9325a338c2f8cc389b877544e/src/backend/tcop/utility.c#L1534) a lock may miss committed between this two actions transactions. [Using](https://github.com/arenadata/gpdb/blob/18d86c55845cecb9325a338c2f8cc389b877544e/src/backend/catalog/index.c#L2466) of such snapshot causing incomplete index creation.