### PR TITLE
Fix SIGSEGV due to non-derived statistics (#12970)

### DIFF
--- a/src/backend/gporca/libgpopt/src/xforms/CXformRightOuterJoin2HashJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformRightOuterJoin2HashJoin.cpp
@@ -78,15 +78,23 @@ CXformRightOuterJoin2HashJoin::Transform(CXformContext *pxfctxt,
 	GPOS_ASSERT(FPromising(pxfctxt->Pmp(), this, pexpr));
 	GPOS_ASSERT(FCheckPattern(pexpr));
 
+	const IStatistics *outerStats = (*pexpr)[0]->Pstats();
+	const IStatistics *innerStats = (*pexpr)[1]->Pstats();
+
+	if (NULL == outerStats || NULL == innerStats)
+	{
+		return;
+	}
+
 	// If the inner row estimate is an arbitary factor larger than the outer, don't generate a ROJ alternative.
 	// Although the ROJ may still be better due to partition selection, which isn't considered below,
 	// we're more cautious so we don't increase optimization time too much and that we account for
 	// poor cardinality estimation. This is admittedly conservative, but mis-estimating the hash side
 	// of a ROJ can cause spilling.
-	CDouble outerRows = (*pexpr)[0]->Pstats()->Rows();
-	CDouble outerWidth = (*pexpr)[0]->Pstats()->Width();
-	CDouble innerRows = (*pexpr)[1]->Pstats()->Rows();
-	CDouble innerWidth = (*pexpr)[1]->Pstats()->Width();
+	CDouble outerRows = outerStats->Rows();
+	CDouble outerWidth = outerStats->Width();
+	CDouble innerRows = innerStats->Rows();
+	CDouble innerWidth = innerStats->Width();
 
 	CDouble confidenceFactor = 2 * (*pexpr)[1]->DeriveJoinDepth();
 	if (innerRows * innerWidth * confidenceFactor > outerRows * outerWidth)

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -492,6 +492,7 @@ add_orca_test(CConstTblGetTest)
 add_orca_test(CScalarIsDistinctFromTest)
 
 add_orca_test(CSubqueryHandlerTest)
+add_orca_test(CXformRightOuterJoin2HashJoinTest)
 
 add_orca_test(CBindingTest)
 add_orca_test(CEngineTest)

--- a/src/backend/gporca/server/include/unittest/gpopt/CTestUtils.h
+++ b/src/backend/gporca/server/include/unittest/gpopt/CTestUtils.h
@@ -352,6 +352,9 @@ public:
 	// generate left outer join on top of n-ary join expression
 	static CExpression *PexprLeftOuterJoinOnNAryJoin(CMemoryPool *mp);
 
+	// generate right outer join expression
+	static CExpression *PexprRightOuterJoin(CMemoryPool *mp);
+
 	// generate n-ary join on top of left outer join expression
 	static CExpression *PexprNAryJoinOnLeftOuterJoin(CMemoryPool *mp);
 

--- a/src/backend/gporca/server/include/unittest/gpopt/xforms/CXformRightOuterJoin2HashJoinTest.h
+++ b/src/backend/gporca/server/include/unittest/gpopt/xforms/CXformRightOuterJoin2HashJoinTest.h
@@ -1,0 +1,47 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2011 EMC Corp.
+//
+//	@filename:
+//		CXformRightOuterJoin2HashJoinTest.h
+//
+//	@doc:
+//		Test for right outer join to hash join transform
+//---------------------------------------------------------------------------
+#ifndef GPOPT_CXformRightOuterJoin2HashJoinTest_H
+#define GPOPT_CXformRightOuterJoin2HashJoinTest_H
+
+#include "gpos/base.h"
+#include "gpos/common/CDynamicPtrArray.h"
+#include "gpos/common/CRefCount.h"
+
+#include "gpopt/base/CColRef.h"
+#include "gpopt/base/CDrvdProp.h"
+#include "gpopt/base/CPrintPrefix.h"
+#include "gpopt/operators/CExpression.h"
+#include "gpopt/operators/COperator.h"
+
+namespace gpopt
+{
+//---------------------------------------------------------------------------
+//	@class:
+//		CXformRightOuterJoin2HashJoinTest
+//
+//	@doc:
+//		Tests for logical right outer transform
+//
+//---------------------------------------------------------------------------
+class CXformRightOuterJoin2HashJoinTest
+{
+public:
+	// unittests
+	static GPOS_RESULT EresUnittest();
+	static GPOS_RESULT EresUnittest_Transform();
+
+};	// class CXformRightOuterJoin2HashJoinTest
+}  // namespace gpopt
+
+
+#endif	// !GPOPT_CXformRightOuterJoin2HashJoinTest_H
+
+// EOF

--- a/src/backend/gporca/server/src/startup/main.cpp
+++ b/src/backend/gporca/server/src/startup/main.cpp
@@ -108,6 +108,7 @@
 #include "unittest/gpopt/xforms/CJoinOrderTest.h"
 #include "unittest/gpopt/xforms/CSubqueryHandlerTest.h"
 #include "unittest/gpopt/xforms/CXformFactoryTest.h"
+#include "unittest/gpopt/xforms/CXformRightOuterJoin2HashJoinTest.h"
 #include "unittest/gpopt/xforms/CXformTest.h"
 
 using namespace gpos;
@@ -179,6 +180,7 @@ static gpos::CUnittest rgut[] = {
 	GPOS_UNITTEST_STD(CConstTblGetTest),
 
 	GPOS_UNITTEST_STD(CSubqueryHandlerTest),
+	GPOS_UNITTEST_STD(CXformRightOuterJoin2HashJoinTest),
 	GPOS_UNITTEST_STD(CBindingTest),
 	GPOS_UNITTEST_STD(CEngineTest),
 	GPOS_UNITTEST_STD(CEquivalenceClassesTest),

--- a/src/backend/gporca/server/src/unittest/CTestUtils.cpp
+++ b/src/backend/gporca/server/src/unittest/CTestUtils.cpp
@@ -1345,6 +1345,25 @@ CTestUtils::PexprLeftOuterJoinOnNAryJoin(CMemoryPool *mp)
 					pexprLOJInnerChild, pexprPred);
 }
 
+CExpression *
+CTestUtils::PexprRightOuterJoin(CMemoryPool *mp)
+{
+	CExpression *pexprInnerChild = PexprLogicalGet(mp);
+	CExpression *pexprOuterChild = PexprLogicalGet(mp);
+
+	// get a random column from inner child output
+	CColRef *pcrLeft = pexprInnerChild->DeriveOutputColumns()->PcrAny();
+
+	// get a random column from outer child output
+	CColRef *pcrRight = pexprOuterChild->DeriveOutputColumns()->PcrAny();
+
+	CExpression *pexprPred = CUtils::PexprScalarEqCmp(mp, pcrLeft, pcrRight);
+
+	return GPOS_NEW(mp)
+		CExpression(mp, GPOS_NEW(mp) CLogicalRightOuterJoin(mp),
+					pexprOuterChild, pexprInnerChild, pexprPred);
+}
+
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/server/src/unittest/gpopt/xforms/CXformRightOuterJoin2HashJoinTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/xforms/CXformRightOuterJoin2HashJoinTest.cpp
@@ -1,0 +1,81 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2011 EMC Corp.
+//
+//	@filename:
+//		CXformRightOuterJoin2HashJoinTest.cpp
+//
+//	@doc:
+//		Test for right outer join to hash join transform
+//---------------------------------------------------------------------------
+#include "unittest/gpopt/xforms/CXformRightOuterJoin2HashJoinTest.h"
+
+#include "gpopt/base/CQueryContext.h"
+#include "gpopt/base/CUtils.h"
+#include "gpopt/operators/CPredicateUtils.h"
+#include "gpopt/operators/ops.h"
+#include "gpopt/xforms/CXformRightOuterJoin2HashJoin.h"
+
+#include "unittest/base.h"
+#include "unittest/gpopt/CTestUtils.h"
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CXformRightOuterJoin2HashJoinTest::EresUnittest
+//
+//	@doc:
+//		Unittest for predicate utilities
+//
+//---------------------------------------------------------------------------
+GPOS_RESULT
+CXformRightOuterJoin2HashJoinTest::EresUnittest()
+{
+	CUnittest rgut[] = {
+		GPOS_UNITTEST_FUNC(
+			CXformRightOuterJoin2HashJoinTest::EresUnittest_Transform),
+	};
+
+	return CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CXformRightOuterJoin2HashJoinTest::EresUnittest_Transform
+//
+//	@doc:
+//		Driver for transform tests
+//
+//---------------------------------------------------------------------------
+GPOS_RESULT
+CXformRightOuterJoin2HashJoinTest::EresUnittest_Transform()
+{
+	CAutoMemoryPool amp;
+	CMemoryPool *mp = amp.Pmp();
+
+	CMDProviderMemory *pmdp = CTestUtils::m_pmdpf;
+	pmdp->AddRef();
+	CMDAccessor mda(mp, CMDCache::Pcache(), CTestUtils::m_sysidDefault, pmdp);
+	CAutoOptCtxt aoc(mp, &mda, NULL, /* pceeval */
+					 CTestUtils::GetCostModel(mp));
+
+	CXformContext *context = GPOS_NEW(mp) CXformContext(mp);
+	CXformResult *result = GPOS_NEW(mp) CXformResult(mp);
+
+	CXformRightOuterJoin2HashJoin *xform =
+		GPOS_NEW(mp) CXformRightOuterJoin2HashJoin(mp);
+
+	CExpression *pLogicalRightOuterJoin = CTestUtils::PexprRightOuterJoin(mp);
+
+	(void) xform->Transform(context, result, pLogicalRightOuterJoin);
+
+	pLogicalRightOuterJoin->Release();
+	xform->Release();
+	context->Release();
+	result->Release();
+
+	return GPOS_OK;
+}
+
+// EOF

--- a/src/backend/gporca/server/src/unittest/gpopt/xforms/CXformRightOuterJoin2HashJoinTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/xforms/CXformRightOuterJoin2HashJoinTest.cpp
@@ -68,6 +68,10 @@ CXformRightOuterJoin2HashJoinTest::EresUnittest_Transform()
 
 	CExpression *pLogicalRightOuterJoin = CTestUtils::PexprRightOuterJoin(mp);
 
+	// xform should work even if child stats aren't derived yet.
+	GPOS_ASSERT(NULL == (*pLogicalRightOuterJoin)[0]->Pstats());
+	GPOS_ASSERT(NULL == (*pLogicalRightOuterJoin)[1]->Pstats());
+
 	(void) xform->Transform(context, result, pLogicalRightOuterJoin);
 
 	pLogicalRightOuterJoin->Release();


### PR DESCRIPTION
Similar to dede33b352f when statistics may not be derived yet, we should
take care to handle the scenario gracefully.

Following demonstrated error using non-assert build:

    ```sql
    CREATE TABLE a_table(col text);

    SELECT a.col FROM (
        SELECT col FROM a_table e
        WHERE exists
        (
            SELECT col FROM a_table
        )
    ) a
    WHERE exists (
        SELECT c.col FROM a_table c
        INNER JOIN a_table b
        ON c.col = a.col
        WHERE exists (
            SELECT distinct _a.col FROM (
                SELECT distinct col FROM a_table _a
            ) _a
            WHERE _a.col = c.col
        )
    );
    ```