### PR TITLE
Prevent AO/AOCO WALs for wal_level=minimal

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -162,7 +162,7 @@ open_ds_write(Relation rel, DatumStreamWrite **ds, TupleDesc relationTupleDesc, 
 										attr,
 										RelationGetRelationName(rel),
 										/* title */ titleBuf.data,
-										RelationNeedsWAL(rel));
+										XLogIsNeeded() && RelationNeedsWAL(rel));
 
 	}
 }
@@ -1992,7 +1992,7 @@ aocs_addcol_init(Relation rel,
 		desc->dsw[i] = create_datumstreamwrite(ct, clvl, checksum, 0, blksz /* safeFSWriteSize */ ,
 											   attr, RelationGetRelationName(rel),
 											   titleBuf.data,
-											   RelationNeedsWAL(rel));
+											   XLogIsNeeded() && RelationNeedsWAL(rel));
 	}
 	return desc;
 }

--- a/src/backend/access/aocs/test/aocsam_test.c
+++ b/src/backend/access/aocs/test/aocsam_test.c
@@ -66,6 +66,7 @@ test__aocs_addcol_init(void **state)
 	int			nattr = 5;
 	StdRdOptions **opts =
 	(StdRdOptions **) malloc(sizeof(StdRdOptions *) * nattr);
+	wal_level = WAL_LEVEL_REPLICA;
 
 	/* 3 existing columns */
 	opts[0] = opts[1] = opts[2] = (StdRdOptions *) NULL;

--- a/src/backend/access/appendonly/aomd.c
+++ b/src/backend/access/appendonly/aomd.c
@@ -191,7 +191,7 @@ TruncateAOSegmentFile(File fd, Relation rel, int32 segFileNum, int64 offset)
 		ereport(ERROR,
 				(errmsg("\"%s\": failed to truncate data after eof: %m",
 					    relname)));
-	if (RelationNeedsWAL(rel))
+	if (XLogIsNeeded() && RelationNeedsWAL(rel))
 		xlog_ao_truncate(rel->rd_node, segFileNum, offset);
 
 	if (file_truncate_hook)

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -2683,7 +2683,7 @@ appendonly_insert_init(Relation rel, int segno)
 								RelationGetRelationName(aoInsertDesc->aoi_rel),
 								aoInsertDesc->title,
 								&aoInsertDesc->storageAttributes,
-                                RelationNeedsWAL(aoInsertDesc->aoi_rel));
+								XLogIsNeeded() && RelationNeedsWAL(aoInsertDesc->aoi_rel));
 
 	aoInsertDesc->storageWrite.compression_functions = fns;
 	aoInsertDesc->storageWrite.compressionState = cs;

--- a/src/test/isolation2/expected/prevent_ao_wal.out
+++ b/src/test/isolation2/expected/prevent_ao_wal.out
@@ -1,0 +1,140 @@
+-- For AO/AOCO tables, their WAL records are only
+-- generated for replication purposes (they are not used for crash
+-- recovery because AO/AOCO table operations are crash-safe). To decrease
+-- disk space usage and to improve performance of AO/AOCO operations, we
+-- suppress generation of XLOG_APPENDONLY_INSERT and
+-- XLOG_APPENDONLY_TRUNCATE WAL records when wal_level=minimal is
+-- specified.
+-- This test is supposed to ensure that XLOG_APPENDONLY_INSERT and
+-- XLOG_APPENDONLY_TRUNCATE WAL records are not generated when
+-- wal_level=minimal is set.
+-- Because on mirrored cluster primary segments have replication slots
+-- and that conflict with the wal_level=minimal GUC
+-- we connect to coordinator in utility mode for AO/AOCO operations and
+-- validate WAL records on the coordinator.
+
+GP_IGNORE: formatted by atmsort.pm
+-- start_matchignore
+-- m/pg_waldump: fatal: error in WAL record at */
+-- m/.*The 'DISTRIBUTED BY' clause determines the distribution of data*/
+-- m/.*Table doesn't have 'DISTRIBUTED BY' clause*/
+-- end_matchignore
+GP_IGNORE: defined new match expression
+
+-- start_matchsubs
+-- m/tx:\s+\d+/
+-- s/tx:\s+\d+/tx: ##/
+
+-- m/lsn: \d\/[0-9a-fA-F]+, prev \d\/[0-9a-fA-F]+/
+-- s/lsn: \d\/[0-9a-fA-F]+, prev \d\/[0-9a-fA-F]+/lsn: #\/########, prev #\/########/
+
+-- m/rel \d+\/\d+\/\d+/
+-- s/rel \d+\/\d+\/\d+/rel ####\/######\/######/
+-- end_matchsubs
+GP_IGNORE: defined new match expression
+
+-- Create tables (AO, AOCO)
+-1U: CREATE TABLE ao_foo (n int) WITH (appendonly=true);
+CREATE
+-1U: CREATE TABLE aoco_foo (n int, m int) WITH (appendonly=true, orientation=column);
+CREATE
+
+-- Switch WAL file
+-1U: SELECT true FROM pg_switch_wal();
+ bool 
+------
+ t    
+(1 row)
+-- Insert data (AO)
+-1U: INSERT INTO ao_foo SELECT generate_series(1,10);
+INSERT 10
+-- Insert data (AOCO)
+-1U: INSERT INTO aoco_foo SELECT generate_series(1,10), generate_series(1,10);
+INSERT 10
+-- Delete data and run vacuum (AO)
+-1U: DELETE FROM ao_foo WHERE n > 5;
+DELETE 5
+-1U: VACUUM;
+VACUUM
+-- Delete data and run vacuum (AOCO)
+-1U: DELETE FROM aoco_foo WHERE n > 5;
+DELETE 5
+-1U: VACUUM;
+VACUUM
+-1Uq: ... <quitting>
+
+-- Validate wal records
+! pushd ${COORDINATOR_DATA_DIRECTORY}/pg_wal > /dev/null && last_wal_file=$(psql -At -c "SELECT pg_walfile_name(pg_current_wal_lsn())" postgres) && pg_waldump ${last_wal_file} -r appendonly && popd > /dev/null;
+rmgr: Appendonly  len (rec/tot):    186/   186, tx: ##, lsn: #/########, prev #/########, desc: APPENDONLY_INSERT insert: rel ####/######/###### seg/offset:0/0 len:136
+rmgr: Appendonly  len (rec/tot):     50/    50, tx: ##, lsn: #/########, prev #/########, desc: APPENDONLY_INSERT insert: rel ####/######/###### seg/offset:128/0 len:0
+rmgr: Appendonly  len (rec/tot):    130/   130, tx: ##, lsn: #/########, prev #/########, desc: APPENDONLY_INSERT insert: rel ####/######/###### seg/offset:0/0 len:80
+rmgr: Appendonly  len (rec/tot):    130/   130, tx: ##, lsn: #/########, prev #/########, desc: APPENDONLY_INSERT insert: rel ####/######/###### seg/offset:128/0 len:80
+rmgr: Appendonly  len (rec/tot):     50/    50, tx: ##, lsn: #/########, prev #/########, desc: APPENDONLY_TRUNCATE truncate: rel ####/######/###### seg/offset:0/136
+rmgr: Appendonly  len (rec/tot):     50/    50, tx: ##, lsn: #/########, prev #/########, desc: APPENDONLY_INSERT insert: rel ####/######/###### seg/offset:1/0 len:0
+rmgr: Appendonly  len (rec/tot):    138/   138, tx: ##, lsn: #/########, prev #/########, desc: APPENDONLY_INSERT insert: rel ####/######/###### seg/offset:1/0 len:88
+rmgr: Appendonly  len (rec/tot):     50/    50, tx: ##, lsn: #/########, prev #/########, desc: APPENDONLY_TRUNCATE truncate: rel ####/######/###### seg/offset:0/0
+rmgr: Appendonly  len (rec/tot):     50/    50, tx: ##, lsn: #/########, prev #/########, desc: APPENDONLY_TRUNCATE truncate: rel ####/######/###### seg/offset:0/80
+rmgr: Appendonly  len (rec/tot):     50/    50, tx: ##, lsn: #/########, prev #/########, desc: APPENDONLY_TRUNCATE truncate: rel ####/######/###### seg/offset:128/80
+rmgr: Appendonly  len (rec/tot):     50/    50, tx: ##, lsn: #/########, prev #/########, desc: APPENDONLY_TRUNCATE truncate: rel ####/######/###### seg/offset:1/88
+rmgr: Appendonly  len (rec/tot):     50/    50, tx: ##, lsn: #/########, prev #/########, desc: APPENDONLY_TRUNCATE truncate: rel ####/######/###### seg/offset:0/0
+rmgr: Appendonly  len (rec/tot):     50/    50, tx: ##, lsn: #/########, prev #/########, desc: APPENDONLY_TRUNCATE truncate: rel ####/######/###### seg/offset:0/80
+rmgr: Appendonly  len (rec/tot):     50/    50, tx: ##, lsn: #/########, prev #/########, desc: APPENDONLY_TRUNCATE truncate: rel ####/######/###### seg/offset:128/80
+rmgr: Appendonly  len (rec/tot):     50/    50, tx: ##, lsn: #/########, prev #/########, desc: APPENDONLY_INSERT insert: rel ####/######/###### seg/offset:1/0 len:0
+rmgr: Appendonly  len (rec/tot):     50/    50, tx: ##, lsn: #/########, prev #/########, desc: APPENDONLY_INSERT insert: rel ####/######/###### seg/offset:129/0 len:0
+rmgr: Appendonly  len (rec/tot):    114/   114, tx: ##, lsn: #/########, prev #/########, desc: APPENDONLY_INSERT insert: rel ####/######/###### seg/offset:1/0 len:64
+rmgr: Appendonly  len (rec/tot):    114/   114, tx: ##, lsn: #/########, prev #/########, desc: APPENDONLY_INSERT insert: rel ####/######/###### seg/offset:129/0 len:64
+rmgr: Appendonly  len (rec/tot):     50/    50, tx: ##, lsn: #/########, prev #/########, desc: APPENDONLY_TRUNCATE truncate: rel ####/######/###### seg/offset:0/0
+rmgr: Appendonly  len (rec/tot):     50/    50, tx: ##, lsn: #/########, prev #/########, desc: APPENDONLY_TRUNCATE truncate: rel ####/######/###### seg/offset:128/0
+
+
+-- *********** Set wal_level=minimal **************
+!\retcode gpconfig -c wal_level -v minimal --masteronly;
+(exited with code 0)
+-- Set max_wal_senders to 0 because a non-zero value requires wal_level >= 'archive'
+!\retcode gpconfig -c max_wal_senders -v 0 --masteronly;
+(exited with code 0)
+-- Restart QD
+!\retcode pg_ctl -l /dev/null -D $COORDINATOR_DATA_DIRECTORY restart -w -t 600 -m fast;
+(exited with code 0)
+
+-- Switch WAL file
+-1U: SELECT true FROM pg_switch_wal();
+ bool 
+------
+ t    
+(1 row)
+-- Insert data (AO)
+-1U: INSERT INTO ao_foo SELECT generate_series(1,10);
+INSERT 10
+-- Insert data (AOCO)
+-1U: INSERT INTO aoco_foo SELECT generate_series(1,10), generate_series(1,10);
+INSERT 10
+-- Delete data and run vacuum (AO)
+-1U: DELETE FROM ao_foo WHERE n > 5;
+DELETE 5
+-1U: VACUUM;
+VACUUM
+-- Delete data and run vacuum (AOCO)
+-1U: DELETE FROM aoco_foo WHERE n > 5;
+DELETE 5
+-1U: VACUUM;
+VACUUM
+
+-- Validate wal records
+! pushd ${COORDINATOR_DATA_DIRECTORY}/pg_wal > /dev/null && last_wal_file=$(psql -At -c "SELECT pg_walfile_name(pg_current_wal_lsn())" postgres) && pg_waldump ${last_wal_file} -r appendonly && popd > /dev/null;
+
+
+-1U: DROP TABLE ao_foo;
+DROP
+-1U: DROP TABLE aoco_foo;
+DROP
+
+-- Reset wal_level
+!\retcode gpconfig -r wal_level --masteronly;
+(exited with code 0)
+-- Reset max_wal_senders
+!\retcode gpconfig -r max_wal_senders --masteronly;
+(exited with code 0)
+-- Restart QD
+!\retcode pg_ctl -l /dev/null -D $COORDINATOR_DATA_DIRECTORY restart -w -t 600 -m fast;
+(exited with code 0)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -25,6 +25,8 @@ test: unlogged_appendonly_tables
 test: udf_exception_blocks_panic_scenarios
 test: ao_same_trans_truncate_crash
 
+test: prevent_ao_wal
+
 # Tests for packcore, will use the coredumps generated in crash_recovery_dtm,
 # so must be scheduled after that one.
 test: packcore

--- a/src/test/isolation2/sql/prevent_ao_wal.sql
+++ b/src/test/isolation2/sql/prevent_ao_wal.sql
@@ -1,0 +1,85 @@
+-- For AO/AOCO tables, their WAL records are only
+-- generated for replication purposes (they are not used for crash
+-- recovery because AO/AOCO table operations are crash-safe). To decrease
+-- disk space usage and to improve performance of AO/AOCO operations, we
+-- suppress generation of XLOG_APPENDONLY_INSERT and
+-- XLOG_APPENDONLY_TRUNCATE WAL records when wal_level=minimal is
+-- specified.
+-- This test is supposed to ensure that XLOG_APPENDONLY_INSERT and
+-- XLOG_APPENDONLY_TRUNCATE WAL records are not generated when
+-- wal_level=minimal is set.
+-- Because on mirrored cluster primary segments have replication slots
+-- and that conflict with the wal_level=minimal GUC
+-- we connect to coordinator in utility mode for AO/AOCO operations and
+-- validate WAL records on the coordinator.
+
+-- start_matchignore
+-- m/pg_waldump: fatal: error in WAL record at */
+-- m/.*The 'DISTRIBUTED BY' clause determines the distribution of data*/
+-- m/.*Table doesn't have 'DISTRIBUTED BY' clause*/
+-- end_matchignore
+
+-- start_matchsubs
+-- m/tx:\s+\d+/
+-- s/tx:\s+\d+/tx: ##/
+
+-- m/lsn: \d\/[0-9a-fA-F]+, prev \d\/[0-9a-fA-F]+/
+-- s/lsn: \d\/[0-9a-fA-F]+, prev \d\/[0-9a-fA-F]+/lsn: #\/########, prev #\/########/
+
+-- m/rel \d+\/\d+\/\d+/
+-- s/rel \d+\/\d+\/\d+/rel ####\/######\/######/
+-- end_matchsubs
+
+-- Create tables (AO, AOCO)
+-1U: CREATE TABLE ao_foo (n int) WITH (appendonly=true);
+-1U: CREATE TABLE aoco_foo (n int, m int) WITH (appendonly=true, orientation=column);
+
+-- Switch WAL file
+-1U: SELECT true FROM pg_switch_wal();
+-- Insert data (AO)
+-1U: INSERT INTO ao_foo SELECT generate_series(1,10);
+-- Insert data (AOCO)
+-1U: INSERT INTO aoco_foo SELECT generate_series(1,10), generate_series(1,10);
+-- Delete data and run vacuum (AO)
+-1U: DELETE FROM ao_foo WHERE n > 5;
+-1U: VACUUM;
+-- Delete data and run vacuum (AOCO)
+-1U: DELETE FROM aoco_foo WHERE n > 5;
+-1U: VACUUM;
+-1Uq:
+
+-- Validate wal records
+! pushd ${COORDINATOR_DATA_DIRECTORY}/pg_wal > /dev/null && last_wal_file=$(psql -At -c "SELECT pg_walfile_name(pg_current_wal_lsn())" postgres) && pg_waldump ${last_wal_file} -r appendonly && popd > /dev/null;
+
+-- *********** Set wal_level=minimal **************
+!\retcode gpconfig -c wal_level -v minimal --masteronly;
+-- Set max_wal_senders to 0 because a non-zero value requires wal_level >= 'archive'
+!\retcode gpconfig -c max_wal_senders -v 0 --masteronly;
+-- Restart QD
+!\retcode pg_ctl -l /dev/null -D $COORDINATOR_DATA_DIRECTORY restart -w -t 600 -m fast;
+
+-- Switch WAL file
+-1U: SELECT true FROM pg_switch_wal();
+-- Insert data (AO)
+-1U: INSERT INTO ao_foo SELECT generate_series(1,10);
+-- Insert data (AOCO)
+-1U: INSERT INTO aoco_foo SELECT generate_series(1,10), generate_series(1,10);
+-- Delete data and run vacuum (AO)
+-1U: DELETE FROM ao_foo WHERE n > 5;
+-1U: VACUUM;
+-- Delete data and run vacuum (AOCO)
+-1U: DELETE FROM aoco_foo WHERE n > 5;
+-1U: VACUUM;
+
+-- Validate wal records
+! pushd ${COORDINATOR_DATA_DIRECTORY}/pg_wal > /dev/null && last_wal_file=$(psql -At -c "SELECT pg_walfile_name(pg_current_wal_lsn())" postgres) && pg_waldump ${last_wal_file} -r appendonly && popd > /dev/null;
+
+-1U: DROP TABLE ao_foo; 
+-1U: DROP TABLE aoco_foo;
+
+-- Reset wal_level
+!\retcode gpconfig -r wal_level --masteronly;
+-- Reset max_wal_senders
+!\retcode gpconfig -r max_wal_senders --masteronly;
+-- Restart QD
+!\retcode pg_ctl -l /dev/null -D $COORDINATOR_DATA_DIRECTORY restart -w -t 600 -m fast;


### PR DESCRIPTION
   For mirrorless clusters, WAL records are only used for crash recovery
   purposes. In the case of AO/AOCO tables, their WAL records are only
   generated for replication purposes (they are not used for crash
   recovery because AO/AOCO table operations are crash-safe). To decrease
   disk space usage and to improve the performance of AO/AOCO operations, we
   suppress the generation of XLOG_APPENDONLY_INSERT and
   XLOG_APPENDONLY_TRUNCATE WAL records when wal_level=minimal is
   specified.