### PR TITLE
fix: before/update row trigger that modifies the distributed key

### DIFF
--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -84,7 +84,13 @@ static ResultRelInfo *getTargetResultRelInfo(ModifyTableState *node);
 static void ExecSetupChildParentMapForSubplan(ModifyTableState *mtstate);
 static TupleConversionMap *tupconv_map_for_subplan(ModifyTableState *node,
 												   int whichplan);
-
+static void GetDistributedKeysValue(Relation relation,
+									TupleTableSlot *slot,
+									Datum *values,
+									bool *isnulls,
+									int16 *typlens,
+									bool *typbyvals,
+									int16 *nkeys);
 /*
  * Verify that the tuples to be produced by INSERT or UPDATE match the
  * target relation's rowtype
@@ -407,8 +413,66 @@ ExecInsert(ModifyTableState *mtstate,
 		resultRelInfo->ri_TrigDesc->trig_insert_before_row &&
 		!splitUpdate)
 	{
+		Datum		values[MaxPolicyAttributeNumber];
+		int16		nkeys;
+		int16		coltyplen[MaxPolicyAttributeNumber];
+		bool		isnull[MaxPolicyAttributeNumber];
+		bool		coltypbyval[MaxPolicyAttributeNumber];
+		bool		check = false;
+		/*
+		 * If is distributed relation, get distributed keys value for latter
+		 * check if distributed keys were modified by the trigger, if modified, give
+		 * an error.
+		 * We only neek check in EXECUTE role.
+		 */
+		if (Gp_role == GP_ROLE_EXECUTE &&
+		    POLICYTYPE_PARTITIONED == resultRelationDesc->rd_cdbpolicy->ptype)
+		{
+			GetDistributedKeysValue(resultRelationDesc,
+									slot,
+									values,
+									isnull,
+									coltyplen,
+									coltypbyval,
+									&nkeys);
+			check = true;
+		}
+
 		if (!ExecBRInsertTriggers(estate, resultRelInfo, slot))
 			return NULL;		/* "do nothing" */
+
+		if (check)
+		{
+			/*
+			 * We do not have to define new_nkeys, new_coltyplen and new_coltypbyval
+			 * , since trigger invocation can guarantee that the row structure(columns
+			 * number and columns type) keep consistent.
+			 */
+			Datum	new_values[MaxPolicyAttributeNumber];
+			bool	new_isnull[MaxPolicyAttributeNumber];
+			int		i;
+			GetDistributedKeysValue(resultRelationDesc,
+									slot,
+									new_values,
+									new_isnull,
+									coltyplen,
+									coltypbyval,
+									&nkeys);
+
+			for (i = 0; i < nkeys; ++i)
+			{
+				if (isnull[i] && new_isnull[i])
+				{
+					continue;
+				}
+
+				if ((isnull[i] || new_isnull[i]) ||
+					!datum_image_eq(values[i], new_values[i], coltypbyval[i], coltyplen[i]))
+				{
+					elog(ERROR, "Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported");
+				}
+			}
+		}
 	}
 
 	/* INSTEAD OF ROW INSERT Triggers */
@@ -1221,9 +1285,66 @@ ExecUpdate(ModifyTableState *mtstate,
 	if (resultRelInfo->ri_TrigDesc &&
 		resultRelInfo->ri_TrigDesc->trig_update_before_row)
 	{
+		Datum		values[MaxPolicyAttributeNumber];
+		int16		nkeys;
+		int16		coltyplen[MaxPolicyAttributeNumber];
+		bool		isnull[MaxPolicyAttributeNumber];
+		bool		coltypbyval[MaxPolicyAttributeNumber];
+		bool		check = false;
+		/*
+		 * If distributed relation, fetch distributed key values, for latter
+		 * check if distributed-keys was modified by the trigger, if did, give
+		 * an error, we only do check in .
+		 */
+		if (Gp_role == GP_ROLE_EXECUTE &&
+		    POLICYTYPE_PARTITIONED == resultRelationDesc->rd_cdbpolicy->ptype)
+		{
+			GetDistributedKeysValue(resultRelationDesc,
+									slot,
+									values,
+									isnull,
+									coltyplen,
+									coltypbyval,
+									&nkeys);
+			check = true;
+		}
+
 		if (!ExecBRUpdateTriggers(estate, epqstate, resultRelInfo,
 								  tupleid, oldtuple, slot))
 			return NULL;		/* "do nothing" */
+
+		if (check)
+		{
+			/*
+			 * We do not have to define new_nkeys, new_coltyplen and new_coltypbyval
+			 * , since trigger invocation can guarantee that the row structure(columns
+			 * number and columns type) keep consistent.
+			 */
+			Datum	new_values[MaxPolicyAttributeNumber];
+			bool	new_isnull[MaxPolicyAttributeNumber];
+			int		i;
+			GetDistributedKeysValue(resultRelationDesc,
+									slot,
+									new_values,
+									new_isnull,
+									coltyplen,
+									coltypbyval,
+									&nkeys);
+
+			for (i = 0; i < nkeys; ++i)
+			{
+				if (isnull[i] && new_isnull[i])
+				{
+					continue;
+				}
+
+				if ((isnull[i] || new_isnull[i]) ||
+					!datum_image_eq(values[i], new_values[i], coltypbyval[i], coltyplen[i]))
+				{
+					elog(ERROR, "Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported");
+				}
+			}
+		}
 	}
 
 	/* INSTEAD OF ROW UPDATE Triggers */
@@ -2256,6 +2377,41 @@ tupconv_map_for_subplan(ModifyTableState *mtstate, int whichplan)
 
 	Assert(whichplan >= 0 && whichplan < mtstate->mt_nplans);
 	return mtstate->mt_per_subplan_tupconv_maps[whichplan];
+}
+
+/*
+ * 
+ */
+static void
+GetDistributedKeysValue(Relation relation,
+					    TupleTableSlot *slot,
+					    Datum *values,
+					    bool *isnulls,
+					    int16 *typlens,
+					    bool *typbyvals,
+					    int16 *nkeys)
+{
+	GpPolicy   *policy = relation->rd_cdbpolicy;
+	TupleDesc	tupdesc = relation->rd_att;
+	
+	Datum		value;
+	bool		isnull;
+	int			i, nattr;
+
+	for (i = 0; i < policy->nattrs; ++i)
+	{
+		Form_pg_attribute att;
+
+		nattr = policy->attrs[i];
+		value = slot_getattr(slot, nattr, &isnull);
+		att = TupleDescAttr(tupdesc, nattr - 1);
+		isnulls[i] = isnull;
+		typlens[i] = att->attlen;
+		typbyvals[i] = att->attbyval;
+		values[i] = datumCopy(value, att->attbyval, att->attlen);
+	}
+
+	*nkeys = i;
 }
 
 /* ----------------------------------------------------------------

--- a/src/test/regress/expected/expand_table_regression.out
+++ b/src/test/regress/expected/expand_table_regression.out
@@ -43,37 +43,18 @@ truncate b;
 create trigger b_t before insert on b for each row execute procedure trig345();
 -- however with the trigger it is inserted on seg1
 insert into b select i from generate_series(1, 10) i;
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported (nodeModifyTable.c:472)
 select gp_segment_id, * from b;
  gp_segment_id | data 
 ---------------+------
-             1 |  345
-             1 |  345
-             0 |  345
-             0 |  345
-             0 |  345
-             0 |  345
-             0 |  345
-             0 |  345
-             0 |  345
-             0 |  345
-(10 rows)
+(0 rows)
 
 -- data expansion should tolerant it
 alter table b expand table;
 select gp_segment_id, * from b;
  gp_segment_id | data 
 ---------------+------
-             0 |  345
-             0 |  345
-             0 |  345
-             0 |  345
-             0 |  345
-             0 |  345
-             0 |  345
-             0 |  345
-             0 |  345
-             0 |  345
-(10 rows)
+(0 rows)
 
 -- start_ignore
 -- We need to do a cluster expansion which will check if there are partial

--- a/src/test/regress/expected/insert.out
+++ b/src/test/regress/expected/insert.out
@@ -806,11 +806,9 @@ create table brtrigpartcon1 partition of brtrigpartcon for values in (1);
 create or replace function brtrigpartcon1trigf() returns trigger as $$begin new.a := 2; return new; end$$ language plpgsql;
 create trigger brtrigpartcon1trig before insert on brtrigpartcon1 for each row execute procedure brtrigpartcon1trigf();
 insert into brtrigpartcon values (1, 'hi there');
-ERROR:  new row for relation "brtrigpartcon1" violates partition constraint
-DETAIL:  Failing row contains (2, hi there).
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported (nodeModifyTable.c:472)
 insert into brtrigpartcon1 values (1, 'hi there');
-ERROR:  new row for relation "brtrigpartcon1" violates partition constraint
-DETAIL:  Failing row contains (2, hi there).
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported (nodeModifyTable.c:472)
 -- check that the message shows the appropriate column description in a
 -- situation where the partitioned table is not the primary ModifyTable node
 create table inserttest3 (f1 text default 'foo', f2 text default 'bar', f3 int);

--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -4785,28 +4785,25 @@ BEFORE INSERT OR UPDATE ON qp_misc_jiras.test_trig
 FOR EACH ROW
     EXECUTE PROCEDURE fn_trig();
 INSERT INTO qp_misc_jiras.test_trig VALUES (0, 'after creating trigger');
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported (nodeModifyTable.c:472)
 NOTICE:  1  (seg1 127.0.0.1:40001 pid=16301)
 INSERT INTO qp_misc_jiras.test_trig VALUES (1, 'aaa');
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported (nodeModifyTable.c:472)
 NOTICE:  2  (seg1 127.0.0.1:40001 pid=16301)
 SELECT gp_segment_id, * FROM qp_misc_jiras.test_trig;
  gp_segment_id | id |           aaa           
 ---------------+----+-------------------------
              1 |  1 | before creating trigger
-             1 |  1 | after creating trigger1
-             1 |  2 | aaa1
-(3 rows)
+(1 row)
 
 UPDATE qp_misc_jiras.test_trig SET id = id;
 NOTICE:  2  (seg1 127.0.0.1:40001 pid=16301)
-NOTICE:  2  (seg1 127.0.0.1:40001 pid=16301)
-NOTICE:  3  (seg1 127.0.0.1:40001 pid=16301)
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported (nodeModifyTable.c:1344)
 SELECT gp_segment_id, * FROM qp_misc_jiras.test_trig;
- gp_segment_id | id |           aaa            
----------------+----+--------------------------
-             1 |  2 | before creating trigger1
-             1 |  2 | after creating trigger11
-             1 |  3 | aaa11
-(3 rows)
+ gp_segment_id | id |           aaa           
+---------------+----+-------------------------
+             1 |  1 | before creating trigger
+(1 row)
 
 DROP TABLE qp_misc_jiras.test_trig;
 DROP FUNCTION fn_trig();

--- a/src/test/regress/expected/triggers.out
+++ b/src/test/regress/expected/triggers.out
@@ -1715,42 +1715,36 @@ WARNING:  after insert (new): (1,black)
 insert into upsert values(2, 'red') on conflict (key) do update set color = 'updated ' || upsert.color;
 WARNING:  before insert (new): (2,red)
 WARNING:  before insert (new, modified): (3,"red trig modified")
-WARNING:  after insert (new): (3,"red trig modified")
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported (nodeModifyTable.c:472)
 insert into upsert values(3, 'orange') on conflict (key) do update set color = 'updated ' || upsert.color;
 WARNING:  before insert (new): (3,orange)
-WARNING:  before update (old): (3,"red trig modified")
-WARNING:  before update (new): (3,"updated red trig modified")
-WARNING:  after update (old): (3,"red trig modified")
-WARNING:  after update (new): (3,"updated red trig modified")
+WARNING:  after insert (new): (3,orange)
 insert into upsert values(4, 'green') on conflict (key) do update set color = 'updated ' || upsert.color;
 WARNING:  before insert (new): (4,green)
 WARNING:  before insert (new, modified): (5,"green trig modified")
-WARNING:  after insert (new): (5,"green trig modified")
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported (nodeModifyTable.c:472)
 insert into upsert values(5, 'purple') on conflict (key) do update set color = 'updated ' || upsert.color;
 WARNING:  before insert (new): (5,purple)
 WARNING:  after insert (new): (5,purple)
 insert into upsert values(6, 'white') on conflict (key) do update set color = 'updated ' || upsert.color;
 WARNING:  before insert (new): (6,white)
 WARNING:  before insert (new, modified): (7,"white trig modified")
-WARNING:  after insert (new): (7,"white trig modified")
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported (nodeModifyTable.c:472)
 insert into upsert values(7, 'pink') on conflict (key) do update set color = 'updated ' || upsert.color;
 WARNING:  before insert (new): (7,pink)
 WARNING:  after insert (new): (7,pink)
 insert into upsert values(8, 'yellow') on conflict (key) do update set color = 'updated ' || upsert.color;
 WARNING:  before insert (new): (8,yellow)
 WARNING:  before insert (new, modified): (9,"yellow trig modified")
-WARNING:  after insert (new): (9,"yellow trig modified")
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported (nodeModifyTable.c:472)
 select * from upsert;
- key |           color           
------+---------------------------
-   3 | updated red trig modified
-   5 | green trig modified
+ key | color  
+-----+--------
+   3 | orange
    7 | pink
-   9 | yellow trig modified
    1 | black
    5 | purple
-   7 | white trig modified
-(7 rows)
+(4 rows)
 
 drop table upsert;
 drop function upsert_before_func();


### PR DESCRIPTION
If the insert/update before row trigger modifies the distributed key,
that would destroy the distributed rule, we should not allow this happen.

The illustration case:

create table t(id int primary key, color text) distributed by(id);

create or replace function insert_before_row() returns trigger as
$$
begin
  new.id = new.id + 1;
  return new;
end;
$$ language plpgsql;

create trigger insert_before_trig before insert on t
  for each row execute procedure insert_before_row();

insert into t values(1, 'red');

select * from t;
 id | color
----+-------
  2 | red
(1 row)

-- no rows return beacuse the row stored in the segment that
-- hashed by value 1, not 2.
select * from t where id=2;
 id | color
----+-------
(0 rows)

-- no rows retrun beacuse the row is filtered out by condition of
-- "id=1".
select * from t where id=1;
 id | color
----+-------
(0 rows)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
