### PR TITLE
[6x] Add another version of gp_inject_funtion() to fix flaky case

### DIFF
--- a/gpcontrib/gp_inject_fault/gp_inject_fault.c
+++ b/gpcontrib/gp_inject_fault/gp_inject_fault.c
@@ -71,6 +71,11 @@ gp_inject_fault(PG_FUNCTION_ARGS)
 	int		endOccurrence = PG_GETARG_INT32(6);
 	int		extraArg = PG_GETARG_INT32(7);
 	int		dbid = PG_GETARG_INT32(8);
+	/*
+	 * gpSessionid: -1 means the fault could be triggered by any process,
+	 * others mean the fault could only be triggered by the specific session.
+	 */
+	int     gpSessionid = PG_GETARG_INT32(9);
 	char	*hostname;
 	int		port;
 	char	*response;
@@ -81,7 +86,7 @@ gp_inject_fault(PG_FUNCTION_ARGS)
 	{
 		response = InjectFault(
 			faultName, type, ddlStatement, databaseName,
-			tableName, startOccurrence, endOccurrence, extraArg);
+			tableName, startOccurrence, endOccurrence, extraArg, gpSessionid);
 		if (!response)
 			elog(ERROR, "failed to inject fault locally (dbid %d)", dbid);
 		if (strncmp(response, "Success:",  strlen("Success:")) != 0)
@@ -113,14 +118,15 @@ gp_inject_fault(PG_FUNCTION_ARGS)
 		if (!tableName || tableName[0] == '\0')
 			tableName = "#";
 		snprintf(msg, 1024, "faultname=%s type=%s ddl=%s db=%s table=%s "
-				 "start=%d end=%d extra=%d",
+				 "start=%d end=%d extra=%d sid=%d ",
 				 faultName, type,
 				 ddlStatement,
 				 databaseName,
 				 tableName,
 				 startOccurrence,
 				 endOccurrence,
-				 extraArg);
+				 extraArg,
+				 gpSessionid);
 		res = PQexec(conn, msg);
 		if (PQresultStatus(res) != PGRES_TUPLES_OK)
 			elog(ERROR, "failed to inject fault: %s", PQerrorMessage(conn));

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -24,6 +24,7 @@
 #include <signal.h>
 #include "access/xact.h"
 #include "cdb/cdbutil.h"
+#include "cdb/cdbvars.h"
 #include "libpq/libpq.h"
 #include "libpq/pqformat.h"
 #include "postmaster/autovacuum.h"
@@ -291,6 +292,10 @@ FaultInjector_InjectFaultIfSet_out_of_line(
 	{
 		if (entryShared == NULL)
 			/* fault injection is not set */
+			break;
+
+		if (entryShared->gpSessionid != InvalidGpSessionId && entryShared->gpSessionid != gp_session_id)
+			/* fault injection is not set for the specified session */
 			break;
 
 		if (entryShared->ddlStatement != ddlStatement)
@@ -666,6 +671,8 @@ FaultInjector_NewHashEntry(
 	entryLocal->startOccurrence = entry->startOccurrence;
 	entryLocal->endOccurrence = entry->endOccurrence;
 
+	entryLocal->gpSessionid = entry->gpSessionid;
+
 	entryLocal->numTimesTriggered = 0;
 	strcpy(entryLocal->databaseName, entry->databaseName);
 	strcpy(entryLocal->tableName, entry->tableName);
@@ -907,12 +914,13 @@ HandleFaultMessage(const char* msg)
 	int start;
 	int end;
 	int extra;
+	int sid;
 	char *result;
 	int len;
 
 	if (sscanf(msg, "faultname=%s type=%s ddl=%s db=%s table=%s "
-			   "start=%d end=%d extra=%d",
-			   name, type, ddl, db, table, &start, &end, &extra) != 8)
+			   "start=%d end=%d extra=%d sid=%d",
+			   name, type, ddl, db, table, &start, &end, &extra, &sid) != 9)
 		elog(ERROR, "invalid fault message: %s", msg);
 	/* The value '#' means not specified. */
 	if (ddl[0] == '#')
@@ -922,7 +930,7 @@ HandleFaultMessage(const char* msg)
 	if (table[0] == '#')
 		table[0] = '\0';
 
-	result = InjectFault(name, type, ddl, db, table, start, end, extra);
+	result = InjectFault(name, type, ddl, db, table, start, end, extra, sid);
 	len = strlen(result);
 
 	StringInfoData buf;
@@ -951,14 +959,14 @@ HandleFaultMessage(const char* msg)
 
 char *
 InjectFault(char *faultName, char *type, char *ddlStatement, char *databaseName,
-			char *tableName, int startOccurrence, int endOccurrence, int extraArg)
+			char *tableName, int startOccurrence, int endOccurrence, int extraArg, int gpSessionid)
 {
 	StringInfo buf = makeStringInfo();
 	FaultInjectorEntry_s faultEntry;
 
-	elog(DEBUG1, "injecting fault: name %s, type %s, DDL %s, db %s, table %s, startOccurrence %d, endOccurrence %d, extraArg %d",
+	elog(DEBUG1, "injecting fault: name %s, type %s, DDL %s, db %s, table %s, startOccurrence %d, endOccurrence %d, extraArg %d, sid %d",
 		 faultName, type, ddlStatement, databaseName, tableName,
-		 startOccurrence, endOccurrence, extraArg );
+		 startOccurrence, endOccurrence, extraArg, gpSessionid );
 
 	if (strlcpy(faultEntry.faultName, faultName, sizeof(faultEntry.faultName)) >=
 		sizeof(faultEntry.faultName))
@@ -1026,6 +1034,8 @@ InjectFault(char *faultName, char *type, char *ddlStatement, char *databaseName,
 
 	faultEntry.startOccurrence = startOccurrence;
 	faultEntry.endOccurrence = endOccurrence;
+
+	faultEntry.gpSessionid = gpSessionid;
 
 	if (FaultInjector_SetFaultInjection(&faultEntry) == STATUS_OK)
 	{

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -62,7 +62,9 @@ typedef struct FaultInjectorEntry_s {
 	
 	int						extraArg;
 		/* in seconds, in use if fault injection type is sleep */
-		
+	int						gpSessionid;
+		/* -1 means the fault can be triggered by any process */
+
 	DDLStatement_e			ddlStatement;
 	
 	char					databaseName[NAMEDATALEN];
@@ -105,7 +107,7 @@ extern int *numActiveFaults_ptr;
 
 extern char *InjectFault(
 	char *faultName, char *type, char *ddlStatement, char *databaseName,
-	char *tableName, int startOccurrence, int endOccurrence, int extraArg);
+	char *tableName, int startOccurrence, int endOccurrence, int extraArg, int gpSessionid);
 
 extern void HandleFaultMessage(const char* msg);
 

--- a/src/test/regress/expected/psql_gp_commands.out
+++ b/src/test/regress/expected/psql_gp_commands.out
@@ -14,16 +14,18 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 (1 row)
 
 \dx+ gp_inject*
-                       Objects in extension "gp_inject_fault"
-                                 Object Description                                 
-------------------------------------------------------------------------------------
+                           Objects in extension "gp_inject_fault"
+                                     Object Description                                     
+--------------------------------------------------------------------------------------------
  function force_mirrors_to_catch_up()
  function gp_inject_fault(text,text,integer)
+ function gp_inject_fault(text,text,integer,integer)
  function gp_inject_fault(text,text,text,text,text,integer,integer,integer,integer)
+ function gp_inject_fault(text,text,text,text,text,integer,integer,integer,integer,integer)
  function gp_inject_fault_infinite(text,text,integer)
  function gp_wait_until_triggered_fault(text,integer,integer)
  function insert_noop_xlog_record()
-(6 rows)
+(8 rows)
 
 --
 -- Test extended \du flags

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -262,7 +262,8 @@ where dispatch_test_t1.c2 = dispatch_test_t2.c2 and dispatch_test_t2.c3 = dispat
 select cleanupAllGangs();
 
 -- segment 0 report an error when get a request 
-select gp_inject_fault('send_qe_details_init_backend', 'error', 2);
+-- the fault may be triggered by other backend process, such as dtx recovery process, specify a session id.
+select gp_inject_fault('send_qe_details_init_backend', 'error', 2, current_setting('gp_session_id')::int);
 select cleanupAllGangs();
 
 -- expect failure
@@ -280,7 +281,8 @@ select cleanupAllGangs();
 
 select gp_inject_fault('send_qe_details_init_backend', 'reset', 2);
 -- segment 0 report an error when get the second request (reader gang creation request)
-select gp_inject_fault('send_qe_details_init_backend', 'error', '', '', '', 3, 3, 0, 2::smallint);
+-- the fault may be triggered by other backend process, such as dtx recovery process, specify a session id.
+select gp_inject_fault('send_qe_details_init_backend', 'error', '', '', '', 3, 3, 0, 2::smallint, current_setting('gp_session_id')::int);
 select cleanupAllGangs();
 
 -- expect failure

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -411,7 +411,8 @@ select cleanupAllGangs();
 (1 row)
 
 -- segment 0 report an error when get a request 
-select gp_inject_fault('send_qe_details_init_backend', 'error', 2);
+-- the fault may be triggered by other backend process, such as dtx recovery process, specify a session id.
+select gp_inject_fault('send_qe_details_init_backend', 'error', 2, current_setting('gp_session_id')::int);
  gp_inject_fault 
 -----------------
  Success:
@@ -457,7 +458,8 @@ select gp_inject_fault('send_qe_details_init_backend', 'reset', 2);
 (1 row)
 
 -- segment 0 report an error when get the second request (reader gang creation request)
-select gp_inject_fault('send_qe_details_init_backend', 'error', '', '', '', 3, 3, 0, 2::smallint);
+-- the fault may be triggered by other backend process, such as dtx recovery process, specify a session id.
+select gp_inject_fault('send_qe_details_init_backend', 'error', '', '', '', 3, 3, 0, 2::smallint, current_setting('gp_session_id')::int);
  gp_inject_fault 
 -----------------
  Success:


### PR DESCRIPTION
The fault 'send_qe_details_init_backend' injected in dispatch.source was
triggered by other backend processes by accident, which makes the
dispatch case flaky.

This commit provide another version of gp_inject_funtion() with an extra
parameter, so that the fault could be fixed by specific session, to
avoid the fault triggered by other backend process unexpectly.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
