### PR TITLE
Reconcile duplicate pg_hba update logic

### DIFF
--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -18,7 +18,7 @@
                        'use_concourse_cluster': true,
                        'set_max_connections': true},
                       {'name': 'gpinitstandby',
-                       'use_concourse_cluster': false},
+                       'use_concourse_cluster': true},
                       {'name': 'gp_bash_functions.sh',
                        'use_concourse_cluster': false},
                       {'name': 'gpcheckcat',

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -40,6 +40,7 @@ try:
     from gppylib.heapchecksum import HeapChecksum
     from gppylib.commands.pg import PgBaseBackup
     from gppylib.mainUtils import ExceptionNoStackTraceNeeded
+    from gppylib.operations.update_pg_hba_on_segments import update_pg_hba_on_segments
 
 except ImportError as e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
@@ -825,24 +826,13 @@ class SegmentTemplate:
         self.pool.check_results()
 
         # Map primary and mirror hostnames to expanded segment's contentid
-        m = defaultdict(lambda: [])
+        expanded_host_content = defaultdict(lambda: [])
         for seg in self.gparray.getExpansionSegDbList():
-            m[seg.getSegmentContentId()].append(seg.getSegmentHostName())
+            expanded_host_content[seg.getSegmentContentId()].append(seg.getSegmentHostName())
 
         # Now update the primary's hba config with the corresponding primary
         # and mirror information
-        for seg in self.gparray.getExpansionSegDbList():
-            if seg.isSegmentPrimary():
-                modifyConfCmd = ModifyPgHbaConfSetting(
-                        'Updating %s/pg_hba.conf' % seg.getSegmentHostName(),
-                        os.path.join(seg.getSegmentDataDirectory(), 'pg_hba.conf'),
-                        ctxt=REMOTE, remoteHost=seg.getSegmentHostName(),
-                        addresses=m[seg.getSegmentContentId()],
-                        is_hba_hostnames=self.isHbaHostnames)
-                self.pool.addCommand(modifyConfCmd)
-
-        self.pool.join()
-        self.pool.check_results()
+        update_pg_hba_on_segments(self.gparray, self.isHbaHostnames, self.batch_size, expanded_host_content)
 
         self._start_new_primary_segments()
         self._stop_new_primary_segments()

--- a/gpMgmt/bin/gpinitstandby
+++ b/gpMgmt/bin/gpinitstandby
@@ -15,8 +15,9 @@ try:
     from gppylib import gparray
     from gppylib.db import dbconn
     from gppylib.userinput import *
-    from gppylib.operations.detect_unreachable_hosts import get_unreachable_segment_hosts
-    from gppylib.operations.initstandby import cleanup_pg_hba_backup_on_segment, update_pg_hba_conf_on_segments, restore_pg_hba_on_segment
+    from gppylib.operations.detect_unreachable_hosts import get_unreachable_segment_hosts, update_unreachable_flag_for_segments
+    from gppylib.operations.initstandby import cleanup_pg_hba_backup_on_segment, restore_pg_hba_on_segment
+    from gppylib.operations.update_pg_hba_on_segments import update_pg_hba_on_segments_for_standby
     from gppylib.operations.package import SyncPackages
     from gppylib.commands.pg import PgBaseBackup
 except ImportError as e:
@@ -353,15 +354,6 @@ def check_and_start_standby():
                            standby.port)
     logger.info("Successfully started standby coordinator")
 
-#-------------------------------------------------------------------------
-def get_standby_pg_hba_info(standby_host):
-    standby_ips = gp.IfAddrs.list_addrs(standby_host)
-    current_user = unix.UserId.local('get userid')
-    new_section = ['# standby coordinator host ip addresses\n']
-    for ip in standby_ips:
-        cidr_suffix = '/128' if ':' in ip else '/32' # MPP-15889
-        new_section.append('host\tall\t%s\t%s%s\ttrust\n' % (current_user, ip, cidr_suffix))
-    return new_section
 
 #-------------------------------------------------------------------------
 def create_standby(options):
@@ -407,13 +399,17 @@ def create_standby(options):
         # Disable Ctrl-C
         signal.signal(signal.SIGINT,signal.SIG_IGN)
 
+        batch_size = 1
         # update the catalog if needed
         array = add_standby_to_catalog(options, standby_datadir)
+
+        # update unreachable flag for primary and mirror segments
+        update_unreachable_flag_for_segments(array, unreachable_hosts)
 
         logger.info('Updating pg_hba.conf file...')
         update_pg_hba_conf(options, array)
         logger.debug('Updating pg_hba.conf file on segments...')
-        update_pg_hba_conf_on_segments(array, options.standby_host, options.hba_hostnames, unreachable_hosts)
+        update_pg_hba_on_segments_for_standby(array, options.standby_host, options.hba_hostnames, batch_size)
         logger.info('pg_hba.conf files updated successfully.')
 
         copy_coordinator_datadir_to_standby(options, array, standby_datadir)

--- a/gpMgmt/bin/gppylib/operations/detect_unreachable_hosts.py
+++ b/gpMgmt/bin/gppylib/operations/detect_unreachable_hosts.py
@@ -42,10 +42,10 @@ def get_unreachable_segment_hosts(hosts, num_workers):
 
 def update_unreachable_flag_for_segments(gparray, unreachable_hosts):
     for i, segmentPair in enumerate(gparray.segmentPairs):
-        if segmentPair.primaryDB.getSegmentHostName() in unreachable_hosts:
+        if segmentPair.primaryDB and segmentPair.primaryDB.getSegmentHostName() in unreachable_hosts:
             gparray.segmentPairs[i].primaryDB.unreachable = True
 
-        if segmentPair.mirrorDB.getSegmentHostName() in unreachable_hosts:
+        if segmentPair.mirrorDB and segmentPair.mirrorDB.getSegmentHostName() in unreachable_hosts:
             gparray.segmentPairs[i].mirrorDB.unreachable = True
 
 

--- a/gpMgmt/bin/gppylib/operations/detect_unreachable_hosts.py
+++ b/gpMgmt/bin/gppylib/operations/detect_unreachable_hosts.py
@@ -39,6 +39,16 @@ def get_unreachable_segment_hosts(hosts, num_workers):
 
     return unreachable_hosts
 
+
+def update_unreachable_flag_for_segments(gparray, unreachable_hosts):
+    for i, segmentPair in enumerate(gparray.segmentPairs):
+        if segmentPair.primaryDB.getSegmentHostName() in unreachable_hosts:
+            gparray.segmentPairs[i].primaryDB.unreachable = True
+
+        if segmentPair.mirrorDB.getSegmentHostName() in unreachable_hosts:
+            gparray.segmentPairs[i].mirrorDB.unreachable = True
+
+
 def mark_segments_down_for_unreachable_hosts(segmentPairs, unreachable_hosts):
     # We only mark the segment down in gparray for use by later checks, as
     # setting the actual segment down in gp_segment_configuration leads to

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_update_pg_hba_on_segments.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_update_pg_hba_on_segments.py
@@ -30,7 +30,7 @@ class UpdatePgHBAConfTests(GpTestCase):
 
         self.gparray = _setup_gparray()
         self.apply_patches([
-            patch('gppylib.operations.update_pg_hba_on_segments.logger', return_value=Mock(spec=['log', 'info', 'debug', 'error'])),
+            patch('gppylib.operations.update_pg_hba_on_segments.logger', return_value=Mock(spec=['log', 'info', 'debug', 'error', 'warning'])),
             patch('gppylib.commands.unix.getUserName', return_value="gpadmin")
         ])
         self.logger = self.get_mock_from_apply_patch('logger')
@@ -52,6 +52,16 @@ host replication gpadmin {ip_primary2}/32 trust"""
         entries = create_entries(primary_hostname, mirror_hostname, False)
         entries_str = "\n".join(entries)
         entries_expected = self.entries_block.format(ip_primary1 = '192.168.1.1', ip_primary2 = '192.168.2.1', ip_mirror1 = '192.168.1.1', ip_mirror2 = '192.168.2.1')
+        self.assertEqual(entries_str, entries_expected)
+
+    @patch('socket.gethostbyaddr', return_value=['sdw1', '', ''])
+    def test_create_entries_hba_hostnames_true(self, gethost):
+        pair0 = self.gparray.getSegmentList()[0]
+        primary_hostname = pair0.primaryDB.getSegmentHostName()
+        mirror_hostname = pair0.mirrorDB.getSegmentHostName()
+        entries = create_entries(primary_hostname, mirror_hostname, True)
+        entries_str = "\n".join(entries)
+        entries_expected = "\nhost replication gpadmin samehost trust\nhost all gpadmin sdw1 trust\nhost replication gpadmin sdw1 trust"
         self.assertEqual(entries_str, entries_expected)
 
     @patch('gppylib.operations.update_pg_hba_on_segments.gp.IfAddrs.list_addrs', return_value=[])
@@ -90,10 +100,31 @@ host replication gpadmin {ip_primary2}/32 trust"""
 
     @patch('gppylib.operations.update_pg_hba_on_segments.update_on_segments')
     @patch('gppylib.operations.update_pg_hba_on_segments.create_entries', side_effect=[['entry0', 'entry1']])
-    def test_one_seg_unreachable(self, mock_entries, mock_update):
+    def test_one_primary_seg_unreachable(self, mock_entries, mock_update):
         pair0, pair1 = self.gparray.getSegmentList()
         pair0.primaryDB.unreachable = True
 
+        os.environ["GPHOME"] = "/usr/local/gpdb"
+        expected_batch_size = 16
+        update_pg_hba_on_segments(self.gparray, False, expected_batch_size)
+
+        self.assertEqual(mock_update.call_count, 1)
+        mock_call_args = mock_update.call_args[0]
+
+        result_cmds = mock_call_args[0]
+        result_batch_size = mock_call_args[1]
+
+        expected_string = "$GPHOME/sbin/seg_update_pg_hba.py --data-dir /data/primary1 --entries 'entry0\nentry1'"
+
+        self.assertEqual(len(result_cmds), 1)
+        self.assertEqual(result_batch_size, expected_batch_size)
+        self.assertEqual(result_cmds[0].cmdStr, expected_string)
+
+    @patch('gppylib.operations.update_pg_hba_on_segments.update_on_segments')
+    @patch('gppylib.operations.update_pg_hba_on_segments.create_entries', side_effect=[['entry0', 'entry1']])
+    def test_mirror_seg_is_none(self, mock_entries, mock_update):
+        pair0, pair1 = self.gparray.getSegmentList()
+        pair0.mirrorDB = None
         os.environ["GPHOME"] = "/usr/local/gpdb"
         expected_batch_size = 16
         update_pg_hba_on_segments(self.gparray, False, expected_batch_size)
@@ -120,6 +151,8 @@ host replication gpadmin {ip_primary2}/32 trust"""
         expected_batch_size = 16
         update_pg_hba_on_segments(self.gparray, False, expected_batch_size)
 
+        self.logger.warning.assert_any_call("Not updating pg_hba.conf for segments on unreachable hosts: sdw1, sdw2."
+                                               "You can manually update pg_hba.conf once you make the hosts reachable.")
         self.logger.info.assert_any_call("None of the reachable segments require update to pg_hba.conf")
         self.assertEqual(mock_update.call_count, 0)
 
@@ -129,7 +162,7 @@ host replication gpadmin {ip_primary2}/32 trust"""
         pair0, pair1 = self.gparray.getSegmentList()
         os.environ["GPHOME"] = "/usr/local/gpdb"
         expected_batch_size = 16
-        update_pg_hba_on_segments(self.gparray, False, expected_batch_size, [0])
+        update_pg_hba_on_segments(self.gparray, False, expected_batch_size, contents_to_update=[0])
 
         self.assertEqual(mock_update.call_count, 1)
         mock_call_args = mock_update.call_args[0]

--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -459,3 +459,18 @@ Feature: expand the cluster by adding more segments
         When the user runs gpexpand to redistribute
         Then the numsegments of table "partition_test" is 4
         Then distribution information from table "partition_test" with data in "gptest" is verified against saved data
+
+    @gpexpand_segment
+    Scenario: expand a cluster and check pg_hba entries on segment
+        Given the database is not running
+        And a working directory of the test as '/data/gpdata/gpexpand'
+        And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
+        And a cluster is created with mirrors on "mdw" and "sdw1"
+        And database "gptest" exists
+        And there are no gpexpand_inputfiles
+        And the cluster is setup for an expansion on hosts "mdw,sdw1,sdw2,sdw3"
+        And the new host "sdw2,sdw3" is ready to go
+        When the user runs gpexpand interview to add 0 new segment and 2 new host "sdw2,sdw3"
+        Then the number of segments have been saved
+        When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
+        Then verify that pg_hba.conf file has "replication" entries in each segment data directories

--- a/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
@@ -72,7 +72,6 @@ Feature: Tests for gpinitstandby feature
 
          Then gpinitstandby should return a return code of 0
           And gpinitstandby should print "If you continue with initialization, pg_hba.conf files on these hosts will not be updated." to stdout
-          And gpinitstandby should print "Not updating pg_hba.conf for segments on unreachable hosts: invalid_host.You can manually update pg_hba.conf once you make the hosts reachable." to stdout
           And the cluster is returned to a good state
 
     Scenario: gpinitstandby exits if confirmation is not given when a segment host is unreachable
@@ -134,9 +133,20 @@ Feature: Tests for gpinitstandby feature
         Then gpinitstandby should return a return code of 0
         And verify that the file "pg_hba.conf" in the coordinator data directory has "no" line starting with "host.*replication.*(127.0.0.1|::1).*trust"
 
-    Scenario: gpinitstandby should not throw error when banner exists on the hsot
+    Scenario: gpinitstandby should not throw error when banner exists on the host
         Given the database is running
         And the standby is not initialized
         When the user sets banner on host
         And the user runs gpinitstandby with options " "
         Then gpinitstandby should return a return code of 0
+
+    @concourse_cluster
+    Scenario: gpinitstandby should create pg_hba entry to segment primary
+        Given the database is not running
+        And a working directory of the test as '/tmp/gpinitstandby'
+        And a cluster is created with mirrors on "mdw" and "sdw1"
+        And the standby is not initialized
+        When running gpinitstandby on host "mdw" to create a standby on host "sdw1"
+        Then gpinitstandby should return a return code of 0
+        And verify the standby coordinator entries in catalog
+        And verify that pg_hba.conf file has "standby" entries in each segment data directories

--- a/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
@@ -72,7 +72,7 @@ Feature: Tests for gpinitstandby feature
 
          Then gpinitstandby should return a return code of 0
           And gpinitstandby should print "If you continue with initialization, pg_hba.conf files on these hosts will not be updated." to stdout
-          And gpinitstandby should print "Manual update of the pg_hba_conf files for all segments on unreachable host invalid_host will be required." to stdout
+          And gpinitstandby should print "Not updating pg_hba.conf for segments on unreachable hosts: invalid_host.You can manually update pg_hba.conf once you make the hosts reachable." to stdout
           And the cluster is returned to a good state
 
     Scenario: gpinitstandby exits if confirmation is not given when a segment host is unreachable

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -274,7 +274,8 @@ Feature: gprecoverseg tests
       And the user runs psql with "-c 'INSERT INTO foo SELECT generate_series(1, 10000)'" against database "postgres"
 
       When the user runs "gprecoverseg <args>"
-      Then gprecoverseg should print "Not recovering segment \d because invalid_host is unreachable" to stdout
+      Then gprecoverseg should print "One or more hosts are not reachable via SSH." to stdout
+      And gprecoverseg should print "Host invalid_host is unreachable" to stdout
       And the user runs psql with "-c 'SELECT gp_request_fts_probe_scan()'" against database "postgres"
       And the status of the primary on content 0 should be "u"
       And the status of the primary on content 1 should be "d"


### PR DESCRIPTION
Removed update_pg_hba_conf_on_segments() which is the old one. 
Updated update_pg_hba_on_segments() to handle unreachable hosts 
Added new test cases and updated existing test cases accordingly.
Updated gpexpand utility to have new logic to update pg_hba.  

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
