### PR TITLE
7X: enable pg_trgm by default

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -24,6 +24,7 @@ all:
 	$(MAKE) -C contrib/hstore all
 	$(MAKE) -C contrib/pgcrypto all
 	$(MAKE) -C contrib/btree_gin all
+	$(MAKE) -C contrib/pg_trgm all
 ifeq ($(with_openssl), yes)
 	$(MAKE) -C contrib/sslinfo all
 endif
@@ -58,6 +59,7 @@ install:
 	$(MAKE) -C contrib/hstore $@
 	$(MAKE) -C contrib/pgcrypto $@
 	$(MAKE) -C contrib/btree_gin $@
+	$(MAKE) -C contrib/pg_trgm $@
 ifeq ($(with_openssl), yes)
 	$(MAKE) -C contrib/sslinfo $@
 endif
@@ -148,7 +150,7 @@ $(call recurse,checkprep,  src/test src/pl src/interfaces/ecpg contrib src/bin g
 ICW_TARGETS  = src/test src/pl src/interfaces/gppc
 ICW_TARGETS += contrib/auto_explain contrib/citext contrib/btree_gin
 ICW_TARGETS += contrib/file_fdw contrib/formatter_fixedwidth
-ICW_TARGETS += contrib/extprotocol contrib/dblink
+ICW_TARGETS += contrib/extprotocol contrib/dblink contrib/pg_trgm
 ICW_TARGETS += contrib/indexscan contrib/hstore contrib/pgcrypto
 # sslinfo depends on openssl
 ifeq ($(with_openssl), yes)

--- a/contrib/pg_trgm/expected/pg_trgm.out
+++ b/contrib/pg_trgm/expected/pg_trgm.out
@@ -2351,7 +2351,6 @@ select t <-> 'q0987wertyu0988', t from test_trgm order by t <-> 'q0987wertyu0988
          ->  Limit
                ->  Index Scan using trgm_idx on test_trgm
                      Order By: (t <-> 'q0987wertyu0988'::text)
- Optimizer: Postgres query optimizer
 (7 rows)
 
 select t <-> 'q0987wertyu0988', t from test_trgm order by t <-> 'q0987wertyu0988' limit 2;
@@ -3518,7 +3517,6 @@ explain (costs off)
          Recheck Cond: (t ~~ '%BCD%'::text)
          ->  Bitmap Index Scan on test2_idx_gin
                Index Cond: (t ~~ '%BCD%'::text)
- Optimizer: Postgres query optimizer
 (6 rows)
 
 explain (costs off)
@@ -3530,7 +3528,6 @@ explain (costs off)
          Recheck Cond: (t ~~* '%BCD%'::text)
          ->  Bitmap Index Scan on test2_idx_gin
                Index Cond: (t ~~* '%BCD%'::text)
- Optimizer: Postgres query optimizer
 (6 rows)
 
 select * from test2 where t like '%BCD%';
@@ -3583,7 +3580,6 @@ explain (costs off)
          Recheck Cond: (t ~ '[abc]{3}'::text)
          ->  Bitmap Index Scan on test2_idx_gin
                Index Cond: (t ~ '[abc]{3}'::text)
- Optimizer: Postgres query optimizer
 (6 rows)
 
 explain (costs off)
@@ -3595,7 +3591,6 @@ explain (costs off)
          Recheck Cond: (t ~* 'DEF'::text)
          ->  Bitmap Index Scan on test2_idx_gin
                Index Cond: (t ~* 'DEF'::text)
- Optimizer: Postgres query optimizer
 (6 rows)
 
 select * from test2 where t ~ '[abc]{3}';

--- a/contrib/pg_trgm/expected/pg_trgm.out
+++ b/contrib/pg_trgm/expected/pg_trgm.out
@@ -1,4 +1,3 @@
-set optimizer=off; -- force use planner to reduce noise
 CREATE EXTENSION pg_trgm;
 -- Check whether any of our opclasses fail amvalidate
 SELECT amname, opcname

--- a/contrib/pg_trgm/expected/pg_trgm.out
+++ b/contrib/pg_trgm/expected/pg_trgm.out
@@ -1,3 +1,4 @@
+set optimizer=off; -- force use planner to reduce noise
 CREATE EXTENSION pg_trgm;
 -- Check whether any of our opclasses fail amvalidate
 SELECT amname, opcname
@@ -2351,6 +2352,7 @@ select t <-> 'q0987wertyu0988', t from test_trgm order by t <-> 'q0987wertyu0988
          ->  Limit
                ->  Index Scan using trgm_idx on test_trgm
                      Order By: (t <-> 'q0987wertyu0988'::text)
+ Optimizer: Postgres query optimizer
 (7 rows)
 
 select t <-> 'q0987wertyu0988', t from test_trgm order by t <-> 'q0987wertyu0988' limit 2;
@@ -3517,6 +3519,7 @@ explain (costs off)
          Recheck Cond: (t ~~ '%BCD%'::text)
          ->  Bitmap Index Scan on test2_idx_gin
                Index Cond: (t ~~ '%BCD%'::text)
+ Optimizer: Postgres query optimizer
 (6 rows)
 
 explain (costs off)
@@ -3528,6 +3531,7 @@ explain (costs off)
          Recheck Cond: (t ~~* '%BCD%'::text)
          ->  Bitmap Index Scan on test2_idx_gin
                Index Cond: (t ~~* '%BCD%'::text)
+ Optimizer: Postgres query optimizer
 (6 rows)
 
 select * from test2 where t like '%BCD%';
@@ -3580,6 +3584,7 @@ explain (costs off)
          Recheck Cond: (t ~ '[abc]{3}'::text)
          ->  Bitmap Index Scan on test2_idx_gin
                Index Cond: (t ~ '[abc]{3}'::text)
+ Optimizer: Postgres query optimizer
 (6 rows)
 
 explain (costs off)
@@ -3591,6 +3596,7 @@ explain (costs off)
          Recheck Cond: (t ~* 'DEF'::text)
          ->  Bitmap Index Scan on test2_idx_gin
                Index Cond: (t ~* 'DEF'::text)
+ Optimizer: Postgres query optimizer
 (6 rows)
 
 select * from test2 where t ~ '[abc]{3}';
@@ -3715,21 +3721,27 @@ create index test2_idx_gist on test2 using gist (t gist_trgm_ops);
 set enable_seqscan=off;
 explain (costs off)
   select * from test2 where t like '%BCD%';
-                   QUERY PLAN                   
-------------------------------------------------
+                   QUERY PLAN                    
+-------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using test2_idx_gist on test2
-         Index Cond: (t ~~ '%BCD%'::text)
-(4 rows)
+   ->  Bitmap Heap Scan on test2
+         Recheck Cond: (t ~~ '%BCD%'::text)
+         ->  Bitmap Index Scan on test2_idx_gist
+               Index Cond: (t ~~ '%BCD%'::text)
+ Optimizer: Postgres query optimizer
+(6 rows)
 
 explain (costs off)
   select * from test2 where t ilike '%BCD%';
-                   QUERY PLAN                   
-------------------------------------------------
+                   QUERY PLAN                    
+-------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using test2_idx_gist on test2
-         Index Cond: (t ~~* '%BCD%'::text)
-(4 rows)
+   ->  Bitmap Heap Scan on test2
+         Recheck Cond: (t ~~* '%BCD%'::text)
+         ->  Bitmap Index Scan on test2_idx_gist
+               Index Cond: (t ~~* '%BCD%'::text)
+ Optimizer: Postgres query optimizer
+(6 rows)
 
 select * from test2 where t like '%BCD%';
  t 
@@ -3774,21 +3786,27 @@ select * from test2 where t like '  z foo%';
 
 explain (costs off)
   select * from test2 where t ~ '[abc]{3}';
-                   QUERY PLAN                   
-------------------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using test2_idx_gist on test2
-         Index Cond: (t ~ '[abc]{3}'::text)
-(4 rows)
+   ->  Bitmap Heap Scan on test2
+         Recheck Cond: (t ~ '[abc]{3}'::text)
+         ->  Bitmap Index Scan on test2_idx_gist
+               Index Cond: (t ~ '[abc]{3}'::text)
+ Optimizer: Postgres query optimizer
+(6 rows)
 
 explain (costs off)
   select * from test2 where t ~* 'DEF';
-                   QUERY PLAN                   
-------------------------------------------------
+                   QUERY PLAN                    
+-------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using test2_idx_gist on test2
-         Index Cond: (t ~* 'DEF'::text)
-(4 rows)
+   ->  Bitmap Heap Scan on test2
+         Recheck Cond: (t ~* 'DEF'::text)
+         ->  Bitmap Index Scan on test2_idx_gist
+               Index Cond: (t ~* 'DEF'::text)
+ Optimizer: Postgres query optimizer
+(6 rows)
 
 select * from test2 where t ~ '[abc]{3}';
    t    
@@ -3923,17 +3941,20 @@ SELECT similarity('Szczecin', 'Warsaw');
 EXPLAIN (COSTS OFF)
 SELECT DISTINCT city, similarity(city, 'Warsaw'), show_limit()
   FROM restaurants WHERE city % 'Warsaw';
-                               QUERY PLAN                                
--------------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  HashAggregate
-         Group Key: city, similarity(city, 'Warsaw'::text), show_limit()
-         ->  Bitmap Heap Scan on restaurants
-               Recheck Cond: (city % 'Warsaw'::text)
-               ->  Bitmap Index Scan on restaurants_city_idx
-                     Index Cond: (city % 'Warsaw'::text)
+   Merge Key: city, (similarity(city, 'Warsaw'::text))
+   ->  Unique
+         Group Key: city, (similarity(city, 'Warsaw'::text))
+         ->  Sort
+               Sort Key: city, (similarity(city, 'Warsaw'::text))
+               ->  Bitmap Heap Scan on restaurants
+                     Recheck Cond: (city % 'Warsaw'::text)
+                     ->  Bitmap Index Scan on restaurants_city_idx
+                           Index Cond: (city % 'Warsaw'::text)
  Optimizer: Postgres query optimizer
-(8 rows)
+(11 rows)
 
 SELECT set_limit(0.3);
  set_limit 

--- a/contrib/pg_trgm/expected/pg_trgm_optimizer.out
+++ b/contrib/pg_trgm/expected/pg_trgm_optimizer.out
@@ -1,0 +1,3987 @@
+CREATE EXTENSION pg_trgm;
+-- Check whether any of our opclasses fail amvalidate
+SELECT amname, opcname
+FROM pg_opclass opc LEFT JOIN pg_am am ON am.oid = opcmethod
+WHERE opc.oid >= 16384 AND NOT amvalidate(opc.oid);
+ amname | opcname 
+--------+---------
+(0 rows)
+
+--backslash is used in tests below, installcheck will fail if
+--standard_conforming_string is off
+set standard_conforming_strings=on;
+-- reduce noise
+set extra_float_digits = 0;
+select show_trgm('');
+ show_trgm 
+-----------
+ {}
+(1 row)
+
+select show_trgm('(*&^$@%@');
+ show_trgm 
+-----------
+ {}
+(1 row)
+
+select show_trgm('a b c');
+               show_trgm               
+---------------------------------------
+ {"  a","  b","  c"," a "," b "," c "}
+(1 row)
+
+select show_trgm(' a b c ');
+               show_trgm               
+---------------------------------------
+ {"  a","  b","  c"," a "," b "," c "}
+(1 row)
+
+select show_trgm('aA bB cC');
+                        show_trgm                        
+---------------------------------------------------------
+ {"  a","  b","  c"," aa"," bb"," cc","aa ","bb ","cc "}
+(1 row)
+
+select show_trgm(' aA bB cC ');
+                        show_trgm                        
+---------------------------------------------------------
+ {"  a","  b","  c"," aa"," bb"," cc","aa ","bb ","cc "}
+(1 row)
+
+select show_trgm('a b C0*%^');
+                  show_trgm                  
+---------------------------------------------
+ {"  a","  b","  c"," a "," b "," c0","c0 "}
+(1 row)
+
+select similarity('wow','WOWa ');
+ similarity 
+------------
+        0.5
+(1 row)
+
+select similarity('wow',' WOW ');
+ similarity 
+------------
+          1
+(1 row)
+
+select similarity('---', '####---');
+ similarity 
+------------
+          0
+(1 row)
+
+CREATE TABLE test_trgm(t text COLLATE "C");
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 't' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+\copy test_trgm from 'data/trgm.data'
+select t,similarity(t,'qwertyu0988') as sml from test_trgm where t % 'qwertyu0988' order by sml desc, t;
+      t      |   sml    
+-------------+----------
+ qwertyu0988 |        1
+ qwertyu0980 | 0.714286
+ qwertyu0981 | 0.714286
+ qwertyu0982 | 0.714286
+ qwertyu0983 | 0.714286
+ qwertyu0984 | 0.714286
+ qwertyu0985 | 0.714286
+ qwertyu0986 | 0.714286
+ qwertyu0987 | 0.714286
+ qwertyu0989 | 0.714286
+ qwertyu0088 |      0.6
+ qwertyu0098 |      0.6
+ qwertyu0188 |      0.6
+ qwertyu0288 |      0.6
+ qwertyu0388 |      0.6
+ qwertyu0488 |      0.6
+ qwertyu0588 |      0.6
+ qwertyu0688 |      0.6
+ qwertyu0788 |      0.6
+ qwertyu0888 |      0.6
+ qwertyu0900 |      0.6
+ qwertyu0901 |      0.6
+ qwertyu0902 |      0.6
+ qwertyu0903 |      0.6
+ qwertyu0904 |      0.6
+ qwertyu0905 |      0.6
+ qwertyu0906 |      0.6
+ qwertyu0907 |      0.6
+ qwertyu0908 |      0.6
+ qwertyu0909 |      0.6
+ qwertyu0910 |      0.6
+ qwertyu0911 |      0.6
+ qwertyu0912 |      0.6
+ qwertyu0913 |      0.6
+ qwertyu0914 |      0.6
+ qwertyu0915 |      0.6
+ qwertyu0916 |      0.6
+ qwertyu0917 |      0.6
+ qwertyu0918 |      0.6
+ qwertyu0919 |      0.6
+ qwertyu0920 |      0.6
+ qwertyu0921 |      0.6
+ qwertyu0922 |      0.6
+ qwertyu0923 |      0.6
+ qwertyu0924 |      0.6
+ qwertyu0925 |      0.6
+ qwertyu0926 |      0.6
+ qwertyu0927 |      0.6
+ qwertyu0928 |      0.6
+ qwertyu0929 |      0.6
+ qwertyu0930 |      0.6
+ qwertyu0931 |      0.6
+ qwertyu0932 |      0.6
+ qwertyu0933 |      0.6
+ qwertyu0934 |      0.6
+ qwertyu0935 |      0.6
+ qwertyu0936 |      0.6
+ qwertyu0937 |      0.6
+ qwertyu0938 |      0.6
+ qwertyu0939 |      0.6
+ qwertyu0940 |      0.6
+ qwertyu0941 |      0.6
+ qwertyu0942 |      0.6
+ qwertyu0943 |      0.6
+ qwertyu0944 |      0.6
+ qwertyu0945 |      0.6
+ qwertyu0946 |      0.6
+ qwertyu0947 |      0.6
+ qwertyu0948 |      0.6
+ qwertyu0949 |      0.6
+ qwertyu0950 |      0.6
+ qwertyu0951 |      0.6
+ qwertyu0952 |      0.6
+ qwertyu0953 |      0.6
+ qwertyu0954 |      0.6
+ qwertyu0955 |      0.6
+ qwertyu0956 |      0.6
+ qwertyu0957 |      0.6
+ qwertyu0958 |      0.6
+ qwertyu0959 |      0.6
+ qwertyu0960 |      0.6
+ qwertyu0961 |      0.6
+ qwertyu0962 |      0.6
+ qwertyu0963 |      0.6
+ qwertyu0964 |      0.6
+ qwertyu0965 |      0.6
+ qwertyu0966 |      0.6
+ qwertyu0967 |      0.6
+ qwertyu0968 |      0.6
+ qwertyu0969 |      0.6
+ qwertyu0970 |      0.6
+ qwertyu0971 |      0.6
+ qwertyu0972 |      0.6
+ qwertyu0973 |      0.6
+ qwertyu0974 |      0.6
+ qwertyu0975 |      0.6
+ qwertyu0976 |      0.6
+ qwertyu0977 |      0.6
+ qwertyu0978 |      0.6
+ qwertyu0979 |      0.6
+ qwertyu0990 |      0.6
+ qwertyu0991 |      0.6
+ qwertyu0992 |      0.6
+ qwertyu0993 |      0.6
+ qwertyu0994 |      0.6
+ qwertyu0995 |      0.6
+ qwertyu0996 |      0.6
+ qwertyu0997 |      0.6
+ qwertyu0998 |      0.6
+ qwertyu0999 |      0.6
+ qwertyu0001 |      0.5
+ qwertyu0002 |      0.5
+ qwertyu0003 |      0.5
+ qwertyu0004 |      0.5
+ qwertyu0005 |      0.5
+ qwertyu0006 |      0.5
+ qwertyu0007 |      0.5
+ qwertyu0008 |      0.5
+ qwertyu0009 |      0.5
+ qwertyu0010 |      0.5
+ qwertyu0011 |      0.5
+ qwertyu0012 |      0.5
+ qwertyu0013 |      0.5
+ qwertyu0014 |      0.5
+ qwertyu0015 |      0.5
+ qwertyu0016 |      0.5
+ qwertyu0017 |      0.5
+ qwertyu0018 |      0.5
+ qwertyu0019 |      0.5
+ qwertyu0020 |      0.5
+ qwertyu0021 |      0.5
+ qwertyu0022 |      0.5
+ qwertyu0023 |      0.5
+ qwertyu0024 |      0.5
+ qwertyu0025 |      0.5
+ qwertyu0026 |      0.5
+ qwertyu0027 |      0.5
+ qwertyu0028 |      0.5
+ qwertyu0029 |      0.5
+ qwertyu0030 |      0.5
+ qwertyu0031 |      0.5
+ qwertyu0032 |      0.5
+ qwertyu0033 |      0.5
+ qwertyu0034 |      0.5
+ qwertyu0035 |      0.5
+ qwertyu0036 |      0.5
+ qwertyu0037 |      0.5
+ qwertyu0038 |      0.5
+ qwertyu0039 |      0.5
+ qwertyu0040 |      0.5
+ qwertyu0041 |      0.5
+ qwertyu0042 |      0.5
+ qwertyu0043 |      0.5
+ qwertyu0044 |      0.5
+ qwertyu0045 |      0.5
+ qwertyu0046 |      0.5
+ qwertyu0047 |      0.5
+ qwertyu0048 |      0.5
+ qwertyu0049 |      0.5
+ qwertyu0050 |      0.5
+ qwertyu0051 |      0.5
+ qwertyu0052 |      0.5
+ qwertyu0053 |      0.5
+ qwertyu0054 |      0.5
+ qwertyu0055 |      0.5
+ qwertyu0056 |      0.5
+ qwertyu0057 |      0.5
+ qwertyu0058 |      0.5
+ qwertyu0059 |      0.5
+ qwertyu0060 |      0.5
+ qwertyu0061 |      0.5
+ qwertyu0062 |      0.5
+ qwertyu0063 |      0.5
+ qwertyu0064 |      0.5
+ qwertyu0065 |      0.5
+ qwertyu0066 |      0.5
+ qwertyu0067 |      0.5
+ qwertyu0068 |      0.5
+ qwertyu0069 |      0.5
+ qwertyu0070 |      0.5
+ qwertyu0071 |      0.5
+ qwertyu0072 |      0.5
+ qwertyu0073 |      0.5
+ qwertyu0074 |      0.5
+ qwertyu0075 |      0.5
+ qwertyu0076 |      0.5
+ qwertyu0077 |      0.5
+ qwertyu0078 |      0.5
+ qwertyu0079 |      0.5
+ qwertyu0080 |      0.5
+ qwertyu0081 |      0.5
+ qwertyu0082 |      0.5
+ qwertyu0083 |      0.5
+ qwertyu0084 |      0.5
+ qwertyu0085 |      0.5
+ qwertyu0086 |      0.5
+ qwertyu0087 |      0.5
+ qwertyu0089 |      0.5
+ qwertyu0090 |      0.5
+ qwertyu0091 |      0.5
+ qwertyu0092 |      0.5
+ qwertyu0093 |      0.5
+ qwertyu0094 |      0.5
+ qwertyu0095 |      0.5
+ qwertyu0096 |      0.5
+ qwertyu0097 |      0.5
+ qwertyu0099 |      0.5
+ qwertyu0100 |      0.5
+ qwertyu0101 |      0.5
+ qwertyu0102 |      0.5
+ qwertyu0103 |      0.5
+ qwertyu0104 |      0.5
+ qwertyu0105 |      0.5
+ qwertyu0106 |      0.5
+ qwertyu0107 |      0.5
+ qwertyu0108 |      0.5
+ qwertyu0109 |      0.5
+ qwertyu0110 |      0.5
+ qwertyu0111 |      0.5
+ qwertyu0112 |      0.5
+ qwertyu0113 |      0.5
+ qwertyu0114 |      0.5
+ qwertyu0115 |      0.5
+ qwertyu0116 |      0.5
+ qwertyu0117 |      0.5
+ qwertyu0118 |      0.5
+ qwertyu0119 |      0.5
+ qwertyu0120 |      0.5
+ qwertyu0121 |      0.5
+ qwertyu0122 |      0.5
+ qwertyu0123 |      0.5
+ qwertyu0124 |      0.5
+ qwertyu0125 |      0.5
+ qwertyu0126 |      0.5
+ qwertyu0127 |      0.5
+ qwertyu0128 |      0.5
+ qwertyu0129 |      0.5
+ qwertyu0130 |      0.5
+ qwertyu0131 |      0.5
+ qwertyu0132 |      0.5
+ qwertyu0133 |      0.5
+ qwertyu0134 |      0.5
+ qwertyu0135 |      0.5
+ qwertyu0136 |      0.5
+ qwertyu0137 |      0.5
+ qwertyu0138 |      0.5
+ qwertyu0139 |      0.5
+ qwertyu0140 |      0.5
+ qwertyu0141 |      0.5
+ qwertyu0142 |      0.5
+ qwertyu0143 |      0.5
+ qwertyu0144 |      0.5
+ qwertyu0145 |      0.5
+ qwertyu0146 |      0.5
+ qwertyu0147 |      0.5
+ qwertyu0148 |      0.5
+ qwertyu0149 |      0.5
+ qwertyu0150 |      0.5
+ qwertyu0151 |      0.5
+ qwertyu0152 |      0.5
+ qwertyu0153 |      0.5
+ qwertyu0154 |      0.5
+ qwertyu0155 |      0.5
+ qwertyu0156 |      0.5
+ qwertyu0157 |      0.5
+ qwertyu0158 |      0.5
+ qwertyu0159 |      0.5
+ qwertyu0160 |      0.5
+ qwertyu0161 |      0.5
+ qwertyu0162 |      0.5
+ qwertyu0163 |      0.5
+ qwertyu0164 |      0.5
+ qwertyu0165 |      0.5
+ qwertyu0166 |      0.5
+ qwertyu0167 |      0.5
+ qwertyu0168 |      0.5
+ qwertyu0169 |      0.5
+ qwertyu0170 |      0.5
+ qwertyu0171 |      0.5
+ qwertyu0172 |      0.5
+ qwertyu0173 |      0.5
+ qwertyu0174 |      0.5
+ qwertyu0175 |      0.5
+ qwertyu0176 |      0.5
+ qwertyu0177 |      0.5
+ qwertyu0178 |      0.5
+ qwertyu0179 |      0.5
+ qwertyu0180 |      0.5
+ qwertyu0181 |      0.5
+ qwertyu0182 |      0.5
+ qwertyu0183 |      0.5
+ qwertyu0184 |      0.5
+ qwertyu0185 |      0.5
+ qwertyu0186 |      0.5
+ qwertyu0187 |      0.5
+ qwertyu0189 |      0.5
+ qwertyu0190 |      0.5
+ qwertyu0191 |      0.5
+ qwertyu0192 |      0.5
+ qwertyu0193 |      0.5
+ qwertyu0194 |      0.5
+ qwertyu0195 |      0.5
+ qwertyu0196 |      0.5
+ qwertyu0197 |      0.5
+ qwertyu0198 |      0.5
+ qwertyu0199 |      0.5
+ qwertyu0200 |      0.5
+ qwertyu0201 |      0.5
+ qwertyu0202 |      0.5
+ qwertyu0203 |      0.5
+ qwertyu0204 |      0.5
+ qwertyu0205 |      0.5
+ qwertyu0206 |      0.5
+ qwertyu0207 |      0.5
+ qwertyu0208 |      0.5
+ qwertyu0209 |      0.5
+ qwertyu0210 |      0.5
+ qwertyu0211 |      0.5
+ qwertyu0212 |      0.5
+ qwertyu0213 |      0.5
+ qwertyu0214 |      0.5
+ qwertyu0215 |      0.5
+ qwertyu0216 |      0.5
+ qwertyu0217 |      0.5
+ qwertyu0218 |      0.5
+ qwertyu0219 |      0.5
+ qwertyu0220 |      0.5
+ qwertyu0221 |      0.5
+ qwertyu0222 |      0.5
+ qwertyu0223 |      0.5
+ qwertyu0224 |      0.5
+ qwertyu0225 |      0.5
+ qwertyu0226 |      0.5
+ qwertyu0227 |      0.5
+ qwertyu0228 |      0.5
+ qwertyu0229 |      0.5
+ qwertyu0230 |      0.5
+ qwertyu0231 |      0.5
+ qwertyu0232 |      0.5
+ qwertyu0233 |      0.5
+ qwertyu0234 |      0.5
+ qwertyu0235 |      0.5
+ qwertyu0236 |      0.5
+ qwertyu0237 |      0.5
+ qwertyu0238 |      0.5
+ qwertyu0239 |      0.5
+ qwertyu0240 |      0.5
+ qwertyu0241 |      0.5
+ qwertyu0242 |      0.5
+ qwertyu0243 |      0.5
+ qwertyu0244 |      0.5
+ qwertyu0245 |      0.5
+ qwertyu0246 |      0.5
+ qwertyu0247 |      0.5
+ qwertyu0248 |      0.5
+ qwertyu0249 |      0.5
+ qwertyu0250 |      0.5
+ qwertyu0251 |      0.5
+ qwertyu0252 |      0.5
+ qwertyu0253 |      0.5
+ qwertyu0254 |      0.5
+ qwertyu0255 |      0.5
+ qwertyu0256 |      0.5
+ qwertyu0257 |      0.5
+ qwertyu0258 |      0.5
+ qwertyu0259 |      0.5
+ qwertyu0260 |      0.5
+ qwertyu0261 |      0.5
+ qwertyu0262 |      0.5
+ qwertyu0263 |      0.5
+ qwertyu0264 |      0.5
+ qwertyu0265 |      0.5
+ qwertyu0266 |      0.5
+ qwertyu0267 |      0.5
+ qwertyu0268 |      0.5
+ qwertyu0269 |      0.5
+ qwertyu0270 |      0.5
+ qwertyu0271 |      0.5
+ qwertyu0272 |      0.5
+ qwertyu0273 |      0.5
+ qwertyu0274 |      0.5
+ qwertyu0275 |      0.5
+ qwertyu0276 |      0.5
+ qwertyu0277 |      0.5
+ qwertyu0278 |      0.5
+ qwertyu0279 |      0.5
+ qwertyu0280 |      0.5
+ qwertyu0281 |      0.5
+ qwertyu0282 |      0.5
+ qwertyu0283 |      0.5
+ qwertyu0284 |      0.5
+ qwertyu0285 |      0.5
+ qwertyu0286 |      0.5
+ qwertyu0287 |      0.5
+ qwertyu0289 |      0.5
+ qwertyu0290 |      0.5
+ qwertyu0291 |      0.5
+ qwertyu0292 |      0.5
+ qwertyu0293 |      0.5
+ qwertyu0294 |      0.5
+ qwertyu0295 |      0.5
+ qwertyu0296 |      0.5
+ qwertyu0297 |      0.5
+ qwertyu0298 |      0.5
+ qwertyu0299 |      0.5
+ qwertyu0300 |      0.5
+ qwertyu0301 |      0.5
+ qwertyu0302 |      0.5
+ qwertyu0303 |      0.5
+ qwertyu0304 |      0.5
+ qwertyu0305 |      0.5
+ qwertyu0306 |      0.5
+ qwertyu0307 |      0.5
+ qwertyu0308 |      0.5
+ qwertyu0309 |      0.5
+ qwertyu0310 |      0.5
+ qwertyu0311 |      0.5
+ qwertyu0312 |      0.5
+ qwertyu0313 |      0.5
+ qwertyu0314 |      0.5
+ qwertyu0315 |      0.5
+ qwertyu0316 |      0.5
+ qwertyu0317 |      0.5
+ qwertyu0318 |      0.5
+ qwertyu0319 |      0.5
+ qwertyu0320 |      0.5
+ qwertyu0321 |      0.5
+ qwertyu0322 |      0.5
+ qwertyu0323 |      0.5
+ qwertyu0324 |      0.5
+ qwertyu0325 |      0.5
+ qwertyu0326 |      0.5
+ qwertyu0327 |      0.5
+ qwertyu0328 |      0.5
+ qwertyu0329 |      0.5
+ qwertyu0330 |      0.5
+ qwertyu0331 |      0.5
+ qwertyu0332 |      0.5
+ qwertyu0333 |      0.5
+ qwertyu0334 |      0.5
+ qwertyu0335 |      0.5
+ qwertyu0336 |      0.5
+ qwertyu0337 |      0.5
+ qwertyu0338 |      0.5
+ qwertyu0339 |      0.5
+ qwertyu0340 |      0.5
+ qwertyu0341 |      0.5
+ qwertyu0342 |      0.5
+ qwertyu0343 |      0.5
+ qwertyu0344 |      0.5
+ qwertyu0345 |      0.5
+ qwertyu0346 |      0.5
+ qwertyu0347 |      0.5
+ qwertyu0348 |      0.5
+ qwertyu0349 |      0.5
+ qwertyu0350 |      0.5
+ qwertyu0351 |      0.5
+ qwertyu0352 |      0.5
+ qwertyu0353 |      0.5
+ qwertyu0354 |      0.5
+ qwertyu0355 |      0.5
+ qwertyu0356 |      0.5
+ qwertyu0357 |      0.5
+ qwertyu0358 |      0.5
+ qwertyu0359 |      0.5
+ qwertyu0360 |      0.5
+ qwertyu0361 |      0.5
+ qwertyu0362 |      0.5
+ qwertyu0363 |      0.5
+ qwertyu0364 |      0.5
+ qwertyu0365 |      0.5
+ qwertyu0366 |      0.5
+ qwertyu0367 |      0.5
+ qwertyu0368 |      0.5
+ qwertyu0369 |      0.5
+ qwertyu0370 |      0.5
+ qwertyu0371 |      0.5
+ qwertyu0372 |      0.5
+ qwertyu0373 |      0.5
+ qwertyu0374 |      0.5
+ qwertyu0375 |      0.5
+ qwertyu0376 |      0.5
+ qwertyu0377 |      0.5
+ qwertyu0378 |      0.5
+ qwertyu0379 |      0.5
+ qwertyu0380 |      0.5
+ qwertyu0381 |      0.5
+ qwertyu0382 |      0.5
+ qwertyu0383 |      0.5
+ qwertyu0384 |      0.5
+ qwertyu0385 |      0.5
+ qwertyu0386 |      0.5
+ qwertyu0387 |      0.5
+ qwertyu0389 |      0.5
+ qwertyu0390 |      0.5
+ qwertyu0391 |      0.5
+ qwertyu0392 |      0.5
+ qwertyu0393 |      0.5
+ qwertyu0394 |      0.5
+ qwertyu0395 |      0.5
+ qwertyu0396 |      0.5
+ qwertyu0397 |      0.5
+ qwertyu0398 |      0.5
+ qwertyu0399 |      0.5
+ qwertyu0400 |      0.5
+ qwertyu0401 |      0.5
+ qwertyu0402 |      0.5
+ qwertyu0403 |      0.5
+ qwertyu0404 |      0.5
+ qwertyu0405 |      0.5
+ qwertyu0406 |      0.5
+ qwertyu0407 |      0.5
+ qwertyu0408 |      0.5
+ qwertyu0409 |      0.5
+ qwertyu0410 |      0.5
+ qwertyu0411 |      0.5
+ qwertyu0412 |      0.5
+ qwertyu0413 |      0.5
+ qwertyu0414 |      0.5
+ qwertyu0415 |      0.5
+ qwertyu0416 |      0.5
+ qwertyu0417 |      0.5
+ qwertyu0418 |      0.5
+ qwertyu0419 |      0.5
+ qwertyu0420 |      0.5
+ qwertyu0421 |      0.5
+ qwertyu0422 |      0.5
+ qwertyu0423 |      0.5
+ qwertyu0424 |      0.5
+ qwertyu0425 |      0.5
+ qwertyu0426 |      0.5
+ qwertyu0427 |      0.5
+ qwertyu0428 |      0.5
+ qwertyu0429 |      0.5
+ qwertyu0430 |      0.5
+ qwertyu0431 |      0.5
+ qwertyu0432 |      0.5
+ qwertyu0433 |      0.5
+ qwertyu0434 |      0.5
+ qwertyu0435 |      0.5
+ qwertyu0436 |      0.5
+ qwertyu0437 |      0.5
+ qwertyu0438 |      0.5
+ qwertyu0439 |      0.5
+ qwertyu0440 |      0.5
+ qwertyu0441 |      0.5
+ qwertyu0442 |      0.5
+ qwertyu0443 |      0.5
+ qwertyu0444 |      0.5
+ qwertyu0445 |      0.5
+ qwertyu0446 |      0.5
+ qwertyu0447 |      0.5
+ qwertyu0448 |      0.5
+ qwertyu0449 |      0.5
+ qwertyu0450 |      0.5
+ qwertyu0451 |      0.5
+ qwertyu0452 |      0.5
+ qwertyu0453 |      0.5
+ qwertyu0454 |      0.5
+ qwertyu0455 |      0.5
+ qwertyu0456 |      0.5
+ qwertyu0457 |      0.5
+ qwertyu0458 |      0.5
+ qwertyu0459 |      0.5
+ qwertyu0460 |      0.5
+ qwertyu0461 |      0.5
+ qwertyu0462 |      0.5
+ qwertyu0463 |      0.5
+ qwertyu0464 |      0.5
+ qwertyu0465 |      0.5
+ qwertyu0466 |      0.5
+ qwertyu0467 |      0.5
+ qwertyu0468 |      0.5
+ qwertyu0469 |      0.5
+ qwertyu0470 |      0.5
+ qwertyu0471 |      0.5
+ qwertyu0472 |      0.5
+ qwertyu0473 |      0.5
+ qwertyu0474 |      0.5
+ qwertyu0475 |      0.5
+ qwertyu0476 |      0.5
+ qwertyu0477 |      0.5
+ qwertyu0478 |      0.5
+ qwertyu0479 |      0.5
+ qwertyu0480 |      0.5
+ qwertyu0481 |      0.5
+ qwertyu0482 |      0.5
+ qwertyu0483 |      0.5
+ qwertyu0484 |      0.5
+ qwertyu0485 |      0.5
+ qwertyu0486 |      0.5
+ qwertyu0487 |      0.5
+ qwertyu0489 |      0.5
+ qwertyu0490 |      0.5
+ qwertyu0491 |      0.5
+ qwertyu0492 |      0.5
+ qwertyu0493 |      0.5
+ qwertyu0494 |      0.5
+ qwertyu0495 |      0.5
+ qwertyu0496 |      0.5
+ qwertyu0497 |      0.5
+ qwertyu0498 |      0.5
+ qwertyu0499 |      0.5
+ qwertyu0500 |      0.5
+ qwertyu0501 |      0.5
+ qwertyu0502 |      0.5
+ qwertyu0503 |      0.5
+ qwertyu0504 |      0.5
+ qwertyu0505 |      0.5
+ qwertyu0506 |      0.5
+ qwertyu0507 |      0.5
+ qwertyu0508 |      0.5
+ qwertyu0509 |      0.5
+ qwertyu0510 |      0.5
+ qwertyu0511 |      0.5
+ qwertyu0512 |      0.5
+ qwertyu0513 |      0.5
+ qwertyu0514 |      0.5
+ qwertyu0515 |      0.5
+ qwertyu0516 |      0.5
+ qwertyu0517 |      0.5
+ qwertyu0518 |      0.5
+ qwertyu0519 |      0.5
+ qwertyu0520 |      0.5
+ qwertyu0521 |      0.5
+ qwertyu0522 |      0.5
+ qwertyu0523 |      0.5
+ qwertyu0524 |      0.5
+ qwertyu0525 |      0.5
+ qwertyu0526 |      0.5
+ qwertyu0527 |      0.5
+ qwertyu0528 |      0.5
+ qwertyu0529 |      0.5
+ qwertyu0530 |      0.5
+ qwertyu0531 |      0.5
+ qwertyu0532 |      0.5
+ qwertyu0533 |      0.5
+ qwertyu0534 |      0.5
+ qwertyu0535 |      0.5
+ qwertyu0536 |      0.5
+ qwertyu0537 |      0.5
+ qwertyu0538 |      0.5
+ qwertyu0539 |      0.5
+ qwertyu0540 |      0.5
+ qwertyu0541 |      0.5
+ qwertyu0542 |      0.5
+ qwertyu0543 |      0.5
+ qwertyu0544 |      0.5
+ qwertyu0545 |      0.5
+ qwertyu0546 |      0.5
+ qwertyu0547 |      0.5
+ qwertyu0548 |      0.5
+ qwertyu0549 |      0.5
+ qwertyu0550 |      0.5
+ qwertyu0551 |      0.5
+ qwertyu0552 |      0.5
+ qwertyu0553 |      0.5
+ qwertyu0554 |      0.5
+ qwertyu0555 |      0.5
+ qwertyu0556 |      0.5
+ qwertyu0557 |      0.5
+ qwertyu0558 |      0.5
+ qwertyu0559 |      0.5
+ qwertyu0560 |      0.5
+ qwertyu0561 |      0.5
+ qwertyu0562 |      0.5
+ qwertyu0563 |      0.5
+ qwertyu0564 |      0.5
+ qwertyu0565 |      0.5
+ qwertyu0566 |      0.5
+ qwertyu0567 |      0.5
+ qwertyu0568 |      0.5
+ qwertyu0569 |      0.5
+ qwertyu0570 |      0.5
+ qwertyu0571 |      0.5
+ qwertyu0572 |      0.5
+ qwertyu0573 |      0.5
+ qwertyu0574 |      0.5
+ qwertyu0575 |      0.5
+ qwertyu0576 |      0.5
+ qwertyu0577 |      0.5
+ qwertyu0578 |      0.5
+ qwertyu0579 |      0.5
+ qwertyu0580 |      0.5
+ qwertyu0581 |      0.5
+ qwertyu0582 |      0.5
+ qwertyu0583 |      0.5
+ qwertyu0584 |      0.5
+ qwertyu0585 |      0.5
+ qwertyu0586 |      0.5
+ qwertyu0587 |      0.5
+ qwertyu0589 |      0.5
+ qwertyu0590 |      0.5
+ qwertyu0591 |      0.5
+ qwertyu0592 |      0.5
+ qwertyu0593 |      0.5
+ qwertyu0594 |      0.5
+ qwertyu0595 |      0.5
+ qwertyu0596 |      0.5
+ qwertyu0597 |      0.5
+ qwertyu0598 |      0.5
+ qwertyu0599 |      0.5
+ qwertyu0600 |      0.5
+ qwertyu0601 |      0.5
+ qwertyu0602 |      0.5
+ qwertyu0603 |      0.5
+ qwertyu0604 |      0.5
+ qwertyu0605 |      0.5
+ qwertyu0606 |      0.5
+ qwertyu0607 |      0.5
+ qwertyu0608 |      0.5
+ qwertyu0609 |      0.5
+ qwertyu0610 |      0.5
+ qwertyu0611 |      0.5
+ qwertyu0612 |      0.5
+ qwertyu0613 |      0.5
+ qwertyu0614 |      0.5
+ qwertyu0615 |      0.5
+ qwertyu0616 |      0.5
+ qwertyu0617 |      0.5
+ qwertyu0618 |      0.5
+ qwertyu0619 |      0.5
+ qwertyu0620 |      0.5
+ qwertyu0621 |      0.5
+ qwertyu0622 |      0.5
+ qwertyu0623 |      0.5
+ qwertyu0624 |      0.5
+ qwertyu0625 |      0.5
+ qwertyu0626 |      0.5
+ qwertyu0627 |      0.5
+ qwertyu0628 |      0.5
+ qwertyu0629 |      0.5
+ qwertyu0630 |      0.5
+ qwertyu0631 |      0.5
+ qwertyu0632 |      0.5
+ qwertyu0633 |      0.5
+ qwertyu0634 |      0.5
+ qwertyu0635 |      0.5
+ qwertyu0636 |      0.5
+ qwertyu0637 |      0.5
+ qwertyu0638 |      0.5
+ qwertyu0639 |      0.5
+ qwertyu0640 |      0.5
+ qwertyu0641 |      0.5
+ qwertyu0642 |      0.5
+ qwertyu0643 |      0.5
+ qwertyu0644 |      0.5
+ qwertyu0645 |      0.5
+ qwertyu0646 |      0.5
+ qwertyu0647 |      0.5
+ qwertyu0648 |      0.5
+ qwertyu0649 |      0.5
+ qwertyu0650 |      0.5
+ qwertyu0651 |      0.5
+ qwertyu0652 |      0.5
+ qwertyu0653 |      0.5
+ qwertyu0654 |      0.5
+ qwertyu0655 |      0.5
+ qwertyu0656 |      0.5
+ qwertyu0657 |      0.5
+ qwertyu0658 |      0.5
+ qwertyu0659 |      0.5
+ qwertyu0660 |      0.5
+ qwertyu0661 |      0.5
+ qwertyu0662 |      0.5
+ qwertyu0663 |      0.5
+ qwertyu0664 |      0.5
+ qwertyu0665 |      0.5
+ qwertyu0666 |      0.5
+ qwertyu0667 |      0.5
+ qwertyu0668 |      0.5
+ qwertyu0669 |      0.5
+ qwertyu0670 |      0.5
+ qwertyu0671 |      0.5
+ qwertyu0672 |      0.5
+ qwertyu0673 |      0.5
+ qwertyu0674 |      0.5
+ qwertyu0675 |      0.5
+ qwertyu0676 |      0.5
+ qwertyu0677 |      0.5
+ qwertyu0678 |      0.5
+ qwertyu0679 |      0.5
+ qwertyu0680 |      0.5
+ qwertyu0681 |      0.5
+ qwertyu0682 |      0.5
+ qwertyu0683 |      0.5
+ qwertyu0684 |      0.5
+ qwertyu0685 |      0.5
+ qwertyu0686 |      0.5
+ qwertyu0687 |      0.5
+ qwertyu0689 |      0.5
+ qwertyu0690 |      0.5
+ qwertyu0691 |      0.5
+ qwertyu0692 |      0.5
+ qwertyu0693 |      0.5
+ qwertyu0694 |      0.5
+ qwertyu0695 |      0.5
+ qwertyu0696 |      0.5
+ qwertyu0697 |      0.5
+ qwertyu0698 |      0.5
+ qwertyu0699 |      0.5
+ qwertyu0700 |      0.5
+ qwertyu0701 |      0.5
+ qwertyu0702 |      0.5
+ qwertyu0703 |      0.5
+ qwertyu0704 |      0.5
+ qwertyu0705 |      0.5
+ qwertyu0706 |      0.5
+ qwertyu0707 |      0.5
+ qwertyu0708 |      0.5
+ qwertyu0709 |      0.5
+ qwertyu0710 |      0.5
+ qwertyu0711 |      0.5
+ qwertyu0712 |      0.5
+ qwertyu0713 |      0.5
+ qwertyu0714 |      0.5
+ qwertyu0715 |      0.5
+ qwertyu0716 |      0.5
+ qwertyu0717 |      0.5
+ qwertyu0718 |      0.5
+ qwertyu0719 |      0.5
+ qwertyu0720 |      0.5
+ qwertyu0721 |      0.5
+ qwertyu0722 |      0.5
+ qwertyu0723 |      0.5
+ qwertyu0724 |      0.5
+ qwertyu0725 |      0.5
+ qwertyu0726 |      0.5
+ qwertyu0727 |      0.5
+ qwertyu0728 |      0.5
+ qwertyu0729 |      0.5
+ qwertyu0730 |      0.5
+ qwertyu0731 |      0.5
+ qwertyu0732 |      0.5
+ qwertyu0733 |      0.5
+ qwertyu0734 |      0.5
+ qwertyu0735 |      0.5
+ qwertyu0736 |      0.5
+ qwertyu0737 |      0.5
+ qwertyu0738 |      0.5
+ qwertyu0739 |      0.5
+ qwertyu0740 |      0.5
+ qwertyu0741 |      0.5
+ qwertyu0742 |      0.5
+ qwertyu0743 |      0.5
+ qwertyu0744 |      0.5
+ qwertyu0745 |      0.5
+ qwertyu0746 |      0.5
+ qwertyu0747 |      0.5
+ qwertyu0748 |      0.5
+ qwertyu0749 |      0.5
+ qwertyu0750 |      0.5
+ qwertyu0751 |      0.5
+ qwertyu0752 |      0.5
+ qwertyu0753 |      0.5
+ qwertyu0754 |      0.5
+ qwertyu0755 |      0.5
+ qwertyu0756 |      0.5
+ qwertyu0757 |      0.5
+ qwertyu0758 |      0.5
+ qwertyu0759 |      0.5
+ qwertyu0760 |      0.5
+ qwertyu0761 |      0.5
+ qwertyu0762 |      0.5
+ qwertyu0763 |      0.5
+ qwertyu0764 |      0.5
+ qwertyu0765 |      0.5
+ qwertyu0766 |      0.5
+ qwertyu0767 |      0.5
+ qwertyu0768 |      0.5
+ qwertyu0769 |      0.5
+ qwertyu0770 |      0.5
+ qwertyu0771 |      0.5
+ qwertyu0772 |      0.5
+ qwertyu0773 |      0.5
+ qwertyu0774 |      0.5
+ qwertyu0775 |      0.5
+ qwertyu0776 |      0.5
+ qwertyu0777 |      0.5
+ qwertyu0778 |      0.5
+ qwertyu0779 |      0.5
+ qwertyu0780 |      0.5
+ qwertyu0781 |      0.5
+ qwertyu0782 |      0.5
+ qwertyu0783 |      0.5
+ qwertyu0784 |      0.5
+ qwertyu0785 |      0.5
+ qwertyu0786 |      0.5
+ qwertyu0787 |      0.5
+ qwertyu0789 |      0.5
+ qwertyu0790 |      0.5
+ qwertyu0791 |      0.5
+ qwertyu0792 |      0.5
+ qwertyu0793 |      0.5
+ qwertyu0794 |      0.5
+ qwertyu0795 |      0.5
+ qwertyu0796 |      0.5
+ qwertyu0797 |      0.5
+ qwertyu0798 |      0.5
+ qwertyu0799 |      0.5
+ qwertyu0800 |      0.5
+ qwertyu0801 |      0.5
+ qwertyu0802 |      0.5
+ qwertyu0803 |      0.5
+ qwertyu0804 |      0.5
+ qwertyu0805 |      0.5
+ qwertyu0806 |      0.5
+ qwertyu0807 |      0.5
+ qwertyu0808 |      0.5
+ qwertyu0809 |      0.5
+ qwertyu0810 |      0.5
+ qwertyu0811 |      0.5
+ qwertyu0812 |      0.5
+ qwertyu0813 |      0.5
+ qwertyu0814 |      0.5
+ qwertyu0815 |      0.5
+ qwertyu0816 |      0.5
+ qwertyu0817 |      0.5
+ qwertyu0818 |      0.5
+ qwertyu0819 |      0.5
+ qwertyu0820 |      0.5
+ qwertyu0821 |      0.5
+ qwertyu0822 |      0.5
+ qwertyu0823 |      0.5
+ qwertyu0824 |      0.5
+ qwertyu0825 |      0.5
+ qwertyu0826 |      0.5
+ qwertyu0827 |      0.5
+ qwertyu0828 |      0.5
+ qwertyu0829 |      0.5
+ qwertyu0830 |      0.5
+ qwertyu0831 |      0.5
+ qwertyu0832 |      0.5
+ qwertyu0833 |      0.5
+ qwertyu0834 |      0.5
+ qwertyu0835 |      0.5
+ qwertyu0836 |      0.5
+ qwertyu0837 |      0.5
+ qwertyu0838 |      0.5
+ qwertyu0839 |      0.5
+ qwertyu0840 |      0.5
+ qwertyu0841 |      0.5
+ qwertyu0842 |      0.5
+ qwertyu0843 |      0.5
+ qwertyu0844 |      0.5
+ qwertyu0845 |      0.5
+ qwertyu0846 |      0.5
+ qwertyu0847 |      0.5
+ qwertyu0848 |      0.5
+ qwertyu0849 |      0.5
+ qwertyu0850 |      0.5
+ qwertyu0851 |      0.5
+ qwertyu0852 |      0.5
+ qwertyu0853 |      0.5
+ qwertyu0854 |      0.5
+ qwertyu0855 |      0.5
+ qwertyu0856 |      0.5
+ qwertyu0857 |      0.5
+ qwertyu0858 |      0.5
+ qwertyu0859 |      0.5
+ qwertyu0860 |      0.5
+ qwertyu0861 |      0.5
+ qwertyu0862 |      0.5
+ qwertyu0863 |      0.5
+ qwertyu0864 |      0.5
+ qwertyu0865 |      0.5
+ qwertyu0866 |      0.5
+ qwertyu0867 |      0.5
+ qwertyu0868 |      0.5
+ qwertyu0869 |      0.5
+ qwertyu0870 |      0.5
+ qwertyu0871 |      0.5
+ qwertyu0872 |      0.5
+ qwertyu0873 |      0.5
+ qwertyu0874 |      0.5
+ qwertyu0875 |      0.5
+ qwertyu0876 |      0.5
+ qwertyu0877 |      0.5
+ qwertyu0878 |      0.5
+ qwertyu0879 |      0.5
+ qwertyu0880 |      0.5
+ qwertyu0881 |      0.5
+ qwertyu0882 |      0.5
+ qwertyu0883 |      0.5
+ qwertyu0884 |      0.5
+ qwertyu0885 |      0.5
+ qwertyu0886 |      0.5
+ qwertyu0887 |      0.5
+ qwertyu0889 |      0.5
+ qwertyu0890 |      0.5
+ qwertyu0891 |      0.5
+ qwertyu0892 |      0.5
+ qwertyu0893 |      0.5
+ qwertyu0894 |      0.5
+ qwertyu0895 |      0.5
+ qwertyu0896 |      0.5
+ qwertyu0897 |      0.5
+ qwertyu0898 |      0.5
+ qwertyu0899 |      0.5
+ qwertyu1000 | 0.411765
+(1000 rows)
+
+select t,similarity(t,'gwertyu0988') as sml from test_trgm where t % 'gwertyu0988' order by sml desc, t;
+      t      |   sml    
+-------------+----------
+ qwertyu0988 |      0.6
+ qwertyu0980 | 0.411765
+ qwertyu0981 | 0.411765
+ qwertyu0982 | 0.411765
+ qwertyu0983 | 0.411765
+ qwertyu0984 | 0.411765
+ qwertyu0985 | 0.411765
+ qwertyu0986 | 0.411765
+ qwertyu0987 | 0.411765
+ qwertyu0989 | 0.411765
+ qwertyu0088 | 0.333333
+ qwertyu0098 | 0.333333
+ qwertyu0188 | 0.333333
+ qwertyu0288 | 0.333333
+ qwertyu0388 | 0.333333
+ qwertyu0488 | 0.333333
+ qwertyu0588 | 0.333333
+ qwertyu0688 | 0.333333
+ qwertyu0788 | 0.333333
+ qwertyu0888 | 0.333333
+ qwertyu0900 | 0.333333
+ qwertyu0901 | 0.333333
+ qwertyu0902 | 0.333333
+ qwertyu0903 | 0.333333
+ qwertyu0904 | 0.333333
+ qwertyu0905 | 0.333333
+ qwertyu0906 | 0.333333
+ qwertyu0907 | 0.333333
+ qwertyu0908 | 0.333333
+ qwertyu0909 | 0.333333
+ qwertyu0910 | 0.333333
+ qwertyu0911 | 0.333333
+ qwertyu0912 | 0.333333
+ qwertyu0913 | 0.333333
+ qwertyu0914 | 0.333333
+ qwertyu0915 | 0.333333
+ qwertyu0916 | 0.333333
+ qwertyu0917 | 0.333333
+ qwertyu0918 | 0.333333
+ qwertyu0919 | 0.333333
+ qwertyu0920 | 0.333333
+ qwertyu0921 | 0.333333
+ qwertyu0922 | 0.333333
+ qwertyu0923 | 0.333333
+ qwertyu0924 | 0.333333
+ qwertyu0925 | 0.333333
+ qwertyu0926 | 0.333333
+ qwertyu0927 | 0.333333
+ qwertyu0928 | 0.333333
+ qwertyu0929 | 0.333333
+ qwertyu0930 | 0.333333
+ qwertyu0931 | 0.333333
+ qwertyu0932 | 0.333333
+ qwertyu0933 | 0.333333
+ qwertyu0934 | 0.333333
+ qwertyu0935 | 0.333333
+ qwertyu0936 | 0.333333
+ qwertyu0937 | 0.333333
+ qwertyu0938 | 0.333333
+ qwertyu0939 | 0.333333
+ qwertyu0940 | 0.333333
+ qwertyu0941 | 0.333333
+ qwertyu0942 | 0.333333
+ qwertyu0943 | 0.333333
+ qwertyu0944 | 0.333333
+ qwertyu0945 | 0.333333
+ qwertyu0946 | 0.333333
+ qwertyu0947 | 0.333333
+ qwertyu0948 | 0.333333
+ qwertyu0949 | 0.333333
+ qwertyu0950 | 0.333333
+ qwertyu0951 | 0.333333
+ qwertyu0952 | 0.333333
+ qwertyu0953 | 0.333333
+ qwertyu0954 | 0.333333
+ qwertyu0955 | 0.333333
+ qwertyu0956 | 0.333333
+ qwertyu0957 | 0.333333
+ qwertyu0958 | 0.333333
+ qwertyu0959 | 0.333333
+ qwertyu0960 | 0.333333
+ qwertyu0961 | 0.333333
+ qwertyu0962 | 0.333333
+ qwertyu0963 | 0.333333
+ qwertyu0964 | 0.333333
+ qwertyu0965 | 0.333333
+ qwertyu0966 | 0.333333
+ qwertyu0967 | 0.333333
+ qwertyu0968 | 0.333333
+ qwertyu0969 | 0.333333
+ qwertyu0970 | 0.333333
+ qwertyu0971 | 0.333333
+ qwertyu0972 | 0.333333
+ qwertyu0973 | 0.333333
+ qwertyu0974 | 0.333333
+ qwertyu0975 | 0.333333
+ qwertyu0976 | 0.333333
+ qwertyu0977 | 0.333333
+ qwertyu0978 | 0.333333
+ qwertyu0979 | 0.333333
+ qwertyu0990 | 0.333333
+ qwertyu0991 | 0.333333
+ qwertyu0992 | 0.333333
+ qwertyu0993 | 0.333333
+ qwertyu0994 | 0.333333
+ qwertyu0995 | 0.333333
+ qwertyu0996 | 0.333333
+ qwertyu0997 | 0.333333
+ qwertyu0998 | 0.333333
+ qwertyu0999 | 0.333333
+(110 rows)
+
+select t,similarity(t,'gwertyu1988') as sml from test_trgm where t % 'gwertyu1988' order by sml desc, t;
+      t      |   sml    
+-------------+----------
+ qwertyu0988 | 0.333333
+(1 row)
+
+select t <-> 'q0987wertyu0988', t from test_trgm order by t <-> 'q0987wertyu0988' limit 2;
+ ?column? |      t      
+----------+-------------
+ 0.411765 | qwertyu0988
+      0.5 | qwertyu0987
+(2 rows)
+
+select count(*) from test_trgm where t ~ '[qwerty]{2}-?[qwerty]{2}';
+ count 
+-------
+  1000
+(1 row)
+
+create index trgm_idx on test_trgm using gist (t gist_trgm_ops);
+set enable_seqscan=off;
+select t,similarity(t,'qwertyu0988') as sml from test_trgm where t % 'qwertyu0988' order by sml desc, t;
+      t      |   sml    
+-------------+----------
+ qwertyu0988 |        1
+ qwertyu0980 | 0.714286
+ qwertyu0981 | 0.714286
+ qwertyu0982 | 0.714286
+ qwertyu0983 | 0.714286
+ qwertyu0984 | 0.714286
+ qwertyu0985 | 0.714286
+ qwertyu0986 | 0.714286
+ qwertyu0987 | 0.714286
+ qwertyu0989 | 0.714286
+ qwertyu0088 |      0.6
+ qwertyu0098 |      0.6
+ qwertyu0188 |      0.6
+ qwertyu0288 |      0.6
+ qwertyu0388 |      0.6
+ qwertyu0488 |      0.6
+ qwertyu0588 |      0.6
+ qwertyu0688 |      0.6
+ qwertyu0788 |      0.6
+ qwertyu0888 |      0.6
+ qwertyu0900 |      0.6
+ qwertyu0901 |      0.6
+ qwertyu0902 |      0.6
+ qwertyu0903 |      0.6
+ qwertyu0904 |      0.6
+ qwertyu0905 |      0.6
+ qwertyu0906 |      0.6
+ qwertyu0907 |      0.6
+ qwertyu0908 |      0.6
+ qwertyu0909 |      0.6
+ qwertyu0910 |      0.6
+ qwertyu0911 |      0.6
+ qwertyu0912 |      0.6
+ qwertyu0913 |      0.6
+ qwertyu0914 |      0.6
+ qwertyu0915 |      0.6
+ qwertyu0916 |      0.6
+ qwertyu0917 |      0.6
+ qwertyu0918 |      0.6
+ qwertyu0919 |      0.6
+ qwertyu0920 |      0.6
+ qwertyu0921 |      0.6
+ qwertyu0922 |      0.6
+ qwertyu0923 |      0.6
+ qwertyu0924 |      0.6
+ qwertyu0925 |      0.6
+ qwertyu0926 |      0.6
+ qwertyu0927 |      0.6
+ qwertyu0928 |      0.6
+ qwertyu0929 |      0.6
+ qwertyu0930 |      0.6
+ qwertyu0931 |      0.6
+ qwertyu0932 |      0.6
+ qwertyu0933 |      0.6
+ qwertyu0934 |      0.6
+ qwertyu0935 |      0.6
+ qwertyu0936 |      0.6
+ qwertyu0937 |      0.6
+ qwertyu0938 |      0.6
+ qwertyu0939 |      0.6
+ qwertyu0940 |      0.6
+ qwertyu0941 |      0.6
+ qwertyu0942 |      0.6
+ qwertyu0943 |      0.6
+ qwertyu0944 |      0.6
+ qwertyu0945 |      0.6
+ qwertyu0946 |      0.6
+ qwertyu0947 |      0.6
+ qwertyu0948 |      0.6
+ qwertyu0949 |      0.6
+ qwertyu0950 |      0.6
+ qwertyu0951 |      0.6
+ qwertyu0952 |      0.6
+ qwertyu0953 |      0.6
+ qwertyu0954 |      0.6
+ qwertyu0955 |      0.6
+ qwertyu0956 |      0.6
+ qwertyu0957 |      0.6
+ qwertyu0958 |      0.6
+ qwertyu0959 |      0.6
+ qwertyu0960 |      0.6
+ qwertyu0961 |      0.6
+ qwertyu0962 |      0.6
+ qwertyu0963 |      0.6
+ qwertyu0964 |      0.6
+ qwertyu0965 |      0.6
+ qwertyu0966 |      0.6
+ qwertyu0967 |      0.6
+ qwertyu0968 |      0.6
+ qwertyu0969 |      0.6
+ qwertyu0970 |      0.6
+ qwertyu0971 |      0.6
+ qwertyu0972 |      0.6
+ qwertyu0973 |      0.6
+ qwertyu0974 |      0.6
+ qwertyu0975 |      0.6
+ qwertyu0976 |      0.6
+ qwertyu0977 |      0.6
+ qwertyu0978 |      0.6
+ qwertyu0979 |      0.6
+ qwertyu0990 |      0.6
+ qwertyu0991 |      0.6
+ qwertyu0992 |      0.6
+ qwertyu0993 |      0.6
+ qwertyu0994 |      0.6
+ qwertyu0995 |      0.6
+ qwertyu0996 |      0.6
+ qwertyu0997 |      0.6
+ qwertyu0998 |      0.6
+ qwertyu0999 |      0.6
+ qwertyu0001 |      0.5
+ qwertyu0002 |      0.5
+ qwertyu0003 |      0.5
+ qwertyu0004 |      0.5
+ qwertyu0005 |      0.5
+ qwertyu0006 |      0.5
+ qwertyu0007 |      0.5
+ qwertyu0008 |      0.5
+ qwertyu0009 |      0.5
+ qwertyu0010 |      0.5
+ qwertyu0011 |      0.5
+ qwertyu0012 |      0.5
+ qwertyu0013 |      0.5
+ qwertyu0014 |      0.5
+ qwertyu0015 |      0.5
+ qwertyu0016 |      0.5
+ qwertyu0017 |      0.5
+ qwertyu0018 |      0.5
+ qwertyu0019 |      0.5
+ qwertyu0020 |      0.5
+ qwertyu0021 |      0.5
+ qwertyu0022 |      0.5
+ qwertyu0023 |      0.5
+ qwertyu0024 |      0.5
+ qwertyu0025 |      0.5
+ qwertyu0026 |      0.5
+ qwertyu0027 |      0.5
+ qwertyu0028 |      0.5
+ qwertyu0029 |      0.5
+ qwertyu0030 |      0.5
+ qwertyu0031 |      0.5
+ qwertyu0032 |      0.5
+ qwertyu0033 |      0.5
+ qwertyu0034 |      0.5
+ qwertyu0035 |      0.5
+ qwertyu0036 |      0.5
+ qwertyu0037 |      0.5
+ qwertyu0038 |      0.5
+ qwertyu0039 |      0.5
+ qwertyu0040 |      0.5
+ qwertyu0041 |      0.5
+ qwertyu0042 |      0.5
+ qwertyu0043 |      0.5
+ qwertyu0044 |      0.5
+ qwertyu0045 |      0.5
+ qwertyu0046 |      0.5
+ qwertyu0047 |      0.5
+ qwertyu0048 |      0.5
+ qwertyu0049 |      0.5
+ qwertyu0050 |      0.5
+ qwertyu0051 |      0.5
+ qwertyu0052 |      0.5
+ qwertyu0053 |      0.5
+ qwertyu0054 |      0.5
+ qwertyu0055 |      0.5
+ qwertyu0056 |      0.5
+ qwertyu0057 |      0.5
+ qwertyu0058 |      0.5
+ qwertyu0059 |      0.5
+ qwertyu0060 |      0.5
+ qwertyu0061 |      0.5
+ qwertyu0062 |      0.5
+ qwertyu0063 |      0.5
+ qwertyu0064 |      0.5
+ qwertyu0065 |      0.5
+ qwertyu0066 |      0.5
+ qwertyu0067 |      0.5
+ qwertyu0068 |      0.5
+ qwertyu0069 |      0.5
+ qwertyu0070 |      0.5
+ qwertyu0071 |      0.5
+ qwertyu0072 |      0.5
+ qwertyu0073 |      0.5
+ qwertyu0074 |      0.5
+ qwertyu0075 |      0.5
+ qwertyu0076 |      0.5
+ qwertyu0077 |      0.5
+ qwertyu0078 |      0.5
+ qwertyu0079 |      0.5
+ qwertyu0080 |      0.5
+ qwertyu0081 |      0.5
+ qwertyu0082 |      0.5
+ qwertyu0083 |      0.5
+ qwertyu0084 |      0.5
+ qwertyu0085 |      0.5
+ qwertyu0086 |      0.5
+ qwertyu0087 |      0.5
+ qwertyu0089 |      0.5
+ qwertyu0090 |      0.5
+ qwertyu0091 |      0.5
+ qwertyu0092 |      0.5
+ qwertyu0093 |      0.5
+ qwertyu0094 |      0.5
+ qwertyu0095 |      0.5
+ qwertyu0096 |      0.5
+ qwertyu0097 |      0.5
+ qwertyu0099 |      0.5
+ qwertyu0100 |      0.5
+ qwertyu0101 |      0.5
+ qwertyu0102 |      0.5
+ qwertyu0103 |      0.5
+ qwertyu0104 |      0.5
+ qwertyu0105 |      0.5
+ qwertyu0106 |      0.5
+ qwertyu0107 |      0.5
+ qwertyu0108 |      0.5
+ qwertyu0109 |      0.5
+ qwertyu0110 |      0.5
+ qwertyu0111 |      0.5
+ qwertyu0112 |      0.5
+ qwertyu0113 |      0.5
+ qwertyu0114 |      0.5
+ qwertyu0115 |      0.5
+ qwertyu0116 |      0.5
+ qwertyu0117 |      0.5
+ qwertyu0118 |      0.5
+ qwertyu0119 |      0.5
+ qwertyu0120 |      0.5
+ qwertyu0121 |      0.5
+ qwertyu0122 |      0.5
+ qwertyu0123 |      0.5
+ qwertyu0124 |      0.5
+ qwertyu0125 |      0.5
+ qwertyu0126 |      0.5
+ qwertyu0127 |      0.5
+ qwertyu0128 |      0.5
+ qwertyu0129 |      0.5
+ qwertyu0130 |      0.5
+ qwertyu0131 |      0.5
+ qwertyu0132 |      0.5
+ qwertyu0133 |      0.5
+ qwertyu0134 |      0.5
+ qwertyu0135 |      0.5
+ qwertyu0136 |      0.5
+ qwertyu0137 |      0.5
+ qwertyu0138 |      0.5
+ qwertyu0139 |      0.5
+ qwertyu0140 |      0.5
+ qwertyu0141 |      0.5
+ qwertyu0142 |      0.5
+ qwertyu0143 |      0.5
+ qwertyu0144 |      0.5
+ qwertyu0145 |      0.5
+ qwertyu0146 |      0.5
+ qwertyu0147 |      0.5
+ qwertyu0148 |      0.5
+ qwertyu0149 |      0.5
+ qwertyu0150 |      0.5
+ qwertyu0151 |      0.5
+ qwertyu0152 |      0.5
+ qwertyu0153 |      0.5
+ qwertyu0154 |      0.5
+ qwertyu0155 |      0.5
+ qwertyu0156 |      0.5
+ qwertyu0157 |      0.5
+ qwertyu0158 |      0.5
+ qwertyu0159 |      0.5
+ qwertyu0160 |      0.5
+ qwertyu0161 |      0.5
+ qwertyu0162 |      0.5
+ qwertyu0163 |      0.5
+ qwertyu0164 |      0.5
+ qwertyu0165 |      0.5
+ qwertyu0166 |      0.5
+ qwertyu0167 |      0.5
+ qwertyu0168 |      0.5
+ qwertyu0169 |      0.5
+ qwertyu0170 |      0.5
+ qwertyu0171 |      0.5
+ qwertyu0172 |      0.5
+ qwertyu0173 |      0.5
+ qwertyu0174 |      0.5
+ qwertyu0175 |      0.5
+ qwertyu0176 |      0.5
+ qwertyu0177 |      0.5
+ qwertyu0178 |      0.5
+ qwertyu0179 |      0.5
+ qwertyu0180 |      0.5
+ qwertyu0181 |      0.5
+ qwertyu0182 |      0.5
+ qwertyu0183 |      0.5
+ qwertyu0184 |      0.5
+ qwertyu0185 |      0.5
+ qwertyu0186 |      0.5
+ qwertyu0187 |      0.5
+ qwertyu0189 |      0.5
+ qwertyu0190 |      0.5
+ qwertyu0191 |      0.5
+ qwertyu0192 |      0.5
+ qwertyu0193 |      0.5
+ qwertyu0194 |      0.5
+ qwertyu0195 |      0.5
+ qwertyu0196 |      0.5
+ qwertyu0197 |      0.5
+ qwertyu0198 |      0.5
+ qwertyu0199 |      0.5
+ qwertyu0200 |      0.5
+ qwertyu0201 |      0.5
+ qwertyu0202 |      0.5
+ qwertyu0203 |      0.5
+ qwertyu0204 |      0.5
+ qwertyu0205 |      0.5
+ qwertyu0206 |      0.5
+ qwertyu0207 |      0.5
+ qwertyu0208 |      0.5
+ qwertyu0209 |      0.5
+ qwertyu0210 |      0.5
+ qwertyu0211 |      0.5
+ qwertyu0212 |      0.5
+ qwertyu0213 |      0.5
+ qwertyu0214 |      0.5
+ qwertyu0215 |      0.5
+ qwertyu0216 |      0.5
+ qwertyu0217 |      0.5
+ qwertyu0218 |      0.5
+ qwertyu0219 |      0.5
+ qwertyu0220 |      0.5
+ qwertyu0221 |      0.5
+ qwertyu0222 |      0.5
+ qwertyu0223 |      0.5
+ qwertyu0224 |      0.5
+ qwertyu0225 |      0.5
+ qwertyu0226 |      0.5
+ qwertyu0227 |      0.5
+ qwertyu0228 |      0.5
+ qwertyu0229 |      0.5
+ qwertyu0230 |      0.5
+ qwertyu0231 |      0.5
+ qwertyu0232 |      0.5
+ qwertyu0233 |      0.5
+ qwertyu0234 |      0.5
+ qwertyu0235 |      0.5
+ qwertyu0236 |      0.5
+ qwertyu0237 |      0.5
+ qwertyu0238 |      0.5
+ qwertyu0239 |      0.5
+ qwertyu0240 |      0.5
+ qwertyu0241 |      0.5
+ qwertyu0242 |      0.5
+ qwertyu0243 |      0.5
+ qwertyu0244 |      0.5
+ qwertyu0245 |      0.5
+ qwertyu0246 |      0.5
+ qwertyu0247 |      0.5
+ qwertyu0248 |      0.5
+ qwertyu0249 |      0.5
+ qwertyu0250 |      0.5
+ qwertyu0251 |      0.5
+ qwertyu0252 |      0.5
+ qwertyu0253 |      0.5
+ qwertyu0254 |      0.5
+ qwertyu0255 |      0.5
+ qwertyu0256 |      0.5
+ qwertyu0257 |      0.5
+ qwertyu0258 |      0.5
+ qwertyu0259 |      0.5
+ qwertyu0260 |      0.5
+ qwertyu0261 |      0.5
+ qwertyu0262 |      0.5
+ qwertyu0263 |      0.5
+ qwertyu0264 |      0.5
+ qwertyu0265 |      0.5
+ qwertyu0266 |      0.5
+ qwertyu0267 |      0.5
+ qwertyu0268 |      0.5
+ qwertyu0269 |      0.5
+ qwertyu0270 |      0.5
+ qwertyu0271 |      0.5
+ qwertyu0272 |      0.5
+ qwertyu0273 |      0.5
+ qwertyu0274 |      0.5
+ qwertyu0275 |      0.5
+ qwertyu0276 |      0.5
+ qwertyu0277 |      0.5
+ qwertyu0278 |      0.5
+ qwertyu0279 |      0.5
+ qwertyu0280 |      0.5
+ qwertyu0281 |      0.5
+ qwertyu0282 |      0.5
+ qwertyu0283 |      0.5
+ qwertyu0284 |      0.5
+ qwertyu0285 |      0.5
+ qwertyu0286 |      0.5
+ qwertyu0287 |      0.5
+ qwertyu0289 |      0.5
+ qwertyu0290 |      0.5
+ qwertyu0291 |      0.5
+ qwertyu0292 |      0.5
+ qwertyu0293 |      0.5
+ qwertyu0294 |      0.5
+ qwertyu0295 |      0.5
+ qwertyu0296 |      0.5
+ qwertyu0297 |      0.5
+ qwertyu0298 |      0.5
+ qwertyu0299 |      0.5
+ qwertyu0300 |      0.5
+ qwertyu0301 |      0.5
+ qwertyu0302 |      0.5
+ qwertyu0303 |      0.5
+ qwertyu0304 |      0.5
+ qwertyu0305 |      0.5
+ qwertyu0306 |      0.5
+ qwertyu0307 |      0.5
+ qwertyu0308 |      0.5
+ qwertyu0309 |      0.5
+ qwertyu0310 |      0.5
+ qwertyu0311 |      0.5
+ qwertyu0312 |      0.5
+ qwertyu0313 |      0.5
+ qwertyu0314 |      0.5
+ qwertyu0315 |      0.5
+ qwertyu0316 |      0.5
+ qwertyu0317 |      0.5
+ qwertyu0318 |      0.5
+ qwertyu0319 |      0.5
+ qwertyu0320 |      0.5
+ qwertyu0321 |      0.5
+ qwertyu0322 |      0.5
+ qwertyu0323 |      0.5
+ qwertyu0324 |      0.5
+ qwertyu0325 |      0.5
+ qwertyu0326 |      0.5
+ qwertyu0327 |      0.5
+ qwertyu0328 |      0.5
+ qwertyu0329 |      0.5
+ qwertyu0330 |      0.5
+ qwertyu0331 |      0.5
+ qwertyu0332 |      0.5
+ qwertyu0333 |      0.5
+ qwertyu0334 |      0.5
+ qwertyu0335 |      0.5
+ qwertyu0336 |      0.5
+ qwertyu0337 |      0.5
+ qwertyu0338 |      0.5
+ qwertyu0339 |      0.5
+ qwertyu0340 |      0.5
+ qwertyu0341 |      0.5
+ qwertyu0342 |      0.5
+ qwertyu0343 |      0.5
+ qwertyu0344 |      0.5
+ qwertyu0345 |      0.5
+ qwertyu0346 |      0.5
+ qwertyu0347 |      0.5
+ qwertyu0348 |      0.5
+ qwertyu0349 |      0.5
+ qwertyu0350 |      0.5
+ qwertyu0351 |      0.5
+ qwertyu0352 |      0.5
+ qwertyu0353 |      0.5
+ qwertyu0354 |      0.5
+ qwertyu0355 |      0.5
+ qwertyu0356 |      0.5
+ qwertyu0357 |      0.5
+ qwertyu0358 |      0.5
+ qwertyu0359 |      0.5
+ qwertyu0360 |      0.5
+ qwertyu0361 |      0.5
+ qwertyu0362 |      0.5
+ qwertyu0363 |      0.5
+ qwertyu0364 |      0.5
+ qwertyu0365 |      0.5
+ qwertyu0366 |      0.5
+ qwertyu0367 |      0.5
+ qwertyu0368 |      0.5
+ qwertyu0369 |      0.5
+ qwertyu0370 |      0.5
+ qwertyu0371 |      0.5
+ qwertyu0372 |      0.5
+ qwertyu0373 |      0.5
+ qwertyu0374 |      0.5
+ qwertyu0375 |      0.5
+ qwertyu0376 |      0.5
+ qwertyu0377 |      0.5
+ qwertyu0378 |      0.5
+ qwertyu0379 |      0.5
+ qwertyu0380 |      0.5
+ qwertyu0381 |      0.5
+ qwertyu0382 |      0.5
+ qwertyu0383 |      0.5
+ qwertyu0384 |      0.5
+ qwertyu0385 |      0.5
+ qwertyu0386 |      0.5
+ qwertyu0387 |      0.5
+ qwertyu0389 |      0.5
+ qwertyu0390 |      0.5
+ qwertyu0391 |      0.5
+ qwertyu0392 |      0.5
+ qwertyu0393 |      0.5
+ qwertyu0394 |      0.5
+ qwertyu0395 |      0.5
+ qwertyu0396 |      0.5
+ qwertyu0397 |      0.5
+ qwertyu0398 |      0.5
+ qwertyu0399 |      0.5
+ qwertyu0400 |      0.5
+ qwertyu0401 |      0.5
+ qwertyu0402 |      0.5
+ qwertyu0403 |      0.5
+ qwertyu0404 |      0.5
+ qwertyu0405 |      0.5
+ qwertyu0406 |      0.5
+ qwertyu0407 |      0.5
+ qwertyu0408 |      0.5
+ qwertyu0409 |      0.5
+ qwertyu0410 |      0.5
+ qwertyu0411 |      0.5
+ qwertyu0412 |      0.5
+ qwertyu0413 |      0.5
+ qwertyu0414 |      0.5
+ qwertyu0415 |      0.5
+ qwertyu0416 |      0.5
+ qwertyu0417 |      0.5
+ qwertyu0418 |      0.5
+ qwertyu0419 |      0.5
+ qwertyu0420 |      0.5
+ qwertyu0421 |      0.5
+ qwertyu0422 |      0.5
+ qwertyu0423 |      0.5
+ qwertyu0424 |      0.5
+ qwertyu0425 |      0.5
+ qwertyu0426 |      0.5
+ qwertyu0427 |      0.5
+ qwertyu0428 |      0.5
+ qwertyu0429 |      0.5
+ qwertyu0430 |      0.5
+ qwertyu0431 |      0.5
+ qwertyu0432 |      0.5
+ qwertyu0433 |      0.5
+ qwertyu0434 |      0.5
+ qwertyu0435 |      0.5
+ qwertyu0436 |      0.5
+ qwertyu0437 |      0.5
+ qwertyu0438 |      0.5
+ qwertyu0439 |      0.5
+ qwertyu0440 |      0.5
+ qwertyu0441 |      0.5
+ qwertyu0442 |      0.5
+ qwertyu0443 |      0.5
+ qwertyu0444 |      0.5
+ qwertyu0445 |      0.5
+ qwertyu0446 |      0.5
+ qwertyu0447 |      0.5
+ qwertyu0448 |      0.5
+ qwertyu0449 |      0.5
+ qwertyu0450 |      0.5
+ qwertyu0451 |      0.5
+ qwertyu0452 |      0.5
+ qwertyu0453 |      0.5
+ qwertyu0454 |      0.5
+ qwertyu0455 |      0.5
+ qwertyu0456 |      0.5
+ qwertyu0457 |      0.5
+ qwertyu0458 |      0.5
+ qwertyu0459 |      0.5
+ qwertyu0460 |      0.5
+ qwertyu0461 |      0.5
+ qwertyu0462 |      0.5
+ qwertyu0463 |      0.5
+ qwertyu0464 |      0.5
+ qwertyu0465 |      0.5
+ qwertyu0466 |      0.5
+ qwertyu0467 |      0.5
+ qwertyu0468 |      0.5
+ qwertyu0469 |      0.5
+ qwertyu0470 |      0.5
+ qwertyu0471 |      0.5
+ qwertyu0472 |      0.5
+ qwertyu0473 |      0.5
+ qwertyu0474 |      0.5
+ qwertyu0475 |      0.5
+ qwertyu0476 |      0.5
+ qwertyu0477 |      0.5
+ qwertyu0478 |      0.5
+ qwertyu0479 |      0.5
+ qwertyu0480 |      0.5
+ qwertyu0481 |      0.5
+ qwertyu0482 |      0.5
+ qwertyu0483 |      0.5
+ qwertyu0484 |      0.5
+ qwertyu0485 |      0.5
+ qwertyu0486 |      0.5
+ qwertyu0487 |      0.5
+ qwertyu0489 |      0.5
+ qwertyu0490 |      0.5
+ qwertyu0491 |      0.5
+ qwertyu0492 |      0.5
+ qwertyu0493 |      0.5
+ qwertyu0494 |      0.5
+ qwertyu0495 |      0.5
+ qwertyu0496 |      0.5
+ qwertyu0497 |      0.5
+ qwertyu0498 |      0.5
+ qwertyu0499 |      0.5
+ qwertyu0500 |      0.5
+ qwertyu0501 |      0.5
+ qwertyu0502 |      0.5
+ qwertyu0503 |      0.5
+ qwertyu0504 |      0.5
+ qwertyu0505 |      0.5
+ qwertyu0506 |      0.5
+ qwertyu0507 |      0.5
+ qwertyu0508 |      0.5
+ qwertyu0509 |      0.5
+ qwertyu0510 |      0.5
+ qwertyu0511 |      0.5
+ qwertyu0512 |      0.5
+ qwertyu0513 |      0.5
+ qwertyu0514 |      0.5
+ qwertyu0515 |      0.5
+ qwertyu0516 |      0.5
+ qwertyu0517 |      0.5
+ qwertyu0518 |      0.5
+ qwertyu0519 |      0.5
+ qwertyu0520 |      0.5
+ qwertyu0521 |      0.5
+ qwertyu0522 |      0.5
+ qwertyu0523 |      0.5
+ qwertyu0524 |      0.5
+ qwertyu0525 |      0.5
+ qwertyu0526 |      0.5
+ qwertyu0527 |      0.5
+ qwertyu0528 |      0.5
+ qwertyu0529 |      0.5
+ qwertyu0530 |      0.5
+ qwertyu0531 |      0.5
+ qwertyu0532 |      0.5
+ qwertyu0533 |      0.5
+ qwertyu0534 |      0.5
+ qwertyu0535 |      0.5
+ qwertyu0536 |      0.5
+ qwertyu0537 |      0.5
+ qwertyu0538 |      0.5
+ qwertyu0539 |      0.5
+ qwertyu0540 |      0.5
+ qwertyu0541 |      0.5
+ qwertyu0542 |      0.5
+ qwertyu0543 |      0.5
+ qwertyu0544 |      0.5
+ qwertyu0545 |      0.5
+ qwertyu0546 |      0.5
+ qwertyu0547 |      0.5
+ qwertyu0548 |      0.5
+ qwertyu0549 |      0.5
+ qwertyu0550 |      0.5
+ qwertyu0551 |      0.5
+ qwertyu0552 |      0.5
+ qwertyu0553 |      0.5
+ qwertyu0554 |      0.5
+ qwertyu0555 |      0.5
+ qwertyu0556 |      0.5
+ qwertyu0557 |      0.5
+ qwertyu0558 |      0.5
+ qwertyu0559 |      0.5
+ qwertyu0560 |      0.5
+ qwertyu0561 |      0.5
+ qwertyu0562 |      0.5
+ qwertyu0563 |      0.5
+ qwertyu0564 |      0.5
+ qwertyu0565 |      0.5
+ qwertyu0566 |      0.5
+ qwertyu0567 |      0.5
+ qwertyu0568 |      0.5
+ qwertyu0569 |      0.5
+ qwertyu0570 |      0.5
+ qwertyu0571 |      0.5
+ qwertyu0572 |      0.5
+ qwertyu0573 |      0.5
+ qwertyu0574 |      0.5
+ qwertyu0575 |      0.5
+ qwertyu0576 |      0.5
+ qwertyu0577 |      0.5
+ qwertyu0578 |      0.5
+ qwertyu0579 |      0.5
+ qwertyu0580 |      0.5
+ qwertyu0581 |      0.5
+ qwertyu0582 |      0.5
+ qwertyu0583 |      0.5
+ qwertyu0584 |      0.5
+ qwertyu0585 |      0.5
+ qwertyu0586 |      0.5
+ qwertyu0587 |      0.5
+ qwertyu0589 |      0.5
+ qwertyu0590 |      0.5
+ qwertyu0591 |      0.5
+ qwertyu0592 |      0.5
+ qwertyu0593 |      0.5
+ qwertyu0594 |      0.5
+ qwertyu0595 |      0.5
+ qwertyu0596 |      0.5
+ qwertyu0597 |      0.5
+ qwertyu0598 |      0.5
+ qwertyu0599 |      0.5
+ qwertyu0600 |      0.5
+ qwertyu0601 |      0.5
+ qwertyu0602 |      0.5
+ qwertyu0603 |      0.5
+ qwertyu0604 |      0.5
+ qwertyu0605 |      0.5
+ qwertyu0606 |      0.5
+ qwertyu0607 |      0.5
+ qwertyu0608 |      0.5
+ qwertyu0609 |      0.5
+ qwertyu0610 |      0.5
+ qwertyu0611 |      0.5
+ qwertyu0612 |      0.5
+ qwertyu0613 |      0.5
+ qwertyu0614 |      0.5
+ qwertyu0615 |      0.5
+ qwertyu0616 |      0.5
+ qwertyu0617 |      0.5
+ qwertyu0618 |      0.5
+ qwertyu0619 |      0.5
+ qwertyu0620 |      0.5
+ qwertyu0621 |      0.5
+ qwertyu0622 |      0.5
+ qwertyu0623 |      0.5
+ qwertyu0624 |      0.5
+ qwertyu0625 |      0.5
+ qwertyu0626 |      0.5
+ qwertyu0627 |      0.5
+ qwertyu0628 |      0.5
+ qwertyu0629 |      0.5
+ qwertyu0630 |      0.5
+ qwertyu0631 |      0.5
+ qwertyu0632 |      0.5
+ qwertyu0633 |      0.5
+ qwertyu0634 |      0.5
+ qwertyu0635 |      0.5
+ qwertyu0636 |      0.5
+ qwertyu0637 |      0.5
+ qwertyu0638 |      0.5
+ qwertyu0639 |      0.5
+ qwertyu0640 |      0.5
+ qwertyu0641 |      0.5
+ qwertyu0642 |      0.5
+ qwertyu0643 |      0.5
+ qwertyu0644 |      0.5
+ qwertyu0645 |      0.5
+ qwertyu0646 |      0.5
+ qwertyu0647 |      0.5
+ qwertyu0648 |      0.5
+ qwertyu0649 |      0.5
+ qwertyu0650 |      0.5
+ qwertyu0651 |      0.5
+ qwertyu0652 |      0.5
+ qwertyu0653 |      0.5
+ qwertyu0654 |      0.5
+ qwertyu0655 |      0.5
+ qwertyu0656 |      0.5
+ qwertyu0657 |      0.5
+ qwertyu0658 |      0.5
+ qwertyu0659 |      0.5
+ qwertyu0660 |      0.5
+ qwertyu0661 |      0.5
+ qwertyu0662 |      0.5
+ qwertyu0663 |      0.5
+ qwertyu0664 |      0.5
+ qwertyu0665 |      0.5
+ qwertyu0666 |      0.5
+ qwertyu0667 |      0.5
+ qwertyu0668 |      0.5
+ qwertyu0669 |      0.5
+ qwertyu0670 |      0.5
+ qwertyu0671 |      0.5
+ qwertyu0672 |      0.5
+ qwertyu0673 |      0.5
+ qwertyu0674 |      0.5
+ qwertyu0675 |      0.5
+ qwertyu0676 |      0.5
+ qwertyu0677 |      0.5
+ qwertyu0678 |      0.5
+ qwertyu0679 |      0.5
+ qwertyu0680 |      0.5
+ qwertyu0681 |      0.5
+ qwertyu0682 |      0.5
+ qwertyu0683 |      0.5
+ qwertyu0684 |      0.5
+ qwertyu0685 |      0.5
+ qwertyu0686 |      0.5
+ qwertyu0687 |      0.5
+ qwertyu0689 |      0.5
+ qwertyu0690 |      0.5
+ qwertyu0691 |      0.5
+ qwertyu0692 |      0.5
+ qwertyu0693 |      0.5
+ qwertyu0694 |      0.5
+ qwertyu0695 |      0.5
+ qwertyu0696 |      0.5
+ qwertyu0697 |      0.5
+ qwertyu0698 |      0.5
+ qwertyu0699 |      0.5
+ qwertyu0700 |      0.5
+ qwertyu0701 |      0.5
+ qwertyu0702 |      0.5
+ qwertyu0703 |      0.5
+ qwertyu0704 |      0.5
+ qwertyu0705 |      0.5
+ qwertyu0706 |      0.5
+ qwertyu0707 |      0.5
+ qwertyu0708 |      0.5
+ qwertyu0709 |      0.5
+ qwertyu0710 |      0.5
+ qwertyu0711 |      0.5
+ qwertyu0712 |      0.5
+ qwertyu0713 |      0.5
+ qwertyu0714 |      0.5
+ qwertyu0715 |      0.5
+ qwertyu0716 |      0.5
+ qwertyu0717 |      0.5
+ qwertyu0718 |      0.5
+ qwertyu0719 |      0.5
+ qwertyu0720 |      0.5
+ qwertyu0721 |      0.5
+ qwertyu0722 |      0.5
+ qwertyu0723 |      0.5
+ qwertyu0724 |      0.5
+ qwertyu0725 |      0.5
+ qwertyu0726 |      0.5
+ qwertyu0727 |      0.5
+ qwertyu0728 |      0.5
+ qwertyu0729 |      0.5
+ qwertyu0730 |      0.5
+ qwertyu0731 |      0.5
+ qwertyu0732 |      0.5
+ qwertyu0733 |      0.5
+ qwertyu0734 |      0.5
+ qwertyu0735 |      0.5
+ qwertyu0736 |      0.5
+ qwertyu0737 |      0.5
+ qwertyu0738 |      0.5
+ qwertyu0739 |      0.5
+ qwertyu0740 |      0.5
+ qwertyu0741 |      0.5
+ qwertyu0742 |      0.5
+ qwertyu0743 |      0.5
+ qwertyu0744 |      0.5
+ qwertyu0745 |      0.5
+ qwertyu0746 |      0.5
+ qwertyu0747 |      0.5
+ qwertyu0748 |      0.5
+ qwertyu0749 |      0.5
+ qwertyu0750 |      0.5
+ qwertyu0751 |      0.5
+ qwertyu0752 |      0.5
+ qwertyu0753 |      0.5
+ qwertyu0754 |      0.5
+ qwertyu0755 |      0.5
+ qwertyu0756 |      0.5
+ qwertyu0757 |      0.5
+ qwertyu0758 |      0.5
+ qwertyu0759 |      0.5
+ qwertyu0760 |      0.5
+ qwertyu0761 |      0.5
+ qwertyu0762 |      0.5
+ qwertyu0763 |      0.5
+ qwertyu0764 |      0.5
+ qwertyu0765 |      0.5
+ qwertyu0766 |      0.5
+ qwertyu0767 |      0.5
+ qwertyu0768 |      0.5
+ qwertyu0769 |      0.5
+ qwertyu0770 |      0.5
+ qwertyu0771 |      0.5
+ qwertyu0772 |      0.5
+ qwertyu0773 |      0.5
+ qwertyu0774 |      0.5
+ qwertyu0775 |      0.5
+ qwertyu0776 |      0.5
+ qwertyu0777 |      0.5
+ qwertyu0778 |      0.5
+ qwertyu0779 |      0.5
+ qwertyu0780 |      0.5
+ qwertyu0781 |      0.5
+ qwertyu0782 |      0.5
+ qwertyu0783 |      0.5
+ qwertyu0784 |      0.5
+ qwertyu0785 |      0.5
+ qwertyu0786 |      0.5
+ qwertyu0787 |      0.5
+ qwertyu0789 |      0.5
+ qwertyu0790 |      0.5
+ qwertyu0791 |      0.5
+ qwertyu0792 |      0.5
+ qwertyu0793 |      0.5
+ qwertyu0794 |      0.5
+ qwertyu0795 |      0.5
+ qwertyu0796 |      0.5
+ qwertyu0797 |      0.5
+ qwertyu0798 |      0.5
+ qwertyu0799 |      0.5
+ qwertyu0800 |      0.5
+ qwertyu0801 |      0.5
+ qwertyu0802 |      0.5
+ qwertyu0803 |      0.5
+ qwertyu0804 |      0.5
+ qwertyu0805 |      0.5
+ qwertyu0806 |      0.5
+ qwertyu0807 |      0.5
+ qwertyu0808 |      0.5
+ qwertyu0809 |      0.5
+ qwertyu0810 |      0.5
+ qwertyu0811 |      0.5
+ qwertyu0812 |      0.5
+ qwertyu0813 |      0.5
+ qwertyu0814 |      0.5
+ qwertyu0815 |      0.5
+ qwertyu0816 |      0.5
+ qwertyu0817 |      0.5
+ qwertyu0818 |      0.5
+ qwertyu0819 |      0.5
+ qwertyu0820 |      0.5
+ qwertyu0821 |      0.5
+ qwertyu0822 |      0.5
+ qwertyu0823 |      0.5
+ qwertyu0824 |      0.5
+ qwertyu0825 |      0.5
+ qwertyu0826 |      0.5
+ qwertyu0827 |      0.5
+ qwertyu0828 |      0.5
+ qwertyu0829 |      0.5
+ qwertyu0830 |      0.5
+ qwertyu0831 |      0.5
+ qwertyu0832 |      0.5
+ qwertyu0833 |      0.5
+ qwertyu0834 |      0.5
+ qwertyu0835 |      0.5
+ qwertyu0836 |      0.5
+ qwertyu0837 |      0.5
+ qwertyu0838 |      0.5
+ qwertyu0839 |      0.5
+ qwertyu0840 |      0.5
+ qwertyu0841 |      0.5
+ qwertyu0842 |      0.5
+ qwertyu0843 |      0.5
+ qwertyu0844 |      0.5
+ qwertyu0845 |      0.5
+ qwertyu0846 |      0.5
+ qwertyu0847 |      0.5
+ qwertyu0848 |      0.5
+ qwertyu0849 |      0.5
+ qwertyu0850 |      0.5
+ qwertyu0851 |      0.5
+ qwertyu0852 |      0.5
+ qwertyu0853 |      0.5
+ qwertyu0854 |      0.5
+ qwertyu0855 |      0.5
+ qwertyu0856 |      0.5
+ qwertyu0857 |      0.5
+ qwertyu0858 |      0.5
+ qwertyu0859 |      0.5
+ qwertyu0860 |      0.5
+ qwertyu0861 |      0.5
+ qwertyu0862 |      0.5
+ qwertyu0863 |      0.5
+ qwertyu0864 |      0.5
+ qwertyu0865 |      0.5
+ qwertyu0866 |      0.5
+ qwertyu0867 |      0.5
+ qwertyu0868 |      0.5
+ qwertyu0869 |      0.5
+ qwertyu0870 |      0.5
+ qwertyu0871 |      0.5
+ qwertyu0872 |      0.5
+ qwertyu0873 |      0.5
+ qwertyu0874 |      0.5
+ qwertyu0875 |      0.5
+ qwertyu0876 |      0.5
+ qwertyu0877 |      0.5
+ qwertyu0878 |      0.5
+ qwertyu0879 |      0.5
+ qwertyu0880 |      0.5
+ qwertyu0881 |      0.5
+ qwertyu0882 |      0.5
+ qwertyu0883 |      0.5
+ qwertyu0884 |      0.5
+ qwertyu0885 |      0.5
+ qwertyu0886 |      0.5
+ qwertyu0887 |      0.5
+ qwertyu0889 |      0.5
+ qwertyu0890 |      0.5
+ qwertyu0891 |      0.5
+ qwertyu0892 |      0.5
+ qwertyu0893 |      0.5
+ qwertyu0894 |      0.5
+ qwertyu0895 |      0.5
+ qwertyu0896 |      0.5
+ qwertyu0897 |      0.5
+ qwertyu0898 |      0.5
+ qwertyu0899 |      0.5
+ qwertyu1000 | 0.411765
+(1000 rows)
+
+select t,similarity(t,'gwertyu0988') as sml from test_trgm where t % 'gwertyu0988' order by sml desc, t;
+      t      |   sml    
+-------------+----------
+ qwertyu0988 |      0.6
+ qwertyu0980 | 0.411765
+ qwertyu0981 | 0.411765
+ qwertyu0982 | 0.411765
+ qwertyu0983 | 0.411765
+ qwertyu0984 | 0.411765
+ qwertyu0985 | 0.411765
+ qwertyu0986 | 0.411765
+ qwertyu0987 | 0.411765
+ qwertyu0989 | 0.411765
+ qwertyu0088 | 0.333333
+ qwertyu0098 | 0.333333
+ qwertyu0188 | 0.333333
+ qwertyu0288 | 0.333333
+ qwertyu0388 | 0.333333
+ qwertyu0488 | 0.333333
+ qwertyu0588 | 0.333333
+ qwertyu0688 | 0.333333
+ qwertyu0788 | 0.333333
+ qwertyu0888 | 0.333333
+ qwertyu0900 | 0.333333
+ qwertyu0901 | 0.333333
+ qwertyu0902 | 0.333333
+ qwertyu0903 | 0.333333
+ qwertyu0904 | 0.333333
+ qwertyu0905 | 0.333333
+ qwertyu0906 | 0.333333
+ qwertyu0907 | 0.333333
+ qwertyu0908 | 0.333333
+ qwertyu0909 | 0.333333
+ qwertyu0910 | 0.333333
+ qwertyu0911 | 0.333333
+ qwertyu0912 | 0.333333
+ qwertyu0913 | 0.333333
+ qwertyu0914 | 0.333333
+ qwertyu0915 | 0.333333
+ qwertyu0916 | 0.333333
+ qwertyu0917 | 0.333333
+ qwertyu0918 | 0.333333
+ qwertyu0919 | 0.333333
+ qwertyu0920 | 0.333333
+ qwertyu0921 | 0.333333
+ qwertyu0922 | 0.333333
+ qwertyu0923 | 0.333333
+ qwertyu0924 | 0.333333
+ qwertyu0925 | 0.333333
+ qwertyu0926 | 0.333333
+ qwertyu0927 | 0.333333
+ qwertyu0928 | 0.333333
+ qwertyu0929 | 0.333333
+ qwertyu0930 | 0.333333
+ qwertyu0931 | 0.333333
+ qwertyu0932 | 0.333333
+ qwertyu0933 | 0.333333
+ qwertyu0934 | 0.333333
+ qwertyu0935 | 0.333333
+ qwertyu0936 | 0.333333
+ qwertyu0937 | 0.333333
+ qwertyu0938 | 0.333333
+ qwertyu0939 | 0.333333
+ qwertyu0940 | 0.333333
+ qwertyu0941 | 0.333333
+ qwertyu0942 | 0.333333
+ qwertyu0943 | 0.333333
+ qwertyu0944 | 0.333333
+ qwertyu0945 | 0.333333
+ qwertyu0946 | 0.333333
+ qwertyu0947 | 0.333333
+ qwertyu0948 | 0.333333
+ qwertyu0949 | 0.333333
+ qwertyu0950 | 0.333333
+ qwertyu0951 | 0.333333
+ qwertyu0952 | 0.333333
+ qwertyu0953 | 0.333333
+ qwertyu0954 | 0.333333
+ qwertyu0955 | 0.333333
+ qwertyu0956 | 0.333333
+ qwertyu0957 | 0.333333
+ qwertyu0958 | 0.333333
+ qwertyu0959 | 0.333333
+ qwertyu0960 | 0.333333
+ qwertyu0961 | 0.333333
+ qwertyu0962 | 0.333333
+ qwertyu0963 | 0.333333
+ qwertyu0964 | 0.333333
+ qwertyu0965 | 0.333333
+ qwertyu0966 | 0.333333
+ qwertyu0967 | 0.333333
+ qwertyu0968 | 0.333333
+ qwertyu0969 | 0.333333
+ qwertyu0970 | 0.333333
+ qwertyu0971 | 0.333333
+ qwertyu0972 | 0.333333
+ qwertyu0973 | 0.333333
+ qwertyu0974 | 0.333333
+ qwertyu0975 | 0.333333
+ qwertyu0976 | 0.333333
+ qwertyu0977 | 0.333333
+ qwertyu0978 | 0.333333
+ qwertyu0979 | 0.333333
+ qwertyu0990 | 0.333333
+ qwertyu0991 | 0.333333
+ qwertyu0992 | 0.333333
+ qwertyu0993 | 0.333333
+ qwertyu0994 | 0.333333
+ qwertyu0995 | 0.333333
+ qwertyu0996 | 0.333333
+ qwertyu0997 | 0.333333
+ qwertyu0998 | 0.333333
+ qwertyu0999 | 0.333333
+(110 rows)
+
+select t,similarity(t,'gwertyu1988') as sml from test_trgm where t % 'gwertyu1988' order by sml desc, t;
+      t      |   sml    
+-------------+----------
+ qwertyu0988 | 0.333333
+(1 row)
+
+explain (costs off)
+select t <-> 'q0987wertyu0988', t from test_trgm order by t <-> 'q0987wertyu0988' limit 2;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Limit
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: ((t <-> 'q0987wertyu0988'::text))
+         ->  Limit
+               ->  Index Scan using trgm_idx on test_trgm
+                     Order By: (t <-> 'q0987wertyu0988'::text)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select t <-> 'q0987wertyu0988', t from test_trgm order by t <-> 'q0987wertyu0988' limit 2;
+ ?column? |      t      
+----------+-------------
+ 0.411765 | qwertyu0988
+      0.5 | qwertyu0987
+(2 rows)
+
+select count(*) from test_trgm where t ~ '[qwerty]{2}-?[qwerty]{2}';
+ count 
+-------
+  1000
+(1 row)
+
+drop index trgm_idx;
+create index trgm_idx on test_trgm using gin (t gin_trgm_ops);
+set enable_seqscan=off;
+select t,similarity(t,'qwertyu0988') as sml from test_trgm where t % 'qwertyu0988' order by sml desc, t;
+      t      |   sml    
+-------------+----------
+ qwertyu0988 |        1
+ qwertyu0980 | 0.714286
+ qwertyu0981 | 0.714286
+ qwertyu0982 | 0.714286
+ qwertyu0983 | 0.714286
+ qwertyu0984 | 0.714286
+ qwertyu0985 | 0.714286
+ qwertyu0986 | 0.714286
+ qwertyu0987 | 0.714286
+ qwertyu0989 | 0.714286
+ qwertyu0088 |      0.6
+ qwertyu0098 |      0.6
+ qwertyu0188 |      0.6
+ qwertyu0288 |      0.6
+ qwertyu0388 |      0.6
+ qwertyu0488 |      0.6
+ qwertyu0588 |      0.6
+ qwertyu0688 |      0.6
+ qwertyu0788 |      0.6
+ qwertyu0888 |      0.6
+ qwertyu0900 |      0.6
+ qwertyu0901 |      0.6
+ qwertyu0902 |      0.6
+ qwertyu0903 |      0.6
+ qwertyu0904 |      0.6
+ qwertyu0905 |      0.6
+ qwertyu0906 |      0.6
+ qwertyu0907 |      0.6
+ qwertyu0908 |      0.6
+ qwertyu0909 |      0.6
+ qwertyu0910 |      0.6
+ qwertyu0911 |      0.6
+ qwertyu0912 |      0.6
+ qwertyu0913 |      0.6
+ qwertyu0914 |      0.6
+ qwertyu0915 |      0.6
+ qwertyu0916 |      0.6
+ qwertyu0917 |      0.6
+ qwertyu0918 |      0.6
+ qwertyu0919 |      0.6
+ qwertyu0920 |      0.6
+ qwertyu0921 |      0.6
+ qwertyu0922 |      0.6
+ qwertyu0923 |      0.6
+ qwertyu0924 |      0.6
+ qwertyu0925 |      0.6
+ qwertyu0926 |      0.6
+ qwertyu0927 |      0.6
+ qwertyu0928 |      0.6
+ qwertyu0929 |      0.6
+ qwertyu0930 |      0.6
+ qwertyu0931 |      0.6
+ qwertyu0932 |      0.6
+ qwertyu0933 |      0.6
+ qwertyu0934 |      0.6
+ qwertyu0935 |      0.6
+ qwertyu0936 |      0.6
+ qwertyu0937 |      0.6
+ qwertyu0938 |      0.6
+ qwertyu0939 |      0.6
+ qwertyu0940 |      0.6
+ qwertyu0941 |      0.6
+ qwertyu0942 |      0.6
+ qwertyu0943 |      0.6
+ qwertyu0944 |      0.6
+ qwertyu0945 |      0.6
+ qwertyu0946 |      0.6
+ qwertyu0947 |      0.6
+ qwertyu0948 |      0.6
+ qwertyu0949 |      0.6
+ qwertyu0950 |      0.6
+ qwertyu0951 |      0.6
+ qwertyu0952 |      0.6
+ qwertyu0953 |      0.6
+ qwertyu0954 |      0.6
+ qwertyu0955 |      0.6
+ qwertyu0956 |      0.6
+ qwertyu0957 |      0.6
+ qwertyu0958 |      0.6
+ qwertyu0959 |      0.6
+ qwertyu0960 |      0.6
+ qwertyu0961 |      0.6
+ qwertyu0962 |      0.6
+ qwertyu0963 |      0.6
+ qwertyu0964 |      0.6
+ qwertyu0965 |      0.6
+ qwertyu0966 |      0.6
+ qwertyu0967 |      0.6
+ qwertyu0968 |      0.6
+ qwertyu0969 |      0.6
+ qwertyu0970 |      0.6
+ qwertyu0971 |      0.6
+ qwertyu0972 |      0.6
+ qwertyu0973 |      0.6
+ qwertyu0974 |      0.6
+ qwertyu0975 |      0.6
+ qwertyu0976 |      0.6
+ qwertyu0977 |      0.6
+ qwertyu0978 |      0.6
+ qwertyu0979 |      0.6
+ qwertyu0990 |      0.6
+ qwertyu0991 |      0.6
+ qwertyu0992 |      0.6
+ qwertyu0993 |      0.6
+ qwertyu0994 |      0.6
+ qwertyu0995 |      0.6
+ qwertyu0996 |      0.6
+ qwertyu0997 |      0.6
+ qwertyu0998 |      0.6
+ qwertyu0999 |      0.6
+ qwertyu0001 |      0.5
+ qwertyu0002 |      0.5
+ qwertyu0003 |      0.5
+ qwertyu0004 |      0.5
+ qwertyu0005 |      0.5
+ qwertyu0006 |      0.5
+ qwertyu0007 |      0.5
+ qwertyu0008 |      0.5
+ qwertyu0009 |      0.5
+ qwertyu0010 |      0.5
+ qwertyu0011 |      0.5
+ qwertyu0012 |      0.5
+ qwertyu0013 |      0.5
+ qwertyu0014 |      0.5
+ qwertyu0015 |      0.5
+ qwertyu0016 |      0.5
+ qwertyu0017 |      0.5
+ qwertyu0018 |      0.5
+ qwertyu0019 |      0.5
+ qwertyu0020 |      0.5
+ qwertyu0021 |      0.5
+ qwertyu0022 |      0.5
+ qwertyu0023 |      0.5
+ qwertyu0024 |      0.5
+ qwertyu0025 |      0.5
+ qwertyu0026 |      0.5
+ qwertyu0027 |      0.5
+ qwertyu0028 |      0.5
+ qwertyu0029 |      0.5
+ qwertyu0030 |      0.5
+ qwertyu0031 |      0.5
+ qwertyu0032 |      0.5
+ qwertyu0033 |      0.5
+ qwertyu0034 |      0.5
+ qwertyu0035 |      0.5
+ qwertyu0036 |      0.5
+ qwertyu0037 |      0.5
+ qwertyu0038 |      0.5
+ qwertyu0039 |      0.5
+ qwertyu0040 |      0.5
+ qwertyu0041 |      0.5
+ qwertyu0042 |      0.5
+ qwertyu0043 |      0.5
+ qwertyu0044 |      0.5
+ qwertyu0045 |      0.5
+ qwertyu0046 |      0.5
+ qwertyu0047 |      0.5
+ qwertyu0048 |      0.5
+ qwertyu0049 |      0.5
+ qwertyu0050 |      0.5
+ qwertyu0051 |      0.5
+ qwertyu0052 |      0.5
+ qwertyu0053 |      0.5
+ qwertyu0054 |      0.5
+ qwertyu0055 |      0.5
+ qwertyu0056 |      0.5
+ qwertyu0057 |      0.5
+ qwertyu0058 |      0.5
+ qwertyu0059 |      0.5
+ qwertyu0060 |      0.5
+ qwertyu0061 |      0.5
+ qwertyu0062 |      0.5
+ qwertyu0063 |      0.5
+ qwertyu0064 |      0.5
+ qwertyu0065 |      0.5
+ qwertyu0066 |      0.5
+ qwertyu0067 |      0.5
+ qwertyu0068 |      0.5
+ qwertyu0069 |      0.5
+ qwertyu0070 |      0.5
+ qwertyu0071 |      0.5
+ qwertyu0072 |      0.5
+ qwertyu0073 |      0.5
+ qwertyu0074 |      0.5
+ qwertyu0075 |      0.5
+ qwertyu0076 |      0.5
+ qwertyu0077 |      0.5
+ qwertyu0078 |      0.5
+ qwertyu0079 |      0.5
+ qwertyu0080 |      0.5
+ qwertyu0081 |      0.5
+ qwertyu0082 |      0.5
+ qwertyu0083 |      0.5
+ qwertyu0084 |      0.5
+ qwertyu0085 |      0.5
+ qwertyu0086 |      0.5
+ qwertyu0087 |      0.5
+ qwertyu0089 |      0.5
+ qwertyu0090 |      0.5
+ qwertyu0091 |      0.5
+ qwertyu0092 |      0.5
+ qwertyu0093 |      0.5
+ qwertyu0094 |      0.5
+ qwertyu0095 |      0.5
+ qwertyu0096 |      0.5
+ qwertyu0097 |      0.5
+ qwertyu0099 |      0.5
+ qwertyu0100 |      0.5
+ qwertyu0101 |      0.5
+ qwertyu0102 |      0.5
+ qwertyu0103 |      0.5
+ qwertyu0104 |      0.5
+ qwertyu0105 |      0.5
+ qwertyu0106 |      0.5
+ qwertyu0107 |      0.5
+ qwertyu0108 |      0.5
+ qwertyu0109 |      0.5
+ qwertyu0110 |      0.5
+ qwertyu0111 |      0.5
+ qwertyu0112 |      0.5
+ qwertyu0113 |      0.5
+ qwertyu0114 |      0.5
+ qwertyu0115 |      0.5
+ qwertyu0116 |      0.5
+ qwertyu0117 |      0.5
+ qwertyu0118 |      0.5
+ qwertyu0119 |      0.5
+ qwertyu0120 |      0.5
+ qwertyu0121 |      0.5
+ qwertyu0122 |      0.5
+ qwertyu0123 |      0.5
+ qwertyu0124 |      0.5
+ qwertyu0125 |      0.5
+ qwertyu0126 |      0.5
+ qwertyu0127 |      0.5
+ qwertyu0128 |      0.5
+ qwertyu0129 |      0.5
+ qwertyu0130 |      0.5
+ qwertyu0131 |      0.5
+ qwertyu0132 |      0.5
+ qwertyu0133 |      0.5
+ qwertyu0134 |      0.5
+ qwertyu0135 |      0.5
+ qwertyu0136 |      0.5
+ qwertyu0137 |      0.5
+ qwertyu0138 |      0.5
+ qwertyu0139 |      0.5
+ qwertyu0140 |      0.5
+ qwertyu0141 |      0.5
+ qwertyu0142 |      0.5
+ qwertyu0143 |      0.5
+ qwertyu0144 |      0.5
+ qwertyu0145 |      0.5
+ qwertyu0146 |      0.5
+ qwertyu0147 |      0.5
+ qwertyu0148 |      0.5
+ qwertyu0149 |      0.5
+ qwertyu0150 |      0.5
+ qwertyu0151 |      0.5
+ qwertyu0152 |      0.5
+ qwertyu0153 |      0.5
+ qwertyu0154 |      0.5
+ qwertyu0155 |      0.5
+ qwertyu0156 |      0.5
+ qwertyu0157 |      0.5
+ qwertyu0158 |      0.5
+ qwertyu0159 |      0.5
+ qwertyu0160 |      0.5
+ qwertyu0161 |      0.5
+ qwertyu0162 |      0.5
+ qwertyu0163 |      0.5
+ qwertyu0164 |      0.5
+ qwertyu0165 |      0.5
+ qwertyu0166 |      0.5
+ qwertyu0167 |      0.5
+ qwertyu0168 |      0.5
+ qwertyu0169 |      0.5
+ qwertyu0170 |      0.5
+ qwertyu0171 |      0.5
+ qwertyu0172 |      0.5
+ qwertyu0173 |      0.5
+ qwertyu0174 |      0.5
+ qwertyu0175 |      0.5
+ qwertyu0176 |      0.5
+ qwertyu0177 |      0.5
+ qwertyu0178 |      0.5
+ qwertyu0179 |      0.5
+ qwertyu0180 |      0.5
+ qwertyu0181 |      0.5
+ qwertyu0182 |      0.5
+ qwertyu0183 |      0.5
+ qwertyu0184 |      0.5
+ qwertyu0185 |      0.5
+ qwertyu0186 |      0.5
+ qwertyu0187 |      0.5
+ qwertyu0189 |      0.5
+ qwertyu0190 |      0.5
+ qwertyu0191 |      0.5
+ qwertyu0192 |      0.5
+ qwertyu0193 |      0.5
+ qwertyu0194 |      0.5
+ qwertyu0195 |      0.5
+ qwertyu0196 |      0.5
+ qwertyu0197 |      0.5
+ qwertyu0198 |      0.5
+ qwertyu0199 |      0.5
+ qwertyu0200 |      0.5
+ qwertyu0201 |      0.5
+ qwertyu0202 |      0.5
+ qwertyu0203 |      0.5
+ qwertyu0204 |      0.5
+ qwertyu0205 |      0.5
+ qwertyu0206 |      0.5
+ qwertyu0207 |      0.5
+ qwertyu0208 |      0.5
+ qwertyu0209 |      0.5
+ qwertyu0210 |      0.5
+ qwertyu0211 |      0.5
+ qwertyu0212 |      0.5
+ qwertyu0213 |      0.5
+ qwertyu0214 |      0.5
+ qwertyu0215 |      0.5
+ qwertyu0216 |      0.5
+ qwertyu0217 |      0.5
+ qwertyu0218 |      0.5
+ qwertyu0219 |      0.5
+ qwertyu0220 |      0.5
+ qwertyu0221 |      0.5
+ qwertyu0222 |      0.5
+ qwertyu0223 |      0.5
+ qwertyu0224 |      0.5
+ qwertyu0225 |      0.5
+ qwertyu0226 |      0.5
+ qwertyu0227 |      0.5
+ qwertyu0228 |      0.5
+ qwertyu0229 |      0.5
+ qwertyu0230 |      0.5
+ qwertyu0231 |      0.5
+ qwertyu0232 |      0.5
+ qwertyu0233 |      0.5
+ qwertyu0234 |      0.5
+ qwertyu0235 |      0.5
+ qwertyu0236 |      0.5
+ qwertyu0237 |      0.5
+ qwertyu0238 |      0.5
+ qwertyu0239 |      0.5
+ qwertyu0240 |      0.5
+ qwertyu0241 |      0.5
+ qwertyu0242 |      0.5
+ qwertyu0243 |      0.5
+ qwertyu0244 |      0.5
+ qwertyu0245 |      0.5
+ qwertyu0246 |      0.5
+ qwertyu0247 |      0.5
+ qwertyu0248 |      0.5
+ qwertyu0249 |      0.5
+ qwertyu0250 |      0.5
+ qwertyu0251 |      0.5
+ qwertyu0252 |      0.5
+ qwertyu0253 |      0.5
+ qwertyu0254 |      0.5
+ qwertyu0255 |      0.5
+ qwertyu0256 |      0.5
+ qwertyu0257 |      0.5
+ qwertyu0258 |      0.5
+ qwertyu0259 |      0.5
+ qwertyu0260 |      0.5
+ qwertyu0261 |      0.5
+ qwertyu0262 |      0.5
+ qwertyu0263 |      0.5
+ qwertyu0264 |      0.5
+ qwertyu0265 |      0.5
+ qwertyu0266 |      0.5
+ qwertyu0267 |      0.5
+ qwertyu0268 |      0.5
+ qwertyu0269 |      0.5
+ qwertyu0270 |      0.5
+ qwertyu0271 |      0.5
+ qwertyu0272 |      0.5
+ qwertyu0273 |      0.5
+ qwertyu0274 |      0.5
+ qwertyu0275 |      0.5
+ qwertyu0276 |      0.5
+ qwertyu0277 |      0.5
+ qwertyu0278 |      0.5
+ qwertyu0279 |      0.5
+ qwertyu0280 |      0.5
+ qwertyu0281 |      0.5
+ qwertyu0282 |      0.5
+ qwertyu0283 |      0.5
+ qwertyu0284 |      0.5
+ qwertyu0285 |      0.5
+ qwertyu0286 |      0.5
+ qwertyu0287 |      0.5
+ qwertyu0289 |      0.5
+ qwertyu0290 |      0.5
+ qwertyu0291 |      0.5
+ qwertyu0292 |      0.5
+ qwertyu0293 |      0.5
+ qwertyu0294 |      0.5
+ qwertyu0295 |      0.5
+ qwertyu0296 |      0.5
+ qwertyu0297 |      0.5
+ qwertyu0298 |      0.5
+ qwertyu0299 |      0.5
+ qwertyu0300 |      0.5
+ qwertyu0301 |      0.5
+ qwertyu0302 |      0.5
+ qwertyu0303 |      0.5
+ qwertyu0304 |      0.5
+ qwertyu0305 |      0.5
+ qwertyu0306 |      0.5
+ qwertyu0307 |      0.5
+ qwertyu0308 |      0.5
+ qwertyu0309 |      0.5
+ qwertyu0310 |      0.5
+ qwertyu0311 |      0.5
+ qwertyu0312 |      0.5
+ qwertyu0313 |      0.5
+ qwertyu0314 |      0.5
+ qwertyu0315 |      0.5
+ qwertyu0316 |      0.5
+ qwertyu0317 |      0.5
+ qwertyu0318 |      0.5
+ qwertyu0319 |      0.5
+ qwertyu0320 |      0.5
+ qwertyu0321 |      0.5
+ qwertyu0322 |      0.5
+ qwertyu0323 |      0.5
+ qwertyu0324 |      0.5
+ qwertyu0325 |      0.5
+ qwertyu0326 |      0.5
+ qwertyu0327 |      0.5
+ qwertyu0328 |      0.5
+ qwertyu0329 |      0.5
+ qwertyu0330 |      0.5
+ qwertyu0331 |      0.5
+ qwertyu0332 |      0.5
+ qwertyu0333 |      0.5
+ qwertyu0334 |      0.5
+ qwertyu0335 |      0.5
+ qwertyu0336 |      0.5
+ qwertyu0337 |      0.5
+ qwertyu0338 |      0.5
+ qwertyu0339 |      0.5
+ qwertyu0340 |      0.5
+ qwertyu0341 |      0.5
+ qwertyu0342 |      0.5
+ qwertyu0343 |      0.5
+ qwertyu0344 |      0.5
+ qwertyu0345 |      0.5
+ qwertyu0346 |      0.5
+ qwertyu0347 |      0.5
+ qwertyu0348 |      0.5
+ qwertyu0349 |      0.5
+ qwertyu0350 |      0.5
+ qwertyu0351 |      0.5
+ qwertyu0352 |      0.5
+ qwertyu0353 |      0.5
+ qwertyu0354 |      0.5
+ qwertyu0355 |      0.5
+ qwertyu0356 |      0.5
+ qwertyu0357 |      0.5
+ qwertyu0358 |      0.5
+ qwertyu0359 |      0.5
+ qwertyu0360 |      0.5
+ qwertyu0361 |      0.5
+ qwertyu0362 |      0.5
+ qwertyu0363 |      0.5
+ qwertyu0364 |      0.5
+ qwertyu0365 |      0.5
+ qwertyu0366 |      0.5
+ qwertyu0367 |      0.5
+ qwertyu0368 |      0.5
+ qwertyu0369 |      0.5
+ qwertyu0370 |      0.5
+ qwertyu0371 |      0.5
+ qwertyu0372 |      0.5
+ qwertyu0373 |      0.5
+ qwertyu0374 |      0.5
+ qwertyu0375 |      0.5
+ qwertyu0376 |      0.5
+ qwertyu0377 |      0.5
+ qwertyu0378 |      0.5
+ qwertyu0379 |      0.5
+ qwertyu0380 |      0.5
+ qwertyu0381 |      0.5
+ qwertyu0382 |      0.5
+ qwertyu0383 |      0.5
+ qwertyu0384 |      0.5
+ qwertyu0385 |      0.5
+ qwertyu0386 |      0.5
+ qwertyu0387 |      0.5
+ qwertyu0389 |      0.5
+ qwertyu0390 |      0.5
+ qwertyu0391 |      0.5
+ qwertyu0392 |      0.5
+ qwertyu0393 |      0.5
+ qwertyu0394 |      0.5
+ qwertyu0395 |      0.5
+ qwertyu0396 |      0.5
+ qwertyu0397 |      0.5
+ qwertyu0398 |      0.5
+ qwertyu0399 |      0.5
+ qwertyu0400 |      0.5
+ qwertyu0401 |      0.5
+ qwertyu0402 |      0.5
+ qwertyu0403 |      0.5
+ qwertyu0404 |      0.5
+ qwertyu0405 |      0.5
+ qwertyu0406 |      0.5
+ qwertyu0407 |      0.5
+ qwertyu0408 |      0.5
+ qwertyu0409 |      0.5
+ qwertyu0410 |      0.5
+ qwertyu0411 |      0.5
+ qwertyu0412 |      0.5
+ qwertyu0413 |      0.5
+ qwertyu0414 |      0.5
+ qwertyu0415 |      0.5
+ qwertyu0416 |      0.5
+ qwertyu0417 |      0.5
+ qwertyu0418 |      0.5
+ qwertyu0419 |      0.5
+ qwertyu0420 |      0.5
+ qwertyu0421 |      0.5
+ qwertyu0422 |      0.5
+ qwertyu0423 |      0.5
+ qwertyu0424 |      0.5
+ qwertyu0425 |      0.5
+ qwertyu0426 |      0.5
+ qwertyu0427 |      0.5
+ qwertyu0428 |      0.5
+ qwertyu0429 |      0.5
+ qwertyu0430 |      0.5
+ qwertyu0431 |      0.5
+ qwertyu0432 |      0.5
+ qwertyu0433 |      0.5
+ qwertyu0434 |      0.5
+ qwertyu0435 |      0.5
+ qwertyu0436 |      0.5
+ qwertyu0437 |      0.5
+ qwertyu0438 |      0.5
+ qwertyu0439 |      0.5
+ qwertyu0440 |      0.5
+ qwertyu0441 |      0.5
+ qwertyu0442 |      0.5
+ qwertyu0443 |      0.5
+ qwertyu0444 |      0.5
+ qwertyu0445 |      0.5
+ qwertyu0446 |      0.5
+ qwertyu0447 |      0.5
+ qwertyu0448 |      0.5
+ qwertyu0449 |      0.5
+ qwertyu0450 |      0.5
+ qwertyu0451 |      0.5
+ qwertyu0452 |      0.5
+ qwertyu0453 |      0.5
+ qwertyu0454 |      0.5
+ qwertyu0455 |      0.5
+ qwertyu0456 |      0.5
+ qwertyu0457 |      0.5
+ qwertyu0458 |      0.5
+ qwertyu0459 |      0.5
+ qwertyu0460 |      0.5
+ qwertyu0461 |      0.5
+ qwertyu0462 |      0.5
+ qwertyu0463 |      0.5
+ qwertyu0464 |      0.5
+ qwertyu0465 |      0.5
+ qwertyu0466 |      0.5
+ qwertyu0467 |      0.5
+ qwertyu0468 |      0.5
+ qwertyu0469 |      0.5
+ qwertyu0470 |      0.5
+ qwertyu0471 |      0.5
+ qwertyu0472 |      0.5
+ qwertyu0473 |      0.5
+ qwertyu0474 |      0.5
+ qwertyu0475 |      0.5
+ qwertyu0476 |      0.5
+ qwertyu0477 |      0.5
+ qwertyu0478 |      0.5
+ qwertyu0479 |      0.5
+ qwertyu0480 |      0.5
+ qwertyu0481 |      0.5
+ qwertyu0482 |      0.5
+ qwertyu0483 |      0.5
+ qwertyu0484 |      0.5
+ qwertyu0485 |      0.5
+ qwertyu0486 |      0.5
+ qwertyu0487 |      0.5
+ qwertyu0489 |      0.5
+ qwertyu0490 |      0.5
+ qwertyu0491 |      0.5
+ qwertyu0492 |      0.5
+ qwertyu0493 |      0.5
+ qwertyu0494 |      0.5
+ qwertyu0495 |      0.5
+ qwertyu0496 |      0.5
+ qwertyu0497 |      0.5
+ qwertyu0498 |      0.5
+ qwertyu0499 |      0.5
+ qwertyu0500 |      0.5
+ qwertyu0501 |      0.5
+ qwertyu0502 |      0.5
+ qwertyu0503 |      0.5
+ qwertyu0504 |      0.5
+ qwertyu0505 |      0.5
+ qwertyu0506 |      0.5
+ qwertyu0507 |      0.5
+ qwertyu0508 |      0.5
+ qwertyu0509 |      0.5
+ qwertyu0510 |      0.5
+ qwertyu0511 |      0.5
+ qwertyu0512 |      0.5
+ qwertyu0513 |      0.5
+ qwertyu0514 |      0.5
+ qwertyu0515 |      0.5
+ qwertyu0516 |      0.5
+ qwertyu0517 |      0.5
+ qwertyu0518 |      0.5
+ qwertyu0519 |      0.5
+ qwertyu0520 |      0.5
+ qwertyu0521 |      0.5
+ qwertyu0522 |      0.5
+ qwertyu0523 |      0.5
+ qwertyu0524 |      0.5
+ qwertyu0525 |      0.5
+ qwertyu0526 |      0.5
+ qwertyu0527 |      0.5
+ qwertyu0528 |      0.5
+ qwertyu0529 |      0.5
+ qwertyu0530 |      0.5
+ qwertyu0531 |      0.5
+ qwertyu0532 |      0.5
+ qwertyu0533 |      0.5
+ qwertyu0534 |      0.5
+ qwertyu0535 |      0.5
+ qwertyu0536 |      0.5
+ qwertyu0537 |      0.5
+ qwertyu0538 |      0.5
+ qwertyu0539 |      0.5
+ qwertyu0540 |      0.5
+ qwertyu0541 |      0.5
+ qwertyu0542 |      0.5
+ qwertyu0543 |      0.5
+ qwertyu0544 |      0.5
+ qwertyu0545 |      0.5
+ qwertyu0546 |      0.5
+ qwertyu0547 |      0.5
+ qwertyu0548 |      0.5
+ qwertyu0549 |      0.5
+ qwertyu0550 |      0.5
+ qwertyu0551 |      0.5
+ qwertyu0552 |      0.5
+ qwertyu0553 |      0.5
+ qwertyu0554 |      0.5
+ qwertyu0555 |      0.5
+ qwertyu0556 |      0.5
+ qwertyu0557 |      0.5
+ qwertyu0558 |      0.5
+ qwertyu0559 |      0.5
+ qwertyu0560 |      0.5
+ qwertyu0561 |      0.5
+ qwertyu0562 |      0.5
+ qwertyu0563 |      0.5
+ qwertyu0564 |      0.5
+ qwertyu0565 |      0.5
+ qwertyu0566 |      0.5
+ qwertyu0567 |      0.5
+ qwertyu0568 |      0.5
+ qwertyu0569 |      0.5
+ qwertyu0570 |      0.5
+ qwertyu0571 |      0.5
+ qwertyu0572 |      0.5
+ qwertyu0573 |      0.5
+ qwertyu0574 |      0.5
+ qwertyu0575 |      0.5
+ qwertyu0576 |      0.5
+ qwertyu0577 |      0.5
+ qwertyu0578 |      0.5
+ qwertyu0579 |      0.5
+ qwertyu0580 |      0.5
+ qwertyu0581 |      0.5
+ qwertyu0582 |      0.5
+ qwertyu0583 |      0.5
+ qwertyu0584 |      0.5
+ qwertyu0585 |      0.5
+ qwertyu0586 |      0.5
+ qwertyu0587 |      0.5
+ qwertyu0589 |      0.5
+ qwertyu0590 |      0.5
+ qwertyu0591 |      0.5
+ qwertyu0592 |      0.5
+ qwertyu0593 |      0.5
+ qwertyu0594 |      0.5
+ qwertyu0595 |      0.5
+ qwertyu0596 |      0.5
+ qwertyu0597 |      0.5
+ qwertyu0598 |      0.5
+ qwertyu0599 |      0.5
+ qwertyu0600 |      0.5
+ qwertyu0601 |      0.5
+ qwertyu0602 |      0.5
+ qwertyu0603 |      0.5
+ qwertyu0604 |      0.5
+ qwertyu0605 |      0.5
+ qwertyu0606 |      0.5
+ qwertyu0607 |      0.5
+ qwertyu0608 |      0.5
+ qwertyu0609 |      0.5
+ qwertyu0610 |      0.5
+ qwertyu0611 |      0.5
+ qwertyu0612 |      0.5
+ qwertyu0613 |      0.5
+ qwertyu0614 |      0.5
+ qwertyu0615 |      0.5
+ qwertyu0616 |      0.5
+ qwertyu0617 |      0.5
+ qwertyu0618 |      0.5
+ qwertyu0619 |      0.5
+ qwertyu0620 |      0.5
+ qwertyu0621 |      0.5
+ qwertyu0622 |      0.5
+ qwertyu0623 |      0.5
+ qwertyu0624 |      0.5
+ qwertyu0625 |      0.5
+ qwertyu0626 |      0.5
+ qwertyu0627 |      0.5
+ qwertyu0628 |      0.5
+ qwertyu0629 |      0.5
+ qwertyu0630 |      0.5
+ qwertyu0631 |      0.5
+ qwertyu0632 |      0.5
+ qwertyu0633 |      0.5
+ qwertyu0634 |      0.5
+ qwertyu0635 |      0.5
+ qwertyu0636 |      0.5
+ qwertyu0637 |      0.5
+ qwertyu0638 |      0.5
+ qwertyu0639 |      0.5
+ qwertyu0640 |      0.5
+ qwertyu0641 |      0.5
+ qwertyu0642 |      0.5
+ qwertyu0643 |      0.5
+ qwertyu0644 |      0.5
+ qwertyu0645 |      0.5
+ qwertyu0646 |      0.5
+ qwertyu0647 |      0.5
+ qwertyu0648 |      0.5
+ qwertyu0649 |      0.5
+ qwertyu0650 |      0.5
+ qwertyu0651 |      0.5
+ qwertyu0652 |      0.5
+ qwertyu0653 |      0.5
+ qwertyu0654 |      0.5
+ qwertyu0655 |      0.5
+ qwertyu0656 |      0.5
+ qwertyu0657 |      0.5
+ qwertyu0658 |      0.5
+ qwertyu0659 |      0.5
+ qwertyu0660 |      0.5
+ qwertyu0661 |      0.5
+ qwertyu0662 |      0.5
+ qwertyu0663 |      0.5
+ qwertyu0664 |      0.5
+ qwertyu0665 |      0.5
+ qwertyu0666 |      0.5
+ qwertyu0667 |      0.5
+ qwertyu0668 |      0.5
+ qwertyu0669 |      0.5
+ qwertyu0670 |      0.5
+ qwertyu0671 |      0.5
+ qwertyu0672 |      0.5
+ qwertyu0673 |      0.5
+ qwertyu0674 |      0.5
+ qwertyu0675 |      0.5
+ qwertyu0676 |      0.5
+ qwertyu0677 |      0.5
+ qwertyu0678 |      0.5
+ qwertyu0679 |      0.5
+ qwertyu0680 |      0.5
+ qwertyu0681 |      0.5
+ qwertyu0682 |      0.5
+ qwertyu0683 |      0.5
+ qwertyu0684 |      0.5
+ qwertyu0685 |      0.5
+ qwertyu0686 |      0.5
+ qwertyu0687 |      0.5
+ qwertyu0689 |      0.5
+ qwertyu0690 |      0.5
+ qwertyu0691 |      0.5
+ qwertyu0692 |      0.5
+ qwertyu0693 |      0.5
+ qwertyu0694 |      0.5
+ qwertyu0695 |      0.5
+ qwertyu0696 |      0.5
+ qwertyu0697 |      0.5
+ qwertyu0698 |      0.5
+ qwertyu0699 |      0.5
+ qwertyu0700 |      0.5
+ qwertyu0701 |      0.5
+ qwertyu0702 |      0.5
+ qwertyu0703 |      0.5
+ qwertyu0704 |      0.5
+ qwertyu0705 |      0.5
+ qwertyu0706 |      0.5
+ qwertyu0707 |      0.5
+ qwertyu0708 |      0.5
+ qwertyu0709 |      0.5
+ qwertyu0710 |      0.5
+ qwertyu0711 |      0.5
+ qwertyu0712 |      0.5
+ qwertyu0713 |      0.5
+ qwertyu0714 |      0.5
+ qwertyu0715 |      0.5
+ qwertyu0716 |      0.5
+ qwertyu0717 |      0.5
+ qwertyu0718 |      0.5
+ qwertyu0719 |      0.5
+ qwertyu0720 |      0.5
+ qwertyu0721 |      0.5
+ qwertyu0722 |      0.5
+ qwertyu0723 |      0.5
+ qwertyu0724 |      0.5
+ qwertyu0725 |      0.5
+ qwertyu0726 |      0.5
+ qwertyu0727 |      0.5
+ qwertyu0728 |      0.5
+ qwertyu0729 |      0.5
+ qwertyu0730 |      0.5
+ qwertyu0731 |      0.5
+ qwertyu0732 |      0.5
+ qwertyu0733 |      0.5
+ qwertyu0734 |      0.5
+ qwertyu0735 |      0.5
+ qwertyu0736 |      0.5
+ qwertyu0737 |      0.5
+ qwertyu0738 |      0.5
+ qwertyu0739 |      0.5
+ qwertyu0740 |      0.5
+ qwertyu0741 |      0.5
+ qwertyu0742 |      0.5
+ qwertyu0743 |      0.5
+ qwertyu0744 |      0.5
+ qwertyu0745 |      0.5
+ qwertyu0746 |      0.5
+ qwertyu0747 |      0.5
+ qwertyu0748 |      0.5
+ qwertyu0749 |      0.5
+ qwertyu0750 |      0.5
+ qwertyu0751 |      0.5
+ qwertyu0752 |      0.5
+ qwertyu0753 |      0.5
+ qwertyu0754 |      0.5
+ qwertyu0755 |      0.5
+ qwertyu0756 |      0.5
+ qwertyu0757 |      0.5
+ qwertyu0758 |      0.5
+ qwertyu0759 |      0.5
+ qwertyu0760 |      0.5
+ qwertyu0761 |      0.5
+ qwertyu0762 |      0.5
+ qwertyu0763 |      0.5
+ qwertyu0764 |      0.5
+ qwertyu0765 |      0.5
+ qwertyu0766 |      0.5
+ qwertyu0767 |      0.5
+ qwertyu0768 |      0.5
+ qwertyu0769 |      0.5
+ qwertyu0770 |      0.5
+ qwertyu0771 |      0.5
+ qwertyu0772 |      0.5
+ qwertyu0773 |      0.5
+ qwertyu0774 |      0.5
+ qwertyu0775 |      0.5
+ qwertyu0776 |      0.5
+ qwertyu0777 |      0.5
+ qwertyu0778 |      0.5
+ qwertyu0779 |      0.5
+ qwertyu0780 |      0.5
+ qwertyu0781 |      0.5
+ qwertyu0782 |      0.5
+ qwertyu0783 |      0.5
+ qwertyu0784 |      0.5
+ qwertyu0785 |      0.5
+ qwertyu0786 |      0.5
+ qwertyu0787 |      0.5
+ qwertyu0789 |      0.5
+ qwertyu0790 |      0.5
+ qwertyu0791 |      0.5
+ qwertyu0792 |      0.5
+ qwertyu0793 |      0.5
+ qwertyu0794 |      0.5
+ qwertyu0795 |      0.5
+ qwertyu0796 |      0.5
+ qwertyu0797 |      0.5
+ qwertyu0798 |      0.5
+ qwertyu0799 |      0.5
+ qwertyu0800 |      0.5
+ qwertyu0801 |      0.5
+ qwertyu0802 |      0.5
+ qwertyu0803 |      0.5
+ qwertyu0804 |      0.5
+ qwertyu0805 |      0.5
+ qwertyu0806 |      0.5
+ qwertyu0807 |      0.5
+ qwertyu0808 |      0.5
+ qwertyu0809 |      0.5
+ qwertyu0810 |      0.5
+ qwertyu0811 |      0.5
+ qwertyu0812 |      0.5
+ qwertyu0813 |      0.5
+ qwertyu0814 |      0.5
+ qwertyu0815 |      0.5
+ qwertyu0816 |      0.5
+ qwertyu0817 |      0.5
+ qwertyu0818 |      0.5
+ qwertyu0819 |      0.5
+ qwertyu0820 |      0.5
+ qwertyu0821 |      0.5
+ qwertyu0822 |      0.5
+ qwertyu0823 |      0.5
+ qwertyu0824 |      0.5
+ qwertyu0825 |      0.5
+ qwertyu0826 |      0.5
+ qwertyu0827 |      0.5
+ qwertyu0828 |      0.5
+ qwertyu0829 |      0.5
+ qwertyu0830 |      0.5
+ qwertyu0831 |      0.5
+ qwertyu0832 |      0.5
+ qwertyu0833 |      0.5
+ qwertyu0834 |      0.5
+ qwertyu0835 |      0.5
+ qwertyu0836 |      0.5
+ qwertyu0837 |      0.5
+ qwertyu0838 |      0.5
+ qwertyu0839 |      0.5
+ qwertyu0840 |      0.5
+ qwertyu0841 |      0.5
+ qwertyu0842 |      0.5
+ qwertyu0843 |      0.5
+ qwertyu0844 |      0.5
+ qwertyu0845 |      0.5
+ qwertyu0846 |      0.5
+ qwertyu0847 |      0.5
+ qwertyu0848 |      0.5
+ qwertyu0849 |      0.5
+ qwertyu0850 |      0.5
+ qwertyu0851 |      0.5
+ qwertyu0852 |      0.5
+ qwertyu0853 |      0.5
+ qwertyu0854 |      0.5
+ qwertyu0855 |      0.5
+ qwertyu0856 |      0.5
+ qwertyu0857 |      0.5
+ qwertyu0858 |      0.5
+ qwertyu0859 |      0.5
+ qwertyu0860 |      0.5
+ qwertyu0861 |      0.5
+ qwertyu0862 |      0.5
+ qwertyu0863 |      0.5
+ qwertyu0864 |      0.5
+ qwertyu0865 |      0.5
+ qwertyu0866 |      0.5
+ qwertyu0867 |      0.5
+ qwertyu0868 |      0.5
+ qwertyu0869 |      0.5
+ qwertyu0870 |      0.5
+ qwertyu0871 |      0.5
+ qwertyu0872 |      0.5
+ qwertyu0873 |      0.5
+ qwertyu0874 |      0.5
+ qwertyu0875 |      0.5
+ qwertyu0876 |      0.5
+ qwertyu0877 |      0.5
+ qwertyu0878 |      0.5
+ qwertyu0879 |      0.5
+ qwertyu0880 |      0.5
+ qwertyu0881 |      0.5
+ qwertyu0882 |      0.5
+ qwertyu0883 |      0.5
+ qwertyu0884 |      0.5
+ qwertyu0885 |      0.5
+ qwertyu0886 |      0.5
+ qwertyu0887 |      0.5
+ qwertyu0889 |      0.5
+ qwertyu0890 |      0.5
+ qwertyu0891 |      0.5
+ qwertyu0892 |      0.5
+ qwertyu0893 |      0.5
+ qwertyu0894 |      0.5
+ qwertyu0895 |      0.5
+ qwertyu0896 |      0.5
+ qwertyu0897 |      0.5
+ qwertyu0898 |      0.5
+ qwertyu0899 |      0.5
+ qwertyu1000 | 0.411765
+(1000 rows)
+
+select t,similarity(t,'gwertyu0988') as sml from test_trgm where t % 'gwertyu0988' order by sml desc, t;
+      t      |   sml    
+-------------+----------
+ qwertyu0988 |      0.6
+ qwertyu0980 | 0.411765
+ qwertyu0981 | 0.411765
+ qwertyu0982 | 0.411765
+ qwertyu0983 | 0.411765
+ qwertyu0984 | 0.411765
+ qwertyu0985 | 0.411765
+ qwertyu0986 | 0.411765
+ qwertyu0987 | 0.411765
+ qwertyu0989 | 0.411765
+ qwertyu0088 | 0.333333
+ qwertyu0098 | 0.333333
+ qwertyu0188 | 0.333333
+ qwertyu0288 | 0.333333
+ qwertyu0388 | 0.333333
+ qwertyu0488 | 0.333333
+ qwertyu0588 | 0.333333
+ qwertyu0688 | 0.333333
+ qwertyu0788 | 0.333333
+ qwertyu0888 | 0.333333
+ qwertyu0900 | 0.333333
+ qwertyu0901 | 0.333333
+ qwertyu0902 | 0.333333
+ qwertyu0903 | 0.333333
+ qwertyu0904 | 0.333333
+ qwertyu0905 | 0.333333
+ qwertyu0906 | 0.333333
+ qwertyu0907 | 0.333333
+ qwertyu0908 | 0.333333
+ qwertyu0909 | 0.333333
+ qwertyu0910 | 0.333333
+ qwertyu0911 | 0.333333
+ qwertyu0912 | 0.333333
+ qwertyu0913 | 0.333333
+ qwertyu0914 | 0.333333
+ qwertyu0915 | 0.333333
+ qwertyu0916 | 0.333333
+ qwertyu0917 | 0.333333
+ qwertyu0918 | 0.333333
+ qwertyu0919 | 0.333333
+ qwertyu0920 | 0.333333
+ qwertyu0921 | 0.333333
+ qwertyu0922 | 0.333333
+ qwertyu0923 | 0.333333
+ qwertyu0924 | 0.333333
+ qwertyu0925 | 0.333333
+ qwertyu0926 | 0.333333
+ qwertyu0927 | 0.333333
+ qwertyu0928 | 0.333333
+ qwertyu0929 | 0.333333
+ qwertyu0930 | 0.333333
+ qwertyu0931 | 0.333333
+ qwertyu0932 | 0.333333
+ qwertyu0933 | 0.333333
+ qwertyu0934 | 0.333333
+ qwertyu0935 | 0.333333
+ qwertyu0936 | 0.333333
+ qwertyu0937 | 0.333333
+ qwertyu0938 | 0.333333
+ qwertyu0939 | 0.333333
+ qwertyu0940 | 0.333333
+ qwertyu0941 | 0.333333
+ qwertyu0942 | 0.333333
+ qwertyu0943 | 0.333333
+ qwertyu0944 | 0.333333
+ qwertyu0945 | 0.333333
+ qwertyu0946 | 0.333333
+ qwertyu0947 | 0.333333
+ qwertyu0948 | 0.333333
+ qwertyu0949 | 0.333333
+ qwertyu0950 | 0.333333
+ qwertyu0951 | 0.333333
+ qwertyu0952 | 0.333333
+ qwertyu0953 | 0.333333
+ qwertyu0954 | 0.333333
+ qwertyu0955 | 0.333333
+ qwertyu0956 | 0.333333
+ qwertyu0957 | 0.333333
+ qwertyu0958 | 0.333333
+ qwertyu0959 | 0.333333
+ qwertyu0960 | 0.333333
+ qwertyu0961 | 0.333333
+ qwertyu0962 | 0.333333
+ qwertyu0963 | 0.333333
+ qwertyu0964 | 0.333333
+ qwertyu0965 | 0.333333
+ qwertyu0966 | 0.333333
+ qwertyu0967 | 0.333333
+ qwertyu0968 | 0.333333
+ qwertyu0969 | 0.333333
+ qwertyu0970 | 0.333333
+ qwertyu0971 | 0.333333
+ qwertyu0972 | 0.333333
+ qwertyu0973 | 0.333333
+ qwertyu0974 | 0.333333
+ qwertyu0975 | 0.333333
+ qwertyu0976 | 0.333333
+ qwertyu0977 | 0.333333
+ qwertyu0978 | 0.333333
+ qwertyu0979 | 0.333333
+ qwertyu0990 | 0.333333
+ qwertyu0991 | 0.333333
+ qwertyu0992 | 0.333333
+ qwertyu0993 | 0.333333
+ qwertyu0994 | 0.333333
+ qwertyu0995 | 0.333333
+ qwertyu0996 | 0.333333
+ qwertyu0997 | 0.333333
+ qwertyu0998 | 0.333333
+ qwertyu0999 | 0.333333
+(110 rows)
+
+select t,similarity(t,'gwertyu1988') as sml from test_trgm where t % 'gwertyu1988' order by sml desc, t;
+      t      |   sml    
+-------------+----------
+ qwertyu0988 | 0.333333
+(1 row)
+
+select count(*) from test_trgm where t ~ '[qwerty]{2}-?[qwerty]{2}';
+ count 
+-------
+  1000
+(1 row)
+
+create table test2(t text COLLATE "C");
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 't' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into test2 values ('abcdef');
+insert into test2 values ('quark');
+insert into test2 values ('  z foo bar');
+insert into test2 values ('/123/-45/');
+create index test2_idx_gin on test2 using gin (t gin_trgm_ops);
+set enable_seqscan=off;
+explain (costs off)
+  select * from test2 where t like '%BCD%';
+                   QUERY PLAN                   
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Bitmap Heap Scan on test2
+         Recheck Cond: (t ~~ '%BCD%'::text)
+         ->  Bitmap Index Scan on test2_idx_gin
+               Index Cond: (t ~~ '%BCD%'::text)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+explain (costs off)
+  select * from test2 where t ilike '%BCD%';
+                   QUERY PLAN                    
+-------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Bitmap Heap Scan on test2
+         Recheck Cond: (t ~~* '%BCD%'::text)
+         ->  Bitmap Index Scan on test2_idx_gin
+               Index Cond: (t ~~* '%BCD%'::text)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+select * from test2 where t like '%BCD%';
+ t 
+---
+(0 rows)
+
+select * from test2 where t like '%bcd%';
+   t    
+--------
+ abcdef
+(1 row)
+
+select * from test2 where t like E'%\\bcd%';
+   t    
+--------
+ abcdef
+(1 row)
+
+select * from test2 where t ilike '%BCD%';
+   t    
+--------
+ abcdef
+(1 row)
+
+select * from test2 where t ilike 'qua%';
+   t   
+-------
+ quark
+(1 row)
+
+select * from test2 where t like '%z foo bar%';
+      t      
+-------------
+   z foo bar
+(1 row)
+
+select * from test2 where t like '  z foo%';
+      t      
+-------------
+   z foo bar
+(1 row)
+
+explain (costs off)
+  select * from test2 where t ~ '[abc]{3}';
+                    QUERY PLAN                    
+--------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Bitmap Heap Scan on test2
+         Recheck Cond: (t ~ '[abc]{3}'::text)
+         ->  Bitmap Index Scan on test2_idx_gin
+               Index Cond: (t ~ '[abc]{3}'::text)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+explain (costs off)
+  select * from test2 where t ~* 'DEF';
+                   QUERY PLAN                   
+------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Bitmap Heap Scan on test2
+         Recheck Cond: (t ~* 'DEF'::text)
+         ->  Bitmap Index Scan on test2_idx_gin
+               Index Cond: (t ~* 'DEF'::text)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+select * from test2 where t ~ '[abc]{3}';
+   t    
+--------
+ abcdef
+(1 row)
+
+select * from test2 where t ~ 'a[bc]+d';
+   t    
+--------
+ abcdef
+(1 row)
+
+select * from test2 where t ~ '(abc)*$';
+      t      
+-------------
+ abcdef
+ quark
+   z foo bar
+ /123/-45/
+(4 rows)
+
+select * from test2 where t ~* 'DEF';
+   t    
+--------
+ abcdef
+(1 row)
+
+select * from test2 where t ~ 'dEf';
+ t 
+---
+(0 rows)
+
+select * from test2 where t ~* '^q';
+   t   
+-------
+ quark
+(1 row)
+
+select * from test2 where t ~* '[abc]{3}[def]{3}';
+   t    
+--------
+ abcdef
+(1 row)
+
+select * from test2 where t ~* 'ab[a-z]{3}';
+   t    
+--------
+ abcdef
+(1 row)
+
+select * from test2 where t ~* '(^| )qua';
+   t   
+-------
+ quark
+(1 row)
+
+select * from test2 where t ~ 'q.*rk$';
+   t   
+-------
+ quark
+(1 row)
+
+select * from test2 where t ~ 'q';
+   t   
+-------
+ quark
+(1 row)
+
+select * from test2 where t ~ '[a-z]{3}';
+      t      
+-------------
+   z foo bar
+ quark
+ abcdef
+(3 rows)
+
+select * from test2 where t ~* '(a{10}|b{10}|c{10}){10}';
+ t 
+---
+(0 rows)
+
+select * from test2 where t ~ 'z foo bar';
+      t      
+-------------
+   z foo bar
+(1 row)
+
+select * from test2 where t ~ ' z foo bar';
+      t      
+-------------
+   z foo bar
+(1 row)
+
+select * from test2 where t ~ '  z foo bar';
+      t      
+-------------
+   z foo bar
+(1 row)
+
+select * from test2 where t ~ '  z foo';
+      t      
+-------------
+   z foo bar
+(1 row)
+
+select * from test2 where t ~ 'qua(?!foo)';
+   t   
+-------
+ quark
+(1 row)
+
+select * from test2 where t ~ '/\d+/-\d';
+     t     
+-----------
+ /123/-45/
+(1 row)
+
+drop index test2_idx_gin;
+create index test2_idx_gist on test2 using gist (t gist_trgm_ops);
+set enable_seqscan=off;
+explain (costs off)
+  select * from test2 where t like '%BCD%';
+                   QUERY PLAN                    
+-------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Bitmap Heap Scan on test2
+         Recheck Cond: (t ~~ '%BCD%'::text)
+         ->  Bitmap Index Scan on test2_idx_gist
+               Index Cond: (t ~~ '%BCD%'::text)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+explain (costs off)
+  select * from test2 where t ilike '%BCD%';
+                   QUERY PLAN                    
+-------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Bitmap Heap Scan on test2
+         Recheck Cond: (t ~~* '%BCD%'::text)
+         ->  Bitmap Index Scan on test2_idx_gist
+               Index Cond: (t ~~* '%BCD%'::text)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+select * from test2 where t like '%BCD%';
+ t 
+---
+(0 rows)
+
+select * from test2 where t like '%bcd%';
+   t    
+--------
+ abcdef
+(1 row)
+
+select * from test2 where t like E'%\\bcd%';
+   t    
+--------
+ abcdef
+(1 row)
+
+select * from test2 where t ilike '%BCD%';
+   t    
+--------
+ abcdef
+(1 row)
+
+select * from test2 where t ilike 'qua%';
+   t   
+-------
+ quark
+(1 row)
+
+select * from test2 where t like '%z foo bar%';
+      t      
+-------------
+   z foo bar
+(1 row)
+
+select * from test2 where t like '  z foo%';
+      t      
+-------------
+   z foo bar
+(1 row)
+
+explain (costs off)
+  select * from test2 where t ~ '[abc]{3}';
+                    QUERY PLAN                    
+--------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Bitmap Heap Scan on test2
+         Recheck Cond: (t ~ '[abc]{3}'::text)
+         ->  Bitmap Index Scan on test2_idx_gist
+               Index Cond: (t ~ '[abc]{3}'::text)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+explain (costs off)
+  select * from test2 where t ~* 'DEF';
+                   QUERY PLAN                    
+-------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Bitmap Heap Scan on test2
+         Recheck Cond: (t ~* 'DEF'::text)
+         ->  Bitmap Index Scan on test2_idx_gist
+               Index Cond: (t ~* 'DEF'::text)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+select * from test2 where t ~ '[abc]{3}';
+   t    
+--------
+ abcdef
+(1 row)
+
+select * from test2 where t ~ 'a[bc]+d';
+   t    
+--------
+ abcdef
+(1 row)
+
+select * from test2 where t ~ '(abc)*$';
+      t      
+-------------
+ quark
+ abcdef
+   z foo bar
+ /123/-45/
+(4 rows)
+
+select * from test2 where t ~* 'DEF';
+   t    
+--------
+ abcdef
+(1 row)
+
+select * from test2 where t ~ 'dEf';
+ t 
+---
+(0 rows)
+
+select * from test2 where t ~* '^q';
+   t   
+-------
+ quark
+(1 row)
+
+select * from test2 where t ~* '[abc]{3}[def]{3}';
+   t    
+--------
+ abcdef
+(1 row)
+
+select * from test2 where t ~* 'ab[a-z]{3}';
+   t    
+--------
+ abcdef
+(1 row)
+
+select * from test2 where t ~* '(^| )qua';
+   t   
+-------
+ quark
+(1 row)
+
+select * from test2 where t ~ 'q.*rk$';
+   t   
+-------
+ quark
+(1 row)
+
+select * from test2 where t ~ 'q';
+   t   
+-------
+ quark
+(1 row)
+
+select * from test2 where t ~ '[a-z]{3}';
+      t      
+-------------
+ abcdef
+ quark
+   z foo bar
+(3 rows)
+
+select * from test2 where t ~* '(a{10}|b{10}|c{10}){10}';
+ t 
+---
+(0 rows)
+
+select * from test2 where t ~ 'z foo bar';
+      t      
+-------------
+   z foo bar
+(1 row)
+
+select * from test2 where t ~ ' z foo bar';
+      t      
+-------------
+   z foo bar
+(1 row)
+
+select * from test2 where t ~ '  z foo bar';
+      t      
+-------------
+   z foo bar
+(1 row)
+
+select * from test2 where t ~ '  z foo';
+      t      
+-------------
+   z foo bar
+(1 row)
+
+select * from test2 where t ~ 'qua(?!foo)';
+   t   
+-------
+ quark
+(1 row)
+
+select * from test2 where t ~ '/\d+/-\d';
+     t     
+-----------
+ /123/-45/
+(1 row)
+
+-- Check similarity threshold (bug #14202)
+CREATE TEMP TABLE restaurants (city text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'city' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO restaurants SELECT 'Warsaw' FROM generate_series(1, 10000);
+INSERT INTO restaurants SELECT 'Szczecin' FROM generate_series(1, 10000);
+CREATE INDEX ON restaurants USING gist(city gist_trgm_ops);
+-- Similarity of the two names (for reference).
+SELECT similarity('Szczecin', 'Warsaw');
+ similarity 
+------------
+          0
+(1 row)
+
+-- Should get only 'Warsaw' for either setting of set_limit.
+EXPLAIN (COSTS OFF)
+SELECT DISTINCT city, similarity(city, 'Warsaw'), show_limit()
+  FROM restaurants WHERE city % 'Warsaw';
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  GroupAggregate
+         Group Key: city, (similarity(city, 'Warsaw'::text)), ('0.3'::real)
+         ->  Sort
+               Sort Key: city, (similarity(city, 'Warsaw'::text)), ('0.3'::real)
+               ->  Index Scan using restaurants_city_idx on restaurants
+                     Index Cond: (city % 'Warsaw'::text)
+                     Filter: (city % 'Warsaw'::text)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+SELECT set_limit(0.3);
+ set_limit 
+-----------
+       0.3
+(1 row)
+
+SELECT DISTINCT city, similarity(city, 'Warsaw'), show_limit()
+  FROM restaurants WHERE city % 'Warsaw';
+  city  | similarity | show_limit 
+--------+------------+------------
+ Warsaw |          1 |        0.3
+(1 row)
+
+SELECT set_limit(0.5);
+ set_limit 
+-----------
+       0.5
+(1 row)
+
+SELECT DISTINCT city, similarity(city, 'Warsaw'), show_limit()
+  FROM restaurants WHERE city % 'Warsaw';
+  city  | similarity | show_limit 
+--------+------------+------------
+ Warsaw |          1 |        0.5
+(1 row)
+

--- a/contrib/pg_trgm/sql/pg_trgm.sql
+++ b/contrib/pg_trgm/sql/pg_trgm.sql
@@ -1,3 +1,4 @@
+set optimizer=off; -- force use planner to reduce noise
 CREATE EXTENSION pg_trgm;
 
 -- Check whether any of our opclasses fail amvalidate

--- a/contrib/pg_trgm/sql/pg_trgm.sql
+++ b/contrib/pg_trgm/sql/pg_trgm.sql
@@ -1,4 +1,3 @@
-set optimizer=off; -- force use planner to reduce noise
 CREATE EXTENSION pg_trgm;
 
 -- Check whether any of our opclasses fail amvalidate


### PR DESCRIPTION
pg_trgm is a build-in extension of PostgreSQL. this patch enables it in Greenplum.

pg_trgm does not contain new file formats or executor changes, which has good compatibility with
Greenplum.

Signed-off-by: Sasasu <i@sasa.su>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Pass `make installcheck`

