### PR TITLE
[6X] support kerberos delegation in libpq

### DIFF
--- a/configure
+++ b/configure
@@ -13996,6 +13996,18 @@ fi
 
 done
 
+ac_fn_c_check_decl "$LINENO" "gss_store_cred_into" "ac_cv_have_decl_gss_store_cred_into" "#include <gssapi/gssapi_ext.h>
+"
+if test "x$ac_cv_have_decl_gss_store_cred_into" = xyes; then :
+  ac_have_decl=1
+else
+  ac_have_decl=0
+fi
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_GSSAPI_PROXY $ac_have_decl
+_ACEOF
+
 fi
 
 if test "$with_openssl" = yes ; then
@@ -16291,7 +16303,6 @@ $as_echo "#define HAVE_IPV6 1" >>confdefs.h
 
          HAVE_IPV6=yes
 fi
-
 
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for PS_STRINGS" >&5

--- a/configure
+++ b/configure
@@ -738,6 +738,7 @@ with_uuid
 with_selinux
 with_openssl
 krb_srvtab
+with_gssapi
 with_python
 with_perl
 with_tcl
@@ -813,6 +814,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -949,6 +951,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1201,6 +1204,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1338,7 +1350,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1491,6 +1503,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -7371,6 +7384,7 @@ $as_echo "$with_gssapi" >&6; }
 
 
 
+
 #
 # Kerberos configuration parameters
 #
@@ -9565,7 +9579,7 @@ fi
 
 if test "$with_python" = yes; then
   if test -z "$PYTHON"; then
-  for ac_prog in python python3 python2
+  for ac_prog in python python2
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
 set dummy $ac_prog; ac_word=$2
@@ -15624,7 +15638,7 @@ else
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -15670,7 +15684,7 @@ else
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -15694,7 +15708,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -15739,7 +15753,7 @@ else
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -15763,7 +15777,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -18297,7 +18311,7 @@ else
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -18343,7 +18357,7 @@ else
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -18367,7 +18381,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -18412,7 +18426,7 @@ else
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -18436,7 +18450,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];

--- a/configure.in
+++ b/configure.in
@@ -1699,9 +1699,14 @@ if test "$with_quicklz" = yes; then
   AC_CHECK_HEADER(quicklz.h, [], [AC_MSG_ERROR([header file <quicklz.h> is required for QuickLZ support])])
 fi
 
+# Check for GSSAPI
 if test "$with_gssapi" = yes ; then
   AC_CHECK_HEADERS(gssapi/gssapi.h, [],
 	[AC_CHECK_HEADERS(gssapi.h, [], [AC_MSG_ERROR([gssapi.h header file is required for GSSAPI])])])
+  AC_CHECK_DECLS(gs_store_cred_into,
+      [AC_DEFINE(HAVE_GSSAPI_PROXY, 1, [Define to 1 if you have GSSAPI extension support. ])],
+      [AC_MSG_ERROR([gssapi_ext.h header file is required for GSSAPI proxy])],
+  [#include <gssapi/gssapi_ext.h>])
 fi
 
 if test "$with_openssl" = yes ; then

--- a/configure.in
+++ b/configure.in
@@ -941,6 +941,7 @@ PGAC_ARG_BOOL(with, gssapi, no, [build with GSSAPI support],
   krb_srvtab="FILE:\$(sysconfdir)/krb5.keytab"
 ])
 AC_MSG_RESULT([$with_gssapi])
+AC_SUBST(with_gssapi)
 
 
 AC_SUBST(krb_srvtab)

--- a/src/Makefile.global.in
+++ b/src/Makefile.global.in
@@ -200,7 +200,7 @@ with_libbz2	= @with_libbz2@
 with_apr_config	= @with_apr_config@
 with_apu_config	= @with_apu_config@
 with_libsigar	= @with_libsigar@
-enable_shared	= @enable_shared@
+with_gssapi	= @with_gssapi@
 enable_rpath	= @enable_rpath@
 # NLS is not supported in Greenplum, see comment documenting
 # this in configure.in

--- a/src/backend/libpq/Makefile
+++ b/src/backend/libpq/Makefile
@@ -11,7 +11,7 @@
 subdir = src/backend/libpq
 top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
-override CPPFLAGS += -DHAVE_GSSAPI_PROXY -I$(libpq_srcdir) -I$(top_srcdir)/src/port
+override CPPFLAGS += -I$(libpq_srcdir) -I$(top_srcdir)/src/port
 
 # be-fsstubs is here for historical reasons, probably belongs elsewhere
 

--- a/src/backend/libpq/Makefile
+++ b/src/backend/libpq/Makefile
@@ -11,7 +11,7 @@
 subdir = src/backend/libpq
 top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
-override CPPFLAGS += -I$(libpq_srcdir) -I$(top_srcdir)/src/port
+override CPPFLAGS += -DHAVE_GSSAPI_PROXY -I$(libpq_srcdir) -I$(top_srcdir)/src/port
 
 # be-fsstubs is here for historical reasons, probably belongs elsewhere
 

--- a/src/backend/libpq/Makefile
+++ b/src/backend/libpq/Makefile
@@ -20,6 +20,10 @@ OBJS = be-fsstubs.o be-secure.o auth.o crypt.o hba.o ip.o md5.o pqcomm.o \
        fe-exec.o pqexpbuffer.o fe-auth.o fe-misc.o fe-protocol2.o fe-secure.o \
        $(filter getpeereid.o, $(LIBOBJS))
 
+ifeq ($(with_gssapi),yes)
+OBJS += be-gssapi-common.o
+endif
+
 fe-protocol3.c fe-connect.c fe-exec.c pqexpbuffer.c fe-auth.c fe-misc.c fe-protocol2.c fe-secure.c: % : $(top_srcdir)/src/interfaces/libpq/%
 	rm -f $@ && $(LN_S) $< .
 

--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -35,6 +35,7 @@
 #include "libpq/libpq.h"
 #include "libpq/pqformat.h"
 #include "libpq/md5.h"
+#include "libpq/be-gssapi-common.h"
 #include "miscadmin.h"
 #include "pgtime.h"
 #include "postmaster/postmaster.h"
@@ -1030,6 +1031,7 @@ pg_GSS_recvauth(Port *port)
 	int			ret;
 	StringInfoData buf;
 	gss_buffer_desc gbuf;
+	gss_cred_id_t proxy;
 
 	/*
 	 * GSS auth is not supported for protocol versions before 3, because it
@@ -1082,7 +1084,7 @@ pg_GSS_recvauth(Port *port)
 	 * Initialize sequence with an empty context
 	 */
 	port->gss->ctx = GSS_C_NO_CONTEXT;
-
+	proxy = NULL;
 	/*
 	 * Loop through GSSAPI message exchange. This exchange can consist of
 	 * multiple messags sent in both directions. First message is always from
@@ -1131,7 +1133,7 @@ pg_GSS_recvauth(Port *port)
 										  &port->gss->outbuf,
 										  &gflags,
 										  NULL,
-										  NULL);
+										  &proxy);
 
 		/* gbuf no longer used */
 		pfree(buf.data);
@@ -1140,6 +1142,10 @@ pg_GSS_recvauth(Port *port)
 			 "minor: %d, outlen: %u, outflags: %x",
 			 maj_stat, min_stat,
 			 (unsigned int) port->gss->outbuf.length, gflags);
+
+		CHECK_FOR_INTERRUPTS();
+		if (proxy != NULL)
+			pg_store_proxy_credential(proxy);
 
 		if (port->gss->outbuf.length != 0)
 		{

--- a/src/backend/libpq/be-gssapi-common.c
+++ b/src/backend/libpq/be-gssapi-common.c
@@ -77,7 +77,7 @@ pg_GSS_error_be(int severity, const char *errmsg,
 			 errdetail_internal("%s: %s", msg_major, msg_minor)));
 }
 
-
+#if HAVE_GSSAPI_PROXY
 void
 pg_store_proxy_credential(gss_cred_id_t cred)
 {
@@ -114,3 +114,9 @@ pg_store_proxy_credential(gss_cred_id_t cred)
 	 * gss_acquire_cred calls. */
 	putenv("KRB5CCNAME=MEMORY:");
 }
+#else
+void
+pg_store_proxy_credential(gss_cred_id_t cred){
+
+}
+#endif

--- a/src/backend/libpq/be-gssapi-common.c
+++ b/src/backend/libpq/be-gssapi-common.c
@@ -111,6 +111,6 @@ pg_store_proxy_credential(gss_cred_id_t cred)
 #else
 void
 pg_store_proxy_credential(gss_cred_id_t cred){
-	elog(DEBUG, "HAVE_GSSAPI_PROXY=0!");
+	elog(DEBUG1, "HAVE_GSSAPI_PROXY=0!");
 }
 #endif

--- a/src/backend/libpq/be-gssapi-common.c
+++ b/src/backend/libpq/be-gssapi-common.c
@@ -82,13 +82,12 @@ void
 pg_store_proxy_credential(gss_cred_id_t cred)
 {
 	OM_uint32 major, minor;
-	gss_OID_set mech;
-	gss_cred_usage_t usage;
 	gss_key_value_element_desc cc;
 	gss_key_value_set_desc ccset;
+	const char *ccache_name = "MEMORY:proxy";
 
 	cc.key = "ccache";
-	cc.value = "MEMORY:";
+	cc.value = ccache_name;
 	ccset.count = 1;
 	ccset.elements = &cc;
 
@@ -100,23 +99,18 @@ pg_store_proxy_credential(gss_cred_id_t cred)
 		true, /* overwrite */
 		true, /* make default */
 		&ccset,
-		&mech,
-		&usage);
+		NULL,
+		NULL);
 
 
 	if (major != GSS_S_COMPLETE)
 	{
 		pg_GSS_error_be(ERROR, "gss_store_cred", major, minor);
 	}
-
-	/* quite strange that gss_store_cred doesn't work with "KRB5CCNAME=MEMORY:",
-	 * we have to use gss_store_cred_into instead and set the env for later
-	 * gss_acquire_cred calls. */
-	putenv("KRB5CCNAME=MEMORY:");
 }
 #else
 void
 pg_store_proxy_credential(gss_cred_id_t cred){
-
+	elog(DEBUG, "HAVE_GSSAPI_PROXY=0!");
 }
 #endif

--- a/src/backend/libpq/be-gssapi-common.c
+++ b/src/backend/libpq/be-gssapi-common.c
@@ -1,0 +1,116 @@
+/*-------------------------------------------------------------------------
+ *
+ * be-gssapi-common.c
+ *     Common code for GSSAPI authentication and encryption
+ *
+ * Portions Copyright (c) 1996-2019, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * IDENTIFICATION
+ *       src/backend/libpq/be-gssapi-common.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "libpq/be-gssapi-common.h"
+
+/*
+ * Helper function for getting all strings of a GSSAPI error (of specified
+ * stat).  Call once for GSS_CODE and once for MECH_CODE.
+ */
+static void
+pg_GSS_error_int(char *s, size_t len, OM_uint32 stat, int type)
+{
+	gss_buffer_desc gmsg;
+	size_t		i = 0;
+	OM_uint32	lmin_s,
+				msg_ctx = 0;
+
+	gmsg.value = NULL;
+	gmsg.length = 0;
+
+	do
+	{
+		gss_display_status(&lmin_s, stat, type,
+						   GSS_C_NO_OID, &msg_ctx, &gmsg);
+		strlcpy(s + i, gmsg.value, len - i);
+		i += gmsg.length;
+		gss_release_buffer(&lmin_s, &gmsg);
+	}
+	while (msg_ctx && i < len);
+
+	if (msg_ctx || i == len)
+		ereport(WARNING,
+				(errmsg_internal("incomplete GSS error report")));
+}
+
+/*
+ * Fetch and report all error messages from GSSAPI.  To avoid allocation,
+ * total error size is capped (at 128 bytes for each of major and minor).  No
+ * known mechanisms will produce error messages beyond this cap.
+ */
+/*
+ * In GPDB backend, we also link with fe-gssapi-common.o, which contains
+ * this same function. Rename it with a "_be" suffix here to avoid linker error.
+ */
+void
+pg_GSS_error_be(int severity, const char *errmsg,
+			 OM_uint32 maj_stat, OM_uint32 min_stat)
+{
+	char		msg_major[128],
+				msg_minor[128];
+
+	/* Fetch major status message */
+	pg_GSS_error_int(msg_major, sizeof(msg_major), maj_stat, GSS_C_GSS_CODE);
+
+	/* Fetch mechanism minor status message */
+	pg_GSS_error_int(msg_minor, sizeof(msg_minor), min_stat, GSS_C_MECH_CODE);
+
+	/*
+	 * errmsg_internal, since translation of the first part must be done
+	 * before calling this function anyway.
+	 */
+	ereport(severity,
+			(errmsg_internal("%s", errmsg),
+			 errdetail_internal("%s: %s", msg_major, msg_minor)));
+}
+
+
+void
+pg_store_proxy_credential(gss_cred_id_t cred)
+{
+	OM_uint32 major, minor;
+	gss_OID_set mech;
+	gss_cred_usage_t usage;
+	gss_key_value_element_desc cc;
+	gss_key_value_set_desc ccset;
+
+	cc.key = "ccache";
+	cc.value = "MEMORY:";
+	ccset.count = 1;
+	ccset.elements = &cc;
+
+	/* Make the proxy credential only available to current process */
+	major = gss_store_cred_into(&minor,
+		cred,
+		GSS_C_INITIATE, /* credential only used for starting libpq connection */
+		GSS_C_NULL_OID, /* store all */
+		true, /* overwrite */
+		true, /* make default */
+		&ccset,
+		&mech,
+		&usage);
+
+
+	if (major != GSS_S_COMPLETE)
+	{
+		pg_GSS_error_be(ERROR, "gss_store_cred", major, minor);
+	}
+
+	/* quite strange that gss_store_cred doesn't work with "KRB5CCNAME=MEMORY:",
+	 * we have to use gss_store_cred_into instead and set the env for later
+	 * gss_acquire_cred calls. */
+	putenv("KRB5CCNAME=MEMORY:");
+}

--- a/src/include/libpq/be-gssapi-common.h
+++ b/src/include/libpq/be-gssapi-common.h
@@ -1,0 +1,27 @@
+/*-------------------------------------------------------------------------
+ *
+ * be-gssapi-common.h
+ *       Definitions for GSSAPI authentication and encryption handling
+ *
+ * Portions Copyright (c) 1996-2019, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * src/include/libpq/be-gssapi-common.h
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef BE_GSSAPI_COMMON_H
+#define BE_GSSAPI_COMMON_H
+
+#if defined(HAVE_GSSAPI_H)
+#include <gssapi.h>
+#else
+#include <gssapi/gssapi.h>
+#include <gssapi/gssapi_ext.h>
+#endif
+
+void		pg_GSS_error_be(int severity, const char *errmsg,
+						 OM_uint32 maj_stat, OM_uint32 min_stat);
+void		pg_store_proxy_credential(gss_cred_id_t cred);
+#endif							/* BE_GSSAPI_COMMON_H */

--- a/src/include/libpq/be-gssapi-common.h
+++ b/src/include/libpq/be-gssapi-common.h
@@ -18,7 +18,9 @@
 #include <gssapi.h>
 #else
 #include <gssapi/gssapi.h>
+#if HAVE_GSSAPI_PROXY
 #include <gssapi/gssapi_ext.h>
+#endif
 #endif
 
 void		pg_GSS_error_be(int severity, const char *errmsg,

--- a/src/include/pg_config.h.in
+++ b/src/include/pg_config.h.in
@@ -295,6 +295,9 @@
 /* Define to 1 if you have the <gssapi.h> header file. */
 #undef HAVE_GSSAPI_H
 
+/* Define to 1 if you have the <gssapi_ext.h> header file */
+#undef HAVE_GSSAPI_PROXY
+
 /* Define to 1 if you have the <history.h> header file. */
 #undef HAVE_HISTORY_H
 

--- a/src/interfaces/libpq/fe-auth.c
+++ b/src/interfaces/libpq/fe-auth.c
@@ -104,7 +104,7 @@ pg_GSS_error(const char *mprefix, PGconn *conn,
 /*
  * Check if we can acquire credentials at all (and yield them if so).
  */
-bool
+static bool
 pg_GSS_have_ccache(gss_cred_id_t *cred_out)
 {
 	OM_uint32	major,

--- a/src/interfaces/libpq/fe-auth.c
+++ b/src/interfaces/libpq/fe-auth.c
@@ -49,8 +49,10 @@
 #include "fe-auth.h"
 #include "libpq/md5.h"
 
+#if HAVE_GSSAPI_PROXY
 #include <gssapi/gssapi_ext.h>
 #include <gssapi/gssapi_krb5.h>
+#endif
 
 #ifdef ENABLE_GSS
 /*
@@ -110,6 +112,7 @@ pg_GSS_error(const char *mprefix, PGconn *conn,
 static bool
 pg_GSS_have_ccache(gss_cred_id_t *cred_out)
 {
+#if HAVE_GSSAPI_PROXY
 	OM_uint32	major, minor;
 	gss_cred_id_t cred = GSS_C_NO_CREDENTIAL;
 	gss_key_value_element_desc cc;
@@ -130,6 +133,9 @@ pg_GSS_have_ccache(gss_cred_id_t *cred_out)
 	}
 	*cred_out = cred;
 	return true;
+#else
+	return false;
+#endif
 }
 
 /*


### PR DESCRIPTION
1. Create the with_gssapi output variable for autoconf 

2. Stores kerberos proxy credentials in memory of backend,  and check the cache and reuse it in fe-auth.

```
+--------+      +-----------+          +---------------+
| client |------| Greenplum |----------| remote server |
+--------+      +-----------+   (FDW)  +---------------+
             Kerberos delegation
```
3. Add `HAVE_GSSAPI_PROXY` macro in configure to indicate wether the krb5-lib supports kerberos proxy API.

This PR is split from PR #12789. 
It depends on krb5-lib 1.15+.