### PR TITLE
fix gpload cannot process multiple input files

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -1770,7 +1770,8 @@ class gpload:
                 # MPP-13617
                 if ':' in l:
                     l = '[' + l + ']'
-                self.locations.append('%s://%s:%d%s%s%s' % (protocol, l, port, sep, '%20'.join(file), fragment))
+                for f in file:
+                    self.locations.append('%s://%s:%d%s%s%s' % (protocol, l, port, sep, f, fragment))
         if not found_source:
             self.control_file_error("configuration file must contain source definition")
 


### PR DESCRIPTION
backport pr #12794 to keep gpload code same in 6x and 5x

* fix gpload cannot process multiple input files
gpload can process multiple files in one input source.
We need the file location when creating or finding reuse external tables.
The original location string is wrong. We make it write in the right way.

* add test case for multiple hostname in one input source

the input yaml config is like :

```
GPLOAD:
   INPUT:
     - SOURCE:
         LOCAL_HOSTNAME:
           - 10.117.190.113
           - 10.117.190.51
         PORT: 8081
         FILE: 
           - /home/gpadmin/workspace/test.txt
           - /home/gpadmin/workspace/test1.txt

```
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
