### PR TITLE
6X: Disable pg_upgrade check for line datatypes

### DIFF
--- a/contrib/pg_upgrade/check.c
+++ b/contrib/pg_upgrade/check.c
@@ -153,9 +153,14 @@ check_and_dump_old_cluster(bool live_check, char **sequence_script_file_name)
 				old_8_3_create_sequence_script(&old_cluster);
 		}
 	}
+#if 0
+	/*
+	 * GPDB 5 does not support the line datatype.
+	 */
 	/* Pre-PG 9.4 had a different 'line' data type internal format */
 	if (GET_MAJOR_VERSION(old_cluster.major_version) <= 903)
 		old_9_3_check_for_line_data_type_usage(&old_cluster);
+#endif
 
 #if 0
 	/*

--- a/contrib/pg_upgrade/pg_upgrade.h
+++ b/contrib/pg_upgrade/pg_upgrade.h
@@ -590,8 +590,12 @@ void		pg_putenv(const char *var, const char *val);
 void new_9_0_populate_pg_largeobject_metadata(ClusterInfo *cluster,
 										 bool check_mode);
 #endif
+#if 0
+/*
+ * GPDB 5 does not support the line datatype.
+ */
 void old_9_3_check_for_line_data_type_usage(ClusterInfo *cluster);
-
+#endif
 /* version_old_8_3.c */
 
 void		old_8_3_check_for_name_data_type_usage(ClusterInfo *cluster);

--- a/contrib/pg_upgrade/version.c
+++ b/contrib/pg_upgrade/version.c
@@ -102,6 +102,19 @@ new_9_0_populate_pg_largeobject_metadata(ClusterInfo *cluster, bool check_mode)
 
 #endif
 
+#if 0
+/*
+ * GPDB: This is dead code as the only erstwhile caller is
+ * old_9_3_check_for_line_data_type_usage(), which is not applicable to upgrades
+ * from GPDB 5. See old_9_3_check_for_line_data_type_usage() for details.
+ *
+ * Besides, this makes use of a recursive CTE, which will result in:
+ * ERROR:  RECURSIVE option in WITH clause is not supported
+ * when executed on a source 5X cluster.
+ *
+ * To make use of this function for things like the name datatype for instance,
+ * we would need to rewrite the query.
+ */
 /*
  * check_for_data_type_usage
  *	Detect whether there are any stored columns depending on the given type
@@ -226,8 +239,12 @@ check_for_data_type_usage(ClusterInfo *cluster, const char *typename,
 
 	return found;
 }
+#endif
 
-
+#if 0
+/*
+ * GPDB 5 does not support the line datatype.
+ */
 /*
  * old_9_3_check_for_line_data_type_usage()
  *	9.3 -> 9.4
@@ -258,3 +275,4 @@ old_9_3_check_for_line_data_type_usage(ClusterInfo *cluster)
 	else
 		check_ok();
 }
+#endif


### PR DESCRIPTION
This check is not necessary for a 5X->6X upgrade, as we don't support
the line datatype in 5X. Recently, the 9_4_STABLE merge commit
af96694494c, brought in upstream fixes 235a52ca0f2 and 56c06999d3c,
which added a recursive CTE to search for the line datatype in
composite types, domains, arrays and ranges. A recursive CTE, when
executed on a 5X cluster results in:
ERROR:  RECURSIVE option in WITH clause is not supported

So, in this commit we compile these functions out.

Co-authored-by: Ashwin Agrawal <aashwin@vmware.com>
