### PR TITLE
Add GUC to re-enable YYYYMMDDHH24MISS timestamp support

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -244,6 +244,7 @@ bool		gp_maintenance_mode;
 bool		gp_maintenance_conn;
 bool		allow_segment_DML;
 bool		gp_allow_rename_relation_without_lock = false;
+bool		enable_implicit_timeformat_YYYYMMDDHH24MISS;
 
 /* ignore EXCLUDE clauses in window spec for backwards compatibility */
 bool		gp_ignore_window_exclude = false;
@@ -3122,6 +3123,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 		 &optimizer_force_comprehensive_join_implementation,
 		 false,
 		 NULL, NULL, NULL
+	},
+
+	{
+		{"enable_implicit_timeformat_YYYYMMDDHH24MISS", PGC_USERSET, COMPAT_OPTIONS_PREVIOUS,
+			gettext_noop("If set, implicitly converts strings to timestamps using YYYYMMDDHH24MISS format"),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&enable_implicit_timeformat_YYYYMMDDHH24MISS,
+		false,
+		NULL, NULL, NULL
 	},
 
 	/* End-of-list marker */

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -271,6 +271,7 @@ extern bool gp_local_distributed_cache_stats;
 extern bool gp_appendonly_verify_block_checksums;
 extern bool gp_appendonly_verify_write_block;
 extern bool gp_appendonly_compaction;
+extern bool enable_implicit_timeformat_YYYYMMDDHH24MISS;
 
 /*
  * Threshold of the ratio of dirty data in a segment file

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -9,6 +9,7 @@
 		"dev_opt_unsafe_truncate_in_subtransaction",
 		"dml_ignore_target_partition_check",
 		"dtx_phase2_retry_count",
+		"enable_implicit_timeformat_YYYYMMDDHH24MISS",
 		"execute_pruned_plan",
 		"explain_memory_verbosity",
 		"gin_fuzzy_search_limit",

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -534,4 +534,3 @@
 		"xmloption",
 		"zero_damaged_pages",
 		"max_slot_wal_keep_size",
-		"enable_implicit_timeformat_YYYYMMDDHH24MISS",

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -534,3 +534,4 @@
 		"xmloption",
 		"zero_damaged_pages",
 		"max_slot_wal_keep_size",
+		"enable_implicit_timeformat_YYYYMMDDHH24MISS",

--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -1326,6 +1326,28 @@ select * from qp_misc_jiras.tbl_694_1 join qp_misc_jiras.tbl_694_2 on qp_misc_ji
 
 drop table qp_misc_jiras.tbl_694_1;
 drop table qp_misc_jiras.tbl_694_2;
+-- Postgres timestamp
+select '20081225 130000'::timestamp;
+      timestamp      
+---------------------
+ 2008-12-25 13:00:00
+(1 row)
+
+-- Teradata timestamp
+select '20081225130000'::timestamp;
+ERROR:  date/time field value out of range: "20081225130000"
+LINE 1: select '20081225130000'::timestamp;
+               ^
+HINT:  Perhaps you need a different "datestyle" setting.
+-- Teradata timestamp
+SET enable_implicit_timeformat_YYYYMMDDHH24MISS=on;
+select '20081225130000'::timestamp;
+      timestamp      
+---------------------
+ 2008-12-25 13:00:00
+(1 row)
+
+RESET enable_implicit_timeformat_YYYYMMDDHH24MISS;
 select * from ( select 'a' as a) x join (select 'a' as b) y on a=b;
  a | b 
 ---+---

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -1324,6 +1324,28 @@ select * from qp_misc_jiras.tbl_694_1 join qp_misc_jiras.tbl_694_2 on qp_misc_ji
 
 drop table qp_misc_jiras.tbl_694_1;
 drop table qp_misc_jiras.tbl_694_2;
+-- Postgres timestamp
+select '20081225 130000'::timestamp;
+      timestamp      
+---------------------
+ 2008-12-25 13:00:00
+(1 row)
+
+-- Teradata timestamp
+select '20081225130000'::timestamp;
+ERROR:  date/time field value out of range: "20081225130000"
+LINE 1: select '20081225130000'::timestamp;
+               ^
+HINT:  Perhaps you need a different "datestyle" setting.
+-- Teradata timestamp
+SET enable_implicit_timeformat_YYYYMMDDHH24MISS=on;
+select '20081225130000'::timestamp;
+      timestamp      
+---------------------
+ 2008-12-25 13:00:00
+(1 row)
+
+RESET enable_implicit_timeformat_YYYYMMDDHH24MISS;
 select * from ( select 'a' as a) x join (select 'a' as b) y on a=b;
  a | b 
 ---+---

--- a/src/test/regress/expected/timestamp.out
+++ b/src/test/regress/expected/timestamp.out
@@ -1835,3 +1835,65 @@ select timeofday()::date = current_timestamp::date;
  t
 (1 row)
 
+--MPP-5665
+select '20081225130000.123456'::timestamp;
+ERROR:  invalid input syntax for type timestamp: "20081225130000.123456"
+LINE 1: select '20081225130000.123456'::timestamp;
+               ^
+select '20081225130000'::timestamp;
+ERROR:  date/time field value out of range: "20081225130000"
+LINE 1: select '20081225130000'::timestamp;
+               ^
+HINT:  Perhaps you need a different "datestyle" setting.
+select '20081225130000.000000000000000000000'::timestamp;
+ERROR:  invalid input syntax for type timestamp: "20081225130000.000000000000000000000"
+LINE 1: select '20081225130000.000000000000000000000'::timestamp;
+               ^
+select '20090625123002.111111111111'::timestamp;
+ERROR:  invalid input syntax for type timestamp: "20090625123002.111111111111"
+LINE 1: select '20090625123002.111111111111'::timestamp;
+               ^
+-- should error out
+select '2009062512300.111111111111'::timestamp;
+ERROR:  invalid input syntax for type timestamp: "2009062512300.111111111111"
+LINE 1: select '2009062512300.111111111111'::timestamp;
+               ^
+select '200906251230021.111111111111'::timestamp;
+ERROR:  invalid input syntax for type timestamp: "200906251230021.111111111111"
+LINE 1: select '200906251230021.111111111111'::timestamp;
+               ^
+SET enable_implicit_timeformat_YYYYMMDDHH24MISS=on;
+select '20081225130000.123456'::timestamp;
+            timestamp            
+---------------------------------
+ Thu Dec 25 13:00:00.123456 2008
+(1 row)
+
+select '20081225130000'::timestamp;
+        timestamp         
+--------------------------
+ Thu Dec 25 13:00:00 2008
+(1 row)
+
+select '20081225130000.000000000000000000000'::timestamp;
+        timestamp         
+--------------------------
+ Thu Dec 25 13:00:00 2008
+(1 row)
+
+select '20090625123002.111111111111'::timestamp;
+            timestamp            
+---------------------------------
+ Thu Jun 25 12:30:02.111111 2009
+(1 row)
+
+-- should error out
+select '2009062512300.111111111111'::timestamp;
+ERROR:  invalid input syntax for type timestamp: "2009062512300.111111111111"
+LINE 1: select '2009062512300.111111111111'::timestamp;
+               ^
+select '200906251230021.111111111111'::timestamp;
+ERROR:  invalid input syntax for type timestamp: "200906251230021.111111111111"
+LINE 1: select '200906251230021.111111111111'::timestamp;
+               ^
+RESET enable_implicit_timeformat_YYYYMMDDHH24MISS;

--- a/src/test/regress/sql/qp_misc_jiras.sql
+++ b/src/test/regress/sql/qp_misc_jiras.sql
@@ -788,7 +788,14 @@ select * from qp_misc_jiras.tbl_694_1 join qp_misc_jiras.tbl_694_2 on qp_misc_ji
 
 drop table qp_misc_jiras.tbl_694_1;
 drop table qp_misc_jiras.tbl_694_2;
-
+-- Postgres timestamp
+select '20081225 130000'::timestamp;
+-- Teradata timestamp
+select '20081225130000'::timestamp;
+-- Teradata timestamp
+SET enable_implicit_timeformat_YYYYMMDDHH24MISS=on;
+select '20081225130000'::timestamp;
+RESET enable_implicit_timeformat_YYYYMMDDHH24MISS;
 select * from ( select 'a' as a) x join (select 'a' as b) y on a=b;
 select * from ( ( select 'a' as a ) xx join (select 'a' as b) yy on a = b ) x join (select 'a' as c) y on a=c;
 select x.b from ( ( select 'a' as a ) xx join (select 'a' as b) yy on a = b ) x join (select 'a' as c) y on a=c;

--- a/src/test/regress/sql/timestamp.sql
+++ b/src/test/regress/sql/timestamp.sql
@@ -282,3 +282,22 @@ SET DateStyle TO DEFAULT;
 
 -- Make sure timeofdate() and current_time() are doing roughly the same thing
 select timeofday()::date = current_timestamp::date;
+
+--MPP-5665
+select '20081225130000.123456'::timestamp;
+select '20081225130000'::timestamp;
+select '20081225130000.000000000000000000000'::timestamp;
+select '20090625123002.111111111111'::timestamp;
+-- should error out
+select '2009062512300.111111111111'::timestamp;
+select '200906251230021.111111111111'::timestamp;
+
+SET enable_implicit_timeformat_YYYYMMDDHH24MISS=on;
+select '20081225130000.123456'::timestamp;
+select '20081225130000'::timestamp;
+select '20081225130000.000000000000000000000'::timestamp;
+select '20090625123002.111111111111'::timestamp;
+-- should error out
+select '2009062512300.111111111111'::timestamp;
+select '200906251230021.111111111111'::timestamp;
+RESET enable_implicit_timeformat_YYYYMMDDHH24MISS;


### PR DESCRIPTION
Commit 71ec37a9136 removed the implicit format in favor of better
aligning with Postgres. However, it broke existing customers upgrades
from 5X to 6X. This patch brings back the old behavior behind a GUC
'enable_implicit_timeformat_YYYYMMDDHH24MISS' that is disabled by
default.

Co-authored-by: Ashwin Agrawal <aashwin@vmware.com>
