### PR TITLE
6X: Fix assert when inserting/updating table with trigger and returning ctid

### DIFF
--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -589,8 +589,8 @@ ExecInsert(TupleTableSlot *parentslot,
 	/* Process RETURNING if present */
 	if (projectReturning)
 	{
-		/* slot has been modified by trigger or others*/
-		if (slot != parentslot)
+		/* slot has been modified by trigger and it is not from partition table */
+		if (slot != parentslot && NULL == resultRelInfo->ri_partInsertMap)
 		{
 			int         natts = slot->tts_tupleDescriptor->natts;
 			slot_getallattrs(slot);

--- a/src/test/regress/expected/returning_gp.out
+++ b/src/test/regress/expected/returning_gp.out
@@ -116,3 +116,39 @@ SELECT * FROM returning_disttest;
   2
 (2 rows)
 
+-- Test returning ctid with trigger
+CREATE TABLE returning_ctid (f1 serial, f2 text) DISTRIBUTED BY (f1);
+CREATE TABLE
+-- Create function used by trigger
+CREATE FUNCTION trig_row_before_insupdate() RETURNS TRIGGER AS $$
+  BEGIN
+    NEW.f2 := NEW.f2 || ' triggered !';
+    RETURN NEW;
+  END
+$$ language plpgsql;
+CREATE FUNCTION
+-- Create trigger for each row insert
+CREATE TRIGGER trig_row_before BEFORE INSERT OR UPDATE ON returning_ctid
+FOR EACH ROW EXECUTE PROCEDURE trig_row_before_insupdate();
+CREATE TRIGGER
+-- Check returning sys attribute on insert 
+INSERT INTO returning_ctid(f2) VALUES ('test') RETURNING ctid;
+ ctid  
+-------
+ (0,1)
+(1 row)
+
+INSERT 0 1
+SELECT *, ctid FROM returning_ctid;
+ f1 |        f2        | ctid  
+----+------------------+-------
+  1 | test triggered ! | (0,1)
+(1 row)
+
+-- Clean up
+DROP TRIGGER trig_row_before ON returning_ctid;
+DROP TRIGGER
+DROP FUNCTION trig_row_before_insupdate() CASCADE;
+DROP FUNCTION
+DROP TABLE returning_ctid;
+DROP TABLE

--- a/src/test/regress/expected/returning_gp.out
+++ b/src/test/regress/expected/returning_gp.out
@@ -116,7 +116,9 @@ SELECT * FROM returning_disttest;
   2
 (2 rows)
 
+--
 -- Test returning ctid with trigger
+--
 CREATE TABLE returning_ctid (f1 serial, f2 text) DISTRIBUTED BY (f1);
 CREATE TABLE
 -- Create function used by trigger
@@ -127,7 +129,7 @@ CREATE FUNCTION trig_row_before_insupdate() RETURNS TRIGGER AS $$
   END
 $$ language plpgsql;
 CREATE FUNCTION
--- Create trigger for each row insert
+-- Create trigger for each row insert or update
 CREATE TRIGGER trig_row_before BEFORE INSERT OR UPDATE ON returning_ctid
 FOR EACH ROW EXECUTE PROCEDURE trig_row_before_insupdate();
 CREATE TRIGGER
@@ -151,4 +153,42 @@ DROP TRIGGER
 DROP FUNCTION trig_row_before_insupdate() CASCADE;
 DROP FUNCTION
 DROP TABLE returning_ctid;
+DROP TABLE
+--
+-- Test returning ctid with trigger for AOCO table
+--
+CREATE TABLE returning_ctid_aoco (f1 serial, f2 text) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (f1);
+CREATE TABLE
+-- Create function used by trigger
+CREATE FUNCTION trig_row_before_insupdate() RETURNS TRIGGER AS $$
+  BEGIN
+    NEW.f2 := NEW.f2 || ' triggered !';
+    RETURN NEW;
+  END
+$$ language plpgsql;
+CREATE FUNCTION
+-- Create trigger for each row insert
+CREATE TRIGGER trig_row_before BEFORE INSERT ON returning_ctid_aoco
+FOR EACH ROW EXECUTE PROCEDURE trig_row_before_insupdate();
+CREATE TRIGGER
+-- Check returning sys attribute on insert
+INSERT INTO returning_ctid_aoco(f2) VALUES ('test') RETURNING ctid;
+     ctid     
+--------------
+ (33554432,2)
+(1 row)
+
+INSERT 0 1
+SELECT *, ctid FROM returning_ctid_aoco;
+ f1 |        f2        |     ctid     
+----+------------------+--------------
+  1 | test triggered ! | (33554432,2)
+(1 row)
+
+-- Clean up
+DROP TRIGGER trig_row_before ON returning_ctid_aoco;
+DROP TRIGGER
+DROP FUNCTION trig_row_before_insupdate() CASCADE;
+DROP FUNCTION
+DROP TABLE returning_ctid_aoco;
 DROP TABLE

--- a/src/test/regress/sql/returning_gp.sql
+++ b/src/test/regress/sql/returning_gp.sql
@@ -63,3 +63,25 @@ INSERT INTO returning_disttest VALUES (1), (2);
 UPDATE returning_disttest SET id = id + 1;
 
 SELECT * FROM returning_disttest;
+
+-- Test returning ctid with trigger
+CREATE TABLE returning_ctid (f1 serial, f2 text) DISTRIBUTED BY (f1);
+-- Create function used by trigger
+CREATE FUNCTION trig_row_before_insupdate() RETURNS TRIGGER AS $$
+  BEGIN
+    NEW.f2 := NEW.f2 || ' triggered !';
+    RETURN NEW;
+  END
+$$ language plpgsql;
+-- Create trigger for each row insert
+CREATE TRIGGER trig_row_before BEFORE INSERT OR UPDATE ON returning_ctid
+FOR EACH ROW EXECUTE PROCEDURE trig_row_before_insupdate();
+
+-- Check returning sys attribute on insert 
+INSERT INTO returning_ctid(f2) VALUES ('test') RETURNING ctid;
+SELECT *, ctid FROM returning_ctid;
+
+-- Clean up
+DROP TRIGGER trig_row_before ON returning_ctid;
+DROP FUNCTION trig_row_before_insupdate() CASCADE;
+DROP TABLE returning_ctid;

--- a/src/test/regress/sql/returning_gp.sql
+++ b/src/test/regress/sql/returning_gp.sql
@@ -64,7 +64,9 @@ UPDATE returning_disttest SET id = id + 1;
 
 SELECT * FROM returning_disttest;
 
+--
 -- Test returning ctid with trigger
+--
 CREATE TABLE returning_ctid (f1 serial, f2 text) DISTRIBUTED BY (f1);
 -- Create function used by trigger
 CREATE FUNCTION trig_row_before_insupdate() RETURNS TRIGGER AS $$
@@ -73,7 +75,7 @@ CREATE FUNCTION trig_row_before_insupdate() RETURNS TRIGGER AS $$
     RETURN NEW;
   END
 $$ language plpgsql;
--- Create trigger for each row insert
+-- Create trigger for each row insert or update
 CREATE TRIGGER trig_row_before BEFORE INSERT OR UPDATE ON returning_ctid
 FOR EACH ROW EXECUTE PROCEDURE trig_row_before_insupdate();
 
@@ -85,3 +87,27 @@ SELECT *, ctid FROM returning_ctid;
 DROP TRIGGER trig_row_before ON returning_ctid;
 DROP FUNCTION trig_row_before_insupdate() CASCADE;
 DROP TABLE returning_ctid;
+
+--
+-- Test returning ctid with trigger for AOCO table
+--
+CREATE TABLE returning_ctid_aoco (f1 serial, f2 text) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (f1);
+-- Create function used by trigger
+CREATE FUNCTION trig_row_before_insupdate() RETURNS TRIGGER AS $$
+  BEGIN
+    NEW.f2 := NEW.f2 || ' triggered !';
+    RETURN NEW;
+  END
+$$ language plpgsql;
+-- Create trigger for each row insert
+CREATE TRIGGER trig_row_before BEFORE INSERT ON returning_ctid_aoco
+FOR EACH ROW EXECUTE PROCEDURE trig_row_before_insupdate();
+
+-- Check returning sys attribute on insert
+INSERT INTO returning_ctid_aoco(f2) VALUES ('test') RETURNING ctid;
+SELECT *, ctid FROM returning_ctid_aoco;
+
+-- Clean up
+DROP TRIGGER trig_row_before ON returning_ctid_aoco;
+DROP FUNCTION trig_row_before_insupdate() CASCADE;
+DROP TABLE returning_ctid_aoco;


### PR DESCRIPTION
- How to reproduce
1. create table and trigger
```
gpadmin=# create table loc1 (f1 serial, f2 text);
gpadmin=# CREATE FUNCTION trig_row_before_insupdate() RETURNS TRIGGER AS $$
  BEGIN
    NEW.f2 := NEW.f2 || ' triggered !';
    RETURN NEW;
  END
$$ language plpgsql;
gpadmin=# CREATE TRIGGER trig_local_before BEFORE INSERT OR UPDATE ON loc1
FOR EACH ROW EXECUTE PROCEDURE trig_row_before_insupdate();
```
2. insert a value, then assert pops
```
gpadmin=# INSERT INTO loc1(f2) VALUES ('test') RETURNING ctid;
ERROR:  Unexpected internal error (execTuples.c:1559)  (seg1 slice2 10.117.190.45:7001 pid=19255) (execTuples.c:1559)
DETAIL:  FailedAssertion("!(((bool) (((const void*)(&(htup->t_self)) != ((void *)0)) && ((&(htup->t_self))->ip_posid != 0))))", File: "execTuples.c", Line: 1559)
HINT:  Process 19255 will wait for gp_debug_linger=120 seconds before termination.
Note that its locks and other resources will not be released until then.
```
- root cause
the root cause is that if a table has trigger, the slot will be modified by trigger and be different from parentslot in `ExecInsert()`
and then the ExecProcessReturning() will crash due to invalid parentslot.

so we fix this issue referring to the fdw handling in `ExecInsert()`

Co-authored-by: Amy Bai <ajie@vmware.com>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
