### PR TITLE
(6x) backport quote when resetting a GUC and resolve empty values to 6x

### DIFF
--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -59,6 +59,7 @@
 #include "cdb/cdbvars.h"
 #include "cdb/memquota.h"
 #include "utils/metrics_utils.h"
+#include "utils/faultinjector.h"
 
 typedef struct
 {
@@ -339,6 +340,14 @@ ExecCreateTableAs(CreateTableAsStmt *stmt, const char *queryString,
 
 	Assert(Gp_role != GP_ROLE_EXECUTE);
 
+#ifdef FAULT_INJECTOR
+	if (SIMPLE_FAULT_INJECTOR("change_string_guc") == FaultInjectorTypeSkip)
+	{
+		set_config_option("search_path", "public",
+						 PGC_USERSET, PGC_S_SESSION,
+						 GUC_ACTION_SAVE, true, 0);
+	}
+#endif
 	/*
 	 * Create the tuple receiver object and insert info it will need
 	 */

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1568,6 +1568,10 @@ restore_guc_to_QE(void )
 		}
 		PG_CATCH();
 		{
+
+#ifdef FAULT_INJECTOR
+			SIMPLE_FAULT_INJECTOR("restore_string_guc");
+#endif
 			/* if some guc can not restore successful
 			 * we can not keep alive gang anymore.
 			 */

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1572,6 +1572,13 @@ restore_guc_to_QE(void )
 			 * we can not keep alive gang anymore.
 			 */
 			DisconnectAndDestroyAllGangs(false);
+			/*
+			 * when qe elog an error, qd will use ReThrowError to
+			 * re throw the error, the errordata_stack_depth will ++,
+			 * when we catch the error we should reset errordata_stack_depth
+			 * by FlushErrorState.
+			 */
+			FlushErrorState();
 		}
 		PG_END_TRY();
 	}

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -7520,10 +7520,7 @@ DispatchSetPGVariable(const char *name, List *args, bool is_local)
 						 * Plain string literal or identifier. Quote it.
 						 */
 
-						if (val[0] != '\'')
-							appendStringInfo(&buffer, "%s", quote_literal_cstr(val));
-						else
-							appendStringInfo(&buffer, "%s",val);
+						appendStringInfo(&buffer, "%s", quote_literal_cstr(val));
 
 
 						break;

--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -336,3 +336,52 @@ INFO:  iteration:3 unsafe truncate performed
  
 (1 row)
 
+-- when the original string guc is empty, we change the guc to new value during executing a command.
+-- this guc will be added to gp_guc_restore_list, and they will be restored
+-- to original value to qe when the next command is executed.
+-- however, the dispatch command is "set xxx to ;" that is wrong.
+create extension if not exists gp_inject_fault;
+create table public.restore_guc_test(tc1 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'tc1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- inject fault to change the value of search_path during creating materialized view
+SELECT gp_inject_fault('change_string_guc', 'skip', 1);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- inject fault when dispatch guc restore command occur errors, we throw an error.
+SELECT gp_inject_fault('restore_string_guc', 'error', 1);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- set search_path to '';
+SELECT pg_catalog.set_config('search_path', '', false);
+ set_config 
+------------
+ 
+(1 row)
+
+-- trigger inject fault of change_string_guc, and add this guc to gp_guc_restore_list
+create MATERIALIZED VIEW public.view_restore_guc_test as select * from public.restore_guc_test;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+--we should restore gucs in gp_guc_restore_list to qe, no error occurs.
+drop MATERIALIZED VIEW public.view_restore_guc_test;
+drop table public.restore_guc_test;
+--cleanup
+reset search_path;
+SELECT gp_inject_fault('change_string_guc', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+SELECT gp_inject_fault('restore_string_guc', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+

--- a/src/test/regress/sql/guc_gp.sql
+++ b/src/test/regress/sql/guc_gp.sql
@@ -218,3 +218,29 @@ $$
 $$ language plpythonu;
 
 select run_all_in_one();
+
+-- when the original string guc is empty, we change the guc to new value during executing a command.
+-- this guc will be added to gp_guc_restore_list, and they will be restored
+-- to original value to qe when the next command is executed.
+-- however, the dispatch command is "set xxx to ;" that is wrong.
+create extension if not exists gp_inject_fault;
+create table public.restore_guc_test(tc1 int);
+
+-- inject fault to change the value of search_path during creating materialized view
+SELECT gp_inject_fault('change_string_guc', 'skip', 1);
+-- inject fault when dispatch guc restore command occur errors, we throw an error.
+SELECT gp_inject_fault('restore_string_guc', 'error', 1);
+
+-- set search_path to '';
+SELECT pg_catalog.set_config('search_path', '', false);
+-- trigger inject fault of change_string_guc, and add this guc to gp_guc_restore_list
+create MATERIALIZED VIEW public.view_restore_guc_test as select * from public.restore_guc_test;
+
+--we should restore gucs in gp_guc_restore_list to qe, no error occurs.
+drop MATERIALIZED VIEW public.view_restore_guc_test;
+drop table public.restore_guc_test;
+
+--cleanup
+reset search_path;
+SELECT gp_inject_fault('change_string_guc', 'reset', 1);
+SELECT gp_inject_fault('restore_string_guc', 'reset', 1);


### PR DESCRIPTION
When a string guc such as search_path is set to '', Then some command such as create an extension with schema xxx, will add the changed guc to restore_list, before the next command begins to execute, call restore_guc_to_QE to restore changed guc. the restoring string is "set search_path to ;", then the string will be dispatched to QEs, QE elog an error, QD gets the error, and call ReThrowError to re-throw the error, errordata_stack_depth++, however, when we catch the error did not call FlushErrorState() to reset errordata_stack_depth.
when we execute other commands, after all, the errordata_stack_depth is not -1, The return value of elog_geterrcode shows there is an error.

related commits:320af40  and c4f03b8
related issue: #12900

tests: current extensions set search_path to public, so we can not reproduce this issue, but if I modify SQL for extension, It will be reproduced, reproduce step please see related issue:12900.
