### PR TITLE
Docs: specified that skipvalidation option needs to be used when chan…

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -2134,6 +2134,10 @@
               >gp_default_storage_options</xref></codeph>.</li>
           <li> The default data compression setting.</li>
         </ol></p>
+      <p>You must specify <codeph>--skipvalidation</codeph> when modifying this parameter as it is a
+        restricted configuration parameter. Use extreme caution when setting configuration
+        parameters with this option. For
+        example:<codeblock>gpconfig --skipvalidation -c gp_add_column_inherits_table_setting -v on</codeblock></p>
       <p>For information about the data storage compression parameters, see <codeph><xref
             href="../sql_commands/CREATE_TABLE.xml">CREATE TABLE</xref></codeph>.</p>
       <table id="table_nyn_wjd_lmb">


### PR DESCRIPTION
Skipvalidation option needs to be used when changing guc gp_add_column_inherits_table_setting.
This is based on KB article https://community.pivotal.io/s/article/gpconfig-failed-GUC-Validation-Failed-xxxxxx-cannot-be-changed-under-normal-condition?language=en_US
If this should not be part of the documentation let me know we can discard this PR.
Opened against 6X_STABLE since GUC is not documented in master branch.