### PR TITLE
6X: enable pg_trgm and btree_gin 

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -21,6 +21,7 @@ all:
 	$(MAKE) -C contrib/fuzzystrmatch all
 	$(MAKE) -C contrib/extprotocol all
 	$(MAKE) -C contrib/pg_trgm all
+	$(MAKE) -C contrib/btree_gin all
 ifeq ($(OS),Darwin)
 	@echo "dblink and postgres_fdw can't be built on Mac"
 else
@@ -67,6 +68,7 @@ install:
 	$(MAKE) -C contrib/fuzzystrmatch $@
 	$(MAKE) -C contrib/extprotocol $@
 	$(MAKE) -C contrib/pg_trgm $@
+	$(MAKE) -C contrib/btree_gin $@
 ifneq ($(OS),Darwin)
 	$(MAKE) -C contrib/dblink $@
 	$(MAKE) -C contrib/postgres_fdw $@
@@ -162,7 +164,7 @@ ICW_TARGETS  = src/test src/pl src/interfaces/gppc
 ICW_TARGETS += contrib/amcheck contrib/auto_explain contrib/citext
 ICW_TARGETS += contrib/formatter_fixedwidth
 ICW_TARGETS += contrib/extprotocol
-ICW_TARGETS += contrib/pg_trgm
+ICW_TARGETS += contrib/pg_trgm contrib/btree_gin
 ifneq ($(OS),Darwin)
 	ICW_TARGETS += contrib/dblink contrib/postgres_fdw
 endif

--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -19,7 +19,8 @@ all:
 	$(MAKE) -C contrib/formatter all
 	$(MAKE) -C contrib/formatter_fixedwidth all
 	$(MAKE) -C contrib/fuzzystrmatch all
-	$(MAKE) -C contrib/extprotocol all	
+	$(MAKE) -C contrib/extprotocol all
+	$(MAKE) -C contrib/pg_trgm all
 ifeq ($(OS),Darwin)
 	@echo "dblink and postgres_fdw can't be built on Mac"
 else
@@ -65,6 +66,7 @@ install:
 	$(MAKE) -C contrib/formatter_fixedwidth $@
 	$(MAKE) -C contrib/fuzzystrmatch $@
 	$(MAKE) -C contrib/extprotocol $@
+	$(MAKE) -C contrib/pg_trgm $@
 ifneq ($(OS),Darwin)
 	$(MAKE) -C contrib/dblink $@
 	$(MAKE) -C contrib/postgres_fdw $@
@@ -160,6 +162,7 @@ ICW_TARGETS  = src/test src/pl src/interfaces/gppc
 ICW_TARGETS += contrib/amcheck contrib/auto_explain contrib/citext
 ICW_TARGETS += contrib/formatter_fixedwidth
 ICW_TARGETS += contrib/extprotocol
+ICW_TARGETS += contrib/pg_trgm
 ifneq ($(OS),Darwin)
 	ICW_TARGETS += contrib/dblink contrib/postgres_fdw
 endif

--- a/contrib/btree_gin/Makefile
+++ b/contrib/btree_gin/Makefile
@@ -10,6 +10,7 @@ REGRESS = install_btree_gin int2 int4 int8 float4 float8 money oid \
 	timestamp timestamptz time timetz date interval \
 	macaddr inet cidr text varchar char bytea bit varbit \
 	numeric
+REGRESS_OPTS += --init-file=$(top_builddir)/src/test/regress/init_file
 
 ifdef USE_PGXS
 PG_CONFIG = pg_config

--- a/contrib/btree_gin/btree_gin.c
+++ b/contrib/btree_gin/btree_gin.c
@@ -90,6 +90,8 @@ gin_extract_query_##type(PG_FUNCTION_ARGS)									\
 		case BTGreaterEqualStrategyNumber:									\
 		case BTGreaterStrategyNumber:										\
 			*ptr_partialmatch = true;										\
+			entries[0] = datum;												\
+			break; /* make linter happy */									\
 		case BTEqualStrategyNumber:											\
 			entries[0] = datum;												\
 			break;															\

--- a/contrib/btree_gin/expected/money.out
+++ b/contrib/btree_gin/expected/money.out
@@ -1,7 +1,7 @@
 set enable_seqscan=off;
 CREATE TABLE test_money (
 	i money
-);
+); -- NOTE: Greenplum dose not support hash for money type, distributed by NULL is expected
 INSERT INTO test_money VALUES ('-2'),('-1'),('0'),('1'),('2'),('3');
 CREATE INDEX idx_money ON test_money USING gin (i);
 SELECT * FROM test_money WHERE i<'1'::money ORDER BY i;

--- a/contrib/btree_gin/sql/money.sql
+++ b/contrib/btree_gin/sql/money.sql
@@ -2,7 +2,7 @@ set enable_seqscan=off;
 
 CREATE TABLE test_money (
 	i money
-);
+); -- NOTE: Greenplum dose not support hash for money type, distributed by NULL is expected
 
 INSERT INTO test_money VALUES ('-2'),('-1'),('0'),('1'),('2'),('3');
 

--- a/contrib/pg_trgm/Makefile
+++ b/contrib/pg_trgm/Makefile
@@ -7,6 +7,7 @@ EXTENSION = pg_trgm
 DATA = pg_trgm--1.1.sql pg_trgm--1.0--1.1.sql pg_trgm--unpackaged--1.0.sql
 
 REGRESS = pg_trgm
+REGRESS_OPTS += --init-file=$(top_builddir)/src/test/regress/init_file
 
 ifdef USE_PGXS
 PG_CONFIG = pg_config

--- a/contrib/pg_trgm/expected/pg_trgm_optimizer.out
+++ b/contrib/pg_trgm/expected/pg_trgm_optimizer.out
@@ -2336,10 +2336,11 @@ select t <-> 'q0987wertyu0988', t from test_trgm order by t <-> 'q0987wertyu0988
    ->  Gather Motion 3:1  (slice1; segments: 3)
          Merge Key: ((t <-> 'q0987wertyu0988'::text))
          ->  Limit
-               ->  Index Scan using trgm_idx on test_trgm
-                     Order By: (t <-> 'q0987wertyu0988'::text)
- Optimizer: Postgres query optimizer
-(7 rows)
+               ->  Sort
+                     Sort Key: ((t <-> 'q0987wertyu0988'::text))
+                     ->  Result
+                           ->  Seq Scan on test_trgm
+(9 rows)
 
 select t <-> 'q0987wertyu0988', t from test_trgm order by t <-> 'q0987wertyu0988' limit 2;
  ?column? |      t      
@@ -3712,8 +3713,8 @@ explain (costs off)
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Index Scan using test2_idx_gist on test2
          Index Cond: (t ~~ '%BCD%'::text)
- Optimizer: Postgres query optimizer
-(4 rows)
+         Filter: (t ~~ '%BCD%'::text)
+(5 rows)
 
 explain (costs off)
   select * from test2 where t ilike '%BCD%';
@@ -3722,8 +3723,8 @@ explain (costs off)
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Index Scan using test2_idx_gist on test2
          Index Cond: (t ~~* '%BCD%'::text)
- Optimizer: Postgres query optimizer
-(4 rows)
+         Filter: (t ~~* '%BCD%'::text)
+(5 rows)
 
 select * from test2 where t like '%BCD%';
  t 
@@ -3773,8 +3774,8 @@ explain (costs off)
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Index Scan using test2_idx_gist on test2
          Index Cond: (t ~ '[abc]{3}'::text)
- Optimizer: Postgres query optimizer
-(4 rows)
+         Filter: (t ~ '[abc]{3}'::text)
+(5 rows)
 
 explain (costs off)
   select * from test2 where t ~* 'DEF';
@@ -3783,8 +3784,8 @@ explain (costs off)
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Index Scan using test2_idx_gist on test2
          Index Cond: (t ~* 'DEF'::text)
- Optimizer: Postgres query optimizer
-(4 rows)
+         Filter: (t ~* 'DEF'::text)
+(5 rows)
 
 select * from test2 where t ~ '[abc]{3}';
    t    


### PR DESCRIPTION
from 7X branch #12927 #12928

those extensions do not contain new file formats or executor changes. so they have good compatibility with Greenplum.

this PR includes 2 commits in order to avoid merge conflicts.