### PR TITLE
to #12808 Fix elog info of ExecModifyTable function is not suitable. 

### DIFF
--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -2517,7 +2517,7 @@ ExecModifyTable(PlanState *pstate)
 												 &isNull);
 					/* shouldn't ever get a null result... */
 					if (isNull)
-						elog(ERROR, "action is NULL");
+						elog(ERROR, "gp_segment_id is NULL");
 
 					segid = DatumGetInt32(datum);
 				}
@@ -2528,7 +2528,7 @@ ExecModifyTable(PlanState *pstate)
 												 &isNull);
 					/* shouldn't ever get a null result... */
 					if (isNull)
-						elog(ERROR, "gp_segment_id is NULL");
+						elog(ERROR, "action is NULL");
 
 					action = DatumGetInt32(datum);
 				}


### PR DESCRIPTION
GPDB-specific junk attributes elog info is not correct.
For now elog info of segid_attno attribute is "action is NULL".
and elog info of action_attno attribute is "gp_segment_id is NULL".