### PR TITLE
Docs: added missing column in doc for gp_log_master_concise

### DIFF
--- a/gpdb-doc/dita/ref_guide/gp_toolkit.xml
+++ b/gpdb-doc/dita/ref_guide/gp_toolkit.xml
@@ -1166,6 +1166,10 @@
                 <entry colname="col2" class="- topic/entry ">The command number within a session
                   (prefixed with "cmd").</entry>
               </row>
+              <row>
+                <entry>logseverity</entry>
+                <entry>The log severity level.</entry>
+              </row>
               <row class="- topic/row ">
                 <entry colname="col1" class="- topic/entry ">logmessage </entry>
                 <entry colname="col2" class="- topic/entry ">Log or error message text.</entry>


### PR DESCRIPTION
Added missing column based on engineering input and version 6.18.1
