### PR TITLE
Make sendControlMessage to retry when interrupted

### DIFF
--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -775,6 +775,8 @@ static void aggregateStatistics(ChunkTransportStateEntry *pEntry);
 
 static inline bool pollAcks(ChunkTransportState *transportStates, int fd, int timeout);
 
+static void sendtoWithRetry(int socket, const void *message, size_t length, int flags, const struct sockaddr *dest_addr, socklen_t dest_len, int retry, const char *errDetail);
+
 /* #define TRANSFER_PROTOCOL_STATS */
 
 #ifdef TRANSFER_PROTOCOL_STATS
@@ -1783,9 +1785,6 @@ destroyConnHashTable(ConnHashTable *ht)
 /*
  * sendControlMessage
  * 		Helper function to send a control message.
- *
- * It is different from sendOnce which retries on interrupts...
- * Here, we leave it to retransmit logic to handle these cases.
  */
 static inline void
 sendControlMessage(icpkthdr *pkt, int fd, struct sockaddr *addr, socklen_t peerLen)
@@ -1806,15 +1805,10 @@ sendControlMessage(icpkthdr *pkt, int fd, struct sockaddr *addr, socklen_t peerL
 	if (gp_interconnect_full_crc)
 		addCRC(pkt);
 
-	n = sendto(fd, (const char *) pkt, pkt->len, 0, addr, peerLen);
-
-	/*
-	 * No need to handle EAGAIN here: no-space just means that we dropped the
-	 * packet: our ordinary retransmit mechanism will handle that case
-	 */
-
-	if (n < pkt->len)
-		write_log("sendcontrolmessage: got error %d errno %d seq %d", n, errno, pkt->seq);
+	char errDetail[100];
+	snprintf(errDetail, sizeof(errDetail), "Send control message: got error with seq %d", pkt->seq);
+	/* Retry for infinite times since we have no retransmit mechanism for control message */
+	sendtoWithRetry(fd, (const char *) pkt, pkt->len, 0, addr, peerLen, 0, errDetail);
 }
 
 /*
@@ -4546,28 +4540,16 @@ prepareXmit(MotionConn *conn)
 	}
 }
 
-/*
- * sendOnce
- * 		Send a packet.
- */
-static void
-sendOnce(ChunkTransportState *transportStates, ChunkTransportStateEntry *pEntry, ICBuffer *buf, MotionConn *conn)
-{
+static void sendtoWithRetry(int socket, const void *message, size_t length,
+           int flags, const struct sockaddr *dest_addr,
+           socklen_t dest_len, int retry, const char *errDetail) {
 	int32		n;
-
-#ifdef USE_ASSERT_CHECKING
-	if (testmode_inject_fault(gp_udpic_dropxmit_percent))
-	{
-#ifdef AMS_VERBOSE_LOGGING
-		write_log("THROW PKT with seq %d srcpid %d despid %d", buf->pkt->seq, buf->pkt->srcPid, buf->pkt->dstPid);
-#endif
-		return;
-	}
-#endif
+	int count = 0;
 
 xmit_retry:
-	n = sendto(pEntry->txfd, buf->pkt, buf->pkt->len, 0,
-			   (struct sockaddr *) &conn->peer, conn->peer_len);
+	if (retry > 0 && ++count > retry)
+		return;
+	n = sendto(socket, message, length, flags, dest_addr, dest_len);
 	if (n < 0)
 	{
 		int			save_errno = errno;
@@ -4588,32 +4570,52 @@ xmit_retry:
 			ereport(LOG,
 					(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
 					 errmsg("Interconnect error writing an outgoing packet: %m"),
-					 errdetail("error during sendto() for Remote Connection: contentId=%d at %s",
-							   conn->remoteContentId, conn->remoteHostAndPort)));
+					 errdetail("error during sendto() %s", errDetail)));
 			return;
 		}
 
 		ereport(ERROR, (errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
 						errmsg("Interconnect error writing an outgoing packet: %m"),
 						errdetail("error during sendto() call (error:%d).\n"
-								  "For Remote Connection: contentId=%d at %s",
-								  save_errno, conn->remoteContentId,
-								  conn->remoteHostAndPort)));
+								  "%s", save_errno, errDetail)));
 		/* not reached */
 	}
 
-	if (n != buf->pkt->len)
+	if (n != dest_len)
 	{
 		if (DEBUG1 >= log_min_messages)
 			write_log("Interconnect error writing an outgoing packet [seq %d]: short transmit (given %d sent %d) during sendto() call."
-					  "For Remote Connection: contentId=%d at %s", buf->pkt->seq, buf->pkt->len, n,
-					  conn->remoteContentId,
-					  conn->remoteHostAndPort);
+					  "%s", ((icpkthdr *) message)->seq, dest_len, n, errDetail);
 #ifdef AMS_VERBOSE_LOGGING
 		logPkt("PKT DETAILS ", buf->pkt);
 #endif
 	}
+}
 
+/*
+ * sendOnce
+ * 		Send a packet.
+ */
+static void
+sendOnce(ChunkTransportState *transportStates, ChunkTransportStateEntry *pEntry, ICBuffer *buf, MotionConn *conn)
+{
+
+#ifdef USE_ASSERT_CHECKING
+	if (testmode_inject_fault(gp_udpic_dropxmit_percent))
+	{
+#ifdef AMS_VERBOSE_LOGGING
+		write_log("THROW PKT with seq %d srcpid %d despid %d", buf->pkt->seq, buf->pkt->srcPid, buf->pkt->dstPid);
+#endif
+		return;
+	}
+#endif
+
+	char errDetail[100];
+	snprintf(errDetail, sizeof(errDetail), "For Remote Connection: contentId=%d at %s",
+					  conn->remoteContentId,
+					  conn->remoteHostAndPort);
+	sendtoWithRetry(pEntry->txfd, buf->pkt, buf->pkt->len, 0,
+                          (struct sockaddr *) &conn->peer, conn->peer_len, 0, errDetail);
 	return;
 }
 
@@ -6934,30 +6936,9 @@ SendDummyPacket(void)
 	/*
 	 * Send a dummy package to the interconnect listener, try 10 times
 	 */
-
-	counter = 0;
-	while (counter < 10)
-	{
-		counter++;
-		ret = sendto(sockfd, dummy_pkt, strlen(dummy_pkt), 0, rp->ai_addr, rp->ai_addrlen);
-		if (ret < 0)
-		{
-			if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)
-				continue;
-			else
-			{
-				elog(LOG, "send dummy packet failed, sendto failed: %m");
-				goto send_error;
-			}
-		}
-		break;
-	}
-
-	if (counter >= 10)
-	{
-		elog(LOG, "send dummy packet failed, sendto failed: %m");
-		goto send_error;
-	}
+	char errDetail[100];
+	snprintf(errDetail, sizeof(errDetail), "Send dummy packet failed");
+	sendtoWithRetry(sockfd, dummy_pkt, strlen(dummy_pkt), 0, rp->ai_addr, rp->ai_addrlen, 10, errDetail);
 
 	pg_freeaddrinfo_all(hint.ai_family, addrs);
 	closesocket(sockfd);


### PR DESCRIPTION
As #12961 mentioned, `sendControlMessage()` is sent without retry, that is because in the normal cases, UDPIFC's retransmit mechanism will handle the normal data packet loss issue, and will retransmit UDP packets with another ACK sent, so there is no need to retry in `sendControlMessage()`, as [the comments](https://github.com/greenplum-db/gpdb/blob/f4ffe428f06616cf50904f5eb5f129f19ce6ba98/src/backend/cdb/motion/ic_udpifc.c#L1774) pointed out. But for some special cases, if the ACK is lost, it will not retransmit with UDP packets, e.g. in the EOS ACK message case.

In this PR, I move `sendto()` call with retry logic to a new method, so any relative call can reuse it enabling retries when interrupted.

For black-box testing, the scenario is hard to reproduce on local dev, and it occurs when the network is bad and the GP cluster is big. For white box testing, the retries are performed when getting certain Error codes returned by the low-level system call `sendto`, but it's hard to mock that through fault injection directly.

We tried to add a test on icudp_full.sql, by using the GUC gp_udpic_dropacks_percent to mock drop ack, but the fault inject in `sendControlMessage()` returns if (random() % 100 < percent).Therefore, it's hard to cover the retry logic.
But still, the current icudp_full.sql has all passed.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
