### PR TITLE
Reconcile duplicate pg_hba update logic

### DIFF
--- a/gpMgmt/bin/gpinitstandby
+++ b/gpMgmt/bin/gpinitstandby
@@ -15,7 +15,8 @@ try:
     from gppylib import gparray
     from gppylib.db import dbconn
     from gppylib.userinput import *
-    from gppylib.operations.initstandby import cleanup_pg_hba_backup_on_segment, update_pg_hba_conf_on_segments, restore_pg_hba_on_segment
+    from gppylib.operations.initstandby import cleanup_pg_hba_backup_on_segment, restore_pg_hba_on_segment
+    from gppylib.operations.update_pg_hba_on_segments import update_pg_hba_on_segments
     from gppylib.operations.package import SyncPackages
     from gppylib.commands.pg import PgBaseBackup
 except ImportError, e:
@@ -385,12 +386,12 @@ def create_standby(options):
         signal.signal(signal.SIGINT,signal.SIG_IGN)
 
         # update the catalog if needed
+        batch_size = 1
         array = add_standby_to_catalog(options, standby_datadir)
-
         logger.info('Updating pg_hba.conf file...')
         update_pg_hba_conf(options, array)
         logger.debug('Updating pg_hba.conf file on segments...')
-        update_pg_hba_conf_on_segments(array, options.standby_host, options.hba_hostnames)
+        update_pg_hba_on_segments(array, options.standby_host, batch_size)
         logger.info('pg_hba.conf files updated successfully.')
 
         copy_master_datadir_to_standby(options, array, standby_datadir)

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_initstandby.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_initstandby.py
@@ -4,7 +4,8 @@ import os
 import unittest
 
 from gppylib.mainUtils import ExceptionNoStackTraceNeeded
-from gppylib.operations.initstandby import get_standby_pg_hba_info, update_pg_hba, update_pg_hba_conf_on_segments
+from gppylib.operations.initstandby import get_standby_pg_hba_info, update_pg_hba
+from gppylib.operations.update_pg_hba_on_segments import update_pg_hba_on_segments
 from mock import MagicMock, Mock, mock_open, patch
 
 class InitStandbyTestCase(unittest.TestCase):
@@ -41,6 +42,7 @@ class InitStandbyTestCase(unittest.TestCase):
     @patch('gppylib.operations.initstandby.get_standby_pg_hba_info', return_value='standby ip')
     def test_update_pg_hba_on_segments(self, m1, m2):
         mock_segs = []
+        batch_size = 1
         for i in range(6):
             m = Mock()
             m.getSegmentContentId = Mock()
@@ -48,6 +50,6 @@ class InitStandbyTestCase(unittest.TestCase):
             m.getSegmentDataDirectory.return_value = '/tmp/d%d' % i
             mock_segs.append(m)
         gparray = Mock()
-        gparray.getDbList = Mock()
-        gparray.getDbList.return_value = mock_segs 
-        update_pg_hba_conf_on_segments(gparray, 'standby_host') 
+        gparray.getSegmentList = Mock()
+        gparray.getSegmentList.return_value = mock_segs
+        update_pg_hba_on_segments(gparray, 'standby_host', batch_size)

--- a/gpMgmt/bin/gppylib/operations/update_pg_hba_on_segments.py
+++ b/gpMgmt/bin/gppylib/operations/update_pg_hba_on_segments.py
@@ -74,7 +74,7 @@ def update_pg_hba_on_segments(gpArray, hba_hostnames, batch_size,
     update_cmds = []
     for segmentPair in gpArray.getSegmentList():
         # We cannot update the pg_hba.conf which uses ssh for hosts that are unreachable.
-        if segmentPair.primaryDB.unreachable or segmentPair.mirrorDB.unreachable:
+        if segmentPair.primaryDB.unreachable or not segmentPair.mirrorDB or segmentPair.mirrorDB.unreachable:
             continue
         if contents_to_update and not segmentPair.primaryDB.getSegmentContentId() in contents_to_update:
             continue


### PR DESCRIPTION
Removed update_pg_hba_conf_on_segments() which is the old one.
Updated update_pg_hba_on_segments() to handle mirror less host 
Updated test cases accordingly.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
