### PR TITLE
Packcore tests were failing on 6x. Current change makes sure that we are in parity with gpdb6.

### DIFF
--- a/gpMgmt/sbin/packcore
+++ b/gpMgmt/sbin/packcore
@@ -128,7 +128,7 @@ def _getLibraryListWithGDB(coreFile, binary):
                                 # list shared libraries explicitly
                  '-c', coreFile,
                  binary],
-                stdout=PIPE, stderr=PIPE)
+                stdout=PIPE, stderr=PIPE, env=environ)
     result = cmd.communicate()[0].decode()
 
     # gdb output looks like below:


### PR DESCRIPTION
Packcore tests on RHEL8 were failing because of GDB failing to start. And this was happening because GDB needs some environment variables set before invoking command.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
