### PR TITLE
Copy postgresql.auto.conf from segment while gpexpand.

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -861,6 +861,14 @@ class SegmentTemplate:
             remoteHost=self.srcSegHostname)
         cpCmd.run(validateAfter=True)
 
+        self.logger.info('Copying postgresql.auto.conf from existing segment into template')
+        cmdName = 'gpexpand copying postgresql.auto.conf to %s:%s/postgresql.auto.conf' \
+                  % (self.srcSegHostname, self.srcSegDataDir)
+        cpCmd = Scp(name=cmdName, srcFile=self.srcSegDataDir + '/postgresql.auto.conf',
+            dstFile=self.tempDir, dstHost=localHostname, ctxt=REMOTE,
+            remoteHost=self.srcSegHostname)
+        cpCmd.run(validateAfter=True)
+
         self.logger.info('Copying pg_hba.conf from existing segment into template')
         cmdName = 'gpexpand copy pg_hba.conf to %s:%s/pg_hba.conf' \
                   % (self.srcSegHostname, self.srcSegDataDir)

--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -459,3 +459,21 @@ Feature: expand the cluster by adding more segments
         When the user runs gpexpand to redistribute
         Then the numsegments of table "partition_test" is 4
         Then distribution information from table "partition_test" with data in "gptest" is verified against saved data
+
+    @gpexpand_verify_autoconf_from_qe
+    Scenario: Verify should succeed when expand partition table
+        Given the database is not running
+        And a working directory of the test as '/data/gpdata/gpexpand'
+        And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
+        And the cluster is generated with "1" primaries only
+        And database "gptest" exists
+        And the user change enable_mergejoin to on only on qd by alter system on gptest
+        And the user restart the whole cluster
+        And enable_mergejoin is on on qd and off on all qes
+        And there are no gpexpand_inputfiles
+        And the cluster is setup for an expansion on hosts "localhost"
+        When the user runs gpexpand interview to add 1 new segment and 0 new host "ignored.host"
+        Then the number of segments have been saved
+        When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
+        Then verify that the cluster has 1 new segments
+        Then enable_mergejoin is on on qd and off on all qes

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2338,7 +2338,7 @@ def impl(context, command, target):
 
 @given('the user change enable_mergejoin to on only on qd by alter system on gptest')
 def impl(context):
-    host, port = get_cooridnator_host_port()
+    host, port = get_coordinator_host_port()
     query = "alter system set enable_mergejoin to on"
     psql_cmd = "PGDATABASE=\'%s\' PGOPTIONS=\'-c gp_role=utility\' psql -h %s -p %s -c \"%s\"; " % (
         "gptest", host, port, query)

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2335,6 +2335,32 @@ def impl(context, command, target):
     if target not in contents:
         raise Exception("cannot find %s in %s" % (target, filename))
 
+
+@given('the user change enable_mergejoin to on only on qd by alter system on gptest')
+def impl(context):
+    host, port = get_cooridnator_host_port()
+    query = "alter system set enable_mergejoin to on"
+    psql_cmd = "PGDATABASE=\'%s\' PGOPTIONS=\'-c gp_role=utility\' psql -h %s -p %s -c \"%s\"; " % (
+        "gptest", host, port, query)
+    Command(name='Running Remote command: %s' % psql_cmd, cmdStr=psql_cmd).run(validateAfter=True)
+
+@given('the user restart the whole cluster')
+def impl(context):
+    cmd = "gpstop -rai"
+    Command(name='Running Remote command: %s' % cmd, cmdStr=cmd).run(validateAfter=True)
+
+@given('enable_mergejoin is on on qd and off on all qes')
+@then('enable_mergejoin is on on qd and off on all qes')
+def impl(context):
+    cmd = "gpconfig -s enable_mergejoin"
+    c = Command(name='Running Remote command: %s' % cmd, cmdStr=cmd)
+    c.run(validateAfter=True)
+    out = c.get_stdout()
+    if ("Coordinator value: on" not in out or
+        "Segment     value: off" not in out):
+        raise Exception('Guc enable_mergejoin value is not correct')
+
+
 @given('verify that a role "{role_name}" exists in database "{dbname}"')
 @then('verify that a role "{role_name}" exists in database "{dbname}"')
 def impl(context, role_name, dbname):

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -682,6 +682,19 @@ def check_count_for_specific_query(dbname, query, nrows):
     if result != nrows:
         raise Exception('%d rows in query: %s. Expected row count = %d' % (result, query, nrows))
 
+def get_cooridnator_host_port():
+    """
+    return host, port of cooridnator (dbid 1)
+    """
+    COORIDNATOR_DBID = 1
+    get_psegment_sql = 'select hostname, port from gp_segment_configuration where dbid=%i;' % COORIDNATOR_DBID
+    with closing(dbconn.connect(dbconn.DbURL(dbname='template1'), unsetSearchPath=False)) as conn:
+        cur = dbconn.query(conn, get_psegment_sql)
+        rows = cur.fetchall()
+        host = rows[0][0]
+        port = rows[0][1]
+    return host, port
+
 
 def get_primary_segment_host_port():
     """

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -682,12 +682,12 @@ def check_count_for_specific_query(dbname, query, nrows):
     if result != nrows:
         raise Exception('%d rows in query: %s. Expected row count = %d' % (result, query, nrows))
 
-def get_cooridnator_host_port():
+def get_coordinator_host_port():
     """
     return host, port of cooridnator (dbid 1)
     """
-    COORIDNATOR_DBID = 1
-    get_psegment_sql = 'select hostname, port from gp_segment_configuration where dbid=%i;' % COORIDNATOR_DBID
+    COORDINATOR_DBID = 1
+    get_psegment_sql = 'select hostname, port from gp_segment_configuration where dbid=%i;' % COORDINATOR_DBID
     with closing(dbconn.connect(dbconn.DbURL(dbname='template1'), unsetSearchPath=False)) as conn:
         cur = dbconn.query(conn, get_psegment_sql)
         rows = cur.fetchall()


### PR DESCRIPTION
The config file postgresql.auto.conf might not the same across
QD or QEs. While execute gpexpand, copy this file from master
is not correct. We should copy them from segment for newly added
segments.

In master branch it is not easy to add a normal case by alter system,
because we dispatch AlterSystem statement to QEs. We add the
case based on the advice in
https://github.com/greenplum-db/gpdb/pull/12212#issuecomment-880255593

Authored-by: Miao Chen <miaochen@mail.ustc.edu.cn>

--------

This is a pre-port version of https://github.com/greenplum-db/gpdb/pull/12212
We hit the issue in some practical env.
