### PR TITLE
Docs: added missing column for gp_pgdatabase

### DIFF
--- a/gpdb-doc/dita/ref_guide/system_catalogs/gp_pgdatabase.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/gp_pgdatabase.xml
@@ -52,6 +52,13 @@
                 from 0-<i>N-1</i>, where <i>N</i> is the number of segments in Greenplum Database.</p><p>For the master, the value is -1.</p></entry>
           </row>
           <row>
+            <entry><codeph>valid</codeph></entry>
+            <entry>boolean</entry>
+            <entry>gp_segment_configuration.mode</entry>
+            <entry>Whether or not this instance is up and the mode is either <i>s</i>(synchronized)
+              or <i>n</i> (not in sync). </entry>
+          </row>
+          <row>
             <entry colname="col1">
               <codeph>definedprimary</codeph>
             </entry>


### PR DESCRIPTION
The column 'valid' was missing from gp_pgdatabase.
Updated according to the following explanation:

6X:
If the segment is down, valid is always false.
If the segment is up,
    If the sync mode of the segment (see gp_segment_configuration.mode) is either 's' (synchronized) or 'n' (Not in Sync) then valid = true
    Otherwise, valid = false