### PR TITLE
docs - psql client too old for pgbouncer scram

### DIFF
--- a/gpdb-doc/dita/admin_guide/access_db/topics/pgbouncer.xml
+++ b/gpdb-doc/dita/admin_guide/access_db/topics/pgbouncer.xml
@@ -141,12 +141,18 @@ admin_users = gpadmin</codeblock></p>
           authentication method is configured. Second, they are used as the passwords for outgoing
           connections to the backend server, if the backend server requires password-based
           authentication (unless the password is specified directly in the database’s connection
-          string). The latter works if the password is stored in plain text or MD5-hashed. SCRAM
+          string). The latter works if the password is stored in plain text or MD5-hashed.</p>
+        <p>SCRAM
           secrets can only be used for logging into a server if the client authentication also uses
           SCRAM, the PgBouncer database definition does not specify a user name, and the SCRAM
           secrets are identical in PgBouncer and the PostgreSQL server (same salt and iterations,
           not merely the same password). This is due to an inherent security property of SCRAM: The
-          stored SCRAM secret cannot by itself be used for deriving login credentials.</p>
+          stored SCRAM secret cannot by itself be used for deriving login credentials.
+          <note>While the <codeph>pgbouncer</codeph> installed with Greenplum 6.x supports
+            the <codeph>SCRAM-SHA-256</codeph> authentication method, the Greenplum 6.x
+            <codeph>psql</codeph> client is too old to support this type of client
+            authentication. You can not use <codeph>SCRAM-SHA-256</codeph> authentication
+            with the Greenplum 6.x <codeph>psql</codeph> client program.</note></p>
         <p>The authentication file can be written by hand, but it’s also useful to generate it from
           some other list of users and passwords. See <codeph>./etc/mkauth.py</codeph> for a
           sample script to generate the authentication file from the


### PR DESCRIPTION
add a note to the pgbouncer docs that the psql client shipped with greenplum 6.x is too old to use the scram authentication method.
