### PR TITLE
fix: before insert/update row trigger that modifies the distributed key

### DIFF
--- a/gpcontrib/orafce/expected/orafce.out
+++ b/gpcontrib/orafce/expected/orafce.out
@@ -4322,27 +4322,27 @@ CREATE TRIGGER trg_test_xx BEFORE INSERT OR UPDATE
   ON trg_test FOR EACH ROW EXECUTE PROCEDURE oracle.replace_empty_strings(true);
 \pset null ***
 INSERT INTO trg_test VALUES('',10, 'AHOJ', NULL, NULL);
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported
 WARNING:  Field "a" of table "trg_test" is empty string (replaced by NULL).
 INSERT INTO trg_test VALUES('AHOJ', NULL, '', '2020-01-01', 100);
 WARNING:  Field "c" of table "trg_test" is empty string (replaced by NULL).
 SELECT * FROM trg_test;
-  a   |  b  |  c   |     d      |  e  
-------+-----+------+------------+-----
- ***  |  10 | AHOJ | ***        | ***
- AHOJ | *** | ***  | 2020-01-01 | 100
-(2 rows)
+  a   |  b  |  c  |     d      |  e  
+------+-----+-----+------------+-----
+ AHOJ | *** | *** | 2020-01-01 | 100
+(1 row)
 
 DELETE FROM trg_test;
 DROP TRIGGER trg_test_xx ON trg_test;
 CREATE TRIGGER trg_test_xx BEFORE INSERT OR UPDATE
   ON trg_test FOR EACH ROW EXECUTE PROCEDURE oracle.replace_null_strings();
 INSERT INTO trg_test VALUES(NULL, 10, 'AHOJ', NULL, NULL);
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported
 INSERT INTO trg_test VALUES('AHOJ', NULL, NULL, '2020-01-01', 100);
 SELECT * FROM trg_test;
-  a   |  b  |  c   |     d      |  e  
-------+-----+------+------------+-----
-      |  10 | AHOJ | ***        | ***
- AHOJ | *** |      | 2020-01-01 | 100
-(2 rows)
+  a   |  b  | c |     d      |  e  
+------+-----+---+------------+-----
+ AHOJ | *** |   | 2020-01-01 | 100
+(1 row)
 
 DROP TABLE trg_test;

--- a/src/pl/plpython/expected/plpython_trigger.out
+++ b/src/pl/plpython/expected/plpython_trigger.out
@@ -534,19 +534,19 @@ CREATE TABLE b(data int); -- different type conversion
 CREATE TRIGGER a_t BEFORE INSERT ON a FOR EACH ROW EXECUTE PROCEDURE trig1234();
 CREATE TRIGGER b_t BEFORE INSERT ON b FOR EACH ROW EXECUTE PROCEDURE trig1234();
 INSERT INTO a DEFAULT VALUES;
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported
 SELECT * FROM a;
  data 
 ------
- 1234
-(1 row)
+(0 rows)
 
 DROP TABLE a;
 INSERT INTO b DEFAULT VALUES;
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported
 SELECT * FROM b;
  data 
 ------
- 1234
-(1 row)
+(0 rows)
 
 -- check that SQL run in trigger code can see transition tables
 CREATE TABLE transition_table_test (id int, name text);

--- a/src/pl/plpython/expected/plpython_unicode.out
+++ b/src/pl/plpython/expected/plpython_unicode.out
@@ -36,11 +36,11 @@ SELECT unicode_return();
 (1 row)
 
 INSERT INTO unicode_test (testvalue) VALUES ('test');
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported
 SELECT * FROM unicode_test;
  testvalue 
 -----------
-  
-(1 row)
+(0 rows)
 
 SELECT unicode_plan1();
  unicode_plan1 

--- a/src/test/regress/expected/expand_table_regression.out
+++ b/src/test/regress/expected/expand_table_regression.out
@@ -43,37 +43,18 @@ truncate b;
 create trigger b_t before insert on b for each row execute procedure trig345();
 -- however with the trigger it is inserted on seg1
 insert into b select i from generate_series(1, 10) i;
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported
 select gp_segment_id, * from b;
  gp_segment_id | data 
 ---------------+------
-             1 |  345
-             1 |  345
-             0 |  345
-             0 |  345
-             0 |  345
-             0 |  345
-             0 |  345
-             0 |  345
-             0 |  345
-             0 |  345
-(10 rows)
+(0 rows)
 
 -- data expansion should tolerant it
 alter table b expand table;
 select gp_segment_id, * from b;
  gp_segment_id | data 
 ---------------+------
-             0 |  345
-             0 |  345
-             0 |  345
-             0 |  345
-             0 |  345
-             0 |  345
-             0 |  345
-             0 |  345
-             0 |  345
-             0 |  345
-(10 rows)
+(0 rows)
 
 -- start_ignore
 -- We need to do a cluster expansion which will check if there are partial

--- a/src/test/regress/expected/insert.out
+++ b/src/test/regress/expected/insert.out
@@ -806,11 +806,9 @@ create table brtrigpartcon1 partition of brtrigpartcon for values in (1);
 create or replace function brtrigpartcon1trigf() returns trigger as $$begin new.a := 2; return new; end$$ language plpgsql;
 create trigger brtrigpartcon1trig before insert on brtrigpartcon1 for each row execute procedure brtrigpartcon1trigf();
 insert into brtrigpartcon values (1, 'hi there');
-ERROR:  new row for relation "brtrigpartcon1" violates partition constraint
-DETAIL:  Failing row contains (2, hi there).
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported
 insert into brtrigpartcon1 values (1, 'hi there');
-ERROR:  new row for relation "brtrigpartcon1" violates partition constraint
-DETAIL:  Failing row contains (2, hi there).
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported
 -- check that the message shows the appropriate column description in a
 -- situation where the partitioned table is not the primary ModifyTable node
 create table inserttest3 (f1 text default 'foo', f2 text default 'bar', f3 int);

--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -4785,28 +4785,25 @@ BEFORE INSERT OR UPDATE ON qp_misc_jiras.test_trig
 FOR EACH ROW
     EXECUTE PROCEDURE fn_trig();
 INSERT INTO qp_misc_jiras.test_trig VALUES (0, 'after creating trigger');
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported
 NOTICE:  1  (seg1 127.0.0.1:40001 pid=16301)
 INSERT INTO qp_misc_jiras.test_trig VALUES (1, 'aaa');
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported
 NOTICE:  2  (seg1 127.0.0.1:40001 pid=16301)
 SELECT gp_segment_id, * FROM qp_misc_jiras.test_trig;
  gp_segment_id | id |           aaa           
 ---------------+----+-------------------------
              1 |  1 | before creating trigger
-             1 |  1 | after creating trigger1
-             1 |  2 | aaa1
-(3 rows)
+(1 row)
 
 UPDATE qp_misc_jiras.test_trig SET id = id;
 NOTICE:  2  (seg1 127.0.0.1:40001 pid=16301)
-NOTICE:  2  (seg1 127.0.0.1:40001 pid=16301)
-NOTICE:  3  (seg1 127.0.0.1:40001 pid=16301)
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported
 SELECT gp_segment_id, * FROM qp_misc_jiras.test_trig;
- gp_segment_id | id |           aaa            
----------------+----+--------------------------
-             1 |  2 | before creating trigger1
-             1 |  2 | after creating trigger11
-             1 |  3 | aaa11
-(3 rows)
+ gp_segment_id | id |           aaa           
+---------------+----+-------------------------
+             1 |  1 | before creating trigger
+(1 row)
 
 DROP TABLE qp_misc_jiras.test_trig;
 DROP FUNCTION fn_trig();

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -4762,28 +4762,25 @@ BEFORE INSERT OR UPDATE ON qp_misc_jiras.test_trig
 FOR EACH ROW
     EXECUTE PROCEDURE fn_trig();
 INSERT INTO qp_misc_jiras.test_trig VALUES (0, 'after creating trigger');
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported
 NOTICE:  1  (seg1 127.0.0.1:40001 pid=16301)
 INSERT INTO qp_misc_jiras.test_trig VALUES (1, 'aaa');
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported
 NOTICE:  2  (seg1 127.0.0.1:40001 pid=16301)
 SELECT gp_segment_id, * FROM qp_misc_jiras.test_trig;
  gp_segment_id | id |           aaa           
 ---------------+----+-------------------------
              1 |  1 | before creating trigger
-             1 |  1 | after creating trigger1
-             1 |  2 | aaa1
-(3 rows)
+(1 row)
 
 UPDATE qp_misc_jiras.test_trig SET id = id;
 NOTICE:  2  (seg1 127.0.0.1:40001 pid=16301)
-NOTICE:  2  (seg1 127.0.0.1:40001 pid=16301)
-NOTICE:  3  (seg1 127.0.0.1:40001 pid=16301)
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported
 SELECT gp_segment_id, * FROM qp_misc_jiras.test_trig;
- gp_segment_id | id |           aaa            
----------------+----+--------------------------
-             1 |  2 | before creating trigger1
-             1 |  2 | after creating trigger11
-             1 |  3 | aaa11
-(3 rows)
+ gp_segment_id | id |           aaa           
+---------------+----+-------------------------
+             1 |  1 | before creating trigger
+(1 row)
 
 DROP TABLE qp_misc_jiras.test_trig;
 DROP FUNCTION fn_trig();

--- a/src/test/regress/expected/triggers.out
+++ b/src/test/regress/expected/triggers.out
@@ -1715,42 +1715,36 @@ WARNING:  after insert (new): (1,black)
 insert into upsert values(2, 'red') on conflict (key) do update set color = 'updated ' || upsert.color;
 WARNING:  before insert (new): (2,red)
 WARNING:  before insert (new, modified): (3,"red trig modified")
-WARNING:  after insert (new): (3,"red trig modified")
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported
 insert into upsert values(3, 'orange') on conflict (key) do update set color = 'updated ' || upsert.color;
 WARNING:  before insert (new): (3,orange)
-WARNING:  before update (old): (3,"red trig modified")
-WARNING:  before update (new): (3,"updated red trig modified")
-WARNING:  after update (old): (3,"red trig modified")
-WARNING:  after update (new): (3,"updated red trig modified")
+WARNING:  after insert (new): (3,orange)
 insert into upsert values(4, 'green') on conflict (key) do update set color = 'updated ' || upsert.color;
 WARNING:  before insert (new): (4,green)
 WARNING:  before insert (new, modified): (5,"green trig modified")
-WARNING:  after insert (new): (5,"green trig modified")
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported
 insert into upsert values(5, 'purple') on conflict (key) do update set color = 'updated ' || upsert.color;
 WARNING:  before insert (new): (5,purple)
 WARNING:  after insert (new): (5,purple)
 insert into upsert values(6, 'white') on conflict (key) do update set color = 'updated ' || upsert.color;
 WARNING:  before insert (new): (6,white)
 WARNING:  before insert (new, modified): (7,"white trig modified")
-WARNING:  after insert (new): (7,"white trig modified")
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported
 insert into upsert values(7, 'pink') on conflict (key) do update set color = 'updated ' || upsert.color;
 WARNING:  before insert (new): (7,pink)
 WARNING:  after insert (new): (7,pink)
 insert into upsert values(8, 'yellow') on conflict (key) do update set color = 'updated ' || upsert.color;
 WARNING:  before insert (new): (8,yellow)
 WARNING:  before insert (new, modified): (9,"yellow trig modified")
-WARNING:  after insert (new): (9,"yellow trig modified")
+ERROR:  Modifying distributed key in a BEFORE FOR EACH ROW trigger is not supported
 select * from upsert;
- key |           color           
------+---------------------------
-   3 | updated red trig modified
-   5 | green trig modified
+ key | color  
+-----+--------
+   3 | orange
    7 | pink
-   9 | yellow trig modified
    1 | black
    5 | purple
-   7 | white trig modified
-(7 rows)
+(4 rows)
 
 drop table upsert;
 drop function upsert_before_func();


### PR DESCRIPTION
If the insert/update before row trigger modifies the distributed key,
that would destroy the distributed rule, we should not allow this happen.

The illustration case:

create table t(id int primary key, color text) distributed by(id);

create or replace function insert_before_row() returns trigger as
$$
begin
  new.id = new.id + 1;
  return new;
end;
$$ language plpgsql;

create trigger insert_before_trig before insert on t
  for each row execute procedure insert_before_row();

insert into t values(1, 'red');

select * from t;
 id | color
----+-------
  2 | red
(1 row)

-- no rows return beacuse the row stored in the segment that
-- hashed by value 1, not 2.
select * from t where id=2;
 id | color
----+-------
(0 rows)

-- no rows retrun beacuse the row is filtered out by condition of
-- "id=1".
select * from t where id=1;
 id | color
----+-------
(0 rows)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
