### PR TITLE
6X: Fix bug that Orca generates wrong plan for CTAS

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalJoin.cpp
@@ -466,9 +466,15 @@ CPhysicalJoin::PdsDerive(CMemoryPool *mp, CExpressionHandle &exprhdl) const
 		if (!pdsHashed->HasCompleteEquivSpec(mp))
 		{
 			CExpressionArray *pdrgpexpr = pdsHashed->Pdrgpexpr();
+			IMdIdArray *opfamilies = pdsHashed->Opfamilies();
+
+			if (NULL != opfamilies)
+			{
+				opfamilies->AddRef();
+			}
 			pdrgpexpr->AddRef();
 			return GPOS_NEW(mp) CDistributionSpecHashed(
-				pdrgpexpr, pdsHashed->FNullsColocated());
+				pdrgpexpr, pdsHashed->FNullsColocated(), opfamilies);
 		}
 	}
 

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14076,6 +14076,40 @@ select count(*) from (select trim(regexp_split_to_table((a)::text, ','::text)) f
 (1 row)
 
 reset optimizer_trace_fallback;
+--- Test if orca can produce the correct plan for CTAS
+CREATE TABLE dist_tab_a (a varchar(15)) DISTRIBUTED BY(a);
+INSERT INTO dist_tab_a VALUES('1 '), ('2  '), ('3    ');
+CREATE TABLE dist_tab_b (a char(15), b bigint) DISTRIBUTED BY(a);
+INSERT INTO dist_tab_b VALUES('1 ', 1), ('2  ', 2), ('3    ', 3);
+EXPLAIN CREATE TABLE result_tab AS
+	(SELECT a.a, b.b FROM dist_tab_a a LEFT JOIN dist_tab_b b ON a.a=b.a) DISTRIBUTED BY(a);
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Redistribute Motion 3:3  (slice2; segments: 3)  (cost=2.07..5.20 rows=2 width=12)
+   Hash Key: a.a
+   ->  Hash Left Join  (cost=2.07..5.20 rows=2 width=12)
+         Hash Cond: ((a.a)::bpchar = b.a)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.09 rows=1 width=4)
+               Hash Key: a.a
+               ->  Seq Scan on dist_tab_a a  (cost=0.00..3.03 rows=1 width=4)
+         ->  Hash  (cost=2.03..2.03 rows=1 width=24)
+               ->  Seq Scan on dist_tab_b b  (cost=0.00..2.03 rows=1 width=24)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+CREATE TABLE result_tab AS
+	(SELECT a.a, b.b FROM dist_tab_a a LEFT JOIN dist_tab_b b ON a.a=b.a) DISTRIBUTED BY(a);
+SELECT gp_segment_id, * FROM result_tab;
+ gp_segment_id |   a   | b 
+---------------+-------+---
+             0 | 3     | 3
+             1 | 2     | 2
+             2 | 1     | 1
+(3 rows)
+
+DROP TABLE IF EXISTS dist_tab_a;
+DROP TABLE IF EXISTS dist_tab_b;
+DROP TABLE IF EXISTS result_tab;
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 NOTICE:  drop cascades to 167 other objects

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14322,6 +14322,42 @@ select count(*) from (select trim(regexp_split_to_table((a)::text, ','::text)) f
 (1 row)
 
 reset optimizer_trace_fallback;
+--- Test if orca can produce the correct plan for CTAS
+CREATE TABLE dist_tab_a (a varchar(15)) DISTRIBUTED BY(a);
+INSERT INTO dist_tab_a VALUES('1 '), ('2  '), ('3    ');
+CREATE TABLE dist_tab_b (a char(15), b bigint) DISTRIBUTED BY(a);
+INSERT INTO dist_tab_b VALUES('1 ', 1), ('2  ', 2), ('3    ', 3);
+EXPLAIN CREATE TABLE result_tab AS
+	(SELECT a.a, b.b FROM dist_tab_a a LEFT JOIN dist_tab_b b ON a.a=b.a) DISTRIBUTED BY(a);
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..0.00 rows=0 width=0)
+   ->  Result  (cost=0.00..862.16 rows=2 width=12)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=2 width=12)
+               Hash Key: dist_tab_a.a
+               ->  Hash Left Join  (cost=0.00..862.00 rows=2 width=12)
+                     Hash Cond: ((dist_tab_a.a)::bpchar = dist_tab_b.a)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                           Hash Key: dist_tab_a.a
+                           ->  Seq Scan on dist_tab_a  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=24)
+                           ->  Seq Scan on dist_tab_b  (cost=0.00..431.00 rows=1 width=24)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
+CREATE TABLE result_tab AS
+	(SELECT a.a, b.b FROM dist_tab_a a LEFT JOIN dist_tab_b b ON a.a=b.a) DISTRIBUTED BY(a);
+SELECT gp_segment_id, * FROM result_tab;
+ gp_segment_id |   a   | b 
+---------------+-------+---
+             0 | 3     | 3
+             1 | 2     | 2
+             2 | 1     | 1
+(3 rows)
+
+DROP TABLE IF EXISTS dist_tab_a;
+DROP TABLE IF EXISTS dist_tab_b;
+DROP TABLE IF EXISTS result_tab;
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 NOTICE:  drop cascades to 167 other objects


### PR DESCRIPTION
Backport of #12811

For the following query, Orca generated plan that caused wrong results:
```
CREATE TABLE dist_tab_a (a varchar(15)) DISTRIBUTED BY(a);
INSERT INTO dist_tab_a VALUES('1 '), ('2  '), ('3    ');
CREATE TABLE dist_tab_b (a char(15), b bigint) DISTRIBUTED BY(a);
INSERT INTO dist_tab_b VALUES('1 ', 1), ('2  ', 2), ('3    ', 3);
CREATE TABLE result_tab_a AS
    (SELECT a.a, b.b FROM dist_tab_a a LEFT JOIN dist_tab_b b ON a.a=b.a) DISTRIBUTED BY(a);
EXPLAIN CREATE TABLE result_tab_a AS
    (SELECT a.a, b.b FROM dist_tab_a a LEFT JOIN dist_tab_b b ON a.a=b.a) DISTRIBUTED BY(a);
     Hash Left Join  (cost=0.00..862.00 rows=2 width=16)
       Hash Cond: ((dist_tab_a.a)::bpchar = dist_tab_b.a)
       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
             Hash Key: dist_tab_a.a
             ->  Seq Scan on dist_tab_a  (cost=0.00..431.00 rows=1 width=8)
       ->  Hash  (cost=431.00..431.00 rows=1 width=16)
             ->  Seq Scan on dist_tab_b  (cost=0.00..431.00 rows=1 width=16)
Optimizer: Pivotal Optimizer (GPORCA)
SELECT gp_table_distribution_check('result_tab_a');
gp_table_distribution_check
-----------------------------
 (2,t)
 (0,f)
 (1,f)
(3 rows)
```
Correct plan and results should be:
```
EXPLAIN CREATE TABLE result_tab_a AS
    (SELECT a.a, b.b FROM dist_tab_a a LEFT JOIN dist_tab_b b ON a.a=b.a) DISTRIBUTED BY(a);
     Result  (cost=0.00..862.05 rows=2 width=16)
       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=16)
             Hash Key: dist_tab_a.a
             ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=16)
                   Hash Cond: ((dist_tab_a.a)::bpchar = dist_tab_b.a)
                   ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
                         Hash Key: dist_tab_a.a
                         ->  Seq Scan on dist_tab_a  (cost=0.00..431.00 rows=1 width=8)
                   ->  Hash  (cost=431.00..431.00 rows=1 width=16)
                         ->  Seq Scan on dist_tab_b  (cost=0.00..431.00 rows=1 width=16)
Optimizer: Pivotal Optimizer (GPORCA)
(11 rows)
SELECT gp_table_distribution_check('result_tab_a');
gp_table_distribution_check
-----------------------------
 (2,t)
 (0,t)
 (1,t)
(3 rows)
```
I think the root cause is that when we derive distribution of Hash Left
Outer Join, we create a hash distribution spec with wrong opfamilies.
As a result, there isn't a mismatch between distribution spec
requested/derived, Motion Redistribute node is not added to plantree

Authored-by: Robert Mu <muguoqing@hashdata.cn>
(cherry picked from commit 9ea14459bf816f267adbff44b9bf14d1411ed159)