### PR TITLE
Docs: corrected format for gpmovemirrors input file

### DIFF
--- a/gpdb-doc/dita/best_practices/ha.xml
+++ b/gpdb-doc/dita/best_practices/ha.xml
@@ -424,15 +424,14 @@
           <li>Create an input file for the <codeph>gpmovemirrors</codeph> utility with an entry for
             each mirror that must be moved.<p>The <codeph>gpmovemirrors</codeph> input file has the
               following
-              format:<codeblock><varname>contentID</varname>|<varname>address</varname>|<varname>port</varname>|<varname>data_dir</varname> <varname>new_address</varname>|<varname>port</varname>|<varname>data_dir</varname></codeblock></p>Where
-              <varname>contentID</varname> is the segment instance content ID,
-              <varname>address</varname> is the host name or IP address of the segment host,
+              format:<codeblock><varname>old_address</varname>|<varname>port</varname>|<varname>data_dir</varname> <varname>new_address</varname>|<varname>port</varname>|<varname>data_dir</varname></codeblock></p>Where
+              <varname>old_address</varname> is the host name or IP address of the segment host,
               <varname>port</varname> is the communication port, and <codeph>data_dir</codeph> is
             the segment instance data directory.<p>The following example
                 <codeph>gpmovemirrors</codeph> input file specifies three mirror segments to move.
-              <codeblock>1|sdw2|50001|/data2/mirror/gpseg1 sdw3|50001|/data/mirror/gpseg1
-2|sdw2|50001|/data2/mirror/gpseg2 sdw4|50001|/data/mirror/gpseg2
-3|sdw3|50001|/data2/mirror/gpseg3 sdw1|50001|/data/mirror/gpseg3
+              <codeblock>sdw2|50001|/data2/mirror/gpseg1 sdw3|50001|/data/mirror/gpseg1
+sdw2|50001|/data2/mirror/gpseg2 sdw4|50001|/data/mirror/gpseg2
+sdw3|50001|/data2/mirror/gpseg3 sdw1|50001|/data/mirror/gpseg3
 </codeblock></p></li>
           <li>Run <codeph>gpmovemirrors</codeph> with a command like the
             following:<codeblock>gpmovemirrors -i <varname>mirror_config_file</varname></codeblock></li>


### PR DESCRIPTION
The current documentation is incorrectly indicating that the first column of the input file passed to gpmovemirrors is contentID. This is not a valid field. Removing it and making it consistent with the utility help.