### PR TITLE
Speed up AOCS index build by only scan needed columns.

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -31,6 +31,7 @@
 #include "cdb/cdbvars.h"
 #include "commands/vacuum.h"
 #include "executor/executor.h"
+#include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
 #include "pgstat.h"
 #include "storage/lmgr.h"
@@ -1283,6 +1284,11 @@ aoco_index_build_range_scan(Relation heapRelation,
 	ExprContext *econtext;
 	Snapshot	snapshot;
 	bool		need_unregister_snapshot = false;
+	bool		need_create_blk_directory = false;
+	List	   *tlist = NIL;
+	List	   *qual = indexInfo->ii_Predicate;
+	Oid			blkdirrelid;
+	Oid			blkidxrelid;
 	TransactionId OldestXmin;
 
 	/*
@@ -1336,6 +1342,17 @@ aoco_index_build_range_scan(Relation heapRelation,
 	if (!IsBootstrapProcessingMode() && !indexInfo->ii_Concurrent)
 		OldestXmin = GetOldestXmin(heapRelation, PROCARRAY_FLAGS_VACUUM);
 
+	/*
+	 * If block directory is empty, it must also be built along with the index.
+	 */
+	GetAppendOnlyEntryAuxOids(RelationGetRelid(heapRelation), NULL, NULL,
+							  &blkdirrelid, &blkidxrelid, NULL, NULL);
+
+	Relation blkdir = relation_open(blkdirrelid, AccessShareLock);
+
+	need_create_blk_directory = RelationGetNumberOfBlocks(blkdir) == 0;
+	relation_close(blkdir, NoLock);
+
 	if (!scan)
 	{
 		/*
@@ -1352,12 +1369,50 @@ aoco_index_build_range_scan(Relation heapRelation,
 		else
 			snapshot = SnapshotAny;
 
-		scan = table_beginscan_strat(heapRelation,	/* relation */
-		                             snapshot,	/* snapshot */
-		                             0, /* number of keys */
-		                             NULL,	/* scan key */
-		                             true,	/* buffer access strategy OK */
-		                             allow_sync);	/* syncscan OK? */
+		/*
+		 * Scan all columns if we need to create block directory.
+		 */
+		if (need_create_blk_directory)
+		{
+			scan = table_beginscan_strat(heapRelation,	/* relation */
+										 snapshot,		/* snapshot */
+										 0,		/* number of keys */
+										 NULL,		/* scan key */
+										 true,			/* buffer access strategy OK */
+										 allow_sync);	/* syncscan OK? */
+		}
+		else
+		{
+			/*
+			 * if block directory has created, we can only scan needed column.
+			 */
+			for (int i = 0; i < indexInfo->ii_NumIndexAttrs; i++)
+			{
+				AttrNumber attrnum = indexInfo->ii_IndexAttrNumbers[i];
+				Form_pg_attribute attr = TupleDescAttr(RelationGetDescr(heapRelation), attrnum - 1);
+				Var *var = makeVar(i,
+								   attrnum,
+								   attr->atttypid,
+								   attr->atttypmod,
+								   attr->attcollation,
+								   0);
+
+				/* Build a target list from index info */
+				tlist = lappend(tlist,
+								makeTargetEntry((Expr *) var,
+												list_length(tlist) + 1,
+												NULL,
+												false));
+			}
+
+			/* Push down target list and qual to scan */
+			scan = table_beginscan_strat_extractcolumns(heapRelation, /* relation */
+														snapshot,     /* snapshot */
+														tlist,        /* targetlist */
+														qual,         /* qual */
+														true,         /* buffer access strategy OK */
+														allow_sync);  /* syncscan OK? */
+		}
 	}
 	else
 	{
@@ -1376,14 +1431,6 @@ aoco_index_build_range_scan(Relation heapRelation,
 	aocoscan = (AOCSScanDesc) scan;
 
 	/*
-	 * If block directory is empty, it must also be built along with the index.
-	 */
-	Oid blkdirrelid;
-	Oid blkidxrelid;
-
-	GetAppendOnlyEntryAuxOids(RelationGetRelid(aocoscan->rs_base.rs_rd), NULL, NULL,
-	                          &blkdirrelid, &blkidxrelid, NULL, NULL);
-	/*
 	 * Note that block directory is created during creation of the first
 	 * index.  If it is found empty, it means the block directory was created
 	 * by this create index transaction.  The caller (DefineIndex) must have
@@ -1392,8 +1439,7 @@ aoco_index_build_range_scan(Relation heapRelation,
 	 * blocked.  We can rest assured of exclusive access to the block
 	 * directory relation.
 	 */
-	Relation blkdir = relation_open(blkdirrelid, AccessShareLock);
-	if (RelationGetNumberOfBlocks(blkdir) == 0)
+	if (need_create_blk_directory)
 	{
 		/*
 		 * Allocate blockDirectory in scan descriptor to let the access method
@@ -1403,7 +1449,6 @@ aoco_index_build_range_scan(Relation heapRelation,
 		Assert(aocoscan->blockDirectory == NULL);
 		aocoscan->blockDirectory = palloc0(sizeof(AppendOnlyBlockDirectory));
 	}
-	relation_close(blkdir, NoLock);
 
 
 	/* GPDB_12_MERGE_FIXME */

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -2517,7 +2517,7 @@ ExecModifyTable(PlanState *pstate)
 												 &isNull);
 					/* shouldn't ever get a null result... */
 					if (isNull)
-						elog(ERROR, "action is NULL");
+						elog(ERROR, "gp_segment_id is NULL");
 
 					segid = DatumGetInt32(datum);
 				}
@@ -2528,7 +2528,7 @@ ExecModifyTable(PlanState *pstate)
 												 &isNull);
 					/* shouldn't ever get a null result... */
 					if (isNull)
-						elog(ERROR, "gp_segment_id is NULL");
+						elog(ERROR, "action is NULL");
 
 					action = DatumGetInt32(datum);
 				}

--- a/src/include/access/tableam.h
+++ b/src/include/access/tableam.h
@@ -816,6 +816,26 @@ table_beginscan_strat(Relation rel, Snapshot snapshot,
 }
 
 /*
+ * Like table_beginscan_strat(), but table_beginscan_strat_extractcolumns()
+ * extract columns for scan from target list and qualifications.
+ * This is mainly for AOCS tables.
+ */
+static inline TableScanDesc
+table_beginscan_strat_extractcolumns(Relation rel, Snapshot snapshot,
+									 List *targetlist, List *qual,
+									 bool allow_strat, bool allow_sync)
+{
+	uint32		flags = SO_TYPE_SEQSCAN | SO_ALLOW_PAGEMODE;
+
+	if (allow_strat)
+		flags |= SO_ALLOW_STRAT;
+	if (allow_sync)
+		flags |= SO_ALLOW_SYNC;
+
+	return rel->rd_tableam->scan_begin_extractcolumns(rel, snapshot, targetlist, qual, flags);
+}
+
+/*
  * table_beginscan_bm is an alternative entry point for setting up a
  * TableScanDesc for a bitmap heap scan.  Although that scan technology is
  * really quite unlike a standard seqscan, there is just enough commonality to

--- a/src/test/regress/input/aocs.source
+++ b/src/test/regress/input/aocs.source
@@ -613,7 +613,7 @@ insert into aocs_index_cols values (1, 'foo', 'bar');
 
 -- Create an index on the table. This is the first index on the table, so it
 -- creates the ao block directory, and scans all columns.
-create index on aocs_index_cols (id);
+create index aocs_index_cols_id_idx on aocs_index_cols (id);
 
 -- Create a partial index. This index needs to scan two columns; one is used
 -- as the index column, and the other in the WHERE clause.
@@ -629,6 +629,13 @@ select * from aocs_index_cols where a like 'f%';
 select * from aocs_index_cols where length(b) = 3;
 reset enable_seqscan;
 
+-- Recreate aocs_index_cols_id_idx. This index needs to scan only one columns.
+drop index aocs_index_cols_id_idx;
+create index aocs_index_cols_id_idx on aocs_index_cols (id);
+-- Check that the row is found using the new index.
+set enable_seqscan=off;
+select * from aocs_index_cols where id = 1;
+reset enable_seqscan;
 
 -- Small content as well as bulk dense content headers need to be used
 -- appropriately if compression is found to be not useful.  This test

--- a/src/test/regress/output/aocs.source
+++ b/src/test/regress/output/aocs.source
@@ -1200,7 +1200,7 @@ create table aocs_index_cols (id int4, a text, b text) with (appendonly=true, or
 insert into aocs_index_cols values (1, 'foo', 'bar');
 -- Create an index on the table. This is the first index on the table, so it
 -- creates the ao block directory, and scans all columns.
-create index on aocs_index_cols (id);
+create index aocs_index_cols_id_idx on aocs_index_cols (id);
 -- Create a partial index. This index needs to scan two columns; one is used
 -- as the index column, and the other in the WHERE clause.
 create index on aocs_index_cols (id) WHERE a like 'f%';
@@ -1221,6 +1221,18 @@ select * from aocs_index_cols where a like 'f%';
 (1 row)
 
 select * from aocs_index_cols where length(b) = 3;
+ id |  a  |  b  
+----+-----+-----
+  1 | foo | bar
+(1 row)
+
+reset enable_seqscan;
+-- Recreate aocs_index_cols_id_idx. This index needs to scan only one columns.
+drop index aocs_index_cols_id_idx;
+create index aocs_index_cols_id_idx on aocs_index_cols (id);
+-- Check that the row is found using the new index.
+set enable_seqscan=off;
+select * from aocs_index_cols where id = 1;
  id |  a  |  b  
 ----+-----+-----
   1 | foo | bar


### PR DESCRIPTION
## Speed up AOCS index build by only scan needed columns.
On first index creation (block directory is created) and only that time all columns are scanned. 
Later any index creation just scans needed columns.
