### PR TITLE
add gpload input newline config

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -114,6 +114,7 @@ valid_tokens = {
     "delimiter": {'parse_children': True, 'parent': "input"},
     "escape": {'parse_children': True, 'parent': "input"},
     "null_as": {'parse_children': True, 'parent': "input"},
+    "newline": {'parse_children': True, 'parent': "input"},
     "quote": {'parse_children': True, 'parent': "input"},
     "encoding": {'parse_children': True, 'parent': "input"},
     "force_not_null": {'parse_children': False, 'parent': "input"},
@@ -373,6 +374,7 @@ keywords = {
 	"natural": True,
 	"nchar": True,
 	"new": True,
+	"newline": True,
 	"next": True,
 	"no": True,
 	"nocreatedb": True,
@@ -2410,6 +2412,10 @@ class gpload:
         if formatType=='csv':
             self.get_external_table_formatOpts('quote')
 
+        newline = self.getconfig('gpload:input:newline', unicode, False)
+        self.log(self.DEBUG, "newline " + unicode(newline))
+        if newline != False: # could be empty string
+            self.formatOpts += "newline %s " % quote_no_slash(newline)
         if self.getconfig('gpload:input:header',bool,False) and not self.use_customfmt: #TODO:text_in format not support header now
             self.formatOpts += "header "
             self.reuse_tbl_Opts += "header "

--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -2412,10 +2412,6 @@ class gpload:
         if formatType=='csv':
             self.get_external_table_formatOpts('quote')
 
-        newline = self.getconfig('gpload:input:newline', unicode, False)
-        self.log(self.DEBUG, "newline " + unicode(newline))
-        if newline != False: # could be empty string
-            self.formatOpts += "newline %s " % quote_no_slash(newline)
         if self.getconfig('gpload:input:header',bool,False) and not self.use_customfmt: #TODO:text_in format not support header now
             self.formatOpts += "header "
             self.reuse_tbl_Opts += "header "
@@ -2436,6 +2432,16 @@ class gpload:
                     self.control_file_error("gpload:input:force_not_null must be a YAML sequence of strings")
             self.formatOpts += "force not null %s " % ','.join(force_not_null_columns) #only for csv
             self.reuse_tbl_Opts += "force not null %s " % ','.join(force_not_null_columns)
+
+        newline = self.getconfig('gpload:input:newline', unicode, False)
+        self.log(self.DEBUG, "newline " + unicode(newline))
+        if newline != False: # could be empty string
+            if self.use_customfmt:
+                self.formatOpts += ', newline=%s' % quote_no_slash(newline)
+                self.reuse_tbl_Opts += "newline %s " % quote_no_slash(newline)
+            else:
+                self.formatOpts += "newline %s " % quote_no_slash(newline)
+                self.reuse_tbl_Opts += "newline %s " % quote_no_slash(newline)
 
         encodingCode = None
         encodingStr = self.getconfig('gpload:input:encoding', unicode, None)

--- a/gpMgmt/doc/gpload_help
+++ b/gpMgmt/doc/gpload_help
@@ -213,6 +213,8 @@ GPLOAD:
     - ERROR_LIMIT: <integer>
     - ERROR_TABLE: <schema>.<table_name>
     - LOG_ERRORS: true | false
+     - NEWLINE: 'LF' | 'CR' | 'CRLF'
+
    EXTERNAL:
     - SCHEMA: <schema> | '%'
    OUTPUT:
@@ -366,6 +368,13 @@ DELIMITER - Optional. Specifies a single ASCII character that separates columns
             "\u001B". The escape string syntax, E'<character-code>', is also
             supported for non-printable characters. The ASCII or unicode character
             must be enclosed in single quotes. For example: E'\x1B' or E'\u001B'. 
+
+NEWLINE - Optional. Specifies the newline used in your data files – LF
+          (Line feed, 0x0A), CR (Carriage return, 0x0D), or CRLF
+          (Carriage return plus line feed, 0x0D 0x0A). If not
+          specified, a Greenplum Database segment will detect the
+          newline type by looking at the first row of data it receives
+          and using the first newline type encountered.
 
 ESCAPE - Specifies the single character that is used for C escape sequences
         (such as \n,\t,\100, and so on) and for escaping data characters 


### PR DESCRIPTION
backport pr #12739 in master to 5X
Introduce an optional NEWLINE gpload INPUT configuration. This
configuration will in turn be passed to the create external table
FORMAT configuration.

An example of this usage is for the handling of DOS formatted
files (CRLF terminated lines). If used, instead of erroring out, we
can now load data with embedded CR or LF characters in text fields. To
allow this, an optional line termination NEWLINE field ('CR', 'LF',
'CRLF') has been introduced into the gpload INPUT configuration.

The gplaod REUSE_TABLES option is also supported.

The change validates with CSV and TXT file formats.

The change validates an error is received when using an unsupported
NEWLINE value.

The change adds the ability to specify "None" for the 'delimiter' test
configuration. This allows a CSV testing to generate a config file
without a DELIMITER value thus using the default "," value.

Additionally, here are the recommended GP doc gpload utility reference
updates:

CONFIG FILE FORMAT
```
GPLOAD:
   INPUT:

    - NEWLINE: 'LF' | 'CR' | 'CRLF'
```
GPLOAD
INPUT
```
    NEWLINE

      Specifies the newline used in your data files – LF (Line feed,
      0x0A), CR (Carriage return, 0x0D), or CRLF (Carriage return plus
      line feed, 0x0D 0x0A). If not specified, a Greenplum Database
      segment will detect the newline type by looking at the first row
      of data it receives and using the first newline type
      encountered.
```
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
