### PR TITLE
Updating logs for restricted mode along with gpstart -m

### DIFF
--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpstart.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpstart.py
@@ -210,7 +210,7 @@ class GpStart(GpTestCase):
 
         self.assertEqual([expected_args], self.subject.gp.CoordinatorStart.call_args_list) # assert that the CoordinatorStart function was called with the right arguments
         self.assertEqual(self.mock_userinput.ask_yesno.call_count, 0)
-        self.subject.logger.info.assert_any_call('Starting Coordinator instance in admin mode')
+        self.subject.logger.info.assert_any_call('Starting Coordinator instance in admin and RESTRICTED mode')
         self.subject.logger.info.assert_any_call('Coordinator Started...')
         self.assertEqual(return_code, 0)
 
@@ -233,7 +233,7 @@ class GpStart(GpTestCase):
         self.assertEqual([expected_args], self.subject.gp.CoordinatorStart.call_args_list) # assert that the CoordinatorStart function was called with the right arguments
         self.assertEqual(self.mock_userinput.ask_yesno.call_count, 1)
         self.mock_userinput.ask_yesno.assert_called_once_with(None, '\nContinue with coordinator-only startup', 'N')
-        self.subject.logger.info.assert_any_call('Starting Coordinator instance in admin mode')
+        self.subject.logger.info.assert_any_call('Starting Coordinator instance in admin and RESTRICTED mode')
         self.subject.logger.info.assert_any_call('Coordinator Started...')
         self.assertEqual(return_code, 0)
 

--- a/gpMgmt/bin/gpstart
+++ b/gpMgmt/bin/gpstart
@@ -397,7 +397,10 @@ class GpStart:
 
     ######
     def _startCoordinator(self):
-        logger.info("Starting Coordinator instance in admin mode")
+        if self.restricted:
+            logger.info("Starting Coordinator instance in admin and RESTRICTED mode")
+        else:
+            logger.info("Starting Coordinator instance in admin mode")
 
         cmd = gp.CoordinatorStart('Coordinator in utility mode with restricted set to {0}'.format(self.restricted),
                             self.coordinator_datadir, self.port, self.era, wrapper=self.wrapper,
@@ -407,7 +410,10 @@ class GpStart:
         cmd.run()
 
         if cmd.get_results().rc != 0:
-            logger.fatal("Failed to start Coordinator instance in admin mode")
+            if self.restricted:
+                logger.fatal("Failed to start Coordinator instance in admin and RESTRICTED mode")
+            else:
+                logger.fatal("Failed to start Coordinator instance in admin mode")
             cmd.validate()
 
         logger.info("Obtaining Greenplum Coordinator catalog information")

--- a/gpMgmt/test/behave/mgmt_utils/gpstart.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstart.feature
@@ -41,10 +41,9 @@ Feature: gpstart behave tests
           And gpstart should print unreachable host messages for the down segments
           And the status of the primary on content 0 should be "d"
           And the status of the mirror on content 1 should be "d"
-
           And the cluster is returned to a good state
 
-  @concourse_cluster
+    @concourse_cluster
     @demo_cluster
     Scenario: non-super user 'foouser' can connect to psql database
         Given the database is running

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2021,8 +2021,8 @@ def impl(context, query, dbname, host, port):
 @then('The user runs psql "{psql_cmd}" against database "{dbname}" when utility mode is set to {utility_mode}')
 @given('The user runs psql "{psql_cmd}" against database "{dbname}" when utility mode is set to {utility_mode}')
 def impl(context, psql_cmd, dbname, utility_mode):
-    if utility_mode:
-        cmd = "export PGOPTIONS=\'-c gp_role=utility\'; psql -d \'{}\' {};".format(dbname, psql_cmd)
+    if utility_mode == "True":
+        cmd = "PGOPTIONS=\'-c gp_role=utility\' psql -d \'{}\' {};".format(dbname, psql_cmd)
     else:
         cmd = "psql -d \'{}\' {};".format(dbname, psql_cmd)
 


### PR DESCRIPTION
Restricted mode mentioned in log when using -R option along with gpstart -m.
Updated respective unit tests.

Co-authored-by: Deena Venkatesan <vdeenathayal@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
