### PR TITLE
Refactor convert_IN_to_antijoin.

### DIFF
--- a/src/test/regress/expected/notin.out
+++ b/src/test/regress/expected/notin.out
@@ -1272,9 +1272,173 @@ select * from table_source4 where c3 = 'INC' and c4 = '0000000001' and c2 not in
  000181202006010000003158 | a  | INC | 0000000001
 (1 row)
 
+--
+-- Multi Column NOT-IN
+-- Please refer to https://github.com/greenplum-db/gpdb/issues/12930
+--
+create table t1_12930(a int not null, b int not null);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t2_12930(a int not null, b int not null);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- non-nullable: t1.a, t1.b, t2.a, t2.b
+insert into t1_12930 values (1, 1), (2, 2);
+insert into t2_12930 values (1, 1), (2, 3), (3,3);
+explain select * from t1_12930 where (a, b) not in (select a, b from t2_12930);
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=751.50..207138.77 rows=16 width=8)
+   ->  Hash Left Anti Semi (Not-In) Join  (cost=751.50..207138.55 rows=5 width=8)
+         Hash Cond: ((t1_12930.a = t2_12930.a) AND (t1_12930.b = t2_12930.b))
+         ->  Seq Scan on t1_12930  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
+               ->  Seq Scan on t2_12930  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select * from t1_12930 where (a, b) not in (select a, b from t2_12930);
+ a | b 
+---+---
+ 2 | 2
+(1 row)
+
+explain select * from t1_12930 where (a+1, b+1) not in (select a, b from t2_12930);
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=751.50..413635.27 rows=16 width=8)
+   ->  Hash Left Anti Semi (Not-In) Join  (cost=751.50..413635.05 rows=5 width=8)
+         Hash Cond: (((t1_12930.a + 1) = t2_12930.a) AND ((t1_12930.b + 1) = t2_12930.b))
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..895.00 rows=28700 width=8)
+               Hash Key: (t1_12930.a + 1)
+               ->  Seq Scan on t1_12930  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
+               ->  Seq Scan on t2_12930  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+select * from t1_12930 where (a+1, b+1) not in (select a, b from t2_12930);
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+explain select * from t1_12930 where (a,b) <> ALL (select a, b from t2_12930);
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=751.50..207138.77 rows=16 width=8)
+   ->  Hash Left Anti Semi (Not-In) Join  (cost=751.50..207138.55 rows=5 width=8)
+         Hash Cond: ((t1_12930.a = t2_12930.a) AND (t1_12930.b = t2_12930.b))
+         ->  Seq Scan on t1_12930  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
+               ->  Seq Scan on t2_12930  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select * from t1_12930 where (a,b) <> ALL (select a, b from t2_12930);
+ a | b 
+---+---
+ 2 | 2
+(1 row)
+
+-- non-nullable: t1.a, t2.a, t2.b
+-- nullable: t1.b
+truncate t1_12930;
+truncate t2_12930;
+alter table t2_12930 alter column b set not null;
+alter table t1_12930 alter column b drop not null;
+insert into t1_12930 values (1, null);
+insert into t2_12930 values (1, 1);
+explain select * from t1_12930 where (a, b) <>ALL (select a, b from t2_12930);
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10079226671.22 rows=16 width=8)
+   ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000000.00..10079226671.00 rows=5 width=8)
+         Join Filter: ((t1_12930.a = t2_12930.a) AND (t1_12930.b = t2_12930.b))
+         ->  Seq Scan on t1_12930  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Materialize  (cost=0.00..1899.50 rows=86100 width=8)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1469.00 rows=86100 width=8)
+                     ->  Seq Scan on t2_12930  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select * from t1_12930 where (a, b) <>ALL (select a, b from t2_12930);
+ a | b 
+---+---
+(0 rows)
+
+-- non-nullable: t1.a, t1.b, t2.a
+-- nullable: t2.b
+truncate t1_12930;
+truncate t2_12930;
+alter table t2_12930 alter column b drop not null;
+insert into t1_12930 values (1, 1);
+insert into t2_12930 values (1, null);
+explain select * from t1_12930 where (a, b) not in (select a, b from t2_12930);
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10079226671.22 rows=16 width=8)
+   ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000000.00..10079226671.00 rows=5 width=8)
+         Join Filter: ((t1_12930.a = t2_12930.a) AND (t1_12930.b = t2_12930.b))
+         ->  Seq Scan on t1_12930  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Materialize  (cost=0.00..1899.50 rows=86100 width=8)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1469.00 rows=86100 width=8)
+                     ->  Seq Scan on t2_12930  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select * from t1_12930 where (a, b) not in (select a, b from t2_12930);
+ a | b 
+---+---
+(0 rows)
+
+-- non-nullable: t1.a, t2.a, t2.b
+-- nullable: t1.b
+truncate t1_12930;
+truncate t2_12930;
+alter table t2_12930 alter column b set not null;
+alter table t1_12930 alter column b drop not null;
+insert into t1_12930 values (1, null);
+insert into t2_12930 values (1, 1);
+explain select * from t1_12930 where (a, b) not in (select a, b from t2_12930);
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10079226671.22 rows=16 width=8)
+   ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000000.00..10079226671.00 rows=5 width=8)
+         Join Filter: ((t1_12930.a = t2_12930.a) AND (t1_12930.b = t2_12930.b))
+         ->  Seq Scan on t1_12930  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Materialize  (cost=0.00..1899.50 rows=86100 width=8)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1469.00 rows=86100 width=8)
+                     ->  Seq Scan on t2_12930  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select * from t1_12930 where (a, b) not in (select a, b from t2_12930);
+ a | b 
+---+---
+(0 rows)
+
+explain select * from t1_12930 where (a, b) not in (select a, b from t2_12930) and b is not null;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=751.50..206932.71 rows=16 width=8)
+   ->  Hash Left Anti Semi (Not-In) Join  (cost=751.50..206932.49 rows=5 width=8)
+         Hash Cond: ((t1_12930.a = t2_12930.a) AND (t1_12930.b = t2_12930.b))
+         ->  Seq Scan on t1_12930  (cost=0.00..321.00 rows=28671 width=8)
+               Filter: (b IS NOT NULL)
+         ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
+               ->  Seq Scan on t2_12930  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select * from t1_12930 where (a, b) not in (select a, b from t2_12930) and b is not null;
+ a | b 
+---+---
+(0 rows)
+
 reset search_path;
 drop schema notin cascade;
-NOTICE:  drop cascades to 16 other objects
+NOTICE:  drop cascades to 18 other objects
 DETAIL:  drop cascades to table notin.t1
 drop cascades to table notin.t2
 drop cascades to table notin.t3
@@ -1291,3 +1455,5 @@ drop cascades to table notin.table_source2
 drop cascades to table notin.table_source3
 drop cascades to table notin.table_source4
 drop cascades to table notin.table_config
+drop cascades to table notin.t1_12930
+drop cascades to table notin.t2_12930

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -1316,9 +1316,173 @@ select * from table_source4 where c3 = 'INC' and c4 = '0000000001' and c2 not in
  000181202006010000003158 | a  | INC | 0000000001
 (1 row)
 
+--
+-- Multi Column NOT-IN
+-- Please refer to https://github.com/greenplum-db/gpdb/issues/12930
+--
+create table t1_12930(a int not null, b int not null);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t2_12930(a int not null, b int not null);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- non-nullable: t1.a, t1.b, t2.a, t2.b
+insert into t1_12930 values (1, 1), (2, 2);
+insert into t2_12930 values (1, 1), (2, 3), (3,3);
+explain select * from t1_12930 where (a, b) not in (select a, b from t2_12930);
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=751.50..207138.77 rows=16 width=8)
+   ->  Hash Left Anti Semi (Not-In) Join  (cost=751.50..207138.55 rows=5 width=8)
+         Hash Cond: ((t1_12930.a = t2_12930.a) AND (t1_12930.b = t2_12930.b))
+         ->  Seq Scan on t1_12930  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
+               ->  Seq Scan on t2_12930  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select * from t1_12930 where (a, b) not in (select a, b from t2_12930);
+ a | b 
+---+---
+ 2 | 2
+(1 row)
+
+explain select * from t1_12930 where (a+1, b+1) not in (select a, b from t2_12930);
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=751.50..413635.27 rows=16 width=8)
+   ->  Hash Left Anti Semi (Not-In) Join  (cost=751.50..413635.05 rows=5 width=8)
+         Hash Cond: (((t1_12930.a + 1) = t2_12930.a) AND ((t1_12930.b + 1) = t2_12930.b))
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..895.00 rows=28700 width=8)
+               Hash Key: (t1_12930.a + 1)
+               ->  Seq Scan on t1_12930  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
+               ->  Seq Scan on t2_12930  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+select * from t1_12930 where (a+1, b+1) not in (select a, b from t2_12930);
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+explain select * from t1_12930 where (a,b) <> ALL (select a, b from t2_12930);
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=751.50..207138.77 rows=16 width=8)
+   ->  Hash Left Anti Semi (Not-In) Join  (cost=751.50..207138.55 rows=5 width=8)
+         Hash Cond: ((t1_12930.a = t2_12930.a) AND (t1_12930.b = t2_12930.b))
+         ->  Seq Scan on t1_12930  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
+               ->  Seq Scan on t2_12930  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select * from t1_12930 where (a,b) <> ALL (select a, b from t2_12930);
+ a | b 
+---+---
+ 2 | 2
+(1 row)
+
+-- non-nullable: t1.a, t2.a, t2.b
+-- nullable: t1.b
+truncate t1_12930;
+truncate t2_12930;
+alter table t2_12930 alter column b set not null;
+alter table t1_12930 alter column b drop not null;
+insert into t1_12930 values (1, null);
+insert into t2_12930 values (1, 1);
+explain select * from t1_12930 where (a, b) <>ALL (select a, b from t2_12930);
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10079226671.22 rows=16 width=8)
+   ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000000.00..10079226671.00 rows=5 width=8)
+         Join Filter: ((t1_12930.a = t2_12930.a) AND (t1_12930.b = t2_12930.b))
+         ->  Seq Scan on t1_12930  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Materialize  (cost=0.00..1899.50 rows=86100 width=8)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1469.00 rows=86100 width=8)
+                     ->  Seq Scan on t2_12930  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select * from t1_12930 where (a, b) <>ALL (select a, b from t2_12930);
+ a | b 
+---+---
+(0 rows)
+
+-- non-nullable: t1.a, t1.b, t2.a
+-- nullable: t2.b
+truncate t1_12930;
+truncate t2_12930;
+alter table t2_12930 alter column b drop not null;
+insert into t1_12930 values (1, 1);
+insert into t2_12930 values (1, null);
+explain select * from t1_12930 where (a, b) not in (select a, b from t2_12930);
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10079226671.22 rows=16 width=8)
+   ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000000.00..10079226671.00 rows=5 width=8)
+         Join Filter: ((t1_12930.a = t2_12930.a) AND (t1_12930.b = t2_12930.b))
+         ->  Seq Scan on t1_12930  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Materialize  (cost=0.00..1899.50 rows=86100 width=8)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1469.00 rows=86100 width=8)
+                     ->  Seq Scan on t2_12930  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select * from t1_12930 where (a, b) not in (select a, b from t2_12930);
+ a | b 
+---+---
+(0 rows)
+
+-- non-nullable: t1.a, t2.a, t2.b
+-- nullable: t1.b
+truncate t1_12930;
+truncate t2_12930;
+alter table t2_12930 alter column b set not null;
+alter table t1_12930 alter column b drop not null;
+insert into t1_12930 values (1, null);
+insert into t2_12930 values (1, 1);
+explain select * from t1_12930 where (a, b) not in (select a, b from t2_12930);
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10079226671.22 rows=16 width=8)
+   ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000000.00..10079226671.00 rows=5 width=8)
+         Join Filter: ((t1_12930.a = t2_12930.a) AND (t1_12930.b = t2_12930.b))
+         ->  Seq Scan on t1_12930  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Materialize  (cost=0.00..1899.50 rows=86100 width=8)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1469.00 rows=86100 width=8)
+                     ->  Seq Scan on t2_12930  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select * from t1_12930 where (a, b) not in (select a, b from t2_12930);
+ a | b 
+---+---
+(0 rows)
+
+explain select * from t1_12930 where (a, b) not in (select a, b from t2_12930) and b is not null;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=751.50..206932.71 rows=16 width=8)
+   ->  Hash Left Anti Semi (Not-In) Join  (cost=751.50..206932.49 rows=5 width=8)
+         Hash Cond: ((t1_12930.a = t2_12930.a) AND (t1_12930.b = t2_12930.b))
+         ->  Seq Scan on t1_12930  (cost=0.00..321.00 rows=28671 width=8)
+               Filter: (b IS NOT NULL)
+         ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
+               ->  Seq Scan on t2_12930  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select * from t1_12930 where (a, b) not in (select a, b from t2_12930) and b is not null;
+ a | b 
+---+---
+(0 rows)
+
 reset search_path;
 drop schema notin cascade;
-NOTICE:  drop cascades to 16 other objects
+NOTICE:  drop cascades to 18 other objects
 DETAIL:  drop cascades to table notin.t1
 drop cascades to table notin.t2
 drop cascades to table notin.t3
@@ -1335,3 +1499,5 @@ drop cascades to table notin.table_source2
 drop cascades to table notin.table_source3
 drop cascades to table notin.table_source4
 drop cascades to table notin.table_config
+drop cascades to table notin.t1_12930
+drop cascades to table notin.t2_12930

--- a/src/test/regress/sql/notin.sql
+++ b/src/test/regress/sql/notin.sql
@@ -424,6 +424,56 @@ select * from table_source3 where c3 = 'INC' and c4 = '0000000001' and c2 not in
 explain select * from table_source4 where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
 select * from table_source4 where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
 
+--
+-- Multi Column NOT-IN
+-- Please refer to https://github.com/greenplum-db/gpdb/issues/12930
+--
+create table t1_12930(a int not null, b int not null);
+create table t2_12930(a int not null, b int not null);
+
+-- non-nullable: t1.a, t1.b, t2.a, t2.b
+insert into t1_12930 values (1, 1), (2, 2);
+insert into t2_12930 values (1, 1), (2, 3), (3,3);
+explain select * from t1_12930 where (a, b) not in (select a, b from t2_12930);
+select * from t1_12930 where (a, b) not in (select a, b from t2_12930);
+explain select * from t1_12930 where (a+1, b+1) not in (select a, b from t2_12930);
+select * from t1_12930 where (a+1, b+1) not in (select a, b from t2_12930);
+explain select * from t1_12930 where (a,b) <> ALL (select a, b from t2_12930);
+select * from t1_12930 where (a,b) <> ALL (select a, b from t2_12930);
+
+-- non-nullable: t1.a, t2.a, t2.b
+-- nullable: t1.b
+truncate t1_12930;
+truncate t2_12930;
+alter table t2_12930 alter column b set not null;
+alter table t1_12930 alter column b drop not null;
+insert into t1_12930 values (1, null);
+insert into t2_12930 values (1, 1);
+explain select * from t1_12930 where (a, b) <>ALL (select a, b from t2_12930);
+select * from t1_12930 where (a, b) <>ALL (select a, b from t2_12930);
+
+-- non-nullable: t1.a, t1.b, t2.a
+-- nullable: t2.b
+truncate t1_12930;
+truncate t2_12930;
+alter table t2_12930 alter column b drop not null;
+insert into t1_12930 values (1, 1);
+insert into t2_12930 values (1, null);
+explain select * from t1_12930 where (a, b) not in (select a, b from t2_12930);
+select * from t1_12930 where (a, b) not in (select a, b from t2_12930);
+
+-- non-nullable: t1.a, t2.a, t2.b
+-- nullable: t1.b
+truncate t1_12930;
+truncate t2_12930;
+alter table t2_12930 alter column b set not null;
+alter table t1_12930 alter column b drop not null;
+insert into t1_12930 values (1, null);
+insert into t2_12930 values (1, 1);
+explain select * from t1_12930 where (a, b) not in (select a, b from t2_12930);
+select * from t1_12930 where (a, b) not in (select a, b from t2_12930);
+explain select * from t1_12930 where (a, b) not in (select a, b from t2_12930) and b is not null;
+select * from t1_12930 where (a, b) not in (select a, b from t2_12930) and b is not null;
 
 reset search_path;
 drop schema notin cascade;


### PR DESCRIPTION
Greenplum pulls up NOT-IN sublink to achieve better OLAP performance.
Generally, NOT-IN sublink is not semantically equivalent to NOT-EXIST
sublink because of NULL values. Besides, Greenplum cannot choose Hash
Join and cannot take advantage of partition-distribution  due to the
limitation of Executor currently (refer f77bf0879a28 and the comments
https://github.com/greenplum-db/gpdb/pull/11579#issuecomment-793385278).
Life will be much easier if both sides of NOT-IN sublink testexpr are
sure non-nullable.

We might seek for a great improvement of the executor to better support
NOT_IN. This commit just refactors the code and make the non-nullable
deduction clearer and can cover more cases. It does the following things:

  * Rename the function find_nonnullable_vars_walker.
    I find that cdbsubselect.c:find_nonnullable_vars_walker shares the
    same name with clauses.c:find_nonnullable_vars_walker even both
    are qualified by static.

  * Remove is_targetlist_nullable and is_param_nullable.
    These two functions almost do the same thing (testing a list of
    exprs if non-nullable).

  * Introduce new logic to test non-nullable.
    1. build a list of exprs from the source (either the inner subselect's
       targetlist or the outer part of the sublink's testexpr)
    2. build a set of non-nullable vars
    3. try our best to deduct non-nullable of the list of exprs.

See github issue: https://github.com/greenplum-db/gpdb/issues/12930

Co-authored-by: Tao Tang <tang.tao.cn@gmail.com>
