### PR TITLE
Set correct resultcollid for RelabelType

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -1223,7 +1223,7 @@ CTranslatorDXLToScalar::TranslateDXLScalarCastWithChildExpr(
 	relabel_type->location = -1;
 	relabel_type->relabelformat = COERCE_IMPLICIT_CAST;
 	// GPDB_91_MERGE_FIXME: collation
-	relabel_type->resultcollid = gpdb::TypeCollation(relabel_type->resulttype);
+	relabel_type->resultcollid = gpdb::ExprCollation((Node *) child_expr);
 
 	return (Expr *) relabel_type;
 }

--- a/src/test/regress/expected/qp_misc.out
+++ b/src/test/regress/expected/qp_misc.out
@@ -20480,3 +20480,16 @@ SELECT NULLIF( f1,'') AS f3, CASE WHEN f2 = 'A' THEN 'X' ELSE 'Z' END AS f4 FROM
     | Z
 (2 rows)
 
+-- Test Relabel get correct collation OID
+CREATE TABLE relabel_coll_test ( tkn_json JSON); 
+WITH cte_coll AS
+(
+       SELECT string_to_array( unnest( array[ coalesce(tkn_json ->> 'base', 'nullout'),      coalesce(        tkn_json ->> 'double_metaphone', 'nullout'      )      ] ), ',' ) AS tkn_arr
+       FROM   relabel_coll_test l )
+SELECT *
+FROM   cte_coll
+WHERE  tkn_arr <> '{nullout}' ;
+ tkn_arr 
+---------
+(0 rows)
+

--- a/src/test/regress/sql/qp_misc.sql
+++ b/src/test/regress/sql/qp_misc.sql
@@ -15594,3 +15594,12 @@ INSERT INTO test_nullifexpr VALUES (null,'A');
 INSERT INTO test_nullifexpr VALUES ('','y');
 ANALYZE test_nullifexpr;
 SELECT NULLIF( f1,'') AS f3, CASE WHEN f2 = 'A' THEN 'X' ELSE 'Z' END AS f4 FROM test_nullifexpr ORDER BY f3, f4;
+-- Test Relabel get correct collation OID
+CREATE TABLE relabel_coll_test ( tkn_json JSON); 
+WITH cte_coll AS
+(
+       SELECT string_to_array( unnest( array[ coalesce(tkn_json ->> 'base', 'nullout'),      coalesce(        tkn_json ->> 'double_metaphone', 'nullout'      )      ] ), ',' ) AS tkn_arr
+       FROM   relabel_coll_test l )
+SELECT *
+FROM   cte_coll
+WHERE  tkn_arr <> '{nullout}' ;


### PR DESCRIPTION
Earlier it was set to collation id of resulttype. But consider an expression
like  below :

string_to_array(unnest(anyarray)) <> '{nullout}'

annyarray has a collation oid of 0 but string_to_array returns a TEXTARRAY
which has a collation oid of 100.  So for resultcollid we should rely on
collation type of the expression.

Co-authored-by: Bhuvnesh Chaudhary bhuvnesh2703@gmail.com

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
