### PR TITLE
6X: Fix a resource queue active stmt leak case

### DIFF
--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -1811,15 +1811,22 @@ CheckDeadLock(void)
 		if (Gp_role == GP_ROLE_DISPATCH && IsResQueueEnabled() &&
 			LOCK_LOCKMETHOD(*(MyProc->waitLock)) == RESOURCE_LOCKMETHOD)
 		{
-			ResRemoveFromWaitQueue(MyProc, 
-								   LockTagHashCode(&(MyProc->waitLock->tag)));
 			/*
-			 * lockAwaited's lock/proclock pointers are dangling after the call
-			 * to ResRemoveFromWaitQueue(). So clean up the locallock as well,
-			 * to avoid de-referencing them in the eventual ResLockRelease() in
-			 * ResLockPortal/ResLockUtilityPortal.
+			 * If there are no other locked portals resident in this backend
+			 * (i.e. nLocks == 0), lockAwaited's lock/proclock pointers are dangling
+			 * after the following call to ResRemoveFromWaitQueue(). So clean up the
+			 * locallock as well, to avoid de-referencing them in the eventual
+			 * ResLockRelease() in ResLockPortal()/ResLockUtilityPortal().
+			 *
+			 * If there are other locked portals resident in this backend
+			 * (i.e. nLocks > 0), as always, the lock and proclock cannot be cleaned
+			 * up now. Thus, defer the cleanup of the locallock.
 			 */
-			RemoveLocalLock(lockAwaited);
+			if (MyProc->waitProcLock->nLocks == 0)
+				RemoveLocalLock(lockAwaited);
+
+			ResRemoveFromWaitQueue(MyProc,
+								   LockTagHashCode(&(MyProc->waitLock->tag)));
 		}
 		else
 		{
@@ -2052,14 +2059,21 @@ ResLockWaitCancel(void)
 			/* We should only be trying to cancel resource locks. */
 			Assert(LOCALLOCK_LOCKMETHOD(*lockAwaited) == RESOURCE_LOCKMETHOD);
 
-			ResRemoveFromWaitQueue(MyProc, lockAwaited->hashcode);
 			/*
-			 * lockAwaited's lock/proclock pointers are dangling after the call
-			 * to ResRemoveFromWaitQueue(). So clean up the locallock as well,
-			 * to avoid de-referencing them in the eventual ResLockRelease() in
-			 * ResLockPortal/ResLockUtilityPortal.
+			 * If there are no other locked portals resident in this backend
+			 * (i.e. nLocks == 0), lockAwaited's lock/proclock pointers are dangling
+			 * after the following call to ResRemoveFromWaitQueue(). So clean up the
+			 * locallock as well, to avoid de-referencing them in the eventual
+			 * ResLockRelease() in ResLockPortal()/ResLockUtilityPortal().
+			 *
+			 * If there are other locked portals resident in this backend
+			 * (i.e. nLocks > 0), as always, the lock and proclock cannot be cleaned
+			 * up now. Thus, defer the cleanup of the locallock.
 			 */
-			RemoveLocalLock(lockAwaited);
+			if (MyProc->waitProcLock->nLocks == 0)
+				RemoveLocalLock(lockAwaited);
+
+			ResRemoveFromWaitQueue(MyProc, lockAwaited->hashcode);
 		}
 
 		lockAwaited = NULL;

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -329,7 +329,11 @@ ResLockAcquire(LOCKTAG *locktag, ResPortalIncrement *incrementSet)
 		lock->requested[lockmode]--;
 		Assert((lock->nRequested >= 0) && (lock->requested[lockmode] >= 0));
 
-		/* Clean up this lock. */
+		/*
+		 * Clean up the locallock. Since a single locallock can represent
+		 * multiple locked portals in the same backend, we can only remove it if
+		 * this is the last portal.
+		 */
 		if (proclock->nLocks == 0)
 			RemoveLocalLock(locallock);
 
@@ -391,7 +395,11 @@ ResLockAcquire(LOCKTAG *locktag, ResPortalIncrement *incrementSet)
 		lock->requested[lockmode]--;
 		Assert((lock->nRequested >= 0) && (lock->requested[lockmode] >= 0));
 
-		/* Clean up this lock. */
+		/*
+		 * Clean up the locallock. Since a single locallock can represent
+		 * multiple locked portals in the same backend, we can only remove it if
+		 * this is the last portal.
+		 */
 		if (proclock->nLocks == 0)
 			RemoveLocalLock(locallock);
 
@@ -603,6 +611,11 @@ ResLockRelease(LOCKTAG *locktag, uint32 resPortalId)
 	if (!incrementSet)
 	{
 		elog(DEBUG1, "Resource queue %d: increment not found on unlock", locktag->locktag_field1);
+		/*
+		 * Clean up the locallock. Since a single locallock can represent
+		 * multiple locked portals in the same backend, we can only remove it if
+		 * this is the last portal.
+		 */
 		if (proclock->nLocks == 0)
 		{
 			RemoveLocalLock(locallock);
@@ -622,6 +635,10 @@ ResLockRelease(LOCKTAG *locktag, uint32 resPortalId)
 
 	/*
 	 * Perform clean-up, waking up any waiters!
+	 *
+	 * Clean up the locallock. Since a single locallock can represent
+	 * multiple locked portals in the same backend, we can only remove it if
+	 * this is the last portal.
 	 */
 	if (proclock->nLocks == 0)
 		RemoveLocalLock(locallock);

--- a/src/test/isolation2/expected/resource_queue.out
+++ b/src/test/isolation2/expected/resource_queue.out
@@ -39,6 +39,13 @@ END
 2:END;
 END
 
+-- Sanity check: Ensure that the resource queue is now empty.
+0: SELECT rsqcountlimit, rsqcountvalue from pg_resqueue_status WHERE rsqname = 'rq_concurrency_test';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 1.0           | 0.0           
+(1 row)
+
 0:DROP role role_concurrency_test;
 DROP
 0:DROP RESOURCE QUEUE rq_concurrency_test;

--- a/src/test/isolation2/expected/resource_queue_cancel.out
+++ b/src/test/isolation2/expected/resource_queue_cancel.out
@@ -1,0 +1,57 @@
+-- Simple test for cancellation of a query stuck on a resource queue when the
+-- active statements limit is reached.
+
+0:CREATE RESOURCE QUEUE rq_cancel WITH (active_statements = 1);
+CREATE
+0:CREATE ROLE role_cancel RESOURCE QUEUE rq_cancel;
+CREATE
+
+-- Consume an active statement in session 1.
+1:SET ROLE role_cancel;
+SET
+1:BEGIN;
+BEGIN
+1:DECLARE c CURSOR FOR SELECT 0;
+DECLARE
+
+-- Make session 2 wait on the resource queue lock.
+2:SET ROLE role_cancel;
+SET
+2&:SELECT 100;  <waiting ...>
+
+-- Cancel SELECT from session 2.
+0:SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE query='SELECT 100;';
+ pg_cancel_backend 
+-------------------
+ t                 
+(1 row)
+
+-- Now once we end session 1's transaction, we should be able to consume the
+-- vacated active statement slot in session 2.
+1:END;
+END
+
+2<:  <... completed>
+ERROR:  canceling statement due to user request
+2:END;
+END
+2:BEGIN;
+BEGIN
+2:DECLARE c CURSOR FOR SELECT 0;
+DECLARE
+
+2:END;
+END
+
+-- Sanity check: Ensure that the resource queue is now empty.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_cancel';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 1.0           | 0.0           
+(1 row)
+
+-- Cleanup
+0:DROP ROLE role_cancel;
+DROP
+0:DROP RESOURCE QUEUE rq_cancel;
+DROP

--- a/src/test/isolation2/expected/resource_queue_deadlock.out
+++ b/src/test/isolation2/expected/resource_queue_deadlock.out
@@ -64,14 +64,22 @@ ANALYZE
 -- catch the issue and error out session 2.
 2: SELECT * FROM t_deadlock_test;
 ERROR:  deadlock detected
-DETAIL:  Process 26804 waits for ExclusiveLock on resource queue 57544; blocked by process 26795.
-Process 26795 waits for ShareUpdateExclusiveLock on relation 57546 of database 57503; blocked by process 26804.
+DETAIL:  Process 238028 waits for ExclusiveLock on resource queue 16416; blocked by process 238019.
+Process 238019 waits for ShareUpdateExclusiveLock on relation 16420 of database 16408; blocked by process 238028.
+HINT:  See server log for query details.
 
 -- Finish up the two sessions.
 2: ROLLBACK;
 ROLLBACK
 1<:  <... completed>
 INSERT 1
+
+-- Sanity check: Ensure that the resource queue is now empty.
+0: SELECT rsqcountlimit, rsqcountvalue from pg_resqueue_status WHERE rsqname = 'rq_deadlock_test';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 1.0           | 0.0           
+(1 row)
 
 -- Clean up the test
 0: DROP TABLE t_deadlock_test;

--- a/src/test/isolation2/expected/resource_queue_multi_portal.out
+++ b/src/test/isolation2/expected/resource_queue_multi_portal.out
@@ -1,0 +1,180 @@
+-- Here we ensure that we clean up resource queue in-memory state gracefully
+-- in the face of deadlocks and statement cancellations, when there is more than
+-- one active portal in the session.
+0:CREATE RESOURCE QUEUE rq_multi_portal WITH (active_statements = 2);
+CREATE
+0:CREATE ROLE role_multi_portal RESOURCE QUEUE rq_multi_portal;
+CREATE
+
+1:SET ROLE role_multi_portal;
+SET
+2:SET ROLE role_multi_portal;
+SET
+
+--
+-- Scenario 1:
+-- Multiple explicit cursors active in the same session with a deadlock.
+--
+
+1:BEGIN;
+BEGIN
+1:DECLARE c1 CURSOR FOR SELECT 1;
+DECLARE
+
+2:BEGIN;
+BEGIN
+2:DECLARE c2 CURSOR FOR SELECT 1;
+DECLARE
+
+-- There should be 2 active statements.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 2.0           | 2.0           
+(1 row)
+
+-- This should block as it will exceed the active statements limit.
+1&:DECLARE c3 CURSOR FOR SELECT 1;  <waiting ...>
+
+-- There should be 2 active statements.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 2.0           | 2.0           
+(1 row)
+
+-- This should cause a deadlock.
+2:DECLARE c4 CURSOR FOR SELECT 1;
+DECLARE
+
+-- After the deadlock report, one session should have ERRORed out with the
+-- deadlock report and aborted, while the other session should remain active
+-- and idle in transaction. The active statement count should be 2, contributed
+-- to by the session that is idle in transaction.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 2.0           | 2.0           
+(1 row)
+0:SELECT count(*) from pg_stat_activity WHERE query LIKE 'DECLARE c% CURSOR FOR SELECT 1;' AND state = 'idle in transaction';
+ count 
+-------
+ 1     
+(1 row)
+0:SELECT count(*) from pg_stat_activity WHERE query LIKE 'DECLARE c% CURSOR FOR SELECT 1;' AND state = 'idle in transaction (aborted)';
+ count 
+-------
+ 1     
+(1 row)
+
+-- After ending the transactions, there should be 0 active statements.
+1<:  <... completed>
+ERROR:  deadlock detected
+DETAIL:  Process 738539 waits for ExclusiveLock on resource queue 90366; blocked by process 738548.
+Process 738548 waits for ExclusiveLock on resource queue 90366; blocked by process 738539.
+HINT:  See server log for query details.
+1:END;
+END
+2:END;
+END
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 2.0           | 0.0           
+(1 row)
+
+--
+-- Scenario 2:
+-- Multiple explicit cursors active in the same session with a self deadlock.
+--
+1:BEGIN;
+BEGIN
+1:DECLARE c1 CURSOR FOR SELECT 1;
+DECLARE
+1:DECLARE c2 CURSOR FOR SELECT 1;
+DECLARE
+
+-- There should be 2 active statements.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 2.0           | 2.0           
+(1 row)
+
+-- This should cause a self-deadlock and session 1 should error out, aborting
+-- its transaction.
+1:DECLARE c3 CURSOR FOR SELECT 1;
+ERROR:  deadlock detected, locking against self
+
+-- There should be 0 active statements following the transaction abort.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 2.0           | 0.0           
+(1 row)
+
+1:END;
+END
+
+--
+-- Scenario 3:
+-- Multiple explicit cursors active in the same session with cancellation.
+--
+1:BEGIN;
+BEGIN
+1:DECLARE c1 CURSOR FOR SELECT 1;
+DECLARE
+
+2:BEGIN;
+BEGIN
+2:DECLARE c2 CURSOR FOR SELECT 1;
+DECLARE
+
+-- This should block as it will exceed the active statements limit.
+1&:DECLARE c3 CURSOR FOR SELECT 1;  <waiting ...>
+
+-- There should be 2 active statements.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 2.0           | 2.0           
+(1 row)
+
+-- Cancel session 1's transaction.
+0:SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE query = 'DECLARE c3 CURSOR FOR SELECT 1;';
+ pg_cancel_backend 
+-------------------
+ t                 
+(1 row)
+
+-- There should now only be one active statement, following the abort of session
+-- 1's transaction. The active statement is contributed by session 2.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 2.0           | 1.0           
+(1 row)
+0:SELECT query, state from pg_stat_activity WHERE query = 'DECLARE c2 CURSOR FOR SELECT 1;';
+ query                           | state               
+---------------------------------+---------------------
+ DECLARE c2 CURSOR FOR SELECT 1; | idle in transaction 
+(1 row)
+
+-- After ending the transactions, there should be 0 active statements.
+1<:  <... completed>
+ERROR:  canceling statement due to user request
+1:END;
+END
+2:END;
+END
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+ rsqcountlimit | rsqcountvalue 
+---------------+---------------
+ 2.0           | 0.0           
+(1 row)
+
+-- Cleanup
+0:DROP ROLE role_multi_portal;
+DROP
+0:DROP RESOURCE QUEUE rq_multi_portal;
+DROP

--- a/src/test/isolation2/init_file_isolation2
+++ b/src/test/isolation2/init_file_isolation2
@@ -50,8 +50,8 @@ m/^Process \d+ waits for ShareLock on transaction \d+; blocked by process \d+./
 s/^Process \d+ waits for ShareLock on transaction \d+; blocked by process \d+./Process PID waits for ShareLock on transaction XID; blocked by process PID./
 
 # For resource queue deadlock
-m/^DETAIL:  Process \d+ waits for ExclusiveLock on resource queue \d+; blocked by process \d+./
-s/^DETAIL:  Process \d+ waits for ExclusiveLock on resource queue \d+; blocked by process \d+./DETAIL:  Process PID waits for ExclusiveLock on resource queue OID; blocked by process PID./
+m/.*Process \d+ waits for ExclusiveLock on resource queue \d+; blocked by process \d+./
+s/.*Process \d+ waits for ExclusiveLock on resource queue \d+; blocked by process \d+./Process PID waits for ExclusiveLock on resource queue OID; blocked by process PID./
 
 # For resource queue deadlock
 m/^Process \d+ waits for ShareUpdateExclusiveLock on relation \d+ of database \d+; blocked by process \d+./

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -64,6 +64,10 @@ test: misc
 test: starve_case pg_views_concurrent_drop alter_blocks_for_update_and_viceversa drop_rename reader_waits_for_lock resource_queue
 test: vacuum_drop_phase_ao
 
+# Test simple cancellation for resource queues and cancellation/deadlocks for
+# sessions with multiple portals.
+test: resource_queue_cancel resource_queue_multi_portal
+
 # below test(s) inject faults so each of them need to be in a separate group
 test: pg_terminate_backend
 

--- a/src/test/isolation2/sql/resource_queue.sql
+++ b/src/test/isolation2/sql/resource_queue.sql
@@ -18,5 +18,8 @@
 2<:
 2:END;
 
+-- Sanity check: Ensure that the resource queue is now empty.
+0: SELECT rsqcountlimit, rsqcountvalue from pg_resqueue_status WHERE rsqname = 'rq_concurrency_test';
+
 0:DROP role role_concurrency_test;
 0:DROP RESOURCE QUEUE rq_concurrency_test;

--- a/src/test/isolation2/sql/resource_queue_cancel.sql
+++ b/src/test/isolation2/sql/resource_queue_cancel.sql
@@ -1,0 +1,36 @@
+-- Simple test for cancellation of a query stuck on a resource queue when the
+-- active statements limit is reached.
+
+0:CREATE RESOURCE QUEUE rq_cancel WITH (active_statements = 1);
+0:CREATE ROLE role_cancel RESOURCE QUEUE rq_cancel;
+
+-- Consume an active statement in session 1.
+1:SET ROLE role_cancel;
+1:BEGIN;
+1:DECLARE c CURSOR FOR SELECT 0;
+
+-- Make session 2 wait on the resource queue lock.
+2:SET ROLE role_cancel;
+2&:SELECT 100;
+
+-- Cancel SELECT from session 2.
+0:SELECT pg_cancel_backend(pid) FROM pg_stat_activity
+  WHERE query='SELECT 100;';
+
+-- Now once we end session 1's transaction, we should be able to consume the
+-- vacated active statement slot in session 2.
+1:END;
+
+2<:
+2:END;
+2:BEGIN;
+2:DECLARE c CURSOR FOR SELECT 0;
+
+2:END;
+
+-- Sanity check: Ensure that the resource queue is now empty.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_cancel';
+
+-- Cleanup
+0:DROP ROLE role_cancel;
+0:DROP RESOURCE QUEUE rq_cancel;

--- a/src/test/isolation2/sql/resource_queue_deadlock.sql
+++ b/src/test/isolation2/sql/resource_queue_deadlock.sql
@@ -45,6 +45,9 @@
 2: ROLLBACK;
 1<:
 
+-- Sanity check: Ensure that the resource queue is now empty.
+0: SELECT rsqcountlimit, rsqcountvalue from pg_resqueue_status WHERE rsqname = 'rq_deadlock_test';
+
 -- Clean up the test
 0: DROP TABLE t_deadlock_test;
 0: DROP ROLE role_deadlock_test;

--- a/src/test/isolation2/sql/resource_queue_multi_portal.sql
+++ b/src/test/isolation2/sql/resource_queue_multi_portal.sql
@@ -1,0 +1,103 @@
+-- Here we ensure that we clean up resource queue in-memory state gracefully
+-- in the face of deadlocks and statement cancellations, when there is more than
+-- one active portal in the session.
+0:CREATE RESOURCE QUEUE rq_multi_portal WITH (active_statements = 2);
+0:CREATE ROLE role_multi_portal RESOURCE QUEUE rq_multi_portal;
+
+1:SET ROLE role_multi_portal;
+2:SET ROLE role_multi_portal;
+
+--
+-- Scenario 1:
+-- Multiple explicit cursors active in the same session with a deadlock.
+--
+
+1:BEGIN;
+1:DECLARE c1 CURSOR FOR SELECT 1;
+
+2:BEGIN;
+2:DECLARE c2 CURSOR FOR SELECT 1;
+
+-- There should be 2 active statements.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+
+-- This should block as it will exceed the active statements limit.
+1&:DECLARE c3 CURSOR FOR SELECT 1;
+
+-- There should be 2 active statements.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+
+-- This should cause a deadlock.
+2:DECLARE c4 CURSOR FOR SELECT 1;
+
+-- After the deadlock report, one session should have ERRORed out with the
+-- deadlock report and aborted, while the other session should remain active
+-- and idle in transaction. The active statement count should be 2, contributed
+-- to by the session that is idle in transaction.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+0:SELECT count(*) from pg_stat_activity WHERE query LIKE 'DECLARE c% CURSOR FOR SELECT 1;'
+    AND state = 'idle in transaction';
+0:SELECT count(*) from pg_stat_activity WHERE query LIKE 'DECLARE c% CURSOR FOR SELECT 1;'
+    AND state = 'idle in transaction (aborted)';
+
+-- After ending the transactions, there should be 0 active statements.
+1<:
+1:END;
+2:END;
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+
+--
+-- Scenario 2:
+-- Multiple explicit cursors active in the same session with a self deadlock.
+--
+1:BEGIN;
+1:DECLARE c1 CURSOR FOR SELECT 1;
+1:DECLARE c2 CURSOR FOR SELECT 1;
+
+-- There should be 2 active statements.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+
+-- This should cause a self-deadlock and session 1 should error out, aborting
+-- its transaction.
+1:DECLARE c3 CURSOR FOR SELECT 1;
+
+-- There should be 0 active statements following the transaction abort.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+
+1:END;
+
+--
+-- Scenario 3:
+-- Multiple explicit cursors active in the same session with cancellation.
+--
+1:BEGIN;
+1:DECLARE c1 CURSOR FOR SELECT 1;
+
+2:BEGIN;
+2:DECLARE c2 CURSOR FOR SELECT 1;
+
+-- This should block as it will exceed the active statements limit.
+1&:DECLARE c3 CURSOR FOR SELECT 1;
+
+-- There should be 2 active statements.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+
+-- Cancel session 1's transaction.
+0:SELECT pg_cancel_backend(pid) FROM pg_stat_activity
+    WHERE query = 'DECLARE c3 CURSOR FOR SELECT 1;';
+
+-- There should now only be one active statement, following the abort of session
+-- 1's transaction. The active statement is contributed by session 2.
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+0:SELECT query, state from pg_stat_activity
+  WHERE query = 'DECLARE c2 CURSOR FOR SELECT 1;';
+
+-- After ending the transactions, there should be 0 active statements.
+1<:
+1:END;
+2:END;
+0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
+
+-- Cleanup
+0:DROP ROLE role_multi_portal;
+0:DROP RESOURCE QUEUE rq_multi_portal;


### PR DESCRIPTION
Cherry-picked from e4c6c368cda9f2928dbd530967fb56acf214a326 and
follow-up 780005f8026600b91e9c88e32c35b41614014d50 with minor conflicts
resolved. Original commit message follows along with a manual repro for
6X that involves named portals in extended protocol:

-------------------------------------------------------------------------
Since commit 2fa7c06d6a5, we have introduced an opportunity where the
active statement count is leaked (the active statements is not
decremented with ResLockUpdateLimit(.., .., false, ..). This can happen
during a deadlock report or a statement cancellation of a statement
if the session has at least one other active named portal. During
CheckDeadlock()/ResLockWaitCancel(), we would clean up the locallock,
which would cause a subsequent call to ResLockRelease(), for the other
active portal to early return here:

```c
/*
 * If the lock request did not get very far, cleanup is easy.
 */
if (!locallock ||
	!locallock->lock ||
	!locallock->proclock)
{
	elog(LOG, "Resource queue %d: no lock to release", locktag->locktag_field1);
	if (locallock)
	{
		RemoveLocalLock(locallock);
	}

	return false;
}
```

and not call ResLockUpdateLimit(.., .., false, ..)

The resultant active statement leak would cause subsequently submitted
statements to block forever on the resource queue lock, once the #active
statements = active statement limit.

Additionally, added test coverage for query cancellation and general
sanity checks for leaks in other tests.

-------------------------------------------------------------------------

Manual repro applicable to 6X with extended protocol and named portals:

Consider a JDBC program using named portals with extended protocol (with
prepareThreshold=1, autoCommit=false, fetchSize=1). Let the program run
2 select statements inside the same transaction. Have 2 sessions run
each statement in an interleaved fashion similar to the tests added in
resource_queue_multi_portal.sql with jdb. Use a similar resource queue
with a limit of 2 active statements. This will give rise to a deadlock
and active statement leak.

Note: using the same program described above, a leak with cancellation
can also be achieved.

Co-authored-by: Ashwin Agrawal <aashwin@vmware.com>
Co-authored-by: Yao Wang <wayao@vmware.com>
Co-authored-by: Hongxu Ma <interma@outlook.com>
Co-authored-by: Zhenghua Lyu <78182909+kainwen@users.noreply.github.com>
