### PR TITLE
(6x) Not use temp tablespaces for snapshot buf-file passed to reader cursor.

### DIFF
--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -75,6 +75,7 @@
 #include "catalog/pg_tablespace.h"
 #include "cdb/cdbvars.h"
 #include "pgstat.h"
+#include "storage/buffile.h"
 #include "storage/fd.h"
 #include "storage/ipc.h"
 #include "utils/guc.h"
@@ -1255,7 +1256,7 @@ OpenNamedTemporaryFile(const char *fileName,
 	 * force it into the database's default tablespace, so that it will not
 	 * pose a threat to possible tablespace drop attempts.
 	 */
-	if (numTempTableSpaces > 0 && !interXact)
+	if (numTempTableSpaces > 0 && !interXact && !GetForceDefaultTableSpaceVal())
 	{
 		Oid            tblspcOid = GetNextTempTableSpace();
 

--- a/src/backend/utils/time/sharedsnapshot.c
+++ b/src/backend/utils/time/sharedsnapshot.c
@@ -834,6 +834,16 @@ readSharedLocalSnapshot_forCursor(Snapshot snapshot, DtxContext distributedTrans
 		snapshot->curcid,
 		distributedTransactionContext);
 
+	/*
+	 * After SetSharedTransactionId_reader is called, we need to
+	 * invalidate catalog snapshot so that next time it will get
+	 * a new catalog snapshot containing the correct command id.
+	 *
+	 * See Issue https://github.com/greenplum-db/gpdb/issues/12871#issuecomment-982627753
+	 * for details.
+	 */
+	InvalidateCatalogSnapshot();
+
 	return;
 }
 

--- a/src/include/storage/buffile.h
+++ b/src/include/storage/buffile.h
@@ -64,4 +64,11 @@ extern bool gp_workfile_compression;
 extern void BufFilePledgeSequential(BufFile *buffile);
 extern void BufFileSetIsTempFile(BufFile *file, bool isTempFile);
 
+extern void SetForceDefaultTableSpaceVal(bool val);
+extern bool GetForceDefaultTableSpaceVal(void);
+extern BufFile *BufFileCreateNamedTemp_ForceDefaultSpace(const char *fileName, bool interXact,
+														 struct workfile_set *work_set);
+extern BufFile *BufFileOpenNamedTemp_ForceDefaultSpace(const char *fileName,
+													   bool interXact);
+
 #endif   /* BUFFILE_H */

--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -182,6 +182,7 @@ tablespace-setup:
 	./testtablespace_mytempsp2 \
 	./testtablespace_mytempsp3 \
 	./testtablespace_mytempsp4 \
+	./testtablespace_space_12871 \
 	./testtablespace_database_tablespace
 
 .PHONY: hooktest

--- a/src/test/regress/input/temp_tablespaces.source
+++ b/src/test/regress/input/temp_tablespaces.source
@@ -276,3 +276,28 @@ drop tablespace mytempsp1;
 drop tablespace mytempsp2;
 drop tablespace mytempsp3;
 drop tablespace mytempsp4;
+
+-- test for Github Issue 12871
+create tablespace space_12871 location '@testtablespace@_space_12871';
+set temp_tablespaces = space_12871;
+DO
+$$
+    DECLARE l_rec RECORD;
+    BEGIN
+        CREATE TEMPORARY TABLE tmp_table_12871
+        (
+            key VARCHAR NOT NULL,
+            value   VARCHAR NOT NULL
+        )   DISTRIBUTED RANDOMLY;
+        INSERT INTO tmp_table_12871  VALUES ('a',1),('b',2);
+        FOR l_rec IN ( SELECT key, value
+                       FROM tmp_table_12871
+                       )
+            LOOP
+                RAISE NOTICE 'ok';
+            END LOOP;
+    END;
+$$;
+drop table tmp_table_12871;
+drop tablespace space_12871;
+

--- a/src/test/regress/output/temp_tablespaces.source
+++ b/src/test/regress/output/temp_tablespaces.source
@@ -469,3 +469,28 @@ drop tablespace mytempsp1;
 drop tablespace mytempsp2;
 drop tablespace mytempsp3;
 drop tablespace mytempsp4;
+-- test for Github Issue 12871
+create tablespace space_12871 location '@testtablespace@_space_12871';
+set temp_tablespaces = space_12871;
+DO
+$$
+    DECLARE l_rec RECORD;
+    BEGIN
+        CREATE TEMPORARY TABLE tmp_table_12871
+        (
+            key VARCHAR NOT NULL,
+            value   VARCHAR NOT NULL
+        )   DISTRIBUTED RANDOMLY;
+        INSERT INTO tmp_table_12871  VALUES ('a',1),('b',2);
+        FOR l_rec IN ( SELECT key, value
+                       FROM tmp_table_12871
+                       )
+            LOOP
+                RAISE NOTICE 'ok';
+            END LOOP;
+    END;
+$$;
+NOTICE:  ok
+NOTICE:  ok
+drop table tmp_table_12871;
+drop tablespace space_12871;


### PR DESCRIPTION
The buf-file of snapshot passed to reader cursor is not large so we
do not need to put it in temp tablespaces even the GUC is set. This
can fix a complicated infinite recursive function call problem 
mentioned in Github Issue 12871. (So long, not suitable to elaborate
here).

This commit also invalidate CatalogSnapshot at the end of the function
readSharedLocalSnapshot_forCursor(), so that next it will create a
new CatalogSnapshot that contains the correct command id from the
shared snapshot loaded.

Fix Issue: https://github.com/greenplum-db/gpdb/issues/12871, refer to
the issue page for details.
