### PR TITLE
(Backport to 6X) Make svec_l2_eq strict function to handle NULL properly.

### DIFF
--- a/gpcontrib/Makefile
+++ b/gpcontrib/Makefile
@@ -85,11 +85,6 @@ installcheck:
 		$(MAKE) -C gpmapreduce installcheck; \
 	fi
 	if [ "$(enable_orafce)" = "yes" ]; then $(MAKE) -C orafce installcheck; fi
-
-ifeq "$(with_zstd)" "yes"
-	$(MAKE) -C zstd installcheck
-endif
-
-ifeq "$(with_quicklz)" "yes"
-	$(MAKE) -C quicklz installcheck
-endif
+	if [ "$(with_zstd)" = "yes" ]; then $(MAKE) -C zstd installcheck; fi
+	if [ "$(with_quicklz)" = "yes" ]; then $(MAKE) -C quicklz installcheck; fi
+	$(MAKE) -C gp_sparse_vector installcheck

--- a/gpcontrib/gp_sparse_vector/expected/gp_svec.out
+++ b/gpcontrib/gp_sparse_vector/expected/gp_svec.out
@@ -249,13 +249,38 @@ SELECT vec_median('{9960,9926,10053,9993,10080,10050,9938,9941,10030,10029}:{1,9
           5
 (1 row)
 
-select a.table_name,b.column_name,a.character_maximum_length as char_maxlen_a,b.character_maximum_length as char_maxlen_b,case when ((a.character_maximum_length == b.character_maximum_length) or ( a.numeric_precision==b.numeric_precision) or (a.numeric_scale==b.numeric_scale)) then 'Y' else 'N' end from information_schema.columns a inner join information_schema.columns b on a.table_name=b.table_name and a.column_name=b.column_name where a.table_name='applicable_roles' order by a.ordinal_position;
-    table_name    | column_name  | char_maxlen_a | char_maxlen_b | case 
-------------------+--------------+---------------+---------------+------
- applicable_roles | grantee      |               |               | N
- applicable_roles | role_name    |               |               | N
- applicable_roles | is_grantable |             3 |             3 | Y
-(3 rows)
+-- Test operator == as a joining condition when this column could be null. (See issue #12986)
+SELECT DISTINCT a.table_name, a.character_maximum_length
+FROM information_schema.columns a INNER JOIN information_schema.columns b ON a.table_name=b.table_name AND a.column_name=b.column_name 
+WHERE a.character_maximum_length == b.character_maximum_length ORDER BY a.table_name;
+            table_name             | character_maximum_length 
+-----------------------------------+--------------------------
+ administrable_role_authorizations |                        3
+ applicable_roles                  |                        3
+ attributes                        |                        3
+ column_privileges                 |                        3
+ columns                           |                        3
+ domain_constraints                |                        3
+ parameters                        |                        3
+ role_column_grants                |                        3
+ role_routine_grants               |                        3
+ role_table_grants                 |                        3
+ role_udt_grants                   |                        3
+ role_usage_grants                 |                        3
+ routine_privileges                |                        3
+ routines                          |                        3
+ sequences                         |                        3
+ sql_features                      |                        3
+ sql_packages                      |                        3
+ sql_parts                         |                        3
+ table_constraints                 |                        3
+ table_privileges                  |                        3
+ tables                            |                        3
+ udt_privileges                    |                        3
+ usage_privileges                  |                        3
+ user_defined_types                |                        3
+ views                             |                        3
+(25 rows)
 
 DROP EXTENSION gp_sparse_vector;
-SET search_path TO DEFAULT;
+RESET search_path;

--- a/gpcontrib/gp_sparse_vector/expected/gp_svec.out
+++ b/gpcontrib/gp_sparse_vector/expected/gp_svec.out
@@ -249,5 +249,13 @@ SELECT vec_median('{9960,9926,10053,9993,10080,10050,9938,9941,10030,10029}:{1,9
           5
 (1 row)
 
+select a.table_name,b.column_name,a.character_maximum_length as char_maxlen_a,b.character_maximum_length as char_maxlen_b,case when ((a.character_maximum_length == b.character_maximum_length) or ( a.numeric_precision==b.numeric_precision) or (a.numeric_scale==b.numeric_scale)) then 'Y' else 'N' end from information_schema.columns a inner join information_schema.columns b on a.table_name=b.table_name and a.column_name=b.column_name where a.table_name='applicable_roles' order by a.ordinal_position;
+    table_name    | column_name  | char_maxlen_a | char_maxlen_b | case 
+------------------+--------------+---------------+---------------+------
+ applicable_roles | grantee      |               |               | N
+ applicable_roles | role_name    |               |               | N
+ applicable_roles | is_grantable |             3 |             3 | Y
+(3 rows)
+
 DROP EXTENSION gp_sparse_vector;
 SET search_path TO DEFAULT;

--- a/gpcontrib/gp_sparse_vector/gp_sparse_vector--1.0.1.sql
+++ b/gpcontrib/gp_sparse_vector/gp_sparse_vector--1.0.1.sql
@@ -320,13 +320,13 @@ CREATE AGGREGATE median_inmemory (float8) (
 );
 
 -- Comparisons based on L2 Norm
-CREATE OR REPLACE FUNCTION svec_l2_lt(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_lt' LANGUAGE C IMMUTABLE;
-CREATE OR REPLACE FUNCTION svec_l2_le(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_le' LANGUAGE C IMMUTABLE;
-CREATE OR REPLACE FUNCTION svec_l2_eq(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_eq' LANGUAGE C IMMUTABLE;
-CREATE OR REPLACE FUNCTION svec_l2_ne(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_ne' LANGUAGE C IMMUTABLE;
-CREATE OR REPLACE FUNCTION svec_l2_gt(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_gt' LANGUAGE C IMMUTABLE;
-CREATE OR REPLACE FUNCTION svec_l2_ge(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_ge' LANGUAGE C IMMUTABLE;
-CREATE OR REPLACE FUNCTION svec_l2_cmp(svec,svec) RETURNS integer AS 'gp_svec.so', 'svec_l2_cmp' LANGUAGE C IMMUTABLE;
+CREATE OR REPLACE FUNCTION svec_l2_lt(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_lt' STRICT LANGUAGE C IMMUTABLE;
+CREATE OR REPLACE FUNCTION svec_l2_le(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_le' STRICT LANGUAGE C IMMUTABLE;
+CREATE OR REPLACE FUNCTION svec_l2_eq(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_eq' STRICT LANGUAGE C IMMUTABLE;
+CREATE OR REPLACE FUNCTION svec_l2_ne(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_ne' STRICT LANGUAGE C IMMUTABLE;
+CREATE OR REPLACE FUNCTION svec_l2_gt(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_gt' STRICT LANGUAGE C IMMUTABLE;
+CREATE OR REPLACE FUNCTION svec_l2_ge(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_ge' STRICT LANGUAGE C IMMUTABLE;
+CREATE OR REPLACE FUNCTION svec_l2_cmp(svec,svec) RETURNS integer AS 'gp_svec.so', 'svec_l2_cmp' STRICT LANGUAGE C IMMUTABLE;
 
 CREATE OPERATOR < (
 	leftarg = svec, rightarg = svec, procedure = svec_l2_lt,

--- a/gpcontrib/gp_sparse_vector/sql/gp_svec.sql
+++ b/gpcontrib/gp_sparse_vector/sql/gp_svec.sql
@@ -82,7 +82,10 @@ SELECT array_agg(a) FROM (SELECT trunc(7) a,generate_series(1,100000) ORDER BY a
 SELECT vec_median('{9960,9926,10053,9993,10080,10050,9938,9941,10030,10029}:{1,9,8,7,6,5,4,3,2,0}'::svec);
 SELECT vec_median('{9960,9926,10053,9993,10080,10050,9938,9941,10030,10029}:{1,9,8,7,6,5,4,3,2,0}'::svec::float8[]);
 
-select a.table_name,b.column_name,a.character_maximum_length as char_maxlen_a,b.character_maximum_length as char_maxlen_b,case when ((a.character_maximum_length == b.character_maximum_length) or ( a.numeric_precision==b.numeric_precision) or (a.numeric_scale==b.numeric_scale)) then 'Y' else 'N' end from information_schema.columns a inner join information_schema.columns b on a.table_name=b.table_name and a.column_name=b.column_name where a.table_name='applicable_roles' order by a.ordinal_position;
+-- Test operator == as a joining condition when this column could be null. (See issue #12986)
+SELECT DISTINCT a.table_name, a.character_maximum_length
+FROM information_schema.columns a INNER JOIN information_schema.columns b ON a.table_name=b.table_name AND a.column_name=b.column_name 
+WHERE a.character_maximum_length == b.character_maximum_length ORDER BY a.table_name;
 
 DROP EXTENSION gp_sparse_vector;
-SET search_path TO DEFAULT;
+RESET search_path;

--- a/gpcontrib/gp_sparse_vector/sql/gp_svec.sql
+++ b/gpcontrib/gp_sparse_vector/sql/gp_svec.sql
@@ -82,5 +82,7 @@ SELECT array_agg(a) FROM (SELECT trunc(7) a,generate_series(1,100000) ORDER BY a
 SELECT vec_median('{9960,9926,10053,9993,10080,10050,9938,9941,10030,10029}:{1,9,8,7,6,5,4,3,2,0}'::svec);
 SELECT vec_median('{9960,9926,10053,9993,10080,10050,9938,9941,10030,10029}:{1,9,8,7,6,5,4,3,2,0}'::svec::float8[]);
 
+select a.table_name,b.column_name,a.character_maximum_length as char_maxlen_a,b.character_maximum_length as char_maxlen_b,case when ((a.character_maximum_length == b.character_maximum_length) or ( a.numeric_precision==b.numeric_precision) or (a.numeric_scale==b.numeric_scale)) then 'Y' else 'N' end from information_schema.columns a inner join information_schema.columns b on a.table_name=b.table_name and a.column_name=b.column_name where a.table_name='applicable_roles' order by a.ordinal_position;
+
 DROP EXTENSION gp_sparse_vector;
 SET search_path TO DEFAULT;


### PR DESCRIPTION
As #12986 mentioned, some binary operators function definition in GP extension `gp_sparse_vector` is not `strict`, which cannot properly handle NULL rows, may cause SIGSEV memory crush as follow:

```
#0  0x00007fdf3f7d74fb in raise () from /data/logs/298723/packcore-postgres.626108.181669.core/lib64/libpthread.so.0

#1  0x0000000000bf8260 in StandardHandlerForSigillSigsegvSigbus_OnMainThread (processName=<optimized out>, postgres_signal_arg=11) at elog.c:5579

#2  <signal handler called>

#3  pg_detoast_datum (datum=0x0) at fmgr.c:2209

#4  0x00007fdf183bec11 in svec_l2_eq () from /data/logs/298723/packcore-postgres.626108.181669.core/ms/dist/gpdb/PROJ/ds/6.17.7/.exec/@sys/lib/postgresql/gp_svec.so

#5  0x00000000008c590b in ExecMakeFunctionResultNoSets (fcache=0x33d19d8, econtext=0x33ddf38, isNull=0x7ffdeb86392f "", isDone=<optimized out>) at execQual.c:2161

#6  0x00000000008c4dc6 in ExecEvalOr (orExpr=<optimized out>, econtext=0x33ddf38, isNull=0x7ffdeb86392f "", isDone=<optimized out>) at execQual.c:3292

#7  0x00000000008c4f2d in ExecEvalCase (caseExpr=0x33d18b8, econtext=0x33ddf38, isNull=0x8a3e252 "", isDone=0x8a3e400) at execQual.c:3498

#8  0x00000000008cf662 in ExecTargetList (isDone=0x0, itemIsDone=0x8a3e3f8, isnull=0x8a3e250 "", values=0x8a3e220, econtext=0x33ddf38, targetlist=0x8a3e368) at execQual.c:6333

#9  ExecProject (projInfo=<optimized out>, isDone=isDone@entry=0x0) at execQual.c:6548

#10 0x00000000008e3ed7 in ExecHashJoin_guts (node=node@entry=0x8a5a100) at nodeHashjoin.c:489

#11 ExecHashJoin (node=node@entry=0x33ddad8) at nodeHashjoin.c:520

#12 0x00000000008c20f8 in ExecProcNode (node=node@entry=0x33ddad8) at execProcnode.c:1078

#13 0x00000000008f0fc0 in ExecSort (node=node@entry=0x33dd3c0) at nodeSort.c:185

#14 0x00000000008c20d8 in ExecProcNode (node=node@entry=0x33dd3c0) at execProcnode.c:1089

#15 0x00000000008b9489 in ExecutePlan (estate=estate@entry=0x33dd0a8, planstate=0x33dd3c0, operati
```

If the operand is a NULL row, pg_detoast_datum will hit a memory segmentation fault. 
This PR fixed this issue and added some test.

This is a backport to 6X branch of PR: #12988

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
