### PR TITLE
6X: Don't collect execution stats if the query failed

### DIFF
--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -586,6 +586,11 @@ cdbexplain_sendExecStats(QueryDesc *queryDesc)
 	 */
 	memcpy(ctx.buf.data + hoff, (char *) &ctx.hdr, sizeof(ctx.hdr) - sizeof(ctx.hdr.inst));
 
+#ifdef FAULT_INJECTOR
+	/* Inject a fault before sending a message to qDisp process */
+	SIMPLE_FAULT_INJECTOR("send_exec_stats");
+#endif /* FAULT_INJECTOR */
+
 	/* Send message to qDisp process. */
 	pq_endmessage(&ctx.buf);
 }								/* cdbexplain_sendExecStats */
@@ -734,7 +739,7 @@ cdbexplain_recvExecStats(struct PlanState *planstate,
 			ctx.nStatInst = hdr->nInst;
 		else
 		{
-			/* MPP-2140: what causes this ? */
+			/* Check for stats corruption */
 			if (ctx.nStatInst != hdr->nInst)
 				ereport(ERROR, (errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
 								errmsg("Invalid execution statistics "

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -2958,6 +2958,11 @@ ExecutePlan(EState *estate,
 	 */
 	ExecSliceDependencyNode(planstate);
 
+#ifdef FAULT_INJECTOR
+	/* Inject a fault before tuple processing started */
+	SIMPLE_FAULT_INJECTOR("executor_pre_tuple_processed");
+#endif /* FAULT_INJECTOR */
+
 	/*
 	 * Loop until we've processed the proper number of tuples from the plan.
 	 */

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1017,25 +1017,6 @@ standard_ExecutorRun(QueryDesc *queryDesc,
     }
 	PG_CATCH();
 	{
-        /* If EXPLAIN ANALYZE, let qExec try to return stats to qDisp. */
-        if (estate->es_sliceTable &&
-            estate->es_sliceTable->instrument_options &&
-            (estate->es_sliceTable->instrument_options & INSTRUMENT_CDB) &&
-            Gp_role == GP_ROLE_EXECUTE)
-        {
-            PG_TRY();
-            {
-                cdbexplain_sendExecStats(queryDesc);
-            }
-            PG_CATCH();
-            {
-                /* Close down interconnect etc. */
-				mppExecutorCleanup(queryDesc);
-		        PG_RE_THROW();
-            }
-            PG_END_TRY();
-        }
-
         /* Close down interconnect etc. */
 		mppExecutorCleanup(queryDesc);
 		PG_RE_THROW();

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -967,7 +967,7 @@ ExecSetParamPlan(SubPlanState *node, ExprContext *econtext, QueryDesc *queryDesc
 	SubLinkType subLinkType = subplan->subLinkType;
 	EState	   *estate = planstate->state;
 	ScanDirection dir = estate->es_direction;
-	MemoryContext oldcontext;
+	MemoryContext oldcontext = NULL;;
 	TupleTableSlot *slot;
 	ListCell   *l;
 	bool		found = false;
@@ -1252,6 +1252,12 @@ PG_CATCH();
 {
 	/* Restore memory high-water mark for root slice of main query. */
 	MemoryContextSetPeakSpace(planstate->state->es_query_cxt, savepeakspace);
+
+	if (oldcontext)
+		MemoryContextSwitchTo(oldcontext);
+
+	/* restore scan direction */
+	estate->es_direction = dir;
 
 	/*
 	 * Clean up the interconnect.

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -1250,25 +1250,6 @@ PG_TRY();
 }
 PG_CATCH();
 {
-	/* If EXPLAIN ANALYZE, collect local and distributed execution stats. */
-	if (planstate->instrument && planstate->instrument->need_cdb)
-	{
-		if(Gp_role == GP_ROLE_DISPATCH)
-			cdbexplain_localExecStats(planstate, econtext->ecxt_estate->showstatctx);
-		if (!explainRecvStats &&
-			shouldDispatch &&
-			queryDesc->estate->dispatcherState)
-		{
-			/* Wait for all gangs to finish.  Cancel slowpokes. */
-			cdbdisp_cancelDispatch(queryDesc->estate->dispatcherState);
-
-			cdbexplain_recvExecStats(planstate,
-									 queryDesc->estate->dispatcherState->primaryResults,
-									 LocallyExecutingSliceIndex(queryDesc->estate),
-									 econtext->ecxt_estate->showstatctx);
-		}
-	}
-
 	/* Restore memory high-water mark for root slice of main query. */
 	MemoryContextSetPeakSpace(planstate->state->es_query_cxt, savepeakspace);
 

--- a/src/backend/executor/test/nodeSubplan_test.c
+++ b/src/backend/executor/test/nodeSubplan_test.c
@@ -101,21 +101,8 @@ test__ExecSetParamPlan__Check_Dispatch_Results(void **state)
 	/* Force SetupInterconnect to fail */
 	will_be_called_with_sideeffect(SetupInterconnect, &setupinterconnect_fail, NULL);
 
-	expect_any(cdbexplain_localExecStats,planstate);
-	expect_any(cdbexplain_localExecStats,showstatctx);
-	will_be_called(cdbexplain_localExecStats);
-
-	expect_any(cdbdisp_cancelDispatch,ds);
-	will_be_called(cdbdisp_cancelDispatch);
-
 	expect_any(CdbDispatchHandleError, ds);
 	will_be_called(CdbDispatchHandleError);
-
-	expect_any(cdbexplain_recvExecStats,planstate);
-	expect_any(cdbexplain_recvExecStats,dispatchResults);
-	expect_any(cdbexplain_recvExecStats,sliceIndex);
-	expect_any(cdbexplain_recvExecStats,showstatctx);
-	will_be_called(cdbexplain_recvExecStats);
 
 	/* Catch PG_RE_THROW(); after cleaning with CdbCheckDispatchResult */
 	PG_TRY();

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -526,5 +526,50 @@ returning
          as pg_lsn),
       cast(pg_catalog.pg_last_xlog_receive_location() as pg_lsn)), cast(null as "numeric")) as "numeric") as c24;
 
+--
+-- Test executor double fault
+-- check PG_TRY/PG_CATCH - we should always return an original error
+-- (for a query and its explain analyze)
+--
+drop table if exists double_fault;
+create table double_fault(a int) distributed by (a);
+insert into double_fault select generate_series(1, 10);
+create or replace function fault_exec_plan(explain_analyze bool default true) returns void as $_$
+declare
+    query text;
+begin
+    perform gp_inject_fault('executor_pre_tuple_processed', 'reset', dbid) from gp_segment_configuration;
+    perform gp_inject_fault('send_exec_stats', 'reset', dbid) from gp_segment_configuration;
+
+    perform gp_inject_fault('executor_pre_tuple_processed', 'error', dbid)
+    from gp_segment_configuration where role = 'p' and content > -1;
+    perform gp_inject_fault('send_exec_stats', 'error', dbid)
+    from gp_segment_configuration where role = 'p' and content > -1;
+
+    if explain_analyze then
+        query := 'explain analyze select count(*) from double_fault';
+    else
+        query := 'select count(*) from double_fault';
+    end if;
+    execute query;
+
+    perform gp_inject_fault('executor_pre_tuple_processed', 'reset', dbid) from gp_segment_configuration;
+    perform gp_inject_fault('send_exec_stats', 'reset', dbid) from gp_segment_configuration;
+exception when fault_inject then
+    perform gp_inject_fault('executor_pre_tuple_processed', 'reset', dbid) from gp_segment_configuration;
+    perform gp_inject_fault('send_exec_stats', 'reset', dbid) from gp_segment_configuration;
+
+    raise exception $$'%' fault triggered$$, case
+        when coalesce(substring(sqlerrm from 'send_exec_stats'), '') != '' then 'send_exec_stats'
+        when coalesce(substring(sqlerrm from 'executor_pre_tuple_processed'), '') != '' then 'executor_pre_tuple_processed'
+    end;
+end;
+$_$ language plpgsql;
+-- Query raising 'executor_pre_tuple_processed' error
+select fault_exec_plan(false);
+-- Same query with explain analyze (should raise
+-- 'executor_pre_tuple_processed' not 'send_exec_stats')
+select fault_exec_plan(true);
+
 \c regression
 DROP DATABASE dispatch_test_db;

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -889,5 +889,51 @@ returning
 -----
 (0 rows)
 
+--
+-- Test executor double fault
+-- check PG_TRY/PG_CATCH - we should always return an original error
+-- (for a query and its explain analyze)
+--
+drop table if exists double_fault;
+create table double_fault(a int) distributed by (a);
+insert into double_fault select generate_series(1, 10);
+create or replace function fault_exec_plan(explain_analyze bool default true) returns void as $_$
+declare
+    query text;
+begin
+    perform gp_inject_fault('executor_pre_tuple_processed', 'reset', dbid) from gp_segment_configuration;
+    perform gp_inject_fault('send_exec_stats', 'reset', dbid) from gp_segment_configuration;
+
+    perform gp_inject_fault('executor_pre_tuple_processed', 'error', dbid)
+    from gp_segment_configuration where role = 'p' and content > -1;
+    perform gp_inject_fault('send_exec_stats', 'error', dbid)
+    from gp_segment_configuration where role = 'p' and content > -1;
+
+    if explain_analyze then
+        query := 'explain analyze select count(*) from double_fault';
+    else
+        query := 'select count(*) from double_fault';
+    end if;
+    execute query;
+
+    perform gp_inject_fault('executor_pre_tuple_processed', 'reset', dbid) from gp_segment_configuration;
+    perform gp_inject_fault('send_exec_stats', 'reset', dbid) from gp_segment_configuration;
+exception when fault_inject then
+    perform gp_inject_fault('executor_pre_tuple_processed', 'reset', dbid) from gp_segment_configuration;
+    perform gp_inject_fault('send_exec_stats', 'reset', dbid) from gp_segment_configuration;
+
+    raise exception $$'%' fault triggered$$, case
+        when coalesce(substring(sqlerrm from 'send_exec_stats'), '') != '' then 'send_exec_stats'
+        when coalesce(substring(sqlerrm from 'executor_pre_tuple_processed'), '') != '' then 'executor_pre_tuple_processed'
+    end;
+end;
+$_$ language plpgsql;
+-- Query raising 'executor_pre_tuple_processed' error
+select fault_exec_plan(false);
+ERROR:  'executor_pre_tuple_processed' fault triggered
+-- Same query with explain analyze (should raise
+-- 'executor_pre_tuple_processed' not 'send_exec_stats')
+select fault_exec_plan(true);
+ERROR:  'executor_pre_tuple_processed' fault triggered
 \c regression
 DROP DATABASE dispatch_test_db;


### PR DESCRIPTION
Currently, if one segment (like seg1) panics due to some reason, other
segments (like seg0) will report "InstrEndLoop called on running node".

This is because QE on seg1 reports ERROR to QD when execution fails,
and the QD dispatches cancel command to all the QEs, but another QE on
seg0 is not finished yet, its `instr` structure is not cleaned up.

This commit is to remove the logic of sending stats when execution
failed, which is not needed.

Fixes https://github.com/greenplum-db/gpdb/issues/9904

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
