### PR TITLE
Docs remove deprecated parameter stats_command_string

### DIFF
--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_activity.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_stat_activity.xml
@@ -5,8 +5,7 @@
   <title id="hq141670">pg_stat_activity</title>
   <body>
     <p>The view <codeph>pg_stat_activity</codeph> shows one row per server process with details
-      about the associated user session and query. The columns that report data on the current query
-      are available unless the parameter <codeph>stats_command_string</codeph> has been turned off.
+      about the associated user session and query. The columns report data on the current query.
       Furthermore, these columns are only visible if the user examining the view is a superuser or
       the same as the user owning the process being reported on.</p>
     <p>The maximum length of the query text string stored in the column <codeph>query</codeph> can


### PR DESCRIPTION
Docs remove deprecated parameter stats_command_string. This is a deprecated parameter since PG 8.3, which is renamed to `track_activities` since then.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [x] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
