### PR TITLE
Fix bug that Orca generates wrong plan for CTAS

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalJoin.cpp
@@ -427,7 +427,7 @@ CPhysicalJoin::PdsDerive(CMemoryPool *mp, CExpressionHandle &exprhdl) const
 			CExpressionArray *pdrgpexpr = pdsHashed->Pdrgpexpr();
 			IMdIdArray *opfamilies = pdsHashed->Opfamilies();
 
-			if (NULL != opfamilies)
+			if (nullptr != opfamilies)
 			{
 				opfamilies->AddRef();
 			}

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalJoin.cpp
@@ -425,9 +425,15 @@ CPhysicalJoin::PdsDerive(CMemoryPool *mp, CExpressionHandle &exprhdl) const
 		if (!pdsHashed->HasCompleteEquivSpec(mp))
 		{
 			CExpressionArray *pdrgpexpr = pdsHashed->Pdrgpexpr();
+			IMdIdArray *opfamilies = pdsHashed->Opfamilies();
+
+			if (NULL != opfamilies)
+			{
+				opfamilies->AddRef();
+			}
 			pdrgpexpr->AddRef();
 			return GPOS_NEW(mp) CDistributionSpecHashed(
-				pdrgpexpr, pdsHashed->FNullsColocated());
+				pdrgpexpr, pdsHashed->FNullsColocated(), opfamilies);
 		}
 	}
 

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14190,3 +14190,37 @@ SELECT * FROM tone t1 LEFT OUTER JOIN tone t2 ON t1.a = t2.a;
 
 RESET optimizer_enable_redistribute_nestloop_loj_inner_child;
 RESET optimizer_enable_hashjoin;
+--- Test if orca can produce the correct plan for CTAS
+CREATE TABLE dist_tab_a (a varchar(15)) DISTRIBUTED BY(a);
+INSERT INTO dist_tab_a VALUES('1 '), ('2  '), ('3    ');
+CREATE TABLE dist_tab_b (a char(15), b bigint) DISTRIBUTED BY(a);
+INSERT INTO dist_tab_b VALUES('1 ', 1), ('2  ', 2), ('3    ', 3);
+EXPLAIN CREATE TABLE result_tab AS
+	(SELECT a.a, b.b FROM dist_tab_a a LEFT JOIN dist_tab_b b ON a.a=b.a) DISTRIBUTED BY(a);
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Redistribute Motion 3:3  (slice1; segments: 3)  (cost=274.75..32892.98 rows=448330 width=56)
+   Hash Key: a.a
+   ->  Hash Left Join  (cost=274.75..23926.38 rows=448330 width=56)
+         Hash Cond: ((a.a)::bpchar = b.a)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..453.00 rows=13967 width=48)
+               Hash Key: a.a
+               ->  Seq Scan on dist_tab_a a  (cost=0.00..173.67 rows=13967 width=48)
+         ->  Hash  (cost=141.00..141.00 rows=10700 width=72)
+               ->  Seq Scan on dist_tab_b b  (cost=0.00..141.00 rows=10700 width=72)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+CREATE TABLE result_tab AS
+	(SELECT a.a, b.b FROM dist_tab_a a LEFT JOIN dist_tab_b b ON a.a=b.a) DISTRIBUTED BY(a);
+SELECT gp_segment_id, * FROM result_tab;
+ gp_segment_id |   a   | b 
+---------------+-------+---
+             0 | 3     | 3
+             2 | 1     | 1
+             1 | 2     | 2
+(3 rows)
+
+DROP TABLE IF EXISTS dist_tab_a;
+DROP TABLE IF EXISTS dist_tab_b;
+DROP TABLE IF EXISTS result_tab;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14562,3 +14562,38 @@ SELECT * FROM tone t1 LEFT OUTER JOIN tone t2 ON t1.a = t2.a;
 
 RESET optimizer_enable_redistribute_nestloop_loj_inner_child;
 RESET optimizer_enable_hashjoin;
+--- Test if orca can produce the correct plan for CTAS
+CREATE TABLE dist_tab_a (a varchar(15)) DISTRIBUTED BY(a);
+INSERT INTO dist_tab_a VALUES('1 '), ('2  '), ('3    ');
+CREATE TABLE dist_tab_b (a char(15), b bigint) DISTRIBUTED BY(a);
+INSERT INTO dist_tab_b VALUES('1 ', 1), ('2  ', 2), ('3    ', 3);
+EXPLAIN CREATE TABLE result_tab AS
+	(SELECT a.a, b.b FROM dist_tab_a a LEFT JOIN dist_tab_b b ON a.a=b.a) DISTRIBUTED BY(a);
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..862.05 rows=2 width=16)
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=16)
+         Hash Key: dist_tab_a.a
+         ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=16)
+               Hash Cond: ((dist_tab_a.a)::bpchar = dist_tab_b.a)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                     Hash Key: dist_tab_a.a
+                     ->  Seq Scan on dist_tab_a  (cost=0.00..431.00 rows=1 width=8)
+               ->  Hash  (cost=431.00..431.00 rows=1 width=16)
+                     ->  Seq Scan on dist_tab_b  (cost=0.00..431.00 rows=1 width=16)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+CREATE TABLE result_tab AS
+	(SELECT a.a, b.b FROM dist_tab_a a LEFT JOIN dist_tab_b b ON a.a=b.a) DISTRIBUTED BY(a);
+SELECT gp_segment_id, * FROM result_tab;
+ gp_segment_id |   a   | b 
+---------------+-------+---
+             0 | 3     | 3
+             1 | 2     | 2
+             2 | 1     | 1
+(3 rows)
+
+DROP TABLE IF EXISTS dist_tab_a;
+DROP TABLE IF EXISTS dist_tab_b;
+DROP TABLE IF EXISTS result_tab;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3420,6 +3420,21 @@ EXPLAIN (COSTS OFF) SELECT * FROM tone t1 LEFT OUTER JOIN tone t2 ON t1.a = t2.a
 SELECT * FROM tone t1 LEFT OUTER JOIN tone t2 ON t1.a = t2.a;
 RESET optimizer_enable_redistribute_nestloop_loj_inner_child;
 RESET optimizer_enable_hashjoin;
+
+--- Test if orca can produce the correct plan for CTAS
+CREATE TABLE dist_tab_a (a varchar(15)) DISTRIBUTED BY(a);
+INSERT INTO dist_tab_a VALUES('1 '), ('2  '), ('3    ');
+CREATE TABLE dist_tab_b (a char(15), b bigint) DISTRIBUTED BY(a);
+INSERT INTO dist_tab_b VALUES('1 ', 1), ('2  ', 2), ('3    ', 3);
+EXPLAIN CREATE TABLE result_tab AS
+	(SELECT a.a, b.b FROM dist_tab_a a LEFT JOIN dist_tab_b b ON a.a=b.a) DISTRIBUTED BY(a);
+CREATE TABLE result_tab AS
+	(SELECT a.a, b.b FROM dist_tab_a a LEFT JOIN dist_tab_b b ON a.a=b.a) DISTRIBUTED BY(a);
+SELECT gp_segment_id, * FROM result_tab;
+DROP TABLE IF EXISTS dist_tab_a;
+DROP TABLE IF EXISTS dist_tab_b;
+DROP TABLE IF EXISTS result_tab;
+
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 -- end_ignore


### PR DESCRIPTION
For the following query, Orca generated plan that caused wrong results:

```
CREATE TABLE dist_tab_a (a varchar(15)) DISTRIBUTED BY(a);
INSERT INTO dist_tab_a VALUES('1 '), ('2  '), ('3    ');
CREATE TABLE dist_tab_b (a char(15), b bigint) DISTRIBUTED BY(a);
INSERT INTO dist_tab_b VALUES('1 ', 1), ('2  ', 2), ('3    ', 3);
CREATE TABLE result_tab_a AS
    (SELECT a.a, b.b FROM dist_tab_a a LEFT JOIN dist_tab_b b ON a.a=b.a) DISTRIBUTED BY(a);
EXPLAIN CREATE TABLE result_tab_a AS
    (SELECT a.a, b.b FROM dist_tab_a a LEFT JOIN dist_tab_b b ON a.a=b.a) DISTRIBUTED BY(a);
     Hash Left Join  (cost=0.00..862.00 rows=2 width=16)
       Hash Cond: ((dist_tab_a.a)::bpchar = dist_tab_b.a)
       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
             Hash Key: dist_tab_a.a
             ->  Seq Scan on dist_tab_a  (cost=0.00..431.00 rows=1 width=8)
       ->  Hash  (cost=431.00..431.00 rows=1 width=16)
             ->  Seq Scan on dist_tab_b  (cost=0.00..431.00 rows=1 width=16)
Optimizer: Pivotal Optimizer (GPORCA)
SELECT gp_table_distribution_check('result_tab_a');
gp_table_distribution_check
-----------------------------
 (2,t)
 (0,f)
 (1,f)
(3 rows)
```

Correct plan and results should be:

```
EXPLAIN CREATE TABLE result_tab_a AS
    (SELECT a.a, b.b FROM dist_tab_a a LEFT JOIN dist_tab_b b ON a.a=b.a) DISTRIBUTED BY(a);
     Result  (cost=0.00..862.05 rows=2 width=16)
       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=16)
             Hash Key: dist_tab_a.a
             ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=16)
                   Hash Cond: ((dist_tab_a.a)::bpchar = dist_tab_b.a)
                   ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
                         Hash Key: dist_tab_a.a
                         ->  Seq Scan on dist_tab_a  (cost=0.00..431.00 rows=1 width=8)
                   ->  Hash  (cost=431.00..431.00 rows=1 width=16)
                         ->  Seq Scan on dist_tab_b  (cost=0.00..431.00 rows=1 width=16)
Optimizer: Pivotal Optimizer (GPORCA)
(11 rows)
SELECT gp_table_distribution_check('result_tab_a');
gp_table_distribution_check
-----------------------------
 (2,t)
 (0,t)
 (1,t)
(3 rows)
```

I think the root cause is that when we derive distribution of Hash Left
Outer Join, we create a hash distribution spec with wrong opfamilies.
As a result, there isn't a mismatch between distribution spec
requested/derived, Motion Redistribute node is not added to plantree