### PR TITLE
Gprecoverseg targetdirectory check

### DIFF
--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegsetuprecovery.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegsetuprecovery.py
@@ -145,7 +145,7 @@ class ValidationForFullRecoveryTestCase(GpTestCase):
             self.validation_recovery_cmd.forceoverwrite = True
             self.validation_recovery_cmd.run()
             expected_error = "for segment with port {}: Segment directory '{}' exists but does not have valid permissions" \
-                .format(self.seg_recovery_info.target_port, os.path.dirname(d))
+                .format(self.seg_recovery_info.target_port, d)
             self._assert_failed(expected_error)
 
     def test_forceoverwrite_True_dir_exists_with_permissions(self):

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegsetuprecovery.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegsetuprecovery.py
@@ -255,7 +255,6 @@ class SegSetupRecoveryTestCase(GpTestCase):
         mock_dburl.return_value = Mock()
         buf = io.StringIO()
         with tempfile.TemporaryDirectory() as d:
-
             with redirect_stderr(buf):
                 with self.assertRaises(SystemExit) as ex:
                     full_ri = RecoveryInfo('target_data_dir1', 5001, 1, 'source_hostname1',
@@ -326,7 +325,5 @@ class SegSetupRecoveryTestCase(GpTestCase):
             self.full_r1, self.incr_r2], True, self.mock_logger)
         self._assert_validation_full_call(cmd_list[0], self.full_r1, expected_forceoverwrite=True)
         self._assert_setup_incr_call(cmd_list[1], self.incr_r2)
-
-
 
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegsetuprecovery.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegsetuprecovery.py
@@ -138,6 +138,18 @@ class ValidationForFullRecoveryTestCase(GpTestCase):
 
         self._assert_failed("mkdirs failed")
 
+    def test_checkFilePermissions(self):
+        tmp_dir1 = '/tmp/testdir_CFP1'
+        tmp_dir2 = '/tmp/testdir_CFP2'
+        os.makedirs(tmp_dir1, mode=0o750)
+        os.makedirs(tmp_dir2, mode=0o700)
+        self.assertFalse(self.validation_recovery_cmd.checkFilePermission(tmp_dir1, '700'))
+        self.assertTrue(self.validation_recovery_cmd.checkFilePermission(tmp_dir2, '700'))
+        os.rmdir(tmp_dir1)
+        os.rmdir(tmp_dir2)
+        with self.assertRaises(Exception):
+            self.validation_recovery_cmd.checkFilePermission(tmp_dir1, '700')
+            self.validation_recovery_cmd.checkFilePermission(tmp_dir2, '700')
 
 class SetupForIncrementalRecoveryTestCase(GpTestCase):
     def setUp(self):
@@ -243,6 +255,7 @@ class SegSetupRecoveryTestCase(GpTestCase):
         mock_dburl.return_value = Mock()
         buf = io.StringIO()
         with tempfile.TemporaryDirectory() as d:
+
             with redirect_stderr(buf):
                 with self.assertRaises(SystemExit) as ex:
                     full_ri = RecoveryInfo('target_data_dir1', 5001, 1, 'source_hostname1',
@@ -313,4 +326,7 @@ class SegSetupRecoveryTestCase(GpTestCase):
             self.full_r1, self.incr_r2], True, self.mock_logger)
         self._assert_validation_full_call(cmd_list[0], self.full_r1, expected_forceoverwrite=True)
         self._assert_setup_incr_call(cmd_list[1], self.incr_r2)
+
+
+
 

--- a/gpMgmt/sbin/gpsegsetuprecovery.py
+++ b/gpMgmt/sbin/gpsegsetuprecovery.py
@@ -97,26 +97,17 @@ class ValidationForFullRecovery(Command):
                 raise ValidationException("for segment with port {}: Segment directory '{}' exists but is not empty!"
                                       .format(self.recovery_info.target_port,
                                               self.recovery_info.target_datadir))
-        elif os.path.exists(self.recovery_info.target_datadir) and not self.checkFilePermission(self.recovery_info.target_datadir, '700'):
+        elif os.path.exists(self.recovery_info.target_datadir) and\
+            oct(os.stat(self.recovery_info.target_datadir).st_mode & 0o777) != oct(0o700):
                 raise ValidationException("for segment with port {}: Segment directory '{}' exists but does not have valid permissions"
                                           .format(self.recovery_info.target_port,
                                             self.recovery_info.target_datadir))
-
-    def checkFilePermission(self, path, expected_permissions):
-        try:
-            dirpermissions = oct(os.stat(path).st_mode)[-4:]
-            if int(dirpermissions, 8) != int(expected_permissions, 8):
-                return False
-            return True
-        except Exception as e:
-            raise Exception("%s", str(e))
 
     def make_or_update_data_directory(self):
         if os.path.exists(self.recovery_info.target_datadir):
             os.chmod(self.recovery_info.target_datadir, 0o700)
         else:
             os.makedirs(self.recovery_info.target_datadir, 0o700)
-
 
 
 #TODO we may not need this class

--- a/gpMgmt/sbin/gpsegsetuprecovery.py
+++ b/gpMgmt/sbin/gpsegsetuprecovery.py
@@ -75,26 +75,41 @@ class ValidationForFullRecovery(Command):
     def run(self):
         self.logger.info("Validate data directories for segment with dbid {}".
                          format(self.recovery_info.target_segment_dbid))
-        if not self.forceoverwrite:
-            self.validate_failover_data_directory()
+
+        self.validate_failover_data_directory(self.forceoverwrite)
+
         self.logger.info("Validation successful for segment with dbid: {}".format(
             self.recovery_info.target_segment_dbid))
 
-    def validate_failover_data_directory(self):
+    def validate_failover_data_directory(self, forceoverwrite):
         """
         Raises ValidationException when a validation problem is detected
         """
 
-        if not os.path.exists(os.path.dirname(self.recovery_info.target_datadir)):
-            self.make_or_update_data_directory()
+        if not forceoverwrite:
+            if not os.path.exists(os.path.dirname(self.recovery_info.target_datadir)):
+                self.make_or_update_data_directory()
 
-        if not os.path.exists(self.recovery_info.target_datadir):
-            return
+            if not os.path.exists(self.recovery_info.target_datadir):
+                return
 
-        if len(os.listdir(self.recovery_info.target_datadir)) != 0:
-            raise ValidationException("for segment with port {}: Segment directory '{}' exists but is not empty!"
+            if len(os.listdir(self.recovery_info.target_datadir)) != 0:
+                raise ValidationException("for segment with port {}: Segment directory '{}' exists but is not empty!"
                                       .format(self.recovery_info.target_port,
                                               self.recovery_info.target_datadir))
+        elif os.path.exists(self.recovery_info.target_datadir) and not self.checkFilePermission(self.recovery_info.target_datadir, '700'):
+                raise ValidationException("for segment with port {}: Segment directory '{}' exists but does not have valid permissions"
+                                          .format(self.recovery_info.target_port,
+                                            self.recovery_info.target_datadir))
+
+    def checkFilePermission(self, path, expected_permissions):
+        try:
+            dirpermissions = oct(os.stat(path).st_mode)[-4:]
+            if int(dirpermissions, 8) != int(expected_permissions, 8):
+                return False
+            return True
+        except Exception as e:
+            raise Exception("%s", str(e))
 
     def make_or_update_data_directory(self):
         if os.path.exists(self.recovery_info.target_datadir):

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -143,7 +143,7 @@ Feature: gprecoverseg tests
         And a gprecoverseg input file is created for mixed recovery for 2 segments with full and 1 incremental with 'invalid' target directory
         When the user runs gprecoverseg with input file and additional args "-a"
         And gprecoverseg should return a return code of 2
-        And gprecoverseg should print "Segment directory * exists but does not have valid permissions" to stdout
+        And gprecoverseg should print "exists but does not have valid permissions" to stdout
         And gprecoverseg should not print "pg_basebackup: base backup completed" to stdout
         And gprecoverseg should not print "pg_rewind: Done!" to stdout
         And the user runs "gprecoverseg -a"

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -133,42 +133,6 @@ Feature: gprecoverseg tests
       And gprecoverseg should return a return code of 0
       And the row count from table "t" in "postgres" is verified against the saved data
 
-    Scenario: gprecoverseg full recovery should fail if target data directory has invalid permissions
-        Given the database is running
-        And all the segments are running
-        And the segments are synchronized
-        And user immediately stops all primary processes
-        And user can start transactions
-        And 2 gprecoverseg directory under '/tmp' with mode '0750' is created
-        And a gprecoverseg input file is created for mixed recovery for 2 segments with full and 1 incremental with 'invalid' target directory
-        When the user runs gprecoverseg with input file and additional args "-a"
-        And gprecoverseg should return a return code of 2
-        And gprecoverseg should print "exists but does not have valid permissions" to stdout
-        And gprecoverseg should not print "pg_basebackup: base backup completed" to stdout
-        And gprecoverseg should not print "pg_rewind: Done!" to stdout
-        And the user runs "gprecoverseg -a"
-        And gprecoverseg should return a return code of 0
-        And all the segments are running
-        And the segments are synchronized
-        And the user runs "gprecoverseg -ar"
-        And gprecoverseg should return a return code of 0
-
-    Scenario: gprecoverseg full recovery should not fail when target data directory does not exists
-        Given the database is running
-        And all the segments are running
-        And the segments are synchronized
-        And user immediately stops all primary processes
-        And user can start transactions
-        And a gprecoverseg input file is created for mixed recovery for 2 segments with full and 1 incremental with 'dummy' target directory
-        When the user runs gprecoverseg with input file and additional args "-a"
-        And gprecoverseg should return a return code of 0
-        And gprecoverseg should print "pg_basebackup: base backup completed" to stdout
-        And gprecoverseg should print "pg_rewind: Done!" to stdout
-        And all the segments are running
-        And the segments are synchronized
-        And the user runs "gprecoverseg -ar"
-        And gprecoverseg should return a return code of 0
-
     Scenario: gprecoverseg incremental recovery displays pg_rewind progress to the user
         Given the database is running
         And all the segments are running
@@ -329,6 +293,46 @@ Feature: gprecoverseg tests
         | scenario    | args |
         | incremental | -a   |
         | full        | -aF  |
+
+    @demo_cluster
+    Scenario: gprecoverseg full recovery should fail if target data directory has invalid permissions
+        Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And user immediately stops all primary processes
+        And user can start transactions
+        And 2 gprecoverseg directory under '/tmp' with mode '0750' is created
+        And a gprecoverseg input file is created for mixed recovery for 2 segments with full and 1 incremental with 'invalid' target directory
+        When the user runs gprecoverseg with input file and additional args "-a"
+        And gprecoverseg should return a return code of 2
+        And gprecoverseg should print "exists but does not have valid permissions" to stdout
+        And gprecoverseg should not print "pg_basebackup: base backup completed" to stdout
+        And gprecoverseg should not print "pg_rewind: Done!" to stdout
+        And the user runs "gprecoverseg -a"
+        And gprecoverseg should return a return code of 0
+        And all the segments are running
+        And the segments are synchronized
+        And the user runs "gprecoverseg -ar"
+        And gprecoverseg should return a return code of 0
+
+    @demo_cluster
+    Scenario: gprecoverseg full recovery should not fail when target data directory does not exists
+        Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And user immediately stops all primary processes
+        And user can start transactions
+        And a gprecoverseg directory under '/tmp' with mode '0700' is created
+        And a gprecoverseg input file is created for mixed recovery for 2 segments with full and 1 incremental with 'dummy' target directory
+        When the user runs gprecoverseg with input file and additional args "-a"
+        And gprecoverseg should return a return code of 0
+        And gprecoverseg should print "pg_basebackup: base backup completed" to stdout
+        And gprecoverseg should print "pg_rewind: Done!" to stdout
+        And all the segments are running
+        And the segments are synchronized
+        And the user runs "gprecoverseg -ar"
+        And gprecoverseg should return a return code of 0
+
 
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -677,7 +677,7 @@ def impl(context, command, out_msg):
 def impl(context, command, out_msg):
     check_stdout_msg(context, out_msg)
 
-
+@when('{command} should not print "{out_msg}" to stdout')
 @then('{command} should not print "{out_msg}" to stdout')
 def impl(context, command, out_msg):
     check_string_not_present_stdout(context, out_msg)

--- a/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
@@ -345,7 +345,7 @@ def impl(context, full, incr, dir_type):
                 if dir_type == 'dummy':
                     invalid_dir_config = '%s|%s|%s' % (mirror.getSegmentHostName(),
                                             mirror.getSegmentPort(),
-                                            "%s/%s"%(context.working_directory,full_seg_count))
+                                            "%s/%s"%(context.mirror_context.working_directory[0],full_seg_count))
                 elif dir_type == 'invalid':
                     invalid_dir_config = '%s|%s|%s' % (mirror.getSegmentHostName(),
                                             mirror.getSegmentPort(),

--- a/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
@@ -330,6 +330,35 @@ def impl(context, full, incr):
     with open(context.mirror_context.input_file_path(), 'w') as fd:
         fd.write(contents)
 
+@given("a gprecoverseg input file is created for mixed recovery for {full} segments with full and {incr} incremental with '{dir_type}' target directory")
+def impl(context, full, incr, dir_type):
+    full_seg_count = int(full)
+    incr_seg_count = int(incr)
+    segments = GpArray.initFromCatalog(dbconn.DbURL()).getSegmentList()
+    contents = ''
+    for i in range(len(segments)):
+        mirror = segments[i].mirrorDB
+        valid_config = '%s|%s|%s' % (mirror.getSegmentHostName(),
+                                        mirror.getSegmentPort(),
+                                        mirror.getSegmentDataDirectory())
+        if full_seg_count > 0:
+                if dir_type == 'dummy':
+                    invalid_dir_config = '%s|%s|%s' % (mirror.getSegmentHostName(),
+                                            mirror.getSegmentPort(),
+                                            "%s/%s"%(context.working_directory,full_seg_count))
+                elif dir_type == 'invalid':
+                    invalid_dir_config = '%s|%s|%s' % (mirror.getSegmentHostName(),
+                                            mirror.getSegmentPort(),
+                                            context.mirror_context.working_directory[full_seg_count-1])
+                contents += '%s %s\n' % (valid_config, invalid_dir_config)
+                full_seg_count -= 1
+        elif incr_seg_count > 0:
+                incr_seg_count -= 1
+                contents += '%s\n' % (valid_config)
+        context.mirror_context.input_file = "gprecoverseg_mixed.txt"
+        with open(context.mirror_context.input_file_path(), 'w') as fd:
+                fd.write(contents)
+
 
 @given("{num} gpmovemirrors directory under '{parent_dir}' with mode '{mode}' is created")
 @given("{num} gprecoverseg directory under '{parent_dir}' with mode '{mode}' is created")


### PR DESCRIPTION
gprecoverseg: Target data dir validation 

gprecoverseg does not validate the target directory during full
recovery. Currently if the target data dir exists with the wrong
permissions (755 etc), basebackup doesn't fail but pg_ctl start fails.

PR tries to validate the target directory and if any of the target directory
doesn't has valid permissions gprecoverseg fails with valid message
before baseback executes. So that the user can correct the target
directory permissions and run gprecoverseg.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
