### PR TITLE
Docs gp dispatch gucs

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -2682,8 +2682,8 @@
   <topic id="gp_dispatch_keepalives_count">
     <title>gp_dispatch_keepalives_count</title>
     <body>
-      <p>Maximum number of TCP keepalive retransmits from Greenplum Query Dispatcher to its Query
-        Executors QD. It controls the number of consecutive keepalive retransmits that can be lost
+      <p>Maximum number of TCP keepalive retransmits from a Greenplum Query Dispatcher to its Query
+        Executors. It controls the number of consecutive keepalive retransmits that can be lost
         before a connection between a Query Dispatcher and a Query Executor is considered dead.</p>
       <table id="table_orj_wng_rrb">
         <tgroup cols="3">
@@ -2701,7 +2701,7 @@
             <row>
               <entry colname="col1">0 to 127</entry>
               <entry colname="col2">0 (it uses the system default)</entry>
-              <entry colname="col3">master<p>session</p><p>reload</p></entry>
+              <entry colname="col3">local<p>system</p><p>restart</p></entry>
             </row>
           </tbody>
         </tgroup>
@@ -2711,8 +2711,8 @@
   <topic id="gp_dispatch_keepalives_idle">
     <title>gp_dispatch_keepalives_idle</title>
     <body>
-      <p>Time in seconds between issuing TCP keepalives from Greenplum Query Dispatcher to its Query
-        Executors.</p>
+      <p>Time in seconds between issuing TCP keepalives from a Greenplum Query Dispatcher to its
+        Query Executors.</p>
       <table id="table_pwn_wng_rrb">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
@@ -2729,7 +2729,7 @@
             <row>
               <entry colname="col1">0 to 32767</entry>
               <entry colname="col2">0  (it uses the system default)</entry>
-              <entry colname="col3">master<p>session</p><p>reload</p></entry>
+              <entry colname="col3">local<p>system</p><p>restart</p></entry>
             </row>
           </tbody>
         </tgroup>
@@ -2739,7 +2739,7 @@
   <topic id="gp_dispatch_keepalives_interval">
     <title>gp_dispatch_keepalives_interval</title>
     <body>
-      <p>Time in seconds between TCP keepalive retransmits from Greenplum Query Dispatcher to its
+      <p>Time in seconds between TCP keepalive retransmits from a Greenplum Query Dispatcher to its
         Query Executors.</p>
       <table id="table_jpq_wng_rrb">
         <tgroup cols="3">
@@ -2757,7 +2757,7 @@
             <row>
               <entry colname="col1">0 to 32767</entry>
               <entry colname="col2">0  (it uses the system default)</entry>
-              <entry colname="col3">master<p>session</p><p>reload</p></entry>
+              <entry colname="col3">local<p>system</p><p>restart</p></entry>
             </row>
           </tbody>
         </tgroup>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -2701,7 +2701,7 @@
             <row>
               <entry colname="col1">0 to 127</entry>
               <entry colname="col2">0 (it uses the system default)</entry>
-              <entry colname="col3">local<p>system</p><p>restart</p></entry>
+              <entry colname="col3">master<p>system</p><p>restart</p></entry>
             </row>
           </tbody>
         </tgroup>
@@ -2729,7 +2729,7 @@
             <row>
               <entry colname="col1">0 to 32767</entry>
               <entry colname="col2">0  (it uses the system default)</entry>
-              <entry colname="col3">local<p>system</p><p>restart</p></entry>
+              <entry colname="col3">master<p>system</p><p>restart</p></entry>
             </row>
           </tbody>
         </tgroup>
@@ -2757,7 +2757,7 @@
             <row>
               <entry colname="col1">0 to 32767</entry>
               <entry colname="col2">0  (it uses the system default)</entry>
-              <entry colname="col3">local<p>system</p><p>restart</p></entry>
+              <entry colname="col3">master<p>system</p><p>restart</p></entry>
             </row>
           </tbody>
         </tgroup>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -193,6 +193,15 @@
               <xref href="#gp_default_storage_options"/>
             </li>
             <li>
+              <xref href="#gp_dispatch_keepalives_count"/>
+            </li>
+            <li>
+              <xref href="#gp_dispatch_keepalives_idle"/>
+            </li>
+            <li>
+              <xref href="#gp_dispatch_keepalives_interval"/>
+            </li>
+            <li>
               <xref href="#gp_dynamic_partition_pruning"/>
             </li>
             <li>
@@ -2668,6 +2677,91 @@
       <note>
         <sup>2</sup>QuickLZ compression is available only in the commercial release of Tanzu
         Greenplum.</note>
+    </body>
+  </topic>
+  <topic id="gp_dispatch_keepalives_count">
+    <title>gp_dispatch_keepalives_count</title>
+    <body>
+      <p>Maximum number of TCP keepalive retransmits from Greenplum Query Dispatcher to its Query
+        Executors QD. It controls the number of consecutive keepalive retransmits that can be lost
+        before a connection between a Query Dispatcher and a Query Executor is considered dead.</p>
+      <table id="table_orj_wng_rrb">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">0 to 127</entry>
+              <entry colname="col2">0 (it uses the system default)</entry>
+              <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="gp_dispatch_keepalives_idle">
+    <title>gp_dispatch_keepalives_idle</title>
+    <body>
+      <p>Time in seconds between issuing TCP keepalives from Greenplum Query Dispatcher to its Query
+        Executors.</p>
+      <table id="table_pwn_wng_rrb">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">0 to 32767</entry>
+              <entry colname="col2">0  (it uses the system default)</entry>
+              <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="gp_dispatch_keepalives_interval">
+    <title>gp_dispatch_keepalives_interval</title>
+    <body>
+      <p>Time in seconds between TCP keepalive retransmits from Greenplum Query Dispatcher to its
+        Query Executors.</p>
+      <table id="table_jpq_wng_rrb">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">0 to 32767</entry>
+              <entry colname="col2">0  (it uses the system default)</entry>
+              <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
     </body>
   </topic>
   <topic id="gp_dynamic_partition_pruning">

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -77,6 +77,18 @@
                   >gp_connection_send_timeout</xref>
               </p>
               <p>
+                <xref href="guc-list.xml#gp_dispatch_keepalives_count" type="section"
+                  >gp_dispatch_keepalives_count</xref>
+              </p>
+              <p>
+                <xref href="guc-list.xml#gp_dispatch_keepalives_idle" type="section"
+                  >gp_dispatch_keepalives_idle</xref>
+              </p>
+              <p>
+                <xref href="guc-list.xml#gp_dispatch_keepalives_interval" type="section"
+                  >gp_dispatch_keepalives_interval</xref>
+              </p>              
+              <p>
                 <xref href="guc-list.xml#gp_vmem_idle_resource_timeout" type="section"
                   >gp_vmem_idle_resource_timeout</xref>
               </p>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -87,6 +87,9 @@
             <topicref href="guc-list.xml#gp_dbid"/>
             <topicref href="guc-list.xml#gp_debug_linger"/>
             <topicref href="guc-list.xml#gp_default_storage_options"/>
+            <topicref href="guc-list.xml#gp_dispatch_keepalives_count"/>
+            <topicref href="guc-list.xml#gp_dispatch_keepalives_idle"/>
+            <topicref href="guc-list.xml#gp_dispatch_keepalives_interval"/>
             <topicref href="guc-list.xml#gp_dynamic_partition_pruning"/>
             <topicref href="guc-list.xml#gp_enable_agg_distinct"/>
             <topicref href="guc-list.xml#gp_enable_agg_distinct_pruning"/>


### PR DESCRIPTION
Documented three new GUCs: gp_dispatch_keepalives_idle, gp_dispatch_keepalives_interval, gp_dispatch_keepalives_count to tune TCP keepalives for QD/QE libpq connections.
I have based the Set Classification values on the same ones as tcp_keepalives_idle, tcp_keepalives_interval, tcp_keepalives_count.
Preview site:
https://mireia-gucs.sc2-04-pcf1-apps.oc.vmware.com/7-0/ref_guide/config_params/guc-list.html#gp_dispatch_keepalives_count