### PR TITLE
Don't rely on quits for resqueue cleanup tests

### DIFF
--- a/src/test/isolation2/expected/resource_queue_cancel.out
+++ b/src/test/isolation2/expected/resource_queue_cancel.out
@@ -26,9 +26,10 @@ SET
  t                 
 (1 row)
 
--- Now once we quit session 1, we should be able to consume the vacated active
--- statement slot in session 2.
-1q: ... <quitting>
+-- Now once we end session 1's transaction, we should be able to consume the
+-- vacated active statement slot in session 2.
+1:END;
+END
 
 2<:  <... completed>
 ERROR:  canceling statement due to user request
@@ -39,7 +40,8 @@ BEGIN
 2:DECLARE c CURSOR FOR SELECT 0;
 DECLARE
 
-2q: ... <quitting>
+2:END;
+END
 
 -- Sanity check: Ensure that the resource queue is now empty.
 0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_cancel';

--- a/src/test/isolation2/expected/resource_queue_multi_portal.out
+++ b/src/test/isolation2/expected/resource_queue_multi_portal.out
@@ -6,19 +6,21 @@ CREATE
 0:CREATE ROLE role_multi_portal RESOURCE QUEUE rq_multi_portal;
 CREATE
 
+1:SET ROLE role_multi_portal;
+SET
+2:SET ROLE role_multi_portal;
+SET
+
 --
 -- Scenario 1:
 -- Multiple explicit cursors active in the same session with a deadlock.
 --
-1:SET ROLE role_multi_portal;
-SET
+
 1:BEGIN;
 BEGIN
 1:DECLARE c1 CURSOR FOR SELECT 1;
 DECLARE
 
-2:SET ROLE role_multi_portal;
-SET
 2:BEGIN;
 BEGIN
 2:DECLARE c2 CURSOR FOR SELECT 1;
@@ -65,14 +67,16 @@ DECLARE
  1     
 (1 row)
 
--- After quitting the sessions there should be 0 active statements.
+-- After ending the transactions, there should be 0 active statements.
 1<:  <... completed>
 ERROR:  deadlock detected
 DETAIL:  Process 738539 waits for ExclusiveLock on resource queue 90366; blocked by process 738548.
 Process 738548 waits for ExclusiveLock on resource queue 90366; blocked by process 738539.
 HINT:  See server log for query details.
-1q: ... <quitting>
-2q: ... <quitting>
+1:END;
+END
+2:END;
+END
 0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
  rsqcountlimit | rsqcountvalue 
 ---------------+---------------
@@ -83,8 +87,6 @@ HINT:  See server log for query details.
 -- Scenario 2:
 -- Multiple explicit cursors active in the same session with a self deadlock.
 --
-1:SET ROLE role_multi_portal;
-SET
 1:BEGIN;
 BEGIN
 1:DECLARE c1 CURSOR FOR SELECT 1;
@@ -111,21 +113,18 @@ ERROR:  deadlock detected, locking against self
  2             | 0             
 (1 row)
 
-1q: ... <quitting>
+1:END;
+END
 
 --
 -- Scenario 3:
 -- Multiple explicit cursors active in the same session with cancellation.
 --
-1:SET ROLE role_multi_portal;
-SET
 1:BEGIN;
 BEGIN
 1:DECLARE c1 CURSOR FOR SELECT 1;
 DECLARE
 
-2:SET ROLE role_multi_portal;
-SET
 2:BEGIN;
 BEGIN
 2:DECLARE c2 CURSOR FOR SELECT 1;
@@ -161,12 +160,13 @@ DECLARE
  DECLARE c2 CURSOR FOR SELECT 1; | idle in transaction 
 (1 row)
 
+-- After ending the transactions, there should be 0 active statements.
 1<:  <... completed>
 ERROR:  canceling statement due to user request
-1q: ... <quitting>
-
--- After quitting session 2 there should be 0 active statements.
-2q: ... <quitting>
+1:END;
+END
+2:END;
+END
 0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
  rsqcountlimit | rsqcountvalue 
 ---------------+---------------

--- a/src/test/isolation2/sql/resource_queue_cancel.sql
+++ b/src/test/isolation2/sql/resource_queue_cancel.sql
@@ -17,16 +17,16 @@
 0:SELECT pg_cancel_backend(pid) FROM pg_stat_activity
   WHERE query='SELECT 100;';
 
--- Now once we quit session 1, we should be able to consume the vacated active
--- statement slot in session 2.
-1q:
+-- Now once we end session 1's transaction, we should be able to consume the
+-- vacated active statement slot in session 2.
+1:END;
 
 2<:
 2:END;
 2:BEGIN;
 2:DECLARE c CURSOR FOR SELECT 0;
 
-2q:
+2:END;
 
 -- Sanity check: Ensure that the resource queue is now empty.
 0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_cancel';

--- a/src/test/isolation2/sql_isolation_testcase.py
+++ b/src/test/isolation2/sql_isolation_testcase.py
@@ -848,7 +848,7 @@ class SQLIsolationTestCase:
             &: expect blocking behavior
             >: running in background without blocking
             <: join an existing session
-            q: quit the given session
+            q: quit the given session without blocking
 
             U: connect in utility mode to primary contentid from gp_segment_configuration
             U&: expect blocking behavior in utility mode (does not currently support an asterisk target)
@@ -939,6 +939,9 @@ class SQLIsolationTestCase:
         2q:  ---> Will quit the session established with test2db.
 
         The subsequent 2: @db_name test: <sql> will open a new session with the database test and execute the sql against that session.
+        Note: Do not expect blocking behavior from explicit quit statements.
+        This implies that a subsequent statement can execute while the relevant
+        session is still undergoing exit.
 
         Shell Execution for SQL or Output:
 


### PR DESCRIPTION
isolation2 quit syntax is not blocking. Thus relying on session quits,
like in e4c6c36, in order to assert resource queue emptiness, can
lead to flakes.

Use END instead to ensure deterministic behavior. Using END is more
accurate too, as resource queue cleanup occurs at transaction end,
rather than during backend exit.

Also update this fact in the isolation2 in-code documentation.

This needs to be backported into https://github.com/greenplum-db/gpdb/pull/12909 and https://github.com/greenplum-db/gpdb/pull/12908