### PR TITLE
[6X] Prevent AO/AOCO WALs for wal_level=minimal

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -164,7 +164,7 @@ open_ds_write(Relation rel, DatumStreamWrite **ds, TupleDesc relationTupleDesc,
 										attr,
 										RelationGetRelationName(rel),
 										/* title */ titleBuf.data,
-										RelationNeedsWAL(rel));
+										XLogIsNeeded() && RelationNeedsWAL(rel));
 
 	}
 }
@@ -1837,7 +1837,7 @@ aocs_addcol_init(Relation rel,
 		desc->dsw[i] = create_datumstreamwrite(ct, clvl, rel->rd_appendonly->checksum, 0, blksz /* safeFSWriteSize */ ,
 											   attr, RelationGetRelationName(rel),
 											   titleBuf.data,
-											   RelationNeedsWAL(rel));
+											   XLogIsNeeded() && RelationNeedsWAL(rel));
 	}
 	return desc;
 }

--- a/src/backend/access/aocs/test/aocsam_test.c
+++ b/src/backend/access/aocs/test/aocsam_test.c
@@ -63,6 +63,7 @@ test__aocs_addcol_init(void **state)
 	int			nattr = 5;
 	StdRdOptions **opts =
 	(StdRdOptions **) malloc(sizeof(StdRdOptions *) * nattr);
+	wal_level = WAL_LEVEL_ARCHIVE;
 
 	/* 3 existing columns */
 	opts[0] = opts[1] = opts[2] = (StdRdOptions *) NULL;

--- a/src/backend/access/appendonly/aomd.c
+++ b/src/backend/access/appendonly/aomd.c
@@ -189,7 +189,7 @@ TruncateAOSegmentFile(File fd, Relation rel, int32 segFileNum, int64 offset)
 		ereport(ERROR,
 				(errmsg("\"%s\": failed to truncate data after eof: %m",
 					    relname)));
-	if (RelationNeedsWAL(rel))
+	if (XLogIsNeeded() && RelationNeedsWAL(rel))
 		xlog_ao_truncate(rel->rd_node, segFileNum, offset);
 
 	if (file_truncate_hook)

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -2729,7 +2729,7 @@ appendonly_insert_init(Relation rel, int segno, bool update_mode)
 								RelationGetRelationName(aoInsertDesc->aoi_rel),
 								aoInsertDesc->title,
 								&aoInsertDesc->storageAttributes,
-                                RelationNeedsWAL(aoInsertDesc->aoi_rel));
+								XLogIsNeeded() && RelationNeedsWAL(aoInsertDesc->aoi_rel));
 
 	aoInsertDesc->storageWrite.compression_functions = fns;
 	aoInsertDesc->storageWrite.compressionState = cs;

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2209,13 +2209,12 @@ static struct config_int ConfigureNamesInt[] =
 		},
 		&max_wal_senders,
 		/*
-		 * GPDB doesn't support 1:n replication yet.  In normal operation,
-		 * when primary and mirror are streaming WAL, only 1 WalSnd should be
-		 * active.  We need 2 during base backup, 1 WalSnd to serve backup
+		 * For cluster with mirrors we need 2 WalSnds during base backup, 1 WalSnd to serve backup
 		 * request and 1 WalSnd to serve the log streamer process started by
-		 * pg_basebackup.
+		 * pg_basebackup. For mirrorless cluster replication is disabled, and in this case
+		 * max_wal_senders=0 should be specified.
 		 */
-		10, 2, MAX_BACKENDS,
+		10, 0, MAX_BACKENDS,
 		NULL, NULL, NULL
 	},
 

--- a/src/test/isolation2/expected/prevent_ao_wal.out
+++ b/src/test/isolation2/expected/prevent_ao_wal.out
@@ -1,0 +1,144 @@
+-- For AO/AOCO tables, their WAL records are only
+-- generated for replication purposes (they are not used for crash
+-- recovery because AO/AOCO table operations are crash-safe). To decrease
+-- disk space usage and to improve performance of AO/AOCO operations, we
+-- suppress generation of XLOG_APPENDONLY_INSERT and
+-- XLOG_APPENDONLY_TRUNCATE WAL records when wal_level=minimal is
+-- specified.
+-- This test is supposed to ensure that XLOG_APPENDONLY_INSERT and
+-- XLOG_APPENDONLY_TRUNCATE WAL records are not generated when
+-- wal_level=minimal is set.
+-- Because on mirrored cluster primary segments have replication slots
+-- and that conflict with the wal_level=minimal GUC
+-- we connect to coordinator in utility mode for AO/AOCO operations and
+-- validate WAL records on the coordinator.
+
+GP_IGNORE: formatted by atmsort.pm
+-- start_matchignore
+-- m/pg_xlogdump: FATAL:  error in WAL record at */
+-- m/.*The 'DISTRIBUTED BY' clause determines the distribution of data*/
+-- m/.*Table doesn't have 'DISTRIBUTED BY' clause*/
+-- end_matchignore
+GP_IGNORE: defined new match expression
+
+-- start_matchsubs
+-- m/tx:\s+\d+/
+-- s/tx:\s+\d+/tx: ##/
+
+-- m/lsn: \d\/[0-9a-fA-F]+, prev \d\/[0-9a-fA-F]+/
+-- s/lsn: \d\/[0-9a-fA-F]+, prev \d\/[0-9a-fA-F]+/lsn: #\/########, prev #\/########/
+
+-- m/rel \d+\/\d+\/\d+/
+-- s/rel \d+\/\d+\/\d+/rel ####\/######\/######/
+-- end_matchsubs
+GP_IGNORE: defined new match expression
+
+-- Create tables (AO, AOCO)
+-1U: CREATE TABLE ao_foo (n int) WITH (appendonly=true);
+CREATE
+-1U: CREATE TABLE aoco_foo (n int, m int) WITH (appendonly=true, orientation=column);
+CREATE
+
+-- Switch WAL file
+-1U: SELECT true FROM pg_switch_xlog();
+ bool 
+------
+ t    
+(1 row)
+-- Insert data (AO)
+-1U: INSERT INTO ao_foo SELECT generate_series(1,10);
+INSERT 10
+-- Insert data (AOCO)
+-1U: INSERT INTO aoco_foo SELECT generate_series(1,10), generate_series(1,10);
+INSERT 10
+-- Delete data and run vacuum (AO)
+-1U: DELETE FROM ao_foo WHERE n > 5;
+DELETE 5
+-1U: VACUUM;
+VACUUM
+-- Delete data and run vacuum (AOCO)
+-1U: DELETE FROM aoco_foo WHERE n > 5;
+DELETE 5
+-1U: VACUUM;
+VACUUM
+-1Uq: ... <quitting>
+
+-- Validate wal records
+! last_wal_file=$(psql -At -c "SELECT pg_xlogfile_name(pg_current_xlog_location())" postgres) && pg_xlogdump ${last_wal_file} -p ${MASTER_DATA_DIRECTORY}/pg_xlog -r appendonly;
+rmgr: Appendonly  len (rec/tot):    160/   192, tx: ##, lsn: #/########, prev #/########, bkp: 0000, desc: insert: rel ####/######/###### seg/offset:0/0 len:136
+rmgr: Appendonly  len (rec/tot):     24/    56, tx: ##, lsn: #/########, prev #/########, bkp: 0000, desc: insert: rel ####/######/###### seg/offset:128/0 len:0
+rmgr: Appendonly  len (rec/tot):    104/   136, tx: ##, lsn: #/########, prev #/########, bkp: 0000, desc: insert: rel ####/######/###### seg/offset:0/0 len:80
+rmgr: Appendonly  len (rec/tot):    104/   136, tx: ##, lsn: #/########, prev #/########, bkp: 0000, desc: insert: rel ####/######/###### seg/offset:128/0 len:80
+rmgr: Appendonly  len (rec/tot):     24/    56, tx: ##, lsn: #/########, prev #/########, bkp: 0000, desc: insert: rel ####/######/###### seg/offset:128/0 len:0
+rmgr: Appendonly  len (rec/tot):     24/    56, tx: ##, lsn: #/########, prev #/########, bkp: 0000, desc: insert: rel ####/######/###### seg/offset:256/0 len:0
+rmgr: Appendonly  len (rec/tot):     24/    56, tx: ##, lsn: #/########, prev #/########, bkp: 0000, desc: truncate: rel ####/######/###### seg/offset:0/136
+rmgr: Appendonly  len (rec/tot):     24/    56, tx: ##, lsn: #/########, prev #/########, bkp: 0000, desc: truncate: rel ####/######/###### seg/offset:0/80
+rmgr: Appendonly  len (rec/tot):     24/    56, tx: ##, lsn: #/########, prev #/########, bkp: 0000, desc: truncate: rel ####/######/###### seg/offset:128/80
+rmgr: Appendonly  len (rec/tot):     24/    56, tx: ##, lsn: #/########, prev #/########, bkp: 0000, desc: truncate: rel ####/######/###### seg/offset:0/0
+rmgr: Appendonly  len (rec/tot):     24/    56, tx: ##, lsn: #/########, prev #/########, bkp: 0000, desc: truncate: rel ####/######/###### seg/offset:0/0
+rmgr: Appendonly  len (rec/tot):     24/    56, tx: ##, lsn: #/########, prev #/########, bkp: 0000, desc: truncate: rel ####/######/###### seg/offset:0/0
+rmgr: Appendonly  len (rec/tot):     24/    56, tx: ##, lsn: #/########, prev #/########, bkp: 0000, desc: truncate: rel ####/######/###### seg/offset:128/0
+rmgr: Appendonly  len (rec/tot):     24/    56, tx: ##, lsn: #/########, prev #/########, bkp: 0000, desc: truncate: rel ####/######/###### seg/offset:256/0
+rmgr: Appendonly  len (rec/tot):     24/    56, tx: ##, lsn: #/########, prev #/########, bkp: 0000, desc: insert: rel ####/######/###### seg/offset:128/0 len:0
+rmgr: Appendonly  len (rec/tot):     24/    56, tx: ##, lsn: #/########, prev #/########, bkp: 0000, desc: insert: rel ####/######/###### seg/offset:256/0 len:0
+rmgr: Appendonly  len (rec/tot):     24/    56, tx: ##, lsn: #/########, prev #/########, bkp: 0000, desc: truncate: rel ####/######/###### seg/offset:0/0
+rmgr: Appendonly  len (rec/tot):     24/    56, tx: ##, lsn: #/########, prev #/########, bkp: 0000, desc: truncate: rel ####/######/###### seg/offset:0/0
+rmgr: Appendonly  len (rec/tot):     24/    56, tx: ##, lsn: #/########, prev #/########, bkp: 0000, desc: truncate: rel ####/######/###### seg/offset:0/0
+rmgr: Appendonly  len (rec/tot):     24/    56, tx: ##, lsn: #/########, prev #/########, bkp: 0000, desc: truncate: rel ####/######/###### seg/offset:0/0
+rmgr: Appendonly  len (rec/tot):     24/    56, tx: ##, lsn: #/########, prev #/########, bkp: 0000, desc: truncate: rel ####/######/###### seg/offset:0/0
+rmgr: Appendonly  len (rec/tot):     24/    56, tx: ##, lsn: #/########, prev #/########, bkp: 0000, desc: truncate: rel ####/######/###### seg/offset:0/136
+rmgr: Appendonly  len (rec/tot):     24/    56, tx: ##, lsn: #/########, prev #/########, bkp: 0000, desc: truncate: rel ####/######/###### seg/offset:0/80
+rmgr: Appendonly  len (rec/tot):     24/    56, tx: ##, lsn: #/########, prev #/########, bkp: 0000, desc: truncate: rel ####/######/###### seg/offset:128/80
+
+
+-- *********** Set wal_level=minimal **************
+!\retcode gpconfig -c wal_level -v minimal --masteronly --skipvalidation;
+(exited with code 0)
+-- Set max_wal_senders to 0 because a non-zero value requires wal_level >= 'archive'
+!\retcode gpconfig -c max_wal_senders -v 0 --masteronly --skipvalidation;
+(exited with code 0)
+-- Restart QD
+!\retcode pg_ctl -l /dev/null -D $MASTER_DATA_DIRECTORY restart -w -t 600 -m fast;
+(exited with code 0)
+
+-- Switch WAL file
+-1U: SELECT true FROM pg_switch_xlog();
+ bool 
+------
+ t    
+(1 row)
+-- Insert data (AO)
+-1U: INSERT INTO ao_foo SELECT generate_series(1,10);
+INSERT 10
+-- Insert data (AOCO)
+-1U: INSERT INTO aoco_foo SELECT generate_series(1,10), generate_series(1,10);
+INSERT 10
+-- Delete data and run vacuum (AO)
+-1U: DELETE FROM ao_foo WHERE n > 5;
+DELETE 5
+-1U: VACUUM;
+VACUUM
+-- Delete data and run vacuum (AOCO)
+-1U: DELETE FROM aoco_foo WHERE n > 5;
+DELETE 5
+-1U: VACUUM;
+VACUUM
+
+-- Validate wal records
+! last_wal_file=$(psql -At -c "SELECT pg_xlogfile_name(pg_current_xlog_location())" postgres) && pg_xlogdump ${last_wal_file} -p ${MASTER_DATA_DIRECTORY}/pg_xlog -r appendonly;
+
+
+-1U: DROP TABLE ao_foo;
+DROP
+-1U: DROP TABLE aoco_foo;
+DROP
+
+-- Reset wal_level
+!\retcode gpconfig -r wal_level --masteronly --skipvalidation;
+(exited with code 0)
+-- Reset max_wal_senders
+!\retcode gpconfig -r max_wal_senders --masteronly --skipvalidation;
+(exited with code 0)
+-- Restart QD
+!\retcode pg_ctl -l /dev/null -D $MASTER_DATA_DIRECTORY restart -w -t 600 -m fast;
+(exited with code 0)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -26,6 +26,8 @@ test: udf_exception_blocks_panic_scenarios
 test: ao_same_trans_truncate_crash
 test: ao_fsync_panic
 
+test: prevent_ao_wal
+
 # Tests for packcore, will use the coredumps generated in crash_recovery_dtm,
 # so must be scheduled after that one.
 test: packcore

--- a/src/test/isolation2/sql/prevent_ao_wal.sql
+++ b/src/test/isolation2/sql/prevent_ao_wal.sql
@@ -1,0 +1,85 @@
+-- For AO/AOCO tables, their WAL records are only
+-- generated for replication purposes (they are not used for crash
+-- recovery because AO/AOCO table operations are crash-safe). To decrease
+-- disk space usage and to improve performance of AO/AOCO operations, we
+-- suppress generation of XLOG_APPENDONLY_INSERT and
+-- XLOG_APPENDONLY_TRUNCATE WAL records when wal_level=minimal is
+-- specified.
+-- This test is supposed to ensure that XLOG_APPENDONLY_INSERT and
+-- XLOG_APPENDONLY_TRUNCATE WAL records are not generated when
+-- wal_level=minimal is set.
+-- Because on mirrored cluster primary segments have replication slots
+-- and that conflict with the wal_level=minimal GUC
+-- we connect to coordinator in utility mode for AO/AOCO operations and
+-- validate WAL records on the coordinator.
+
+-- start_matchignore
+-- m/pg_xlogdump: FATAL:  error in WAL record at */
+-- m/.*The 'DISTRIBUTED BY' clause determines the distribution of data*/
+-- m/.*Table doesn't have 'DISTRIBUTED BY' clause*/
+-- end_matchignore
+
+-- start_matchsubs
+-- m/tx:\s+\d+/
+-- s/tx:\s+\d+/tx: ##/
+
+-- m/lsn: \d\/[0-9a-fA-F]+, prev \d\/[0-9a-fA-F]+/
+-- s/lsn: \d\/[0-9a-fA-F]+, prev \d\/[0-9a-fA-F]+/lsn: #\/########, prev #\/########/
+
+-- m/rel \d+\/\d+\/\d+/
+-- s/rel \d+\/\d+\/\d+/rel ####\/######\/######/
+-- end_matchsubs
+
+-- Create tables (AO, AOCO)
+-1U: CREATE TABLE ao_foo (n int) WITH (appendonly=true);
+-1U: CREATE TABLE aoco_foo (n int, m int) WITH (appendonly=true, orientation=column);
+
+-- Switch WAL file
+-1U: SELECT true FROM pg_switch_xlog();
+-- Insert data (AO)
+-1U: INSERT INTO ao_foo SELECT generate_series(1,10);
+-- Insert data (AOCO)
+-1U: INSERT INTO aoco_foo SELECT generate_series(1,10), generate_series(1,10);
+-- Delete data and run vacuum (AO)
+-1U: DELETE FROM ao_foo WHERE n > 5;
+-1U: VACUUM;
+-- Delete data and run vacuum (AOCO)
+-1U: DELETE FROM aoco_foo WHERE n > 5;
+-1U: VACUUM;
+-1Uq:
+
+-- Validate wal records
+! last_wal_file=$(psql -At -c "SELECT pg_xlogfile_name(pg_current_xlog_location())" postgres) && pg_xlogdump ${last_wal_file} -p ${MASTER_DATA_DIRECTORY}/pg_xlog -r appendonly;
+
+-- *********** Set wal_level=minimal **************
+!\retcode gpconfig -c wal_level -v minimal --masteronly --skipvalidation;
+-- Set max_wal_senders to 0 because a non-zero value requires wal_level >= 'archive'
+!\retcode gpconfig -c max_wal_senders -v 0 --masteronly --skipvalidation;
+-- Restart QD
+!\retcode pg_ctl -l /dev/null -D $MASTER_DATA_DIRECTORY restart -w -t 600 -m fast;
+
+-- Switch WAL file
+-1U: SELECT true FROM pg_switch_xlog();
+-- Insert data (AO)
+-1U: INSERT INTO ao_foo SELECT generate_series(1,10);
+-- Insert data (AOCO)
+-1U: INSERT INTO aoco_foo SELECT generate_series(1,10), generate_series(1,10);
+-- Delete data and run vacuum (AO)
+-1U: DELETE FROM ao_foo WHERE n > 5;
+-1U: VACUUM;
+-- Delete data and run vacuum (AOCO)
+-1U: DELETE FROM aoco_foo WHERE n > 5;
+-1U: VACUUM;
+
+-- Validate wal records
+! last_wal_file=$(psql -At -c "SELECT pg_xlogfile_name(pg_current_xlog_location())" postgres) && pg_xlogdump ${last_wal_file} -p ${MASTER_DATA_DIRECTORY}/pg_xlog -r appendonly;
+
+-1U: DROP TABLE ao_foo;
+-1U: DROP TABLE aoco_foo;
+
+-- Reset wal_level
+!\retcode gpconfig -r wal_level --masteronly --skipvalidation;
+-- Reset max_wal_senders
+!\retcode gpconfig -r max_wal_senders --masteronly --skipvalidation;
+-- Restart QD
+!\retcode pg_ctl -l /dev/null -D $MASTER_DATA_DIRECTORY restart -w -t 600 -m fast;


### PR DESCRIPTION
Prevent AO/AOCO WALs for wal_level=minimal [6X]

     - For mirrorless clusters, WAL records are only used for crash recovery
       purposes. In the case of AO/AOCO tables, their WAL records are only
       generated for replication purposes (they are not used for crash
       recovery because AO/AOCO table operations are crash-safe). To decrease
       disk space usage and to improve performance of AO/AOCO operations, we
       suppress generation of XLOG_APPENDONLY_INSERT and
       XLOG_APPENDONLY_TRUNCATE WAL records when wal_level=minimal is
       specified.

       Cherry-picked from:
       https://github.com/greenplum-db/gpdb/commit/e1720dd12ad87ebb61439d10a75044ddc97fd07a
       with modifications.

     Changes compare to master:

   - seperate commit to set max_wal_senders minimal value to 0 and allows wal_level=minimal

   - using WAL_LEVEL_ARCHIVE instead of WAL_LEVEL_REPLICA in the aocsam_test

   In the isolation2 test:
   - using pg_xlogdump instead of pg_waldump
   - using MASTER_DATA_DIRECTORY instead of COORDINATOR_DATA_DIRECTORY
   - using --skipvalidation flag for configuring wal_level and max_wal_senders
   - using pg_switch_xlog() instead of pg_switch_wal(), pg_xlogfile_name()
     instead of pg_walfile_name() and pg_current_xlog_location() instead of
     pg_current_wal_lsn()
   - checking pg_xlog directory instead of pg_wal directory for wal files
   - different format of AO/AOCO wal records expected from pg_xlogdump
