### PR TITLE
[6x]Gpcheckcat: Removing 'acl' and 'owner' tests from default run all option

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -2994,7 +2994,8 @@ all_checks = {
             "fn": lambda: checkACL(),
             "version": 'main',
             "order": 6,
-            "online": True
+            "online": True,
+            "defaultSkip": True
         },
     "pgclass":
         {
@@ -3034,7 +3035,8 @@ all_checks = {
             "fn": lambda: checkOwners(),
             "version": 'main',
             "order": 11,
-            "online": True
+            "online": True,
+            "defaultSkip": True
         },
     "part_integrity":
         {
@@ -3131,7 +3133,10 @@ def runAllChecks(run_tests):
     '''
     for name in sorted(all_checks, key=lambda x: all_checks[x]["order"]):
         if all_checks[name]["version"] >= GV.version and name in run_tests:
-            runOneCheck(name)
+            if (not GV.opt['-R'] and  "defaultSkip" in all_checks[name] and all_checks[name]["defaultSkip"] == True):
+                logger.debug("Default skipping test:"+name)
+            else:
+                runOneCheck(name)
 
     closeDbs()
     logger.info("------------------------------------")

--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -3133,8 +3133,8 @@ def runAllChecks(run_tests):
     '''
     for name in sorted(all_checks, key=lambda x: all_checks[x]["order"]):
         if all_checks[name]["version"] >= GV.version and name in run_tests:
-            if (not GV.opt['-R'] and  "defaultSkip" in all_checks[name] and all_checks[name]["defaultSkip"]):
-                logger.debug("Default skipping test:"+name)
+            if (not GV.opt['-R'] and "defaultSkip" in all_checks[name] and all_checks[name]["defaultSkip"]):
+                logger.debug("Default skipping test: "+name)
             else:
                 runOneCheck(name)
 

--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -3133,7 +3133,7 @@ def runAllChecks(run_tests):
     '''
     for name in sorted(all_checks, key=lambda x: all_checks[x]["order"]):
         if all_checks[name]["version"] >= GV.version and name in run_tests:
-            if (not GV.opt['-R'] and  "defaultSkip" in all_checks[name] and all_checks[name]["defaultSkip"] == True):
+            if (not GV.opt['-R'] and  "defaultSkip" in all_checks[name] and all_checks[name]["defaultSkip"]):
                 logger.debug("Default skipping test:"+name)
             else:
                 runOneCheck(name)

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -540,6 +540,14 @@ Feature: gpcheckcat tests
         And gpcheckcat should print "distribution_policy" to stdout
         And the user runs "dropdb all_good"
 
+    Scenario: run all the checks in gpcheckcat and default skips acl, owner tests  a
+        Given database "all_good" is dropped and recreated
+        Then the user runs "gpcheckcat -v"
+        Then gpcheckcat should return a return code of 0
+        And validate gpcheckcat logs contain skipping ACL and Owner tests
+        And the user runs "dropdb all_good"
+
+
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster
 

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -547,7 +547,6 @@ Feature: gpcheckcat tests
         And validate gpcheckcat logs contain skipping ACL and Owner tests
         And the user runs "dropdb all_good"
 
-
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1858,11 +1858,11 @@ def imp(context):
     logs_for_a_util = glob.glob(pattern)
     if not logs_for_a_util:
         raise Exception('Logs matching "%s" were not created' % pattern)
-    rc, error, output = run_cmd("grep 'Default skipping test:acl' %s" % pattern)
+    rc, error, output = run_cmd("grep 'Default skipping test: acl' %s" % pattern)
     if rc:
         raise Exception("Error executing grep on gpcheckcat logs while finding ACL: %s" % error)
 
-    rc, error, output = run_cmd("grep 'Default skipping test:owner' %s" % pattern)
+    rc, error, output = run_cmd("grep 'Default skipping test: owner' %s" % pattern)
     if rc:
         raise Exception("Error executing grep on gpcheckcat logs while finding Owner: %s" % error)
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1848,6 +1848,23 @@ def impl(context, dbname):
     drop_database_if_exists(context, dbname)
     create_database(context, dbname)
 
+@then('validate gpcheckcat logs contain skipping ACL and Owner tests')
+def imp(context):
+    dirname = 'gpAdminLogs'
+    absdirname = "%s/%s" % (os.path.expanduser("~"), dirname)
+    if not os.path.exists(absdirname):
+        raise Exception('No such directory: %s' % absdirname)
+    pattern = "%s/gpcheckcat_*.log" % (absdirname)
+    logs_for_a_util = glob.glob(pattern)
+    if not logs_for_a_util:
+        raise Exception('Logs matching "%s" were not created' % pattern)
+    rc, error, output = run_cmd("grep 'Default skipping test:acl' %s" % pattern)
+    if rc:
+        raise Exception("Error executing grep on gpcheckcat logs while finding ACL: %s" % error)
+
+    rc, error, output = run_cmd("grep 'Default skipping test:owner' %s" % pattern)
+    if rc:
+        raise Exception("Error executing grep on gpcheckcat logs while finding Owner: %s" % error)
 
 @then('validate and run gpcheckcat repair')
 def impl(context):


### PR DESCRIPTION
 Requirement was to remove all and owner test from default running those, and run them when user specified it with -R option.
* removing acl and owner test from default run
* Adding behave test case for confirming the skip test in log message

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
