### PR TITLE
Fix gpfdist writable external table false success for 5X.

### DIFF
--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -1177,8 +1177,15 @@ static int local_send(request_t *r, const char* buf, int buflen)
 		{
 			gwarning(r, "gpfdist_send failed - the connection was terminated by the client (%d: %s)", e, strerror(e));
 			/* close stream and release fd & flock on pipe file*/
-			if (r->session)
+			if (r->session && r->is_get)
 				session_end(r->session, 0);
+			/* For post requests, the error msg may not be transmited
+ 			 * to the client side because of network failure. So the 
+ 			 * session has to be set an error to inform the client
+ 			 * through the following request response with an 
+ 			 * internal error. */
+			else if (r->session && !r->is_get)
+				session_end(r->session, 1);
 		} else {
 			if (!ok) {
 				gwarning(r, "gpfdist_send failed - due to (%d: %s)", e, strerror(e));
@@ -1655,6 +1662,13 @@ static int session_attach(request_t* r)
 
 	/* found a session in hashtable*/
 
+	/* if error, send an error and close */
+	if (session->is_error)
+	{
+		http_error(r, FDIST_INTERNAL_ERROR, "session error");
+		request_end(r, 1, 0);
+		return -1;
+	}
 	/* session already ended. send an empty response, and close. */
 	if (NULL == session->fstream)
 	{
@@ -1662,14 +1676,6 @@ static int session_attach(request_t* r)
 
 		http_empty(r);
 		request_end(r, 0, 0);
-		return -1;
-	}
-
-	/* if error, send an error and close */
-	if (session->is_error)
-	{
-		http_error(r, FDIST_INTERNAL_ERROR, "session error");
-		request_end(r, 1, 0);
 		return -1;
 	}
 


### PR DESCRIPTION
###Background
When writing an external table of gpfdist protocol, segments will send 
tuples of data to gpfdist through http protocol. For each segment, it
sends a start post request with "X-GP-SEQ" set to 1 as a start request
with no data. Then it will send several post requests with sequence number
of "X-GP-SEQ".
```azure
[segment] ---->> start post request with header "X-GP-SEQ:1"
Then
    [segment] ---->> data post request with header "X-GP-SEQ:2"
    [segment] ---->> data post request with header "X-GP-SEQ:3"
    ...
    [segment] ---->> data post request with header "X-GP-SEQ:n"
```
But in production environment, the socket between the segment and gpfdist 
in one post request will fail because of the network environment. The 
return value of the syscalls of "send" or "recv" through the failing socket
will be -1.
```azure
    [segment] ---->> data post request with header "X-GP-SEQ:x"  failed
```
At the gpfdist side, it will detect the error and try to send an error msg
back to the segment to inform an error. In normal scenario, the error can
be received by segment which acts as a QE and will report an error to QD so
that the psql will report an error happened during the writing procedure.
But in this network failing situation, the socket is corrupted, any syscall 
through this failed socket will return -1. Then gpfdist will close the file
stream. So any following writing post request to this file stream will be 
ended without any error.
```azure
    [segment] ---->> retry post request with header "X-GP-SEQ:x"  failed
    [segment] ---->> retry post request with header "X-GP-SEQ:x"  failed
    [segment] ---->> retry post request with header "X-GP-SEQ:x"  failed
    [segment] ---->> retry post request with header "X-GP-SEQ:x"  success
```
So at the segment side, no http error code is received but only one socket
error is detected. It will retry through libcurl API "curl_easy_perform" to
resend the post request. And libcurl API will create a new socket and 
connect to the gpfdist listen socket and then retry to send the tuples data.
After many times of tries the network is ok again, then the following post 
requests are sent to gpfdist without any errors reported.
```azure
    [segment] ---->> retry post request with header "X-GP-SEQ:x"  failed
    [segment] ---->> retry post request with header "X-GP-SEQ:x"  success
    [segment] ---->> data post request with header "X-GP-SEQ:x+1" success
        ...
    [segment] ---->> data post request with header "X-GP-SEQ: n"  success
```
There are point of this problem:

- HTTP ERROR msg cannot be sent back to segment
- The file stream has been closed, any following post requests will be closed directly

For the first point cannot be controlled because of the network environment.
But for the second point, we should add an error flag after file stream has
been closed for this reason. 

###Solution
So the solution is to add an error flag when gpfdist tries to send http 
response back to the segments in writable situation. When the "send" fails
because of the network failure, it will record the error and then send 
back "FDIST_INTERNAL_ERROR" to any following post request of this session.

###Step to reproduce
Unfortunately it cannot be easily to reproduce this bug in experimental 
environment by using "curl" or "iptables". Any interference with process
of the socket will cause the socket syscall return 0 but not -1. So the
only way to reproduce is to gdb the gpfdist and set the return value of
"recv" to -1 and then continue. So there is no way to add regress cases
for this commit.



Cherry-pick from 0b63c6e6301f75d30f98b071e276e0c5b38bfb71
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
