### PR TITLE
(6x) Throw error when try to Init SubPlan with Motion during EvalPlanQual.

### DIFF
--- a/src/test/isolation2/expected/gdd/concurrent_update_optimizer.out
+++ b/src/test/isolation2/expected/gdd/concurrent_update_optimizer.out
@@ -323,25 +323,30 @@ UPDATE 1
 -- make sure planner will contain InitPlan
 -- NOTE: orca does not generate InitPlan.
 2: explain update t_epq_subplans set b = b + 1 where a > -1.5 * (select max(a) from t_epq_subplans);
- QUERY PLAN                                                                                              
----------------------------------------------------------------------------------------------------------
- Update on t_epq_subplans  (cost=1.08..2.11 rows=1 width=18)                                             
-   InitPlan 1 (returns $0)  (slice2)                                                                     
-     ->  Aggregate  (cost=1.07..1.08 rows=1 width=4)                                                     
-           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=1.01..1.06 rows=1 width=4)                
-                 ->  Aggregate  (cost=1.01..1.02 rows=1 width=4)                                         
-                       ->  Seq Scan on t_epq_subplans t_epq_subplans_1  (cost=0.00..1.01 rows=1 width=4) 
-   ->  Seq Scan on t_epq_subplans  (cost=0.00..1.02 rows=1 width=18)                                     
-         Filter: ((a)::numeric > ((-1.5) * ($0)::numeric))                                               
- Optimizer: Postgres query optimizer                                                                     
-(9 rows)
+ QUERY PLAN                                                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Update  (cost=0.00..1324032.68 rows=1 width=1)                                                                                                
+   ->  Result  (cost=0.00..1324032.61 rows=1 width=26)                                                                                         
+         ->  Split  (cost=0.00..1324032.61 rows=1 width=22)                                                                                    
+               ->  Result  (cost=0.00..1324032.61 rows=1 width=22)                                                                             
+                     ->  Seq Scan on t_epq_subplans  (cost=0.00..1324032.61 rows=1 width=18)                                                   
+                           Filter: ((a)::numeric > ((-1.5) * ((SubPlan 1))::numeric))                                                          
+                           SubPlan 1  (slice0; segments: 3)                                                                                    
+                             ->  Materialize  (cost=0.00..431.00 rows=1 width=4)                                                               
+                                   ->  Broadcast Motion 1:3  (slice2; segments: 1)  (cost=0.00..431.00 rows=3 width=4)                         
+                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)                                                     
+                                               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)                
+                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)                                         
+                                                           ->  Seq Scan on t_epq_subplans t_epq_subplans_1  (cost=0.00..431.00 rows=1 width=4) 
+ Optimizer: Pivotal Optimizer (GPORCA)                                                                                                         
+(14 rows)
 2&: update t_epq_subplans set b = b + 1 where a > -1.5 * (select max(a) from t_epq_subplans);  <waiting ...>
 
 1: end;
 END
 -- session 2 should throw error and not PANIC
 2<:  <... completed>
-ERROR:  EvalPlanQual can not handle subPlan with Motion node  (seg1 127.0.1.1:6003 pid=88214)
+ERROR:  tuple to be updated was already moved to another segment due to concurrent update  (seg1 127.0.1.1:6003 pid=116712)
 
 1: drop table t_epq_subplans;
 DROP


### PR DESCRIPTION
With GDD enabled, QE might be blocked by other transaction's UPDATE
operation, and later wakes up, EvalPlanQual logic is triggered. To
re-evaluate the plan, it will try to init all subplans (even if the
subplan is not needed in the plan to re-eval), we should also consider
nmotions when init such subplans. Throw error to avoid PANIC when
such subplans contain motion.

NOTE: this is not a behavior change and this just makes thing correct.
See Greenplum's document: https://docs.greenplum.org/6-16/admin_guide/dml.html#topic_gdd
for details. Error out here to make the database consistent is the same idea
as the Postgres's repeatable read isolation level, see the Postgres doc for
details: https://www.postgresql.org/docs/9.4/transaction-iso.html.

-------

Master branch does not need this, since it already contains such logic (thanks to commit 1c2489d07ec58dbde8e1374f4982adb1d455c7a5).

5X does not have GDD thus no change to have the issue.
