### PR TITLE
(6x backport) Removing some invocation of DisconnectAndDestroyAllGangs that might P…

### DIFF
--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -73,8 +73,6 @@ CreateGangFunc pCreateGangFunc = cdbgang_createGang_async;
 static bool NeedResetSession = false;
 static Oid	OldTempNamespace = InvalidOid;
 
-static void resetSessionForPrimaryGangLoss(void);
-
 /*
  * cdbgang_createGang:
  *
@@ -688,6 +686,11 @@ getCdbProcessesForQD(int isPrimary)
 	return list;
 }
 
+/*
+ * This function should not be used in the context of named portals
+ * as it destroys the CdbComponentsContext, which is accessed later
+ * during named portal cleanup.
+ */
 void
 DisconnectAndDestroyAllGangs(bool resetSession)
 {
@@ -826,7 +829,7 @@ CheckForResetSession(void)
 	}
 }
 
-static void
+void
 resetSessionForPrimaryGangLoss(void)
 {
 	if (ProcCanSetMppSessionId())

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -99,6 +99,8 @@ extern bool segment_failure_due_to_missing_writer(const char *error_message);
  */
 extern void cdbgang_parse_gpqeid_params(struct Port *port, const char *gpqeid_value);
 
+extern void resetSessionForPrimaryGangLoss(void);
+
 /*
  * MPP Worker Process information
  *

--- a/src/test/isolation2/expected/gpdispatch.out
+++ b/src/test/isolation2/expected/gpdispatch.out
@@ -1,3 +1,6 @@
+include: helpers/server_helpers.sql;
+CREATE
+
 -- Try to verify that a session fatal due to OOM should have no effect on other sessions.
 -- Report on https://github.com/greenplum-db/gpdb/issues/12399
 
@@ -17,7 +20,7 @@ BEGIN
 -- session1 will fatal
 1: select count(*) > 0 from gp_dist_random('pg_class');
 FATAL:  could not allocate resources for segworker communication (cdbdisp_async.c:301)
-HINT:  Process 31746 will wait for gp_debug_linger=1 seconds before termination.
+HINT:  Process 91151 will wait for gp_debug_linger=1 seconds before termination.
 Note that its locks and other resources will not be released until then.
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
@@ -38,4 +41,122 @@ select gp_inject_fault('make_dispatch_result_error', 'reset', dbid) from gp_segm
  gp_inject_fault 
 -----------------
  Success:        
+(1 row)
+
+--
+-- Test for issue https://github.com/greenplum-db/gpdb/issues/12703
+--
+
+-- Case for cdbgang_createGang_async
+1: create table t_12703(a int);
+CREATE
+
+1:begin;
+BEGIN
+-- make a cursor so that we have a named portal
+1: declare cur12703 cursor for select * from t_12703;
+DECLARE
+
+2: select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=1), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+-- next sql will trigger FTS to mark seg1 as down
+2: select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- this will go to cdbgang_createGang_async's code path
+-- for some segments are DOWN. It should not PANIC even
+-- with a named portal existing.
+1: select * from t_12703;
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:98)
+1: abort;
+ABORT
+
+1q: ... <quitting>
+2q: ... <quitting>
+
+-- Case for cdbCopyEndInternal
+-- Provide some data to copy in
+insert into t_12703 select * from generate_series(1, 10)i;
+INSERT 10
+copy t_12703 to '/tmp/t_12703';
+COPY 10
+-- make copy in statement hang at the entry point of cdbCopyEndInternal
+select gp_inject_fault('cdb_copy_end_internal_start', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: copy t_12703 from '/tmp/t_12703';  <waiting ...>
+select gp_wait_until_triggered_fault('cdb_copy_end_internal_start', 1, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+-- make Gang connection is BAD
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=2), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+2: select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+2: begin;
+BEGIN
+select gp_inject_fault('cdb_copy_end_internal_start', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- continue copy it should not PANIC
+1<:  <... completed>
+ERROR:  MPP detected 1 segment failures, system is reconnected
+1q: ... <quitting>
+-- session 2 still alive (means not PANIC happens)
+2: select 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+2: end;
+END
+2q: ... <quitting>
+
+!\retcode gprecoverseg -aF --no-progress;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+-- loop while segments come in sync
+select wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+!\retcode gprecoverseg -ar;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+-- loop while segments come in sync
+select wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+-- verify no segment is down after recovery
+select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 0     
 (1 row)

--- a/src/test/isolation2/expected/gpdispatch_1.out
+++ b/src/test/isolation2/expected/gpdispatch_1.out
@@ -1,0 +1,329 @@
+include: helpers/server_helpers.sql;
+CREATE
+
+-- Try to verify that a session fatal due to OOM should have no effect on other sessions.
+-- Report on https://github.com/greenplum-db/gpdb/issues/12399
+
+create extension if not exists gp_inject_fault;
+CREATE
+
+1: set gp_debug_linger = '1s';
+SET
+1: select gp_inject_fault('make_dispatch_result_error', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2: begin;
+BEGIN
+
+-- session1 will fatal
+1: select count(*) > 0 from gp_dist_random('pg_class');
+FATAL:  could not allocate resources for segworker communication (cdbdisp_async.c:301)
+HINT:  Process 98844 will wait for gp_debug_linger=1 seconds before termination.
+Note that its locks and other resources will not be released until then.
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+
+-- session 2 should be ok
+2: select count(*) > 0 from gp_dist_random('pg_class');
+ ?column? 
+----------
+ t        
+(1 row)
+2: commit;
+COMMIT
+1q: ... <quitting>
+2q: ... <quitting>
+
+select gp_inject_fault('make_dispatch_result_error', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+--
+-- Test for issue https://github.com/greenplum-db/gpdb/issues/12703
+--
+
+-- Case for cdbgang_createGang_async
+1: create table t_12703(a int);
+CREATE
+
+1:begin;
+BEGIN
+-- make a cursor so that we have a named portal
+1: declare cur12703 cursor for select * from t_12703;
+DECLARE
+
+2: select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=1), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+-- next sql will trigger FTS to mark seg1 as down
+2: select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- this will go to cdbgang_createGang_async's code path
+-- for some segments are DOWN. It should not PANIC even
+-- with a named portal existing.
+1: select * from t_12703;
+ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:95)
+ERROR:  Error on receive from seg1 slice1 127.0.1.1:6003 pid=98861: server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+1: abort;
+ABORT
+
+1q: ... <quitting>
+2q: ... <quitting>
+
+-- Case for cdbCopyEndInternal
+-- Provide some data to copy in
+insert into t_12703 select * from generate_series(1, 10)i;
+INSERT 10
+copy t_12703 to '/tmp/t_12703';
+COPY 10
+-- make copy in statement hang at the entry point of cdbCopyEndInternal
+select gp_inject_fault('cdb_copy_end_internal_start', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: copy t_12703 from '/tmp/t_12703';  <waiting ...>
+select gp_wait_until_triggered_fault('cdb_copy_end_internal_start', 1, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+-- make Gang connection is BAD
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=2), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+2: select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+2: begin;
+BEGIN
+select gp_inject_fault('cdb_copy_end_internal_start', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- continue copy it should not PANIC
+1<:  <... completed>
+ERROR:  MPP detected 1 segment failures, system is reconnected
+1q: ... <quitting>
+-- session 2 still alive (means not PANIC happens)
+2: select 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+2: end;
+END
+2q: ... <quitting>
+
+!\retcode gprecoverseg -aF --no-progress;
+-- start_ignore
+20211220:20:32:19:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-Starting gprecoverseg with args: -aF --no-progress
+20211220:20:32:19:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 6.18.2+dev.211.g4a7b54e7bc build dev'
+20211220:20:32:19:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 9.4.26 (Greenplum Database 6.18.2+dev.211.g4a7b54e7bc build dev) on x86_64-unknown-linux-gnu, compiled by gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0, 64-bit compiled on Dec 20 2021 20:20:16 (with assert checking)'
+20211220:20:32:19:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-Obtaining Segment details from master...
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-Heap checksum setting is consistent between master and the segments that are candidates for recoverseg
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-Greenplum instance recovery parameters
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-Recovery type              = Standard
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-Recovery 1 of 2
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-   Synchronization mode                 = Full
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance host                 = zlyu
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance address              = zlyu
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance directory            = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast2/demoDataDir1
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance port                 = 6003
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance host        = zlyu
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance address     = zlyu
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance directory   = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror2/demoDataDir1
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance port        = 6006
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Target                      = in-place
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-Recovery 2 of 2
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-   Synchronization mode                 = Full
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance host                 = zlyu
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance address              = zlyu
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance directory            = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast3/demoDataDir2
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance port                 = 6004
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance host        = zlyu
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance address     = zlyu
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance directory   = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror3/demoDataDir2
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance port        = 6007
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Target                      = in-place
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211220:20:32:20:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-Starting to create new pg_hba.conf on primary segments
+20211220:20:32:21:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-Successfully modified pg_hba.conf on primary segments to allow replication connections
+20211220:20:32:21:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-2 segment(s) to recover
+20211220:20:32:21:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-Ensuring 2 failed segment(s) are stopped
+20211220:20:32:23:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-Ensuring that shared memory is cleaned up for stopped segments
+20211220:20:32:24:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-Validating remote directories
+20211220:20:32:25:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-Configuring new segments
+.
+20211220:20:32:27:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-Updating configuration with new mirrors
+20211220:20:32:27:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-Updating mirrors
+20211220:20:32:27:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-Starting mirrors
+20211220:20:32:27:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-era is 27bd61f9586c5519_211220202207
+20211220:20:32:27:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-Commencing parallel segment instance startup, please wait...
+20211220:20:32:28:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-Process results...
+20211220:20:32:28:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-Triggering FTS probe
+20211220:20:32:28:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-********************************
+20211220:20:32:28:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-Segments successfully recovered.
+20211220:20:32:28:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-********************************
+20211220:20:32:28:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-Recovered mirror segments need to sync WAL with primary segments.
+20211220:20:32:28:098932 gprecoverseg:zlyu:gpadmin-[INFO]:-Use 'gpstate -e' to check progress of WAL sync remaining bytes
+
+-- end_ignore
+(exited with code 0)
+
+-- loop while segments come in sync
+select wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+!\retcode gprecoverseg -ar;
+-- start_ignore
+20211220:20:32:28:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Starting gprecoverseg with args: -ar
+20211220:20:32:28:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 6.18.2+dev.211.g4a7b54e7bc build dev'
+20211220:20:32:28:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 9.4.26 (Greenplum Database 6.18.2+dev.211.g4a7b54e7bc build dev) on x86_64-unknown-linux-gnu, compiled by gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0, 64-bit compiled on Dec 20 2021 20:20:16 (with assert checking)'
+20211220:20:32:28:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Obtaining Segment details from master...
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Greenplum instance recovery parameters
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Recovery type              = Rebalance
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Unbalanced segment 1 of 4
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance host        = zlyu
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance address     = zlyu
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance directory   = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror2/demoDataDir1
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance port        = 6006
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Balanced role                   = Mirror
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Current role                    = Primary
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Unbalanced segment 2 of 4
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance host        = zlyu
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance address     = zlyu
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance directory   = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast2/demoDataDir1
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance port        = 6003
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Balanced role                   = Primary
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Current role                    = Mirror
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Unbalanced segment 3 of 4
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance host        = zlyu
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance address     = zlyu
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance directory   = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror3/demoDataDir2
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance port        = 6007
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Balanced role                   = Mirror
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Current role                    = Primary
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Unbalanced segment 4 of 4
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance host        = zlyu
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance address     = zlyu
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance directory   = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast3/demoDataDir2
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Unbalanced instance port        = 6004
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Balanced role                   = Primary
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Current role                    = Mirror
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Determining primary and mirror segment pairs to rebalance
+20211220:20:32:29:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Stopping unbalanced primary segments...
+20211220:20:32:30:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Triggering segment reconfiguration
+20211220:20:32:37:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Starting segment synchronization
+20211220:20:32:37:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-=============================START ANOTHER RECOVER=========================================
+20211220:20:32:37:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 6.18.2+dev.211.g4a7b54e7bc build dev'
+20211220:20:32:37:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 9.4.26 (Greenplum Database 6.18.2+dev.211.g4a7b54e7bc build dev) on x86_64-unknown-linux-gnu, compiled by gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0, 64-bit compiled on Dec 20 2021 20:20:16 (with assert checking)'
+20211220:20:32:37:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Obtaining Segment details from master...
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Heap checksum setting is consistent between master and the segments that are candidates for recoverseg
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Greenplum instance recovery parameters
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Recovery type              = Standard
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Recovery 1 of 2
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Synchronization mode                 = Incremental
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance host                 = zlyu
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance address              = zlyu
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance directory            = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror2/demoDataDir1
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance port                 = 6006
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance host        = zlyu
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance address     = zlyu
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance directory   = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast2/demoDataDir1
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance port        = 6003
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Target                      = in-place
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Recovery 2 of 2
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Synchronization mode                 = Incremental
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance host                 = zlyu
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance address              = zlyu
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance directory            = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror3/demoDataDir2
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Failed instance port                 = 6007
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance host        = zlyu
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance address     = zlyu
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance directory   = /home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast3/demoDataDir2
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Source instance port        = 6004
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-   Recovery Target                      = in-place
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:----------------------------------------------------------
+20211220:20:32:38:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Starting to create new pg_hba.conf on primary segments
+20211220:20:32:39:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Successfully modified pg_hba.conf on primary segments to allow replication connections
+20211220:20:32:39:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-2 segment(s) to recover
+20211220:20:32:39:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Ensuring 2 failed segment(s) are stopped
+20211220:20:32:41:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Ensuring that shared memory is cleaned up for stopped segments
+20211220:20:32:41:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Updating configuration with new mirrors
+20211220:20:32:42:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Updating mirrors
+20211220:20:32:42:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Running pg_rewind on failed segments
+zlyu (dbid 6): no rewind required
+zlyu (dbid 7): no rewind required
+20211220:20:32:45:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Starting mirrors
+20211220:20:32:45:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-era is 27bd61f9586c5519_211220202207
+20211220:20:32:45:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Commencing parallel segment instance startup, please wait...
+20211220:20:32:46:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Process results...
+20211220:20:32:46:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Triggering FTS probe
+20211220:20:32:46:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-********************************
+20211220:20:32:46:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Segments successfully recovered.
+20211220:20:32:46:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-********************************
+20211220:20:32:46:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Recovered mirror segments need to sync WAL with primary segments.
+20211220:20:32:46:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-Use 'gpstate -e' to check progress of WAL sync remaining bytes
+20211220:20:32:46:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-==============================END ANOTHER RECOVER==========================================
+20211220:20:32:46:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-******************************************************************
+20211220:20:32:46:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-The rebalance operation has completed successfully.
+20211220:20:32:46:100504 gprecoverseg:zlyu:gpadmin-[INFO]:-******************************************************************
+
+-- end_ignore
+(exited with code 0)
+
+-- loop while segments come in sync
+select wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+-- verify no segment is down after recovery
+select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 0     
+(1 row)

--- a/src/test/isolation2/init_file_isolation2
+++ b/src/test/isolation2/init_file_isolation2
@@ -15,6 +15,10 @@ s/cdbdisp_async.c:[0-9]+/cdbdisp_async.c:xxx/
 m/^\d+.*gpconfig.*-\[INFO\]:-/
 s/^\d+.*gpconfig.*-\[INFO\]:-//
 
+# line number in error message
+m/\(cdbgang_async\.c\:\d+\)/
+s/\(cdbgang_async\.c:\d+\)/\(cdbgang_async\.c:LINE_NUM\)/
+
 # ignore OID and file/line number diffs for invalid toast indexes
 m/^ERROR:  no valid index found for toast relation/
 s/with Oid \d+ \(.*\)/with Oid OID/

--- a/src/test/isolation2/sql/gpdispatch.sql
+++ b/src/test/isolation2/sql/gpdispatch.sql
@@ -1,3 +1,5 @@
+include: helpers/server_helpers.sql;
+
 -- Try to verify that a session fatal due to OOM should have no effect on other sessions.
 -- Report on https://github.com/greenplum-db/gpdb/issues/12399
 
@@ -17,3 +19,61 @@ create extension if not exists gp_inject_fault;
 2q:
 
 select gp_inject_fault('make_dispatch_result_error', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+--
+-- Test for issue https://github.com/greenplum-db/gpdb/issues/12703
+--
+
+-- Case for cdbgang_createGang_async
+1: create table t_12703(a int);
+
+1:begin;
+-- make a cursor so that we have a named portal
+1: declare cur12703 cursor for select * from t_12703;
+
+2: select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=1), 'stop');
+-- next sql will trigger FTS to mark seg1 as down
+2: select gp_request_fts_probe_scan();
+
+-- this will go to cdbgang_createGang_async's code path
+-- for some segments are DOWN. It should not PANIC even
+-- with a named portal existing.
+1: select * from t_12703;
+1: abort;
+
+1q:
+2q:
+
+-- Case for cdbCopyEndInternal
+-- Provide some data to copy in
+insert into t_12703 select * from generate_series(1, 10)i;
+copy t_12703 to '/tmp/t_12703';
+-- make copy in statement hang at the entry point of cdbCopyEndInternal
+select gp_inject_fault('cdb_copy_end_internal_start', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+1&: copy t_12703 from '/tmp/t_12703';
+select gp_wait_until_triggered_fault('cdb_copy_end_internal_start', 1, dbid) from gp_segment_configuration where role = 'p' and content = -1;
+-- make Gang connection is BAD
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=2), 'stop');
+2: select gp_request_fts_probe_scan();
+2: begin;
+select gp_inject_fault('cdb_copy_end_internal_start', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+-- continue copy it should not PANIC
+1<:
+1q:
+-- session 2 still alive (means not PANIC happens)
+2: select 1;
+2: end;
+2q:
+
+!\retcode gprecoverseg -aF --no-progress;
+
+-- loop while segments come in sync
+select wait_until_all_segments_synchronized();
+
+!\retcode gprecoverseg -ar;
+
+-- loop while segments come in sync
+select wait_until_all_segments_synchronized();
+
+-- verify no segment is down after recovery
+select count(*) from gp_segment_configuration where status = 'd';


### PR DESCRIPTION
When there is some primary segment down, we will DisconnectAndDestroyAllGangs and throw an error.
however, DisconnectAndDestroyAllGangs will destroy the memory context CdbComponentsContext.
But if we have named portal exists (cursors), we will use CdbComponentsContext when aborting portals,
it will PANIC due to null pointer reference to the destroyed CdbComponentsContext.

So it is safe to call this function:
1. call it after all portals are cleaned up
2. call it when there cannot be any named portals

In this commit, I remove the invocation of DisconnectAndDestroyAllGangs in:
1. cdbgang_createGang_async
2. cdbCopyEndInternal

Here we just call resetSessionForPrimaryGangLoss instead of DisconnectAndDestroyAllGangs.
Because some primary segment is down writerGangLost will be marked when recycling gangs,
All Gangs will be destroyed by ResetAllGangs in AtAbort_DispatcherState.

For details, please refer to Github Issue #12703. This commit fixes it.

(cherry picked from commit d70a4bb44da16265928ebc8818597170309a55f0
and commit 39f2a74534fd0d31da1d57c62b139b380169beaa)
