### PR TITLE
Docs: changed path to download netperf

### DIFF
--- a/gpdb-doc/dita/utility_guide/ref/gpcheckperf.xml
+++ b/gpdb-doc/dita/utility_guide/ref/gpcheckperf.xml
@@ -144,7 +144,7 @@ sdw3-1</codeblock>
                     <pd>Specifies that the <codeph>netperf</codeph> binary should be used to perform
                         the network test instead of the Greenplum network test. To use this option,
                         you must download <codeph>netperf</codeph> from <xref
-                            href="http://www.netperf.org" format="html" scope="external"/> and
+                            href="https://github.com/HewlettPackard/netperf" format="html" scope="external"/> and
                         install it into <codeph>$GPHOME/bin/lib</codeph> on all Greenplum hosts
                         (coordinator and segments).</pd>
                 </plentry>
@@ -162,7 +162,7 @@ sdw3-1</codeblock>
                                     (<codeph>N</codeph>) mode, you must run the test on an
                                     <varname>even</varname> number of hosts.<p>If you would rather
                                     use <codeph>netperf</codeph> (<xref
-                                        href="http://www.netperf.org" format="html" scope="external"
+                                        href="https://github.com/HewlettPackard/netperf" format="html" scope="external"
                                     />) instead of the Greenplum network test, you can download it
                                     and install it into <codeph>$GPHOME/bin/lib</codeph> on all
                                     Greenplum hosts (coordinator and segments). You would then specify


### PR DESCRIPTION
netperf has now migrated to github. Updated references to http://www.netperf.org/ with new link https://github.com/HewlettPackard/netperf