### PR TITLE
Remove stale assertion in ORCA

### DIFF
--- a/src/backend/gporca/libgpopt/src/xforms/CSubqueryHandler.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CSubqueryHandler.cpp
@@ -1430,13 +1430,6 @@ CSubqueryHandler::FRemoveAnySubquery(CExpression *pexprOuter,
 #ifdef GPOS_DEBUG
 	AssertValidArguments(mp, pexprOuter, pexprSubquery, ppexprNewOuter,
 						 ppexprResidualScalar);
-	COperator *popSubqChild = (*pexprSubquery)[0]->Pop();
-	GPOS_ASSERT_IMP(
-		COperator::EopLogicalConstTableGet == popSubqChild->Eopid(),
-		0 == CLogicalConstTableGet::PopConvert(popSubqChild)
-					->Pdrgpdrgpdatum()
-					->Size() &&
-			"Constant subqueries must be unnested during preprocessing");
 #endif	// GPOS_DEBUG
 
 	CScalarSubqueryAny *pScalarSubqAny =
@@ -1601,13 +1594,6 @@ CSubqueryHandler::FRemoveAllSubquery(CExpression *pexprOuter,
 #ifdef GPOS_DEBUG
 	AssertValidArguments(mp, pexprOuter, pexprSubquery, ppexprNewOuter,
 						 ppexprResidualScalar);
-	COperator *popSubqChild = (*pexprSubquery)[0]->Pop();
-	GPOS_ASSERT_IMP(
-		COperator::EopLogicalConstTableGet == popSubqChild->Eopid(),
-		0 == CLogicalConstTableGet::PopConvert(popSubqChild)
-					->Pdrgpdrgpdatum()
-					->Size() &&
-			"Constant subqueries must be unnested during preprocessing");
 #endif	// GPOS_DEBUG
 
 	if (m_fEnforceCorrelatedApply)

--- a/src/backend/gporca/server/include/unittest/gpopt/xforms/CSubqueryHandlerTest.h
+++ b/src/backend/gporca/server/include/unittest/gpopt/xforms/CSubqueryHandlerTest.h
@@ -43,7 +43,6 @@ public:
 	static GPOS_RESULT EresUnittest_Subquery2Apply();
 	static GPOS_RESULT EresUnittest_Subquery2OrTree();
 	static GPOS_RESULT EresUnittest_Subquery2AndTree();
-	static GPOS_RESULT EresUnittest_SubqueryWithConstSubqueries();
 	static GPOS_RESULT EresUnittest_SubqueryWithDisjunction();
 	static GPOS_RESULT EresUnittest_RunMinidumpTests();
 


### PR DESCRIPTION
Commit bc4a66ebba9 in repo gp-qp-orca removed code in the preprocessor
that converted an ANY/ALL subquery with child CLogicalConstTableGet
into a disjunction (conjunction) of equalities.  After that code was
removed assertions in FRemoveAnySubquery and FRemoveAllSubquery became
invalid.

Commit eb9d1f0504a contained in Postgres 9.4.26 merge (commit
af96694494c) exposed this invalid assertion.

---

Cherry-pick of https://github.com/greenplum-db/gpdb/pull/12861