### PR TITLE
Fix a resource queue active stmt leak case

### DIFF
--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -339,7 +339,11 @@ ResLockAcquire(LOCKTAG *locktag, ResPortalIncrement *incrementSet)
 		lock->requested[lockmode]--;
 		Assert((lock->nRequested >= 0) && (lock->requested[lockmode] >= 0));
 
-		/* Clean up this lock. */
+		/*
+		 * Clean up the locallock. Since a single locallock can represent
+		 * multiple locked portals in the same backend, we can only remove it if
+		 * this is the last portal.
+		 */
 		if (proclock->nLocks == 0)
 			RemoveLocalLock(locallock);
 
@@ -401,7 +405,11 @@ ResLockAcquire(LOCKTAG *locktag, ResPortalIncrement *incrementSet)
 		lock->requested[lockmode]--;
 		Assert((lock->nRequested >= 0) && (lock->requested[lockmode] >= 0));
 
-		/* Clean up this lock. */
+		/*
+		 * Clean up the locallock. Since a single locallock can represent
+		 * multiple locked portals in the same backend, we can only remove it if
+		 * this is the last portal.
+		 */
 		if (proclock->nLocks == 0)
 			RemoveLocalLock(locallock);
 
@@ -601,6 +609,11 @@ ResLockRelease(LOCKTAG *locktag, uint32 resPortalId)
 	if (!incrementSet)
 	{
 		elog(DEBUG1, "Resource queue %d: increment not found on unlock", locktag->locktag_field1);
+		/*
+		 * Clean up the locallock. Since a single locallock can represent
+		 * multiple locked portals in the same backend, we can only remove it if
+		 * this is the last portal.
+		 */
 		if (proclock->nLocks == 0)
 		{
 			RemoveLocalLock(locallock);
@@ -620,6 +633,10 @@ ResLockRelease(LOCKTAG *locktag, uint32 resPortalId)
 
 	/*
 	 * Perform clean-up, waking up any waiters!
+	 *
+	 * Clean up the locallock. Since a single locallock can represent
+	 * multiple locked portals in the same backend, we can only remove it if
+	 * this is the last portal.
 	 */
 	if (proclock->nLocks == 0)
 		RemoveLocalLock(locallock);

--- a/src/test/isolation2/expected/resource_queue.out
+++ b/src/test/isolation2/expected/resource_queue.out
@@ -73,6 +73,13 @@ END
 3:END;
 END
 
+-- Sanity check: Ensure that the resource queue is now empty.
+0: SELECT rsqcountlimit, rsqcountvalue from pg_resqueue_status WHERE rsqname = 'rq_concurrency_test';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 1             | 0             
+(1 row)
+
 0:DROP role role_concurrency_test;
 DROP
 0:DROP RESOURCE QUEUE rq_concurrency_test;

--- a/src/test/isolation2/expected/resource_queue_cancel.out
+++ b/src/test/isolation2/expected/resource_queue_cancel.out
@@ -1,0 +1,55 @@
+-- Simple test for cancellation of a query stuck on a resource queue when the
+-- active statements limit is reached.
+
+0:CREATE RESOURCE QUEUE rq_cancel WITH (active_statements = 1);
+CREATE
+0:CREATE ROLE role_cancel RESOURCE QUEUE rq_cancel;
+CREATE
+
+-- Consume an active statement in session 1.
+1:SET ROLE role_cancel;
+SET
+1:BEGIN;
+BEGIN
+1:DECLARE c CURSOR FOR SELECT 0;
+DECLARE
+
+-- Make session 2 wait on the resource queue lock.
+2:SET ROLE role_cancel;
+SET
+2&:SELECT 100;  <waiting ...>
+
+-- Cancel SELECT from session 2.
+0:SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE query='SELECT 100;';
+ pg_cancel_backend 
+-------------------
+ t                 
+(1 row)
+
+-- Now once we quit session 1, we should be able to consume the vacated active
+-- statement slot in session 2.
+1q: ... <quitting>
+
+2<:  <... completed>
+ERROR:  canceling statement due to user request
+2:END;
+END
+2:BEGIN;
+BEGIN
+2:DECLARE c CURSOR FOR SELECT 0;
+DECLARE
+
+2q: ... <quitting>
+
+-- Sanity check: Ensure that the resource queue is now empty.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_cancel';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 1             | 0             
+(1 row)
+
+-- Cleanup
+0:DROP ROLE role_cancel;
+DROP
+0:DROP RESOURCE QUEUE rq_cancel;
+DROP

--- a/src/test/isolation2/expected/resource_queue_deadlock.out
+++ b/src/test/isolation2/expected/resource_queue_deadlock.out
@@ -52,6 +52,13 @@ ROLLBACK
 1<:  <... completed>
 INSERT 1
 
+-- Sanity check: Ensure that the resource queue is now empty.
+0: SELECT rsqcountlimit, rsqcountvalue from pg_resqueue_status WHERE rsqname = 'rq_deadlock_test';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 1             | 0             
+(1 row)
+
 -- Clean up the test
 0: DROP TABLE t_deadlock_test;
 DROP

--- a/src/test/isolation2/expected/resource_queue_multi_portal.out
+++ b/src/test/isolation2/expected/resource_queue_multi_portal.out
@@ -1,0 +1,180 @@
+-- Here we ensure that we clean up resource queue in-memory state gracefully
+-- in the face of deadlocks and statement cancellations, when there is more than
+-- one active portal in the session.
+0:CREATE RESOURCE QUEUE rq_multi_portal WITH (active_statements = 2);
+CREATE
+0:CREATE ROLE role_multi_portal RESOURCE QUEUE rq_multi_portal;
+CREATE
+
+--
+-- Scenario 1:
+-- Multiple explicit cursors active in the same session with a deadlock.
+--
+1:SET ROLE role_multi_portal;
+SET
+1:BEGIN;
+BEGIN
+1:DECLARE c1 CURSOR FOR SELECT 1;
+DECLARE
+
+2:SET ROLE role_multi_portal;
+SET
+2:BEGIN;
+BEGIN
+2:DECLARE c2 CURSOR FOR SELECT 1;
+DECLARE
+
+-- There should be 2 active statements.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 2             | 2             
+(1 row)
+
+-- This should block as it will exceed the active statements limit.
+1&:DECLARE c3 CURSOR FOR SELECT 1;  <waiting ...>
+
+-- There should be 2 active statements.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 2             | 2             
+(1 row)
+
+-- This should cause a deadlock.
+2:DECLARE c4 CURSOR FOR SELECT 1;
+DECLARE
+
+-- After the deadlock report, one session should have ERRORed out with the
+-- deadlock report and aborted, while the other session should remain active
+-- and idle in transaction. The active statement count should be 2, contributed
+-- to by the session that is idle in transaction.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 2             | 2             
+(1 row)
+0:SELECT count(*) from pg_stat_activity WHERE query LIKE 'DECLARE c% CURSOR FOR SELECT 1;' AND state = 'idle in transaction';
+ count 
+-------
+ 1     
+(1 row)
+0:SELECT count(*) from pg_stat_activity WHERE query LIKE 'DECLARE c% CURSOR FOR SELECT 1;' AND state = 'idle in transaction (aborted)';
+ count 
+-------
+ 1     
+(1 row)
+
+-- After quitting the sessions there should be 0 active statements.
+1<:  <... completed>
+ERROR:  deadlock detected
+DETAIL:  Process 738539 waits for ExclusiveLock on resource queue 90366; blocked by process 738548.
+Process 738548 waits for ExclusiveLock on resource queue 90366; blocked by process 738539.
+HINT:  See server log for query details.
+1q: ... <quitting>
+2q: ... <quitting>
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 2             | 0             
+(1 row)
+
+--
+-- Scenario 2:
+-- Multiple explicit cursors active in the same session with a self deadlock.
+--
+1:SET ROLE role_multi_portal;
+SET
+1:BEGIN;
+BEGIN
+1:DECLARE c1 CURSOR FOR SELECT 1;
+DECLARE
+1:DECLARE c2 CURSOR FOR SELECT 1;
+DECLARE
+
+-- There should be 2 active statements.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 2             | 2             
+(1 row)
+
+-- This should cause a self-deadlock and session 1 should error out, aborting
+-- its transaction.
+1:DECLARE c3 CURSOR FOR SELECT 1;
+ERROR:  deadlock detected, locking against self
+
+-- There should be 0 active statements following the transaction abort.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 2             | 0             
+(1 row)
+
+1q: ... <quitting>
+
+--
+-- Scenario 3:
+-- Multiple explicit cursors active in the same session with cancellation.
+--
+1:SET ROLE role_multi_portal;
+SET
+1:BEGIN;
+BEGIN
+1:DECLARE c1 CURSOR FOR SELECT 1;
+DECLARE
+
+2:SET ROLE role_multi_portal;
+SET
+2:BEGIN;
+BEGIN
+2:DECLARE c2 CURSOR FOR SELECT 1;
+DECLARE
+
+-- This should block as it will exceed the active statements limit.
+1&:DECLARE c3 CURSOR FOR SELECT 1;  <waiting ...>
+
+-- There should be 2 active statements.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 2             | 2             
+(1 row)
+
+-- Cancel session 1's transaction.
+0:SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE query = 'DECLARE c3 CURSOR FOR SELECT 1;';
+ pg_cancel_backend 
+-------------------
+ t                 
+(1 row)
+
+-- There should now only be one active statement, following the abort of session
+-- 1's transaction. The active statement is contributed by session 2.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 2             | 1             
+(1 row)
+0:SELECT query, state from pg_stat_activity WHERE query = 'DECLARE c2 CURSOR FOR SELECT 1;';
+ query                           | state               
+---------------------------------+---------------------
+ DECLARE c2 CURSOR FOR SELECT 1; | idle in transaction 
+(1 row)
+
+1<:  <... completed>
+ERROR:  canceling statement due to user request
+1q: ... <quitting>
+
+-- After quitting session 2 there should be 0 active statements.
+2q: ... <quitting>
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 2             | 0             
+(1 row)
+
+-- Cleanup
+0:DROP ROLE role_multi_portal;
+DROP
+0:DROP RESOURCE QUEUE rq_multi_portal;
+DROP

--- a/src/test/isolation2/init_file_isolation2
+++ b/src/test/isolation2/init_file_isolation2
@@ -39,8 +39,8 @@ m/^DETAIL:  Process \d+ waits for ShareLock on transaction \d+; blocked by proce
 s/^DETAIL:  Process \d+ waits for ShareLock on transaction \d+; blocked by process \d+./DETAIL:  Process PID waits for ShareLock on transaction XID; blocked by process PID./
 
 # For resource queue deadlock
-m/^DETAIL:  Process \d+ waits for ExclusiveLock on resource queue \d+; blocked by process \d+./
-s/^DETAIL:  Process \d+ waits for ExclusiveLock on resource queue \d+; blocked by process \d+./DETAIL:  Process PID waits for ExclusiveLock on resource queue OID; blocked by process PID./
+m/.*Process \d+ waits for ExclusiveLock on resource queue \d+; blocked by process \d+./
+s/.*Process \d+ waits for ExclusiveLock on resource queue \d+; blocked by process \d+./Process PID waits for ExclusiveLock on resource queue OID; blocked by process PID./
 
 m/^Process \d+ waits for ShareLock on transaction \d+; blocked by process \d+./
 s/^Process \d+ waits for ShareLock on transaction \d+; blocked by process \d+./Process PID waits for ShareLock on transaction XID; blocked by process PID./

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -64,6 +64,10 @@ test: starve_case pg_views_concurrent_drop alter_blocks_for_update_and_viceversa
 # Test deadlock situation when waiting on a resource queue lock
 test: resource_queue_deadlock
 
+# Test simple cancellation for resource queues and cancellation/deadlocks for
+# sessions with multiple portals.
+test: resource_queue_cancel resource_queue_multi_portal
+
 # below test(s) inject faults so each of them need to be in a separate group
 test: pg_terminate_backend
 test: gp_terminate_mpp_backends

--- a/src/test/isolation2/sql/resource_queue.sql
+++ b/src/test/isolation2/sql/resource_queue.sql
@@ -34,5 +34,8 @@
 3<:
 3:END;
 
+-- Sanity check: Ensure that the resource queue is now empty.
+0: SELECT rsqcountlimit, rsqcountvalue from pg_resqueue_status WHERE rsqname = 'rq_concurrency_test';
+
 0:DROP role role_concurrency_test;
 0:DROP RESOURCE QUEUE rq_concurrency_test;

--- a/src/test/isolation2/sql/resource_queue_cancel.sql
+++ b/src/test/isolation2/sql/resource_queue_cancel.sql
@@ -1,0 +1,36 @@
+-- Simple test for cancellation of a query stuck on a resource queue when the
+-- active statements limit is reached.
+
+0:CREATE RESOURCE QUEUE rq_cancel WITH (active_statements = 1);
+0:CREATE ROLE role_cancel RESOURCE QUEUE rq_cancel;
+
+-- Consume an active statement in session 1.
+1:SET ROLE role_cancel;
+1:BEGIN;
+1:DECLARE c CURSOR FOR SELECT 0;
+
+-- Make session 2 wait on the resource queue lock.
+2:SET ROLE role_cancel;
+2&:SELECT 100;
+
+-- Cancel SELECT from session 2.
+0:SELECT pg_cancel_backend(pid) FROM pg_stat_activity
+  WHERE query='SELECT 100;';
+
+-- Now once we quit session 1, we should be able to consume the vacated active
+-- statement slot in session 2.
+1q:
+
+2<:
+2:END;
+2:BEGIN;
+2:DECLARE c CURSOR FOR SELECT 0;
+
+2q:
+
+-- Sanity check: Ensure that the resource queue is now empty.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_cancel';
+
+-- Cleanup
+0:DROP ROLE role_cancel;
+0:DROP RESOURCE QUEUE rq_cancel;

--- a/src/test/isolation2/sql/resource_queue_deadlock.sql
+++ b/src/test/isolation2/sql/resource_queue_deadlock.sql
@@ -22,6 +22,9 @@
 2: ROLLBACK;
 1<:
 
+-- Sanity check: Ensure that the resource queue is now empty.
+0: SELECT rsqcountlimit, rsqcountvalue from pg_resqueue_status WHERE rsqname = 'rq_deadlock_test';
+
 -- Clean up the test
 0: DROP TABLE t_deadlock_test;
 0: DROP ROLE role_deadlock_test;

--- a/src/test/isolation2/sql/resource_queue_multi_portal.sql
+++ b/src/test/isolation2/sql/resource_queue_multi_portal.sql
@@ -1,0 +1,105 @@
+-- Here we ensure that we clean up resource queue in-memory state gracefully
+-- in the face of deadlocks and statement cancellations, when there is more than
+-- one active portal in the session.
+0:CREATE RESOURCE QUEUE rq_multi_portal WITH (active_statements = 2);
+0:CREATE ROLE role_multi_portal RESOURCE QUEUE rq_multi_portal;
+
+--
+-- Scenario 1:
+-- Multiple explicit cursors active in the same session with a deadlock.
+--
+1:SET ROLE role_multi_portal;
+1:BEGIN;
+1:DECLARE c1 CURSOR FOR SELECT 1;
+
+2:SET ROLE role_multi_portal;
+2:BEGIN;
+2:DECLARE c2 CURSOR FOR SELECT 1;
+
+-- There should be 2 active statements.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+
+-- This should block as it will exceed the active statements limit.
+1&:DECLARE c3 CURSOR FOR SELECT 1;
+
+-- There should be 2 active statements.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+
+-- This should cause a deadlock.
+2:DECLARE c4 CURSOR FOR SELECT 1;
+
+-- After the deadlock report, one session should have ERRORed out with the
+-- deadlock report and aborted, while the other session should remain active
+-- and idle in transaction. The active statement count should be 2, contributed
+-- to by the session that is idle in transaction.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+0:SELECT count(*) from pg_stat_activity WHERE query LIKE 'DECLARE c% CURSOR FOR SELECT 1;'
+    AND state = 'idle in transaction';
+0:SELECT count(*) from pg_stat_activity WHERE query LIKE 'DECLARE c% CURSOR FOR SELECT 1;'
+    AND state = 'idle in transaction (aborted)';
+
+-- After quitting the sessions there should be 0 active statements.
+1<:
+1q:
+2q:
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+
+--
+-- Scenario 2:
+-- Multiple explicit cursors active in the same session with a self deadlock.
+--
+1:SET ROLE role_multi_portal;
+1:BEGIN;
+1:DECLARE c1 CURSOR FOR SELECT 1;
+1:DECLARE c2 CURSOR FOR SELECT 1;
+
+-- There should be 2 active statements.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+
+-- This should cause a self-deadlock and session 1 should error out, aborting
+-- its transaction.
+1:DECLARE c3 CURSOR FOR SELECT 1;
+
+-- There should be 0 active statements following the transaction abort.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+
+1q:
+
+--
+-- Scenario 3:
+-- Multiple explicit cursors active in the same session with cancellation.
+--
+1:SET ROLE role_multi_portal;
+1:BEGIN;
+1:DECLARE c1 CURSOR FOR SELECT 1;
+
+2:SET ROLE role_multi_portal;
+2:BEGIN;
+2:DECLARE c2 CURSOR FOR SELECT 1;
+
+-- This should block as it will exceed the active statements limit.
+1&:DECLARE c3 CURSOR FOR SELECT 1;
+
+-- There should be 2 active statements.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+
+-- Cancel session 1's transaction.
+0:SELECT pg_cancel_backend(pid) FROM pg_stat_activity
+    WHERE query = 'DECLARE c3 CURSOR FOR SELECT 1;';
+
+-- There should now only be one active statement, following the abort of session
+-- 1's transaction. The active statement is contributed by session 2.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+0:SELECT query, state from pg_stat_activity
+  WHERE query = 'DECLARE c2 CURSOR FOR SELECT 1;';
+
+1<:
+1q:
+
+-- After quitting session 2 there should be 0 active statements.
+2q:
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+
+-- Cleanup
+0:DROP ROLE role_multi_portal;
+0:DROP RESOURCE QUEUE rq_multi_portal;


### PR DESCRIPTION
Since commit 2fa7c06d6a5, we have introduced an opportunity where the
active statement count is leaked (the active statements is not
decremented with `ResLockUpdateLimit(.., .., false, ..)`. This can happen
during a deadlock report or a statement cancellation of a statement
if the session has at least one other active named portal. During
`CheckDeadlock()/ResLockWaitCancel()`, we would clean up the locallock,
which would cause a subsequent call to `ResLockRelease()`, for the other
active portal to early return here:

```c
/*
 * If the lock request did not get very far, cleanup is easy.
 */
if (!locallock ||
	!locallock->lock ||
	!locallock->proclock)
{
	elog(LOG, "Resource queue %d: no lock to release", locktag->locktag_field1);
	if (locallock)
	{
		RemoveLocalLock(locallock);
	}

	return false;
}
```

and not call `ResLockUpdateLimit(.., .., false, ..)`

The resultant active statement leak would cause subsequently submitted
statements to block forever on the resource queue lock, once the #active
statements = active statement limit.

Additionally, added test coverage for query cancellation and general
sanity checks for leaks in other tests.

Co-authored-by: Ashwin Agrawal <aashwin@vmware.com>
Co-authored-by: Yao Wang <wayao@vmware.com>
Co-authored-by: Hongxu Ma <interma@outlook.com>
Co-authored-by: Zhenghua Lyu <78182909+kainwen@users.noreply.github.com>
