### PR TITLE
Fix colref in preprocessing for SubqueryALL with outer refs

### DIFF
--- a/src/test/regress/expected/notin.out
+++ b/src/test/regress/expected/notin.out
@@ -1274,9 +1274,67 @@ select * from table_source4 where c3 = 'INC' and c4 = '0000000001' and c2 not in
  000181202006010000003158 | a  | INC | 0000000001
 (1 row)
 
+-- Test notin with outerrefs in the subquery
+--
+-- q47
+--
+create table outerref (a int, b text, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into outerref (a,b,c) values(1,'1',1);
+insert into outerref (a,b,c) values(1,'1',2);
+-- For a cluster with only 1 segment, this test doesn't crash without the fix.
+-- We can disable_xform('CXformSimplifySelectWithSubquery'); for testing for a
+-- cluster with only 1 segment. Not adding here as it changes the default plan
+-- that ORCA picks
+explain select b from outerref where b not in (select distinct b where c>1);
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=2)
+   ->  Seq Scan on outerref  (cost=0.00..1.03 rows=1 width=2)
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice1; segments: 1)
+           ->  GroupAggregate  (cost=0.00..0.03 rows=1 width=32)
+                 Group Key: outerref.b
+                 ->  Result  (cost=0.00..0.01 rows=1 width=0)
+                       One-Time Filter: (outerref.c > 1)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+select b from outerref where b not in (select distinct b where c>1);
+ b 
+---
+ 1
+(1 row)
+
+create table outerref_int (a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into outerref_int (a,b,c) values(1,2,1);
+insert into outerref_int (a,b,c) values(1,2,2);
+explain select b from outerref_int where b not in (select distinct b where c>1);
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=4)
+   ->  Seq Scan on outerref_int  (cost=0.00..1.03 rows=1 width=4)
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice1; segments: 1)
+           ->  GroupAggregate  (cost=0.00..0.03 rows=1 width=4)
+                 Group Key: outerref_int.b
+                 ->  Result  (cost=0.00..0.01 rows=1 width=0)
+                       One-Time Filter: (outerref_int.c > 1)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+select b from outerref_int where b not in (select distinct b where c>1);
+ b 
+---
+ 2
+(1 row)
+
 reset search_path;
 drop schema notin cascade;
-NOTICE:  drop cascades to 16 other objects
+NOTICE:  drop cascades to 18 other objects
 DETAIL:  drop cascades to table notin.t1
 drop cascades to table notin.t2
 drop cascades to table notin.t3
@@ -1293,3 +1351,5 @@ drop cascades to table notin.table_source2
 drop cascades to table notin.table_source3
 drop cascades to table notin.table_source4
 drop cascades to table notin.table_config
+drop cascades to table notin.outerref
+drop cascades to table notin.outerref_int

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -1340,9 +1340,81 @@ select * from table_source4 where c3 = 'INC' and c4 = '0000000001' and c2 not in
  000181202006010000003158 | a  | INC | 0000000001
 (1 row)
 
+-- Test notin with outerrefs in the subquery
+--
+-- q47
+--
+create table outerref (a int, b text, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into outerref (a,b,c) values(1,'1',1);
+insert into outerref (a,b,c) values(1,'1',2);
+-- For a cluster with only 1 segment, this test doesn't crash without the fix.
+-- We can disable_xform('CXformSimplifySelectWithSubquery'); for testing for a
+-- cluster with only 1 segment. Not adding here as it changes the default plan
+-- that ORCA picks
+explain select b from outerref where b not in (select distinct b where c>1);
+                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                                 
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..882688.11 rows=1 width=2)
+   ->  Result  (cost=0.00..882688.11 rows=1 width=2)
+         ->  Seq Scan on outerref  (cost=0.00..882688.11 rows=1 width=2)
+               Filter: (SubPlan 1)
+               SubPlan 1  (slice1; segments: 3)
+                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                       ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                             Filter: ((CASE WHEN ((sum((CASE WHEN (outerref.b = (outerref.b)) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN ((outerref.b) IS NULL) THEN 1 ELSE 0 END))) > 0::bigint) THEN NULL::boolean WHEN (outerref.b IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN (outerref.b = (outerref.b)) THEN 1 ELSE 0 END))) = 0::bigint) THEN true ELSE false END) = true)
+                             ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                                   ->  Aggregate  (cost=0.00..0.00 rows=1 width=16)
+                                         ->  Result  (cost=0.00..0.00 rows=1 width=8)
+                                               ->  Result  (cost=0.00..0.00 rows=1 width=8)
+                                                     ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                                                           One-Time Filter: (outerref.c > 1)
+                                                           ->  Result  (cost=0.00..0.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(16 rows)
+
+select b from outerref where b not in (select distinct b where c>1);
+ b 
+---
+ 1
+(1 row)
+
+create table outerref_int (a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into outerref_int (a,b,c) values(1,2,1);
+insert into outerref_int (a,b,c) values(1,2,2);
+explain select b from outerref_int where b not in (select distinct b where c>1);
+                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                             
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..882688.11 rows=1 width=4)
+   ->  Result  (cost=0.00..882688.11 rows=1 width=4)
+         ->  Seq Scan on outerref_int  (cost=0.00..882688.11 rows=1 width=4)
+               Filter: (SubPlan 1)
+               SubPlan 1  (slice1; segments: 3)
+                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                       ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                             Filter: ((CASE WHEN ((sum((CASE WHEN (outerref_int.b = (outerref_int.b)) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN ((outerref_int.b) IS NULL) THEN 1 ELSE 0 END))) > 0::bigint) THEN NULL::boolean WHEN (outerref_int.b IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN (outerref_int.b = (outerref_int.b)) THEN 1 ELSE 0 END))) = 0::bigint) THEN true ELSE false END) = true)
+                             ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                                   ->  Aggregate  (cost=0.00..0.00 rows=1 width=16)
+                                         ->  Result  (cost=0.00..0.00 rows=1 width=8)
+                                               ->  Result  (cost=0.00..0.00 rows=1 width=4)
+                                                     ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                                                           One-Time Filter: (outerref_int.c > 1)
+                                                           ->  Result  (cost=0.00..0.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(16 rows)
+
+select b from outerref_int where b not in (select distinct b where c>1);
+ b 
+---
+ 2
+(1 row)
+
 reset search_path;
 drop schema notin cascade;
-NOTICE:  drop cascades to 16 other objects
+NOTICE:  drop cascades to 18 other objects
 DETAIL:  drop cascades to table notin.t1
 drop cascades to table notin.t2
 drop cascades to table notin.t3
@@ -1359,3 +1431,5 @@ drop cascades to table notin.table_source2
 drop cascades to table notin.table_source3
 drop cascades to table notin.table_source4
 drop cascades to table notin.table_config
+drop cascades to table notin.outerref
+drop cascades to table notin.outerref_int

--- a/src/test/regress/sql/notin.sql
+++ b/src/test/regress/sql/notin.sql
@@ -415,6 +415,27 @@ select * from table_source3 where c3 = 'INC' and c4 = '0000000001' and c2 not in
 explain select * from table_source4 where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
 select * from table_source4 where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
 
+-- Test notin with outerrefs in the subquery
+--
+-- q47
+--
+create table outerref (a int, b text, c int);
+insert into outerref (a,b,c) values(1,'1',1);
+insert into outerref (a,b,c) values(1,'1',2);
+
+-- For a cluster with only 1 segment, this test doesn't crash without the fix.
+-- We can disable_xform('CXformSimplifySelectWithSubquery'); for testing for a
+-- cluster with only 1 segment. Not adding here as it changes the default plan
+-- that ORCA picks
+explain select b from outerref where b not in (select distinct b where c>1);
+select b from outerref where b not in (select distinct b where c>1);
+
+create table outerref_int (a int, b int, c int);
+insert into outerref_int (a,b,c) values(1,2,1);
+insert into outerref_int (a,b,c) values(1,2,2);
+
+explain select b from outerref_int where b not in (select distinct b where c>1);
+select b from outerref_int where b not in (select distinct b where c>1);
 
 reset search_path;
 drop schema notin cascade;


### PR DESCRIPTION
The commit 8f4c96e, introduced adding a project node on top of group by
for outer references. The changes work fine for `CScalarSubqueryAny` as
in a later preprocessing step, the CScalarSubqueryAny with colref gets
processed to CScalarSubqueryExists (no colref). Whereas for
CScalarSubqueryAll, this colref would not be adjusted and still point to
the original colref, causing ORCA to generate a plan that would either
cause incorrect results or segment crash when executing the query.

Consider the following query,
select b from foo where b not in (select distinct b where c>1 );

The above query will get preprocessed as shown below:

```
Algebrized query:
+--CLogicalSelect
   |--CLogicalGet "foo" ("foo"), Columns: ["a" (0), "b" (1), "c" (2), "ctid" (3), "xmin" (4), "cmin" (5), "xmax" (6), "cmax" (7), "tableoid" (8), "gp_segment_id" (9)] Key sets: {[3,9]}
   +--CScalarSubqueryAll(<>)["b" (1)]
      |--CLogicalGbAgg( Global ) Grp Cols: ["b" (1)][Global], Minimal Grp Cols: [], Generates Duplicates :[ 0 ]
      |  |--CLogicalSelect
      |  |  |--CLogicalConstTableGet Columns: ["" (10)] Values: [(1)]
      |  |  +--CScalarCmp (>)
      |  |     |--CScalarIdent "c" (2)
      |  |     +--CScalarConst (2)
      |  +--CScalarProjectList
      +--CScalarIdent "b" (1)

Algebrized preprocessed query:
+--CLogicalSelect
   |--CLogicalGet "foo" ("foo"), Columns: ["a" (0), "b" (1), "c" (2), "ctid" (3), "xmin" (4), "cmin" (5), "xmax" (6), "cmax" (7), "tableoid" (8), "gp_segment_id" (9)] Key sets: {[3,9]}
   +--CScalarSubqueryAll(<>)["b" (1)]
      |--CLogicalGbAgg( Global ) Grp Cols: ["ColRef_0011" (11)][Global], Minimal Grp Cols: ["ColRef_0011" (11)], Generates Duplicates :[ 0 ]
      |  |--CLogicalProject
      |  |  |--CLogicalSelect
      |  |  |  |--CLogicalConstTableGet Columns: ["" (10)] Values: [(1)]
      |  |  |  +--CScalarCmp (>)
      |  |  |     |--CScalarIdent "c" (2)
      |  |  |     +--CScalarConst (2)
      |  |  +--CScalarProjectList
      |  |     +--CScalarProjectElement "ColRef_0011" (11)
      |  |        +--CScalarIdent "b" (1)
      |  +--CScalarProjectList
      +--CScalarIdent "b" (1)
```
The colref for CScalarSubqueryAll(<>) is ["b" (1)], whereas the
projected column underneath is "ColRef_0011" (11).
This commit, fixes the colref by creating a new CScalarSubqueryAll
operator with the colref as projected from the ProjectList below it.
Now, for the above query, the preprocessed query is :

```
Algebrized preprocessed query:
+--CLogicalSelect
   |--CLogicalGet "foo" ("foo"), Columns: ["a" (0), "b" (1), "c" (2), "ctid" (3), "xmin" (4), "cmin" (5), "xmax" (6), "cmax" (7), "tableoid" (8), "gp_segment_id" (9)] Key sets: {[3,9]}
   +--CScalarSubqueryAll(<>)["ColRef_0011" (11)]
      |--CLogicalGbAgg( Global ) Grp Cols: ["ColRef_0011" (11)][Global], Minimal Grp Cols: ["ColRef_0011" (11)], Generates Duplicates :[ 0 ]
      |  |--CLogicalProject
      |  |  |--CLogicalSelect
      |  |  |  |--CLogicalConstTableGet Columns: ["" (10)] Values: [(1)]
      |  |  |  +--CScalarCmp (>)
      |  |  |     |--CScalarIdent "c" (2)
      |  |  |     +--CScalarConst (1)
      |  |  +--CScalarProjectList
      |  |     +--CScalarProjectElement "ColRef_0011" (11)
      |  |        +--CScalarIdent "b" (1)
      |  +--CScalarProjectList
      +--CScalarIdent "b" (1)
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
