### PR TITLE
Fix checkpoint wal replay failed issue

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -8356,6 +8356,8 @@ ReadCheckpointRecord(XLogReaderState *xlogreader, XLogRecPtr RecPtr,
 	bool sizeOk;
 	uint32 chkpt_len;
 	uint32 chkpt_tot_len;
+	uint32 chkpt_tot_len_long;
+	bool length_match;
 
 	if (!XRecOffIsValid(RecPtr))
 	{
@@ -8442,10 +8444,13 @@ ReadCheckpointRecord(XLogReaderState *xlogreader, XLogRecPtr RecPtr,
 	sizeOk = false;
 	chkpt_len = XLogRecGetDataLen(xlogreader);
 	chkpt_tot_len = SizeOfXLogRecord + SizeOfXLogRecordDataHeaderShort + sizeof(CheckPoint);
+	chkpt_tot_len_long = SizeOfXLogRecord + SizeOfXLogRecordDataHeaderLong + sizeof(CheckPoint);
+	length_match = ((chkpt_len - sizeof(CheckPoint)) == (record->xl_tot_len - chkpt_tot_len))
+					|| ((chkpt_len - sizeof(CheckPoint)) == (record->xl_tot_len - chkpt_tot_len_long));
 	if ((chkpt_len == sizeof(CheckPoint) && record->xl_tot_len == chkpt_tot_len) ||
 		((chkpt_len > sizeof(CheckPoint) &&
 		  record->xl_tot_len > chkpt_tot_len &&
-		  ((chkpt_len - sizeof(CheckPoint)) == (record->xl_tot_len - chkpt_tot_len)))))
+		  length_match)))
 		sizeOk = true;
 
 	if (!sizeOk)


### PR DESCRIPTION
Stop the cluster with immediate mode, the instance does not have
a chance to write a SHUTDOWN_CHECKPOINT WAL. Hence, WAL replay is
trigger in the startup process next time the cluster start. It will
collect a bunch of global txn which is not finished and write a
SHUTDOWN_CHECKPOINT to promise the cluster consistency.

Before we believe a RecordShort is enough for we extended checkpoint
wal due to global txn information. It is not always true, in data
bulk import into env, at least ten import session is working, so
RecordLong may be used.

For every time the cluster instance start, it will valid the last
checkpoint wal size and replay. If the checkpoint wal was used
RecordLong the size validation believes it is an illegal xlog. The
issue is triggered.

Fix #12977 
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
