### PR TITLE
Fix gpload cannot find reuse table

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -2395,11 +2395,6 @@ class gpload:
         if formatType=='csv':
             self.get_external_table_formatOpts('quote')
 
-        newline = self.getconfig('gpload:input:newline', str, False)
-        self.log(self.DEBUG, "newline " + str(newline))
-        if newline != False: # could be empty string
-            self.formatOpts += "newline %s " % quote_no_slash(newline)
-
         if self.getconfig('gpload:input:header',bool,False):
             self.formatOpts += "header "
 
@@ -2410,6 +2405,11 @@ class gpload:
                 if type(i) != str and type(i) != str:
                     self.control_file_error("gpload:input:force_not_null must be a YAML sequence of strings")
             self.formatOpts += "force not null %s " % ','.join(force_not_null_columns)
+
+        newline = self.getconfig('gpload:input:newline', str, False)
+        self.log(self.DEBUG, "newline " + str(newline))
+        if newline != False: # could be empty string
+            self.formatOpts += "newline %s " % quote_no_slash(newline)
 
         encodingCode = None
         encodingStr = self.getconfig('gpload:input:encoding', str, None)
@@ -2526,7 +2526,7 @@ class gpload:
         try:
             self.db.query(sql.encode('utf-8'))
         except Exception as e:
-            self.log(self.ERROR, 'could not run SQL "%s": %s' % (sql, unicode(e)))
+            self.log(self.ERROR, 'could not run SQL "%s": %s' % (sql, str(e)))
 
         # set up to drop the external table at the end of operation, unless user
         # specified the 'reuse_tables' option, in which case we don't drop

--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -2406,6 +2406,10 @@ class gpload:
                     self.control_file_error("gpload:input:force_not_null must be a YAML sequence of strings")
             self.formatOpts += "force not null %s " % ','.join(force_not_null_columns)
 
+        if formatType == 'csv' or formatType == 'text':
+            if self.getconfig('gpload:input:fill_missing_fields', bool, False):
+                self.formatOpts += 'fill missing fields '
+
         newline = self.getconfig('gpload:input:newline', str, False)
         self.log(self.DEBUG, "newline " + str(newline))
         if newline != False: # could be empty string
@@ -2439,10 +2443,6 @@ class gpload:
             from_cols = [a for a in self.from_columns if a[3] != True]
         else:
             from_cols = self.from_columns
-
-        if formatType == 'csv' or formatType == 'text':
-            if self.getconfig('gpload:input:fill_missing_fields', bool, False):
-                self.formatOpts += 'fill missing fields'
 
         # If the 'reuse tables' option was specified we now try to find an
         # already existing external table in the catalog which will match

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_base.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_base.py
@@ -224,8 +224,8 @@ def write_config_file(version='1.0.0.1', database='reuse_gptest', user=os.enviro
         f.write("\n    - FILL_MISSING_FIELDS: "+str(fill_missing_fields))
     if quote:
         f.write("\n    - QUOTE: "+quote)
-    if header:
-        f.write("\n    - HEADER: "+header)
+    if header != None:
+        f.write("\n    - HEADER: "+str(header))
     if transform:
         f.write("\n    - TRANSFORM: "+transform)
     if transform_config:
@@ -505,7 +505,7 @@ def ModifyOutFile(file,old_str,new_str):
     os.remove(file)
     os.rename("%s.bak" % file, file)
 
-Modify_Output_Case = [46,51,57,65]
+Modify_Output_Case = [46,51,57,65,76]
 
 
 def doTest(num):
@@ -523,7 +523,9 @@ def doTest(num):
         newpat2 = 'pathto/data_file'
         pat3 = r', SSL off$'
         newpat3 = ''
-        ModifyOutFile(str(num), [pat1,pat2,pat3], [newpat1,newpat2,newpat3])  # some strings in outfile are different each time, such as host and file location
+        pat4 = r'LINE 1: ...[a-zA-Z0-9\_]*\('
+        newpat4 = 'LINE 1: ...('
+        ModifyOutFile(str(num), [pat1,pat2,pat3,pat4], [newpat1,newpat2,newpat3,newpat4])  # some strings in outfile are different each time, such as host and file location
         # we modify the out file here to make it match the ans file
 
     check_result(file,num=num)

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_base.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_base.py
@@ -505,7 +505,7 @@ def ModifyOutFile(file,old_str,new_str):
     os.remove(file)
     os.rename("%s.bak" % file, file)
 
-Modify_Output_Case = [46,51,57,65,76]
+Modify_Output_Case = [46,51,57,65,76,260,402]
 
 
 def doTest(num):

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_data_format.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_data_format.py
@@ -298,6 +298,7 @@ def test_253_gpload_eol_CRLF_txt():
                       format='text',
                       file='data_file.txt',
                       table='texttable2',
+                      header = True,
                       newline='CRLF')
 
 @prepare_before_test(num=254)

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_data_format.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_data_format.py
@@ -298,6 +298,8 @@ def test_253_gpload_eol_CRLF_txt():
                       format='text',
                       file='data_file.txt',
                       table='texttable2',
+                      fill_missing_fields = True,
+                      escape = '\\',
                       header = True,
                       newline='CRLF')
 

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_schema_and_mode.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_schema_and_mode.py
@@ -36,9 +36,10 @@ def test_402_gpload_yaml_non_existing_external_schema():
     """402 test gpload reports error when external schema doesn't exist."""
     TestBase.drop_tables()
     schema = "non_ext_schema_test"
+    TestBase.copy_data('external_file_01.txt','data_file.txt')
     TestBase.psql_run(cmd=f'DROP SCHEMA IF EXISTS {schema} CASCADE;',
                       dbname='reuse_gptest')
-    TestBase.write_config_file(externalSchema=schema)
+    TestBase.write_config_file(externalSchema=schema,file='data_file.txt')
 
 
 @TestBase.prepare_before_test(num=403, times=1)

--- a/gpMgmt/bin/gpload_test/gpload2/query205.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query205.ans
@@ -1,9 +1,10 @@
-2020-12-17 11:42:02|INFO|gpload session started 2020-12-17 11:42:02
-2020-12-17 11:42:02|INFO|setting schema 'public' for table 'texttable2'
-2020-12-17 11:42:02|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
-2020-12-17 11:42:02|INFO|did not find an external table to reuse. creating ext_gpload_reusable_d311e440_4019_11eb_aedb_00505698d059
-2020-12-17 11:42:02|ERROR|unexpected error -- backtrace written to log file
-2020-12-17 11:42:02|INFO|rows Inserted          = 0
-2020-12-17 11:42:02|INFO|rows Updated           = 0
-2020-12-17 11:42:02|INFO|data formatting errors = 0
-2020-12-17 11:42:02|INFO|gpload failed
+2021-11-29 11:56:45|INFO|gpload session started 2021-11-29 11:56:45
+2021-11-29 11:56:45|INFO|setting schema 'public' for table 'texttable2'
+2021-11-29 11:56:45|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-11-29 11:56:45|INFO|did not find an external table to reuse. creating ext_gpload_reusable_5e8c16ac_50c8_11ec_a3c6_0050569e2380
+2021-11-29 11:56:45|ERROR|could not run SQL "create external table ext_gpload_reusable_5e8c16ac_50c8_11ec_a3c6_0050569e2380("s1" text,"s2" text)location('gpfdist://10.117.190.10:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter '' null '\N' escape '\' ) encoding'UTF8' ": ERROR:  COPY delimiter must be a single one-byte character, or 'off'
+
+2021-11-29 11:56:45|INFO|rows Inserted          = 0
+2021-11-29 11:56:45|INFO|rows Updated           = 0
+2021-11-29 11:56:45|INFO|data formatting errors = 0
+2021-11-29 11:56:45|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query233.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query233.ans
@@ -1,9 +1,12 @@
-2020-12-21 17:35:27|INFO|gpload session started 2020-12-21 17:35:27
-2020-12-21 17:35:27|INFO|setting schema 'public' for table 'texttable2'
-2020-12-21 17:35:27|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
-2020-12-21 17:35:27|INFO|did not find an external table to reuse. creating ext_gpload_reusable_dbd968f6_436f_11eb_bfb0_00505698d059
-2020-12-21 17:35:27|ERROR|unexpected error -- backtrace written to log file
-2020-12-21 17:35:27|INFO|rows Inserted          = 0
-2020-12-21 17:35:27|INFO|rows Updated           = 0
-2020-12-21 17:35:27|INFO|data formatting errors = 0
-2020-12-21 17:35:27|INFO|gpload failed
+2021-11-29 11:56:55|INFO|gpload session started 2021-11-29 11:56:55
+2021-11-29 11:56:55|INFO|setting schema 'public' for table 'texttable2'
+2021-11-29 11:56:55|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-11-29 11:56:55|INFO|did not find an external table to reuse. creating ext_gpload_reusable_64b5f930_50c8_11ec_ad50_0050569e2380
+2021-11-29 11:56:55|ERROR|could not run SQL "create external table ext_gpload_reusable_64b5f930_50c8_11ec_ad50_0050569e2380("s1" text,"s2" text)location('gpfdist://10.117.190.10:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter '|' null 'E''\x08E'\'' escape '\' ) encoding'UTF8' ": ERROR:  syntax error at or near "\"
+LINE 1: ....txt') format'text' (delimiter '|' null 'E''\x08E'\'' escape...
+                                                             ^
+
+2021-11-29 11:56:55|INFO|rows Inserted          = 0
+2021-11-29 11:56:55|INFO|rows Updated           = 0
+2021-11-29 11:56:55|INFO|data formatting errors = 0
+2021-11-29 11:56:55|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query253.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query253.ans
@@ -1,18 +1,19 @@
-2021-01-06 15:26:17|INFO|gpload session started 2021-01-06 15:26:17
-2021-01-06 15:26:17|INFO|setting schema 'public' for table 'texttable2'
-2021-01-06 15:26:17|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
-2021-01-06 15:26:17|INFO|did not find an external table to reuse. creating ext_gpload_reusable_7723d6fc_4ff0_11eb_bbcd_00505698d059
-2021-01-06 15:26:17|INFO|running time: 0.08 seconds
-2021-01-06 15:26:17|INFO|rows Inserted          = 5
-2021-01-06 15:26:17|INFO|rows Updated           = 0
-2021-01-06 15:26:17|INFO|data formatting errors = 0
-2021-01-06 15:26:17|INFO|gpload succeeded
-2021-01-06 15:26:17|INFO|gpload session started 2021-01-06 15:26:17
-2021-01-06 15:26:17|INFO|setting schema 'public' for table 'texttable2'
-2021-01-06 15:26:17|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
-2021-01-06 15:26:17|INFO|reusing external table ext_gpload_reusable_7723d6fc_4ff0_11eb_bbcd_00505698d059
-2021-01-06 15:26:17|INFO|running time: 0.06 seconds
-2021-01-06 15:26:17|INFO|rows Inserted          = 5
-2021-01-06 15:26:17|INFO|rows Updated           = 0
-2021-01-06 15:26:17|INFO|data formatting errors = 0
-2021-01-06 15:26:17|INFO|gpload succeeded
+NOTICE:  HEADER means that each one of the data files has a header row
+2021-11-29 11:57:02|INFO|gpload session started 2021-11-29 11:57:02
+2021-11-29 11:57:02|INFO|setting schema 'public' for table 'texttable2'
+2021-11-29 11:57:02|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-11-29 11:57:02|INFO|did not find an external table to reuse. creating ext_gpload_reusable_68d0a164_50c8_11ec_add4_0050569e2380
+2021-11-29 11:57:02|INFO|running time: 0.05 seconds
+2021-11-29 11:57:02|INFO|rows Inserted          = 4
+2021-11-29 11:57:02|INFO|rows Updated           = 0
+2021-11-29 11:57:02|INFO|data formatting errors = 0
+2021-11-29 11:57:02|INFO|gpload succeeded
+2021-11-29 11:57:02|INFO|gpload session started 2021-11-29 11:57:02
+2021-11-29 11:57:02|INFO|setting schema 'public' for table 'texttable2'
+2021-11-29 11:57:02|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-11-29 11:57:02|INFO|reusing external table ext_gpload_reusable_68d0a164_50c8_11ec_add4_0050569e2380
+2021-11-29 11:57:02|INFO|running time: 0.05 seconds
+2021-11-29 11:57:02|INFO|rows Inserted          = 4
+2021-11-29 11:57:02|INFO|rows Updated           = 0
+2021-11-29 11:57:02|INFO|data formatting errors = 0
+2021-11-29 11:57:02|INFO|gpload succeeded

--- a/gpMgmt/bin/gpload_test/gpload2/query259.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query259.ans
@@ -1,9 +1,11 @@
-2021-10-25 07:07:31|INFO|gpload session started 2021-10-25 07:07:31
-2021-10-25 07:07:31|INFO|setting schema 'public' for table 'texttable2'
-2021-10-25 07:07:31|INFO|started gpfdist -p 8081 -P 8082 -f "/tmp/build/e18b2f02/gpdb_src/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-10-25 07:07:31|INFO|did not find an external table to reuse. creating ext_gpload_reusable_38cea190_3562_11ec_9d95_92812239cffc
-2021-10-25 07:07:31|ERROR|unexpected error -- backtrace written to log file
-2021-10-25 07:07:31|INFO|rows Inserted          = 0
-2021-10-25 07:07:31|INFO|rows Updated           = 0
-2021-10-25 07:07:31|INFO|data formatting errors = 0
-2021-10-25 07:07:31|INFO|gpload failed
+2021-11-29 11:57:05|INFO|gpload session started 2021-11-29 11:57:05
+2021-11-29 11:57:05|INFO|setting schema 'public' for table 'texttable2'
+2021-11-29 11:57:05|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-11-29 11:57:05|INFO|did not find an external table to reuse. creating ext_gpload_reusable_6adbab20_50c8_11ec_94a0_0050569e2380
+2021-11-29 11:57:05|ERROR|could not run SQL "create external table ext_gpload_reusable_6adbab20_50c8_11ec_94a0_0050569e2380("s1" text,"s2" text)location('gpfdist://10.117.190.10:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter '|' null '\N' escape '\' newline 'LFCR' ) encoding'UTF8' ": ERROR:  invalid value for NEWLINE "LFCR"
+HINT:  Valid options are: 'LF', 'CRLF' and 'CR'.
+
+2021-11-29 11:57:05|INFO|rows Inserted          = 0
+2021-11-29 11:57:05|INFO|rows Updated           = 0
+2021-11-29 11:57:05|INFO|data formatting errors = 0
+2021-11-29 11:57:05|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query260.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query260.ans
@@ -1,9 +1,11 @@
-2021-10-25 07:07:31|INFO|gpload session started 2021-10-25 07:07:31
-2021-10-25 07:07:31|INFO|setting schema 'public' for table 'texttable2'
-2021-10-25 07:07:31|INFO|started gpfdist -p 8081 -P 8082 -f "/tmp/build/e18b2f02/gpdb_src/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-10-25 07:07:31|INFO|did not find an external table to reuse. creating ext_gpload_reusable_38cea190_3562_11ec_9d95_92812239cffc
-2021-10-25 07:07:31|ERROR|unexpected error -- backtrace written to log file
-2021-10-25 07:07:31|INFO|rows Inserted          = 0
-2021-10-25 07:07:31|INFO|rows Updated           = 0
-2021-10-25 07:07:31|INFO|data formatting errors = 0
-2021-10-25 07:07:31|INFO|gpload failed
+2021-11-29 11:57:06|INFO|gpload session started 2021-11-29 11:57:06
+2021-11-29 11:57:06|INFO|setting schema 'public' for table 'texttable2'
+2021-11-29 11:57:06|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.csv" -t 30
+2021-11-29 11:57:06|INFO|did not find an external table to reuse. creating ext_gpload_reusable_6b1916f4_50c8_11ec_8cc5_0050569e2380
+2021-11-29 11:57:06|ERROR|could not run SQL "create external table ext_gpload_reusable_6b1916f4_50c8_11ec_8cc5_0050569e2380("s1" text,"s2" text)location('gpfdist://10.117.190.10:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.csv') format'csv' (delimiter ',' null '' escape '"' quote '"' newline 'LFCR' ) encoding'UTF8' ": ERROR:  invalid value for NEWLINE "LFCR"
+HINT:  Valid options are: 'LF', 'CRLF' and 'CR'.
+
+2021-11-29 11:57:06|INFO|rows Inserted          = 0
+2021-11-29 11:57:06|INFO|rows Updated           = 0
+2021-11-29 11:57:06|INFO|data formatting errors = 0
+2021-11-29 11:57:06|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query260.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query260.ans
@@ -1,11 +1,11 @@
-2021-11-29 11:57:06|INFO|gpload session started 2021-11-29 11:57:06
-2021-11-29 11:57:06|INFO|setting schema 'public' for table 'texttable2'
-2021-11-29 11:57:06|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.csv" -t 30
-2021-11-29 11:57:06|INFO|did not find an external table to reuse. creating ext_gpload_reusable_6b1916f4_50c8_11ec_8cc5_0050569e2380
-2021-11-29 11:57:06|ERROR|could not run SQL "create external table ext_gpload_reusable_6b1916f4_50c8_11ec_8cc5_0050569e2380("s1" text,"s2" text)location('gpfdist://10.117.190.10:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.csv') format'csv' (delimiter ',' null '' escape '"' quote '"' newline 'LFCR' ) encoding'UTF8' ": ERROR:  invalid value for NEWLINE "LFCR"
+2021-11-30 15:00:23|INFO|gpload session started 2021-11-30 15:00:23
+2021-11-30 15:00:23|INFO|setting schema 'public' for table 'texttable2'
+2021-11-30 15:00:23|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.csv" -t 30
+2021-11-30 15:00:23|INFO|did not find an external table to reuse. creating ext_gpload_reusable_30a0dcd0_51ab_11ec_839b_0050569e2380
+2021-11-30 15:00:23|ERROR|could not run SQL "create external table ext_gpload_reusable_30a0dcd0_51ab_11ec_839b_0050569e2380("s1" text,"s2" text)location('gpfdist://*:pathto/data_file.csv') format'csv' (delimiter ',' null '' escape '"' quote '"' newline 'LFCR' ) encoding'UTF8' ": ERROR:  invalid value for NEWLINE "LFCR"
 HINT:  Valid options are: 'LF', 'CRLF' and 'CR'.
 
-2021-11-29 11:57:06|INFO|rows Inserted          = 0
-2021-11-29 11:57:06|INFO|rows Updated           = 0
-2021-11-29 11:57:06|INFO|data formatting errors = 0
-2021-11-29 11:57:06|INFO|gpload failed
+2021-11-30 15:00:23|INFO|rows Inserted          = 0
+2021-11-30 15:00:23|INFO|rows Updated           = 0
+2021-11-30 15:00:23|INFO|data formatting errors = 0
+2021-11-30 15:00:23|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query37.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query37.ans
@@ -1,24 +1,26 @@
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 's1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-2020-10-19 11:09:21|INFO|gpload session started 2020-10-19 11:09:21
-2020-10-19 11:09:21|INFO|setting schema 'public' for table 'texttable'
-2020-10-19 11:09:21|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2020-10-19 11:09:21|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
-2020-10-19 11:09:21|INFO|did not find an external table to reuse. creating ext_gpload_reusable_7bf26200_11b8_11eb_a45c_00505698707d
-2020-10-19 11:09:21|ERROR|unexpected error -- backtrace written to log file
-2020-10-19 11:09:21|INFO|rows Inserted          = 0
-2020-10-19 11:09:21|INFO|rows Updated           = 0
-2020-10-19 11:09:21|INFO|data formatting errors = 0
-2020-10-19 11:09:21|INFO|gpload failed
+2021-11-29 11:57:32|INFO|gpload session started 2021-11-29 11:57:32
+2021-11-29 11:57:32|INFO|setting schema 'public' for table 'texttable'
+2021-11-29 11:57:32|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-11-29 11:57:32|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2021-11-29 11:57:32|INFO|did not find an external table to reuse. creating ext_gpload_reusable_7ac93e9e_50c8_11ec_821e_0050569e2380
+2021-11-29 11:57:32|ERROR|could not run SQL "create external table ext_gpload_reusable_7ac93e9e_50c8_11ec_821e_0050569e2380("s1" text,"s2" text,"s3" text,"dt" timestamp without time zone,"n1" smallint,"n2" integer,"n3" bigint,"n4" numeric,"n5" numeric,"n6" real,"n7" double precision)location('gpfdist://10.117.190.10:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter '|' null '\N' escape '\' ) encoding'xxxx' ": ERROR:  xxxx is not a valid encoding name
+
+2021-11-29 11:57:32|INFO|rows Inserted          = 0
+2021-11-29 11:57:32|INFO|rows Updated           = 0
+2021-11-29 11:57:32|INFO|data formatting errors = 0
+2021-11-29 11:57:32|INFO|gpload failed
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 's1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-2020-10-19 11:09:22|INFO|gpload session started 2020-10-19 11:09:22
-2020-10-19 11:09:22|INFO|setting schema 'public' for table 'texttable'
-2020-10-19 11:09:22|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2020-10-19 11:09:22|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
-2020-10-19 11:09:22|INFO|did not find an external table to reuse. creating ext_gpload_reusable_7c2d9dde_11b8_11eb_af8a_00505698707d
-2020-10-19 11:09:22|ERROR|unexpected error -- backtrace written to log file
-2020-10-19 11:09:22|INFO|rows Inserted          = 0
-2020-10-19 11:09:22|INFO|rows Updated           = 0
-2020-10-19 11:09:22|INFO|data formatting errors = 0
-2020-10-19 11:09:22|INFO|gpload failed
+2021-11-29 11:57:32|INFO|gpload session started 2021-11-29 11:57:32
+2021-11-29 11:57:32|INFO|setting schema 'public' for table 'texttable'
+2021-11-29 11:57:32|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-11-29 11:57:32|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2021-11-29 11:57:32|INFO|did not find an external table to reuse. creating ext_gpload_reusable_7ae5d7e8_50c8_11ec_9979_0050569e2380
+2021-11-29 11:57:32|ERROR|could not run SQL "create external table ext_gpload_reusable_7ae5d7e8_50c8_11ec_9979_0050569e2380("s1" text,"s2" text,"s3" text,"dt" timestamp without time zone,"n1" smallint,"n2" integer,"n3" bigint,"n4" numeric,"n5" numeric,"n6" real,"n7" double precision)location('gpfdist://10.117.190.10:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter '|' null '\N' escape '\' ) encoding'xxxx' ": ERROR:  xxxx is not a valid encoding name
+
+2021-11-29 11:57:32|INFO|rows Inserted          = 0
+2021-11-29 11:57:32|INFO|rows Updated           = 0
+2021-11-29 11:57:32|INFO|data formatting errors = 0
+2021-11-29 11:57:32|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query402.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query402.ans
@@ -1,10 +1,10 @@
-2021-11-29 11:57:43|INFO|gpload session started 2021-11-29 11:57:43
-2021-11-29 11:57:43|INFO|setting schema 'public' for table 'texttable'
-2021-11-29 11:57:43|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/external_file_01.txt" -t 30
-2021-11-29 11:57:43|INFO|did not find an external table to reuse. creating non_ext_schema_test.ext_gpload_reusable_818d6a0c_50c8_11ec_afe5_0050569e2380
-2021-11-29 11:57:43|ERROR|could not run SQL "create external table non_ext_schema_test.ext_gpload_reusable_818d6a0c_50c8_11ec_afe5_0050569e2380("s1" text,"s2" text,"s3" text,"dt" timestamp without time zone,"n1" smallint,"n2" integer,"n3" bigint,"n4" numeric,"n5" numeric,"n6" real,"n7" double precision)location('gpfdist://10.117.190.10:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/external_file_01.txt') format'text' (delimiter '|' null '\N' escape '\' ) encoding'UTF8' ": ERROR:  schema "non_ext_schema_test" does not exist
+2021-11-30 15:17:58|INFO|gpload session started 2021-11-30 15:17:58
+2021-11-30 15:17:58|INFO|setting schema 'public' for table 'texttable'
+2021-11-30 15:17:58|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2021-11-30 15:17:58|INFO|did not find an external table to reuse. creating non_ext_schema_test.ext_gpload_reusable_a53b654a_51ad_11ec_b1b3_0050569e2380
+2021-11-30 15:17:58|ERROR|could not run SQL "create external table non_ext_schema_test.ext_gpload_reusable_a53b654a_51ad_11ec_b1b3_0050569e2380("s1" text,"s2" text,"s3" text,"dt" timestamp without time zone,"n1" smallint,"n2" integer,"n3" bigint,"n4" numeric,"n5" numeric,"n6" real,"n7" double precision)location('gpfdist://*:pathto/data_file.txt') format'text' (delimiter '|' null '\N' escape '\' ) encoding'UTF8' ": ERROR:  schema "non_ext_schema_test" does not exist
 
-2021-11-29 11:57:43|INFO|rows Inserted          = 0
-2021-11-29 11:57:43|INFO|rows Updated           = 0
-2021-11-29 11:57:43|INFO|data formatting errors = 0
-2021-11-29 11:57:43|INFO|gpload failed
+2021-11-30 15:17:58|INFO|rows Inserted          = 0
+2021-11-30 15:17:58|INFO|rows Updated           = 0
+2021-11-30 15:17:58|INFO|data formatting errors = 0
+2021-11-30 15:17:58|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query402.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query402.ans
@@ -1,9 +1,10 @@
-2021-01-05 17:03:42|INFO|gpload session started 2021-01-05 17:03:42
-2021-01-05 17:03:42|INFO|setting schema 'public' for table 'texttable'
-2021-01-05 17:03:42|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/external_file_01.txt" -t 30
-2021-01-05 17:03:42|INFO|did not find an external table to reuse. creating non_ext_schema_test.ext_gpload_reusable_e8969ec6_4f34_11eb_9b77_7085c2381836
-2021-01-05 17:03:42|ERROR|unexpected error -- backtrace written to log file
-2021-01-05 17:03:42|INFO|rows Inserted          = 0
-2021-01-05 17:03:42|INFO|rows Updated           = 0
-2021-01-05 17:03:42|INFO|data formatting errors = 0
-2021-01-05 17:03:42|INFO|gpload failed
+2021-11-29 11:57:43|INFO|gpload session started 2021-11-29 11:57:43
+2021-11-29 11:57:43|INFO|setting schema 'public' for table 'texttable'
+2021-11-29 11:57:43|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/external_file_01.txt" -t 30
+2021-11-29 11:57:43|INFO|did not find an external table to reuse. creating non_ext_schema_test.ext_gpload_reusable_818d6a0c_50c8_11ec_afe5_0050569e2380
+2021-11-29 11:57:43|ERROR|could not run SQL "create external table non_ext_schema_test.ext_gpload_reusable_818d6a0c_50c8_11ec_afe5_0050569e2380("s1" text,"s2" text,"s3" text,"dt" timestamp without time zone,"n1" smallint,"n2" integer,"n3" bigint,"n4" numeric,"n5" numeric,"n6" real,"n7" double precision)location('gpfdist://10.117.190.10:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/external_file_01.txt') format'text' (delimiter '|' null '\N' escape '\' ) encoding'UTF8' ": ERROR:  schema "non_ext_schema_test" does not exist
+
+2021-11-29 11:57:43|INFO|rows Inserted          = 0
+2021-11-29 11:57:43|INFO|rows Updated           = 0
+2021-11-29 11:57:43|INFO|data formatting errors = 0
+2021-11-29 11:57:43|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query76.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query76.ans
@@ -3,43 +3,49 @@ LINE 13:                  and pgext.fmtopts like '%delimiter '';'' nu...
                                                  ^
 HINT:  Use the escape string syntax for backslashes, e.g., E'\\'.
 WARNING:  nonstandard use of escape in a string literal
-LINE 1: .../data_file.txt') format'text' (delimiter ';' null '\N' escap...
+LINE 1: ...pathto/data_file.txt') format'text' (delimiter ';' null '\N' escap...
                                                              ^
 HINT:  Use the escape string syntax for escapes, e.g., E'\r\n'.
 WARNING:  nonstandard use of \' in a string literal
 LINE 1: ...xt') format'text' (delimiter ';' null '\N' escape '\' ) enco...
                                                              ^
 HINT:  Use '' to write quotes in strings, or use the escape string syntax (E'...').
-2021-08-10 14:56:47|INFO|gpload session started 2021-08-10 14:56:47
-2021-08-10 14:56:47|INFO|setting schema 'public' for table 'chinese表'
-2021-08-10 14:56:47|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-08-10 14:56:47|INFO|did not find an external table to reuse. creating ext_gpload_reusable_211fb6e2_f9a8_11eb_9c97_0050569e2380
-2021-08-10 14:56:47|ERROR|unexpected error -- backtrace written to log file
-2021-08-10 14:56:47|INFO|rows Inserted          = 0
-2021-08-10 14:56:47|INFO|rows Updated           = 0
-2021-08-10 14:56:47|INFO|data formatting errors = 0
-2021-08-10 14:56:47|INFO|gpload failed
-2021-08-10 14:56:47|ERROR|configuration file error: expected <block end>, but found '<scalar>', line 14
-2021-08-10 14:56:47|INFO|gpload session started 2021-08-10 14:56:47
-2021-08-10 14:56:47|INFO|setting schema 'public' for table 'chinese表'
-2021-08-10 14:56:47|ERROR|no mapping for input column "'列1'" to output table
-2021-08-10 14:56:47|INFO|rows Inserted          = 0
-2021-08-10 14:56:47|INFO|rows Updated           = 0
-2021-08-10 14:56:47|INFO|data formatting errors = 0
-2021-08-10 14:56:47|INFO|gpload failed
+2021-11-29 15:29:03|INFO|gpload session started 2021-11-29 15:29:03
+2021-11-29 15:29:03|INFO|setting schema 'public' for table 'chinese表'
+2021-11-29 15:29:03|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2021-11-29 15:29:03|INFO|did not find an external table to reuse. creating ext_gpload_reusable_075bc846_50e6_11ec_8cb7_0050569e2380
+2021-11-29 15:29:03|ERROR|could not run SQL "create external table ext_gpload_reusable_075bc846_50e6_11ec_8cb7_0050569e2380("列1" text,"列#2" int,"lie3" timestamp)location('gpfdist://*:pathto/data_file.txt') format'text' (delimiter ';' null '\N' escape '\' ) encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+LINE 1: ...'text' (delimiter ';' null '\N' escape '\' ) encoding'UTF8' 
+                                                                 ^
+
+2021-11-29 15:29:03|INFO|rows Inserted          = 0
+2021-11-29 15:29:03|INFO|rows Updated           = 0
+2021-11-29 15:29:03|INFO|data formatting errors = 0
+2021-11-29 15:29:03|INFO|gpload failed
+2021-11-29 15:29:03|ERROR|configuration file error: expected <block end>, but found '<scalar>', line 14
+2021-11-29 15:29:04|INFO|gpload session started 2021-11-29 15:29:04
+2021-11-29 15:29:04|INFO|setting schema 'public' for table 'chinese表'
+2021-11-29 15:29:04|ERROR|no mapping for input column "'列1'" to output table
+2021-11-29 15:29:04|INFO|rows Inserted          = 0
+2021-11-29 15:29:04|INFO|rows Updated           = 0
+2021-11-29 15:29:04|INFO|data formatting errors = 0
+2021-11-29 15:29:04|INFO|gpload failed
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named '列1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 WARNING:  nonstandard use of \\ in a string literal
 LINE 13:                  and pgext.fmtopts like '%delimiter '';'' nu...
                                                  ^
 HINT:  Use the escape string syntax for backslashes, e.g., E'\\'.
-2021-08-10 14:56:47|INFO|gpload session started 2021-08-10 14:56:47
-2021-08-10 14:56:47|INFO|setting schema 'public' for table 'chinese表'
-2021-08-10 14:56:47|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-08-10 14:56:47|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_5171458efa83aaf8c5bc7004bae85d5b
-2021-08-10 14:56:47|INFO|did not find an external table to reuse. creating ext_gpload_reusable_21691346_f9a8_11eb_a96a_0050569e2380
-2021-08-10 14:56:47|ERROR|unexpected error -- backtrace written to log file
-2021-08-10 14:56:47|INFO|rows Inserted          = 0
-2021-08-10 14:56:47|INFO|rows Updated           = 0
-2021-08-10 14:56:47|INFO|data formatting errors = 0
-2021-08-10 14:56:47|INFO|gpload failed
+2021-11-29 15:29:04|INFO|gpload session started 2021-11-29 15:29:04
+2021-11-29 15:29:04|INFO|setting schema 'public' for table 'chinese表'
+2021-11-29 15:29:04|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2021-11-29 15:29:04|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_5171458efa83aaf8c5bc7004bae85d5b
+2021-11-29 15:29:04|INFO|did not find an external table to reuse. creating ext_gpload_reusable_07a3c70e_50e6_11ec_9873_0050569e2380
+2021-11-29 15:29:04|ERROR|could not run SQL "create external table ext_gpload_reusable_07a3c70e_50e6_11ec_9873_0050569e2380(列1 text,列#2 int,lie3 timestamp)location('gpfdist://*:pathto/data_file.txt') format'text' (delimiter ';' null '\N' escape '\' ) encoding'UTF8' ": ERROR:  syntax error at or near "#"
+LINE 1: ...(列1 text,列#2 int,lie...
+                                                             ^
+
+2021-11-29 15:29:04|INFO|rows Inserted          = 0
+2021-11-29 15:29:04|INFO|rows Updated           = 0
+2021-11-29 15:29:04|INFO|data formatting errors = 0
+2021-11-29 15:29:04|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query77.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query77.ans
@@ -10,15 +10,18 @@ WARNING:  nonstandard use of \' in a string literal
 LINE 1: ...xt') format'text' (delimiter ';' null '\N' escape '\' ) enco...
                                                              ^
 HINT:  Use '' to write quotes in strings, or use the escape string syntax (E'...').
-2021-08-10 14:56:47|INFO|gpload session started 2021-08-10 14:56:47
-2021-08-10 14:56:47|INFO|setting schema 'public' for table 'testspecialchar'
-2021-08-10 14:56:47|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-08-10 14:56:47|INFO|did not find an external table to reuse. creating ext_gpload_reusable_2196b198_f9a8_11eb_a63f_0050569e2380
-2021-08-10 14:56:47|ERROR|unexpected error -- backtrace written to log file
-2021-08-10 14:56:47|INFO|rows Inserted          = 0
-2021-08-10 14:56:47|INFO|rows Updated           = 0
-2021-08-10 14:56:47|INFO|data formatting errors = 0
-2021-08-10 14:56:47|INFO|gpload failed
+2021-11-29 11:57:13|INFO|gpload session started 2021-11-29 11:57:13
+2021-11-29 11:57:13|INFO|setting schema 'public' for table 'testspecialchar'
+2021-11-29 11:57:13|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-11-29 11:57:13|INFO|did not find an external table to reuse. creating ext_gpload_reusable_6f40f210_50c8_11ec_89e8_0050569e2380
+2021-11-29 11:57:13|ERROR|could not run SQL "create external table ext_gpload_reusable_6f40f210_50c8_11ec_89e8_0050569e2380("Field1" text,"Field#2" text)location('gpfdist://10.117.190.10:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter ';' null '\N' escape '\' ) encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+LINE 1: ...'text' (delimiter ';' null '\N' escape '\' ) encoding'UTF8' 
+                                                                 ^
+
+2021-11-29 11:57:13|INFO|rows Inserted          = 0
+2021-11-29 11:57:13|INFO|rows Updated           = 0
+2021-11-29 11:57:13|INFO|data formatting errors = 0
+2021-11-29 11:57:13|INFO|gpload failed
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'Field1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 WARNING:  nonstandard use of \\ in a string literal
@@ -33,27 +36,30 @@ WARNING:  nonstandard use of \' in a string literal
 LINE 1: ...xt') format'text' (delimiter ';' null '\N' escape '\' ) enco...
                                                              ^
 HINT:  Use '' to write quotes in strings, or use the escape string syntax (E'...').
-2021-08-10 14:56:48|INFO|gpload session started 2021-08-10 14:56:48
-2021-08-10 14:56:48|INFO|setting schema 'public' for table 'testspecialchar'
-2021-08-10 14:56:48|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-08-10 14:56:48|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_40df9a45044f2d17b97f89bbbc58f24f
-2021-08-10 14:56:48|INFO|did not find an external table to reuse. creating ext_gpload_reusable_21b32daa_f9a8_11eb_acb0_0050569e2380
-2021-08-10 14:56:48|ERROR|unexpected error -- backtrace written to log file
-2021-08-10 14:56:48|INFO|rows Inserted          = 0
-2021-08-10 14:56:48|INFO|rows Updated           = 0
-2021-08-10 14:56:48|INFO|data formatting errors = 0
-2021-08-10 14:56:48|INFO|gpload failed
-2021-08-10 14:56:48|INFO|gpload session started 2021-08-10 14:56:48
-2021-08-10 14:56:48|INFO|setting schema 'public' for table 'testspecialchar'
-2021-08-10 14:56:48|ERROR|no mapping for input column "'Field1'" to output table
-2021-08-10 14:56:48|INFO|rows Inserted          = 0
-2021-08-10 14:56:48|INFO|rows Updated           = 0
-2021-08-10 14:56:48|INFO|data formatting errors = 0
-2021-08-10 14:56:48|INFO|gpload failed
-2021-08-10 14:56:48|INFO|gpload session started 2021-08-10 14:56:48
-2021-08-10 14:56:48|INFO|setting schema 'public' for table 'testspecialchar'
-2021-08-10 14:56:48|ERROR|no mapping for input column "Field1" to output table
-2021-08-10 14:56:48|INFO|rows Inserted          = 0
-2021-08-10 14:56:48|INFO|rows Updated           = 0
-2021-08-10 14:56:48|INFO|data formatting errors = 0
-2021-08-10 14:56:48|INFO|gpload failed
+2021-11-29 11:57:13|INFO|gpload session started 2021-11-29 11:57:13
+2021-11-29 11:57:13|INFO|setting schema 'public' for table 'testspecialchar'
+2021-11-29 11:57:13|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-11-29 11:57:13|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_40df9a45044f2d17b97f89bbbc58f24f
+2021-11-29 11:57:13|INFO|did not find an external table to reuse. creating ext_gpload_reusable_6f5c6568_50c8_11ec_ae2f_0050569e2380
+2021-11-29 11:57:13|ERROR|could not run SQL "create external table ext_gpload_reusable_6f5c6568_50c8_11ec_ae2f_0050569e2380("Field1" text,"Field#2" text)location('gpfdist://10.117.190.10:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format'text' (delimiter ';' null '\N' escape '\' ) encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+LINE 1: ...'text' (delimiter ';' null '\N' escape '\' ) encoding'UTF8' 
+                                                                 ^
+
+2021-11-29 11:57:13|INFO|rows Inserted          = 0
+2021-11-29 11:57:13|INFO|rows Updated           = 0
+2021-11-29 11:57:13|INFO|data formatting errors = 0
+2021-11-29 11:57:13|INFO|gpload failed
+2021-11-29 11:57:13|INFO|gpload session started 2021-11-29 11:57:13
+2021-11-29 11:57:13|INFO|setting schema 'public' for table 'testspecialchar'
+2021-11-29 11:57:13|ERROR|no mapping for input column "'Field1'" to output table
+2021-11-29 11:57:13|INFO|rows Inserted          = 0
+2021-11-29 11:57:13|INFO|rows Updated           = 0
+2021-11-29 11:57:13|INFO|data formatting errors = 0
+2021-11-29 11:57:13|INFO|gpload failed
+2021-11-29 11:57:13|INFO|gpload session started 2021-11-29 11:57:13
+2021-11-29 11:57:13|INFO|setting schema 'public' for table 'testspecialchar'
+2021-11-29 11:57:13|ERROR|no mapping for input column "Field1" to output table
+2021-11-29 11:57:13|INFO|rows Inserted          = 0
+2021-11-29 11:57:13|INFO|rows Updated           = 0
+2021-11-29 11:57:13|INFO|data formatting errors = 0
+2021-11-29 11:57:13|INFO|gpload failed


### PR DESCRIPTION
When gpload finds reuse external tables, it will check the format option(as a string) of the external table. The order of the format options matters.
Modify the order of adding newline option when creating the sql to create external table and find it.

Also, change the type of an error message to make it print normally.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
