### PR TITLE
Bump ORCA version to 3.122.0

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -40,10 +40,10 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]],
 [
-return strncmp("3.121.", GPORCA_VERSION_STRING, 6);
+return strncmp("3.122.", GPORCA_VERSION_STRING, 6);
 ])],
 [AC_MSG_RESULT([[ok]])],
-[AC_MSG_ERROR([Your ORCA version is expected to be 3.121.XXX])]
+[AC_MSG_ERROR([Your ORCA version is expected to be 3.122.XXX])]
 )
 AC_LANG_POP([C++])
 ])# PGAC_CHECK_ORCA_VERSION

--- a/configure
+++ b/configure
@@ -12487,7 +12487,7 @@ int
 main ()
 {
 
-return strncmp("3.121.", GPORCA_VERSION_STRING, 6);
+return strncmp("3.122.", GPORCA_VERSION_STRING, 6);
 
   ;
   return 0;
@@ -12497,7 +12497,7 @@ if ac_fn_cxx_try_run "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
 $as_echo "ok" >&6; }
 else
-  as_fn_error $? "Your ORCA version is expected to be 3.121.XXX" "$LINENO" 5
+  as_fn_error $? "Your ORCA version is expected to be 3.122.XXX" "$LINENO" 5
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \

--- a/gpAux/releng/releng.mk
+++ b/gpAux/releng/releng.mk
@@ -120,7 +120,7 @@ sync_tools: opt_write_test /opt/releng/apache-ant
 	-Divyrepo.user=$(IVYREPO_USER) -Divyrepo.passwd="$(IVYREPO_PASSWD)" -quiet resolve);
 
 ifeq "$(findstring aix,$(BLD_ARCH))" ""
-	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.121.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
+	LD_LIBRARY_PATH='' wget --no-check-certificate -q -O - https://github.com/greenplum-db/gporca/releases/download/v3.122.0/bin_orca_centos5_release.tar.gz | tar zxf - -C $(BLD_TOP)/ext/$(BLD_ARCH)
 endif
 
 clean_tools: opt_write_test

--- a/src/test/regress/expected/notin.out
+++ b/src/test/regress/expected/notin.out
@@ -1276,8 +1276,70 @@ select * from table_source4 where c3 = 'INC' and c4 = '0000000001' and c2 not in
  000181202006010000003158 | a  | INC | 0000000001
 (1 row)
 
+-- Test notin with outerrefs in the subquery
+--
+-- q47
+--
+create table outerref (a int, b text, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into outerref (a,b,c) values(1,'1',1);
+insert into outerref (a,b,c) values(1,'1',2);
+-- For a cluster with only 1 segment, this test doesn't crash without the fix.
+-- We can disable_xform('CXformSimplifySelectWithSubquery'); for testing for a
+-- cluster with only 1 segment. Not adding here as it changes the default plan
+-- that ORCA picks
+explain select b from outerref where b not in (select distinct b where c>1);
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=2)
+   ->  Seq Scan on outerref  (cost=0.00..1.03 rows=1 width=2)
+         Filter: (subplan)
+         SubPlan 1
+           ->  GroupAggregate  (cost=0.00..0.03 rows=1 width=32)
+                 Group By: $0
+                 ->  Result  (cost=0.00..0.01 rows=1 width=0)
+                       One-Time Filter: $1 > 1
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(10 rows)
+
+select b from outerref where b not in (select distinct b where c>1);
+ b 
+---
+ 1
+(1 row)
+
+create table outerref_int (a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into outerref_int (a,b,c) values(1,2,1);
+insert into outerref_int (a,b,c) values(1,2,2);
+explain select b from outerref_int where b not in (select distinct b where c>1);
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=4)
+   ->  Seq Scan on outerref_int  (cost=0.00..1.03 rows=1 width=4)
+         Filter: (subplan)
+         SubPlan 1
+           ->  GroupAggregate  (cost=0.00..0.03 rows=1 width=4)
+                 Group By: $0
+                 ->  Result  (cost=0.00..0.01 rows=1 width=0)
+                       One-Time Filter: $1 > 1
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(10 rows)
+
+select b from outerref_int where b not in (select distinct b where c>1);
+ b 
+---
+ 2
+(1 row)
+
 reset search_path;
 drop schema notin cascade;
+NOTICE:  drop cascades to table notin.outerref_int
+NOTICE:  drop cascades to table notin.outerref
 NOTICE:  drop cascades to table notin.table_config
 NOTICE:  drop cascades to table notin.table_source4
 NOTICE:  drop cascades to table notin.table_source2

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -1292,8 +1292,82 @@ select * from table_source4 where c3 = 'INC' and c4 = '0000000001' and c2 not in
  000181202006010000003158 | a  | INC | 0000000001
 (1 row)
 
+-- Test notin with outerrefs in the subquery
+--
+-- q47
+--
+create table outerref (a int, b text, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into outerref (a,b,c) values(1,'1',1);
+insert into outerref (a,b,c) values(1,'1',2);
+-- For a cluster with only 1 segment, this test doesn't crash without the fix.
+-- We can disable_xform('CXformSimplifySelectWithSubquery'); for testing for a
+-- cluster with only 1 segment. Not adding here as it changes the default plan
+-- that ORCA picks
+explain select b from outerref where b not in (select distinct b where c>1);
+                                                                                                                                                                QUERY PLAN                                                                                                                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..882688.11 rows=1 width=2)
+   ->  Result  (cost=0.00..882688.11 rows=1 width=2)
+         ->  Table Scan on outerref  (cost=0.00..882688.11 rows=1 width=2)
+               Filter: (subplan)
+               SubPlan 1
+                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                       ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                             Filter: (CASE WHEN (sum((CASE WHEN $0 = ($0) THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN ($0) IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN $0 IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN $0 = ($0) THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
+                             ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                                   ->  Aggregate  (cost=0.00..0.00 rows=1 width=16)
+                                         ->  Result  (cost=0.00..0.00 rows=1 width=8)
+                                               ->  Result  (cost=0.00..0.00 rows=1 width=8)
+                                                     ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                                                           One-Time Filter: $1 > 1
+                                                           ->  Result  (cost=0.00..0.00 rows=1 width=1)
+ Optimizer status: PQO version 3.122.0
+(16 rows)
+
+select b from outerref where b not in (select distinct b where c>1);
+ b 
+---
+ 1
+(1 row)
+
+create table outerref_int (a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into outerref_int (a,b,c) values(1,2,1);
+insert into outerref_int (a,b,c) values(1,2,2);
+explain select b from outerref_int where b not in (select distinct b where c>1);
+                                                                                                                                                                QUERY PLAN                                                                                                                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..882688.11 rows=1 width=4)
+   ->  Result  (cost=0.00..882688.11 rows=1 width=4)
+         ->  Table Scan on outerref_int  (cost=0.00..882688.11 rows=1 width=4)
+               Filter: (subplan)
+               SubPlan 1
+                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                       ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                             Filter: (CASE WHEN (sum((CASE WHEN $0 = ($0) THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN ($0) IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN $0 IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN $0 = ($0) THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
+                             ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                                   ->  Aggregate  (cost=0.00..0.00 rows=1 width=16)
+                                         ->  Result  (cost=0.00..0.00 rows=1 width=8)
+                                               ->  Result  (cost=0.00..0.00 rows=1 width=4)
+                                                     ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                                                           One-Time Filter: $1 > 1
+                                                           ->  Result  (cost=0.00..0.00 rows=1 width=1)
+ Optimizer status: PQO version 3.122.0
+(16 rows)
+
+select b from outerref_int where b not in (select distinct b where c>1);
+ b 
+---
+ 2
+(1 row)
+
 reset search_path;
 drop schema notin cascade;
+NOTICE:  drop cascades to table notin.outerref_int
+NOTICE:  drop cascades to table notin.outerref
 NOTICE:  drop cascades to table notin.table_config
 NOTICE:  drop cascades to table notin.table_source4
 NOTICE:  drop cascades to table notin.table_source2

--- a/src/test/regress/sql/notin.sql
+++ b/src/test/regress/sql/notin.sql
@@ -397,6 +397,27 @@ select * from table_source2 where c3 = 'INC' and c4 = '0000000001' and c2 not in
 explain select * from table_source4 where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
 select * from table_source4 where c3 = 'INC' and c4 = '0000000001' and c2 not in (SELECT c1 from table_config where c2='test');
 
+-- Test notin with outerrefs in the subquery
+--
+-- q47
+--
+create table outerref (a int, b text, c int);
+insert into outerref (a,b,c) values(1,'1',1);
+insert into outerref (a,b,c) values(1,'1',2);
+
+-- For a cluster with only 1 segment, this test doesn't crash without the fix.
+-- We can disable_xform('CXformSimplifySelectWithSubquery'); for testing for a
+-- cluster with only 1 segment. Not adding here as it changes the default plan
+-- that ORCA picks
+explain select b from outerref where b not in (select distinct b where c>1);
+select b from outerref where b not in (select distinct b where c>1);
+
+create table outerref_int (a int, b int, c int);
+insert into outerref_int (a,b,c) values(1,2,1);
+insert into outerref_int (a,b,c) values(1,2,2);
+
+explain select b from outerref_int where b not in (select distinct b where c>1);
+select b from outerref_int where b not in (select distinct b where c>1);
 
 reset search_path;
 drop schema notin cascade;


### PR DESCRIPTION
This version of ORCA fixes colref in preprocessing for SubqueryALL with
outer refs. Adding regression tests for the same.

Corresponding ORCA PR: https://github.com/greenplum-db/gporca/pull/633
