### PR TITLE
Fix index corruption when invalid snapshot used with AO tables.

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -496,13 +496,15 @@ aocs_beginscan(Relation relation,
 	RelationIncrementReferenceCount(relation);
 
 	/*
-	 * the append-only meta data should never be fetched with
+	 * The append-only meta data should never be fetched with
 	 * SnapshotAny as bogus results are returned.
+	 * We use SnapshotSelf for metadata, as regular MVCC snapshot can hide newly
+	 * globally inserted tuples from global index build process.
 	 */
 	if (snapshot != SnapshotAny)
 		aocsMetaDataSnapshot = snapshot;
 	else
-		aocsMetaDataSnapshot = GetTransactionSnapshot();
+		aocsMetaDataSnapshot = SnapshotSelf;
 
 	seginfo = GetAllAOCSFileSegInfo(relation, aocsMetaDataSnapshot, &total_seg);
 	return aocs_beginscan_internal(relation,

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -1666,10 +1666,12 @@ appendonly_beginscan(Relation relation,
 	if (appendOnlyMetaDataSnapshot == SnapshotAny)
 	{
 		/*
-		 * the append-only meta data should never be fetched with
+		 * The append-only meta data should never be fetched with
 		 * SnapshotAny as bogus results are returned.
+		 * We use SnapshotSelf for metadata, as regular MVCC snapshot can hide
+		 * newly globally inserted tuples from global index build process.
 		 */
-		appendOnlyMetaDataSnapshot = GetTransactionSnapshot();
+		appendOnlyMetaDataSnapshot = SnapshotSelf;
 	}
 
 	/*

--- a/src/test/isolation2/input/uao/snapshot_index_corruption.source
+++ b/src/test/isolation2/input/uao/snapshot_index_corruption.source
@@ -1,0 +1,35 @@
+-- @Description Test index corruption when invalid snapshot used.
+--
+-- Create AO table, insert few rows on it.
+drop table if exists test_ao;
+create table test_ao(i bigint) using @amname@ distributed by (i);
+insert into test_ao select generate_series(1,100);
+-- Test 1
+-- Begin single-insert transaction.
+1: begin;
+1: insert into test_ao values(101);
+-- Try to create index, it should hold on lock before commit below.
+2&: create index test_ao_idx on test_ao(i);
+-- Commit single-insert transaction, so index continues creation.
+1: commit;
+-- Force index usage and check row is here (false before fix).
+2<:
+2: set optimizer=off;
+2: set enable_seqscan=off;
+2: explain (costs off) select i from test_ao where i = 101;
+2: select i from test_ao where i = 101;
+
+-- Test 2
+-- Drop incomplete index
+1: drop index test_ao_idx;
+-- Check row is here and start repeatable read transaction.
+2: select i from test_ao where i = 100;
+2: begin;
+2: set transaction isolation level repeatable read;
+2: select 1;
+-- Update row selected above and create new index
+1: update test_ao set i = 200 where i = 100;
+1: create index test_ao_idx on test_ao(i);
+-- For the repeatable read isolation level row still there.
+2: explain (costs off) select i from test_ao where i = 100;
+2: select i from test_ao where i = 100;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -132,6 +132,7 @@ test: uao/select_while_vacuum_serializable2_row
 test: uao/selectinsert_while_vacuum_row
 test: uao/selectinsertupdate_while_vacuum_row
 test: uao/selectupdate_while_vacuum_row
+test: uao/snapshot_index_corruption_row
 test: uao/update_while_vacuum_row
 test: uao/vacuum_self_serializable_row
 test: uao/vacuum_self_serializable2_row
@@ -182,6 +183,7 @@ test: uao/select_while_vacuum_serializable2_column
 test: uao/selectinsert_while_vacuum_column
 test: uao/selectinsertupdate_while_vacuum_column
 test: uao/selectupdate_while_vacuum_column
+test: uao/snapshot_index_corruption_column
 test: uao/update_while_vacuum_column
 test: uao/vacuum_self_serializable_column
 test: uao/vacuum_self_serializable2_column

--- a/src/test/isolation2/output/uao/snapshot_index_corruption.source
+++ b/src/test/isolation2/output/uao/snapshot_index_corruption.source
@@ -1,0 +1,83 @@
+-- @Description Test index corruption when invalid snapshot used.
+--
+-- Create AO table, insert few rows on it.
+drop table if exists test_ao;
+DROP
+create table test_ao(i bigint) using @amname@ distributed by (i);
+CREATE
+insert into test_ao select generate_series(1,100);
+INSERT 100
+-- Test 1
+-- Begin single-insert transaction.
+1: begin;
+BEGIN
+1: insert into test_ao values(101);
+INSERT 1
+-- Try to create index, it should hold on lock before commit below.
+2&: create index test_ao_idx on test_ao(i);  <waiting ...>
+-- Commit single-insert transaction, so index continues creation.
+1: commit;
+COMMIT
+-- Force index usage and check row is here (false before fix).
+2<:  <... completed>
+CREATE
+2: set optimizer=off;
+SET
+2: set enable_seqscan=off;
+SET
+2: explain (costs off) select i from test_ao where i = 101;
+ QUERY PLAN                                   
+----------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)     
+   ->  Bitmap Heap Scan on test_ao            
+         Recheck Cond: (i = 101)              
+         ->  Bitmap Index Scan on test_ao_idx 
+               Index Cond: (i = 101)          
+ Optimizer: Postgres query optimizer          
+(6 rows)
+2: select i from test_ao where i = 101;
+ i   
+-----
+ 101 
+(1 row)
+
+-- Test 2
+-- Drop incomplete index
+1: drop index test_ao_idx;
+DROP
+-- Check row is here and start repeatable read transaction.
+2: select i from test_ao where i = 100;
+ i   
+-----
+ 100 
+(1 row)
+2: begin;
+BEGIN
+2: set transaction isolation level repeatable read;
+SET
+2: select 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+-- Update row selected above and create new index
+1: update test_ao set i = 200 where i = 100;
+UPDATE 1
+1: create index test_ao_idx on test_ao(i);
+CREATE
+-- For the repeatable read isolation level row still there.
+2: explain (costs off) select i from test_ao where i = 100;
+ QUERY PLAN                                   
+----------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)     
+   ->  Bitmap Heap Scan on test_ao            
+         Recheck Cond: (i = 100)              
+         ->  Bitmap Index Scan on test_ao_idx 
+               Index Cond: (i = 100)          
+ Optimizer: Postgres query optimizer          
+(6 rows)
+2: select i from test_ao where i = 100;
+ i   
+-----
+ 100 
+(1 row)


### PR DESCRIPTION
Using of regular MVCC snapshot to access AO-tables metadata may cause index building (performed globally) inconsistency, because tuples inserted (the same globally) at another opened transactions are not visible.

Commit fixes such behavior using SnapshotSelf for metadata access. Additional isolation test shows how to reproduce the bug before the fix.

Via #12797
___________________


Second test is not actual, because we already use SnapshotAny for data access, but I decided to keep it.
