### PR TITLE
5X: Document that explicit quit syntax is non-blocking

### DIFF
--- a/src/test/isolation2/sql_isolation_testcase.py
+++ b/src/test/isolation2/sql_isolation_testcase.py
@@ -351,7 +351,7 @@ class SQLIsolationTestCase:
             &: expect blocking behavior
             >: running in background without blocking
             <: join an existing session
-            q: quit the given session
+            q: quit the given session without blocking
 
             U: connect in utility mode to dbid from gp_segment_configuration
             U&: expect blocking behavior in utility mode (does not currently support an asterisk target)
@@ -439,6 +439,9 @@ class SQLIsolationTestCase:
         2q:  ---> Will quit the session established with test2db.
 
         The subsequent 2: @db_name test: <sql> will open a new session with the database test and execute the sql against that session.
+        Note: Do not expect blocking behavior from explicit quit statements.
+        This implies that a subsequent statement can execute while the relevant
+        session is still undergoing exit.
 
         Catalog Modification:
 


### PR DESCRIPTION
Discussion: https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/A2JUpJ0NrEA/m/3S6rmd2zBAAJ
(cherry picked from commit b1dc547ccd231f3ce7d66719eafda652a8326748)
