### PR TITLE
Improve enumeration of partition selectors in Orca's DPv2 with bushy trees

### DIFF
--- a/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDPv2.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDPv2.cpp
@@ -1000,12 +1000,6 @@ CJoinOrderDPv2::SearchJoinOrders(ULONG left_level, ULONG right_level)
 					current_level_info, join_bitset, join_expr_info);
 				AddExprToGroupIfNecessary(group_info, join_expr_info);
 
-				// We only want to consider linear trees when enumerating partition selector alternatives
-				if (right_level != 1)
-				{
-					continue;
-				}
-
 				// For PS alternatives, get the best join expression for any properties
 				SExpressionProperties join_props(EJoinOrderAny);
 
@@ -1014,17 +1008,21 @@ CJoinOrderDPv2::SearchJoinOrders(ULONG left_level, ULONG right_level)
 					left_group_info, right_group_info, join_props);
 
 
-
-				// TODO: Reduce non-mandatory cross products
-
-				PopulateDPEInfo(join_expr_info, left_group_info,
-								right_group_info);
-				// For the first level, we should consider joining both ways
-				if (left_level == 1 && right_level == 1)
+				// We only want to consider linear trees when enumerating partition selector alternatives
+				if (right_level == 1)
 				{
-					PopulateDPEInfo(join_expr_info, right_group_info,
-									left_group_info);
+					// TODO: Reduce non-mandatory cross products
+
+					PopulateDPEInfo(join_expr_info, left_group_info,
+									right_group_info);
+					// For the first level, we should consider joining both ways
+					if (left_level == 1 && right_level == 1)
+					{
+						PopulateDPEInfo(join_expr_info, right_group_info,
+										left_group_info);
+					}
 				}
+
 
 				if (join_expr_info->m_contain_PS->Size() > 0)
 				{


### PR DESCRIPTION
In Orca's DPv2 xform, we have a separate stack for expressions
containing a partition selector. We previously only considered linear
trees when adding to this stack in order to minimize optimization time
and to prevent scenarios where a PS is in a different part of the tree
(which would have a chance at being an invalid plan due to motitions).

However, only considering linear trees means that we would miss out on a
bushy tree with 2 separate partition selectors and scans such as below:

HJ
  -HJ
    -DynamicScan2
    - PS2
      -Scan
  -HJ
    -DynamicScan1
    - PS1
      -Scan

We now will mark such trees as containing a PS if a child of a bushy
tree contains a PS. We still won't populate new DPE possibilities for a
bushy tree in order to prevent possible invalid plan from being
considered/higher optimization time.

TODO: See if I can create a somewhat narrow test case