### PR TITLE
Fix PANIC error in ALTER TABLE xxx EXPAND PARTITION PREPARE

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -16397,7 +16397,6 @@ ATExecExpandPartitionTablePrepare(Relation rel)
 		root_dist->numsegments = new_numsegments;
 
 		GpPolicyReplace(relid, root_dist);
-		rel->rd_cdbpolicy = root_dist;
 	}
 	else
 	{
@@ -16424,7 +16423,6 @@ ATExecExpandPartitionTablePrepare(Relation rel)
 			/* we change policy type to randomly for regular leaf partitions distributed by hash */
 			GpPolicy *random_dist = createRandomPartitionedPolicy(new_numsegments);
 			GpPolicyReplace(relid, random_dist);
-			rel->rd_cdbpolicy = random_dist;
 		}
 	}
 }

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -16389,20 +16389,19 @@ ATExecExpandPartitionTablePrepare(Relation rel)
 		GpPolicy	 *new_policy;
 		MemoryContext oldcontext;
 
-		oldcontext = MemoryContextSwitchTo(GetMemoryChunkContext(rel));
 		/*
 		 * we only change numsegments for root/interior/leaf partitions distributed randomly
-		 * and root/interior partitions distributed by hash
+		 * and root/interior partitions distributed by hash, and change the numsegments of policy to
+		 * current cluster size
 		 */
+		oldcontext = MemoryContextSwitchTo(GetMemoryChunkContext(rel));
 		new_policy = GpPolicyCopy(rel->rd_cdbpolicy);
-		/* change numsegments of policy to current cluster size */
 		new_policy->numsegments = new_numsegments;
+		MemoryContextSwitchTo(oldcontext);
 
 		GpPolicyReplace(relid, new_policy);
-
 		/* We should make the policy between on-disk catalog and on-memory relation cache consistently */
 		rel->rd_cdbpolicy = new_policy;
-		MemoryContextSwitchTo(oldcontext);
 	}
 	else
 	{
@@ -16420,17 +16419,15 @@ ATExecExpandPartitionTablePrepare(Relation rel)
 					GpPolicy	 *new_policy;
 					MemoryContext oldcontext;
 
-					oldcontext = MemoryContextSwitchTo(GetMemoryChunkContext(rel));
-
 					/* Just modify the numsegments for external writable leaves */
+					oldcontext = MemoryContextSwitchTo(GetMemoryChunkContext(rel));
 					new_policy = GpPolicyCopy(rel->rd_cdbpolicy);
 					new_policy->numsegments = new_numsegments;
+					MemoryContextSwitchTo(oldcontext);
 
 					GpPolicyReplace(relid, new_policy);
-
 					/* We should make the policy between on-disk catalog and on-memory relation cache consistently */
 					rel->rd_cdbpolicy = new_policy;
-					MemoryContextSwitchTo(oldcontext);
 				}
 			}
 		}
@@ -16439,15 +16436,14 @@ ATExecExpandPartitionTablePrepare(Relation rel)
 			GpPolicy	 *new_policy;
 			MemoryContext oldcontext;
 
-			oldcontext = MemoryContextSwitchTo(GetMemoryChunkContext(rel));
-
 			/* we change policy type to randomly for regular leaf partitions distributed by hash */
+			oldcontext = MemoryContextSwitchTo(GetMemoryChunkContext(rel));
 			new_policy = createRandomPartitionedPolicy(new_numsegments);
-			GpPolicyReplace(relid, new_policy);
+			MemoryContextSwitchTo(oldcontext);
 
+			GpPolicyReplace(relid, new_policy);
 			/* We should make the policy between on-disk catalog and on-memory relation cache consistently */
 			rel->rd_cdbpolicy = new_policy;
-			MemoryContextSwitchTo(oldcontext);
 		}
 	}
 }


### PR DESCRIPTION
The PANIC issue is bringed in by commit: [Expand partition table leaves in parallel.](https://github.com/greenplum-db/gpdb/commit/a45be43489294386c23c5fa068ce071ec068d0d8), here's the setp to reproduce it:

1. Build gpdb without cassert, such as

```
./configure --with-perl --with-python --with-libxml --with-gssapi --enable-debug --disable-cassert --prefix=/usr/local/gpdb
````

2. Run commands:

```
postgres=# create extension if not exists gp_debug_numsegments;
NOTICE:  extension "gp_debug_numsegments" already exists, skipping
CREATE EXTENSION
postgres=# select gp_debug_set_create_table_default_numsegments(1);
 gp_debug_set_create_table_default_numsegments 
-----------------------------------------------
 1
(1 row)

postgres=# begin;
BEGIN
postgres=# ALTER TABLE partition_test EXPAND PARTITION PREPARE;
ALTER TABLE
postgres=# select * from partition_test;
server closed the connection unexpectedly
        This probably means the server terminated abnormally
        before or while processing the request.
The connection to the server was lost. Attempting reset: Succeeded.
```

If we exec `ALTER TABLE partition_test EXPAND PARTITION PREPARE` in a transaction and have an access to it next, sunch `select * from partition_test` or `select * from gp_distribution_policy`, QD or QE will PANIC cause wrong `relation->rd_cdbpolicy`.

The root cause is that we used GpPolicy data that may become invalid in function `ATExecExpandPartitionTablePrepare`:

```cpp
static void
ATExecExpandPartitionTablePrepare(Relation rel)
{
        // ......
	if (GpPolicyIsRandomPartitioned(rel_dist) || rel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE)
	{
		GpPolicyReplace(relid, root_dist);
		rel->rd_cdbpolicy = root_dist;        // here
	}
}
```

In fact, the `ALTER TABLE` command will invoke `ATExecCmd()`, which will call `CommandCounterIncrement()` to increase command numbers and invalid relation cache entry by `CommandEndInvalidationMessages()`, which invoke `RelationClearRelation()` eventually. The function `RelationClearRelation()` will physically blow away a relation cache entry, or reset it and rebuild it from scratch, also include the GpPolicy of a relation.

And in the inner of `GpPolicyReplace()`, it'll invalid the relation cache entry by `CatalogTupleUpdate` by send a message using SI (Share Invalid), which will be processed by `ProcessInvalidationMessages` in `CommandCounterIncrement()`.

Since the relation in `ATExecExpandPartitionTablePrepare` is fetched by `relation_open()`, which could be a cache result in relation cache. If we update the `rd_cdbpolicy`, it could update the relation cache entry's `rd_cdbpolicy ` to the new one, which not we wanted. 

If the relation's GpPolicy is pointer to new policy, `RelationClearRelation()` **will not** swap the GpPolicy with a new relation entry, it still pointer to old memory address. And then, the release of memory will cause a null pointer exception.

