### PR TITLE
6X: Authenticate internal connections via domain sockets

### DIFF
--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -331,64 +331,51 @@ internal_client_authentication(Port *port)
 {
 	if (IS_QUERY_DISPATCHER())
 	{
-		/* 
+		/*
 		 * The entry-DB (or QE at the master) case.
 		 *
 		 * The goal here is to block network connection from out of
 		 * master to master db with magic bit packet.
 		 * So, only when it comes from the same host, the connection
-		 * is authenticated, if this connection is TCP/UDP. We
-		 * don't assume the connection is via unix domain socket,
-		 * but if it comes, just authenticate it. We'll need to
-		 * verify user on UDS case, but for now we don't do too much
-		 * for the goal described above.
+		 * is authenticated, if this connection is TCP/UDP.
+		 *
+		 * If unix domain socket comes, just authenticate it.
 		 */
-		if(port->raddr.addr.ss_family == AF_INET
+		if (port->raddr.addr.ss_family == AF_INET
 #ifdef HAVE_IPV6
-				|| port->raddr.addr.ss_family == AF_INET6
+			|| port->raddr.addr.ss_family == AF_INET6
 #endif   /* HAVE_IPV6 */
-			   )
+		   )
 		{
-			if (check_same_host_or_net(&port->raddr, ipCmpSameHost) &&
-				!gp_reject_internal_tcp_conn)
+			if (check_same_host_or_net(&port->raddr, ipCmpSameHost))
 			{
-				elog(DEBUG1, "received same host internal TCP connection");
-				FakeClientAuthentication(port);
+				if (gp_reject_internal_tcp_conn)
+				{
+					elog(DEBUG1, "rejecting TCP connection to master using internal"
+						 "connection protocol, because the GUC gp_reject_internal_tcp_conn is true");
+					return false;
+				}
+				else
+				{
+					elog(DEBUG1, "received same host internal TCP connection");
+					FakeClientAuthentication(port);
+					return true;
+				}
 			}
-			else
-			{
-				/* Security violation? */
-				elog(LOG, "rejecting TCP connection to master using internal"
-					 "connection protocol");
-				return false;
-			}
-			return true;
+
+			/* Security violation? */
+			elog(LOG, "rejecting TCP connection to master using internal"
+				 "connection protocol");
+			return false;
 		}
 #ifdef HAVE_UNIX_SOCKETS
 		else if (port->raddr.addr.ss_family == AF_UNIX)
 		{
-			/* 
-			 * Internal connection via a domain socket -- use ident
+			/*
+			 * Internal connection via a domain socket -- consider it authenticated
 			 */
-			char *local_name;
-			struct passwd *pw;
-
-			pw = getpwuid(geteuid());
-			if (pw == NULL)
-			{
-				elog(LOG, "invalid effective UID %d ", geteuid());
-				return false;
-			}
-
-			local_name = pw->pw_name;
-
-			if (!auth_peer(port))
-				return false;
-			else
-			{
-				FakeClientAuthentication(port);
-				return true;
-			}
+			FakeClientAuthentication(port);
+			return true;
 		}
 #endif   /* HAVE_UNIX_SOCKETS */
 		else


### PR DESCRIPTION
In `cdbconn_doConnectStart()`, Greenplum cleans the host info to force
using domain socket for entry db connections. Checking the connection's
authentication here is not necessary, even annoying, if the user is not
allowed to connect via domain socket.

This commit authenticates it directly, just as Greenplum authenticates
TCP internal connections coming from the same host.

Fix https://github.com/greenplum-db/gpdb/issues/12851

This is the 6X version of https://github.com/greenplum-db/gpdb/pull/12872

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
