### PR TITLE
Install pg_attribute_encoding for AOCS during CTAS

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -149,10 +149,10 @@ open_ds_write(Relation rel, DatumStreamWrite **ds, TupleDesc relationTupleDesc,
 		 * column of a column oriented table.  Note: checksum is a table level
 		 * attribute.
 		 */
-		if (opts[attno] == NULL || opts[attno]->blocksize == 0)
+		if (opts[i] == NULL || opts[i]->blocksize == 0)
 			elog(ERROR, "No relation attribute options for '%s', column #%d  in pg_attribute_encoding",
 							RelationGetRelationName(rel),
-							attno + 1);
+							i + 1);
 		ct = opts[i]->compresstype;
 		clvl = opts[i]->compresslevel;
 		blksz = opts[i]->blocksize;

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -149,7 +149,8 @@ open_ds_write(Relation rel, DatumStreamWrite **ds, TupleDesc relationTupleDesc,
 		 * column of a column oriented table.  Note: checksum is a table level
 		 * attribute.
 		 */
-		Assert(opts[i]);
+		if (opts[i] == NULL || opts[i]->blocksize == 0)
+			elog(ERROR, "could not find blocksize option for AOCO column in pg_attribute_encoding");
 		ct = opts[i]->compresstype;
 		clvl = opts[i]->compresslevel;
 		blksz = opts[i]->blocksize;
@@ -200,11 +201,8 @@ open_ds_read(Relation rel, DatumStreamRead **ds, TupleDesc relationTupleDesc,
 		 * column of a column oriented table.  Note: checksum is a table level
 		 * attribute.
 		 */
-		if (opts[attno] == NULL)
-			elog(ERROR, "No relation attribute options for '%s', column #%d",
-							RelationGetRelationName(rel),
-							attno + 1);
-
+		if (opts[attno] == NULL || opts[attno]->blocksize == 0)
+			elog(ERROR, "could not find blocksize option for AOCO column in pg_attribute_encoding");
 		ct = opts[attno]->compresstype;
 		clvl = opts[attno]->compresslevel;
 		blksz = opts[attno]->blocksize;

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -200,7 +200,10 @@ open_ds_read(Relation rel, DatumStreamRead **ds, TupleDesc relationTupleDesc,
 		 * column of a column oriented table.  Note: checksum is a table level
 		 * attribute.
 		 */
-		Assert(opts[attno]);
+		if (opts[attno] == NULL)
+			elog(ERROR, "No relation attribute options for '%s', column #%d",
+							RelationGetRelationName(rel),
+							attno + 1);
 
 		ct = opts[attno]->compresstype;
 		clvl = opts[attno]->compresslevel;

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -149,8 +149,10 @@ open_ds_write(Relation rel, DatumStreamWrite **ds, TupleDesc relationTupleDesc,
 		 * column of a column oriented table.  Note: checksum is a table level
 		 * attribute.
 		 */
-		if (opts[i] == NULL || opts[i]->blocksize == 0)
-			elog(ERROR, "could not find blocksize option for AOCO column in pg_attribute_encoding");
+		if (opts[attno] == NULL || opts[attno]->blocksize == 0)
+			elog(ERROR, "No relation attribute options for '%s', column #%d  in pg_attribute_encoding",
+							RelationGetRelationName(rel),
+							attno + 1);
 		ct = opts[i]->compresstype;
 		clvl = opts[i]->compresslevel;
 		blksz = opts[i]->blocksize;
@@ -202,7 +204,10 @@ open_ds_read(Relation rel, DatumStreamRead **ds, TupleDesc relationTupleDesc,
 		 * attribute.
 		 */
 		if (opts[attno] == NULL || opts[attno]->blocksize == 0)
-			elog(ERROR, "could not find blocksize option for AOCO column in pg_attribute_encoding");
+			elog(ERROR, "No relation attribute options for '%s', column #%d  in pg_attribute_encoding",
+							RelationGetRelationName(rel),
+							attno + 1);
+
 		ct = opts[attno]->compresstype;
 		clvl = opts[attno]->compresslevel;
 		blksz = opts[attno]->blocksize;

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -308,8 +308,8 @@ create_ctas_nodata(List *tlist, IntoClause *into, QueryDesc *queryDesc)
 
 	/* Add column encoding entries based on the WITH clause */
 	Relation rel = heap_open(intoRelationOid, AccessExclusiveLock);
-	if (into->options || RelationIsAoCols(rel))
-		AddDefaultRelationAttributeOptions(rel, into->options);
+	/* Noop for non-AOCS */
+	AddDefaultRelationAttributeOptions(rel, into->options);
 	heap_close(rel, NoLock);
 	return intoRelationOid;
 }

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -307,12 +307,10 @@ create_ctas_nodata(List *tlist, IntoClause *into, QueryDesc *queryDesc)
 	intoRelationOid = create_ctas_internal(attrList, into, queryDesc, true);
 
 	/* Add column encoding entries based on the WITH clause */
-	if (into->options)
-	{
-		Relation rel = heap_open(intoRelationOid, AccessExclusiveLock);
+	Relation rel = heap_open(intoRelationOid, AccessExclusiveLock);
+	if (into->options || RelationIsAoCols(rel))
 		AddDefaultRelationAttributeOptions(rel, into->options);
-		heap_close(rel, NoLock);
-	}
+	heap_close(rel, NoLock);
 	return intoRelationOid;
 }
 

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1168,9 +1168,10 @@ ProcessUtilitySlow(Node *parsetree,
 							CommandCounterIncrement();
 
 							/* Add column encoding entries based on the WITH clauses */
-							if (cstmt->isCtas && (cstmt->options || relStorage == RELSTORAGE_AOCOLS))
+							if (cstmt->isCtas)
 							{
 								Relation rel = heap_open(relOid, AccessExclusiveLock);
+								/* Noop for non-AOCS */
 								AddDefaultRelationAttributeOptions(rel, cstmt->options);
 								heap_close(rel, NoLock);
 							}

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1168,7 +1168,7 @@ ProcessUtilitySlow(Node *parsetree,
 							CommandCounterIncrement();
 
 							/* Add column encoding entries based on the WITH clauses */
-							if (cstmt->isCtas && cstmt->options)
+							if (cstmt->isCtas && (cstmt->options || relStorage == RELSTORAGE_AOCOLS))
 							{
 								Relation rel = heap_open(relOid, AccessExclusiveLock);
 								AddDefaultRelationAttributeOptions(rel, cstmt->options);

--- a/src/test/regress/expected/gpctas.out
+++ b/src/test/regress/expected/gpctas.out
@@ -261,6 +261,8 @@ from
 refresh materialized view sro_mv_issue_11999;
 ERROR:  division by zero
 CONTEXT:  SQL function "mv_action_select_issue_11999" during startup
+-- CTAS into AOCS table with not crash
+-- See github issue: https://github.com/greenplum-db/gpdb/issues/12936
 set gp_default_storage_options to 'appendonly=true,blocksize=32768,compresstype=zstd,compresslevel=1,checksum=true,orientation=column';
 CREATE TABLE test_issue_12936 AS (SELECT 'test' as test) WITH NO DATA;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named '' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/expected/gpctas.out
+++ b/src/test/regress/expected/gpctas.out
@@ -271,3 +271,10 @@ SELECT * FROM test_issue_12936;
  test 
 ------
 (0 rows)
+
+SELECT reloptions, attnum, attoptions FROM pg_class c JOIN pg_attribute_encoding ON (oid = attrelid) WHERE relname = 'test_issue_12936';
+                       reloptions                       | attnum |                     attoptions                      
+--------------------------------------------------------+--------+-----------------------------------------------------
+ {appendonly=true,compresstype=zstd,orientation=column} |      1 | {compresstype=zstd,blocksize=32768,compresslevel=1}
+(1 row)
+

--- a/src/test/regress/expected/gpctas.out
+++ b/src/test/regress/expected/gpctas.out
@@ -261,3 +261,13 @@ from
 refresh materialized view sro_mv_issue_11999;
 ERROR:  division by zero
 CONTEXT:  SQL function "mv_action_select_issue_11999" during startup
+set gp_default_storage_options to 'appendonly=true,blocksize=32768,compresstype=zstd,compresslevel=1,checksum=true,orientation=column';
+CREATE TABLE test_issue_12936 AS (SELECT 'test' as test) WITH NO DATA;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named '' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+WARNING:  column "test" has type "unknown"
+DETAIL:  Proceeding with relation creation anyway.
+SELECT * FROM test_issue_12936;
+ test 
+------
+(0 rows)

--- a/src/test/regress/sql/gpctas.sql
+++ b/src/test/regress/sql/gpctas.sql
@@ -168,3 +168,4 @@ refresh materialized view sro_mv_issue_11999;
 set gp_default_storage_options to 'appendonly=true,blocksize=32768,compresstype=zstd,compresslevel=1,checksum=true,orientation=column';
 CREATE TABLE test_issue_12936 AS (SELECT 'test' as test) WITH NO DATA;
 SELECT * FROM test_issue_12936;
+SELECT reloptions, attnum, attoptions FROM pg_class c JOIN pg_attribute_encoding ON (oid = attrelid) WHERE relname = 'test_issue_12936';

--- a/src/test/regress/sql/gpctas.sql
+++ b/src/test/regress/sql/gpctas.sql
@@ -160,3 +160,11 @@ from
 
 -- then refresh should error out
 refresh materialized view sro_mv_issue_11999;
+
+
+-- CTAS into AOCS table with not crash
+-- See github issue: https://github.com/greenplum-db/gpdb/issues/12936
+
+set gp_default_storage_options to 'appendonly=true,blocksize=32768,compresstype=zstd,compresslevel=1,checksum=true,orientation=column';
+CREATE TABLE test_issue_12936 AS (SELECT 'test' as test) WITH NO DATA;
+SELECT * FROM test_issue_12936;


### PR DESCRIPTION
When the table is created using "CREATE TABLE ... AS ... WITH NO DATA" pg_attribute_encoding may be omitted in some cases. This can result in a crash when reading the table with AOCS storage.
This commit fixes installment of pg_attribute_encoding for CTAS WITH NO DATA and adds a test for the case.
Fix for #12936
