### PR TITLE
update the error message when OOM happens

### DIFF
--- a/src/backend/utils/mmgr/memprot.c
+++ b/src/backend/utils/mmgr/memprot.c
@@ -351,7 +351,7 @@ static void gp_failed_to_alloc(MemoryAllocationStatus ec, int en, int sz)
 		/* Hit MOP limit */
 		ereport(ERROR, (errcode(ERRCODE_GP_MEMPROT_KILL),
 				errmsg("Out of memory"),
-				errdetail("VM Protect failed to allocate %d bytes, %d MB available",
+				errdetail("Vmem limit reached, failed to allocate %d bytes from tracker, which has %d MB available",
 						sz, VmemTracker_GetAvailableVmemMB()
 				)
 		));
@@ -361,7 +361,7 @@ static void gp_failed_to_alloc(MemoryAllocationStatus ec, int en, int sz)
 		/* Hit MOP limit */
 		ereport(ERROR, (errcode(ERRCODE_GP_MEMPROT_KILL),
 				errmsg("Out of memory"),
-				errdetail("Per-query VM protect limit reached: current limit is %d kB, requested %d bytes, available %d MB",
+				errdetail("Per-query memory limit reached: current limit is %d kB, requested %d bytes, has %d MB avaiable for this query",
 						gp_vmem_limit_per_query, sz, VmemTracker_GetAvailableQueryVmemMB()
 				)
 		));
@@ -370,9 +370,7 @@ static void gp_failed_to_alloc(MemoryAllocationStatus ec, int en, int sz)
 	{
 		ereport(ERROR, (errcode(ERRCODE_GP_MEMPROT_KILL),
 				errmsg("Out of memory"),
-				errdetail("VM protect failed to allocate %d bytes from system, VM Protect %d MB available",
-						sz, VmemTracker_GetAvailableVmemMB()
-				)
+				errdetail("System memory limit reached, failed to allocate %d bytes from system", sz)
 		));
 	}
 	else if (ec == MemoryFailure_ResourceGroupMemoryExhausted)

--- a/src/test/isolation2/expected/oom_startup_memory.out
+++ b/src/test/isolation2/expected/oom_startup_memory.out
@@ -26,8 +26,8 @@
 1: select * from gp_dist_random('gp_id') t1 join gp_dist_random('gp_id') t2 using(gpname) join gp_dist_random('gp_id') t3 using(gpname) join gp_dist_random('gp_id') t4 using(gpname) ;
 ERROR:  failed to acquire resources on one or more segments
 DETAIL:  FATAL:  Out of memory
-DETAIL:  Per-query VM protect limit reached: current limit is 20480 kB, requested 8388608 bytes, available 0 MB
- (seg0 192.168.99.100:25432)
+DETAIL:  Per-query memory limit reached: current limit is 20480 kB, requested 12582912 bytes, has 0 MB avaiable for this query
+ (seg0 127.0.1.1:7002)
 1q: ... <quitting>
 
 --
@@ -98,5 +98,5 @@ SET
 8: set gp_vmem_idle_resource_timeout to '1h';
 ERROR:  failed to acquire resources on one or more segments
 DETAIL:  FATAL:  Out of memory
-DETAIL:  VM Protect failed to allocate 8388608 bytes, 0 MB available
- (seg0 192.168.99.100:25432)
+DETAIL:  Vmem limit reached, failed to allocate 12582912 bytes from tracker, which has 0 MB available
+ (seg0 127.0.1.1:7002)

--- a/src/test/isolation2/expected/oom_startup_memory.out
+++ b/src/test/isolation2/expected/oom_startup_memory.out
@@ -8,10 +8,13 @@
 
 -- start_matchsubs
 --
--- m/DETAIL:  Per-query VM protect limit reached: current limit is \d+ kB, requested \d+ bytes, available \d+ MB/
+-- m/DETAIL:  Per-query memory limit reached: current limit is \d+ kB, requested \d+ bytes, has \d+ MB avaiable for this query/
 -- s/\d+/XXX/g
 --
--- m/DETAIL:  VM Protect failed to allocate \d+ bytes, \d+ MB available/
+-- m/DETAIL:  Vmem limit reached, failed to allocate \d+ bytes from tracker, which has \d+ MB available/
+-- s/\d+/XXX/g
+--
+-- m/DETAIL:  System memory limit reached, failed to allocate \d+ bytes from system/
 -- s/\d+/XXX/g
 --
 -- m/(seg\d+ \d+.\d+.\d+.\d+:\d+)/

--- a/src/test/isolation2/sql/oom_startup_memory.sql
+++ b/src/test/isolation2/sql/oom_startup_memory.sql
@@ -8,10 +8,13 @@
 
 -- start_matchsubs
 --
--- m/DETAIL:  Per-query VM protect limit reached: current limit is \d+ kB, requested \d+ bytes, available \d+ MB/
+-- m/DETAIL:  Per-query memory limit reached: current limit is \d+ kB, requested \d+ bytes, has \d+ MB avaiable for this query/
 -- s/\d+/XXX/g
 --
--- m/DETAIL:  VM Protect failed to allocate \d+ bytes, \d+ MB available/
+-- m/DETAIL:  Vmem limit reached, failed to allocate \d+ bytes from tracker, which has \d+ MB available/
+-- s/\d+/XXX/g
+--
+-- m/DETAIL:  System memory limit reached, failed to allocate \d+ bytes from system/
 -- s/\d+/XXX/g
 --
 -- m/(seg\d+ \d+.\d+.\d+.\d+:\d+)/


### PR DESCRIPTION
By default, Greenplum tracks virtual memory internally for resource group using a memory auditor referred to as vmtracker, those methods defined in `vmem_tracker.h`.If we enabled resource group, memory allocation will go through an additional step——allocate memory from vmtracker first.

To implement this, Greenplum defines `MemoryAllocationStatus` to represent the state of memory allocation:

```cpp
typedef enum MemoryAllocationStatus
{
	MemoryAllocation_Success,
	MemoryFailure_VmemExhausted,
	MemoryFailure_SystemMemoryExhausted,
	MemoryFailure_QueryMemoryExhausted,
	MemoryFailure_ResourceGroupMemoryExhausted
} MemoryAllocationStatus;
```

When OOM happens, Greenplum should output different logs according to the state of memory allocation. But for now, the error message is confusing and misleading.

So this pr is try to make it clear what things really going on to users when OOM happens.