### PR TITLE
Docs: parameter gp_create_table_random_default_distribution can be ch…

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -2503,7 +2503,7 @@
             <row>
               <entry colname="col1">boolean</entry>
               <entry colname="col2">off</entry>
-              <entry colname="col3">master<p>system</p><p>reload</p></entry>
+              <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>
           </tbody>
         </tgroup>


### PR DESCRIPTION
Configuration parameter gp_create_table_random_default_distribution can be set at session level documentation stated system level.