### PR TITLE
Do not create dataflow extension for gpdb5

### DIFF
--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_data_format.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_data_format.py
@@ -326,3 +326,12 @@ def test_252_gpload_eol_LF_in_quote_csv():
     runfile(file)
     copy_data('external_file_252.csv','data_file.csv')
     write_config_file(reuse_tables=True,format='csv',file='data_file.csv',table='texttable2')
+
+@pytest.mark.order(253)
+@prepare_before_test(num=253)
+def test_253_gpload_custom_format():
+    "253 gpload loads text file without customer format"
+    file = mkpath('setup.sql')
+    runfile(file)
+    copy_data('external_file_253.txt','data_file.txt')
+    write_config_file(reuse_tables=True,log_errors=True,error_limit=2,sql=True,before='set dataflow.prefer_custom_text = false;',file='data_file.txt',table='texttable2')

--- a/gpMgmt/bin/gpload_test/gpload2/data/external_file_253.txt
+++ b/gpMgmt/bin/gpload_test/gpload2/data/external_file_253.txt
@@ -1,0 +1,5 @@
+line1|test1\.test1
+line2|test2\.test2
+line3|test3\.test3
+line4|test4\.test4
+line5|test5\.test5

--- a/gpMgmt/bin/gpload_test/gpload2/query253.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query253.ans
@@ -1,0 +1,24 @@
+2021-11-09 09:42:30|INFO|gpload session started 2021-11-09 09:42:30
+2021-11-09 09:42:30|INFO|setting schema 'public' for table 'texttable2'
+2021-11-09 09:42:30|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/project/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-11-09 09:42:30|INFO|did not find an external table to reuse. creating ext_gpload_reusable_5b93e204_4141_11ec_bca6_005056a051b2
+2021-11-09 09:42:30|ERROR|ERROR:  segment reject limit reached, aborting operation  (seg0 slice1 127.0.0.1:6002 pid=22349)
+DETAIL:  Last error was: missing data for column "s2"
+CONTEXT:  External table ext_gpload_reusable_5b93e204_4141_11ec_bca6_005056a051b2, line 2 of gpfdist://127.0.0.1:8081//home/gpadmin/project/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt: "est1"
+ encountered while running INSERT INTO public."texttable2" ("s1","s2") SELECT "s1","s2" FROM ext_gpload_reusable_5b93e204_4141_11ec_bca6_005056a051b2
+2021-11-09 09:42:30|INFO|rows Inserted          = 0
+2021-11-09 09:42:30|INFO|rows Updated           = 0
+2021-11-09 09:42:30|INFO|data formatting errors = 0
+2021-11-09 09:42:30|INFO|gpload failed
+2021-11-09 09:42:31|INFO|gpload session started 2021-11-09 09:42:31
+2021-11-09 09:42:31|INFO|setting schema 'public' for table 'texttable2'
+2021-11-09 09:42:31|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/project/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-11-09 09:42:31|INFO|reusing external table ext_gpload_reusable_5b93e204_4141_11ec_bca6_005056a051b2
+2021-11-09 09:42:31|ERROR|ERROR:  segment reject limit reached, aborting operation  (seg2 slice1 127.0.0.1:6004 pid=22383)
+DETAIL:  Last error was: missing data for column "s2"
+CONTEXT:  External table ext_gpload_reusable_5b93e204_4141_11ec_bca6_005056a051b2, line 2 of gpfdist://127.0.0.1:8081//home/gpadmin/project/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt: "est1"
+ encountered while running INSERT INTO public."texttable2" ("s1","s2") SELECT "s1","s2" FROM ext_gpload_reusable_5b93e204_4141_11ec_bca6_005056a051b2
+2021-11-09 09:42:31|INFO|rows Inserted          = 0
+2021-11-09 09:42:31|INFO|rows Updated           = 0
+2021-11-09 09:42:31|INFO|data formatting errors = 0
+2021-11-09 09:42:31|INFO|gpload failed


### PR DESCRIPTION
1. It is not necessary to create dataflow extension when gpload connect
to gpdb5.
2. If there's no GUC or not text format is used, do not create
dataflow extension even gpload connect to gpdb6 or above
3. Add unit test cases for the change
This change is fixed in 5X_STABLE branch, but since there's code difference
between gpload5&6, it cannot be backport directly. PR on 5X_STABLE branch:
https://github.com/greenplum-db/gpdb/pull/12788

## Here are some reminders before you submit the pull request
- [*] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
