### PR TITLE
Add GUC to display sleep time for a stmt in RQ

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -218,6 +218,7 @@ int			gp_resqueue_priority_grouping_timeout;
 double		gp_resqueue_priority_cpucores_per_segment;
 char	   *gp_resqueue_priority_default_value;
 bool		gp_debug_resqueue_priority = false;
+bool		gp_log_resqueue_priority_sleep_time = false;
 
 /* Resource group GUCs */
 int			gp_resource_group_cpu_priority;
@@ -3134,6 +3135,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 		&enable_implicit_timeformat_YYYYMMDDHH24MISS,
 		false,
 		NULL, NULL, NULL
+	},
+
+	{
+		{"gp_log_resqueue_priority_sleep_time", PGC_USERSET, RESOURCES_MGM,
+		 gettext_noop("If set, log the duration for which the statement was put to sleep in resource queue"),
+		 NULL,
+		 },
+		 &gp_log_resqueue_priority_sleep_time,
+		 false,
+		 NULL, NULL, NULL
 	},
 
 	/* End-of-list marker */

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -117,3 +117,4 @@
 		"temp_tablespaces",
 		"gp_add_column_inherits_table_setting",
 		"gp_resgroup_debug_wait_queue",
+		"gp_log_resqueue_priority_sleep_time",


### PR DESCRIPTION
This commit allows logging of the duration spent by a statement in sleep
due to resource queues backoff mechanism

If the GUC is enabled a message will be logged like below:
```
2021-12-23 16:03:46.112877 PST,"bchaudhary","bchaudhary",p32725,th357490112,"127.0.0.1","59752",2021-12-23 16:03:43 PST,843,con12,cmd3,seg0,,dx7,x843,sx1,"LOG","00000","Total sleep time in resource queue: 690.479 ms",,,,,,"insert into r1 select i, i from generate_series(1,1000000)i;",0,,"backoff.c",1026,
```

This allow for post-analysis to see the impact of concurrency on the statement.