### PR TITLE
Changes to avoid gpstop errors when standby is not reachable.

### DIFF
--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -34,6 +34,7 @@ try:
     from gppylib.operations.unix import CleanSharedMem
     from gppylib.operations.utils import ParallelOperation, RemoteOperation
     from gppylib.operations.rebalanceSegments import ReconfigDetectionSQLQueryCommand
+    from gppylib.operations.detect_unreachable_hosts import get_unreachable_segment_hosts
 except ImportError, e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
 
@@ -321,16 +322,26 @@ class GpStop:
         logger.info('Cleaning up leftover shared memory')
         cluster_hosts = self.gparray.get_hostlist()
 
+        num_workers = min(len(self.gparray.get_hostlist()), self.parallel)
+        unreachable_hosts = get_unreachable_segment_hosts(cluster_hosts, num_workers)
+
         operations = []
         for gphost in cluster_hosts:
-            operations.append(RemoteOperation(CleanSharedMem(self.gparray.getDbList()), gphost))
+            if gphost not in unreachable_hosts:
+                operations.append(RemoteOperation(CleanSharedMem(self.gparray.getDbList()), gphost))
+            else:
+                logger.warning("Skipping cleaning shared memory on %s because it's unreachable" % (gphost))
 
         operations.append(
             RemoteOperation(CleanSharedMem([self.gparray.master]), self.gparray.master.getSegmentHostName()))
 
         if self.gparray.standbyMaster:
-            operations.append(RemoteOperation(CleanSharedMem([self.gparray.standbyMaster]),
-                                              self.gparray.standbyMaster.getSegmentHostName()))
+            if self.gparray.standbyMaster.getSegmentHostName() not in unreachable_hosts:
+                operations.append(RemoteOperation(CleanSharedMem([self.gparray.standbyMaster]),
+                                                  self.gparray.standbyMaster.getSegmentHostName()))
+            else:
+                logger.warning("Skipping cleaning shared memory on %s because it's unreachable" % (
+                    self.gparray.standbyMaster.getSegmentHostName()))
 
         ParallelOperation(operations).run()
 
@@ -567,6 +578,10 @@ class GpStop:
 
         if self.gparray.standbyMaster:
             standby = self.gparray.standbyMaster
+
+            if get_unreachable_segment_hosts([standby.hostname], 1):
+                logger.warning("Standby is unreachable, continuing to stop other segments...")
+                return True
 
             logger.info("Stopping master standby host %s mode=fast" % standby.hostname)
             try:

--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -330,7 +330,7 @@ class GpStop:
             if gphost not in unreachable_hosts:
                 operations.append(RemoteOperation(CleanSharedMem(self.gparray.getDbList()), gphost))
             else:
-                logger.warning("Skipping cleaning shared memory on %s because it's unreachable" % (gphost))
+                logger.warning("Not attempting shared memory cleanup on %s as it is unreachable" % (gphost))
 
         operations.append(
             RemoteOperation(CleanSharedMem([self.gparray.master]), self.gparray.master.getSegmentHostName()))
@@ -340,7 +340,7 @@ class GpStop:
                 operations.append(RemoteOperation(CleanSharedMem([self.gparray.standbyMaster]),
                                                   self.gparray.standbyMaster.getSegmentHostName()))
             else:
-                logger.warning("Skipping cleaning shared memory on %s because it's unreachable" % (
+                logger.warning("Not attempting shared memory cleanup on %s as it is unreachable" % (
                     self.gparray.standbyMaster.getSegmentHostName()))
 
         ParallelOperation(operations).run()

--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -580,7 +580,7 @@ class GpStop:
             standby = self.gparray.standbyMaster
 
             if get_unreachable_segment_hosts([standby.hostname], 1):
-                logger.warning("Standby is unreachable, continuing to stop other segments...")
+                logger.warning("Standby is unreachable, skipping shutdown on standby")
                 return True
 
             logger.info("Stopping master standby host %s mode=fast" % standby.hostname)

--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -330,7 +330,7 @@ class GpStop:
             if gphost not in unreachable_hosts:
                 operations.append(RemoteOperation(CleanSharedMem(self.gparray.getDbList()), gphost))
             else:
-                logger.warning("Not attempting shared memory cleanup on %s as it is unreachable" % (gphost))
+                logger.warning("%s is unreachable.Skipping cleaning shared memory." % (gphost))
 
         operations.append(
             RemoteOperation(CleanSharedMem([self.gparray.master]), self.gparray.master.getSegmentHostName()))
@@ -340,7 +340,7 @@ class GpStop:
                 operations.append(RemoteOperation(CleanSharedMem([self.gparray.standbyMaster]),
                                                   self.gparray.standbyMaster.getSegmentHostName()))
             else:
-                logger.warning("Not attempting shared memory cleanup on %s as it is unreachable" % (
+                logger.warning("%s is unreachable.Skipping cleaning shared memory." % (
                     self.gparray.standbyMaster.getSegmentHostName()))
 
         ParallelOperation(operations).run()

--- a/gpMgmt/test/behave/mgmt_utils/gpstop.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstop.feature
@@ -35,6 +35,6 @@ Feature: gpstop behave tests
          When the standby host is made unreachable
           And the user runs "gpstop -a"
          Then gpstop should print "Standby is unreachable, continuing to stop other segments" to stdout
-          And gpstop should print "Skipping cleaning shared memory on invalid_host because it's unreachable" to stdout
+          And gpstop should print "Not attempting shared memory cleanup on invalid_host as it is unreachable" to stdout
           And gpstop should return a return code of 0
           And the standby host is made reachable

--- a/gpMgmt/test/behave/mgmt_utils/gpstop.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstop.feature
@@ -34,7 +34,7 @@ Feature: gpstop behave tests
           And the catalog has a standby master entry
          When the standby host is made unreachable
           And the user runs "gpstop -a"
-         Then gpstop should print "Standby is unreachable, continuing to stop other segments" to stdout
+         Then gpstop should print "Standby is unreachable, skipping shutdown on standby" to stdout
           And gpstop should print "invalid_host is unreachable.Skipping cleaning shared memory." to stdout
           And gpstop should return a return code of 0
           And the standby host is made reachable

--- a/gpMgmt/test/behave/mgmt_utils/gpstop.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstop.feature
@@ -35,6 +35,6 @@ Feature: gpstop behave tests
          When the standby host is made unreachable
           And the user runs "gpstop -a"
          Then gpstop should print "Standby is unreachable, continuing to stop other segments" to stdout
-          And gpstop should print "Not attempting shared memory cleanup on invalid_host as it is unreachable" to stdout
+          And gpstop should print "invalid_host is unreachable.Skipping cleaning shared memory." to stdout
           And gpstop should return a return code of 0
           And the standby host is made reachable

--- a/gpMgmt/test/behave/mgmt_utils/gpstop.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstop.feature
@@ -27,3 +27,12 @@ Feature: gpstop behave tests
           And gpstop should print "There were 1 user connections at the start of the shutdown" to stdout
           And gpstop should print "'\(s\)mart_mode', '\(f\)ast_mode', '\(i\)mmediate_mode'" to stdout
          Then gpstop should return a return code of 0
+
+    @demo_cluster
+    Scenario: gpstop succeeds even if the standby host is unreachable
+        Given the database is running
+          And the catalog has a standby master entry
+         When the standby host is made unreachable
+          And the user runs "gpstop -a"
+         Then gpstop should return a return code of 0
+          And the standby host is made reachable

--- a/gpMgmt/test/behave/mgmt_utils/gpstop.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstop.feature
@@ -34,5 +34,7 @@ Feature: gpstop behave tests
           And the catalog has a standby master entry
          When the standby host is made unreachable
           And the user runs "gpstop -a"
-         Then gpstop should return a return code of 0
+         Then gpstop should print "Standby is unreachable, continuing to stop other segments" to stdout
+          And gpstop should print "Skipping cleaning shared memory on invalid_host because it's unreachable" to stdout
+          And gpstop should return a return code of 0
           And the standby host is made reachable

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
@@ -36,33 +36,20 @@ def change_hostname(content, preferred_role, hostname):
 def impl(context):
     change_hostname(-1, 'm', 'invalid_host')
 
-    def cleanup(context):
-        """
-        Reverses the above SQL by starting up in master-only utility mode. Since
-        the standby host is incorrect, a regular gpstart call won't work.
-        """
-        utils.stop_database_if_started(context)
-
-        subprocess.check_call(['gpstart', '-am'])
-        _run_sql("""
-            SET allow_system_table_mods='true';
-            UPDATE gp_segment_configuration
-               SET hostname = master.hostname,
-                    address = master.address
-              FROM (
-                     SELECT hostname, address
-                       FROM gp_segment_configuration
-                      WHERE content = -1 and role = 'p'
-                   ) master
-             WHERE content = -1 AND role = 'm'
-        """, {'gp_session_role': 'utility'}) 
-        subprocess.check_call(['gpstop', '-am'])
-
     context.add_cleanup(cleanup, context)
 
 @when('the standby host is made reachable')
 @then('the standby host is made reachable')
 def impl(context):
+    cleanup(context)
+
+"""
+Reverses the changes done by change_hostname() function by starting up cluster in master-only utility mode. 
+Since the standby host is incorrect, a regular gpstart call won't work.
+"""
+def cleanup(context):
+
+    utils.stop_database_if_started(context)
 
     subprocess.check_call(['gpstart', '-am'])
     _run_sql("""


### PR DESCRIPTION
Added check for standby reachability before stopping the standby to avoid gpstop failures when standby is unreachable.
Added check for unreachable hosts before cleaning shared memory at the end of gpstop process to avoid remove_shared_memory function from throwing errors when hosts are unreachable.
Added behave test case for gpstop when standby is unreachable.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
