### PR TITLE
Fix PANIC when a query in res waiting queue is about to cancel itself

### DIFF
--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -381,6 +381,8 @@ FaultInjectorIdentifierEnumToString[] = {
 		/* inject fault in auto_stats before running autostats logic */
 	_("res_increment_add_oosm"),
 		/* inject fault in ResIncrementAdd to simulate an out-of-shared-memory ERROR */
+	_("reslock_wait_cancel_after_acquire_partition_lock"),
+		/* inject fault in ResLockWaitCancel right after the partition lock has been acquired */
 	_("not recognized"),
 };
 

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -261,6 +261,8 @@ typedef enum FaultInjectorIdentifier_e {
 
 	ResIncrementAddOOSM,
 
+	ReslockWaitCancelAfterAcquirePartitionLock,
+
 	/* INSERT has to be done before that line */
 	FaultInjectorIdMax,
 	

--- a/src/test/isolation2/expected/resource_queue_query_cancel_deadlock_timeout.out
+++ b/src/test/isolation2/expected/resource_queue_query_cancel_deadlock_timeout.out
@@ -1,0 +1,100 @@
+-- This test ensures that we gracefully handle the case where
+-- deadlock_timeout elapses in the middle of query cancellation for a
+-- query waiting on a resource queue. We must ensure that the
+-- deadlock_timeout is disabled in such a situation to avoid a double
+-- acquisition scenario of the partition LWLock which would result in
+-- a PANIC.
+
+-- start_ignore
+! gpconfig -c deadlock_timeout -v '3s';
+! pg_ctl -D ${MASTER_DATA_DIRECTORY} reload;
+-- end_ignore
+
+-- Create a resource queue where only 1 query can run at a time and
+-- new queries must wait. The role attached to the resource queue must
+-- be a nonsuperuser.
+0: CREATE RESOURCE QUEUE rq_query_cancel WITH (active_statements = 1);
+CREATE
+0: CREATE ROLE role_rq_query_cancel RESOURCE QUEUE rq_query_cancel;
+CREATE
+
+-- Inject a sleep fault of significant duration (6 seconds) to suspend
+-- execution right after the partition lock has been acquired in
+-- ResLockWaitCancel(). We cannot use a suspend fault because we'll be
+-- holding the partition lock for resource queues.
+0: CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE
+0: SELECT gp_inject_fault_new('reslock_wait_cancel_after_acquire_partition_lock', 'sleep', '', '', '', 1, -1, 6, dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
+gp_inject_fault_new
+-------------------
+t                  
+(1 row)
+0&: SELECT gp_wait_until_triggered_fault('reslock_wait_cancel_after_acquire_partition_lock', 1, dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';  <waiting ...>
+
+-- Session 1 will hold the active resource queue slot by sleeping for
+-- a large duration - the duration of the test (until it is cancelled
+-- at the very end during test clean up).
+1: SET ROLE role_rq_query_cancel;
+SET
+1&: SELECT pg_sleep(300);  <waiting ...>
+
+-- Session 2 will try to acquire resource queue lock and wait in
+-- queue. We will be ensuring that no "Waiting on lock already held"
+-- PANIC occurs if deadlock_timeout elapses in the middle of query
+-- cancellation (specifically, while the partition lock has been
+-- acquired in ResLockWaitCancel()). We increase the deadlock_timeout
+-- to give a reliable amount of time for Session 2 to trigger the
+-- sleep fault. Note that the 3 second timer starts immediately before
+-- the query starts its semaphore sleep in ResProcSleep() so an
+-- external query cancel must happen with haste.
+2: SET ROLE role_rq_query_cancel;
+SET
+2&: SELECT 1;  <waiting ...>
+
+-- Cancel Session 2's query which will trigger the sleep fault in
+-- ResLockWaitCancel() right after the partition lock is acquired.
+3: SELECT pg_cancel_backend(procpid) FROM pg_stat_activity WHERE current_query = 'SELECT 1;';
+pg_cancel_backend
+-----------------
+t                
+(1 row)
+
+-- Now that the sleep fault has been triggered, wait for 3 seconds to
+-- see if the deadlock check gets triggered on Session 2. If we have
+-- not done the right thing of disabling the check, it will lead to
+-- the aforementioned double partition lock acquisition PANIC.
+0<:  <... completed>
+gp_wait_until_triggered_fault
+-----------------------------
+t                            
+(1 row)
+0: SELECT pg_sleep(3);
+pg_sleep
+--------
+        
+(1 row)
+0: SELECT gp_inject_fault_new('reslock_wait_cancel_after_acquire_partition_lock', 'reset', dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
+gp_inject_fault_new
+-------------------
+t                  
+(1 row)
+2<:  <... completed>
+ERROR:  canceling statement due to user request
+
+-- Clean up the test
+3: SELECT pg_cancel_backend(procpid) FROM pg_stat_activity WHERE current_query = 'SELECT pg_sleep(300);';
+pg_cancel_backend
+-----------------
+t                
+(1 row)
+1<:  <... completed>
+ERROR:  canceling statement due to user request
+0: DROP ROLE role_rq_query_cancel;
+DROP
+0: DROP RESOURCE QUEUE rq_query_cancel;
+DROP
+
+-- start_ignore
+! gpconfig -r deadlock_timeout;
+! pg_ctl -D ${MASTER_DATA_DIRECTORY} reload;
+-- end_ignore

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -27,6 +27,7 @@ test: eval_record
 
 # Test deadlock situation when waiting on a resource queue lock
 test: resource_queue_deadlock
+test: resource_queue_query_cancel_deadlock_timeout
 
 # Test simple cancellation for resource queues and cancellation/deadlocks for
 # sessions with multiple portals.

--- a/src/test/isolation2/sql/resource_queue_query_cancel_deadlock_timeout.sql
+++ b/src/test/isolation2/sql/resource_queue_query_cancel_deadlock_timeout.sql
@@ -1,0 +1,67 @@
+-- This test ensures that we gracefully handle the case where
+-- deadlock_timeout elapses in the middle of query cancellation for a
+-- query waiting on a resource queue. We must ensure that the
+-- deadlock_timeout is disabled in such a situation to avoid a double
+-- acquisition scenario of the partition LWLock which would result in
+-- a PANIC.
+
+-- start_ignore
+! gpconfig -c deadlock_timeout -v '3s';
+! pg_ctl -D ${MASTER_DATA_DIRECTORY} reload;
+-- end_ignore
+
+-- Create a resource queue where only 1 query can run at a time and
+-- new queries must wait. The role attached to the resource queue must
+-- be a nonsuperuser.
+0: CREATE RESOURCE QUEUE rq_query_cancel WITH (active_statements = 1);
+0: CREATE ROLE role_rq_query_cancel RESOURCE QUEUE rq_query_cancel;
+
+-- Inject a sleep fault of significant duration (6 seconds) to suspend
+-- execution right after the partition lock has been acquired in
+-- ResLockWaitCancel(). We cannot use a suspend fault because we'll be
+-- holding the partition lock for resource queues.
+0: CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+0: SELECT gp_inject_fault_new('reslock_wait_cancel_after_acquire_partition_lock', 'sleep', '', '', '', 1, -1, 6, dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
+0&: SELECT gp_wait_until_triggered_fault('reslock_wait_cancel_after_acquire_partition_lock', 1, dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
+
+-- Session 1 will hold the active resource queue slot by sleeping for
+-- a large duration - the duration of the test (until it is cancelled
+-- at the very end during test clean up).
+1: SET ROLE role_rq_query_cancel;
+1&: SELECT pg_sleep(300);
+
+-- Session 2 will try to acquire resource queue lock and wait in
+-- queue. We will be ensuring that no "Waiting on lock already held"
+-- PANIC occurs if deadlock_timeout elapses in the middle of query
+-- cancellation (specifically, while the partition lock has been
+-- acquired in ResLockWaitCancel()). We increase the deadlock_timeout
+-- to give a reliable amount of time for Session 2 to trigger the
+-- sleep fault. Note that the 3 second timer starts immediately before
+-- the query starts its semaphore sleep in ResProcSleep() so an
+-- external query cancel must happen with haste.
+2: SET ROLE role_rq_query_cancel;
+2&: SELECT 1;
+
+-- Cancel Session 2's query which will trigger the sleep fault in
+-- ResLockWaitCancel() right after the partition lock is acquired.
+3: SELECT pg_cancel_backend(procpid) FROM pg_stat_activity WHERE current_query = 'SELECT 1;';
+
+-- Now that the sleep fault has been triggered, wait for 3 seconds to
+-- see if the deadlock check gets triggered on Session 2. If we have
+-- not done the right thing of disabling the check, it will lead to
+-- the aforementioned double partition lock acquisition PANIC.
+0<:
+0: SELECT pg_sleep(3);
+0: SELECT gp_inject_fault_new('reslock_wait_cancel_after_acquire_partition_lock', 'reset', dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';
+2<:
+
+-- Clean up the test
+3: SELECT pg_cancel_backend(procpid) FROM pg_stat_activity WHERE current_query = 'SELECT pg_sleep(300);';
+1<:
+0: DROP ROLE role_rq_query_cancel;
+0: DROP RESOURCE QUEUE rq_query_cancel;
+
+-- start_ignore
+! gpconfig -r deadlock_timeout;
+! pg_ctl -D ${MASTER_DATA_DIRECTORY} reload;
+-- end_ignore


### PR DESCRIPTION
When a query that is in the resource queue waiting queue is in the
process of canceling itself (due to SIGINT from Ctrl-C or
pg_cancel_backend), the deadlock_timeout alarm might trigger. When
this happens, there is a small window where the partition lock has
already been acquired but the deadlock check will try to acquire the
same partition lock leading to error "PANIC: Waiting on lock already
held!".

Example stacktrace from GPDB logs:
"PANIC","XX000","Waiting on lock already held! (lwlock.c:561)","SELECT 1;"
1    0x104c49deb postgres errstart + 0x58b
2    0x104c4db58 postgres elog_finish + 0x208
3    0x104ab6384 postgres LWLockAcquire + 0x334
4    0x104ab379a postgres CheckDeadLock + 0x2a
5    0x104ab3726 postgres handle_sig_alarm + 0x76
6    0x7fff20473d7d libsystem_platform.dylib _sigtramp + 0x1d
7    0x104ab3ecf postgres ResLockWaitCancel + 0x4f
8    0x104cb3905 postgres ResLockPortal + 0x735

To fix the PANIC scenario, we simply need to disable the timeouts
before acquiring the partition lock which is the common pattern in the
code base. An isolation2 test has been added to demonstrate the PANIC.

Co-authored-by: Jimmy Yih <jyih@vmware.com>

Backported from 6X_STABLE:
https://github.com/greenplum-db/gpdb/commit/cf25bc0f0609afeedddcee2c5c1731cef2d648a8

Backport merge conflicts:
Timeouts were changed in 6X+ to use disable_timeouts() so needed to
revert back to the 5X disable_sig_alarm() implementation. Also some
changes to the test: revert to 5X fault injection implementation and
deadlock_timeout is PGC_SIGHUP instead of PGC_SUSET so need to
gpconfig and reload config.