### PR TITLE
Fix gpinitsystem/gpconfig comment other GUCs with same prefix.

### DIFF
--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -371,11 +371,11 @@ SED_PG_CONF () {
 	KEEP_PREV=$1;shift
 	SED_HOST=$1
 	if [ x"" == x"$SED_HOST" ]; then
-			if [ `$GREP -c "${SEARCH_TXT}[ ]*=" $FILENAME` -gt 1 ]; then
+			if [ `$GREP -c "^[ ]*${SEARCH_TXT}[ ]*=" $FILENAME` -gt 1 ]; then
 				LOG_MSG "[INFO]:-Found more than 1 instance of $SEARCH_TXT in $FILENAME, will append" 1
 				APPEND=1
 			fi
-			if [ `$GREP -c "${SEARCH_TXT}[ ]*=" $FILENAME` -eq 0 ] || [ $APPEND -eq 1 ]; then
+			if [ `$GREP -c "^[ ]*${SEARCH_TXT}[ ]*=" $FILENAME` -eq 0 ] || [ $APPEND -eq 1 ]; then
 				$ECHO $SUB_TXT >> $FILENAME
 				RETVAL=$?
 				if [ $RETVAL -ne 0 ]; then
@@ -414,11 +414,11 @@ SED_PG_CONF () {
 		trap RETRY ERR
 		RETVAL=0 # RETVAL gets modified in RETRY function whenever the trap is called
 
-		if [ $( REMOTE_EXECUTE_AND_GET_OUTPUT  $SED_HOST "$GREP -c \"${SEARCH_TXT}\" $FILENAME") -gt 1 ]; then
+		if [ $( REMOTE_EXECUTE_AND_GET_OUTPUT  $SED_HOST "$GREP -c \"^[ ]*${SEARCH_TXT}[ ]*=\" $FILENAME") -gt 1 ]; then
 			LOG_MSG "[INFO]:-Found more than 1 instance of $SEARCH_TXT in $FILENAME on $SED_HOST, will append" 1
 			APPEND=1
 		fi
-		if [ $( REMOTE_EXECUTE_AND_GET_OUTPUT $SED_HOST "$GREP -c \"${SEARCH_TXT}\" $FILENAME") -eq 0 ] || [ $APPEND -eq 1 ]; then
+		if [ $( REMOTE_EXECUTE_AND_GET_OUTPUT $SED_HOST "$GREP -c \"^[ ]*${SEARCH_TXT}[ ]*=\" $FILENAME") -eq 0 ] || [ $APPEND -eq 1 ]; then
 			$TRUSTED_SHELL $SED_HOST "$ECHO \"$SUB_TXT\" >> $FILENAME"
 			if [ $RETVAL -ne 0 ]; then
 				ERROR_EXIT "[FATAL]:-Failed to append line $SUB_TXT to $FILENAME on $SED_HOST" 2

--- a/gpMgmt/sbin/gpconfig_helper.py
+++ b/gpMgmt/sbin/gpconfig_helper.py
@@ -93,7 +93,7 @@ def comment_parameter(filename, name):
     with open(os.path.abspath(temp_conf_path), 'wb') as outfile:
         for line in lines:
             potential_match = line.split("=", 1)[0]
-            if potential_match.lstrip().startswith(name):
+            if potential_match.strip() == name:
                 outfile.write('#')
             outfile.write(line)
             new_lines = new_lines + 1

--- a/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
@@ -216,6 +216,30 @@ Feature: gpconfig integration tests
         | asks for confirmation and aborts when user selects no     | 1           | should         | User Aborted. Exiting. | should not           | should not            | gpconfig -c application_name -v "easy" < test/behave/mgmt_utils/steps/data/no.txt |
         | does not ask for confirmation for master only change      | 0           | should not     | completed successfully | should               | should not            | gpconfig -c application_name -v "easy" --masteronly                               |
 
+    @concourse_cluster
+    @demo_cluster
+    Scenario: gpconfig check for GUC's with same prefix
+      Given the user runs "gpstop -u"
+        And gpstop should return a return code of 0
+        And the gpconfig context is setup
+
+        When the user runs "gpconfig -c gp_resqueue_priority -v 'off'"
+        Then gpconfig should return a return code of 0
+        And verify that the file "postgresql.conf" in the master data directory has "some" line starting with "gp_resqueue_priority"
+        And verify that the file "postgresql.conf" in each segment data directory has "some" line starting with "gp_resqueue_priority"
+
+        When the user runs "gpconfig -c gp_resqueue_priority_cpucores_per_segment -v '4'"
+        Then gpconfig should return a return code of 0
+        And verify that the file "postgresql.conf" in the master data directory has "some" line starting with "gp_resqueue_priority_cpucores_per_segment"
+        And verify that the file "postgresql.conf" in each segment data directory has "some" line starting with "gp_resqueue_priority_cpucores_per_segment"
+
+        When the user runs "gpconfig -c gp_resqueue_priority -v 'on'"
+        Then gpconfig should return a return code of 0
+        And verify that the file "postgresql.conf" in the master data directory has "some" line starting with "gp_resqueue_priority"
+        And verify that the file "postgresql.conf" in each segment data directory has "some" line starting with "gp_resqueue_priority"
+        And verify that the file "postgresql.conf" in the master data directory has "some" line starting with "gp_resqueue_priority_cpucores_per_segment"
+        And verify that the file "postgresql.conf" in each segment data directory has "some" line starting with "gp_resqueue_priority_cpucores_per_segment"
+
     @demo_cluster
     Scenario: gpconfig checks liveness of correct number of hosts
       Given the database is running


### PR DESCRIPTION
Fix #12957, modify regex in gp_bash_functions.sh and gpconfig_helper.py from prefix match to full match after removing spaces.

When we use gpconfig to add a new parameter, it may comment another parameter with the same prefix, because in gpconfig_hepler.py line 96, the function comment_parameter() uses startswith to match the GUC.
The same accident also happens in gpinitsystem with -p option, it will call SED_PG_CONF in gp_bash_functions.sh, which also uses prefix match somewhere.
6X_STABLE and other branches will also benefit from this commit.

Authored-by:  DellCurry

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
