### PR TITLE
Add another version of gp_inject_funtion() to fix flaky case

### DIFF
--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -62,7 +62,9 @@ typedef struct FaultInjectorEntry_s {
 	
 	int						extraArg;
 		/* in seconds, in use if fault injection type is sleep */
-		
+	int						gpSessionid;
+		/* -1 means the fault could be triggered by any process */
+
 	DDLStatement_e			ddlStatement;
 	
 	char					databaseName[NAMEDATALEN];
@@ -106,7 +108,7 @@ extern int *numActiveFaults_ptr;
 
 extern char *InjectFault(
 	char *faultName, char *type, char *ddlStatement, char *databaseName,
-	char *tableName, int startOccurrence, int endOccurrence, int extraArg);
+	char *tableName, int startOccurrence, int endOccurrence, int extraArg, int gpSessionid);
 
 extern void HandleFaultMessage(const char* msg);
 

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -259,7 +259,8 @@ where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispat
 select cleanupAllGangs();
 
 -- segment 0 report an error when get a request 
-select gp_inject_fault('send_qe_details_init_backend', 'error', 2);
+-- the fault may be triggered by other backend process, such as dtx recovery process, specify a session id.
+select gp_inject_fault('send_qe_details_init_backend', 'error', 2, current_setting('gp_session_id')::int);
 select cleanupAllGangs();
 
 -- expect failure
@@ -277,7 +278,8 @@ select cleanupAllGangs();
 
 select gp_inject_fault('send_qe_details_init_backend', 'reset', 2);
 -- segment 0 report an error when get the second request (reader gang creation request)
-select gp_inject_fault('send_qe_details_init_backend', 'error', '', '', '', 3, 3, 0, 2::smallint);
+-- the fault may be triggered by other backend process, such as dtx recovery process, specify a session id.
+select gp_inject_fault('send_qe_details_init_backend', 'error', '', '', '', 3, 3, 0, 2::smallint, current_setting('gp_session_id')::int);
 select cleanupAllGangs();
 
 -- expect failure

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -409,7 +409,8 @@ select cleanupAllGangs();
 (1 row)
 
 -- segment 0 report an error when get a request 
-select gp_inject_fault('send_qe_details_init_backend', 'error', 2);
+-- the fault may be triggered by other backend process, such as dtx recovery process, specify a session id.
+select gp_inject_fault('send_qe_details_init_backend', 'error', 2, current_setting('gp_session_id')::int);
  gp_inject_fault 
 -----------------
  Success:
@@ -455,7 +456,8 @@ select gp_inject_fault('send_qe_details_init_backend', 'reset', 2);
 (1 row)
 
 -- segment 0 report an error when get the second request (reader gang creation request)
-select gp_inject_fault('send_qe_details_init_backend', 'error', '', '', '', 3, 3, 0, 2::smallint);
+-- the fault may be triggered by other backend process, such as dtx recovery process, specify a session id.
+select gp_inject_fault('send_qe_details_init_backend', 'error', '', '', '', 3, 3, 0, 2::smallint, current_setting('gp_session_id')::int);
  gp_inject_fault 
 -----------------
  Success:


### PR DESCRIPTION
The fault 'send_qe_details_init_backend' injected in dispatch.source was
triggered by other backend processes by accident, which makes the
dispatch case flaky.

This commit provides another version of gp_inject_funtion() with an extra
parameter, so that the fault could be triggered by a specific session, to
avoid the fault triggered by other backend processes unexpectedly.
