### PR TITLE
Docs: added missing columns in doc for pg_enum table

### DIFF
--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_enum.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_enum.xml
@@ -32,6 +32,12 @@
             <entry>The OID of the <codeph>pg_type</codeph> entry owning this enum value</entry>
           </row>
           <row>
+            <entry><codeph>enumsortorder</codeph></entry>
+            <entry>float4</entry>
+            <entry/>
+            <entry>The sort position of this enum value within its enum type</entry>
+          </row>
+          <row>
             <entry><codeph>enumlabel</codeph></entry>
             <entry>name</entry>
             <entry/>


### PR DESCRIPTION
Added missing column based on https://www.postgresql.org/docs/9.4/catalog-pg-enum.html and 6.18.1 environment.