### PR TITLE
add testcase for restore guc of empty string

### DIFF
--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -61,6 +61,7 @@
 #include "cdb/cdbvars.h"
 #include "cdb/memquota.h"
 #include "utils/metrics_utils.h"
+#include "utils/faultinjector.h"
 
 typedef struct
 {
@@ -324,7 +325,14 @@ ExecCreateTableAs(CreateTableAsStmt *stmt, const char *queryString,
 			return InvalidObjectAddress;
 		}
 	}
-
+#ifdef FAULT_INJECTOR
+	if (SIMPLE_FAULT_INJECTOR("change_string_guc") == FaultInjectorTypeSkip)
+	{
+		(void) set_config_option("search_path", "public",
+						 PGC_USERSET, PGC_S_SESSION,
+						 GUC_ACTION_SAVE, true, 0, false);
+	}
+#endif
 	/*
 	 * Create the tuple receiver object and insert info it will need
 	 */

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1631,6 +1631,10 @@ restore_guc_to_QE(void )
 		}
 		PG_CATCH();
 		{
+
+#ifdef FAULT_INJECTOR
+			SIMPLE_FAULT_INJECTOR("restore_string_guc");
+#endif
 			/* if some guc can not restore successful
 			 * we can not keep alive gang anymore.
 			 */

--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -438,7 +438,7 @@ SELECT pg_catalog.set_config('search_path', '', false);
 (1 row)
 
 -- trigger inject fault of change_string_guc, and add this guc to gp_guc_restore_list
-create  MATERIALIZED VIEW public.view_restore_guc_test as select * from public.restore_guc_test;
+create MATERIALIZED VIEW public.view_restore_guc_test as select * from public.restore_guc_test;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 --we should restore gucs in gp_guc_restore_list to qe, no error occurs.
 drop MATERIALIZED VIEW public.view_restore_guc_test;

--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -408,3 +408,52 @@ SHOW search_path;
 (1 row)
 
 RESET search_path;
+-- when the original string guc is empty, we change the guc to new value during executing a command.
+-- this guc will be added to gp_guc_restore_list, and they will be restored
+-- to original value to qe when the next command is executed.
+-- however, the dispatch command is "set xxx to ;" that is wrong.
+create extension if not exists gp_inject_fault;
+create table public.restore_guc_test(tc1 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'tc1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- inject fault to change the value of search_path during creating materialized view
+SELECT gp_inject_fault('change_string_guc', 'skip', 1);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- inject fault when dispatch guc restore command occur errors, we throw an error.
+SELECT gp_inject_fault('restore_string_guc', 'error', 1);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- set search_path to '';
+SELECT pg_catalog.set_config('search_path', '', false);
+ set_config 
+------------
+ 
+(1 row)
+
+-- trigger inject fault of change_string_guc, and add this guc to gp_guc_restore_list
+create  MATERIALIZED VIEW public.view_restore_guc_test as select * from public.restore_guc_test;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+--we should restore gucs in gp_guc_restore_list to qe, no error occurs.
+drop MATERIALIZED VIEW public.view_restore_guc_test;
+drop table public.restore_guc_test;
+--cleanup
+reset search_path;
+SELECT gp_inject_fault('change_string_guc', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+SELECT gp_inject_fault('restore_string_guc', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+

--- a/src/test/regress/sql/guc_gp.sql
+++ b/src/test/regress/sql/guc_gp.sql
@@ -259,7 +259,7 @@ SELECT gp_inject_fault('restore_string_guc', 'error', 1);
 -- set search_path to '';
 SELECT pg_catalog.set_config('search_path', '', false);
 -- trigger inject fault of change_string_guc, and add this guc to gp_guc_restore_list
-create  MATERIALIZED VIEW public.view_restore_guc_test as select * from public.restore_guc_test;
+create MATERIALIZED VIEW public.view_restore_guc_test as select * from public.restore_guc_test;
 
 --we should restore gucs in gp_guc_restore_list to qe, no error occurs.
 drop MATERIALIZED VIEW public.view_restore_guc_test;

--- a/src/test/regress/sql/guc_gp.sql
+++ b/src/test/regress/sql/guc_gp.sql
@@ -243,3 +243,29 @@ SHOW search_path;
 SET search_path = '\path';
 SHOW search_path;
 RESET search_path;
+
+-- when the original string guc is empty, we change the guc to new value during executing a command.
+-- this guc will be added to gp_guc_restore_list, and they will be restored
+-- to original value to qe when the next command is executed.
+-- however, the dispatch command is "set xxx to ;" that is wrong.
+create extension if not exists gp_inject_fault;
+create table public.restore_guc_test(tc1 int);
+
+-- inject fault to change the value of search_path during creating materialized view
+SELECT gp_inject_fault('change_string_guc', 'skip', 1);
+-- inject fault when dispatch guc restore command occur errors, we throw an error.
+SELECT gp_inject_fault('restore_string_guc', 'error', 1);
+
+-- set search_path to '';
+SELECT pg_catalog.set_config('search_path', '', false);
+-- trigger inject fault of change_string_guc, and add this guc to gp_guc_restore_list
+create  MATERIALIZED VIEW public.view_restore_guc_test as select * from public.restore_guc_test;
+
+--we should restore gucs in gp_guc_restore_list to qe, no error occurs.
+drop MATERIALIZED VIEW public.view_restore_guc_test;
+drop table public.restore_guc_test;
+
+--cleanup
+reset search_path;
+SELECT gp_inject_fault('change_string_guc', 'reset', 1);
+SELECT gp_inject_fault('restore_string_guc', 'reset', 1);


### PR DESCRIPTION
add testcase for pr: #12903 
when the original string guc is empty, we change the guc to new value during executing a command.
this guc will be added to gp_guc_restore_list, and they will be restored to original value to QE
when the next command is executed.
however, the dispatch command is "set xxx to ;" that is wrong.

we  inject fault to change the value of search_path during creating materialized view
inject fault when dispatch guc restore command occur errors, we throw an error.
