### PR TITLE
Make svec_l2_eq strict function to handle NULL properly.

### DIFF
--- a/gpcontrib/Makefile
+++ b/gpcontrib/Makefile
@@ -95,11 +95,6 @@ installcheck:
 	fi
 	if [ "$(enable_orafce)" = "yes" ]; then $(MAKE) -C orafce installcheck; fi
 	if [ "$(enable_pxf)" = "yes" ]; then $(MAKE) -C pxf_fdw installcheck; fi
-
-ifeq "$(with_zstd)" "yes"
-	$(MAKE) -C zstd installcheck
-endif
-
-ifeq "$(with_quicklz)" "yes"
-	$(MAKE) -C quicklz installcheck
-endif
+	if [ "$(with_zstd)" = "yes" ]; then $(MAKE) -C zstd installcheck; fi
+	if [ "$(with_quicklz)" = "yes" ]; then $(MAKE) -C quicklz installcheck; fi
+	$(MAKE) -C gp_sparse_vector installcheck

--- a/gpcontrib/gp_sparse_vector/Makefile
+++ b/gpcontrib/gp_sparse_vector/Makefile
@@ -7,7 +7,7 @@ override CFLAGS+=-std=gnu99
 
 MODULE_big = gp_svec
 EXTENSION = gp_sparse_vector
-DATA = gp_sparse_vector--1.0.0.sql
+DATA = gp_sparse_vector--1.0.1.sql gp_sparse_vector--1.0.0--1.0.1.sql
 REGRESS = gp_svec gp_svec_features
 
 OBJS = gp_sfv.o sparse_vector.o operators.o SparseData.o

--- a/gpcontrib/gp_sparse_vector/expected/gp_svec.out
+++ b/gpcontrib/gp_sparse_vector/expected/gp_svec.out
@@ -249,6 +249,7 @@ SELECT vec_median('{9960,9926,10053,9993,10080,10050,9938,9941,10030,10029}:{1,9
           5
 (1 row)
 
+-- Test operator == as a joining condition when this column could be null. (See issue #12986)
 SELECT DISTINCT a.table_name, a.character_maximum_length
 FROM information_schema.columns a INNER JOIN information_schema.columns b ON a.table_name=b.table_name AND a.column_name=b.column_name 
 WHERE a.character_maximum_length == b.character_maximum_length ORDER BY a.table_name;
@@ -282,4 +283,4 @@ WHERE a.character_maximum_length == b.character_maximum_length ORDER BY a.table_
 (25 rows)
 
 DROP EXTENSION gp_sparse_vector;
-SET search_path TO DEFAULT;
+RESET search_path;

--- a/gpcontrib/gp_sparse_vector/expected/gp_svec.out
+++ b/gpcontrib/gp_sparse_vector/expected/gp_svec.out
@@ -249,13 +249,37 @@ SELECT vec_median('{9960,9926,10053,9993,10080,10050,9938,9941,10030,10029}:{1,9
           5
 (1 row)
 
-select a.table_name,b.column_name,a.character_maximum_length as char_maxlen_a,b.character_maximum_length as char_maxlen_b,case when ((a.character_maximum_length == b.character_maximum_length) or ( a.numeric_precision==b.numeric_precision) or (a.numeric_scale==b.numeric_scale)) then 'Y' else 'N' end from information_schema.columns a inner join information_schema.columns b on a.table_name=b.table_name and a.column_name=b.column_name where a.table_name='applicable_roles' order by a.ordinal_position;
-    table_name    | column_name  | char_maxlen_a | char_maxlen_b | case 
-------------------+--------------+---------------+---------------+------
- applicable_roles | grantee      |               |               | N
- applicable_roles | role_name    |               |               | N
- applicable_roles | is_grantable |             3 |             3 | Y
-(3 rows)
+SELECT DISTINCT a.table_name, a.character_maximum_length
+FROM information_schema.columns a INNER JOIN information_schema.columns b ON a.table_name=b.table_name AND a.column_name=b.column_name 
+WHERE a.character_maximum_length == b.character_maximum_length ORDER BY a.table_name;
+            table_name             | character_maximum_length 
+-----------------------------------+--------------------------
+ administrable_role_authorizations |                        3
+ applicable_roles                  |                        3
+ attributes                        |                        3
+ column_privileges                 |                        3
+ columns                           |                        3
+ domain_constraints                |                        3
+ parameters                        |                        3
+ role_column_grants                |                        3
+ role_routine_grants               |                        3
+ role_table_grants                 |                        3
+ role_udt_grants                   |                        3
+ role_usage_grants                 |                        3
+ routine_privileges                |                        3
+ routines                          |                        3
+ sequences                         |                        3
+ sql_features                      |                        3
+ sql_packages                      |                        3
+ sql_parts                         |                        3
+ table_constraints                 |                        3
+ table_privileges                  |                        3
+ tables                            |                        3
+ udt_privileges                    |                        3
+ usage_privileges                  |                        3
+ user_defined_types                |                        3
+ views                             |                        3
+(25 rows)
 
 DROP EXTENSION gp_sparse_vector;
 SET search_path TO DEFAULT;

--- a/gpcontrib/gp_sparse_vector/expected/gp_svec.out
+++ b/gpcontrib/gp_sparse_vector/expected/gp_svec.out
@@ -1,5 +1,7 @@
 CREATE EXTENSION gp_sparse_vector;
+SET search_path TO sparse_vector;
 DROP TABLE if exists test;
+NOTICE:  table "test" does not exist, skipping
 CREATE TABLE test (a int, b svec) DISTRIBUTED BY (a);
 INSERT INTO test (SELECT 1,gp_extract_feature_histogram('{"one","two","three","four","five","six"}','{"twe","four","five","six","one","three","two","one"}'));
 INSERT INTO test (SELECT 2,gp_extract_feature_histogram('{"one","two","three","four","five","six"}','{"the","brown","cat","ran","across","three","dogs"}'));
@@ -14,35 +16,36 @@ SELECT a,b::float8[] cross_product_equals FROM (SELECT a,b FROM test) foo WHERE 
 (3 rows)
 
 DROP TABLE IF EXISTS test2;
+NOTICE:  table "test2" does not exist, skipping
 CREATE TABLE test2 AS SELECT * FROM test DISTRIBUTED BY (a);
 -- Test the plus operator (should be 9 rows)
 SELECT (t1.b+t2.b)::float8[] cross_product_sum FROM test t1, test2 t2;
  cross_product_sum 
 -------------------
- {4,2,2,2,2,2}
  {2,1,2,1,1,1}
  {4,3,2,2,2,2}
- {2,2,2,1,1,1}
- {2,1,2,1,1,1}
+ {4,2,2,2,2,2}
  {0,0,2,0,0,0}
  {2,2,2,1,1,1}
- {4,3,2,2,2,2}
+ {2,1,2,1,1,1}
+ {2,2,2,1,1,1}
  {4,4,2,2,2,2}
+ {4,3,2,2,2,2}
 (9 rows)
 
 -- Test ORDER BY
 SELECT (t1.b+t2.b)::float8[] cross_product_sum, l2norm(t1.b+t2.b) l2norm, (t1.b+t2.b) sparse_vector FROM test t1, test2 t2 ORDER BY 3;
- cross_product_sum |      l2norm      |    sparse_vector    
--------------------+------------------+---------------------
- {0,0,2,0,0,0}     |                2 | {2,1,3}:{0,2,0}
- {2,1,2,1,1,1}     | 3.46410161513775 | {1,1,1,3}:{2,1,2,1}
- {2,1,2,1,1,1}     | 3.46410161513775 | {1,1,1,3}:{2,1,2,1}
- {2,2,2,1,1,1}     | 3.87298334620742 | {3,3}:{2,1}
- {2,2,2,1,1,1}     | 3.87298334620742 | {3,3}:{2,1}
- {4,2,2,2,2,2}     |                6 | {1,5}:{4,2}
- {4,3,2,2,2,2}     | 6.40312423743285 | {1,1,4}:{4,3,2}
- {4,3,2,2,2,2}     | 6.40312423743285 | {1,1,4}:{4,3,2}
- {4,4,2,2,2,2}     | 6.92820323027551 | {2,4}:{4,2}
+ cross_product_sum |       l2norm       |    sparse_vector    
+-------------------+--------------------+---------------------
+ {0,0,2,0,0,0}     |                  2 | {2,1,3}:{0,2,0}
+ {2,1,2,1,1,1}     | 3.4641016151377544 | {1,1,1,3}:{2,1,2,1}
+ {2,1,2,1,1,1}     | 3.4641016151377544 | {1,1,1,3}:{2,1,2,1}
+ {2,2,2,1,1,1}     |  3.872983346207417 | {3,3}:{2,1}
+ {2,2,2,1,1,1}     |  3.872983346207417 | {3,3}:{2,1}
+ {4,2,2,2,2,2}     |                  6 | {1,5}:{4,2}
+ {4,3,2,2,2,2}     | 6.4031242374328485 | {1,1,4}:{4,3,2}
+ {4,3,2,2,2,2}     | 6.4031242374328485 | {1,1,4}:{4,3,2}
+ {4,4,2,2,2,2}     |  6.928203230275509 | {2,4}:{4,2}
 (9 rows)
 
 SELECT (sum(t1.b))::float8[] AS features_sum FROM test t1;
@@ -53,29 +56,29 @@ SELECT (sum(t1.b))::float8[] AS features_sum FROM test t1;
 
 -- Test the div operator
 SELECT (t1.b/(SELECT sum(b) FROM test))::float8[] AS weights FROM test t1 ORDER BY a;
-                        weights                        
--------------------------------------------------------
- {0.5,0.333333333333333,0.333333333333333,0.5,0.5,0.5}
- {0,0,0.333333333333333,0,0,0}
- {0.5,0.666666666666667,0.333333333333333,0.5,0.5,0.5}
+                         weights                         
+---------------------------------------------------------
+ {0.5,0.3333333333333333,0.3333333333333333,0.5,0.5,0.5}
+ {0,0,0.3333333333333333,0,0,0}
+ {0.5,0.6666666666666666,0.3333333333333333,0.5,0.5,0.5}
 (3 rows)
 
 -- Test the * operator
 SELECT t1.b %*% (t1.b/(SELECT sum(b) FROM test)) AS raw_score FROM test t1 ORDER BY a;
-     raw_score     
--------------------
-  3.16666666666667
- 0.333333333333333
-  4.16666666666667
+     raw_score      
+--------------------
+ 3.1666666666666665
+ 0.3333333333333333
+  4.166666666666666
 (3 rows)
 
 -- Test the * and l2norm operators
 SELECT (t1.b %*% (t1.b/(SELECT sum(b) FROM test))) / (l2norm(t1.b) * l2norm((SELECT sum(b) FROM test))) AS norm_score FROM test t1 ORDER BY a;
-    norm_score     
--------------------
-  0.15563317594128
- 0.049147318718299
- 0.177345110574739
+     norm_score      
+---------------------
+ 0.15563317594128032
+ 0.04914731871829904
+ 0.17734511057473928
 (3 rows)
 
 -- Test the ^ and l1norm operators
@@ -86,16 +89,18 @@ SELECT ('{1,2}:{20.,10.}'::svec)^('{1}:{3.}'::svec);
 (1 row)
 
 SELECT (t1.b %*% (t1.b/(SELECT sum(b) FROM test))) / (l1norm(t1.b) * l1norm((SELECT sum(b) FROM test))) AS norm_score FROM test t1 ORDER BY a;
-     norm_score     
---------------------
- 0.0282738095238095
- 0.0208333333333333
- 0.0325520833333333
+      norm_score      
+----------------------
+ 0.028273809523809524
+ 0.020833333333333332
+  0.03255208333333333
 (3 rows)
 
 -- Test the multi-concatenation and show sizes compared with a normal array
 DROP TABLE IF EXISTS corpus_proj;
+NOTICE:  table "corpus_proj" does not exist, skipping
 DROP TABLE IF EXISTS corpus_proj_array;
+NOTICE:  table "corpus_proj_array" does not exist, skipping
 CREATE TABLE corpus_proj AS (SELECT 10000 *|| ('{45,2,35,4,15,1}:{0,1,0,1,0,2}'::svec) result ) distributed randomly;
 CREATE TABLE corpus_proj_array AS (SELECT result::float8[] FROM corpus_proj) distributed randomly;
 -- Calculate on-disk size of sparse vector
@@ -128,16 +133,16 @@ SELECT l1norm(result) FROM corpus_proj_array;
 
 -- Calculate L2 norm from sparse vector
 SELECT l2norm(result) FROM corpus_proj;
-      l2norm      
-------------------
- 316.227766016838
+       l2norm       
+--------------------
+ 316.22776601683796
 (1 row)
 
 -- Calculate L2 norm from float8[]
 SELECT l2norm(result) FROM corpus_proj_array;
-      l2norm      
-------------------
- 316.227766016838
+       l2norm       
+--------------------
+ 316.22776601683796
 (1 row)
 
 DROP TABLE corpus_proj;
@@ -207,6 +212,7 @@ SELECT ('{1,2,3,4}:{3,4,5,6}'::svec)::float8[]  -  ('{1,2,3,4}:{3,4,5,6}'::svec)
 
 -- Test the pivot operator in the presence of NULL values
 DROP TABLE IF EXISTS pivot_test;
+NOTICE:  table "pivot_test" does not exist, skipping
 CREATE TABLE pivot_test(a float8) distributed randomly;
 INSERT INTO pivot_test VALUES (0),(1),(NULL),(2),(3);
 SELECT l1norm(array_agg(a)) FROM pivot_test;
@@ -243,4 +249,13 @@ SELECT vec_median('{9960,9926,10053,9993,10080,10050,9938,9941,10030,10029}:{1,9
           5
 (1 row)
 
+select a.table_name,b.column_name,a.character_maximum_length as char_maxlen_a,b.character_maximum_length as char_maxlen_b,case when ((a.character_maximum_length == b.character_maximum_length) or ( a.numeric_precision==b.numeric_precision) or (a.numeric_scale==b.numeric_scale)) then 'Y' else 'N' end from information_schema.columns a inner join information_schema.columns b on a.table_name=b.table_name and a.column_name=b.column_name where a.table_name='applicable_roles' order by a.ordinal_position;
+    table_name    | column_name  | char_maxlen_a | char_maxlen_b | case 
+------------------+--------------+---------------+---------------+------
+ applicable_roles | grantee      |               |               | N
+ applicable_roles | role_name    |               |               | N
+ applicable_roles | is_grantable |             3 |             3 | Y
+(3 rows)
+
 DROP EXTENSION gp_sparse_vector;
+SET search_path TO DEFAULT;

--- a/gpcontrib/gp_sparse_vector/expected/gp_svec_features.out
+++ b/gpcontrib/gp_sparse_vector/expected/gp_svec_features.out
@@ -1,8 +1,13 @@
 CREATE EXTENSION gp_sparse_vector;
+SET search_path TO sparse_vector;
 DROP TABLE IF EXISTS features;
+NOTICE:  table "features" does not exist, skipping
 DROP TABLE IF EXISTS corpus;
+NOTICE:  table "corpus" does not exist, skipping
 DROP TABLE IF EXISTS documents;
+NOTICE:  table "documents" does not exist, skipping
 DROP TABLE IF EXISTS dictionary;
+NOTICE:  table "dictionary" does not exist, skipping
 -- Test simple document classIFication routines
 CREATE TABLE features (dictionary text[][]) DISTRIBUTED RANDOMLY;
 INSERT INTO features values ('{am,before,being,bothered,corpus,document,i,in,is,me,never,now,one,really,second,the,third,this,until}');
@@ -56,26 +61,27 @@ SELECT (sum(feature_vector))::float8[] AS sum_in_document FROM corpus;
 
 -- Calculate Term Frequency / Inverse Document Frequency
 SELECT docnum, (feature_vector*logidf)::float8[] AS tf_idf FROM (SELECT log(count(feature_vector)/vec_count_nonzero(feature_vector)) AS logidf FROM corpus) AS foo, corpus ORDER BY docnum;
- docnum |                                                                              tf_idf                                                                               
---------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
-      1 | {0,0,0,0,0.693147180559945,0.287682072451781,0,0.693147180559945,0.693147180559945,0,0,0,1.38629436111989,0,0,0.287682072451781,0,1.38629436111989,0}
-      2 | {1.38629436111989,0,0,0,0.693147180559945,0.287682072451781,1.38629436111989,0.693147180559945,0,0,0,0,0,0,1.38629436111989,0.575364144903562,0,0,0}
-      3 | {0,0,1.38629436111989,1.38629436111989,0,0,0,0,0,0.693147180559945,1.38629436111989,1.38629436111989,0,1.38629436111989,0,0,0.693147180559945,0,1.38629436111989}
-      4 | {0,1.38629436111989,0,0,0,0.575364144903562,0,0,0.693147180559945,0.693147180559945,0,0,0,0,0,0.575364144903562,0.693147180559945,0,0}
+ docnum |                                                                                     tf_idf                                                                                      
+--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+      1 | {0,0,0,0,0.6931471805599453,0.28768207245178085,0,0.6931471805599453,0.6931471805599453,0,0,0,1.3862943611198906,0,0,0.28768207245178085,0,1.3862943611198906,0}
+      2 | {1.3862943611198906,0,0,0,0.6931471805599453,0.28768207245178085,1.3862943611198906,0.6931471805599453,0,0,0,0,0,0,1.3862943611198906,0.5753641449035617,0,0,0}
+      3 | {0,0,1.3862943611198906,1.3862943611198906,0,0,0,0,0,0.6931471805599453,1.3862943611198906,1.3862943611198906,0,1.3862943611198906,0,0,0.6931471805599453,0,1.3862943611198906}
+      4 | {0,1.3862943611198906,0,0,0,0.5753641449035617,0,0,0.6931471805599453,0.6931471805599453,0,0,0,0,0,0.5753641449035617,0.6931471805599453,0,0}
 (4 rows)
 
 -- Show the same calculation in compressed vector format
 SELECT docnum, (feature_vector*logidf) AS tf_idf FROM (SELECT log(count(feature_vector)/vec_count_nonzero(feature_vector)) AS logidf FROM corpus) foo, corpus ORDER BY docnum;
- docnum |                                                                          tf_idf                                                                          
---------+----------------------------------------------------------------------------------------------------------------------------------------------------------
-      1 | {4,1,1,1,2,3,1,2,1,1,1,1}:{0,0.693147180559945,0.287682072451781,0,0.693147180559945,0,1.38629436111989,0,0.287682072451781,0,1.38629436111989,0}
-      2 | {1,3,1,1,1,1,6,1,1,3}:{1.38629436111989,0,0.693147180559945,0.287682072451781,1.38629436111989,0.693147180559945,0,1.38629436111989,0.575364144903562,0}
-      3 | {2,2,5,1,2,1,1,2,1,1,1}:{0,1.38629436111989,0,0.693147180559945,1.38629436111989,0,1.38629436111989,0,0.693147180559945,0,1.38629436111989}
-      4 | {1,1,3,1,2,2,5,1,1,2}:{0,1.38629436111989,0,0.575364144903562,0,0.693147180559945,0,0.575364144903562,0.693147180559945,0}
+ docnum |                                                                               tf_idf                                                                                
+--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+      1 | {4,1,1,1,2,3,1,2,1,1,1,1}:{0,0.6931471805599453,0.28768207245178085,0,0.6931471805599453,0,1.3862943611198906,0,0.28768207245178085,0,1.3862943611198906,0}
+      2 | {1,3,1,1,1,1,6,1,1,3}:{1.3862943611198906,0,0.6931471805599453,0.28768207245178085,1.3862943611198906,0.6931471805599453,0,1.3862943611198906,0.5753641449035617,0}
+      3 | {2,2,5,1,2,1,1,2,1,1,1}:{0,1.3862943611198906,0,0.6931471805599453,1.3862943611198906,0,1.3862943611198906,0,0.6931471805599453,0,1.3862943611198906}
+      4 | {1,1,3,1,2,2,5,1,1,2}:{0,1.3862943611198906,0,0.5753641449035617,0,0.6931471805599453,0,0.5753641449035617,0.6931471805599453,0}
 (4 rows)
 
 -- Create a table with TF / IDF weighted vectors in it
 DROP TABLE IF EXISTS WEIGHTS;
+NOTICE:  table "weights" does not exist, skipping
 CREATE TABLE weights AS (SELECT docnum, (feature_vector*logidf) tf_idf FROM (SELECT log(count(feature_vector)/vec_count_nonzero(feature_vector)) AS logidf FROM corpus) foo, corpus ORDER BY docnum) DISTRIBUTED RANDOMLY;
 -- Calculate the angular distance between the first document to each other document
 SELECT docnum,trunc((180.*(ACOS(dmin(1.,(tf_idf%*%testdoc)/(l2norm(tf_idf)*l2norm(testdoc))))/(4.*ATAN(1.))))::numeric,2) AS angular_distance FROM weights,(SELECT tf_idf testdoc FROM weights WHERE docnum = 1 LIMIT 1) foo ORDER BY 1;

--- a/gpcontrib/gp_sparse_vector/gp_sparse_vector--1.0.0--1.0.1.sql
+++ b/gpcontrib/gp_sparse_vector/gp_sparse_vector--1.0.0--1.0.1.sql
@@ -1,0 +1,235 @@
+CREATE SCHEMA sparse_vector;
+
+ALTER TYPE svec SET SCHEMA sparse_vector;
+
+ALTER FUNCTION svec_in(cstring) 
+	SET SCHEMA sparse_vector;
+
+ALTER FUNCTION svec_out(sparse_vector.svec)
+    SET SCHEMA sparse_vector;
+
+ALTER FUNCTION svec_recv(internal)
+    SET SCHEMA sparse_vector;
+
+ALTER FUNCTION svec_send(sparse_vector.svec)
+   SET SCHEMA sparse_vector;
+
+
+-- Sparse Feature Vector (text processing) related functions
+ALTER FUNCTION gp_extract_feature_histogram(text[], text[]) SET SCHEMA sparse_vector;
+
+-- Basic floating point scalar operators MIN,MAX
+ALTER FUNCTION dmin(float8,float8) SET SCHEMA sparse_vector;
+ALTER FUNCTION dmax(float8,float8) SET SCHEMA sparse_vector;
+-- Aggregate related functions
+ALTER FUNCTION svec_count(sparse_vector.svec,sparse_vector.svec) SET SCHEMA sparse_vector;
+
+-- Scalar operator functions
+ALTER FUNCTION svec_plus(sparse_vector.svec,sparse_vector.svec) SET SCHEMA sparse_vector;
+ALTER FUNCTION svec_minus(sparse_vector.svec,sparse_vector.svec) SET SCHEMA sparse_vector;
+ALTER FUNCTION log(sparse_vector.svec) SET SCHEMA sparse_vector;
+ALTER FUNCTION svec_div(sparse_vector.svec,sparse_vector.svec) SET SCHEMA sparse_vector;
+ALTER FUNCTION svec_mult(sparse_vector.svec,sparse_vector.svec) SET SCHEMA sparse_vector;
+ALTER FUNCTION svec_pow(sparse_vector.svec,sparse_vector.svec) SET SCHEMA sparse_vector;
+ALTER FUNCTION svec_eq(sparse_vector.svec,sparse_vector.svec) SET SCHEMA sparse_vector;
+ALTER FUNCTION float8arr_eq(float8[],float8[]) SET SCHEMA sparse_vector;
+-- Permutation of float8[] and sparse_vector.svec for basic functions minus,plus,mult,div
+ALTER FUNCTION float8arr_minus_float8arr(float8[],float8[]) SET SCHEMA sparse_vector;
+ALTER FUNCTION float8arr_minus_svec(float8[],sparse_vector.svec) SET SCHEMA sparse_vector;
+ALTER FUNCTION svec_minus_float8arr(sparse_vector.svec,float8[]) SET SCHEMA sparse_vector;
+ALTER FUNCTION float8arr_plus_float8arr(float8[],float8[]) SET SCHEMA sparse_vector;
+ALTER FUNCTION float8arr_plus_svec(float8[],sparse_vector.svec) SET SCHEMA sparse_vector;
+ALTER FUNCTION svec_plus_float8arr(sparse_vector.svec,float8[]) SET SCHEMA sparse_vector;
+ALTER FUNCTION float8arr_mult_float8arr(float8[],float8[]) SET SCHEMA sparse_vector;
+ALTER FUNCTION float8arr_mult_svec(float8[],sparse_vector.svec) SET SCHEMA sparse_vector;
+ALTER FUNCTION svec_mult_float8arr(sparse_vector.svec,float8[]) SET SCHEMA sparse_vector;
+ALTER FUNCTION float8arr_div_float8arr(float8[],float8[]) SET SCHEMA sparse_vector;
+ALTER FUNCTION float8arr_div_svec(float8[],sparse_vector.svec) SET SCHEMA sparse_vector;
+ALTER FUNCTION svec_div_float8arr(sparse_vector.svec,float8[]) SET SCHEMA sparse_vector;
+
+-- Vector operator functions
+ALTER FUNCTION dot(sparse_vector.svec,sparse_vector.svec) SET SCHEMA sparse_vector;
+ALTER FUNCTION dot(float8[],float8[]) SET SCHEMA sparse_vector;
+ALTER FUNCTION dot(sparse_vector.svec,float8[]) SET SCHEMA sparse_vector;
+ALTER FUNCTION dot(float8[],sparse_vector.svec) SET SCHEMA sparse_vector;
+ALTER FUNCTION l2norm(sparse_vector.svec) SET SCHEMA sparse_vector;
+ALTER FUNCTION l2norm(float8[]) SET SCHEMA sparse_vector;
+ALTER FUNCTION l1norm(sparse_vector.svec) SET SCHEMA sparse_vector;
+ALTER FUNCTION l1norm(float8[]) SET SCHEMA sparse_vector;
+
+ALTER FUNCTION unnest(sparse_vector.svec) SET SCHEMA sparse_vector;
+ALTER FUNCTION vec_pivot(sparse_vector.svec,float8) SET SCHEMA sparse_vector;
+ALTER FUNCTION vec_sum(sparse_vector.svec) SET SCHEMA sparse_vector;
+ALTER FUNCTION vec_sum(float8[]) SET SCHEMA sparse_vector;
+ALTER FUNCTION vec_median(float8[]) SET SCHEMA sparse_vector;
+ALTER FUNCTION vec_median(sparse_vector.svec) SET SCHEMA sparse_vector;
+
+-- Casts and transforms
+ALTER FUNCTION svec_cast_int2(int2) SET SCHEMA sparse_vector;
+ALTER FUNCTION svec_cast_int4(int4) SET SCHEMA sparse_vector;
+ALTER FUNCTION svec_cast_int8(bigint) SET SCHEMA sparse_vector;
+ALTER FUNCTION svec_cast_float4(float4) SET SCHEMA sparse_vector;
+ALTER FUNCTION svec_cast_float8(float8) SET SCHEMA sparse_vector;
+ALTER FUNCTION svec_cast_numeric(numeric) SET SCHEMA sparse_vector;
+
+ALTER FUNCTION float8arr_cast_int2(int2) SET SCHEMA sparse_vector;
+ALTER FUNCTION float8arr_cast_int4(int4) SET SCHEMA sparse_vector;
+ALTER FUNCTION float8arr_cast_int8(bigint) SET SCHEMA sparse_vector;
+ALTER FUNCTION float8arr_cast_float4(float4) SET SCHEMA sparse_vector;
+ALTER FUNCTION float8arr_cast_float8(float8) SET SCHEMA sparse_vector;
+ALTER FUNCTION float8arr_cast_numeric(numeric) SET SCHEMA sparse_vector;
+
+ALTER FUNCTION svec_cast_float8arr(float8[]) SET SCHEMA sparse_vector;
+ALTER FUNCTION svec_return_array(sparse_vector.svec) SET SCHEMA sparse_vector;
+ALTER FUNCTION svec_concat(sparse_vector.svec,sparse_vector.svec) SET SCHEMA sparse_vector;
+ALTER FUNCTION svec_concat_replicate(int4,sparse_vector.svec) SET SCHEMA sparse_vector;
+ALTER FUNCTION dimension(sparse_vector.svec) SET SCHEMA sparse_vector;
+
+
+ALTER OPERATOR || (sparse_vector.svec, sparse_vector.svec)
+	SET SCHEMA sparse_vector;
+
+
+ALTER OPERATOR - (sparse_vector.svec, sparse_vector.svec)
+	SET SCHEMA sparse_vector;
+
+
+ALTER OPERATOR + (sparse_vector.svec, sparse_vector.svec)
+	SET SCHEMA sparse_vector;
+
+
+ALTER OPERATOR / (sparse_vector.svec, sparse_vector.svec)
+	SET SCHEMA sparse_vector;
+
+
+ALTER OPERATOR %*% (sparse_vector.svec, sparse_vector.svec)
+	SET SCHEMA sparse_vector;
+
+
+ALTER OPERATOR * (sparse_vector.svec, sparse_vector.svec)
+	SET SCHEMA sparse_vector;
+
+
+ALTER OPERATOR ^ (sparse_vector.svec, sparse_vector.svec)
+	SET SCHEMA sparse_vector;
+
+ALTER OPERATOR = (float8[], float8[])
+	SET SCHEMA sparse_vector;
+
+ALTER OPERATOR %*% (float8[], float8[])
+	SET SCHEMA sparse_vector;
+
+ALTER OPERATOR %*% (float8[], sparse_vector.svec)
+	SET SCHEMA sparse_vector;
+
+ALTER OPERATOR %*% (sparse_vector.svec, float8[])
+	SET SCHEMA sparse_vector;
+
+
+ALTER OPERATOR - (float8[], float8[])
+	SET SCHEMA sparse_vector;
+
+ALTER OPERATOR + (float8[], float8[])
+	SET SCHEMA sparse_vector;
+
+ALTER OPERATOR * (float8[], float8[])
+	SET SCHEMA sparse_vector;
+
+ALTER OPERATOR / (float8[], float8[])
+	SET SCHEMA sparse_vector;
+
+ALTER OPERATOR - (float8[], sparse_vector.svec)
+	SET SCHEMA sparse_vector;
+
+ALTER OPERATOR + (float8[], sparse_vector.svec)
+	SET SCHEMA sparse_vector;
+
+ALTER OPERATOR * (float8[], sparse_vector.svec)
+	SET SCHEMA sparse_vector;
+
+ALTER OPERATOR / (float8[], sparse_vector.svec)
+	SET SCHEMA sparse_vector;
+
+ALTER OPERATOR - (sparse_vector.svec, float8[])
+	SET SCHEMA sparse_vector;
+
+ALTER OPERATOR + (sparse_vector.svec, float8[])
+	SET SCHEMA sparse_vector;
+
+ALTER OPERATOR * (sparse_vector.svec, float8[])
+	SET SCHEMA sparse_vector;
+
+ALTER OPERATOR / (sparse_vector.svec, float8[])
+	SET SCHEMA sparse_vector;
+
+-- CAST no schema issue
+-- CREATE CAST (int2 AS sparse_vector.svec) WITH FUNCTION svec_cast_int2(int2) AS IMPLICIT;
+-- CREATE CAST (integer AS sparse_vector.svec) WITH FUNCTION svec_cast_int4(integer) AS IMPLICIT;
+-- CREATE CAST (bigint AS sparse_vector.svec) WITH FUNCTION svec_cast_int8(bigint) AS IMPLICIT;
+-- CREATE CAST (float4 AS sparse_vector.svec) WITH FUNCTION svec_cast_float4(float4) AS IMPLICIT;
+-- CREATE CAST (float8 AS sparse_vector.svec) WITH FUNCTION svec_cast_float8(float8) AS IMPLICIT;
+-- CREATE CAST (numeric AS sparse_vector.svec) WITH FUNCTION svec_cast_numeric(numeric) AS IMPLICIT;
+
+-- DROP CAST IF EXISTS (int2 AS float8[]) ;
+-- DROP CAST IF EXISTS (integer AS float8[]) ;
+-- DROP CAST IF EXISTS (bigint AS float8[]) ;
+-- DROP CAST IF EXISTS (float4 AS float8[]) ;
+-- DROP CAST IF EXISTS (float8 AS float8[]) ;
+-- DROP CAST IF EXISTS (numeric AS float8[]) ;
+
+-- ALTER CAST (int2 AS float8[]) WITH FUNCTION float8arr_cast_int2(int2) AS IMPLICIT;
+-- ALTER CAST (integer AS float8[]) WITH FUNCTION float8arr_cast_int4(integer) AS IMPLICIT;
+-- ALTER CAST (bigint AS float8[]) WITH FUNCTION float8arr_cast_int8(bigint) AS IMPLICIT;
+-- ALTER CAST (float4 AS float8[]) WITH FUNCTION float8arr_cast_float4(float4) AS IMPLICIT;
+-- ALTER CAST (float8 AS float8[]) WITH FUNCTION float8arr_cast_float8(float8) AS IMPLICIT;
+-- ALTER CAST (numeric AS float8[]) WITH FUNCTION float8arr_cast_numeric(numeric) AS IMPLICIT;
+
+-- CREATE CAST (sparse_vector.svec AS float8[]) WITH FUNCTION svec_return_array(sparse_vector.svec) AS IMPLICIT;
+-- CREATE CAST (float8[] AS sparse_vector.svec) WITH FUNCTION svec_cast_float8arr(float8[]) AS IMPLICIT;
+
+ALTER OPERATOR = (sparse_vector.svec, sparse_vector.svec)
+	SET SCHEMA sparse_vector;
+
+ALTER AGGREGATE sum (sparse_vector.svec) SET SCHEMA sparse_vector;
+
+-- Aggregate that provides a tally of nonzero entries in a list of vectors
+ALTER AGGREGATE count_vec (sparse_vector.svec) SET SCHEMA sparse_vector;
+
+ALTER AGGREGATE vec_count_nonzero (sparse_vector.svec) SET SCHEMA sparse_vector;
+
+ALTER AGGREGATE array_agg (float8) SET SCHEMA sparse_vector;
+
+ALTER AGGREGATE median_inmemory (float8) SET SCHEMA sparse_vector;
+
+-- Comparisons based on L2 Norm
+ALTER FUNCTION svec_l2_lt(sparse_vector.svec,sparse_vector.svec) SET SCHEMA sparse_vector;
+ALTER FUNCTION svec_l2_le(sparse_vector.svec,sparse_vector.svec) SET SCHEMA sparse_vector;
+ALTER FUNCTION svec_l2_eq(sparse_vector.svec,sparse_vector.svec) SET SCHEMA sparse_vector;
+ALTER FUNCTION svec_l2_ne(sparse_vector.svec,sparse_vector.svec) SET SCHEMA sparse_vector;
+ALTER FUNCTION svec_l2_gt(sparse_vector.svec,sparse_vector.svec) SET SCHEMA sparse_vector;
+ALTER FUNCTION svec_l2_ge(sparse_vector.svec,sparse_vector.svec) SET SCHEMA sparse_vector;
+ALTER FUNCTION svec_l2_cmp(sparse_vector.svec,sparse_vector.svec) SET SCHEMA sparse_vector;
+
+ALTER OPERATOR < (sparse_vector.svec, sparse_vector.svec)
+	SET SCHEMA sparse_vector;
+
+ALTER OPERATOR <= (sparse_vector.svec, sparse_vector.svec)
+	SET SCHEMA sparse_vector;
+
+ALTER OPERATOR <> (sparse_vector.svec, sparse_vector.svec)
+	SET SCHEMA sparse_vector;
+
+ALTER OPERATOR == (sparse_vector.svec, sparse_vector.svec)
+	SET SCHEMA sparse_vector;
+
+ALTER OPERATOR >= (sparse_vector.svec, sparse_vector.svec)
+	SET SCHEMA sparse_vector;
+
+ALTER OPERATOR > (sparse_vector.svec, sparse_vector.svec)
+	SET SCHEMA sparse_vector;
+
+ALTER OPERATOR *|| (int4, sparse_vector.svec)
+	SET SCHEMA sparse_vector;
+
+ALTER OPERATOR CLASS svec_l2_ops USING btree SET SCHEMA sparse_vector;
+

--- a/gpcontrib/gp_sparse_vector/gp_sparse_vector--1.0.1.sql
+++ b/gpcontrib/gp_sparse_vector/gp_sparse_vector--1.0.1.sql
@@ -1,5 +1,9 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
-\echo Use "CREATE EXTENSION btree_gin" to load this file. \quit
+\echo Use "CREATE EXTENSION gp_sparse_vector" to load this file. \quit
+
+CREATE SCHEMA sparse_vector;
+
+SET search_path TO sparse_vector;
 
 DROP TYPE IF EXISTS svec CASCADE;
 CREATE TYPE svec;
@@ -316,13 +320,13 @@ CREATE AGGREGATE median_inmemory (float8) (
 );
 
 -- Comparisons based on L2 Norm
-CREATE OR REPLACE FUNCTION svec_l2_lt(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_lt' LANGUAGE C IMMUTABLE;
-CREATE OR REPLACE FUNCTION svec_l2_le(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_le' LANGUAGE C IMMUTABLE;
-CREATE OR REPLACE FUNCTION svec_l2_eq(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_eq' LANGUAGE C IMMUTABLE;
-CREATE OR REPLACE FUNCTION svec_l2_ne(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_ne' LANGUAGE C IMMUTABLE;
-CREATE OR REPLACE FUNCTION svec_l2_gt(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_gt' LANGUAGE C IMMUTABLE;
-CREATE OR REPLACE FUNCTION svec_l2_ge(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_ge' LANGUAGE C IMMUTABLE;
-CREATE OR REPLACE FUNCTION svec_l2_cmp(svec,svec) RETURNS integer AS 'gp_svec.so', 'svec_l2_cmp' LANGUAGE C IMMUTABLE;
+CREATE OR REPLACE FUNCTION svec_l2_lt(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_lt' STRICT LANGUAGE C IMMUTABLE;
+CREATE OR REPLACE FUNCTION svec_l2_le(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_le' STRICT LANGUAGE C IMMUTABLE;
+CREATE OR REPLACE FUNCTION svec_l2_eq(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_eq' STRICT LANGUAGE C IMMUTABLE;
+CREATE OR REPLACE FUNCTION svec_l2_ne(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_ne' STRICT LANGUAGE C IMMUTABLE;
+CREATE OR REPLACE FUNCTION svec_l2_gt(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_gt' STRICT LANGUAGE C IMMUTABLE;
+CREATE OR REPLACE FUNCTION svec_l2_ge(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_ge' STRICT LANGUAGE C IMMUTABLE;
+CREATE OR REPLACE FUNCTION svec_l2_cmp(svec,svec) RETURNS integer AS 'gp_svec.so', 'svec_l2_cmp' STRICT LANGUAGE C IMMUTABLE;
 
 CREATE OPERATOR < (
 	leftarg = svec, rightarg = svec, procedure = svec_l2_lt,
@@ -369,3 +373,5 @@ OPERATOR        3       == ,
 OPERATOR        4       >= ,
 OPERATOR        5       > ,
 FUNCTION        1       svec_l2_cmp(svec, svec);
+
+SET search_path TO DEFAULT;

--- a/gpcontrib/gp_sparse_vector/gp_sparse_vector.control
+++ b/gpcontrib/gp_sparse_vector/gp_sparse_vector.control
@@ -1,3 +1,3 @@
 comment = 'SParse vector implementation for GreenPlum'
-default_version = '1.0.0'
+default_version = '1.0.1'
 relocatable = true

--- a/gpcontrib/gp_sparse_vector/sql/gp_svec.sql
+++ b/gpcontrib/gp_sparse_vector/sql/gp_svec.sql
@@ -1,4 +1,5 @@
 CREATE EXTENSION gp_sparse_vector;
+SET search_path TO sparse_vector;
 
 DROP TABLE if exists test;
 CREATE TABLE test (a int, b svec) DISTRIBUTED BY (a);
@@ -80,4 +81,7 @@ SELECT array_agg(a) FROM (SELECT trunc(7) a,generate_series(1,100000) ORDER BY a
 SELECT vec_median('{9960,9926,10053,9993,10080,10050,9938,9941,10030,10029}:{1,9,8,7,6,5,4,3,2,0}'::svec);
 SELECT vec_median('{9960,9926,10053,9993,10080,10050,9938,9941,10030,10029}:{1,9,8,7,6,5,4,3,2,0}'::svec::float8[]);
 
+select a.table_name,b.column_name,a.character_maximum_length as char_maxlen_a,b.character_maximum_length as char_maxlen_b,case when ((a.character_maximum_length == b.character_maximum_length) or ( a.numeric_precision==b.numeric_precision) or (a.numeric_scale==b.numeric_scale)) then 'Y' else 'N' end from information_schema.columns a inner join information_schema.columns b on a.table_name=b.table_name and a.column_name=b.column_name where a.table_name='applicable_roles' order by a.ordinal_position;
+
 DROP EXTENSION gp_sparse_vector;
+SET search_path TO DEFAULT;

--- a/gpcontrib/gp_sparse_vector/sql/gp_svec.sql
+++ b/gpcontrib/gp_sparse_vector/sql/gp_svec.sql
@@ -81,7 +81,9 @@ SELECT array_agg(a) FROM (SELECT trunc(7) a,generate_series(1,100000) ORDER BY a
 SELECT vec_median('{9960,9926,10053,9993,10080,10050,9938,9941,10030,10029}:{1,9,8,7,6,5,4,3,2,0}'::svec);
 SELECT vec_median('{9960,9926,10053,9993,10080,10050,9938,9941,10030,10029}:{1,9,8,7,6,5,4,3,2,0}'::svec::float8[]);
 
-select a.table_name,b.column_name,a.character_maximum_length as char_maxlen_a,b.character_maximum_length as char_maxlen_b,case when ((a.character_maximum_length == b.character_maximum_length) or ( a.numeric_precision==b.numeric_precision) or (a.numeric_scale==b.numeric_scale)) then 'Y' else 'N' end from information_schema.columns a inner join information_schema.columns b on a.table_name=b.table_name and a.column_name=b.column_name where a.table_name='applicable_roles' order by a.ordinal_position;
+SELECT DISTINCT a.table_name, a.character_maximum_length
+FROM information_schema.columns a INNER JOIN information_schema.columns b ON a.table_name=b.table_name AND a.column_name=b.column_name 
+WHERE a.character_maximum_length == b.character_maximum_length ORDER BY a.table_name;
 
 DROP EXTENSION gp_sparse_vector;
 SET search_path TO DEFAULT;

--- a/gpcontrib/gp_sparse_vector/sql/gp_svec.sql
+++ b/gpcontrib/gp_sparse_vector/sql/gp_svec.sql
@@ -81,9 +81,10 @@ SELECT array_agg(a) FROM (SELECT trunc(7) a,generate_series(1,100000) ORDER BY a
 SELECT vec_median('{9960,9926,10053,9993,10080,10050,9938,9941,10030,10029}:{1,9,8,7,6,5,4,3,2,0}'::svec);
 SELECT vec_median('{9960,9926,10053,9993,10080,10050,9938,9941,10030,10029}:{1,9,8,7,6,5,4,3,2,0}'::svec::float8[]);
 
+-- Test operator == as a joining condition when this column could be null. (See issue #12986)
 SELECT DISTINCT a.table_name, a.character_maximum_length
 FROM information_schema.columns a INNER JOIN information_schema.columns b ON a.table_name=b.table_name AND a.column_name=b.column_name 
 WHERE a.character_maximum_length == b.character_maximum_length ORDER BY a.table_name;
 
 DROP EXTENSION gp_sparse_vector;
-SET search_path TO DEFAULT;
+RESET search_path;

--- a/gpcontrib/gp_sparse_vector/sql/gp_svec_features.sql
+++ b/gpcontrib/gp_sparse_vector/sql/gp_svec_features.sql
@@ -1,5 +1,7 @@
 CREATE EXTENSION gp_sparse_vector;
 
+SET search_path TO sparse_vector;
+
 DROP TABLE IF EXISTS features;
 DROP TABLE IF EXISTS corpus;
 DROP TABLE IF EXISTS documents;


### PR DESCRIPTION
As #12986 mentioned, some binary operators function definition in GP extension `gp_sparse_vector` is not `strict`, which cannot properly handle NULL rows, may cause SIGSEV memory crush as follow:

```
#0  0x00007fdf3f7d74fb in raise () from /data/logs/298723/packcore-postgres.626108.181669.core/lib64/libpthread.so.0

#1  0x0000000000bf8260 in StandardHandlerForSigillSigsegvSigbus_OnMainThread (processName=<optimized out>, postgres_signal_arg=11) at elog.c:5579

#2  <signal handler called>

#3  pg_detoast_datum (datum=0x0) at fmgr.c:2209

#4  0x00007fdf183bec11 in svec_l2_eq () from /data/logs/298723/packcore-postgres.626108.181669.core/ms/dist/gpdb/PROJ/ds/6.17.7/.exec/@sys/lib/postgresql/gp_svec.so

#5  0x00000000008c590b in ExecMakeFunctionResultNoSets (fcache=0x33d19d8, econtext=0x33ddf38, isNull=0x7ffdeb86392f "", isDone=<optimized out>) at execQual.c:2161

#6  0x00000000008c4dc6 in ExecEvalOr (orExpr=<optimized out>, econtext=0x33ddf38, isNull=0x7ffdeb86392f "", isDone=<optimized out>) at execQual.c:3292

#7  0x00000000008c4f2d in ExecEvalCase (caseExpr=0x33d18b8, econtext=0x33ddf38, isNull=0x8a3e252 "", isDone=0x8a3e400) at execQual.c:3498

#8  0x00000000008cf662 in ExecTargetList (isDone=0x0, itemIsDone=0x8a3e3f8, isnull=0x8a3e250 "", values=0x8a3e220, econtext=0x33ddf38, targetlist=0x8a3e368) at execQual.c:6333

#9  ExecProject (projInfo=<optimized out>, isDone=isDone@entry=0x0) at execQual.c:6548

#10 0x00000000008e3ed7 in ExecHashJoin_guts (node=node@entry=0x8a5a100) at nodeHashjoin.c:489

#11 ExecHashJoin (node=node@entry=0x33ddad8) at nodeHashjoin.c:520

#12 0x00000000008c20f8 in ExecProcNode (node=node@entry=0x33ddad8) at execProcnode.c:1078

#13 0x00000000008f0fc0 in ExecSort (node=node@entry=0x33dd3c0) at nodeSort.c:185

#14 0x00000000008c20d8 in ExecProcNode (node=node@entry=0x33dd3c0) at execProcnode.c:1089

#15 0x00000000008b9489 in ExecutePlan (estate=estate@entry=0x33dd0a8, planstate=0x33dd3c0, operati
```

If the operand is a NULL row, pg_detoast_datum will hit a memory segmentation fault. 
This PR fixed this issue and added some test.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community

