### PR TITLE
docs - new 6x guc enable_implicit_timeformat_YYYYMMDDHH24MISS

### DIFF
--- a/gpdb-doc/dita/install_guide/migrate.xml
+++ b/gpdb-doc/dita/install_guide/migrate.xml
@@ -238,10 +238,22 @@
           previous Greenplum Database releases. You can still specify the
             <codeph>YYYYMMDDHH24MISS</codeph> format in conversion functions such as
             <codeph>to_timestamp</codeph> and <codeph>to_char</codeph> for compatibility with other
-          database systems. You can use input formats for converting text to date or timestamp
-          values to avoid unexpected results or query execution failures. For example, this
+          database systems. You have two options to avoid unexpected results or
+          query execution failures:
+          <ul>
+            <li>Set the <codeph><xref href="../ref_guide/config_params/guc-list.xml#enable_implicit_timeformat_YYYYMMDDHH24MISS"
+              format="dita" scope="peer">enable_implicit_timeformat_YYYYMMDDHH24MISS</xref></codeph>
+              server configuration parameter to <codeph>on</codeph> to have Greenplum
+              Database implicitly convert a string with the deprecated 
+              <codeph>YYYYMMDDHH24MISS</codeph> timestamp format to a valid date/time type.
+              You may require this conversion when loading data from Greenplum 5. Be sure to
+              turn <codeph>off</codeph> the parameter when the conversion is no longer
+              required.</li>
+            <li>Use input formats for converting text to date or timestamp values. For example, this
             <codeph>SELECT</codeph> command returns a timestamp in Greenplum Database 5 and fails in
-            6.<codeblock>SELECT to_timestamp('20190905140000');</codeblock><p>To convert the string
+            6 with the default <codeph>enable_implicit_timeformat_YYYYMMDDHH24MISS</codeph> setting
+            (<codeph>off</codeph>):
+            <codeblock>SELECT to_timestamp('20190905140000');</codeblock><p>To convert the string
             to a timestamp in Greenplum Database 6, you must use a valid format. Both of these
             commands return a timestamp in Greenplum Database 6. The first example explicitly
             specifies a timestamp format. The second example uses the string in a format that
@@ -249,9 +261,12 @@
             recognizes.<codeblock>SELECT to_timestamp('20190905140000','YYYYMMDDHH24MISS');
 SELECT to_timestamp('201909051 40000');</codeblock></p><p>The
             timestamp issue also applies when you use the <codeph>::</codeph> syntax. In Greenplum
-            Database 6, the first command returns an error. The second command returns a timestamp.
+            Database 6 with the default <codeph>enable_implicit_timeformat_YYYYMMDDHH24MISS</codeph> setting
+            (<codeph>off</codeph>), the first command returns an error. The second command returns a timestamp.
             <codeblock>SELECT '20190905140000'::timestamp ;
 SELECT '20190905 140000'::timestamp ;</codeblock></p></li>
+          </ul>
+        </li>
         <li>Creating a table using the <codeph>CREATE TABLE AS</codeph> command in Greenplum 4.3 or
           5 could create a table with a duplicate distribution key. The <codeph>gpbackup</codeph>
           utility saves the table to the backup using a <codeph>CREATE TABLE</codeph> command that

--- a/gpdb-doc/dita/install_guide/migrate.xml
+++ b/gpdb-doc/dita/install_guide/migrate.xml
@@ -241,15 +241,7 @@
           database systems. You have two options to avoid unexpected results or
           query execution failures:
           <ul>
-            <li>Set the <codeph><xref href="../ref_guide/config_params/guc-list.xml#enable_implicit_timeformat_YYYYMMDDHH24MISS"
-              format="dita" scope="peer">enable_implicit_timeformat_YYYYMMDDHH24MISS</xref></codeph>
-              server configuration parameter to <codeph>on</codeph> to have Greenplum
-              Database implicitly convert a string with the deprecated 
-              <codeph>YYYYMMDDHH24MISS</codeph> timestamp format to a valid date/time type.
-              You may require this conversion when loading data from Greenplum 5. Be sure to
-              turn <codeph>off</codeph> the parameter when the conversion is no longer
-              required.</li>
-            <li>Use input formats for converting text to date or timestamp values. For example, this
+            <li>(Recommended option) Use input formats for converting text to date or timestamp values. For example, this
             <codeph>SELECT</codeph> command returns a timestamp in Greenplum Database 5 and fails in
             6 with the default <codeph>enable_implicit_timeformat_YYYYMMDDHH24MISS</codeph> setting
             (<codeph>off</codeph>):
@@ -265,7 +257,19 @@ SELECT to_timestamp('201909051 40000');</codeblock></p><p>The
             (<codeph>off</codeph>), the first command returns an error. The second command returns a timestamp.
             <codeblock>SELECT '20190905140000'::timestamp ;
 SELECT '20190905 140000'::timestamp ;</codeblock></p></li>
+            <li>Set the <codeph><xref href="../ref_guide/config_params/guc-list.xml#enable_implicit_timeformat_YYYYMMDDHH24MISS"
+              format="dita" scope="peer">enable_implicit_timeformat_YYYYMMDDHH24MISS</xref></codeph>
+              server configuration parameter to <codeph>on</codeph> to have Greenplum
+              Database implicitly convert a string with the deprecated 
+              <codeph>YYYYMMDDHH24MISS</codeph> timestamp format to a valid date/time type.
+              You may require this conversion when loading data from Greenplum 5. Be sure to
+              turn <codeph>off</codeph> the parameter when the conversion is no longer
+              required.</li>
           </ul>
+          <note>VMware recommends that you choose the input format conversion option. The
+            <codeph>enable_implicit_timeformat_YYYYMMDDHH24MISS</codeph> server
+            configuration parameter is available only in Greenplum Database 6.19+, and will
+            not be supported in future major versions of Greenplum.</note>
         </li>
         <li>Creating a table using the <codeph>CREATE TABLE AS</codeph> command in Greenplum 4.3 or
           5 could create a table with a duplicate distribution key. The <codeph>gpbackup</codeph>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -120,6 +120,9 @@
               <xref href="#enable_hashjoin"/>
             </li>
             <li>
+              <xref href="#enable_implicit_timeformat_YYYYMMDDHH24MISS"/>
+            </li>
+            <li>
               <xref href="#enable_indexscan"/>
             </li>
             <li>
@@ -1828,6 +1831,38 @@
             <row>
               <entry colname="col1">Boolean</entry>
               <entry colname="col2">on</entry>
+              <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="enable_implicit_timeformat_YYYYMMDDHH24MISS">
+    <title>enable_implicit_timeformat_YYYYMMDDHH24MISS</title>
+    <body>
+      <p>Enables or disables implicit conversion of a string with the deprecated
+        <i>YYYYMMDDHH24MISS</i> timestamp format to a valid date/time type.</p>
+      <p>The default value is <codeph>off</codeph>. When this parameter is set to
+        <codeph>on</codeph>, Greenplum Database converts a string with the
+        timestamp format <i>YYYYMMDDHH24MISS</i> into a valid date/time type. You
+        may require this conversion when loading data from Greenplum Database 5.</p>
+      <table id="tbl_enable_implicit_timeformat_YYYYMMDDHH24MISS">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">Boolean</entry>
+              <entry colname="col2">off</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>
           </tbody>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -1841,7 +1841,7 @@
   <topic id="enable_implicit_timeformat_YYYYMMDDHH24MISS">
     <title>enable_implicit_timeformat_YYYYMMDDHH24MISS</title>
     <body>
-      <p>Enables or disables implicit conversion of a string with the deprecated
+      <p>Enables or disables the deprecated implicit conversion of a string with the
         <i>YYYYMMDDHH24MISS</i> timestamp format to a valid date/time type.</p>
       <p>The default value is <codeph>off</codeph>. When this parameter is set to
         <codeph>on</codeph>, Greenplum Database converts a string with the

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1396,6 +1396,9 @@
         <simpletable frame="none" id="simpletable_uy5_1bv_bdb">
           <strow>
             <stentry>
+              <p>
+                <xref href="guc-list.xml#enable_implicit_timeformat_YYYYMMDDHH24MISS" type="section">enable_implicit_timeformat_YYYYMMDDHH24MISS</xref>
+              </p>
               <p><xref href="guc-list.xml#gp_ignore_error_table">gp_ignore_error_table</xref>
               </p>
             </stentry>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -64,6 +64,7 @@
             <topicref href="guc-list.xml#enable_groupagg"/>
             <topicref href="guc-list.xml#enable_hashagg"/>
             <topicref href="guc-list.xml#enable_hashjoin"/>
+            <topicref href="guc-list.xml#enable_implicit_timeformat_YYYYMMDDHH24MISS"/>
             <topicref href="guc-list.xml#enable_indexscan"/>
             <topicref href="guc-list.xml#enable_mergejoin"/>
             <topicref href="guc-list.xml#enable_nestloop"/>


### PR DESCRIPTION
doc the new guc enable_implicit_timeformat_YYYYMMDDHH24MISS.  in this PR:
- add the new guc to the guc reference
- update to the migration topic, which mentions that greenplum no longer automatically converte from the deprecated YYYYMMDDHH24MISS timestamp format.  (the existing examples don't look that useful to me, but i assume that they are there for a reason, so kept them.)