### PR TITLE
Fix flacky dispatch on master

### DIFF
--- a/gpcontrib/gp_inject_fault/gp_inject_fault--1.0.sql
+++ b/gpcontrib/gp_inject_fault/gp_inject_fault--1.0.sql
@@ -12,19 +12,46 @@ CREATE FUNCTION gp_inject_fault(
   start_occurrence int4,
   end_occurrence int4,
   extra_arg int4,
-  db_id int4)
+  db_id int4,
+  gp_session_id int4)
 RETURNS text
 AS 'MODULE_PATHNAME'
 LANGUAGE C VOLATILE STRICT NO SQL;
+
+--Simpler version, without specific session id.
+CREATE FUNCTION  gp_inject_fault(
+  faultname text,
+  type text,
+  ddl text,
+  database text,
+  tablename text,
+  start_occurrence int4,
+  end_occurrence int4,
+  extra_arg int4,
+  db_id int4)
+RETURNS text
+AS $$ select gp_inject_fault($1, $2, $3, $4, $5, $6, $7, $8, $9, -1) $$
+LANGUAGE SQL;
+
+-- Simpler version, trigger only one time, occurrence start at 1 and
+-- end at 1, no sleep and no ddl/database/tablename/sessionid.
+CREATE FUNCTION gp_inject_fault(
+  faultname text,
+  type text,
+  db_id int4)
+RETURNS text
+AS $$ select gp_inject_fault($1, $2, '', '', '', 1, 1, 0, $3, -1) $$
+LANGUAGE SQL;
 
 -- Simpler version, trigger only one time, occurrence start at 1 and
 -- end at 1, no sleep and no ddl/database/tablename.
 CREATE FUNCTION gp_inject_fault(
   faultname text,
   type text,
-  db_id int4)
+  db_id int4,
+  gp_session_id int4)
 RETURNS text
-AS $$ select gp_inject_fault($1, $2, '', '', '', 1, 1, 0, $3) $$
+AS $$ select gp_inject_fault($1, $2, '', '', '', 1, 1, 0, $3, $4) $$
 LANGUAGE SQL;
 
 -- Simpler version, always trigger until fault is reset.
@@ -33,7 +60,7 @@ CREATE FUNCTION gp_inject_fault_infinite(
   type text,
   db_id int4)
 RETURNS text
-AS $$ select gp_inject_fault($1, $2, '', '', '', 1, -1, 0, $3) $$
+AS $$ select gp_inject_fault($1, $2, '', '', '', 1, -1, 0, $3, -1) $$
 LANGUAGE SQL;
 
 -- Simpler version to avoid confusion for wait_until_triggered fault.
@@ -44,7 +71,7 @@ CREATE FUNCTION gp_wait_until_triggered_fault(
   numtimestriggered int4,
   db_id int4)
 RETURNS text
-AS $$ select gp_inject_fault($1, 'wait_until_triggered', '', '', '', 1, 1, $2, $3) $$
+AS $$ select gp_inject_fault($1, 'wait_until_triggered', '', '', '', 1, 1, $2, $3, -1) $$
 LANGUAGE SQL;
 
 CREATE OR REPLACE FUNCTION insert_noop_xlog_record()

--- a/gpcontrib/gp_inject_fault/gp_inject_fault.c
+++ b/gpcontrib/gp_inject_fault/gp_inject_fault.c
@@ -97,6 +97,8 @@ gp_inject_fault(PG_FUNCTION_ARGS)
 	int		endOccurrence = PG_GETARG_INT32(6);
 	int		extraArg = PG_GETARG_INT32(7);
 	int		dbid = PG_GETARG_INT32(8);
+	/*-1 means the fault canbe triggered by any process, others mean the fault can only be triggered by a specific session*/
+	int     gpSessionid = PG_GETARG_INT32(9);
 	char	*hostname;
 	int		port;
 	char	*response;
@@ -106,7 +108,7 @@ gp_inject_fault(PG_FUNCTION_ARGS)
 	{
 		response = InjectFault(
 			faultName, type, ddlStatement, databaseName,
-			tableName, startOccurrence, endOccurrence, extraArg);
+			tableName, startOccurrence, endOccurrence, extraArg, gpSessionid);
 		if (!response)
 			elog(ERROR, "failed to inject fault locally (dbid %d)", dbid);
 		if (strncmp(response, "Success:",  strlen("Success:")) != 0)
@@ -138,14 +140,15 @@ gp_inject_fault(PG_FUNCTION_ARGS)
 		if (!tableName || tableName[0] == '\0')
 			tableName = "#";
 		snprintf(msg, 1024, "faultname=%s type=%s ddl=%s db=%s table=%s "
-				 "start=%d end=%d extra=%d",
+				 "start=%d end=%d extra=%d sid=%d ",
 				 faultName, type,
 				 ddlStatement,
 				 databaseName,
 				 tableName,
 				 startOccurrence,
 				 endOccurrence,
-				 extraArg);
+				 extraArg,
+				 gpSessionid);
 		res = PQexec(conn, msg);
 		if (PQresultStatus(res) != PGRES_TUPLES_OK)
 			elog(ERROR, "failed to inject fault: %s", PQerrorMessage(conn));

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -62,7 +62,9 @@ typedef struct FaultInjectorEntry_s {
 	
 	int						extraArg;
 		/* in seconds, in use if fault injection type is sleep */
-		
+	int						gpSessionid;
+		/*-1 means the fault can be triggered by any process*/
+
 	DDLStatement_e			ddlStatement;
 	
 	char					databaseName[NAMEDATALEN];
@@ -106,7 +108,7 @@ extern int *numActiveFaults_ptr;
 
 extern char *InjectFault(
 	char *faultName, char *type, char *ddlStatement, char *databaseName,
-	char *tableName, int startOccurrence, int endOccurrence, int extraArg);
+	char *tableName, int startOccurrence, int endOccurrence, int extraArg, int gpSessionid);
 
 extern void HandleFaultMessage(const char* msg);
 

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -259,7 +259,8 @@ where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispat
 select cleanupAllGangs();
 
 -- segment 0 report an error when get a request 
-select gp_inject_fault('send_qe_details_init_backend', 'error', 2);
+-- the fault may be triggered by other backend process, such as dtx recovery process, specify a session id.
+select gp_inject_fault('send_qe_details_init_backend', 'error', 2, current_setting('gp_session_id')::int);
 select cleanupAllGangs();
 
 -- expect failure
@@ -277,7 +278,8 @@ select cleanupAllGangs();
 
 select gp_inject_fault('send_qe_details_init_backend', 'reset', 2);
 -- segment 0 report an error when get the second request (reader gang creation request)
-select gp_inject_fault('send_qe_details_init_backend', 'error', '', '', '', 3, 3, 0, 2::smallint);
+-- the fault may be triggered by other backend process, such as dtx recovery process, specify a session id.
+select gp_inject_fault('send_qe_details_init_backend', 'error', '', '', '', 3, 3, 0, 2::smallint, current_setting('gp_session_id')::int);
 select cleanupAllGangs();
 
 -- expect failure

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -409,7 +409,8 @@ select cleanupAllGangs();
 (1 row)
 
 -- segment 0 report an error when get a request 
-select gp_inject_fault('send_qe_details_init_backend', 'error', 2);
+-- the fault may be triggered by other backend process, such as dtx recovery process, specify a session id.
+select gp_inject_fault('send_qe_details_init_backend', 'error', 2, current_setting('gp_session_id')::int);
  gp_inject_fault 
 -----------------
  Success:
@@ -455,7 +456,8 @@ select gp_inject_fault('send_qe_details_init_backend', 'reset', 2);
 (1 row)
 
 -- segment 0 report an error when get the second request (reader gang creation request)
-select gp_inject_fault('send_qe_details_init_backend', 'error', '', '', '', 3, 3, 0, 2::smallint);
+-- the fault may be triggered by other backend process, such as dtx recovery process, specify a session id.
+select gp_inject_fault('send_qe_details_init_backend', 'error', '', '', '', 3, 3, 0, 2::smallint, current_setting('gp_session_id')::int);
  gp_inject_fault 
 -----------------
  Success:


### PR DESCRIPTION
the fault 'send_qe_details_init_backend' injected by dispatch.source was triggered by backend process:dtx recovery early, so that the expect fail select is executed sucessfully. 
add a parameter to gp_inject_funtion, so that the fault can only be triggered by specific session if specify_session parameter set be true, in case that the fault be triggered by other backend process unexpectly.