### PR TITLE
Remove stale assertion in ORCA

### DIFF
--- a/src/backend/gporca/libgpopt/src/xforms/CSubqueryHandler.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CSubqueryHandler.cpp
@@ -1429,13 +1429,6 @@ CSubqueryHandler::FRemoveAnySubquery(CExpression *pexprOuter,
 #ifdef GPOS_DEBUG
 	AssertValidArguments(mp, pexprOuter, pexprSubquery, ppexprNewOuter,
 						 ppexprResidualScalar);
-	COperator *popSubqChild = (*pexprSubquery)[0]->Pop();
-	GPOS_ASSERT_IMP(
-		COperator::EopLogicalConstTableGet == popSubqChild->Eopid(),
-		0 == CLogicalConstTableGet::PopConvert(popSubqChild)
-					->Pdrgpdrgpdatum()
-					->Size() &&
-			"Constant subqueries must be unnested during preprocessing");
 #endif	// GPOS_DEBUG
 
 	CScalarSubqueryAny *pScalarSubqAny =
@@ -1600,13 +1593,6 @@ CSubqueryHandler::FRemoveAllSubquery(CExpression *pexprOuter,
 #ifdef GPOS_DEBUG
 	AssertValidArguments(mp, pexprOuter, pexprSubquery, ppexprNewOuter,
 						 ppexprResidualScalar);
-	COperator *popSubqChild = (*pexprSubquery)[0]->Pop();
-	GPOS_ASSERT_IMP(
-		COperator::EopLogicalConstTableGet == popSubqChild->Eopid(),
-		0 == CLogicalConstTableGet::PopConvert(popSubqChild)
-					->Pdrgpdrgpdatum()
-					->Size() &&
-			"Constant subqueries must be unnested during preprocessing");
 #endif	// GPOS_DEBUG
 
 	if (m_fEnforceCorrelatedApply)

--- a/src/backend/gporca/server/include/unittest/gpopt/xforms/CSubqueryHandlerTest.h
+++ b/src/backend/gporca/server/include/unittest/gpopt/xforms/CSubqueryHandlerTest.h
@@ -43,7 +43,6 @@ public:
 	static GPOS_RESULT EresUnittest_Subquery2Apply();
 	static GPOS_RESULT EresUnittest_Subquery2OrTree();
 	static GPOS_RESULT EresUnittest_Subquery2AndTree();
-	static GPOS_RESULT EresUnittest_SubqueryWithConstSubqueries();
 	static GPOS_RESULT EresUnittest_SubqueryWithDisjunction();
 	static GPOS_RESULT EresUnittest_RunMinidumpTests();
 

--- a/src/backend/gporca/server/src/unittest/gpopt/xforms/CSubqueryHandlerTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/xforms/CSubqueryHandlerTest.cpp
@@ -53,10 +53,6 @@ CSubqueryHandlerTest::EresUnittest()
 		GPOS_UNITTEST_FUNC(
 			CSubqueryHandlerTest::EresUnittest_SubqueryWithDisjunction),
 		GPOS_UNITTEST_FUNC(CSubqueryHandlerTest::EresUnittest_RunMinidumpTests),
-#ifdef GPOS_DEBUG
-		GPOS_UNITTEST_FUNC_ASSERT(
-			CSubqueryHandlerTest::EresUnittest_SubqueryWithConstSubqueries),
-#endif	// GPOS_DEBUG
 	};
 
 	return CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
@@ -194,92 +190,6 @@ CSubqueryHandlerTest::EresUnittest_Subquery2Apply()
 	xform_set->Release();
 
 	return GPOS_OK;
-}
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CSubqueryHandlerTest::EresUnittest_SubqueryWithConstSubqueries
-//
-//	@doc:
-//		Test of subquery handler for ALL subquery over const table get
-//
-//---------------------------------------------------------------------------
-GPOS_RESULT
-CSubqueryHandlerTest::EresUnittest_SubqueryWithConstSubqueries()
-{
-	CAutoMemoryPool amp;
-	CMemoryPool *mp = amp.Pmp();
-
-	// setup a file-based provider
-	CMDProviderMemory *pmdp = CTestUtils::m_pmdpf;
-	pmdp->AddRef();
-
-	// we need to use an auto pointer for the cache here to ensure
-	// deleting memory of cached objects when we throw
-	CAutoP<CMDAccessor::MDCache> apcache;
-	apcache =
-		CCacheFactory::CreateCache<gpopt::IMDCacheObject *, gpopt::CMDKey *>(
-			true,  // fUnique
-			0 /* unlimited cache quota */, CMDKey::UlHashMDKey,
-			CMDKey::FEqualMDKey);
-
-	CMDAccessor::MDCache *pcache = apcache.Value();
-
-	{
-		CMDAccessor mda(mp, pcache, CTestUtils::m_sysidDefault, pmdp);
-
-		// install opt context in TLS
-		CAutoOptCtxt aoc(mp, &mda, NULL, /* pceeval */
-						 CTestUtils::GetCostModel(mp));
-
-		// create a subquery with const table get expression
-		CExpression *pexpr =
-			CSubqueryTestUtils::PexprSubqueryWithDisjunction(mp);
-		CXform *pxform = CXformFactory::Pxff()->Pxf(CXform::ExfSelect2Apply);
-
-		CWStringDynamic str(mp);
-		COstreamString oss(&str);
-
-		oss << std::endl << "EXPRESSION:" << std::endl << *pexpr << std::endl;
-
-		CExpression *pexprLogical = (*pexpr)[0];
-		CExpression *pexprScalar = (*pexpr)[1];
-		oss << std::endl
-			<< "LOGICAL:" << std::endl
-			<< *pexprLogical << std::endl;
-		oss << std::endl << "SCALAR:" << std::endl << *pexprScalar << std::endl;
-
-		GPOS_TRACE(str.GetBuffer());
-		str.Reset();
-
-		CXformContext *pxfctxt = GPOS_NEW(mp) CXformContext(mp);
-		CXformResult *pxfres = GPOS_NEW(mp) CXformResult(mp);
-
-		// calling the xform to perform subquery to Apply transformation;
-		// xform must fail since we do not expect constant subqueries
-		pxform->Transform(pxfctxt, pxfres, pexpr);
-		CExpression *pexprResult = pxfres->PexprNext();
-
-		oss << std::endl
-			<< "NEW LOGICAL:" << std::endl
-			<< *((*pexprResult)[0]) << std::endl;
-		oss << std::endl
-			<< "RESIDUAL SCALAR:" << std::endl
-			<< *((*pexprResult)[1]) << std::endl;
-
-		GPOS_TRACE(str.GetBuffer());
-		str.Reset();
-
-		pxfres->Release();
-		pxfctxt->Release();
-		pexpr->Release();
-	}
-
-	// This test checks for an assert in CSubqueryHandler::FRemoveAnySubquery that
-	// will trigger for the subquery we created above. If we reach here, the test
-	// has failed, since the assert didn't trigger (note that this means that this
-	// test will likely fail in a retail build).
-	return GPOS_FAILED;
 }
 
 //---------------------------------------------------------------------------

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -827,17 +827,28 @@ select * from
   (3 not in (select * from (values (1), (2)) ss1)),
   (false)
 ) ss;
-                  QUERY PLAN                  
-----------------------------------------------
- Values Scan on "*VALUES*"
-   Output: "*VALUES*".column1
-   SubPlan 1
-     ->  Materialize
-           Output: "*VALUES*_1".column1
-           ->  Values Scan on "*VALUES*_1"
-                 Output: "*VALUES*_1".column1
- Optimizer: Postgres query optimizer
-(8 rows)
+                                                                                                                                                                  QUERY PLAN                                                                                                                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Result
+         Output: ((CASE WHEN ((sum((CASE WHEN (3 = column1) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN (column1 IS NULL) THEN 1 ELSE 0 END))) > 0::bigint) THEN NULL::boolean WHEN (3 IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN (3 = column1) THEN 1 ELSE 0 END))) = 0::bigint) THEN true ELSE false END) = true)
+         ->  Nested Loop Left Join
+               Output: (CASE WHEN ((sum((CASE WHEN (3 = column1) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN (column1 IS NULL) THEN 1 ELSE 0 END))) > 0::bigint) THEN NULL::boolean WHEN (3 IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN (3 = column1) THEN 1 ELSE 0 END))) = 0::bigint) THEN true ELSE false END)
+               Join Filter: true
+               ->  Result
+                     Output: true
+               ->  Result
+                     Output: CASE WHEN ((sum((CASE WHEN (3 = column1) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN (column1 IS NULL) THEN 1 ELSE 0 END))) > 0::bigint) THEN NULL::boolean WHEN (3 IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN (3 = column1) THEN 1 ELSE 0 END))) = 0::bigint) THEN true ELSE false END
+                     ->  Aggregate
+                           Output: sum((CASE WHEN (3 = column1) THEN 1 ELSE 0 END)), sum((CASE WHEN (column1 IS NULL) THEN 1 ELSE 0 END))
+                           ->  Result
+                                 Output: CASE WHEN (3 = column1) THEN 1 ELSE 0 END, CASE WHEN (column1 IS NULL) THEN 1 ELSE 0 END
+                                 ->  Values Scan on "Values"
+                                       Output: column1
+   ->  Result
+         Output: false
+ Optimizer: Pivotal Optimizer (GPORCA)
+(19 rows)
 
 select * from
 (values


### PR DESCRIPTION
Commit bc4a66ebba9 in repo gp-qp-orca removed code in the preprocessor
that converted an ANY/ALL subquery with child CLogicalConstTableGet
into a disjunction (conjunction) of equalities.  After that code was
removed assertions in FRemoveAnySubquery and FRemoveAllSubquery became
invalid.

Commit eb9d1f0504a contained in Postgres 9.4.26 merge (commit
af96694494c) exposed this invalid assertion.
