### PR TITLE
Fix gpinitsystem/gpconfig comment other GUCs with same prefix.

### DIFF
--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -339,11 +339,11 @@ SED_PG_CONF () {
 	KEEP_PREV=$1;shift
 	SED_HOST=$1
 	if [ x"" == x"$SED_HOST" ]; then
-			if [ `$GREP -c "${SEARCH_TXT}[ ]*=" $FILENAME` -gt 1 ]; then
+			if [ `$GREP -c "^[ ]*${SEARCH_TXT}[ ]*=" $FILENAME` -gt 1 ]; then
 				LOG_MSG "[INFO]:-Found more than 1 instance of $SEARCH_TXT in $FILENAME, will append" 1
 				APPEND=1
 			fi
-			if [ `$GREP -c "${SEARCH_TXT}[ ]*=" $FILENAME` -eq 0 ] || [ $APPEND -eq 1 ]; then
+			if [ `$GREP -c "^[ ]*${SEARCH_TXT}[ ]*=" $FILENAME` -eq 0 ] || [ $APPEND -eq 1 ]; then
 				$ECHO $SUB_TXT >> $FILENAME
 				RETVAL=$?
 				if [ $RETVAL -ne 0 ]; then
@@ -382,11 +382,11 @@ SED_PG_CONF () {
 		trap RETRY ERR
 		RETVAL=0 # RETVAL gets modified in RETRY function whenever the trap is called
 
-		if [ $( REMOTE_EXECUTE_AND_GET_OUTPUT  $SED_HOST "$GREP -c \"${SEARCH_TXT}\" $FILENAME") -gt 1 ]; then
+		if [ $( REMOTE_EXECUTE_AND_GET_OUTPUT  $SED_HOST "$GREP -c \"^[ ]*${SEARCH_TXT}[ ]*=\" $FILENAME") -gt 1 ]; then
 			LOG_MSG "[INFO]:-Found more than 1 instance of $SEARCH_TXT in $FILENAME on $SED_HOST, will append" 1
 			APPEND=1
 		fi
-		if [ $( REMOTE_EXECUTE_AND_GET_OUTPUT $SED_HOST "$GREP -c \"${SEARCH_TXT}\" $FILENAME") -eq 0 ] || [ $APPEND -eq 1 ]; then
+		if [ $( REMOTE_EXECUTE_AND_GET_OUTPUT $SED_HOST "$GREP -c \"^[ ]*${SEARCH_TXT}[ ]*=\" $FILENAME") -eq 0 ] || [ $APPEND -eq 1 ]; then
 			$TRUSTED_SHELL $SED_HOST "$ECHO \"$SUB_TXT\" >> $FILENAME"
 			if [ $RETVAL -ne 0 ]; then
 				ERROR_EXIT "[FATAL]:-Failed to append line $SUB_TXT to $FILENAME on $SED_HOST"

--- a/gpMgmt/sbin/gpconfig_helper.py
+++ b/gpMgmt/sbin/gpconfig_helper.py
@@ -84,7 +84,7 @@ def comment_parameter(filename, name):
     with open(os.path.abspath(temp_conf_path), 'w') as outfile:
         for line in lines:
             potential_match = line.split("=", 1)[0]
-            if potential_match.lstrip().startswith(name):
+            if potential_match.strip() == name:
                 outfile.write('#')
             outfile.write(line)
             new_lines = new_lines + 1


### PR DESCRIPTION
Fix #12957, modify regex in **gp_bash_functions.sh** and **gpconfig_helper.py** from prefix match to full match after removing spaces.

6X_STABLE and other branches will also benefit from this commit. 