### PR TITLE
cli_cross_subnet failing on 6X_STABLE pipeline

### DIFF
--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -2454,8 +2454,12 @@ jobs:
           output_mapping:
             cluster_env_files: cluster_2
     - task: exchange_keys
-      image: alpine-docker
       config:
+        image_resource:
+          type: registry-image
+          source:
+            repository: centos
+            tag: 7
         platform: linux
         inputs:
           - name: cluster_1
@@ -2465,8 +2469,7 @@ jobs:
           args:
             - -exc
             - |
-              apk add --update --no-progress openssh-client
-
+              yum install --quiet -y openssh-clients
               opts="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i cluster_1/private_key.pem"
               while read -r ip host extra; do
                   scp $opts cluster_2/.ssh/*private_key.pem gpadmin@"$ip":~/.ssh/


### PR DESCRIPTION
ssh and scl commands failing during cli_cross_subnet execution with
error. "Unable to negotiate with 10.0.43.106 port 22: no matching host key type found.
Their offer: ssh-rsa,ssh-dss lost connection"

This could be an issue with OpenSSH (7.0 and greater).OpenSSH implements all of the
cryptographic algorithms needed for compatibility with standards-compliant SSH implementations,
but since some of the older algorithms have been found to be weak, not all of them are
enabled by default.  We can avoid this failures by using below flags while running ssh/scp commands.

HostKeyAlgorithms=+ssh-dss and PubkeyAcceptedKeyTypes=+ssh-rsa

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
