### PR TITLE
Disable autovacuum for isolation2/uao tests to fix flaky test cases

### DIFF
--- a/src/test/isolation2/input/uao/vacuum_cleanup.source
+++ b/src/test/isolation2/input/uao/vacuum_cleanup.source
@@ -4,7 +4,7 @@
 -- The age of the table is 1 after the following statement
 2: create table ao_@amname@_vacuum_cleanup2(a int, b int) using @amname@;
 -- The age of the table is 2 after the following statement
-2: insert into ao_@amname@_vacuum_cleanup2 select 0, i from generate_series(1, 100) i;
+2: insert into ao_@amname@_vacuum_cleanup2 select i, i from generate_series(1, 100) i;
 -- The age of the table is 7 after the following 5 statements
 2: update ao_@amname@_vacuum_cleanup2 set b = b + 1;
 2: update ao_@amname@_vacuum_cleanup2 set b = b + 1;
@@ -13,9 +13,8 @@
 2: update ao_@amname@_vacuum_cleanup2 set b = b + 1;
 
 1: set vacuum_freeze_min_age = 0;
--- Check the age of the table just before vacuum (use BETWEEN to mask minor
--- differences that might happen if e.g. autovacuum kicks in)
-1: select age(relfrozenxid) between 6 and 9, regexp_replace(replace(relname, 'ao_@amname@_vacuum_cleanup2'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','M') and (relname like '%' || 'ao_@amname@_vacuum_cleanup2'::regclass::oid || '%') and gp_segment_id = 0;
+-- Check the age of the table just before vacuum 
+1: select age(relfrozenxid), regexp_replace(replace(relname, 'ao_@amname@_vacuum_cleanup2'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','M') and (relname like '%' || 'ao_@amname@_vacuum_cleanup2'::regclass::oid || '%') and gp_segment_id = 0;
 
 -- Hold AccessShareLock to make AO VACUUM skip drop phase
 2: begin;
@@ -25,7 +24,7 @@
 -- The age should be smaller now. All the xids before the first
 -- vacuum were frozen. The relfrozenxid will be the xid of the last
 -- transaction before the vacuum (in this case it is the update statement)
-1: select age(relfrozenxid) < 7, regexp_replace(replace(relname, 'ao_@amname@_vacuum_cleanup2'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','M') and (relname like '%' || 'ao_@amname@_vacuum_cleanup2'::regclass::oid || '%') and gp_segment_id = 0;
+1: select age(relfrozenxid), regexp_replace(replace(relname, 'ao_@amname@_vacuum_cleanup2'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','M') and (relname like '%' || 'ao_@amname@_vacuum_cleanup2'::regclass::oid || '%') and gp_segment_id = 0;
 2: end;
 
 -- Check that drop phase is skipped, but still the cleanup phase is performed
@@ -36,7 +35,7 @@
 
 -- Check the age of the table before vacuum to make sure that clean phase gets
 -- performed
-1: select age(relfrozenxid) between 3 and 5, regexp_replace(replace(relname, 'ao_@amname@_vacuum_cleanup3'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','M') and (relname like '%' || 'ao_@amname@_vacuum_cleanup3'::regclass::oid || '%') and gp_segment_id = 0;
+1: select age(relfrozenxid), regexp_replace(replace(relname, 'ao_@amname@_vacuum_cleanup3'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','M') and (relname like '%' || 'ao_@amname@_vacuum_cleanup3'::regclass::oid || '%') and gp_segment_id = 0;
 1: select gp_inject_fault_infinite('vacuum_relation_open_relation_during_drop_phase', 'suspend', 1);
 1&: vacuum ao_@amname@_vacuum_cleanup3;
 
@@ -51,7 +50,7 @@
 2: select gp_inject_fault('vacuum_relation_open_relation_during_drop_phase', 'reset', 1);
 
 1<:
-1: select age(relfrozenxid) < 5, regexp_replace(replace(relname, 'ao_@amname@_vacuum_cleanup3'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','M') and (relname like '%' || 'ao_@amname@_vacuum_cleanup3'::regclass::oid || '%') and gp_segment_id = 0;
+1: select age(relfrozenxid), regexp_replace(replace(relname, 'ao_@amname@_vacuum_cleanup3'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','M') and (relname like '%' || 'ao_@amname@_vacuum_cleanup3'::regclass::oid || '%') and gp_segment_id = 0;
 
 -- Validate that the drop phase was skipped. segfile 1 should be in state 2
 -- (AWAITING_DROP)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -101,6 +101,9 @@ test: external_table
 
 test: fsync_ao
 
+# Disable auto-vacuum for below tests
+test: disable_autovacuum
+
 # Tests on Append-Optimized tables (row-oriented).
 test: concurrent_index_creation_should_not_deadlock
 test: uao/alter_while_vacuum_row uao/alter_while_vacuum2_row
@@ -199,8 +202,6 @@ test: uao/vacuum_while_vacuum_column
 test: uao/vacuum_cleanup_column
 test: uao/bitmapindex_rescan_column
 
-# Disable auto-ANALYZE for below tests
-test: disable_autovacuum
 # this case contains fault injection, must be put in a separate test group
 test: terminate_in_gang_creation
 test: prepare_limit

--- a/src/test/isolation2/output/uao/vacuum_cleanup.source
+++ b/src/test/isolation2/output/uao/vacuum_cleanup.source
@@ -5,7 +5,7 @@
 2: create table ao_@amname@_vacuum_cleanup2(a int, b int) using @amname@;
 CREATE
 -- The age of the table is 2 after the following statement
-2: insert into ao_@amname@_vacuum_cleanup2 select 0, i from generate_series(1, 100) i;
+2: insert into ao_@amname@_vacuum_cleanup2 select i, i from generate_series(1, 100) i;
 INSERT 100
 -- The age of the table is 7 after the following 5 statements
 2: update ao_@amname@_vacuum_cleanup2 set b = b + 1;
@@ -21,13 +21,12 @@ UPDATE 100
 
 1: set vacuum_freeze_min_age = 0;
 SET
--- Check the age of the table just before vacuum (use BETWEEN to mask minor
--- differences that might happen if e.g. autovacuum kicks in)
-1: select age(relfrozenxid) between 6 and 9, regexp_replace(replace(relname, 'ao_@amname@_vacuum_cleanup2'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','M') and (relname like '%' || 'ao_@amname@_vacuum_cleanup2'::regclass::oid || '%') and gp_segment_id = 0;
- ?column? | regexp_replace     
-----------+--------------------
- t        | pg_<seg>_<oid>     
- t        | pg_aovisimap_<oid> 
+-- Check the age of the table just before vacuum
+1: select age(relfrozenxid), regexp_replace(replace(relname, 'ao_@amname@_vacuum_cleanup2'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','M') and (relname like '%' || 'ao_@amname@_vacuum_cleanup2'::regclass::oid || '%') and gp_segment_id = 0;
+ age | regexp_replace     
+-----+--------------------
+ 7   | pg_<seg>_<oid>     
+ 7   | pg_aovisimap_<oid> 
 (2 rows)
 
 -- Hold AccessShareLock to make AO VACUUM skip drop phase
@@ -44,11 +43,11 @@ VACUUM
 -- The age should be smaller now. All the xids before the first
 -- vacuum were frozen. The relfrozenxid will be the xid of the last
 -- transaction before the vacuum (in this case it is the update statement)
-1: select age(relfrozenxid) < 7, regexp_replace(replace(relname, 'ao_@amname@_vacuum_cleanup2'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','M') and (relname like '%' || 'ao_@amname@_vacuum_cleanup2'::regclass::oid || '%') and gp_segment_id = 0;
- ?column? | regexp_replace     
-----------+--------------------
- t        | pg_<seg>_<oid>     
- t        | pg_aovisimap_<oid> 
+1: select age(relfrozenxid), regexp_replace(replace(relname, 'ao_@amname@_vacuum_cleanup2'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','M') and (relname like '%' || 'ao_@amname@_vacuum_cleanup2'::regclass::oid || '%') and gp_segment_id = 0;
+ age | regexp_replace     
+-----+--------------------
+ 2   | pg_<seg>_<oid>     
+ 2   | pg_aovisimap_<oid> 
 (2 rows)
 2: end;
 END
@@ -64,11 +63,11 @@ DELETE 100
 
 -- Check the age of the table before vacuum to make sure that clean phase gets
 -- performed
-1: select age(relfrozenxid) between 3 and 5, regexp_replace(replace(relname, 'ao_@amname@_vacuum_cleanup3'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','M') and (relname like '%' || 'ao_@amname@_vacuum_cleanup3'::regclass::oid || '%') and gp_segment_id = 0;
- ?column? | regexp_replace     
-----------+--------------------
- t        | pg_<seg>_<oid>     
- t        | pg_aovisimap_<oid> 
+1: select age(relfrozenxid), regexp_replace(replace(relname, 'ao_@amname@_vacuum_cleanup3'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','M') and (relname like '%' || 'ao_@amname@_vacuum_cleanup3'::regclass::oid || '%') and gp_segment_id = 0;
+ age | regexp_replace     
+-----+--------------------
+ 3   | pg_<seg>_<oid>     
+ 3   | pg_aovisimap_<oid> 
 (2 rows)
 1: select gp_inject_fault_infinite('vacuum_relation_open_relation_during_drop_phase', 'suspend', 1);
  gp_inject_fault_infinite 
@@ -101,11 +100,11 @@ BEGIN
 
 1<:  <... completed>
 VACUUM
-1: select age(relfrozenxid) < 5, regexp_replace(replace(relname, 'ao_@amname@_vacuum_cleanup3'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','M') and (relname like '%' || 'ao_@amname@_vacuum_cleanup3'::regclass::oid || '%') and gp_segment_id = 0;
- ?column? | regexp_replace     
-----------+--------------------
- t        | pg_<seg>_<oid>     
- t        | pg_aovisimap_<oid> 
+1: select age(relfrozenxid), regexp_replace(replace(relname, 'ao_@amname@_vacuum_cleanup3'::regclass::oid::text, '<oid>'), 'ao.*seg', '<seg>') from gp_dist_random('pg_class') where relkind in ('r','t','o','b','M') and (relname like '%' || 'ao_@amname@_vacuum_cleanup3'::regclass::oid || '%') and gp_segment_id = 0;
+ age | regexp_replace     
+-----+--------------------
+ 2   | pg_<seg>_<oid>     
+ 2   | pg_aovisimap_<oid> 
 (2 rows)
 
 -- Validate that the drop phase was skipped. segfile 1 should be in state 2


### PR DESCRIPTION
Autovacuum jobs that are running in the background could cause flaky test cases such as in uao/vacuum_cleanup_row where checking the age of some tables on the segments becomes larger than expected because autovacuum running on the segments.

Since all the uao tests do not need autovacuum, disable it for them (there's already a bunch of tests with autovacuum being disabled, we just include the uao tests there too). 

And in particular, we can now check the exact age instead of an age range in the vacuum_cleanup tests since those results should be deterministic now. Therefore, we don't need to guess around should another failure happens.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
