### PR TITLE
(6x) Fix bug: cdbpullup_findEclassInTargetList not consider compatible types.

### DIFF
--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -1375,3 +1375,53 @@ COPY foo FROM PROGRAM 'cat /tmp/gpcopyenvtest' ESCAPE 'OFF';
 COPY foo FROM PROGRAM '/usr/bin/env bash -c ''echo -E database in COPY FROM: $GP_DATABASE''' ESCAPE 'OFF';
 
 select * from foo;
+
+-- Test for Issue: https://github.com/greenplum-db/gpdb/issues/12700
+-- When under planner, to set a plan's flow based on path's locus and
+-- the locus is hashed, it will try to verify that each distkey in locus
+-- is in plan's targetlist andalso is hashable. Previously, hashable-test
+-- is not correct and will lead to no hash exprs in the plan's flow. A
+-- typical case is that copy-on-segment might add extra motion atop leading
+-- to confusing data files.
+
+-- Distributed by two columns is very important in this case.
+create table t_12700 (a varchar(32), id int)
+distributed by (a, id)
+partition by list (id)
+( partition p1 values (0),
+  partition p2 values (1)
+);
+
+insert into t_12700
+select chr(i)::varchar(32), i%2 from generate_series(97, 122)i;
+
+-- previously, planner will generate a motion atop the plan of query
+-- and distributed by the first column and leads to wrong file data distribution
+copy (select * from t_12700) to '/tmp/out_12700_<SEGID>' on segment;
+
+-- the following statement should not error out
+-- manually abort since we do not want mismatch of table content and outfile.
+begin;
+copy t_12700 from '/tmp/out_12700_<SEGID>' on segment;
+abort;
+
+-- start_ignore
+create language plpythonu;
+-- end_ingore
+
+create function get_file_lines_12700(segid int) returns int
+as
+$$
+with open('/tmp/out_12700_' + str(segid)) as f:
+    return sum(1 for line in f)
+$$
+language plpythonu;
+
+with cte(segid, num) as (
+  select gp_segment_id, count(a) num from t_12700 group by gp_segment_id
+)
+select get_file_lines_12700(segid) = num from cte;
+
+drop table t_12700;
+drop function get_file_lines_12700(int);
+\! rm /tmp/out_12700_* -f

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1673,3 +1673,53 @@ select * from foo;
  database in COPY TO: funny copy"db'with\\quotes
 (3 rows)
 
+-- Test for Issue: https://github.com/greenplum-db/gpdb/issues/12700
+-- When under planner, to set a plan's flow based on path's locus and
+-- the locus is hashed, it will try to verify that each distkey in locus
+-- is in plan's targetlist andalso is hashable. Previously, hashable-test
+-- is not correct and will lead to no hash exprs in the plan's flow. A
+-- typical case is that copy-on-segment might add extra motion atop leading
+-- to confusing data files.
+-- Distributed by two columns is very important in this case.
+create table t_12700 (a varchar(32), id int)
+distributed by (a, id)
+partition by list (id)
+( partition p1 values (0),
+  partition p2 values (1)
+);
+NOTICE:  CREATE TABLE will create partition "t_12700_1_prt_p1" for table "t_12700"
+NOTICE:  CREATE TABLE will create partition "t_12700_1_prt_p2" for table "t_12700"
+insert into t_12700
+select chr(i)::varchar(32), i%2 from generate_series(97, 122)i;
+-- previously, planner will generate a motion atop the plan of query
+-- and distributed by the first column and leads to wrong file data distribution
+copy (select * from t_12700) to '/tmp/out_12700_<SEGID>' on segment;
+-- the following statement should not error out
+-- manually abort since we do not want mismatch of table content and outfile.
+begin;
+copy t_12700 from '/tmp/out_12700_<SEGID>' on segment;
+abort;
+-- start_ignore
+create language plpythonu;
+-- end_ingore
+create function get_file_lines_12700(segid int) returns int
+as
+$$
+with open('/tmp/out_12700_' + str(segid)) as f:
+    return sum(1 for line in f)
+$$
+language plpythonu;
+with cte(segid, num) as (
+  select gp_segment_id, count(a) num from t_12700 group by gp_segment_id
+)
+select get_file_lines_12700(segid) = num from cte;
+ ?column? 
+----------
+ t
+ t
+ t
+(3 rows)
+
+drop table t_12700;
+drop function get_file_lines_12700(int);
+\! rm /tmp/out_12700_* -f


### PR DESCRIPTION
The function cdbpullup_findEclassInTargetList, if passed a valid HashOpFamily,
it will not only check the EquivalenceClass in the targetlist, but also check
the EquivalenceClass is hashable under the given HashOpFamily. Previous code
using get_opfamily_member to verify if it is hashable, this is too strict,
for example, both OpClass hash/varchar_ops and hash/text_ops belong to OpFamily
text_ops, but in OpFamily hash/text_ops, there is only one operator and it only
handles text type (this statement only holds for current version, I check later
version Postgres, small changes, including name type). That's why if the simply
invoking get_opfamily_member is not enough here since it does not consider type
compatible, like varchar is binary compatible with text.

Consider a detailed case:

```
  create table t (a varchar(32), id int)
  distributed by (a, id)
  partition by list (id)
  ( partition p1 values (0),
    partition p2 values (1)
  );
  copy (select * from t) to '/tmp/out_<SEGID>' on segment;
```

Thing happens in the following order:

  1. When under planner, it will generate scan path for each leaf partition,
  and then create append path to combine both.
  2. The locus in the scan path is built from policy: function cdbpathlocus_from_baserel
  calls cdb_build_distribution_keys to built the distkeys.
  3. For each distkey, get type based on the opclass in the table's distkey definition,
  so the type will be text, even if first distributed column's type is varchar.
  4. Then later, when append all leafs' scan paths, deduce the append_path's locus,
  it will try to pullup leafs's locus: set_append_path_locus -> cdbpathlocus_pull_above_projection
  -> cdb_pull_up_eclass.
  5. Here, when building a new EC member, it uses the expr's type as ec member's type,
  which is varchar
  6. Finally, at the end of create_plan, it calls cdbpathtoplan_create_flow to bulid flow,
  we have to test if hashable for a EC member with type varchar. Thus, simply get_opfamily_member
  is not enougth.

This commit calls cdb_hashproc_in_opfamily in cdbpullup_findEclassInTargetList to
check if hashable.

Fix Github Issue https://github.com/greenplum-db/gpdb/issues/12700.

Co-authored-by: Hongxu Ma <mhongxu@vmware.com>