### PR TITLE
[6X] [backport] pageinspect bitmap support

### DIFF
--- a/contrib/pageinspect/Makefile
+++ b/contrib/pageinspect/Makefile
@@ -1,10 +1,11 @@
 # contrib/pageinspect/Makefile
 
 MODULE_big	= pageinspect
-OBJS		= rawpage.o heapfuncs.o btreefuncs.o fsmfuncs.o
+OBJS		= rawpage.o heapfuncs.o bmfuncs.o btreefuncs.o fsmfuncs.o
 
 EXTENSION = pageinspect
-DATA = pageinspect--1.2.sql pageinspect--1.0--1.1.sql \
+DATA = pageinspect--1.8.sql pageinspect--1.2--1.8.sql \
+	pageinspect--1.2.sql pageinspect--1.0--1.1.sql \
 	pageinspect--1.1--1.2.sql pageinspect--unpackaged--1.0.sql
 
 ifdef USE_PGXS

--- a/contrib/pageinspect/bmfuncs.c
+++ b/contrib/pageinspect/bmfuncs.c
@@ -1,0 +1,627 @@
+/*
+ * contrib/pageinspect/bmfuncs.c
+ *
+ * Portions Copyright (c) 2021-Present VMware, Inc. or its affiliates.
+ */
+
+#include "postgres.h"
+
+#include "access/bitmap.h"
+#include "access/heapam.h"
+#include "catalog/namespace.h"
+#include "catalog/pg_am.h"
+#include "funcapi.h"
+#include "miscadmin.h"
+#include "utils/builtins.h"
+#include "utils/rel.h"
+#include "utils/builtins.h"
+
+PG_FUNCTION_INFO_V1(bm_metap);
+PG_FUNCTION_INFO_V1(bm_lov_page_items);
+PG_FUNCTION_INFO_V1(bm_bitmap_page_header);
+PG_FUNCTION_INFO_V1(bm_bitmap_page_items);
+PG_FUNCTION_INFO_V1(bm_bitmap_page_items_bytea);
+
+#define IS_INDEX(r) ((r)->rd_rel->relkind == RELKIND_INDEX)
+#define IS_BITMAP_INDEX(r) ((r)->rd_rel->relam == BITMAP_AM_OID)
+
+/* note: BlockNumber is unsigned, hence can't be negative */
+#define CHECK_RELATION_BLOCK_RANGE(rel, blkno) { \
+		if ( RelationGetNumberOfBlocks(rel) <= (BlockNumber) (blkno) ) \
+			 elog(ERROR, "block number out of range"); }
+
+/* ------------------------------------------------
+ * bm_metap()
+ *
+ * Get a bitmap index's meta-page information
+ *
+ * Usage: SELECT * FROM bm_metap('gender')
+ * ------------------------------------------------
+ */
+Datum
+bm_metap(PG_FUNCTION_ARGS)
+{
+	text	   *relname = PG_GETARG_TEXT_PP(0);
+	Datum		result;
+	Relation	rel;
+	RangeVar   *relrv;
+	BMMetaPageData *metad;
+	TupleDesc	tupleDesc;
+	int			j;
+	char	   *values[5];
+	Buffer		buffer;
+	HeapTuple	tuple;
+
+	if (!superuser())
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 (errmsg("must be superuser to use pageinspect functions"))));
+
+	relrv = makeRangeVarFromNameList(textToQualifiedNameList(relname));
+	rel = relation_openrv(relrv, AccessShareLock);
+
+	if (!IS_INDEX(rel) || !IS_BITMAP_INDEX(rel))
+		elog(ERROR, "relation \"%s\" is not a bitmap index",
+			 RelationGetRelationName(rel));
+
+	/*
+	 * Reject attempts to read non-local temporary relations; we would be
+	 * likely to get wrong data since we have no visibility into the owning
+	 * session's local buffers.
+	 */
+	if (RELATION_IS_OTHER_TEMP(rel))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("cannot access temporary tables of other sessions")));
+
+	buffer = ReadBuffer(rel, BM_METAPAGE);
+	LockBuffer(buffer, BUFFER_LOCK_SHARE);
+
+	metad = _bitmap_get_metapage_data(rel, buffer);
+
+	/* Build a tuple descriptor for our result type */
+	if (get_call_result_type(fcinfo, NULL, &tupleDesc) != TYPEFUNC_COMPOSITE)
+		elog(ERROR, "return type must be a row type");
+
+	j = 0;
+	values[j++] = psprintf("%d", metad->bm_magic);
+	values[j++] = psprintf("%d", metad->bm_version);
+	values[j++] = psprintf("%d", metad->bm_lov_heapId);
+	values[j++] = psprintf("%d", metad->bm_lov_indexId);
+	values[j] = psprintf("%d", metad->bm_lov_lastpage);
+
+	tuple = BuildTupleFromCStrings(TupleDescGetAttInMetadata(tupleDesc),
+								   values);
+
+	result = HeapTupleGetDatum(tuple);
+
+	UnlockReleaseBuffer(buffer);
+	relation_close(rel, AccessShareLock);
+
+	PG_RETURN_DATUM(result);
+}
+
+/*-------------------------------------------------------
+ * bm_get_word_text()
+ *
+ * Get a user-friendly print version of a bitmap word (uint64),
+ * i.e. bytes are printed according to host endianness.
+ * e.g. 31 becomes '00 00 00 00 00 00 00 1f'.
+ * The length of the word is always 24 (including ending '\0').
+ * ------------------------------------------------------
+ */
+static char* 
+bm_get_word_text(BM_HRL_WORD *word)
+{
+	char 			*wtext;
+	int 			wlen = 24;
+	char 			*ptr;
+	int 			off;
+
+	ptr = (char*)word;
+	wtext = palloc0(wlen);
+	/* Be aware of endianness */
+	if (htonl(42) == 42)
+	{
+		/* Big Endian */
+		for (off = 0; off <= 7; off++)
+		{
+			if (off > 0)
+				*wtext++ = ' ';
+			sprintf(wtext, "%02x", *(ptr + off) & 0xff);
+			wtext += 2;
+		}
+	}
+	else
+	{
+		/* Little Endian */
+		for (off = 7; off >= 0; off--)
+		{
+			if (off < 7)
+				*wtext++ = ' ';
+			sprintf(wtext, "%02x", *(ptr + off) & 0xff);
+			wtext += 2;
+		}
+	}
+
+	return wtext - (wlen - 1);
+}
+
+/*-------------------------------------------------------
+ * bm_print_lov_item()
+ *
+ * Form a tuple describing an LOV item at a given offset
+ * ------------------------------------------------------
+ */
+static Datum
+bm_print_lov_item(FuncCallContext *fctx, Page page, OffsetNumber offset)
+{
+	char		*values[9];
+	HeapTuple	tuple;
+	ItemId		id;
+	BMLOVItem	lovItem;
+	int			j;
+
+	id = PageGetItemId(page, offset);
+
+	if (!ItemIdIsValid(id))
+		elog(ERROR, "invalid ItemId");
+
+	lovItem = (BMLOVItem) PageGetItem(page, id);
+
+	j = 0;
+	values[j++] = psprintf("%d", offset);
+	values[j++] = psprintf("%u", lovItem->bm_lov_head);
+	values[j++] = psprintf("%u", lovItem->bm_lov_tail);
+	values[j++] = psprintf("%s", bm_get_word_text(&lovItem->bm_last_compword));
+	values[j++] = psprintf("%s", bm_get_word_text(&lovItem->bm_last_word));
+	values[j++] = psprintf("%lu", lovItem->bm_last_tid_location);
+	values[j++] = psprintf("%lu", lovItem->bm_last_setbit);
+	values[j++] = psprintf("%d", (lovItem->lov_words_header & 2) == 2);
+	values[j]   = psprintf("%d", (lovItem->lov_words_header & 1) == 1);
+
+	tuple = BuildTupleFromCStrings(fctx->attinmeta, values);
+
+	return HeapTupleGetDatum(tuple);
+}
+
+/*
+ * cross-call data structure for bm_lov_page_items() SRF
+ */
+struct user_args_lov_items
+{
+	Page		page;
+	OffsetNumber offset;
+};
+
+/*-------------------------------------------------------
+ * bm_lov_page_items()
+ *
+ * Get LOV items present in a bitmap LOV page
+ *
+ * Usage: SELECT * FROM bm_lov_page_items('t1_pkey', 1);
+ *-------------------------------------------------------
+ */
+Datum
+bm_lov_page_items(PG_FUNCTION_ARGS)
+{
+	text	   *relname = PG_GETARG_TEXT_PP(0);
+	uint32		blkno = PG_GETARG_UINT32(1);
+	Datum		result;
+	FuncCallContext *fctx;
+	MemoryContext              mctx;
+	struct user_args_lov_items *uargs;
+
+	if (!superuser())
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+					(errmsg("must be superuser to use pageinspect functions"))));
+
+	if (SRF_IS_FIRSTCALL())
+	{
+		RangeVar   *relrv;
+		Relation	rel;
+		Buffer		buffer;
+		TupleDesc	tupleDesc;
+
+		fctx = SRF_FIRSTCALL_INIT();
+
+		relrv = makeRangeVarFromNameList(textToQualifiedNameList(relname));
+		rel = relation_openrv(relrv, AccessShareLock);
+
+		if (!IS_INDEX(rel) || !IS_BITMAP_INDEX(rel))
+			elog(ERROR, "relation \"%s\" is not a bitmap index",
+				 RelationGetRelationName(rel));
+
+		/*
+		 * Reject attempts to read non-local temporary relations; we would be
+		 * likely to get wrong data since we have no visibility into the
+		 * owning session's local buffers.
+		 */
+		if (RELATION_IS_OTHER_TEMP(rel))
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						errmsg("cannot access temporary tables of other sessions")));
+
+		if (blkno == 0)
+			elog(ERROR, "block 0 is a meta page");
+
+		CHECK_RELATION_BLOCK_RANGE(rel, blkno);
+
+		buffer = ReadBuffer(rel, blkno);
+		LockBuffer(buffer, BUFFER_LOCK_SHARE);
+
+		/*
+		 * We copy the page into local storage to avoid holding pin on the
+		 * buffer longer than we must, and possibly failing to release it at
+		 * all if the calling query doesn't fetch all rows.
+		 */
+		mctx = MemoryContextSwitchTo(fctx->multi_call_memory_ctx);
+
+		uargs = palloc(sizeof(struct user_args_lov_items));
+
+		uargs->page = palloc(BLCKSZ);
+		memcpy(uargs->page, BufferGetPage(buffer), BLCKSZ);
+
+		UnlockReleaseBuffer(buffer);
+		relation_close(rel, AccessShareLock);
+
+		/*
+		 * Ensure that we are dealing with a LOV item page - they don't have a
+		 * special section.
+		 */
+		if (PageGetSpecialSize(uargs->page))
+			elog(ERROR, "block %d is not an LOV page, it is a bitmap page", blkno);
+
+		uargs->offset = FirstOffsetNumber;
+
+		fctx->max_calls = PageGetMaxOffsetNumber(uargs->page);
+
+		/* Build a tuple descriptor for our result type */
+		if (get_call_result_type(fcinfo, NULL, &tupleDesc) != TYPEFUNC_COMPOSITE)
+			elog(ERROR, "return type must be a row type");
+
+		fctx->attinmeta = TupleDescGetAttInMetadata(tupleDesc);
+
+		fctx->user_fctx = uargs;
+
+		MemoryContextSwitchTo(mctx);
+	}
+
+	fctx = SRF_PERCALL_SETUP();
+	uargs = fctx->user_fctx;
+
+	if (fctx->call_cntr < fctx->max_calls)
+	{
+		result = bm_print_lov_item(fctx, uargs->page, uargs->offset);
+		uargs->offset++;
+		SRF_RETURN_NEXT(fctx, result);
+	}
+	else
+	{
+		pfree(uargs->page);
+		pfree(uargs);
+		SRF_RETURN_DONE(fctx);
+	}
+}
+
+/*-------------------------------------------------------
+ * bm_bitmap_page_header()
+ *
+ * Get the header information for a bitmap page. This
+ * corresponds to the opaque section from the page
+ * header.
+ *
+ * Usage: SELECT * FROM bm_bitmap_page_header('bm_index', 5);
+ *-------------------------------------------------------
+ */
+Datum
+bm_bitmap_page_header(PG_FUNCTION_ARGS)
+{
+	text	   *relname = PG_GETARG_TEXT_PP(0);
+	uint32		blkno = PG_GETARG_UINT32(1);
+	Datum		result;
+	RangeVar   *relrv;
+	Relation	rel;
+	Buffer 		buffer;
+	Page 		page;
+	BMBitmapOpaque bm_opaque;
+	TupleDesc	tupleDesc;
+	int 		j;
+	char	   *values[3];
+	HeapTuple	tuple;
+
+	if (!superuser())
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+					(errmsg("must be superuser to use pageinspect functions"))));
+
+	relrv = makeRangeVarFromNameList(textToQualifiedNameList(relname));
+	rel = relation_openrv(relrv, AccessShareLock);
+
+	if (!IS_INDEX(rel) || !IS_BITMAP_INDEX(rel))
+		elog(ERROR, "relation \"%s\" is not a bitmap index",
+			 RelationGetRelationName(rel));
+
+	/*
+	 * Reject attempts to read non-local temporary relations; we would be
+	 * likely to get wrong data since we have no visibility into the owning
+	 * session's local buffers.
+	 */
+	if (RELATION_IS_OTHER_TEMP(rel))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					errmsg("cannot access temporary tables of other sessions")));
+
+	CHECK_RELATION_BLOCK_RANGE(rel, blkno);
+
+	if (blkno == 0)
+		elog(ERROR, "block 0 is a meta page");
+
+	buffer = ReadBuffer(rel, blkno);
+	LockBuffer(buffer, BUFFER_LOCK_SHARE);
+
+	page = BufferGetPage(buffer);
+
+	/*
+	 * Ensure that we are dealing with a bitmap page - they must have a special
+	 * section.
+	 */
+	if (PageGetSpecialSize(page) <= 0)
+		elog(ERROR, "block %d is not a bitmap page, it is a LOV item page", blkno);
+
+	/* Build a tuple descriptor for our result type */
+	if (get_call_result_type(fcinfo, NULL, &tupleDesc) != TYPEFUNC_COMPOSITE)
+		elog(ERROR, "return type must be a row type");
+
+	bm_opaque = (BMBitmapOpaque) PageGetSpecialPointer(page);
+
+	j = 0;
+	values[j++] = psprintf("%u", bm_opaque->bm_hrl_words_used);
+	values[j++] = psprintf("%u", bm_opaque->bm_bitmap_next);
+	values[j] = psprintf("%lu", bm_opaque->bm_last_tid_location);
+
+	tuple = BuildTupleFromCStrings(TupleDescGetAttInMetadata(tupleDesc),
+								   values);
+
+	result = HeapTupleGetDatum(tuple);
+
+	UnlockReleaseBuffer(buffer);
+	relation_close(rel, AccessShareLock);
+
+	PG_RETURN_DATUM(result);
+}
+
+/*-------------------------------------------------------
+ * bm_print_content_word()
+ *
+ * Print content word in given bitmap page along with its
+ * compression status.
+ * ------------------------------------------------------
+ */
+static Datum
+bm_print_content_word(FuncCallContext *fctx, Page page, int word_num)
+{
+	char			*values[3];
+	HeapTuple		tuple;
+	int				j;
+	BMBitmap 		bitmap = (BMBitmap) PageGetContentsMaxAligned(page);
+
+	j = 0;
+	values[j++] = psprintf("%d", word_num);
+	values[j++] = psprintf("%d", IS_FILL_WORD(bitmap->hwords, word_num));
+	values[j] = psprintf("%s", bm_get_word_text(&bitmap->cwords[word_num]));
+
+	tuple = BuildTupleFromCStrings(fctx->attinmeta, values);
+
+	return HeapTupleGetDatum(tuple);
+}
+
+/*
+ * cross-call data structure for bm_bitmap_page_items() SRF
+ */
+struct user_args_page_items
+{
+	Page   page;
+	uint32 word_num;
+};
+
+/*-------------------------------------------------------
+ * bm_bitmap_page_items()
+ *
+ * Get the content words from a bitmap page along with
+ * their compression statuses.
+ *
+ * Usage: SELECT * FROM bm_bitmap_page_items('t1_pkey', 5);
+ *-------------------------------------------------------
+ */
+Datum
+bm_bitmap_page_items(PG_FUNCTION_ARGS)
+{
+	text	   *relname = PG_GETARG_TEXT_PP(0);
+	uint32		blkno = PG_GETARG_UINT32(1);
+	Datum		result;
+	FuncCallContext *fctx;
+	MemoryContext              mctx;
+	struct user_args_page_items *uargs;
+
+	if (!superuser())
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+					(errmsg("must be superuser to use pageinspect functions"))));
+
+	if (SRF_IS_FIRSTCALL())
+	{
+		RangeVar   		*relrv;
+		Relation		rel;
+		Buffer			buffer;
+		TupleDesc		tupleDesc;
+		BMBitmapOpaque 	bm_opaque;
+
+		fctx = SRF_FIRSTCALL_INIT();
+
+		relrv = makeRangeVarFromNameList(textToQualifiedNameList(relname));
+		rel = relation_openrv(relrv, AccessShareLock);
+
+		if (!IS_INDEX(rel) || !IS_BITMAP_INDEX(rel))
+			elog(ERROR, "relation \"%s\" is not a bitmap index",
+				 RelationGetRelationName(rel));
+
+		/*
+		 * Reject attempts to read non-local temporary relations; we would be
+		 * likely to get wrong data since we have no visibility into the
+		 * owning session's local buffers.
+		 */
+		if (RELATION_IS_OTHER_TEMP(rel))
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						errmsg("cannot access temporary tables of other sessions")));
+
+		if (blkno == 0)
+			elog(ERROR, "block 0 is a meta page");
+
+		CHECK_RELATION_BLOCK_RANGE(rel, blkno);
+
+		buffer = ReadBuffer(rel, blkno);
+		LockBuffer(buffer, BUFFER_LOCK_SHARE);
+
+		/*
+		 * We copy the page into local storage to avoid holding pin on the
+		 * buffer longer than we must, and possibly failing to release it at
+		 * all if the calling query doesn't fetch all rows.
+		 */
+		mctx = MemoryContextSwitchTo(fctx->multi_call_memory_ctx);
+
+		uargs = palloc(sizeof(struct user_args_page_items));
+
+		uargs->page = palloc(BLCKSZ);
+		memcpy(uargs->page, BufferGetPage(buffer), BLCKSZ);
+
+		UnlockReleaseBuffer(buffer);
+		relation_close(rel, AccessShareLock);
+
+		/*
+		 * Ensure that we are dealing with a bitmap page - they must have a special
+		 * section.
+		 */
+		if (PageGetSpecialSize(uargs->page) <= 0)
+			elog(ERROR, "block %d is not a bitmap page, it is a LOV item page", blkno);
+
+		uargs->word_num = 0;
+		bm_opaque = (BMBitmapOpaque) PageGetSpecialPointer(uargs->page);
+		fctx->max_calls = bm_opaque->bm_hrl_words_used;
+
+		/* Build a tuple descriptor for our result type */
+		if (get_call_result_type(fcinfo, NULL, &tupleDesc) != TYPEFUNC_COMPOSITE)
+			elog(ERROR, "return type must be a row type");
+
+		fctx->attinmeta = TupleDescGetAttInMetadata(tupleDesc);
+
+		fctx->user_fctx = uargs;
+
+		MemoryContextSwitchTo(mctx);
+	}
+
+	fctx = SRF_PERCALL_SETUP();
+	uargs = fctx->user_fctx;
+
+	if (fctx->call_cntr < fctx->max_calls)
+	{
+		result = bm_print_content_word(fctx, uargs->page, uargs->word_num);
+		uargs->word_num++;
+		SRF_RETURN_NEXT(fctx, result);
+	}
+	else
+	{
+		pfree(uargs->page);
+		pfree(uargs);
+		SRF_RETURN_DONE(fctx);
+	}
+}
+
+/*-------------------------------------------------------
+ * bm_bitmap_page_items_bytea()
+ *
+ * Get the content words from a bitmap page along with
+ * their compression statuses.
+ *
+ * Usage: SELECT * FROM bm_bitmap_page_items(get_raw_page('t1_pkey', 5));
+ *-------------------------------------------------------
+ */
+Datum
+bm_bitmap_page_items_bytea(PG_FUNCTION_ARGS)
+{
+	bytea 		*raw_page = PG_GETARG_BYTEA_P(0);
+	Datum		result;
+	FuncCallContext *fctx;
+	MemoryContext              mctx;
+	struct user_args_page_items *uargs;
+	int 		raw_page_size;
+
+	if (!superuser())
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+					(errmsg("must be superuser to use pageinspect functions"))));
+
+	if (SRF_IS_FIRSTCALL())
+	{
+		TupleDesc		tupleDesc;
+		BMBitmapOpaque 	bm_opaque;
+
+		raw_page_size = VARSIZE(raw_page) - VARHDRSZ;
+
+		if (raw_page_size < SizeOfPageHeaderData)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("input page too small (%d bytes)", raw_page_size)));
+
+		fctx = SRF_FIRSTCALL_INIT();
+
+		/*
+		 * We copy the page into local storage to avoid holding pin on the
+		 * buffer longer than we must, and possibly failing to release it at
+		 * all if the calling query doesn't fetch all rows.
+		 */
+		mctx = MemoryContextSwitchTo(fctx->multi_call_memory_ctx);
+
+		uargs = palloc(sizeof(struct user_args_page_items));
+
+		uargs->page = VARDATA(raw_page);
+
+		/*
+		 * Ensure that we are dealing with a bitmap page - they must have a special
+		 * section.
+		 */
+		if (PageGetSpecialSize(uargs->page) <= 0)
+			elog(ERROR, "page is not a bitmap page");
+
+		uargs->word_num = 0;
+		bm_opaque = (BMBitmapOpaque) PageGetSpecialPointer(uargs->page);
+		fctx->max_calls = bm_opaque->bm_hrl_words_used;
+
+		/* Build a tuple descriptor for our result type */
+		if (get_call_result_type(fcinfo, NULL, &tupleDesc) != TYPEFUNC_COMPOSITE)
+			elog(ERROR, "return type must be a row type");
+
+		fctx->attinmeta = TupleDescGetAttInMetadata(tupleDesc);
+
+		fctx->user_fctx = uargs;
+
+		MemoryContextSwitchTo(mctx);
+	}
+
+	fctx = SRF_PERCALL_SETUP();
+	uargs = fctx->user_fctx;
+
+	if (fctx->call_cntr < fctx->max_calls)
+	{
+		result = bm_print_content_word(fctx, uargs->page, uargs->word_num);
+		uargs->word_num++;
+		SRF_RETURN_NEXT(fctx, result);
+	}
+	else
+	{
+		pfree(uargs);
+		SRF_RETURN_DONE(fctx);
+	}
+}

--- a/contrib/pageinspect/pageinspect--1.2--1.8.sql
+++ b/contrib/pageinspect/pageinspect--1.2--1.8.sql
@@ -1,0 +1,68 @@
+/* contrib/pageinspect/pageinspect--1.2--1.8.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION pageinspect UPDATE TO '1.8'" to load this file. \quit
+
+--
+-- bm_metap()
+--
+CREATE FUNCTION bm_metap(IN relname text,
+     OUT magic int4,
+     OUT version int4,
+     OUT auxrelid oid,
+     OUT auxindexrelid oid,
+     OUT lovlastblknum bigint)
+AS 'MODULE_PATHNAME', 'bm_metap'
+LANGUAGE C STRICT;
+
+--
+-- bm_lov_page_items()
+--
+CREATE FUNCTION bm_lov_page_items(IN relname text,
+                                  IN blkno int4,
+                                  OUT itemoffset smallint,
+                                  OUT lov_head_blkno bigint,
+                                  OUT lov_tail_blkno bigint,
+                                  OUT last_complete_word text,
+                                  OUT last_word text,
+                                  OUT last_tid numeric,
+                                  OUT last_setbit_tid numeric,
+                                  OUT is_last_complete_word_fill bool,
+                                  OUT is_last_word_fill bool)
+    RETURNS SETOF record
+AS 'MODULE_PATHNAME', 'bm_lov_page_items'
+    LANGUAGE C STRICT;
+
+--
+-- bm_bitmap_page_header()
+--
+CREATE FUNCTION bm_bitmap_page_header(IN relname text,
+                         IN blkno int4,
+                         OUT num_words bigint,
+                         OUT next_blkno bigint,
+                         OUT last_tid numeric)
+AS 'MODULE_PATHNAME', 'bm_bitmap_page_header'
+    LANGUAGE C STRICT;
+
+--
+-- bm_bitmap_page_items()
+--
+CREATE FUNCTION bm_bitmap_page_items(IN relname text,
+                                  IN blkno int4,
+                                  OUT word_num bigint,
+                                  OUT compressed bool,
+                                  OUT content_word text)
+    RETURNS SETOF record
+AS 'MODULE_PATHNAME', 'bm_bitmap_page_items'
+    LANGUAGE C STRICT;
+
+--
+-- bm_bitmap_page_items_bytea()
+--
+CREATE FUNCTION bm_bitmap_page_items(IN page bytea,
+                                  OUT word_num bigint,
+                                  OUT compressed bool,
+                                  OUT content_word text)
+    RETURNS SETOF record
+AS 'MODULE_PATHNAME', 'bm_bitmap_page_items_bytea'
+    LANGUAGE C STRICT;

--- a/contrib/pageinspect/pageinspect--1.8.sql
+++ b/contrib/pageinspect/pageinspect--1.8.sql
@@ -1,0 +1,171 @@
+/* contrib/pageinspect/pageinspect--1.8.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION pageinspect" to load this file. \quit
+
+--
+-- get_raw_page()
+--
+CREATE FUNCTION get_raw_page(text, int4)
+RETURNS bytea
+AS 'MODULE_PATHNAME', 'get_raw_page'
+LANGUAGE C STRICT;
+
+CREATE FUNCTION get_raw_page(text, text, int4)
+RETURNS bytea
+AS 'MODULE_PATHNAME', 'get_raw_page_fork'
+LANGUAGE C STRICT;
+
+--
+-- page_header()
+--
+CREATE FUNCTION page_header(IN page bytea,
+    OUT lsn pg_lsn,
+    OUT checksum smallint,
+    OUT flags smallint,
+    OUT lower smallint,
+    OUT upper smallint,
+    OUT special smallint,
+    OUT pagesize smallint,
+    OUT version smallint,
+    OUT prune_xid xid)
+AS 'MODULE_PATHNAME', 'page_header'
+LANGUAGE C STRICT;
+
+--
+-- heap_page_items()
+--
+CREATE FUNCTION heap_page_items(IN page bytea,
+    OUT lp smallint,
+    OUT lp_off smallint,
+    OUT lp_flags smallint,
+    OUT lp_len smallint,
+    OUT t_xmin xid,
+    OUT t_xmax xid,
+    OUT t_field3 int4,
+    OUT t_ctid tid,
+    OUT t_infomask2 integer,
+    OUT t_infomask integer,
+    OUT t_hoff smallint,
+    OUT t_bits text,
+    OUT t_oid oid)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME', 'heap_page_items'
+LANGUAGE C STRICT;
+
+--
+-- bt_metap()
+--
+CREATE FUNCTION bt_metap(IN relname text,
+    OUT magic int4,
+    OUT version int4,
+    OUT root int4,
+    OUT level int4,
+    OUT fastroot int4,
+    OUT fastlevel int4)
+AS 'MODULE_PATHNAME', 'bt_metap'
+LANGUAGE C STRICT;
+
+--
+-- bt_page_stats()
+--
+CREATE FUNCTION bt_page_stats(IN relname text, IN blkno int4,
+    OUT blkno int4,
+    OUT type "char",
+    OUT live_items int4,
+    OUT dead_items int4,
+    OUT avg_item_size int4,
+    OUT page_size int4,
+    OUT free_size int4,
+    OUT btpo_prev int4,
+    OUT btpo_next int4,
+    OUT btpo int4,
+    OUT btpo_flags int4)
+AS 'MODULE_PATHNAME', 'bt_page_stats'
+LANGUAGE C STRICT;
+
+--
+-- bt_page_items()
+--
+CREATE FUNCTION bt_page_items(IN relname text, IN blkno int4,
+    OUT itemoffset smallint,
+    OUT ctid tid,
+    OUT itemlen smallint,
+    OUT nulls bool,
+    OUT vars bool,
+    OUT data text)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME', 'bt_page_items'
+LANGUAGE C STRICT;
+
+--
+-- fsm_page_contents()
+--
+CREATE FUNCTION fsm_page_contents(IN page bytea)
+RETURNS text
+AS 'MODULE_PATHNAME', 'fsm_page_contents'
+LANGUAGE C STRICT;
+
+--
+-- bm_metap()
+--
+CREATE FUNCTION bm_metap(IN relname text,
+     OUT magic int4,
+     OUT version int4,
+     OUT auxrelid oid,
+     OUT auxindexrelid oid,
+     OUT lovlastblknum bigint)
+AS 'MODULE_PATHNAME', 'bm_metap'
+LANGUAGE C STRICT;
+
+--
+-- bm_lov_page_items()
+--
+CREATE FUNCTION bm_lov_page_items(IN relname text,
+                                  IN blkno int4,
+                                  OUT itemoffset smallint,
+                                  OUT lov_head_blkno bigint,
+                                  OUT lov_tail_blkno bigint,
+                                  OUT last_complete_word text,
+                                  OUT last_word text,
+                                  OUT last_tid numeric,
+                                  OUT last_setbit_tid numeric,
+                                  OUT is_last_complete_word_fill bool,
+                                  OUT is_last_word_fill bool)
+    RETURNS SETOF record
+AS 'MODULE_PATHNAME', 'bm_lov_page_items'
+    LANGUAGE C STRICT;
+
+--
+-- bm_bitmap_page_header()
+--
+CREATE FUNCTION bm_bitmap_page_header(IN relname text,
+                         IN blkno int4,
+                         OUT num_words bigint,
+                         OUT next_blkno bigint,
+                         OUT last_tid numeric)
+AS 'MODULE_PATHNAME', 'bm_bitmap_page_header'
+    LANGUAGE C STRICT;
+
+--
+-- bm_bitmap_page_items()
+--
+CREATE FUNCTION bm_bitmap_page_items(IN relname text,
+                                  IN blkno int4,
+                                  OUT word_num bigint,
+                                  OUT compressed bool,
+                                  OUT content_word text)
+    RETURNS SETOF record
+AS 'MODULE_PATHNAME', 'bm_bitmap_page_items'
+    LANGUAGE C STRICT;
+
+--
+-- bm_bitmap_page_items_bytea()
+--
+CREATE FUNCTION bm_bitmap_page_items(IN page bytea,
+                                  OUT word_num bigint,
+                                  OUT compressed bool,
+                                  OUT content_word text)
+    RETURNS SETOF record
+AS 'MODULE_PATHNAME', 'bm_bitmap_page_items_bytea'
+    LANGUAGE C STRICT;

--- a/contrib/pageinspect/pageinspect.control
+++ b/contrib/pageinspect/pageinspect.control
@@ -1,5 +1,5 @@
 # pageinspect extension
 comment = 'inspect the contents of database pages at a low level'
-default_version = '1.2'
+default_version = '1.8'
 module_pathname = '$libdir/pageinspect'
 relocatable = true

--- a/src/test/isolation2/expected/bitmap_index_inspect.out
+++ b/src/test/isolation2/expected/bitmap_index_inspect.out
@@ -1,0 +1,68 @@
+-- This tests the bitmap index pageinspect functions. The tests reside here, as opposed to
+-- contrib/pageinspect because we want to leverage isolation2's utility mode syntax (since the
+-- inspect functions run against a single node, as opposed to the entire GP cluster)
+
+-- Setup
+1U: CREATE EXTENSION pageinspect;
+CREATE
+1U: CREATE TABLE bmtest_t1(i int, bmfield int);
+CREATE
+1U: CREATE INDEX bmtest_i1 ON bmtest_t1 USING bitmap(bmfield);
+CREATE
+1U: INSERT INTO bmtest_t1 SELECT i,1 FROM generate_series(1, 1000) i;
+INSERT 1000
+1U: INSERT INTO bmtest_t1 SELECT i,2 FROM generate_series(1, 1000) i;
+INSERT 1000
+
+-- start_matchsubs
+-- m/bmfuncs.c:\d+/
+-- s/bmfuncs.c:\d+/bmfuncs.c:XXX/g
+-- end_matchsubs
+
+-- Test metapage
+1U: SELECT magic, version, regexp_replace(auxrelid::regclass::text,'[[:digit:]]+', 'auxrelid') AS auxrelname, regexp_replace(auxindexrelid::regclass::text,'[[:digit:]]+', 'auxindrelid') AS auxindexrelname FROM bm_metap('bmtest_i1');
+ magic      | version | auxrelname                    | auxindexrelname                        
+------------+---------+-------------------------------+----------------------------------------
+ 1112101965 | 2       | pg_bitmapindex.pg_bm_auxrelid | pg_bitmapindex.pg_bm_auxindrelid_index 
+(1 row)
+
+-- Test LOV item pages
+-- Negative cases (not a LOV page)
+1U: SELECT * FROM bm_lov_page_items('bmtest_i1', 0);
+ERROR:  block 0 is a meta page (bmfuncs.c:246)
+1U: SELECT * FROM bm_lov_page_items('bmtest_i1', 2);
+ERROR:  block 2 is not an LOV page, it is a bitmap page (bmfuncs.c:273)
+-- Positive test
+1U: SELECT * FROM bm_lov_page_items('bmtest_i1', 1) order by itemoffset;
+ itemoffset | lov_head_blkno | lov_tail_blkno | last_complete_word      | last_word               | last_tid | last_setbit_tid | is_last_complete_word_fill | is_last_word_fill 
+------------+----------------+----------------+-------------------------+-------------------------+----------+-----------------+----------------------------+-------------------
+ 1          | 4294967295     | 4294967295     | ff ff ff ff ff ff ff ff | 00 00 00 00 00 00 00 00 | 0        | 0               | f                          | f                 
+ 2          | 2              | 2              | 80 00 00 00 00 00 00 01 | 00 00 00 00 07 ff ff ff | 65600    | 65627           | t                          | f                 
+ 3          | 3              | 3              | 80 00 00 00 00 00 00 02 | 00 3f ff ff ff ff ff ff | 131200   | 131254          | t                          | f                 
+(3 rows)
+
+-- Test bitmap pages
+-- Negative cases (not a bitmap page)
+1U: SELECT * FROM bm_bitmap_page_items('bmtest_i1', 0);
+ERROR:  block 0 is a meta page (bmfuncs.c:480)
+1U: SELECT * FROM bm_bitmap_page_items('bmtest_i1', 1);
+ERROR:  block 1 is not a bitmap page, it is a LOV item page (bmfuncs.c:507)
+-- Positive test
+1U: SELECT * FROM bm_bitmap_page_header('bmtest_i1', 2);
+ num_words | next_blkno | last_tid 
+-----------+------------+----------
+ 3         | 4294967295 | 65536    
+(1 row)
+1U: SELECT * FROM bm_bitmap_page_items('bmtest_i1', 2) order by word_num;
+ word_num | compressed | content_word            
+----------+------------+-------------------------
+ 0        | t          | 80 00 00 00 00 00 00 0e 
+ 1        | f          | 00 00 00 00 00 00 1f ff 
+ 2        | t          | 00 00 00 00 00 00 03 f1 
+(3 rows)
+
+-- cleanup
+1U: DROP TABLE bmtest_t1;
+DROP
+1U: DROP EXTENSION pageinspect;
+DROP

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -94,6 +94,7 @@ test: bitmap_update_words_backup_block
 test: bitmap_index_crash
 test: bitmap_index_concurrent
 test: bitmap_union
+test: bitmap_index_inspect
 
 # below test utilizes fault injectors so it needs to be in a group by itself
 test: external_table

--- a/src/test/isolation2/sql/bitmap_index_inspect.sql
+++ b/src/test/isolation2/sql/bitmap_index_inspect.sql
@@ -1,0 +1,38 @@
+-- This tests the bitmap index pageinspect functions. The tests reside here, as opposed to
+-- contrib/pageinspect because we want to leverage isolation2's utility mode syntax (since the
+-- inspect functions run against a single node, as opposed to the entire GP cluster)
+
+-- Setup
+1U: CREATE EXTENSION pageinspect;
+1U: CREATE TABLE bmtest_t1(i int, bmfield int);
+1U: CREATE INDEX bmtest_i1 ON bmtest_t1 USING bitmap(bmfield);
+1U: INSERT INTO bmtest_t1 SELECT i,1 FROM generate_series(1, 1000) i;
+1U: INSERT INTO bmtest_t1 SELECT i,2 FROM generate_series(1, 1000) i;
+
+-- start_matchsubs
+-- m/bmfuncs.c:\d+/
+-- s/bmfuncs.c:\d+/bmfuncs.c:XXX/g
+-- end_matchsubs
+
+-- Test metapage
+1U: SELECT magic, version, regexp_replace(auxrelid::regclass::text,'[[:digit:]]+', 'auxrelid') AS auxrelname,
+           regexp_replace(auxindexrelid::regclass::text,'[[:digit:]]+', 'auxindrelid') AS auxindexrelname FROM bm_metap('bmtest_i1');
+
+-- Test LOV item pages
+-- Negative cases (not a LOV page)
+1U: SELECT * FROM bm_lov_page_items('bmtest_i1', 0);
+1U: SELECT * FROM bm_lov_page_items('bmtest_i1', 2);
+-- Positive test
+1U: SELECT * FROM bm_lov_page_items('bmtest_i1', 1) order by itemoffset;
+
+-- Test bitmap pages
+-- Negative cases (not a bitmap page)
+1U: SELECT * FROM bm_bitmap_page_items('bmtest_i1', 0);
+1U: SELECT * FROM bm_bitmap_page_items('bmtest_i1', 1);
+-- Positive test
+1U: SELECT * FROM bm_bitmap_page_header('bmtest_i1', 2);
+1U: SELECT * FROM bm_bitmap_page_items('bmtest_i1', 2) order by word_num;
+
+-- cleanup
+1U: DROP TABLE bmtest_t1;
+1U: DROP EXTENSION pageinspect;


### PR DESCRIPTION
Original 7X PR: https://github.com/greenplum-db/gpdb/pull/12944

Add pageinspect functions and tests for bitmap meta page, LOV page
items and bitmap pages.

Features that can be added later: bm_page_stats(), similar to
bt_page_stats().

Co-authored-by: Soumyadeep Chakraborty <soumyadeep2007@gmail.com>

### Note
Cherrypicking was mostly clean except for:
* Adding upgrading script 1.2->1.8 instead of 1.7->1.8 like that in 7X, since 6X only has 1.2, and we have to skip versions between 1.2 and 1.8 to make sure we can upgrade from 6X to 7X in future (see @soumyadeep2007 's comment below).
* Removing `PARALLEL` keywords from the function definitions in the scripts since that's not supported in 6X.