### PR TITLE
Allow cancellable ANALYZE queries

### DIFF
--- a/src/backend/catalog/pg_compression.c
+++ b/src/backend/catalog/pg_compression.c
@@ -334,9 +334,10 @@ zlib_decompress(PG_FUNCTION_ARGS)
 
 	Insist(src_sz > 0 && dst_sz > 0);
 
-
 	last_error = state->decompress_fn(dst, &amount_available_used,
 									  (const Bytef *) src, src_sz);
+
+	SIMPLE_FAULT_INJECTOR("zlib_decompress_after_decompress_fn");
 
 	*dst_used = amount_available_used;
 

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -2604,7 +2604,7 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 	 * Execute it.
 	 */
 	elog(elevel, "Executing SQL: %s", str.data);
-	CdbDispatchCommand(str.data, DF_WITH_SNAPSHOT, &cdb_pgresults);
+	CdbDispatchCommand(str.data, DF_WITH_SNAPSHOT | DF_CANCEL_ON_ERROR, &cdb_pgresults);
 
 	/*
 	 * Build a modified tuple descriptor for the table.

--- a/src/test/isolation2/expected/cancel_query.out
+++ b/src/test/isolation2/expected/cancel_query.out
@@ -1,0 +1,51 @@
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE
+
+0:CREATE TABLE a_partition_table_for_analyze_cancellation ( a_date date NOT NULL, a_bigint bigint NOT NULL, b_bigint bigint NOT NULL ) WITH (appendonly='true',  orientation='column') DISTRIBUTED BY (a_bigint, b_bigint) PARTITION BY RANGE(a_date) ( PARTITION p1 START ('2018-01-01'::date) END ('2018-12-31'::date) WITH (appendonly='true', orientation='column') COLUMN a_date ENCODING (compresstype=zlib) COLUMN a_bigint ENCODING (compresstype=zlib) COLUMN b_bigint ENCODING (compresstype=zlib), PARTITION p2 START ('2019-01-01'::date) END ('2019-12-31'::date) WITH (appendonly='true', orientation='column') COLUMN a_date ENCODING (compresstype=zlib) COLUMN a_bigint ENCODING (compresstype=zlib) COLUMN b_bigint ENCODING (compresstype=zlib), PARTITION p3 START ('2020-01-01'::date) END ('2020-12-31'::date) WITH (appendonly='true', orientation='column') COLUMN a_date ENCODING (compresstype=zlib) COLUMN a_bigint ENCODING (compresstype=zlib) COLUMN b_bigint ENCODING (compresstype=zlib) );
+CREATE
+0:INSERT INTO a_partition_table_for_analyze_cancellation VALUES(timestamp '2018-01-01 10:00:00', 1, 3);
+INSERT 1
+0:INSERT INTO a_partition_table_for_analyze_cancellation VALUES(timestamp '2019-01-01 12:00:00', 2, 4);
+INSERT 1
+0:INSERT INTO a_partition_table_for_analyze_cancellation VALUES(timestamp '2020-01-01 13:00:00', 3, 5);
+INSERT 1
+
+0: SELECT gp_inject_fault('zlib_decompress_after_decompress_fn', 'sleep', '', '', '', 1, -1, 3600, dbid) FROM gp_segment_configuration WHERE content=1 AND role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+0&: SELECT gp_wait_until_triggered_fault('zlib_decompress_after_decompress_fn', 1, dbid) FROM gp_segment_configuration WHERE content=1 AND role='p';  <waiting ...>
+
+-- ANALYZE on AO/CO table with zlib compression will hit and fault injection
+-- 'zlib_decompress_after_decompress_fn'
+1&: ANALYZE a_partition_table_for_analyze_cancellation_1_prt_p3;  <waiting ...>
+
+-- It should still be possible to cancel the ANALYZE backend
+2: SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE pid <> pg_backend_pid() AND application_name='pg_regress';
+ pg_cancel_backend 
+-------------------
+ t                 
+ t                 
+ t                 
+(3 rows)
+0<:  <... completed>
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+1<:  <... completed>
+ERROR:  canceling statement due to user request
+
+SELECT gp_inject_fault('zlib_decompress_after_decompress_fn', 'reset', dbid) FROM gp_segment_configuration;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(8 rows)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -255,6 +255,7 @@ test: workfile_mgr_test
 
 # Cancel test
 test: cancel_plpython
+test: cancel_query
 
 # Tests for getting numsegments in utility mode
 test: upgrade_numsegments

--- a/src/test/isolation2/sql/cancel_query.sql
+++ b/src/test/isolation2/sql/cancel_query.sql
@@ -1,0 +1,41 @@
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+
+0:CREATE TABLE a_partition_table_for_analyze_cancellation (
+    a_date date NOT NULL,
+    a_bigint bigint NOT NULL,
+    b_bigint bigint NOT NULL
+)
+WITH (appendonly='true',  orientation='column')
+DISTRIBUTED BY (a_bigint, b_bigint)
+PARTITION BY RANGE(a_date)
+    (
+    PARTITION p1 START ('2018-01-01'::date) END ('2018-12-31'::date) WITH (appendonly='true', orientation='column')
+              COLUMN a_date ENCODING (compresstype=zlib)
+              COLUMN a_bigint ENCODING (compresstype=zlib)
+              COLUMN b_bigint ENCODING (compresstype=zlib),
+    PARTITION p2 START ('2019-01-01'::date) END ('2019-12-31'::date) WITH (appendonly='true', orientation='column')
+              COLUMN a_date ENCODING (compresstype=zlib)
+              COLUMN a_bigint ENCODING (compresstype=zlib)
+              COLUMN b_bigint ENCODING (compresstype=zlib),
+    PARTITION p3 START ('2020-01-01'::date) END ('2020-12-31'::date) WITH (appendonly='true', orientation='column')
+              COLUMN a_date ENCODING (compresstype=zlib)
+              COLUMN a_bigint ENCODING (compresstype=zlib)
+              COLUMN b_bigint ENCODING (compresstype=zlib)
+    );
+0:INSERT INTO a_partition_table_for_analyze_cancellation VALUES(timestamp '2018-01-01 10:00:00', 1, 3);
+0:INSERT INTO a_partition_table_for_analyze_cancellation VALUES(timestamp '2019-01-01 12:00:00', 2, 4);
+0:INSERT INTO a_partition_table_for_analyze_cancellation VALUES(timestamp '2020-01-01 13:00:00', 3, 5);
+
+0: SELECT gp_inject_fault('zlib_decompress_after_decompress_fn', 'sleep', '', '', '', 1, -1, 3600, dbid) FROM gp_segment_configuration WHERE content=1 AND role='p';
+0&: SELECT gp_wait_until_triggered_fault('zlib_decompress_after_decompress_fn', 1, dbid) FROM gp_segment_configuration WHERE content=1 AND role='p';
+
+-- ANALYZE on AO/CO table with zlib compression will hit and fault injection
+-- 'zlib_decompress_after_decompress_fn'
+1&: ANALYZE a_partition_table_for_analyze_cancellation_1_prt_p3;
+
+-- It should still be possible to cancel the ANALYZE backend
+2: SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE pid <> pg_backend_pid() AND application_name='pg_regress';
+0<:
+1<:
+
+SELECT gp_inject_fault('zlib_decompress_after_decompress_fn', 'reset', dbid) FROM gp_segment_configuration;


### PR DESCRIPTION
ANALYZE can be an expensive operation and so there exists a use case when a user
may want to cancel the operation. This commit updates the CdbDispatchCommand()
analyze flag to allow user cancellation.

---

This is a 6X backport of commit https://github.com/greenplum-db/gpdb/commit/bd3562a09df82dca43a09b6e440a06dc6b4d2aea with no conflicts.