### PR TITLE
Break early when creating Memtuple binding from TupleDesc

### DIFF
--- a/src/backend/access/common/memtuple.c
+++ b/src/backend/access/common/memtuple.c
@@ -95,6 +95,8 @@ void destroy_memtuple_binding(MemTupleBinding *pbind)
  * null attribute.  For all possible combinations of 4 null bit,
  * we index into a short[16] array to get how many space is saved
  * by the nulls.
+ * Null bitmap is spilt into bytes and each byte is spilt into low
+ * and high bits. So each byte will need 2 short[16] arrays. 
  */
 
 /* Compute how much space to store the null save entries.
@@ -429,7 +431,10 @@ MemTupleBinding *create_memtuple_binding(TupleDesc tupdesc)
 		Form_pg_attribute attr = TupleDescAttr(tupdesc, i);
 
 		if (attr->attlen > 0 && attr->attalign == 'd')
+		{
 			pbind->column_align = 8;
+			break;
+		}
 	}
 
 	pbind->null_bitmap_extra_size = compute_null_bitmap_extra_size(tupdesc, pbind->column_align); 


### PR DESCRIPTION
MemtupleBinding is column aligned by 4 or 8 bytes.

It can be set to 8 if we find an attribute's attalign is 'd' (8 bytes on
most machines), there is no need to check other attributes.
Add some comments about how to compute null bitmap entries space.

Co-authored-by: Mingli Zhang <avamingli@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
