### PR TITLE
[6X_STABLE] Remove unnecessary projection of recheck/scalar filter columns from Bitmap Scan 

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexScan.mdp
@@ -556,14 +556,7 @@ see sql/BitmapIndexScan.sql
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="388.116355" Rows="1.000000" Width="1"/>
             </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="flex_value_set_id">
-                <dxl:Ident ColId="0" ColName="flex_value_set_id" TypeMdid="0.1700.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="flex_value_id">
-                <dxl:Ident ColId="1" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
+            <dxl:ProjList/>
             <dxl:Filter>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
                 <dxl:Ident ColId="23" ColName="fid" TypeMdid="0.1700.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-Basic.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-Basic.mdp
@@ -242,7 +242,7 @@
       </dxl:LogicalSelect>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:Result>
+      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="392.963445" Rows="1.000000" Width="8"/>
         </dxl:Properties>
@@ -252,71 +252,53 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:OneTimeFilter/>
-        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+        <dxl:SortingColumnList/>
+        <dxl:BitmapTableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="392.963445" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="392.963409" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="x2">
               <dxl:Ident ColId="1" ColName="x2" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="2" Alias="x3">
-              <dxl:Ident ColId="2" ColName="x3" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:SortingColumnList/>
-          <dxl:BitmapTableScan>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="392.963409" Rows="1.000000" Width="8"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="1" Alias="x2">
-                <dxl:Ident ColId="1" ColName="x2" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="2" Alias="x3">
-                <dxl:Ident ColId="2" ColName="x3" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="2" ColName="x3" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="54"/>
-              </dxl:Comparison>
-            </dxl:Filter>
-            <dxl:RecheckCond>
+          <dxl:Filter>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="2" ColName="x3" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="54"/>
+            </dxl:Comparison>
+          </dxl:Filter>
+          <dxl:RecheckCond>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="1" ColName="x2" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+            </dxl:Comparison>
+          </dxl:RecheckCond>
+          <dxl:BitmapIndexProbe>
+            <dxl:IndexCondList>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                 <dxl:Ident ColId="1" ColName="x2" TypeMdid="0.23.1.0"/>
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
               </dxl:Comparison>
-            </dxl:RecheckCond>
-            <dxl:BitmapIndexProbe>
-              <dxl:IndexCondList>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="1" ColName="x2" TypeMdid="0.23.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
-                </dxl:Comparison>
-              </dxl:IndexCondList>
-              <dxl:IndexDescriptor Mdid="0.9459845.1.0" IndexName="x2_idx"/>
-            </dxl:BitmapIndexProbe>
-            <dxl:TableDescriptor Mdid="0.9459819.1.1" TableName="foobar">
-              <dxl:Columns>
-                <dxl:Column ColId="0" Attno="1" ColName="x1" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="1" Attno="2" ColName="x2" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="2" Attno="3" ColName="x3" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:Columns>
-            </dxl:TableDescriptor>
-          </dxl:BitmapTableScan>
-        </dxl:GatherMotion>
-      </dxl:Result>
+            </dxl:IndexCondList>
+            <dxl:IndexDescriptor Mdid="0.9459845.1.0" IndexName="x2_idx"/>
+          </dxl:BitmapIndexProbe>
+          <dxl:TableDescriptor Mdid="0.9459819.1.1" TableName="foobar">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="x1" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="1" Attno="2" ColName="x2" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="2" Attno="3" ColName="x3" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:BitmapTableScan>
+      </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/GinIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GinIndex.mdp
@@ -9,13 +9,12 @@
     EXPLAIN SELECT count(*) FROM t WHERE a @> '{"wait":null}';
                                      QUERY PLAN
 -------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..68.13 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..68.13 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..68.13 rows=1 width=8)
-               ->  Bitmap Heap Scan on t  (cost=0.00..68.13 rows=1 width=1)
-                     Recheck Cond: (a @> '{"wait": null}'::jsonb)
-                     ->  Bitmap Index Scan on jidx  (cost=0.00..0.00 rows=0 width=0)
-                           Index Cond: (a @> '{"wait": null}'::jsonb)
+  Aggregate  (cost=0.00..391.30 rows=1 width=8)
+    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..391.30 rows=1 width=1)
+          ->  Bitmap Heap Scan on t  (cost=0.00..391.30 rows=1 width=1)
+                Recheck Cond: (a @> '{"wait": null}'::jsonb)
+                ->  Bitmap Index Scan on jidx  (cost=0.00..0.00 rows=0 width=0)
+                      Index Cond: (a @> '{"wait": null}'::jsonb)
   ]]>
   </dxl:Comment>
   <dxl:Thread Id="0">
@@ -283,11 +282,7 @@
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="391.295478" Rows="1.000000" Width="1"/>
               </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="a">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.3802.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
+              <dxl:ProjList/>
               <dxl:Filter/>
               <dxl:RecheckCond>
                 <dxl:Comparison ComparisonOperator="@&gt;" OperatorMdid="0.3246.1.0">

--- a/src/backend/gporca/data/dxl/minidump/GinIndexPathOpfamily.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GinIndexPathOpfamily.mdp
@@ -9,13 +9,12 @@
     EXPLAIN SELECT count(*) FROM t WHERE a @> '{"wait":null}';
                                      QUERY PLAN
 -------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..68.13 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..68.13 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..68.13 rows=1 width=8)
-               ->  Bitmap Heap Scan on t  (cost=0.00..68.13 rows=1 width=1)
-                     Recheck Cond: (a @> '{"wait": null}'::jsonb)
-                     ->  Bitmap Index Scan on jidx  (cost=0.00..0.00 rows=0 width=0)
-                           Index Cond: (a @> '{"wait": null}'::jsonb)
+  Aggregate  (cost=0.00..391.30 rows=1 width=8)
+    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..391.30 rows=1 width=1)
+          ->  Bitmap Heap Scan on t  (cost=0.00..391.30 rows=1 width=1)
+                Recheck Cond: (a @> '{"wait": null}'::jsonb)
+                ->  Bitmap Index Scan on jidx  (cost=0.00..0.00 rows=0 width=0)
+                      Index Cond: (a @> '{"wait": null}'::jsonb)
   ]]>
   </dxl:Comment>
   <dxl:Thread Id="0">
@@ -283,11 +282,7 @@
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="391.295478" Rows="1.000000" Width="1"/>
               </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="a">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.3802.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
+              <dxl:ProjList/>
               <dxl:Filter/>
               <dxl:RecheckCond>
                 <dxl:Comparison ComparisonOperator="@&gt;" OperatorMdid="0.3246.1.0">

--- a/src/backend/gporca/data/dxl/minidump/GinIndexSearchModeAll.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GinIndexSearchModeAll.mdp
@@ -9,13 +9,12 @@
     EXPLAIN SELECT count(*) FROM t WHERE a @> '{}';
                                      QUERY PLAN
 -------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..68.13 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..68.13 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..68.13 rows=1 width=8)
-               ->  Bitmap Heap Scan on t  (cost=0.00..68.13 rows=1 width=1)
-                     Recheck Cond: (a @> '{}'::jsonb)
-                     ->  Bitmap Index Scan on jidx  (cost=0.00..0.00 rows=0 width=0)
-                           Index Cond: (a @> '{}'::jsonb)
+  Aggregate  (cost=0.00..391.30 rows=1 width=8)
+    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..391.30 rows=1 width=1)
+          ->  Bitmap Heap Scan on t  (cost=0.00..391.30 rows=1 width=1)
+                Recheck Cond: (a @> '{}'::jsonb)
+                ->  Bitmap Index Scan on jidx  (cost=0.00..0.00 rows=0 width=0)
+                      Index Cond: (a @> '{}'::jsonb)
   ]]>
   </dxl:Comment>
   <dxl:Thread Id="0">
@@ -283,11 +282,7 @@
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="391.295478" Rows="1.000000" Width="1"/>
               </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="a">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.3802.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
+              <dxl:ProjList/>
               <dxl:Filter/>
               <dxl:RecheckCond>
                 <dxl:Comparison ComparisonOperator="@&gt;" OperatorMdid="0.3246.1.0">

--- a/src/backend/gporca/data/dxl/minidump/Gist-AOCOTable-NonLossy-BitmapIndexPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-AOCOTable-NonLossy-BitmapIndexPlan.mdp
@@ -17,17 +17,16 @@ EXPLAIN SELECT id FROM aoco_gist_tbl
  ORDER BY id;
 
                           QUERY PLAN
-Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.00 rows=1 width=4)
-   Merge Key: id
-   ->  Result  (cost=0.00..0.00 rows=1 width=4)
-         ->  Sort  (cost=0.00..0.00 rows=1 width=4)
-               Sort Key: id
-               ->  Bitmap Table Scan on aoco_gist_tbl  (cost=0.00..0.00 rows=1 width=4)
-                     Recheck Cond: b ~= '(3,4),(1,2)'::box
-                     ->  Bitmap Index Scan on boxindex  (cost=0.00..0.00 rows=0 width=0)
-                           Index Cond: b ~= '(3,4),(1,2)'::box
- Optimizer status: PQO version 2.65.1
-(10 rows)
+Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..391.30 rows=1 width=4)
+  Merge Key: id
+  ->  Sort  (cost=0.00..391.30 rows=1 width=4)
+        Sort Key: id
+        ->  Bitmap Heap Scan on aoco_gist_tbl  (cost=0.00..391.30 rows=1 width=4)
+              Recheck Cond: (b ~= '(3,4),(1,2)'::box)
+              ->  Bitmap Index Scan on boxindex  (cost=0.00..0.00 rows=0 width=0)
+                    Index Cond: (b ~= '(3,4),(1,2)'::box)
+Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
 -->
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
@@ -272,7 +271,7 @@ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.00 rows=1 width=4)
         <dxl:SortingColumnList>
           <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
         </dxl:SortingColumnList>
-        <dxl:Result>
+        <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="391.295502" Rows="1.000000" Width="4"/>
           </dxl:Properties>
@@ -282,65 +281,47 @@ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.00 rows=1 width=4)
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:OneTimeFilter/>
-          <dxl:Sort SortDiscardDuplicates="false">
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
+          <dxl:LimitCount/>
+          <dxl:LimitOffset/>
+          <dxl:BitmapTableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="391.295502" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="391.295500" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="id">
                 <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="b">
-                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.603.1.0"/>
-              </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList>
-              <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-            </dxl:SortingColumnList>
-            <dxl:LimitCount/>
-            <dxl:LimitOffset/>
-            <dxl:BitmapTableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="391.295500" Rows="1.000000" Width="4"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="id">
-                  <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="b">
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.603.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:RecheckCond>
+            <dxl:RecheckCond>
+              <dxl:Comparison ComparisonOperator="~=" OperatorMdid="0.499.1.0">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.603.1.0"/>
+                <dxl:ConstValue TypeMdid="0.603.1.0" Value="AAAAAAAACEAAAAAAAAAQQAAAAAAAAPA/AAAAAAAAAEA="/>
+              </dxl:Comparison>
+            </dxl:RecheckCond>
+            <dxl:BitmapIndexProbe>
+              <dxl:IndexCondList>
                 <dxl:Comparison ComparisonOperator="~=" OperatorMdid="0.499.1.0">
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.603.1.0"/>
                   <dxl:ConstValue TypeMdid="0.603.1.0" Value="AAAAAAAACEAAAAAAAAAQQAAAAAAAAPA/AAAAAAAAAEA="/>
                 </dxl:Comparison>
-              </dxl:RecheckCond>
-              <dxl:BitmapIndexProbe>
-                <dxl:IndexCondList>
-                  <dxl:Comparison ComparisonOperator="~=" OperatorMdid="0.499.1.0">
-                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.603.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.603.1.0" Value="AAAAAAAACEAAAAAAAAAQQAAAAAAAAPA/AAAAAAAAAEA="/>
-                  </dxl:Comparison>
-                </dxl:IndexCondList>
-                <dxl:IndexDescriptor Mdid="0.566300.1.0" IndexName="boxindex"/>
-              </dxl:BitmapIndexProbe>
-              <dxl:TableDescriptor Mdid="0.566277.1.0" TableName="aoco_gist_tbl">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.603.1.0" ColWidth="32"/>
-                  <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="5" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="6" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:BitmapTableScan>
-          </dxl:Sort>
-        </dxl:Result>
+              </dxl:IndexCondList>
+              <dxl:IndexDescriptor Mdid="0.566300.1.0" IndexName="boxindex"/>
+            </dxl:BitmapIndexProbe>
+            <dxl:TableDescriptor Mdid="0.566277.1.0" TableName="aoco_gist_tbl">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.603.1.0" ColWidth="32"/>
+                <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="5" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:BitmapTableScan>
+        </dxl:Sort>
       </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
@@ -785,14 +785,6 @@ private:
 	// helper to find subplan type from a correlated join expression
 	static EdxlSubPlanType Edxlsubplantype(CExpression *pexprCorrelatedNLJoin);
 
-	// add used columns in the bitmap re-check and the remaining scalar filter condition to the
-	// required output column
-	static void AddBitmapFilterColumns(
-		CMemoryPool *mp, CPhysicalScan *pop, CExpression *pexprRecheckCond,
-		CExpression *pexprScalar,
-		CColRefSet *pcrsReqdOutput	// append the required column reference
-	);
-
 public:
 	// ctor
 	CTranslatorExprToDXL(CMemoryPool *mp, CMDAccessor *md_accessor,

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -13506,6 +13506,58 @@ and first_id in (select first_id from mat_w);
         1
 (8 rows)
 
+-- Test to ensure bitmapscan doesn't project recheck/scalar filter columns
+create table material_bitmapscan(i int, j int, k timestamp, l timestamp) with(appendonly=true) distributed replicated;
+create index material_bitmapscan_idx on material_bitmapscan using btree(k);
+insert into material_bitmapscan
+select i, mod(i, 10),
+	timestamp '2021-06-01' + interval '1' day * mod(i, 30),
+	timestamp '2021-06-01' + interval '1' day * mod(i, 30)
+from generate_series(1, 10000) i;
+explain verbose with mat as(
+    select i, j from material_bitmapscan where i = 2 and j = 2
+    and k = timestamp '2021-06-03' and l = timestamp '2021-06-03'
+)
+select m1.i
+from mat m1 join mat m2 on m1.j = m2.j;
+                                                                                         QUERY PLAN                                                                                          
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=0.03..0.09 rows=4 width=4)
+   Output: material_bitmapscan.i
+   ->  Hash Join  (cost=0.03..0.09 rows=4 width=4)
+         Output: material_bitmapscan.i
+         Hash Cond: (material_bitmapscan.j = m2.j)
+         ->  Bitmap Heap Scan on orca.material_bitmapscan  (cost=102.67..120.35 rows=1 width=8)
+               Output: material_bitmapscan.i, material_bitmapscan.j
+               Recheck Cond: (material_bitmapscan.k = 'Thu Jun 03 00:00:00 2021'::timestamp without time zone)
+               Filter: ((material_bitmapscan.i = 2) AND (material_bitmapscan.j = 2) AND (material_bitmapscan.l = 'Thu Jun 03 00:00:00 2021'::timestamp without time zone))
+               ->  Bitmap Index Scan on material_bitmapscan_idx  (cost=0.00..102.66 rows=334 width=0)
+                     Index Cond: (material_bitmapscan.k = 'Thu Jun 03 00:00:00 2021'::timestamp without time zone)
+         ->  Hash  (cost=0.02..0.02 rows=1 width=4)
+               Output: m2.j
+               ->  Subquery Scan on m2  (cost=0.00..0.02 rows=1 width=4)
+                     Output: m2.j
+                     ->  Bitmap Heap Scan on orca.material_bitmapscan material_bitmapscan_1  (cost=102.67..120.35 rows=1 width=8)
+                           Output: material_bitmapscan_1.i, material_bitmapscan_1.j
+                           Recheck Cond: (material_bitmapscan_1.k = 'Thu Jun 03 00:00:00 2021'::timestamp without time zone)
+                           Filter: ((material_bitmapscan_1.i = 2) AND (material_bitmapscan_1.j = 2) AND (material_bitmapscan_1.l = 'Thu Jun 03 00:00:00 2021'::timestamp without time zone))
+                           ->  Bitmap Index Scan on material_bitmapscan_idx  (cost=0.00..102.66 rows=334 width=0)
+                                 Index Cond: (material_bitmapscan_1.k = 'Thu Jun 03 00:00:00 2021'::timestamp without time zone)
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(23 rows)
+
+with mat as(
+    select i, j from material_bitmapscan where i = 2 and j = 2
+    and k = timestamp '2021-06-03' and l = timestamp '2021-06-03'
+)
+select m1.i
+from mat m1 join mat m2 on m1.j = m2.j;
+ i 
+---
+ 2
+(1 row)
+
 create table tt_varchar(
 	data character varying
 ) distributed by (data);

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -13716,9 +13716,9 @@ and first_id in (select first_id from mat_w);
          ->  Shared Scan (share slice:id 1:0)  (cost=0.00..387.98 rows=4 width=1)
                Output: share0_ref1.first_id
                ->  Materialize  (cost=0.00..387.98 rows=4 width=1)
-                     Output: material_test.first_id, material_test.second_id
+                     Output: material_test.first_id
                      ->  Bitmap Heap Scan on orca.material_test  (cost=0.00..387.98 rows=4 width=4)
-                           Output: material_test.first_id, material_test.second_id
+                           Output: material_test.first_id
                            Recheck Cond: (material_test.second_id = ANY ('{1,2,3,4}'::integer[]))
                            ->  Bitmap Index Scan on material_test_idx  (cost=0.00..0.00 rows=0 width=0)
                                  Index Cond: (material_test.second_id = ANY ('{1,2,3,4}'::integer[]))
@@ -13739,7 +13739,6 @@ and first_id in (select first_id from mat_w);
                      ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=4 width=4)
                            Output: share0_ref2.first_id
  Optimizer: Pivotal Optimizer (GPORCA)
- Settings: enable_seqscan=on, optimizer=on
 (31 rows)
 
 with mat_w as (
@@ -13762,6 +13761,66 @@ and first_id in (select first_id from mat_w);
         1
         1
 (8 rows)
+
+-- Test to ensure bitmapscan doesn't project recheck/scalar filter columns
+create table material_bitmapscan(i int, j int, k timestamp, l timestamp) with(appendonly=true) distributed replicated;
+create index material_bitmapscan_idx on material_bitmapscan using btree(k);
+insert into material_bitmapscan
+select i, mod(i, 10),
+	timestamp '2021-06-01' + interval '1' day * mod(i, 30),
+	timestamp '2021-06-01' + interval '1' day * mod(i, 30)
+from generate_series(1, 10000) i;
+explain verbose with mat as(
+    select i, j from material_bitmapscan where i = 2 and j = 2
+    and k = timestamp '2021-06-03' and l = timestamp '2021-06-03'
+)
+select m1.i
+from mat m1 join mat m2 on m1.j = m2.j;
+                                                                                      QUERY PLAN                                                                                       
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..1252.25 rows=1 width=4)
+   Output: share0_ref3.i
+   ->  Sequence  (cost=0.00..1252.25 rows=1 width=4)
+         Output: share0_ref3.i
+         ->  Shared Scan (share slice:id 1:0)  (cost=0.00..390.25 rows=1 width=1)
+               Output: share0_ref1.i, share0_ref1.j
+               ->  Materialize  (cost=0.00..390.25 rows=1 width=1)
+                     Output: material_bitmapscan.i, material_bitmapscan.j
+                     ->  Bitmap Heap Scan on orca.material_bitmapscan  (cost=0.00..390.25 rows=1 width=8)
+                           Output: material_bitmapscan.i, material_bitmapscan.j
+                           Recheck Cond: (material_bitmapscan.k = 'Thu Jun 03 00:00:00 2021'::timestamp without time zone)
+                           Filter: ((material_bitmapscan.i = 2) AND (material_bitmapscan.j = 2) AND (material_bitmapscan.l = 'Thu Jun 03 00:00:00 2021'::timestamp without time zone))
+                           ->  Bitmap Index Scan on material_bitmapscan_idx  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (material_bitmapscan.k = 'Thu Jun 03 00:00:00 2021'::timestamp without time zone)
+         ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+               Output: share0_ref3.i
+               Hash Cond: (share0_ref3.j = share0_ref2.j)
+               ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                     Output: share0_ref3.i, share0_ref3.j
+                     Filter: (share0_ref3.j = 2)
+                     ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=8)
+                           Output: share0_ref3.i, share0_ref3.j
+               ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                     Output: share0_ref2.j
+                     ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                           Output: share0_ref2.j
+                           Filter: (share0_ref2.j = 2)
+                           ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=4)
+                                 Output: share0_ref2.i, share0_ref2.j
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: optimizer=on
+(31 rows)
+
+with mat as(
+    select i, j from material_bitmapscan where i = 2 and j = 2
+    and k = timestamp '2021-06-03' and l = timestamp '2021-06-03'
+)
+select m1.i
+from mat m1 join mat m2 on m1.j = m2.j;
+ i 
+---
+ 2
+(1 row)
 
 create table tt_varchar(
 	data character varying

--- a/src/test/regress/output/qp_gist_indexes2_optimizer.source
+++ b/src/test/regress/output/qp_gist_indexes2_optimizer.source
@@ -1290,15 +1290,14 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
-   ->  Result
-         ->  Sort
-               Sort Key: id
-               ->  Bitmap Heap Scan on gisttable1
-                     Recheck Cond: (property ~= '(3,4),(1,2)'::box)
-                     ->  Bitmap Index Scan on propertyboxindex
-                           Index Cond: (property ~= '(3,4),(1,2)'::box)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(10 rows)
+   ->  Sort
+         Sort Key: id
+         ->  Bitmap Heap Scan on gisttable1
+               Recheck Cond: (property ~= '(3,4),(1,2)'::box)
+               ->  Bitmap Index Scan on propertyboxindex
+                     Index Cond: (property ~= '(3,4),(1,2)'::box)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
 
 REINDEX INDEX propertyBoxIndex;
 SELECT id FROM GistTable1 
@@ -1318,15 +1317,14 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
-   ->  Result
-         ->  Sort
-               Sort Key: id
-               ->  Bitmap Heap Scan on gisttable1
-                     Recheck Cond: (property ~= '(3,4),(1,2)'::box)
-                     ->  Bitmap Index Scan on propertyboxindex
-                           Index Cond: (property ~= '(3,4),(1,2)'::box)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(10 rows)
+   ->  Sort
+         Sort Key: id
+         ->  Bitmap Heap Scan on gisttable1
+               Recheck Cond: (property ~= '(3,4),(1,2)'::box)
+               ->  Bitmap Index Scan on propertyboxindex
+                     Index Cond: (property ~= '(3,4),(1,2)'::box)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
 
 DROP INDEX propertyBoxIndex;
 -- Obviously, this shouldn't use the index now that the index is gone.
@@ -1916,15 +1914,14 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
-   ->  Result
-         ->  Sort
-               Sort Key: id
-               ->  Bitmap Heap Scan on gisttable1
-                     Recheck Cond: (property ~= '(3,4),(1,2)'::box)
-                     ->  Bitmap Index Scan on propertyboxindex
-                           Index Cond: (property ~= '(3,4),(1,2)'::box)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(10 rows)
+   ->  Sort
+         Sort Key: id
+         ->  Bitmap Heap Scan on gisttable1
+               Recheck Cond: (property ~= '(3,4),(1,2)'::box)
+               ->  Bitmap Index Scan on propertyboxindex
+                     Index Cond: (property ~= '(3,4),(1,2)'::box)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
 
 REINDEX INDEX propertyBoxIndex;
 SELECT id FROM GistTable1 
@@ -1944,15 +1941,14 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
-   ->  Result
-         ->  Sort
-               Sort Key: id
-               ->  Bitmap Heap Scan on gisttable1
-                     Recheck Cond: (property ~= '(3,4),(1,2)'::box)
-                     ->  Bitmap Index Scan on propertyboxindex
-                           Index Cond: (property ~= '(3,4),(1,2)'::box)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(10 rows)
+   ->  Sort
+         Sort Key: id
+         ->  Bitmap Heap Scan on gisttable1
+               Recheck Cond: (property ~= '(3,4),(1,2)'::box)
+               ->  Bitmap Index Scan on propertyboxindex
+                     Index Cond: (property ~= '(3,4),(1,2)'::box)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
 
 DROP INDEX propertyBoxIndex;
 -- Obviously, this shouldn't use the index now that the index is gone.
@@ -2542,15 +2538,14 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
-   ->  Result
-         ->  Sort
-               Sort Key: id
-               ->  Bitmap Heap Scan on gisttable1
-                     Recheck Cond: (property ~= '(3,4),(1,2)'::box)
-                     ->  Bitmap Index Scan on propertyboxindex
-                           Index Cond: (property ~= '(3,4),(1,2)'::box)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(10 rows)
+   ->  Sort
+         Sort Key: id
+         ->  Bitmap Heap Scan on gisttable1
+               Recheck Cond: (property ~= '(3,4),(1,2)'::box)
+               ->  Bitmap Index Scan on propertyboxindex
+                     Index Cond: (property ~= '(3,4),(1,2)'::box)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
 
 REINDEX INDEX propertyBoxIndex;
 SELECT id FROM GistTable1 
@@ -2570,15 +2565,14 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
-   ->  Result
-         ->  Sort
-               Sort Key: id
-               ->  Bitmap Heap Scan on gisttable1
-                     Recheck Cond: (property ~= '(3,4),(1,2)'::box)
-                     ->  Bitmap Index Scan on propertyboxindex
-                           Index Cond: (property ~= '(3,4),(1,2)'::box)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(10 rows)
+   ->  Sort
+         Sort Key: id
+         ->  Bitmap Heap Scan on gisttable1
+               Recheck Cond: (property ~= '(3,4),(1,2)'::box)
+               ->  Bitmap Index Scan on propertyboxindex
+                     Index Cond: (property ~= '(3,4),(1,2)'::box)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
 
 DROP INDEX propertyBoxIndex;
 -- Obviously, this shouldn't use the index now that the index is gone.
@@ -3168,15 +3162,14 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
 ----------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
-   ->  Result
-         ->  Sort
-               Sort Key: id
-               ->  Bitmap Heap Scan on gisttable1
-                     Recheck Cond: (property ~= '(3,4),(1,2)'::box)
-                     ->  Bitmap Index Scan on propertyboxindex
-                           Index Cond: (property ~= '(3,4),(1,2)'::box)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(10 rows)
+   ->  Sort
+         Sort Key: id
+         ->  Bitmap Heap Scan on gisttable1
+               Recheck Cond: (property ~= '(3,4),(1,2)'::box)
+               ->  Bitmap Index Scan on propertyboxindex
+                     Index Cond: (property ~= '(3,4),(1,2)'::box)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
 
 REINDEX INDEX propertyBoxIndex;
 SELECT id FROM GistTable1 
@@ -3196,15 +3189,14 @@ EXPLAIN (COSTS OFF) SELECT id FROM GistTable1
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: id
-   ->  Result
-         ->  Sort
-               Sort Key: id
-               ->  Bitmap Heap Scan on gisttable1
-                     Recheck Cond: (property ~= '(3,4),(1,2)'::box)
-                     ->  Bitmap Index Scan on propertyboxindex
-                           Index Cond: (property ~= '(3,4),(1,2)'::box)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(10 rows)
+   ->  Sort
+         Sort Key: id
+         ->  Bitmap Heap Scan on gisttable1
+               Recheck Cond: (property ~= '(3,4),(1,2)'::box)
+               ->  Bitmap Index Scan on propertyboxindex
+                     Index Cond: (property ~= '(3,4),(1,2)'::box)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
 
 DROP INDEX propertyBoxIndex;
 -- Obviously, this shouldn't use the index now that the index is gone.


### PR DESCRIPTION
Prior to this PR, ORCA would project recheck/scalar filter columns
in addition to the output columns for BitmapTableScan/DynamicBitmapTableScan. 
This would work fine for most of the cases, but would produce wrong results in case of SharedScan with
BitmapTableScan on AO tables. This commit fixes the issue by removing
the unnecessary projection of recheck/scalar filter columns, similar to how planner projects
for BitmapHeapScan.

This fixes the issue: #12796

This PR also updates regress tests and mdp files with the updated plans and comments.  

Note: This is only an issue with 6X_STABLE and not on master as the materialize for shared scan was removed from master as part of this PR commit https://github.com/greenplum-db/gpdb/pull/10032/commits/5bdf2c8be30fea55fa7badadd1c7a2fd2acc69b9.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
