### PR TITLE
Update parallel cursor test cases

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -104,8 +104,9 @@ cdbdisp_waitDispatchFinish(struct CdbDispatcherState *ds)
  * know if QEs run as expected.
  *
  * message: specifies the expected ACK message to check.
- * wait: if true, this function will wait until required ACK messages
- *       have been received from all dispatched QEs.
+ * timeout_sec: the second that the dispatcher waits for the ack messages at most.
+ *       0 means checking immediately, and -1 means waiting until all ack
+ *       messages are received.
  */
 bool
 cdbdisp_checkDispatchAckMessage(struct CdbDispatcherState *ds,

--- a/src/backend/cdb/endpoint/README
+++ b/src/backend/cdb/endpoint/README
@@ -128,8 +128,8 @@ Start A Retrieve Session
 Once a parallel retrieve cursor has been declared, retrieve sessions can be
 started on each endpoint's host by using the endpoint's token as the session
 authentication password. The user of this retrieve session is the session user
-who declares this parallel retrieve cursor. 
- 
+who declares this parallel retrieve cursor.
+
 gp_retrieve_conn=true needs to be set to start retrieve session.
 
 Examples:

--- a/src/backend/cdb/endpoint/cdbendpoint.c
+++ b/src/backend/cdb/endpoint/cdbendpoint.c
@@ -267,7 +267,7 @@ get_or_create_token(void)
 		sessionId = gp_session_id;
 		if (!pg_strong_random(currentToken, ENDPOINT_TOKEN_HEX_LEN))
 			ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
-							errmsg("failed to generate a new random token.")));
+							errmsg("failed to generate a new random token")));
 	}
 	return currentToken;
 }
@@ -504,7 +504,7 @@ create_and_connect_mq(TupleDesc tupleDesc, dsm_segment **mqSeg /* out */ ,
 	TupleDescNode *node = makeNode(TupleDescNode);
 
 	elog(DEBUG3,
-		 "CDB_ENDPOINTS: create and setup the shared memory message queue.");
+		 "CDB_ENDPOINTS: create and setup the shared memory message queue");
 
 	/* Serialize TupleDesc */
 	node->natts = tupleDesc->natts;
@@ -629,7 +629,7 @@ checkQDConnectionAlive()
 static void
 wait_receiver(EndpointExecState * state)
 {
-	elog(DEBUG3, "CDB_ENDPOINTS: wait receiver.");
+	elog(DEBUG3, "CDB_ENDPOINTS: wait receiver");
 	while (true)
 	{
 		int			wr = 0;
@@ -651,7 +651,7 @@ wait_receiver(EndpointExecState * state)
 			if (!checkQDConnectionAlive())
 			{
 				ereport(LOG,
-						(errmsg("CDB_ENDPOINT: sender found that the connection to QD is broken.")));
+						(errmsg("CDB_ENDPOINT: sender found that the connection to QD is broken")));
 				abort_endpoint(state);
 				proc_exit(0);
 			}
@@ -661,7 +661,7 @@ wait_receiver(EndpointExecState * state)
 		{
 			abort_endpoint(state);
 			ereport(LOG,
-					(errmsg("CDB_ENDPOINT: postmaster exit, close shared memory message queue.")));
+					(errmsg("CDB_ENDPOINT: postmaster exit, close shared memory message queue")));
 			proc_exit(0);
 		}
 
@@ -707,7 +707,7 @@ unset_endpoint_sender_pid(Endpoint endpoint)
 	if (endpoint == NULL || endpoint->empty)
 		return;
 
-	elog(DEBUG3, "CDB_ENDPOINT: unset endpoint sender pid.");
+	elog(DEBUG3, "CDB_ENDPOINT: unset endpoint sender pid");
 
 	/*
 	 * Only the endpoint QE/entry DB execute this unset sender pid function.
@@ -802,7 +802,7 @@ wait_parallel_retrieve_close(void)
 		if (wr & WL_POSTMASTER_DEATH)
 		{
 			ereport(LOG,
-					(errmsg("CDB_ENDPOINT: postmaster exit, close shared memory message queue.")));
+					(errmsg("CDB_ENDPOINT: postmaster exit, close shared memory message queue")));
 			proc_exit(0);
 		}
 
@@ -811,7 +811,7 @@ wait_parallel_retrieve_close(void)
 			if (!checkQDConnectionAlive())
 			{
 				ereport(LOG,
-						(errmsg("CDB_ENDPOINT: sender found that the connection to QD is broken.")));
+						(errmsg("CDB_ENDPOINT: sender found that the connection to QD is broken")));
 				proc_exit(0);
 			}
 		}
@@ -1013,7 +1013,7 @@ allocEndpointExecState()
 
 	if (unlikely(CurrEndpointExecState != NULL))
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
-						errmsg("Previous endpoint estate is not cleaned up.")));
+						errmsg("previous endpoint estate is not cleaned up")));
 
 	oldcontext = MemoryContextSwitchTo(TopMemoryContext);
 

--- a/src/backend/cdb/endpoint/cdbendpointretrieve.c
+++ b/src/backend/cdb/endpoint/cdbendpointretrieve.c
@@ -186,7 +186,7 @@ ExecRetrieveStmt(const RetrieveStmt * stmt, DestReceiver *dest)
 
 	if (RetrieveCtl.entry == NULL)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
-						errmsg("endpoint %s is not attached.",
+						errmsg("endpoint %s is not attached",
 							   stmt->endpoint_name)));
 
 	retrieveCount = stmt->count;
@@ -318,7 +318,7 @@ start_retrieve(const char *endpointName)
 		endpoint = find_endpoint(endpointName, RetrieveCtl.sessionID);
 		if (!endpoint)
 			ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-							errmsg("The endpoint %s does not exist in the session",
+							errmsg("the endpoint %s does not exist in the session",
 								   endpointName)));
 		validate_retrieve_endpoint(endpoint, endpointName);
 		endpoint->receiverPid = MyProcPid;
@@ -361,8 +361,8 @@ validate_retrieve_endpoint(Endpoint endpoint, const char *endpointName)
 	{
 		ereport(ERROR, (errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 						errmsg("the PARALLEL RETRIEVE CURSOR was created by "
-							   "a different user."),
-						errhint("using the same user as the PARALLEL "
+							   "a different user"),
+						errhint("Use the same user as the PARALLEL "
 								"RETRIEVE CURSOR creator to retrieve.")));
 	}
 
@@ -426,7 +426,7 @@ attach_receiver_mq(RetrieveExecEntry * entry, dsm_handle dsmHandle)
 	dsmSeg = dsm_attach(dsmHandle);
 	if (dsmSeg == NULL)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
-						errmsg("attach to shared message queue failed.")));
+						errmsg("attach to shared message queue failed")));
 	entry->mqSeg = dsmSeg;
 
 	dsm_pin_mapping(dsmSeg);
@@ -523,7 +523,7 @@ receive_tuple_slot(RetrieveExecEntry * entry)
 		 * wait_receiver()
 		 */
 		elog(DEBUG3, "CDB_ENDPOINT: receiver notifies sender in "
-			 "receive_tuple_slot() when retrieving data for the first time.");
+			 "receive_tuple_slot() when retrieving data for the first time");
 		notify_sender(entry, false);
 	}
 
@@ -649,7 +649,7 @@ retrieve_cancel_action(RetrieveExecEntry * entry, char *msg)
 
 	LWLockAcquire(ParallelCursorEndpointLock, LW_EXCLUSIVE);
 
-	endpoint = get_endpoint_from_retrieve_exec_entry(entry, false);
+	endpoint = get_endpoint_from_retrieve_exec_entry(entry, true);
 
 	if (endpoint != NULL &&
 		endpoint->receiverPid == MyProcPid &&

--- a/src/backend/cdb/endpoint/cdbendpointutils.c
+++ b/src/backend/cdb/endpoint/cdbendpointutils.c
@@ -59,7 +59,7 @@ endpoint_token_str2hex(int8 *token, const char *tokenStr)
 	else
 		ereport(FATAL,
 				(errcode(ERRCODE_INVALID_PASSWORD),
-				 errmsg("Retrieve auth token is invalid")));
+				 errmsg("retrieve auth token is invalid")));
 }
 
 /*
@@ -125,7 +125,7 @@ gp_wait_parallel_retrieve_cursor(PG_FUNCTION_ARGS)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_SYNTAX_ERROR),
-				 errmsg("this UDF only works for PARALLEL RETRIEVE CURSOR.")));
+				 errmsg("cursor is not a PARALLEL RETRIEVE CURSOR")));
 		PG_RETURN_BOOL(false);
 	}
 
@@ -234,11 +234,9 @@ gp_endpoints(PG_FUNCTION_ARGS)
 			if (PQresultStatus(cdb_pgresults.pg_results[i]) != PGRES_TUPLES_OK)
 			{
 				cdbdisp_clearCdbPgResults(&cdb_pgresults);
-				ereport(
-						ERROR,
-						(errcode(ERRCODE_INTERNAL_ERROR),
-						 errmsg(
-								"gp_segment_endpoints(): resultStatus is not tuples_Ok")));
+				ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("gp_segment_endpoints(): resultStatus is not TUPLES_OK")));
 			}
 			res_number += PQntuples(cdb_pgresults.pg_results[i]);
 		}

--- a/src/backend/commands/portalcmds.c
+++ b/src/backend/commands/portalcmds.c
@@ -247,15 +247,14 @@ PerformPortalFetch(FetchStmt *stmt,
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("The 'MOVE' statement for PARALLEL RETRIEVE CURSOR is not supported."),
-					 errhint("The 'PARALLEL RETRIEVE CURSOR' does not support SCROLLABLE option.")));
+					 errmsg("the 'MOVE' statement for PARALLEL RETRIEVE CURSOR is not supported")));
 		}
 		else
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_SYNTAX_ERROR),
-					 errmsg("Cannot specify 'FETCH' for PARALLEL RETRIEVE CURSOR."),
-					 errhint("Using 'RETRIEVE' statement on endpoint instead.")));
+					 errmsg("cannot specify 'FETCH' for PARALLEL RETRIEVE CURSOR"),
+					 errhint("Use 'RETRIEVE' statement on endpoint instead.")));
 		}
 	}
 

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -1581,13 +1581,15 @@ Portal
 SPI_cursor_find(const char *name)
 {
 	Portal portal = GetPortalByName(name);
+
 	if (portal != NULL && PortalIsParallelRetrieveCursor(portal))
 	{
 		ereport(ERROR,
-		(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				errmsg("The PARALLEL RETRIEVE CURSOR is not supported in SPI."),
-				errhint("Using normal cursor statement instead.")));
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("The PARALLEL RETRIEVE CURSOR is not supported in SPI."),
+				 errhint("Use normal cursor statement instead.")));
 	}
+
 	return portal;
 }
 

--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -1517,7 +1517,7 @@ pg_GSS_recvauth(Port *port)
 		gbuf.length = buf.len;
 		gbuf.value = buf.data;
 
-		elog(DEBUG4, "Processing received GSS token of length %u",
+		elog(DEBUG4, "processing received GSS token of length %u",
 			 (unsigned int) gbuf.length);
 
 		maj_stat = gss_accept_sec_context(
@@ -1795,7 +1795,7 @@ pg_SSPI_recvauth(Port *port)
 		outbuf.ulVersion = SECBUFFER_VERSION;
 
 
-		elog(DEBUG4, "Processing received SSPI token of length %u",
+		elog(DEBUG4, "processing received SSPI token of length %u",
 			 (unsigned int) buf.len);
 
 		r = AcceptSecurityContext(&sspicred,
@@ -3315,7 +3315,7 @@ radius_add_attribute(radius_packet *packet, uint8 type, const unsigned char *dat
 		 * fail.
 		 */
 		elog(WARNING,
-			 "Adding attribute code %d with length %d to radius packet would create oversize packet, ignoring",
+			 "adding attribute code %d with length %d to radius packet would create oversize packet, ignoring",
 			 type, len);
 		return;
 	}

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -356,8 +356,8 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	 * applies to non-QD master slices.  Furthermore, ORCA doesn't currently
 	 * support pl/<lang> statements (relevant when they are planned on the segments).
 	 * For these reasons, restrict to using ORCA on the master QD processes only.
-	 * 
-	 * Don't use orca for PARALLEL RETRIEVE CURSOR.
+	 *
+	 * PARALLEL RETRIEVE CURSOR is not supported by ORCA yet.
 	 */
 	if (optimizer &&
 		GP_ROLE_DISPATCH == Gp_role &&

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -262,7 +262,7 @@ transformOptionalSelectInto(ParseState *pstate, Node *parseTree)
 	if (am_cursor_retrieve_handler != IsA(parseTree, RetrieveStmt))
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				errmsg("This is %s a retrieve connection, but query is %sRETRIEVE.",
+				errmsg("This is %sa retrieve connection, but the query is %sa RETRIEVE.",
 					   am_cursor_retrieve_handler ? "" : "not ",
 					   IsA(parseTree, RetrieveStmt) ? "" : "not ")));
 
@@ -2936,6 +2936,7 @@ transformDeclareCursorStmt(ParseState *pstate, DeclareCursorStmt *stmt)
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("SCROLL is not allowed for the PARALLEL RETRIEVE CURSORs"),
 				 errdetail("Scrollable cursors can not be parallel")));
+
 	/*
 	 * We also disallow data-modifying WITH in a cursor.  (This could be
 	 * allowed, but the semantics of when the updates occur might be

--- a/src/backend/storage/ipc/shm_mq.c
+++ b/src/backend/storage/ipc/shm_mq.c
@@ -927,7 +927,7 @@ shm_mq_send_bytes(shm_mq_handle *mqh, Size nbytes, const void *data,
 		}
 		else if (available == 0)
 		{
-			if(QueryFinishPending)
+			if (QueryFinishPending)
 			{
 				*bytes_written = sent;
 				return SHM_MQ_QUERY_FINISH;

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -1189,7 +1189,7 @@ InitPostgres(const char *in_dbname, Oid dboid, const char *username,
 		process_startup_options(MyProcPort, am_superuser);
 
 	/*
-	 * am_cursor_retrieve_handler is set by guc so need to judge after calling
+	 * am_cursor_retrieve_handler is set by GUC so need to judge after calling
 	 * process_startup_options().
 	 */
 	if (am_cursor_retrieve_handler)

--- a/src/include/cdb/cdbdisp.h
+++ b/src/include/cdb/cdbdisp.h
@@ -128,8 +128,9 @@ cdbdisp_waitDispatchFinish(struct CdbDispatcherState *ds);
  * know if QEs run as expected.
  *
  * message: specifies the expected ACK message to check.
- * wait: if true, this function will wait until required ACK messages
- *       have been received from required QEs.
+ * timeout_sec: the second that the dispatcher waits for the ack messages at most.
+ *       0 means checking immediately, and -1 means waiting until all ack
+ *       messages are received.
  *
  * QEs should call cdbdisp_sendAckMessageToQD to send acknowledge messages to QD.
  */

--- a/src/test/isolation2/.gitignore
+++ b/src/test/isolation2/.gitignore
@@ -2,6 +2,19 @@ regression.diffs
 regression.out
 */dummy.sql
 */dummy.out
+sql/ao_upgrade.sql
+expected/ao_upgrade.out
+expected/ao_upgrade_optimizer.out
+sql/external_table.sql
+expected/external_table.out
+sql/fts_manual_probe.sql
+expected/fts_manual_probe.out
+sql/workfile_mgr_test.sql
+expected/workfile_mgr_test.out
+
+-- ignore generated pg_basebackup tests
+/sql/pg_basebackup*.sql
+/expected/pg_basebackup*.out
 
 # Local binaries and symbolic links
 /extended_protocol_test

--- a/src/test/isolation2/expected/resgroup/.gitignore
+++ b/src/test/isolation2/expected/resgroup/.gitignore
@@ -1,0 +1,2 @@
+resgroup_memory_runaway.out
+resgroup_move_query.out

--- a/src/test/isolation2/global_sh_executor.sh
+++ b/src/test/isolation2/global_sh_executor.sh
@@ -208,7 +208,7 @@ set_endpoint_variable() {
         fi
         i=$((i+1))
     done
-    # echo "Cannot find endpoint for postfix '$postfix', '$GP_HOSTNAME', '$GP_PORT'."
+    # echo "Cannot find endpoint for postfix '$CURRENT_ENDPOINT_POSTFIX', '$GP_HOSTNAME', '$GP_PORT'."
     echo $RAW_STR
 }
 

--- a/src/test/isolation2/input/parallel_retrieve_cursor/corner.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/corner.source
@@ -100,6 +100,8 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 1: ROLLBACK;
 -- check no endpoint info
 1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+-- cleanup retrieve connections
+*Rq:
 
 -- Test5: if conflict with normal cursors
 1: BEGIN;
@@ -122,6 +124,8 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- check no endpoint info
 1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
 1: ROLLBACK;
+-- cleanup retrieve connections
+*Rq:
 
 -- Test6: select order by limit
 1: BEGIN;
@@ -137,6 +141,8 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- check no endpoint info
 1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
 1: ROLLBACK;
+-- cleanup retrieve connections
+*Rq:
 
 -- Test7: select order by limit 0
 1: BEGIN;
@@ -153,6 +159,8 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- check no endpoint info
 1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
 1: ROLLBACK;
+-- cleanup retrieve connections
+*Rq:
 
 -- Test8: select empty table
 1: BEGIN;
@@ -169,6 +177,8 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- check no endpoint info
 1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
 1: ROLLBACK;
+-- cleanup retrieve connections
+*Rq:
 
 -- Test9: select table with text column
 1: BEGIN;
@@ -185,6 +195,8 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- check no endpoint info
 1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
 1: ROLLBACK;
+-- cleanup retrieve connections
+*Rq:
 
 -- Test10: select empty table with text column
 1: BEGIN;
@@ -201,6 +213,8 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- check no endpoint info
 1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
 1: ROLLBACK;
+-- cleanup retrieve connections
+*Rq:
 
 -- Test11: endpoints on one segment.
 1: BEGIN;
@@ -217,6 +231,8 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- check no endpoint info
 1: SELECT state FROM gp_endpoints() WHERE cursorname='c1';
 1: ROLLBACK;
+-- cleanup retrieve connections
+1Rq:
 
 -- Test12: PARALLEL RETRIEVE CURSOR for aggregate function: sum
 1: BEGIN;
@@ -228,10 +244,12 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -1U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
 -1R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
 
-1<: 
+1<:
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', 0);
 1: SELECT state FROM gp_endpoints() WHERE cursorname='c1';
 1: ROLLBACK;
+-- cleanup retrieve connections
+-1Rq:
 
 -- Test13: PARALLEL RETRIEVE CURSOR for aggregate function: avg
 1: BEGIN;
@@ -245,6 +263,8 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
 1: SELECT state FROM gp_endpoints() WHERE cursorname='c1';
 1: ROLLBACK;
+-- cleanup retrieve connections
+-1Rq:
 
 -- Test14: PARALLEL RETRIEVE CURSOR for count(*)
 1: BEGIN;
@@ -258,6 +278,8 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 1<:
 1: SELECT state FROM gp_endpoints() WHERE cursorname='c1';
 1: ROLLBACK;
+-- cleanup retrieve connections
+-1Rq:
 
 -- Test15: PARALLEL RETRIEVE CURSOR for two tables' join;
 1: BEGIN;
@@ -270,6 +292,8 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 1<:
 1: SELECT state FROM gp_endpoints() WHERE cursorname='c1';
 1: ROLLBACK;
+-- cleanup retrieve connections
+*Rq:
 
 -- Test16: PARALLEL RETRIEVE CURSOR for the count of two tables' join;
 1: BEGIN;
@@ -282,6 +306,8 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 1<:
 1: SELECT state FROM gp_endpoints() WHERE cursorname='c1';
 1: ROLLBACK;
+-- cleanup retrieve connections
+-1Rq:
 
 -- Test17: re-execute a PARALLEL RETRIEVE CURSOR and retrieve in same sessions.
 1: BEGIN;
@@ -304,6 +330,8 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 1<:
 1: SELECT state FROM gp_endpoints() WHERE cursorname='c1';
 1: ROLLBACK;
+-- cleanup retrieve connections
+*Rq:
 
 -- Test18: re-execute a PARALLEL RETRIEVE CURSOR and retrieve in different sessions.
 1: BEGIN;
@@ -330,6 +358,8 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 1<:
 1: SELECT state FROM gp_endpoints() WHERE cursorname='c1';
 1: ROLLBACK;
+-- cleanup retrieve connections
+*Rq:
 
 -- Test19: PARALLEL RETRIEVE CURSOR and savepoint
 1: BEGIN;
@@ -361,10 +391,7 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 1: SELECT auth_token FROM gp_endpoints() WHERE cursorname='c21a';
 1: COMMIT;
 1q:
--1Rq:
-0Rq:
-1Rq:
-2Rq:
+*Rq:
 
 -- Test22: UDF plan should be able to run on entry db.
 1: BEGIN;
@@ -382,7 +409,8 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 1: ROLLBACK;
 1q:
 -1Rq:
-
+-- cleanup retrieve connections
+*Rq:
 
 -- Test23: Catalog scan plan should be able to run on entry db.
 1: BEGIN;
@@ -398,7 +426,8 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- check no endpoint info
 1: SELECT state FROM gp_endpoints() WHERE cursorname='c23';
 1: ROLLBACK;
--1Rq:
+-- cleanup retrieve connections
+*Rq:
 
 -- Test24: endpoint name is too long and will be truncated.
 1: BEGIN;
@@ -412,9 +441,8 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 *R: @pre_run 'set_endpoint_variable @ENDPOINT24_1': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT24_1";
 *R: @pre_run 'set_endpoint_variable @ENDPOINT24_2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT24_2";
 1: ROLLBACK;
-0Rq:
-1Rq:
-2Rq:
+-- cleanup retrieve connections
+*Rq:
 
 -- Test25: cursor name is too long and will be truncated.
 1: BEGIN;
@@ -452,7 +480,8 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c27', -1);
 -- check no endpoint info
 1: SELECT state FROM gp_endpoints() WHERE cursorname='c27';
--1Rq:
+-- cleanup retrieve connections
+*Rq:
 
 -- Test28: Parallel retrieve cursor should run on the dispatcher only.
 -1U: BEGIN;

--- a/src/test/isolation2/input/parallel_retrieve_cursor/replicated_table.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/replicated_table.source
@@ -23,34 +23,55 @@ insert into rt1 select generate_series(1,100);
 2: DECLARE c2 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 ORDER BY a;
 3: BEGIN;
 3: DECLARE c3 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 ORDER BY a;
+4: BEGIN;
+4: DECLARE c4 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 ORDER BY a;
+5: BEGIN;
+5: DECLARE c5 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 ORDER BY a;
+6: BEGIN;
+6: DECLARE c6 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 ORDER BY a;
 
 -- Here because replicated table will execute on seg id: session_id % segment_number
--- Just declare & CHECK PARALLEL RETRIEVE CURSORs in all segment_number (i.e. 3) sessions, 
+-- Just declare & CHECK PARALLEL RETRIEVE CURSORs in all segment_number (i.e. 3) sessions,
 -- so that there should have specific session: MOD(sessionid,3)=1;
 -- Get token only in specific session id and retrieve this token.
-4: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE MOD(sessionid,3)=1;
+7: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE MOD(sessionid,3)=1 LIMIT 1;
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
 2&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', -1);
 3&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c3', -1);
+4&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c4', -1);
+5&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c5', -1);
+6&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c6', -1);
 *U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT2";
--- cancel all 3 sessions
-4: select pg_cancel_backend(pid) from pg_stat_activity, gp_endpoints() where sess_id = sessionid AND (cursorname ='c1' or cursorname='c2' or cursorname='c3');
+-- cancel all 6 sessions
+7: select pg_cancel_backend(pid) from pg_stat_activity, gp_endpoints() where sess_id = sessionid AND (cursorname ='c1' or cursorname='c2' or cursorname='c3' or cursorname ='c4' or cursorname='c5' or cursorname='c6');
 1<:
 2<:
 3<:
+4<:
+5<:
+6<:
 
 1: ROLLBACK;
 2: ROLLBACK;
 3: ROLLBACK;
+4: ROLLBACK;
+5: ROLLBACK;
+6: ROLLBACK;
 
 1q:
 2q:
 3q:
+4q:
+5q:
+6q:
 -1Rq:
 1Rq:
 2Rq:
 3Rq:
+4Rq:
+5Rq:
+6Rq:
 
 --------- Test3: Basic test for PARALLEL RETRIEVE CURSOR on replicated table
 1: BEGIN;
@@ -59,34 +80,55 @@ insert into rt1 select generate_series(1,100);
 2: DECLARE c2 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 WHERE MOD(a,3)=1;
 3: BEGIN;
 3: DECLARE c3 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 WHERE MOD(a,3)=1;
+4: BEGIN;
+4: DECLARE c4 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 WHERE MOD(a,3)=1;
+5: BEGIN;
+5: DECLARE c5 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 WHERE MOD(a,3)=1;
+6: BEGIN;
+6: DECLARE c6 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 WHERE MOD(a,3)=1;
 
 -- Here because replicated table will execute on seg id: session_id % segment_number
--- Just declare & CHECK PARALLEL RETRIEVE CURSORs in all segment_number (i.e. 3) sessions, 
+-- Just declare & CHECK PARALLEL RETRIEVE CURSORs in all segment_number (i.e. 3) sessions,
 -- so that there should have specific session: MOD(sessionid,3)=1;
 -- Get token only in specific session id and retrieve this token.
-4: @post_run 'parse_endpoint_info 3 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE MOD(sessionid,3)=1;
+7: @post_run 'parse_endpoint_info 3 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE MOD(sessionid,3)=1 LIMIT 1;
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
 2&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', -1);
 3&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c3', -1);
+4&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c4', -1);
+5&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c5', -1);
+6&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c6', -1);
 *U: @pre_run 'set_endpoint_variable @ENDPOINT3': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT3';
 *R: @pre_run 'set_endpoint_variable @ENDPOINT3': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT3";
--- cancel all 3 sessions
-4: select pg_cancel_backend(pid) from pg_stat_activity, gp_endpoints() where sess_id = sessionid AND (cursorname ='c1' or cursorname='c2' or cursorname='c3');
+-- cancel all 6 sessions
+7: select pg_cancel_backend(pid) from pg_stat_activity, gp_endpoints() where sess_id = sessionid AND (cursorname ='c1' or cursorname='c2' or cursorname='c3' or cursorname ='c4' or cursorname='c5' or cursorname='c6');
 1<:
 2<:
 3<:
+4<:
+5<:
+6<:
 
 1: ROLLBACK;
 2: ROLLBACK;
 3: ROLLBACK;
+4: ROLLBACK;
+5: ROLLBACK;
+6: ROLLBACK;
 
 1q:
 2q:
 3q:
+4q:
+5q:
+6q:
 -1Rq:
 1Rq:
 2Rq:
 3Rq:
+4Rq:
+5Rq:
+6Rq:
 
 --------- Test4: Basic test for PARALLEL RETRIEVE CURSOR on replicated table
 1: BEGIN;
@@ -95,23 +137,38 @@ insert into rt1 select generate_series(1,100);
 2: DECLARE c2 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 WHERE MOD(a,3)=1 OR MOD(a,3)=2;
 3: BEGIN;
 3: DECLARE c3 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 WHERE MOD(a,3)=1 OR MOD(a,3)=2;
+4: BEGIN;
+4: DECLARE c4 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 WHERE MOD(a,3)=1 OR MOD(a,3)=2;
+5: BEGIN;
+5: DECLARE c5 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 WHERE MOD(a,3)=1 OR MOD(a,3)=2;
+6: BEGIN;
+6: DECLARE c6 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 WHERE MOD(a,3)=1 OR MOD(a,3)=2;
 
 -- Here because replicated table will execute on seg id: session_id % segment_number
--- Just declare & CHECK PARALLEL RETRIEVE CURSORs in all segment_number (i.e. 3) sessions, 
+-- Just declare & CHECK PARALLEL RETRIEVE CURSORs in all segment_number (i.e. 3) sessions,
 -- so that there should have specific session: MOD(sessionid,3)=1;
 -- Get token only in specific session id and retrieve this token.
-4: @post_run 'parse_endpoint_info 4 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE MOD(sessionid,3)=1;
+7: @post_run 'parse_endpoint_info 4 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE MOD(sessionid,3)=1 LIMIT 1;
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
 2&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', -1);
 3&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c3', -1);
+4&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c4', -1);
+5&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c5', -1);
+6&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c6', -1);
 *U: @pre_run 'set_endpoint_variable @ENDPOINT4': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT4';
 *R: @pre_run 'set_endpoint_variable @ENDPOINT4': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT4";
--- cancel all 3 sessions
-4: select pg_cancel_backend(pid) from pg_stat_activity, gp_endpoints() where sess_id = sessionid AND (cursorname ='c1' or cursorname='c2' or cursorname='c3');
+-- cancel all 6 sessions
+7: select pg_cancel_backend(pid) from pg_stat_activity, gp_endpoints() where sess_id = sessionid AND (cursorname ='c1' or cursorname='c2' or cursorname='c3' or cursorname ='c4' or cursorname='c5' or cursorname='c6');
 1<:
 2<:
 3<:
+4<:
+5<:
+6<:
 
 1: ROLLBACK;
 2: ROLLBACK;
 3: ROLLBACK;
+4: ROLLBACK;
+5: ROLLBACK;
+6: ROLLBACK;

--- a/src/test/isolation2/input/parallel_retrieve_cursor/security.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/security.source
@@ -11,6 +11,7 @@ $$ LANGUAGE SQL;
 -- Test: Retrieve login without valid token.
 1: @pre_run 'export RETRIEVE_TOKEN="123" ; echo $RAW_STR' : SELECT 1;
 0R: SELECT 1;
+0Rq:
 
 -- Test: Declare a cursor
 1: BEGIN;
@@ -20,7 +21,7 @@ $$ LANGUAGE SQL;
 -- Test: Should not change gp_role in retrieve mode
 0R: set gp_role to 'utility';
 
--- Test: limit all statement which is supported in utility session
+-- Test: limit all statement which is supported in retrieve session
 0R: show gp_role;
 
 0R: begin;
@@ -32,13 +33,12 @@ $$ LANGUAGE SQL;
 0R: insert into t1 select generate_series(100,110);
 0R: update t1 set a=a+100 where a<10;
 0R: truncate table t1;
--- web external table is also disallowed by this restriction.
 0R: select * from t1;
 
 0R: CREATE TABLE t10 (a INT) DISTRIBUTED by (a);
 0R: DROP TABLE t1;
 
--- copy ... on program ... is also disallowed by this restriction.
+-- copy ... on program ... is also disallowed by this retrieve session.
 0R: COPY t1 to '/tmp/1.cvs';
 
 -- Test: builtin function can not be allowed
@@ -50,8 +50,8 @@ $$ LANGUAGE SQL;
 SELECT $1 || $2
 $$ LANGUAGE SQL;
 
--- Test: Different illegal tokens always lead to a same general message
----- Illegal tokens
+-- Test: Different illegal endpoints always lead to an error
+---- invalid endpoints
 1R: RETRIEVE ALL FROM ENDPOINT abc;
 1R: RETRIEVE ALL FROM ENDPOINT 123;
 1R: RETRIEVE ALL FROM ENDPOINT tk1122;

--- a/src/test/isolation2/input/parallel_retrieve_cursor/special_query.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/special_query.source
@@ -1,5 +1,5 @@
 -- @Description Tests create parallel for some special query
--- 
+--
 
 --------- Test1: test for PARALLEL RETRIEVE CURSOR on select transient record types
 DROP TABLE IF EXISTS t1;

--- a/src/test/isolation2/input/parallel_retrieve_cursor/status_check.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/status_check.source
@@ -1,6 +1,6 @@
 -- @Description Tests the state for pg_endpoints AND gp_segment_endpoints(), focus in nowait mode
 -- need to fault injection to gp_wait_parallel_retrieve_cursor()
--- 
+--
 DROP TABLE IF EXISTS t1;
 CREATE TABLE t1 (a INT) DISTRIBUTED by (a);
 insert into t1 select generate_series(1,100);
@@ -86,7 +86,7 @@ insert into t1 select generate_series(1,100);
 -- report error for EXECUTE canceled PARALLEL RETRIEVE CURSOR
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c3', 0);
 1: ROLLBACK;
--- check no endpoint info 
+-- check no endpoint info
 2: SELECT state FROM gp_endpoints() WHERE cursorname='c3';
 *U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c3';
 
@@ -116,7 +116,7 @@ insert into t1 select generate_series(1,100);
 -- report error for EXECUTE canceled PARALLEL RETRIEVE CURSOR
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c4', 0);
 1: ROLLBACK;
--- check no endpoint info 
+-- check no endpoint info
 2: SELECT state FROM gp_endpoints() WHERE cursorname='c4';
 *U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c4';
 2Rq:
@@ -147,7 +147,7 @@ insert into t1 select generate_series(1,100);
 -- report error for EXECUTE canceled PARALLEL RETRIEVE CURSOR
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c5', 0);
 1: ROLLBACK;
--- check no endpoint info 
+-- check no endpoint info
 2: SELECT state FROM gp_endpoints() WHERE cursorname='c5';
 *U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c5';
 

--- a/src/test/isolation2/input/parallel_retrieve_cursor/status_wait.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/status_wait.source
@@ -1,5 +1,5 @@
 -- @Description Tests the state for pg_endpoints AND gp_segment_endpoints(), focus in wait mode
--- 
+--
 DROP TABLE IF EXISTS t1;
 CREATE TABLE t1 (a INT) DISTRIBUTED by (a);
 insert into t1 select generate_series(1,100);
@@ -83,7 +83,7 @@ insert into t1 select generate_series(1,100);
 -- report error for EXECUTE canceled PARALLEL RETRIEVE CURSOR
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c3', -1);
 1: ROLLBACK;
--- check no endpoint info 
+-- check no endpoint info
 2: SELECT state FROM gp_endpoints() WHERE cursorname='c3';
 *U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c3';
 
@@ -111,7 +111,7 @@ insert into t1 select generate_series(1,100);
 -- report error for EXECUTE canceled PARALLEL RETRIEVE CURSOR
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c4', -1);
 1: ROLLBACK;
--- check no endpoint info 
+-- check no endpoint info
 2: SELECT state FROM gp_endpoints() WHERE cursorname='c4';
 *U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c4';
 2Rq:
@@ -140,7 +140,7 @@ insert into t1 select generate_series(1,100);
 -- report error for EXECUTE canceled PARALLEL RETRIEVE CURSOR
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c5', -1);
 1: ROLLBACK;
--- check no endpoint info 
+-- check no endpoint info
 2: SELECT state FROM gp_endpoints() WHERE cursorname='c5';
 *U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c5';
 

--- a/src/test/isolation2/input/parallel_retrieve_cursor/syntax.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/syntax.source
@@ -1,5 +1,5 @@
 -- @Description Tests syntax for the PARALLEL RETRIEVE CURSOR statement
--- 
+--
 DROP TABLE IF EXISTS t1;
 CREATE TABLE t1 (a INT) DISTRIBUTED by (a);
 insert into t1 select generate_series(1,100);

--- a/src/test/isolation2/output/parallel_retrieve_cursor/corner.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/corner.source
@@ -227,7 +227,7 @@ DECLARE
  READY 
 (1 row)
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
-#-1retrieve> FATAL:  Retrieve auth token is invalid
+#-1retrieve> FATAL:  retrieve auth token is invalid
 
 
  a  
@@ -367,6 +367,11 @@ ROLLBACK
  state 
 -------
 (0 rows)
+-- cleanup retrieve connections
+*Rq:Sessions not started cannot be quit
+ ... <quitting>
+ ... <quitting>
+ ... <quitting>
 
 -- Test5: if conflict with normal cursors
 1: BEGIN;
@@ -414,7 +419,7 @@ DECLARE
  READY 
 (1 row)
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
-#-1retrieve> FATAL:  Retrieve auth token is invalid
+#-1retrieve> FATAL:  retrieve auth token is invalid
 
 
  a  
@@ -544,6 +549,11 @@ DECLARE
 (3 rows)
 1: ROLLBACK;
 ROLLBACK
+-- cleanup retrieve connections
+*Rq:Sessions not started cannot be quit
+ ... <quitting>
+ ... <quitting>
+ ... <quitting>
 
 -- Test6: select order by limit
 1: BEGIN;
@@ -586,11 +596,14 @@ DECLARE
  10 
 (10 rows)
 
-ERROR:  The endpoint @ENDPOINT2 does not exist in the session
+#0retrieve> FATAL:  retrieve auth token is invalid
 
-ERROR:  The endpoint @ENDPOINT2 does not exist in the session
 
-ERROR:  The endpoint @ENDPOINT2 does not exist in the session
+#1retrieve> FATAL:  retrieve auth token is invalid
+
+
+#2retrieve> FATAL:  retrieve auth token is invalid
+
 
 -- test check and wait after finished retrieving
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', 0);
@@ -611,6 +624,11 @@ ERROR:  The endpoint @ENDPOINT2 does not exist in the session
 (1 row)
 1: ROLLBACK;
 ROLLBACK
+-- cleanup retrieve connections
+*Rq: ... <quitting>
+Sessions not started cannot be quit
+Sessions not started cannot be quit
+Sessions not started cannot be quit
 
 -- Test7: select order by limit 0
 1: BEGIN;
@@ -649,11 +667,14 @@ DECLARE
 ---
 (0 rows)
 
-ERROR:  The endpoint @ENDPOINT2 does not exist in the session
+#0retrieve> FATAL:  retrieve auth token is invalid
 
-ERROR:  The endpoint @ENDPOINT2 does not exist in the session
 
-ERROR:  The endpoint @ENDPOINT2 does not exist in the session
+#1retrieve> FATAL:  retrieve auth token is invalid
+
+
+#2retrieve> FATAL:  retrieve auth token is invalid
+
 
 1<:  <... completed>
  finished 
@@ -673,6 +694,11 @@ ERROR:  The endpoint @ENDPOINT2 does not exist in the session
 (1 row)
 1: ROLLBACK;
 ROLLBACK
+-- cleanup retrieve connections
+*Rq: ... <quitting>
+Sessions not started cannot be quit
+Sessions not started cannot be quit
+Sessions not started cannot be quit
 
 -- Test8: select empty table
 1: BEGIN;
@@ -711,7 +737,8 @@ DECLARE
  READY 
 (1 row)
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
-ERROR:  The endpoint @ENDPOINT2 does not exist in the session
+#-1retrieve> FATAL:  retrieve auth token is invalid
+
 
  a 
 ---
@@ -745,6 +772,11 @@ ERROR:  The endpoint @ENDPOINT2 does not exist in the session
 (3 rows)
 1: ROLLBACK;
 ROLLBACK
+-- cleanup retrieve connections
+*Rq:Sessions not started cannot be quit
+ ... <quitting>
+ ... <quitting>
+ ... <quitting>
 
 -- Test9: select table with text column
 1: BEGIN;
@@ -783,7 +815,8 @@ DECLARE
  READY 
 (1 row)
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
-ERROR:  The endpoint @ENDPOINT2 does not exist in the session
+#-1retrieve> FATAL:  retrieve auth token is invalid
+
 
  a     
 -------
@@ -827,6 +860,11 @@ ERROR:  The endpoint @ENDPOINT2 does not exist in the session
 (3 rows)
 1: ROLLBACK;
 ROLLBACK
+-- cleanup retrieve connections
+*Rq:Sessions not started cannot be quit
+ ... <quitting>
+ ... <quitting>
+ ... <quitting>
 
 -- Test10: select empty table with text column
 1: BEGIN;
@@ -865,7 +903,8 @@ DECLARE
  READY 
 (1 row)
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
-ERROR:  The endpoint @ENDPOINT2 does not exist in the session
+#-1retrieve> FATAL:  retrieve auth token is invalid
+
 
  a 
 ---
@@ -899,6 +938,11 @@ ERROR:  The endpoint @ENDPOINT2 does not exist in the session
 (3 rows)
 1: ROLLBACK;
 ROLLBACK
+-- cleanup retrieve connections
+*Rq:Sessions not started cannot be quit
+ ... <quitting>
+ ... <quitting>
+ ... <quitting>
 
 -- Test11: endpoints on one segment.
 1: BEGIN;
@@ -944,6 +988,8 @@ DECLARE
 (1 row)
 1: ROLLBACK;
 ROLLBACK
+-- cleanup retrieve connections
+1Rq: ... <quitting>
 
 -- Test12: PARALLEL RETRIEVE CURSOR for aggregate function: sum
 1: BEGIN;
@@ -988,6 +1034,8 @@ DECLARE
 (1 row)
 1: ROLLBACK;
 ROLLBACK
+-- cleanup retrieve connections
+-1Rq: ... <quitting>
 
 -- Test13: PARALLEL RETRIEVE CURSOR for aggregate function: avg
 1: BEGIN;
@@ -1026,6 +1074,8 @@ DECLARE
 (1 row)
 1: ROLLBACK;
 ROLLBACK
+-- cleanup retrieve connections
+-1Rq: ... <quitting>
 
 -- Test14: PARALLEL RETRIEVE CURSOR for count(*)
 1: BEGIN;
@@ -1060,6 +1110,8 @@ DECLARE
 (1 row)
 1: ROLLBACK;
 ROLLBACK
+-- cleanup retrieve connections
+-1Rq: ... <quitting>
 
 -- Test15: PARALLEL RETRIEVE CURSOR for two tables' join;
 1: BEGIN;
@@ -1074,7 +1126,8 @@ DECLARE
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);  <waiting ...>
 
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
-ERROR:  The endpoint @ENDPOINT2 does not exist in the session
+#-1retrieve> FATAL:  retrieve auth token is invalid
+
 
  a | b 
 ---+---
@@ -1112,6 +1165,11 @@ ERROR:  The endpoint @ENDPOINT2 does not exist in the session
 (3 rows)
 1: ROLLBACK;
 ROLLBACK
+-- cleanup retrieve connections
+*Rq:Sessions not started cannot be quit
+ ... <quitting>
+ ... <quitting>
+ ... <quitting>
 
 -- Test16: PARALLEL RETRIEVE CURSOR for the count of two tables' join;
 1: BEGIN;
@@ -1141,6 +1199,8 @@ DECLARE
 (1 row)
 1: ROLLBACK;
 ROLLBACK
+-- cleanup retrieve connections
+-1Rq: ... <quitting>
 
 -- Test17: re-execute a PARALLEL RETRIEVE CURSOR and retrieve in same sessions.
 1: BEGIN;
@@ -1174,7 +1234,8 @@ DECLARE
  READY 
 (1 row)
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
-ERROR:  The endpoint @ENDPOINT2 does not exist in the session
+#-1retrieve> FATAL:  retrieve auth token is invalid
+
 
  a  
 ----
@@ -1324,7 +1385,8 @@ DECLARE
  READY 
 (1 row)
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
-ERROR:  The endpoint @ENDPOINT2 does not exist in the session
+#-1retrieve> FATAL:  retrieve auth token is invalid
+
 
  a  
 ----
@@ -1452,6 +1514,11 @@ ERROR:  The endpoint @ENDPOINT2 does not exist in the session
 (3 rows)
 1: ROLLBACK;
 ROLLBACK
+-- cleanup retrieve connections
+*Rq:Sessions not started cannot be quit
+ ... <quitting>
+ ... <quitting>
+ ... <quitting>
 
 -- Test18: re-execute a PARALLEL RETRIEVE CURSOR and retrieve in different sessions.
 1: BEGIN;
@@ -1485,7 +1552,8 @@ DECLARE
  READY 
 (1 row)
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
-ERROR:  The endpoint @ENDPOINT2 does not exist in the session
+#-1retrieve> FATAL:  retrieve auth token is invalid
+
 
  a  
 ----
@@ -1639,7 +1707,8 @@ DECLARE
  READY 
 (1 row)
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
-ERROR:  The endpoint @ENDPOINT2 does not exist in the session
+#-1retrieve> FATAL:  retrieve auth token is invalid
+
 
  a  
 ----
@@ -1767,6 +1836,11 @@ ERROR:  The endpoint @ENDPOINT2 does not exist in the session
 (3 rows)
 1: ROLLBACK;
 ROLLBACK
+-- cleanup retrieve connections
+*Rq:Sessions not started cannot be quit
+ ... <quitting>
+ ... <quitting>
+ ... <quitting>
 
 -- Test19: PARALLEL RETRIEVE CURSOR and savepoint
 1: BEGIN;
@@ -1832,10 +1906,10 @@ DECLARE
 1: COMMIT;
 COMMIT
 1q: ... <quitting>
--1Rq: ... <quitting>
-0Rq: ... <quitting>
-1Rq: ... <quitting>
-2Rq: ... <quitting>
+*Rq:Sessions not started cannot be quit
+Sessions not started cannot be quit
+Sessions not started cannot be quit
+Sessions not started cannot be quit
 
 -- Test22: UDF plan should be able to run on entry db.
 1: BEGIN;
@@ -1883,13 +1957,13 @@ DECLARE
  9               
 (10 rows)
 
-#0retrieve> FATAL:  Retrieve auth token is invalid
+#0retrieve> FATAL:  retrieve auth token is invalid
 
 
-#1retrieve> FATAL:  Retrieve auth token is invalid
+#1retrieve> FATAL:  retrieve auth token is invalid
 
 
-#2retrieve> FATAL:  Retrieve auth token is invalid
+#2retrieve> FATAL:  retrieve auth token is invalid
 
 
 -- test check and wait after finished retrieving
@@ -1908,7 +1982,11 @@ DECLARE
 ROLLBACK
 1q: ... <quitting>
 -1Rq: ... <quitting>
-
+-- cleanup retrieve connections
+*Rq:Sessions not started cannot be quit
+Sessions not started cannot be quit
+Sessions not started cannot be quit
+Sessions not started cannot be quit
 
 -- Test23: Catalog scan plan should be able to run on entry db.
 1: BEGIN;
@@ -1947,13 +2025,13 @@ DECLARE
  pg_class 
 (1 row)
 
-#0retrieve> FATAL:  Retrieve auth token is invalid
+#0retrieve> FATAL:  retrieve auth token is invalid
 
 
-#1retrieve> FATAL:  Retrieve auth token is invalid
+#1retrieve> FATAL:  retrieve auth token is invalid
 
 
-#2retrieve> FATAL:  Retrieve auth token is invalid
+#2retrieve> FATAL:  retrieve auth token is invalid
 
 
 -- test check and wait after finished retrieving
@@ -1970,7 +2048,11 @@ DECLARE
 (1 row)
 1: ROLLBACK;
 ROLLBACK
--1Rq: ... <quitting>
+-- cleanup retrieve connections
+*Rq: ... <quitting>
+Sessions not started cannot be quit
+Sessions not started cannot be quit
+Sessions not started cannot be quit
 
 -- Test24: endpoint name is too long and will be truncated.
 1: BEGIN;
@@ -1997,7 +2079,7 @@ DECLARE
  endpoint_id24_2 | token_id | host_id | port_id | READY
 (3 rows)
 *R: @pre_run 'set_endpoint_variable @ENDPOINT24': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT24";
-#-1retrieve> FATAL:  Retrieve auth token is invalid
+#-1retrieve> FATAL:  retrieve auth token is invalid
 
 
  b 
@@ -2022,7 +2104,7 @@ DECLARE
  10 
 (4 rows)
 *R: @pre_run 'set_endpoint_variable @ENDPOINT24_1': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT24_1";
-#-1retrieve> FATAL:  Retrieve auth token is invalid
+#-1retrieve> FATAL:  retrieve auth token is invalid
 
 
  b 
@@ -2047,7 +2129,7 @@ DECLARE
  10 
 (4 rows)
 *R: @pre_run 'set_endpoint_variable @ENDPOINT24_2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT24_2";
-#-1retrieve> FATAL:  Retrieve auth token is invalid
+#-1retrieve> FATAL:  retrieve auth token is invalid
 
 
  b 
@@ -2073,9 +2155,11 @@ DECLARE
 (4 rows)
 1: ROLLBACK;
 ROLLBACK
-0Rq: ... <quitting>
-1Rq: ... <quitting>
-2Rq: ... <quitting>
+-- cleanup retrieve connections
+*Rq:Sessions not started cannot be quit
+ ... <quitting>
+ ... <quitting>
+ ... <quitting>
 
 -- Test25: cursor name is too long and will be truncated.
 1: BEGIN;
@@ -2167,13 +2251,13 @@ DECLARE
  10              
 (10 rows)
 
-#0retrieve> FATAL:  Retrieve auth token is invalid
+#0retrieve> FATAL:  retrieve auth token is invalid
 
 
-#1retrieve> FATAL:  Retrieve auth token is invalid
+#1retrieve> FATAL:  retrieve auth token is invalid
 
 
-#2retrieve> FATAL:  Retrieve auth token is invalid
+#2retrieve> FATAL:  retrieve auth token is invalid
 
 
 -- test check and wait after finished retrieving
@@ -2188,7 +2272,11 @@ DECLARE
 ----------
  FINISHED 
 (1 row)
--1Rq: ... <quitting>
+-- cleanup retrieve connections
+*Rq: ... <quitting>
+Sessions not started cannot be quit
+Sessions not started cannot be quit
+Sessions not started cannot be quit
 
 -- Test28: Parallel retrieve cursor should run on the dispatcher only.
 -1U: BEGIN;

--- a/src/test/isolation2/output/parallel_retrieve_cursor/fault_inject.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/fault_inject.source
@@ -76,7 +76,7 @@ DECLARE
  READY 
 (1 row)
 *R: @pre_run 'set_endpoint_variable @ENDPOINT1': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT1";
-#-1retrieve> FATAL:  Retrieve auth token is invalid
+#-1retrieve> FATAL:  retrieve auth token is invalid
 
 
  a  
@@ -263,14 +263,14 @@ ERROR:  canceling MPP operation: "Endpoint retrieve statement aborted"
 -------
 (0 rows)
 1R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
-ERROR:  The endpoint endpoint_id2 does not exist in the session
+ERROR:  the endpoint endpoint_id2 does not exist in the session
 
 2U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
  state 
 -------
 (0 rows)
 2R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
-ERROR:  The endpoint endpoint_id2 does not exist in the session
+ERROR:  the endpoint endpoint_id2 does not exist in the session
 
 1<:  <... completed>
 FAILED:  Execution failed
@@ -325,14 +325,14 @@ ERROR:  canceling MPP operation: "Endpoint retrieve statement aborted"
 -------
 (0 rows)
 0R: @pre_run 'set_endpoint_variable @ENDPOINT3': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT3";
-ERROR:  The endpoint endpoint_id3 does not exist in the session
+ERROR:  the endpoint endpoint_id3 does not exist in the session
 
 2U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
  state 
 -------
 (0 rows)
 2R: @pre_run 'set_endpoint_variable @ENDPOINT3': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT3";
-ERROR:  The endpoint endpoint_id3 does not exist in the session
+ERROR:  the endpoint endpoint_id3 does not exist in the session
 
 1<:  <... completed>
 FAILED:  Execution failed
@@ -429,7 +429,7 @@ ERROR:  canceling MPP operation: "Endpoint retrieve statement aborted"  (seg0 12
 -------
 (0 rows)
 2R: @pre_run 'set_endpoint_variable @ENDPOINT4': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT4";
-ERROR:  The endpoint endpoint_id4 does not exist in the session
+ERROR:  the endpoint endpoint_id4 does not exist in the session
 
 1<:  <... completed>
 FAILED:  Execution failed

--- a/src/test/isolation2/output/parallel_retrieve_cursor/privilege.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/privilege.source
@@ -118,7 +118,7 @@ SET
  1        
 (1 row)
 0R: SELECT SESSION_USER, CURRENT_USER;
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 0U: SELECT auth_token, usename FROM gp_segment_endpoints() AS e, pg_user AS u where e.userid = u.usesysid;
  auth_token                       | usename   
 ----------------------------------+-----------
@@ -142,7 +142,7 @@ ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
 (1 row)
 --- Login as u1 and retrieve all to finish the test
 0R: SELECT SESSION_USER, CURRENT_USER;
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 0R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
  a 
 ---
@@ -199,7 +199,7 @@ DECLARE
 #3retrieve> FATAL:  Authentication failure (Wrong password or no endpoint for the user)
 
 0Rq: ... <quitting>
-3Rq:FAILED:  Sessions not started cannot be quit
+3Rq:Sessions not started cannot be quit
 1<:  <... completed>
 FAILED:  Execution failed
 1: END;
@@ -252,35 +252,35 @@ DECLARE
  1        
 (1 row)
 *R: SET SESSION AUTHORIZATION adminuser;
-#-1retrieve> FATAL:  Retrieve auth token is invalid
+#-1retrieve> FATAL:  retrieve auth token is invalid
 
 
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 *R: SELECT SESSION_USER, CURRENT_USER;
-#-1retrieve> FATAL:  Retrieve auth token is invalid
+#-1retrieve> FATAL:  retrieve auth token is invalid
 
 
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 *R: @pre_run 'set_endpoint_variable @ENDPOINT4': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT4";
-#-1retrieve> FATAL:  Retrieve auth token is invalid
+#-1retrieve> FATAL:  retrieve auth token is invalid
 
 
-ERROR:  the PARALLEL RETRIEVE CURSOR was created by a different user.
-HINT:  using the same user as the PARALLEL RETRIEVE CURSOR creator to retrieve.
+ERROR:  the PARALLEL RETRIEVE CURSOR was created by a different user
+HINT:  Using the same user as the PARALLEL RETRIEVE CURSOR creator to retrieve.
 
-ERROR:  the PARALLEL RETRIEVE CURSOR was created by a different user.
-HINT:  using the same user as the PARALLEL RETRIEVE CURSOR creator to retrieve.
+ERROR:  the PARALLEL RETRIEVE CURSOR was created by a different user
+HINT:  Using the same user as the PARALLEL RETRIEVE CURSOR creator to retrieve.
 
-ERROR:  the PARALLEL RETRIEVE CURSOR was created by a different user.
-HINT:  using the same user as the PARALLEL RETRIEVE CURSOR creator to retrieve.
+ERROR:  the PARALLEL RETRIEVE CURSOR was created by a different user
+HINT:  Using the same user as the PARALLEL RETRIEVE CURSOR creator to retrieve.
 -- cancel the no privilege retrieving endpoints, otherwise it will wait until statement_timeout
 42: select pg_cancel_backend(pid) from pg_stat_activity where query like 'SELECT * FROM gp_wait_parallel_retrieve_cursor(''c1'', -1);';
  pg_cancel_backend 
@@ -362,14 +362,14 @@ SET
 
 --- u2 is not able to see u1's endpoints in RETRIEVE mode
 *R: @pre_run 'export CURRENT_ENDPOINT_POSTFIX=50 ; export RETRIEVE_USER="adminuser" ; echo $RAW_STR' : SET SESSION AUTHORIZATION u2;
-#-1retrieve> FATAL:  Retrieve auth token is invalid
+#-1retrieve> FATAL:  retrieve auth token is invalid
 
 
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 *U: SELECT auth_token, usename FROM gp_segment_endpoints() AS e, pg_user AS u where e.userid = u.usesysid;
  auth_token | usename 
 ------------+---------
@@ -395,17 +395,17 @@ ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
 
 --- u2 is not able to retrieve from u1's endpoints in RETRIEVE mode
 *R: @pre_run 'set_endpoint_variable @ENDPOINT5': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT5";
-#-1retrieve> FATAL:  Retrieve auth token is invalid
+#-1retrieve> FATAL:  retrieve auth token is invalid
 
 
-ERROR:  the PARALLEL RETRIEVE CURSOR was created by a different user.
-HINT:  using the same user as the PARALLEL RETRIEVE CURSOR creator to retrieve.
+ERROR:  the PARALLEL RETRIEVE CURSOR was created by a different user
+HINT:  Using the same user as the PARALLEL RETRIEVE CURSOR creator to retrieve.
 
-ERROR:  the PARALLEL RETRIEVE CURSOR was created by a different user.
-HINT:  using the same user as the PARALLEL RETRIEVE CURSOR creator to retrieve.
+ERROR:  the PARALLEL RETRIEVE CURSOR was created by a different user
+HINT:  Using the same user as the PARALLEL RETRIEVE CURSOR creator to retrieve.
 
-ERROR:  the PARALLEL RETRIEVE CURSOR was created by a different user.
-HINT:  using the same user as the PARALLEL RETRIEVE CURSOR creator to retrieve.
+ERROR:  the PARALLEL RETRIEVE CURSOR was created by a different user
+HINT:  Using the same user as the PARALLEL RETRIEVE CURSOR creator to retrieve.
 -- cancel the no privilege retrieving endpoints, otherwise it will wait until statement_timeout
 42: select pg_cancel_backend(pid) from pg_stat_activity where query like 'SELECT * FROM gp_wait_parallel_retrieve_cursor(''c4'', -1);';
  pg_cancel_backend 

--- a/src/test/isolation2/output/parallel_retrieve_cursor/replicated_table.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/replicated_table.source
@@ -39,17 +39,32 @@ DECLARE
 BEGIN
 3: DECLARE c3 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 ORDER BY a;
 DECLARE
+4: BEGIN;
+BEGIN
+4: DECLARE c4 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 ORDER BY a;
+DECLARE
+5: BEGIN;
+BEGIN
+5: DECLARE c5 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 ORDER BY a;
+DECLARE
+6: BEGIN;
+BEGIN
+6: DECLARE c6 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 ORDER BY a;
+DECLARE
 
 -- Here because replicated table will execute on seg id: session_id % segment_number
 -- Just declare & CHECK PARALLEL RETRIEVE CURSORs in all segment_number (i.e. 3) sessions,
 -- so that there should have specific session: MOD(sessionid,3)=1;
 -- Get token only in specific session id and retrieve this token.
-4: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE MOD(sessionid,3)=1;
+7: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE MOD(sessionid,3)=1 LIMIT 1;
  endpoint_id2 | token_id | host_id | port_id | READY
 (1 row)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);  <waiting ...>
 2&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', -1);  <waiting ...>
 3&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c3', -1);  <waiting ...>
+4&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c4', -1);  <waiting ...>
+5&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c5', -1);  <waiting ...>
+6&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c6', -1);  <waiting ...>
 *U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
  state 
 -------
@@ -68,10 +83,10 @@ DECLARE
 -------
 (0 rows)
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT2";
-#-1retrieve> FATAL:  Retrieve auth token is invalid
+#-1retrieve> FATAL:  retrieve auth token is invalid
 
 
-#0retrieve> FATAL:  Retrieve auth token is invalid
+#0retrieve> FATAL:  retrieve auth token is invalid
 
 
  a  
@@ -88,21 +103,30 @@ DECLARE
  10 
 (10 rows)
 
-#2retrieve> FATAL:  Retrieve auth token is invalid
+#2retrieve> FATAL:  retrieve auth token is invalid
 
--- cancel all 3 sessions
-4: select pg_cancel_backend(pid) from pg_stat_activity, gp_endpoints() where sess_id = sessionid AND (cursorname ='c1' or cursorname='c2' or cursorname='c3');
+-- cancel all 6 sessions
+7: select pg_cancel_backend(pid) from pg_stat_activity, gp_endpoints() where sess_id = sessionid AND (cursorname ='c1' or cursorname='c2' or cursorname='c3' or cursorname ='c4' or cursorname='c5' or cursorname='c6');
  pg_cancel_backend 
 -------------------
  t                 
  t                 
  t                 
-(3 rows)
+ t                 
+ t                 
+ t                 
+(6 rows)
 1<:  <... completed>
 ERROR:  canceling statement due to user request
 2<:  <... completed>
 ERROR:  canceling statement due to user request
 3<:  <... completed>
+ERROR:  canceling statement due to user request
+4<:  <... completed>
+ERROR:  canceling statement due to user request
+5<:  <... completed>
+ERROR:  canceling statement due to user request
+6<:  <... completed>
 ERROR:  canceling statement due to user request
 
 1: ROLLBACK;
@@ -111,14 +135,26 @@ ROLLBACK
 ROLLBACK
 3: ROLLBACK;
 ROLLBACK
+4: ROLLBACK;
+ROLLBACK
+5: ROLLBACK;
+ROLLBACK
+6: ROLLBACK;
+ROLLBACK
 
 1q: ... <quitting>
 2q: ... <quitting>
 3q: ... <quitting>
--1Rq:FAILED:  Sessions not started cannot be quit
+4q: ... <quitting>
+5q: ... <quitting>
+6q: ... <quitting>
+-1Rq:Sessions not started cannot be quit
 1Rq: ... <quitting>
-2Rq:FAILED:  Sessions not started cannot be quit
-3Rq:FAILED:  Sessions not started cannot be quit
+2Rq:Sessions not started cannot be quit
+3Rq:Sessions not started cannot be quit
+4Rq:Sessions not started cannot be quit
+5Rq:Sessions not started cannot be quit
+6Rq:Sessions not started cannot be quit
 
 --------- Test3: Basic test for PARALLEL RETRIEVE CURSOR on replicated table
 1: BEGIN;
@@ -133,17 +169,32 @@ DECLARE
 BEGIN
 3: DECLARE c3 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 WHERE MOD(a,3)=1;
 DECLARE
+4: BEGIN;
+BEGIN
+4: DECLARE c4 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 WHERE MOD(a,3)=1;
+DECLARE
+5: BEGIN;
+BEGIN
+5: DECLARE c5 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 WHERE MOD(a,3)=1;
+DECLARE
+6: BEGIN;
+BEGIN
+6: DECLARE c6 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 WHERE MOD(a,3)=1;
+DECLARE
 
 -- Here because replicated table will execute on seg id: session_id % segment_number
 -- Just declare & CHECK PARALLEL RETRIEVE CURSORs in all segment_number (i.e. 3) sessions,
 -- so that there should have specific session: MOD(sessionid,3)=1;
 -- Get token only in specific session id and retrieve this token.
-4: @post_run 'parse_endpoint_info 3 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE MOD(sessionid,3)=1;
+7: @post_run 'parse_endpoint_info 3 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE MOD(sessionid,3)=1 LIMIT 1;
  endpoint_id3 | token_id | host_id | port_id | READY
 (1 row)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);  <waiting ...>
 2&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', -1);  <waiting ...>
 3&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c3', -1);  <waiting ...>
+4&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c4', -1);  <waiting ...>
+5&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c5', -1);  <waiting ...>
+6&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c6', -1);  <waiting ...>
 *U: @pre_run 'set_endpoint_variable @ENDPOINT3': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT3';
  state 
 -------
@@ -162,10 +213,10 @@ DECLARE
 -------
 (0 rows)
 *R: @pre_run 'set_endpoint_variable @ENDPOINT3': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT3";
-#-1retrieve> FATAL:  Retrieve auth token is invalid
+#-1retrieve> FATAL:  retrieve auth token is invalid
 
 
-#0retrieve> FATAL:  Retrieve auth token is invalid
+#0retrieve> FATAL:  retrieve auth token is invalid
 
 
  a  
@@ -182,21 +233,30 @@ DECLARE
  28 
 (10 rows)
 
-#2retrieve> FATAL:  Retrieve auth token is invalid
+#2retrieve> FATAL:  retrieve auth token is invalid
 
--- cancel all 3 sessions
-4: select pg_cancel_backend(pid) from pg_stat_activity, gp_endpoints() where sess_id = sessionid AND (cursorname ='c1' or cursorname='c2' or cursorname='c3');
+-- cancel all 6 sessions
+7: select pg_cancel_backend(pid) from pg_stat_activity, gp_endpoints() where sess_id = sessionid AND (cursorname ='c1' or cursorname='c2' or cursorname='c3' or cursorname ='c4' or cursorname='c5' or cursorname='c6');
  pg_cancel_backend 
 -------------------
  t                 
  t                 
  t                 
-(3 rows)
+ t                 
+ t                 
+ t                 
+(6 rows)
 1<:  <... completed>
 ERROR:  canceling statement due to user request
 2<:  <... completed>
 ERROR:  canceling statement due to user request
 3<:  <... completed>
+ERROR:  canceling statement due to user request
+4<:  <... completed>
+ERROR:  canceling statement due to user request
+5<:  <... completed>
+ERROR:  canceling statement due to user request
+6<:  <... completed>
 ERROR:  canceling statement due to user request
 
 1: ROLLBACK;
@@ -205,14 +265,26 @@ ROLLBACK
 ROLLBACK
 3: ROLLBACK;
 ROLLBACK
+4: ROLLBACK;
+ROLLBACK
+5: ROLLBACK;
+ROLLBACK
+6: ROLLBACK;
+ROLLBACK
 
 1q: ... <quitting>
 2q: ... <quitting>
 3q: ... <quitting>
--1Rq:FAILED:  Sessions not started cannot be quit
+4q: ... <quitting>
+5q: ... <quitting>
+6q: ... <quitting>
+-1Rq:Sessions not started cannot be quit
 1Rq: ... <quitting>
-2Rq:FAILED:  Sessions not started cannot be quit
-3Rq:FAILED:  Sessions not started cannot be quit
+2Rq:Sessions not started cannot be quit
+3Rq:Sessions not started cannot be quit
+4Rq:Sessions not started cannot be quit
+5Rq:Sessions not started cannot be quit
+6Rq:Sessions not started cannot be quit
 
 --------- Test4: Basic test for PARALLEL RETRIEVE CURSOR on replicated table
 1: BEGIN;
@@ -227,17 +299,32 @@ DECLARE
 BEGIN
 3: DECLARE c3 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 WHERE MOD(a,3)=1 OR MOD(a,3)=2;
 DECLARE
+4: BEGIN;
+BEGIN
+4: DECLARE c4 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 WHERE MOD(a,3)=1 OR MOD(a,3)=2;
+DECLARE
+5: BEGIN;
+BEGIN
+5: DECLARE c5 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 WHERE MOD(a,3)=1 OR MOD(a,3)=2;
+DECLARE
+6: BEGIN;
+BEGIN
+6: DECLARE c6 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 WHERE MOD(a,3)=1 OR MOD(a,3)=2;
+DECLARE
 
 -- Here because replicated table will execute on seg id: session_id % segment_number
 -- Just declare & CHECK PARALLEL RETRIEVE CURSORs in all segment_number (i.e. 3) sessions,
 -- so that there should have specific session: MOD(sessionid,3)=1;
 -- Get token only in specific session id and retrieve this token.
-4: @post_run 'parse_endpoint_info 4 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE MOD(sessionid,3)=1;
+7: @post_run 'parse_endpoint_info 4 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE MOD(sessionid,3)=1 LIMIT 1;
  endpoint_id4 | token_id | host_id | port_id | READY
 (1 row)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);  <waiting ...>
 2&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', -1);  <waiting ...>
 3&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c3', -1);  <waiting ...>
+4&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c4', -1);  <waiting ...>
+5&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c5', -1);  <waiting ...>
+6&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c6', -1);  <waiting ...>
 *U: @pre_run 'set_endpoint_variable @ENDPOINT4': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT4';
  state 
 -------
@@ -256,10 +343,10 @@ DECLARE
 -------
 (0 rows)
 *R: @pre_run 'set_endpoint_variable @ENDPOINT4': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT4";
-#-1retrieve> FATAL:  Retrieve auth token is invalid
+#-1retrieve> FATAL:  retrieve auth token is invalid
 
 
-#0retrieve> FATAL:  Retrieve auth token is invalid
+#0retrieve> FATAL:  retrieve auth token is invalid
 
 
  a  
@@ -276,21 +363,30 @@ DECLARE
  14 
 (10 rows)
 
-#2retrieve> FATAL:  Retrieve auth token is invalid
+#2retrieve> FATAL:  retrieve auth token is invalid
 
--- cancel all 3 sessions
-4: select pg_cancel_backend(pid) from pg_stat_activity, gp_endpoints() where sess_id = sessionid AND (cursorname ='c1' or cursorname='c2' or cursorname='c3');
+-- cancel all 6 sessions
+7: select pg_cancel_backend(pid) from pg_stat_activity, gp_endpoints() where sess_id = sessionid AND (cursorname ='c1' or cursorname='c2' or cursorname='c3' or cursorname ='c4' or cursorname='c5' or cursorname='c6');
  pg_cancel_backend 
 -------------------
  t                 
  t                 
  t                 
-(3 rows)
+ t                 
+ t                 
+ t                 
+(6 rows)
 1<:  <... completed>
 ERROR:  canceling statement due to user request
 2<:  <... completed>
 ERROR:  canceling statement due to user request
 3<:  <... completed>
+ERROR:  canceling statement due to user request
+4<:  <... completed>
+ERROR:  canceling statement due to user request
+5<:  <... completed>
+ERROR:  canceling statement due to user request
+6<:  <... completed>
 ERROR:  canceling statement due to user request
 
 1: ROLLBACK;
@@ -298,4 +394,10 @@ ROLLBACK
 2: ROLLBACK;
 ROLLBACK
 3: ROLLBACK;
+ROLLBACK
+4: ROLLBACK;
+ROLLBACK
+5: ROLLBACK;
+ROLLBACK
+6: ROLLBACK;
 ROLLBACK

--- a/src/test/isolation2/output/parallel_retrieve_cursor/retrieve_quit_wait.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/retrieve_quit_wait.source
@@ -52,7 +52,7 @@ DECLARE
 
 -- in all retrieve sessions, retrieve multiple tokens (begin retrieving, finished retrieving, not yet retrieve)
 *R: @pre_run 'set_endpoint_variable @ENDPOINT1' : RETRIEVE 10 FROM ENDPOINT "@ENDPOINT1";
-#-1retrieve> FATAL:  Retrieve auth token is invalid
+#-1retrieve> FATAL:  retrieve auth token is invalid
 
 
  a  
@@ -97,7 +97,7 @@ DECLARE
  25 
 (10 rows)
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2' : RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
-#-1retrieve> FATAL:  Retrieve auth token is invalid
+#-1retrieve> FATAL:  retrieve auth token is invalid
 
 
  a  
@@ -294,7 +294,7 @@ DECLARE
 
 -- in one retrieve session, retrieve multiple tokens (begin retrieving, finished retrieving, not yet retrieve)
 *R: @pre_run 'set_endpoint_variable @ENDPOINT4' : RETRIEVE 10 FROM ENDPOINT "@ENDPOINT4";
-#-1retrieve> FATAL:  Retrieve auth token is invalid
+#-1retrieve> FATAL:  retrieve auth token is invalid
 
 
  a  
@@ -339,7 +339,7 @@ DECLARE
  25 
 (10 rows)
 *R: @pre_run 'set_endpoint_variable @ENDPOINT5' : RETRIEVE ALL FROM ENDPOINT "@ENDPOINT5";
-#-1retrieve> FATAL:  Retrieve auth token is invalid
+#-1retrieve> FATAL:  retrieve auth token is invalid
 
 
  a  

--- a/src/test/isolation2/output/parallel_retrieve_cursor/security.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/security.source
@@ -17,8 +17,9 @@ CREATE
  1        
 (1 row)
 0R: SELECT 1;
-#0retrieve> FATAL:  Retrieve auth token is invalid
+#0retrieve> FATAL:  retrieve auth token is invalid
 
+0Rq:Sessions not started cannot be quit
 
 -- Test: Declare a cursor
 1: BEGIN;
@@ -33,68 +34,67 @@ DECLARE
 
 -- Test: Should not change gp_role in retrieve mode
 0R: set gp_role to 'utility';
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 
--- Test: limit all statement which is supported in utility session
+-- Test: limit all statement which is supported in retrieve session
 0R: show gp_role;
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 
 0R: begin;
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 0R: declare c1 cursor for select * from t1;
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 0R: fetch 5 from c1;
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 0R: rollback;
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 
 0R: delete FROM t1;
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 0R: insert into t1 select generate_series(100,110);
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 0R: update t1 set a=a+100 where a<10;
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 0R: truncate table t1;
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
--- web external table is also disallowed by this restriction.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 0R: select * from t1;
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 
 0R: CREATE TABLE t10 (a INT) DISTRIBUTED by (a);
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 0R: DROP TABLE t1;
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 
--- copy ... on program ... is also disallowed by this restriction.
+-- copy ... on program ... is also disallowed by this retrieve session.
 0R: COPY t1 to '/tmp/1.cvs';
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 
 -- Test: builtin function can not be allowed
 0R: select '12'::int;
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 -- Test: UDF can not be allowed
 0R: SELECT myappend(ARRAY[42,6], 21);
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 -- Test: Create UDF can not allowed
 0R: CREATE OR REPLACE FUNCTION myappend1(anyarray, anyelement) RETURNS anyarray AS $$ SELECT $1 || $2 $$ LANGUAGE SQL;
-ERROR:  This is  a retrieve connection, but query is not RETRIEVE.
+ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 
--- Test: Different illegal tokens always lead to a same general message
----- Illegal tokens
+-- Test: Different illegal endpoints always lead to an error
+---- invalid endpoints
 1R: RETRIEVE ALL FROM ENDPOINT abc;
-ERROR:  The endpoint abc does not exist in the session
+ERROR:  the endpoint abc does not exist in the session
 1R: RETRIEVE ALL FROM ENDPOINT 123;
 ERROR:  syntax error at or near "123"
 LINE 1: RETRIEVE ALL FROM ENDPOINT 123;
                                    ^
 1R: RETRIEVE ALL FROM ENDPOINT tk1122;
-ERROR:  The endpoint tk1122 does not exist in the session
+ERROR:  the endpoint tk1122 does not exist in the session
 1R: RETRIEVE ALL FROM ENDPOINT tktt223344556677889900112233445566;
-ERROR:  The endpoint tktt223344556677889900112233445566 does not exist in the session
+ERROR:  the endpoint tktt223344556677889900112233445566 does not exist in the session
 
 -- Retrieve data.
 *R: @pre_run 'set_endpoint_variable @ENDPOINT1': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT1";
-#-1retrieve> FATAL:  Retrieve auth token is invalid
+#-1retrieve> FATAL:  retrieve auth token is invalid
 
 
  a  

--- a/src/test/isolation2/output/parallel_retrieve_cursor/special_query.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/special_query.source
@@ -62,7 +62,7 @@ DECLARE
  READY 
 (1 row)
 *R: @pre_run 'set_endpoint_variable @ENDPOINT1': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT1";
-#-1retrieve> FATAL:  Retrieve auth token is invalid
+#-1retrieve> FATAL:  retrieve auth token is invalid
 
 
  make_record 

--- a/src/test/isolation2/output/parallel_retrieve_cursor/status_check.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/status_check.source
@@ -44,7 +44,7 @@ DECLARE
  READY 
 (1 row)
 *R: @pre_run 'set_endpoint_variable @ENDPOINT1': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT1";
-#-1retrieve> FATAL:  Retrieve auth token is invalid
+#-1retrieve> FATAL:  retrieve auth token is invalid
 
 
  a  
@@ -342,7 +342,7 @@ DECLARE
 (0 rows)
 -- finished retrieving all endpoints and check state
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
-#-1retrieve> FATAL:  Retrieve auth token is invalid
+#-1retrieve> FATAL:  retrieve auth token is invalid
 
 
  a  
@@ -796,7 +796,7 @@ DECLARE
 (10 rows)
 -- 1R still bind to Test4 session, so can not retrieve from current endpoint.
 1R: @pre_run 'set_endpoint_variable @ENDPOINT5': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT5";
-ERROR:  The endpoint endpoint_id5 does not exist in the session
+ERROR:  the endpoint endpoint_id5 does not exist in the session
 -- Since seg1 retrieve session is bind to Test4 session. And Test4 session get killed. We need to restart it.
 1Rq: ... <quitting>
 1R: @pre_run 'set_endpoint_variable @ENDPOINT5': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT5";

--- a/src/test/isolation2/output/parallel_retrieve_cursor/status_wait.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/status_wait.source
@@ -39,7 +39,7 @@ DECLARE
  READY 
 (1 row)
 *R: @pre_run 'set_endpoint_variable @ENDPOINT1': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT1";
-#-1retrieve> FATAL:  Retrieve auth token is invalid
+#-1retrieve> FATAL:  retrieve auth token is invalid
 
 
  a  
@@ -333,7 +333,7 @@ DECLARE
 (0 rows)
 -- finished retrieving all endpoints and check state
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
-#-1retrieve> FATAL:  Retrieve auth token is invalid
+#-1retrieve> FATAL:  retrieve auth token is invalid
 
 
  a  
@@ -755,7 +755,7 @@ DECLARE
 (10 rows)
 -- 1R still bind to Test4 session, so can not retrieve from current endpoint.
 1R: @pre_run 'set_endpoint_variable @ENDPOINT5': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT5";
-ERROR:  The endpoint c50000002400000005 does not exist in the session
+ERROR:  the endpoint endpoint_id5 does not exist in the session
 -- Since seg1 retrieve session is bind to Test4 session. And Test4 session get killed. We need to restart it.
 1Rq: ... <quitting>
 1R: @pre_run 'set_endpoint_variable @ENDPOINT5': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT5";

--- a/src/test/isolation2/output/parallel_retrieve_cursor/syntax.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/syntax.source
@@ -34,8 +34,8 @@ BEGIN
 DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
 FETCH ALL FROM c1;
-ERROR:  Cannot specify 'FETCH' for PARALLEL RETRIEVE CURSOR.
-HINT:  Using 'RETRIEVE' statement on endpoint instead.
+ERROR:  cannot specify 'FETCH' for PARALLEL RETRIEVE CURSOR
+HINT:  Use 'RETRIEVE' statement on endpoint instead.
 ROLLBACK;
 ROLLBACK
 
@@ -44,8 +44,7 @@ BEGIN
 DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
 MOVE 10 FROM c1;
-ERROR:  The 'MOVE' statement for PARALLEL RETRIEVE CURSOR is not supported.
-HINT:  The 'PARALLEL RETRIEVE CURSOR' does not support SCROLLABLE option.
+ERROR:  the 'MOVE' statement for PARALLEL RETRIEVE CURSOR is not supported
 ROLLBACK;
 ROLLBACK
 
@@ -55,7 +54,7 @@ BEGIN
 DECLARE c1 CURSOR FOR SELECT * FROM t1;
 DECLARE
 SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', 0);
-ERROR:  this UDF only works for PARALLEL RETRIEVE CURSOR.
+ERROR:  cursor is not a PARALLEL RETRIEVE CURSOR
 ROLLBACK;
 ROLLBACK
 BEGIN;
@@ -63,7 +62,7 @@ BEGIN
 DECLARE c1 CURSOR FOR SELECT * FROM t1;
 DECLARE
 SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
-ERROR:  this UDF only works for PARALLEL RETRIEVE CURSOR.
+ERROR:  cursor is not a PARALLEL RETRIEVE CURSOR
 ROLLBACK;
 ROLLBACK
 
@@ -82,7 +81,7 @@ DECLARE c3 PARALLEL RETRIEVE CURSOR WITHOUT HOLD FOR SELECT * FROM t1;
 DECLARE
 DO $$ DECLARE i int4; c4 refcursor = 'c3'; BEGIN FETCH FROM c4 INTO i; RAISE NOTICE '%', i; END; $$;
 ERROR:  The PARALLEL RETRIEVE CURSOR is not supported in SPI.
-HINT:  Using normal cursor statement instead.
+HINT:  Use normal cursor statement instead.
 CONTEXT:  PL/pgSQL function inline_code_block line 1 at FETCH
 ROLLBACK;
 ROLLBACK

--- a/src/test/isolation2/sql/resgroup/.gitignore
+++ b/src/test/isolation2/sql/resgroup/.gitignore
@@ -1,0 +1,2 @@
+resgroup_memory_runaway.sql
+resgroup_move_query.sql

--- a/src/test/isolation2/sql_isolation_testcase.py
+++ b/src/test/isolation2/sql_isolation_testcase.py
@@ -150,7 +150,6 @@ class GlobalShellExecutor(object):
                     lines = output.splitlines()
                     return lines[len(sh_cmd.splitlines()):len(lines) - 1]
 
-
             if not r and not e:
                 self.terminate(True)
                 raise GlobalShellExecutor.ExecutionError("Timeout happened to the bash daemon, see %s for details." % self.bash_log_file.name)
@@ -163,7 +162,7 @@ class GlobalShellExecutor(object):
         if self.sh_proc == None:
             raise GlobalShellExecutor.ExecutionError("The bash daemon has been terminated abnormally, see %s for details." % self.bash_log_file.name)
 
-        # get the output of shell commmand
+        # get the output of shell command
         output = self.__run_command(sh_cmd)
         if is_trip_output_end_blanklines:
             for i in range(len(output)-1, 0, -1):
@@ -187,7 +186,7 @@ class GlobalShellExecutor(object):
             self.v_cnt, escape_in, self.v_cnt, sh_cmd)
         return self.exec_global_shell(cmd, is_trip_output_end_blanklines)
 
-    # extrac shell shell, sql part from one line with format: @header '': SQL
+    # extract shell, sql part from one line with format: @header '': SQL
     # return row: (found the header or not?, the extracted shell, the SQL in the left part)
     def extract_sh_cmd(self, header, input_str):
         start = len(header)
@@ -229,7 +228,7 @@ class GlobalShellExecutor(object):
                     res_sql = input_str[i+1:]
                     break
         if not is_start or end == 0 or not is_trip_comma:
-            raise Exception("Invalid format: %v", input_str)
+            raise Exception("Invalid format: %s", input_str)
         #unescape \' to ' and \\ to '
         res_cmd = res_cmd.replace('\\\'', '\'')
         res_cmd = res_cmd.replace('\\\\', '\\')
@@ -264,7 +263,7 @@ class SQLIsolationExecutor(object):
             self.passwd = passwd
 
             parent_conn, child_conn = multiprocessing.Pipe(True)
-            self.p = multiprocessing.Process(target=self.session_process, args=(child_conn,))   
+            self.p = multiprocessing.Process(target=self.session_process, args=(child_conn,))
             self.pipe = parent_conn
             self.has_open = False
             self.p.start()
@@ -276,11 +275,11 @@ class SQLIsolationExecutor(object):
             self.out_file = out_file
 
         def session_process(self, pipe):
-            sp = SQLIsolationExecutor.SQLSessionProcess(self.name, 
+            sp = SQLIsolationExecutor.SQLSessionProcess(self.name,
                 self.mode, pipe, self.dbname, user=self.user, passwd=self.passwd)
             sp.do()
 
-        def query(self, command, post_run_cmd, global_sh_executor):
+        def query(self, command, post_run_cmd = None, global_sh_executor = None):
             print(file=self.out_file)
             self.out_file.flush()
             if len(command.strip()) == 0:
@@ -332,7 +331,7 @@ class SQLIsolationExecutor(object):
         def quit(self):
             print(" ... <quitting>", file=self.out_file)
             self.stop()
-        
+
         def terminate(self):
             self.pipe.close()
             self.p.terminate()
@@ -424,7 +423,7 @@ class SQLIsolationExecutor(object):
             if con is not None:
                 con.set_notice_receiver(null_notice_receiver)
             return con
- 
+
         def get_hostname_port(self, contentid, role):
             """
                 Gets the port number/hostname combination of the
@@ -611,7 +610,7 @@ class SQLIsolationExecutor(object):
         global_sh_executor.exec_global_shell("GP_PORT=%s" % port, True)
         sqls = global_sh_executor.exec_global_shell_with_orig_str(sql, pre_run_cmd, True)
         if (len(sqls) != 1):
-            raise Exception("Invalid shell commmand: %v", sqls)
+            raise Exception("Invalid shell command: %s" % "\n".join(sqls))
 
         return sqls[0]
 
@@ -619,14 +618,13 @@ class SQLIsolationExecutor(object):
         (hostname, port) = ConnectionInfo.get_hostname_port(name, 'p')
         global_sh_executor.exec_global_shell("GP_HOSTNAME=%s" % hostname, True)
         global_sh_executor.exec_global_shell("GP_PORT=%s" % port, True)
-        out= global_sh_executor.exec_global_shell("get_retrieve_token", True)
+        out = global_sh_executor.exec_global_shell("get_retrieve_token", True)
         if (len(out) > 0):
             token = out[0]
         out = global_sh_executor.exec_global_shell("echo ${RETRIEVE_USER}", True)
         if (len(out) > 0):
             user = out[0]
         return (user, token)
-
 
     def process_command(self, command, output_file, global_sh_executor):
         """
@@ -757,7 +755,7 @@ class SQLIsolationExecutor(object):
                     (retrieve_user, retrieve_token) = self.__get_retrieve_user_token(name, global_sh_executor)
                     self.get_process(output_file, name, con_mode, dbname=dbname, user=retrieve_user, passwd=retrieve_token).query(sql_new, post_run_cmd, global_sh_executor)
                 except SQLIsolationExecutor.SessionError as e:
-                    print (str(e), file=output_file)
+                    print(str(e), file=output_file)
                     self.processes[(e.name, e.mode)].terminate()
                     del self.processes[(e.name, e.mode)]
         elif flag == "R&":
@@ -772,7 +770,18 @@ class SQLIsolationExecutor(object):
         elif flag == "Rq":
             if len(sql) > 0:
                 raise Exception("No query should be given on quit")
-            self.quit_process(output_file, process_name, con_mode, dbname=dbname)
+
+            if process_name == '*':
+                process_names = [str(content) for content in self.get_all_primary_contentids(dbname)]
+            else:
+                process_names = [process_name]
+
+            for name in process_names:
+                try:
+                    self.quit_process(output_file, name, con_mode, dbname=dbname)
+                except Exception as e:
+                    print(str(e), file=output_file)
+                    pass
         elif flag == "M":
             self.get_process(output_file, process_name, con_mode, dbname=dbname).query(sql.strip(), post_run_cmd, global_sh_executor)
         else:
@@ -799,9 +808,9 @@ class SQLIsolationExecutor(object):
                 else:
                     command_part = line
                 if command_part == "" or command_part == "\n":
-                    print(file=output_file) 
+                    print(file=output_file)
                     newline = True
-                elif re.match(r".*;\s*$", command_part) or re.match(r"^\d+[q\\<]:\s*$", line) or re.match(r"^-?\d+[SUR][q\\<]:\s*$", line):
+                elif re.match(r".*;\s*$", command_part) or re.match(r"^\d+[q\\<]:\s*$", line) or re.match(r"^\*Rq:$", line) or re.match(r"^-?\d+[SUR][q\\<]:\s*$", line):
                     command += command_part
                     try:
                         self.process_command(command, output_file, shell_executor)
@@ -838,12 +847,12 @@ class SQLIsolationTestCase:
            content-id can alternatively be an asterisk '*' to perform a
            utility-mode/retrieve-mode query on the master and all primary segments.
            If you want to create multiple connections to the same content-id, just
-           increase N in: "content-id + {gpdb segment node number} * N", 
+           increase N in: "content-id + {gpdb segment node number} * N",
            e.g. if gpdb cluster segment number is 3, then:
-           (1) the master utility connections can be: -1U, -4U, -7U; 
-           (2) the seg0 connections can be: 0U, 3U, 6U; 
-           (3) the seg1 connections can be: 1U, 4U, 7U; 
-           (4) the seg2 connections can be: 2U, 5U, 8U; 
+           (1) the master utility connections can be: -1U, -4U, -7U;
+           (2) the seg0 connections can be: 0U, 3U, 6U;
+           (3) the seg1 connections can be: 1U, 4U, 7U;
+           (4) the seg2 connections can be: 2U, 5U, 8U;
         flag:
             &: expect blocking behavior
             >: running in background without blocking
@@ -888,12 +897,12 @@ class SQLIsolationTestCase:
 
         2& forks the command. It is executed in the background. If the
         command is NOT blocking at this point, it is considered an error.
-        2< joins the background command and outputs the result of the   
+        2< joins the background command and outputs the result of the
         command execution.
 
         Session ids should be smaller than 1024.
 
-        2U: Executes a utility command connected to port 40000. 
+        2U: Executes a utility command connected to port 40000.
 
         One difference to SQLTestCase is the output of INSERT.
         SQLTestCase would output "INSERT 0 1" if one tuple is inserted.
@@ -945,7 +954,7 @@ class SQLIsolationTestCase:
         @pre_run can be used for executing shell command to change input (i.e. each SQL statement) or get input info;
         @post_run can be used for executing shell command to change ouput (i.e. the result set printed for each SQL execution)
         or get output info. Just use the env variable ${RAW_STR} to refer to the input/out stream before shell execution,
-        and the output of the shell commmand will be used as the SQL exeucted or output printed into results file.
+        and the output of the shell command will be used as the SQL exeucted or output printed into results file.
 
         1: @post_run ' TOKEN1=` echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && export MATCHSUBS="${MATCHSUBS}${NL}m/${TOKEN1}/${NL}s/${TOKEN1}/token_id1/${NL}" && echo "${RAW_STR}" ': SELECT token,hostname,status FROM GP_ENDPOINTS WHERE cursorname='c1';
         2R: @pre_run ' echo "${RAW_STR}" | sed "s#@TOKEN1#${TOKEN1}#" ': RETRIEVE ALL FROM "@TOKEN1";
@@ -1011,33 +1020,33 @@ class SQLIsolationTestCase:
         # Add gucs to the test sql and form the actual sql file to be run
         if not out_dir:
             out_dir = self.get_out_dir()
-            
+
         if not os.path.exists(out_dir):
             TINCSystem.make_dirs(out_dir, ignore_exists_error = True)
-            
+
         if optimizer is None:
             gucs_sql_file = os.path.join(out_dir, os.path.basename(sql_file))
         else:
             # sql file will be <basename>_opt.sql or <basename>_planner.sql based on optimizer
             gucs_sql_file = os.path.join(out_dir, os.path.basename(sql_file).replace('.sql', '_%s.sql' %self._optimizer_suffix(optimizer)))
-            
+
         self._add_gucs_to_sql_file(sql_file, gucs_sql_file, optimizer)
         self.test_artifacts.append(gucs_sql_file)
 
-        
+
         if not out_file:
             if optimizer is None:
                 out_file = os.path.join(self.get_out_dir(), os.path.basename(sql_file).replace('.sql', '.out'))
             else:
                 # out file will be *_opt.out or *_planner.out based on optimizer
                 out_file = os.path.join(self.get_out_dir(), os.path.basename(sql_file).replace('.sql', '_%s.out' %self._optimizer_suffix(optimizer)))
-        
+
         self.test_artifacts.append(out_file)
         executor = SQLIsolationExecutor(dbname=self.db_name)
         with open(out_file, "w") as f:
             executor.process_isolation_file(open(sql_file), f, out_file)
-            f.flush()   
-        
+            f.flush()
+
         if out_file[-2:] == '.t':
             out_file = out_file[:-2]
 

--- a/src/test/isolation2/test_parallel_retrieve_cursor_extended_query.c
+++ b/src/test/isolation2/test_parallel_retrieve_cursor_extended_query.c
@@ -503,7 +503,7 @@ main(int argc, char **argv)
 			PQclear(res);
 			goto LABEL_ERR;
 		}
-		printf("Call PQfn() via retrieve mode connection: %s \n", PQresultErrorMessage(res));
+		printf("Expected forbidden: Call PQfn() via retrieve mode connection: %s \n", PQresultErrorMessage(res));
 
 		PQclear(res);
 		printf("\n------ End of testing fast path(PQfn) in retrieve mode # ------.\n");


### PR DESCRIPTION
Fix the flaky replicated_table case, and quit retrieve connections
between cases to test the expected behaviors.

Also update some comments and error messages, which were refined while
we back porting the parallel cursor to 6X_STABLE branch.
