### PR TITLE
add pkg-config to README.Ubuntu.bash

### DIFF
--- a/README.Ubuntu.bash
+++ b/README.Ubuntu.bash
@@ -32,6 +32,7 @@ sudo apt-get install -y \
 	openssh-client \
 	openssh-server \
 	openssl \
+	pkg-config \
 	python3-dev \
 	python3-pip \
 	python3-psutil \


### PR DESCRIPTION
Since everytime I build gpdb in a new environment of ubuntu 20.04, I will got this error:

```bash
configure: error: The pkg-config script could not be found or is too old.  Make sure it
is in your PATH or set the PKG_CONFIG environment variable to the full
path to pkg-config.
```

So I think add pkg-config to bash script will be more convenient.
