### PR TITLE
Docs: removed reference to update pg_class

### DIFF
--- a/gpdb-doc/dita/best_practices/data_loading.xml
+++ b/gpdb-doc/dita/best_practices/data_loading.xml
@@ -149,11 +149,6 @@ Segment 12 - gpfdist 4</screen></p>
             <codeph>gp_autostats_mode</codeph> configuration parameter to
           <codeph>NONE</codeph>.</li>
         <li>External tables are not intended for frequent or ad hoc access.</li>
-        <li>External tables have no statistics to inform the optimizer. You can set rough estimates
-          for the number of rows and disk pages for the external table in the
-            <codeph>pg_class</codeph> system catalog with a statement like the
-          following:<codeblock>UPDATE pg_class SET reltuples=400000, relpages=400
-WHERE relname='myexttable';</codeblock></li>
         <li>When using <codeph>gpfdist</codeph>, maximize network bandwidth by running one
             <codeph>gpfdist</codeph> instance for each NIC on the ETL server. Divide the source data
           evenly between the <codeph>gpfdist</codeph> instances.</li>


### PR DESCRIPTION
Section https://greenplum.docs.pivotal.io/6-18/best_practices/data_loading.html was recommending users to update `pg_class` to set rough estimates for external table statistics. Updating catalog tables is not best practices so we are removing the section.