### PR TITLE
quote when resetting a GUC and resolve empty values

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1634,6 +1634,13 @@ restore_guc_to_QE(void )
 			 * we can not keep alive gang anymore.
 			 */
 			DisconnectAndDestroyAllGangs(false);
+			/*
+			 * when qe elog an error, qd will use ReThrowError to
+			 * re throw the error, the errordata_stack_depth will ++,
+			 * when we catch the error we should reset errordata_stack_depth
+			 * by FlushErrorState.
+			 */
+			FlushErrorState();
 		}
 		PG_END_TRY();
 	}

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -5010,12 +5010,13 @@ DispatchSyncPGVariable(struct config_generic * gconfig)
 			/*
 			 * If it's a list, we need to split the list into elements and
 			 * quote the elements individually.
+			 * else if it's empty or not a list, we should quote the whole src.
 			 *
 			 * This is the copied from pg_get_functiondef()'s handling of
 			 * proconfig options.
 			 * .
 			 */
-			if (sguc->gen.flags & GUC_LIST_QUOTE)
+			if (sguc->gen.flags & GUC_LIST_QUOTE && str[0] != '\0')
 			{
 				List	   *namelist;
 				ListCell   *lc;


### PR DESCRIPTION
When a string guc such as search_path is set to '', Then some command such as create an extension with schema xxx, will add the changed guc to restore_list, before the next command begins to execute, call restore_guc_to_QE to restore changed guc. the restoring string is "set search_path to ;",  then the string will be dispatched to QEs, QE elog an error, QD gets the error, and call ReThrowError to re-throw the error, errordata_stack_depth++, however, when we catch the error did not call FlushErrorState() to reset errordata_stack_depth.
when we execute other commands, after all, the errordata_stack_depth is not -1, The return value of elog_geterrcode shows there is an error. 

related commits:https://github.com/greenplum-db/gpdb/commit/320af40b31f571dbb9fa7323f33f4963ff02f4ec
related issue: https://github.com/greenplum-db/gpdb/issues/12900

tests: current extensions set search_path to public, so we can not reproduce this issue, but if I modify SQL for extension, It will be reproduced, reproduce step please see related issue:12900.
