### PR TITLE
[6X] Fix compile warnings which imported in "synchronization of amgetbitmap definition with upstream"

### DIFF
--- a/src/backend/access/bitmap/bitmap.c
+++ b/src/backend/access/bitmap/bitmap.c
@@ -198,7 +198,7 @@ bmgetbitmap(PG_FUNCTION_ARGS)
 {
 	/* We ignore the second argument as we're returning a hash bitmap */
 	IndexScanDesc scan = (IndexScanDesc) PG_GETARG_POINTER(0);
-	Node		**bmNodeP = (Node *)PG_GETARG_POINTER(1);
+	Node		**bmNodeP = (Node **)PG_GETARG_POINTER(1);
 	IndexStream	 *is;
 	BMScanPosition	scanPos;
 	bool res;

--- a/src/backend/access/gin/ginget.c
+++ b/src/backend/access/gin/ginget.c
@@ -1776,7 +1776,7 @@ Datum
 gingetbitmap(PG_FUNCTION_ARGS)
 {
 	IndexScanDesc scan = (IndexScanDesc) PG_GETARG_POINTER(0);
-	Node 	  **bmNodeP = (Node *) PG_GETARG_POINTER(1);
+	Node 	  **bmNodeP = (Node **) PG_GETARG_POINTER(1);
 	TIDBitmap  *tbm;
 	GinScanOpaque so = (GinScanOpaque) scan->opaque;
 	int64		ntids;

--- a/src/backend/access/gist/gistget.c
+++ b/src/backend/access/gist/gistget.c
@@ -558,7 +558,7 @@ Datum
 gistgetbitmap(PG_FUNCTION_ARGS)
 {
 	IndexScanDesc scan = (IndexScanDesc) PG_GETARG_POINTER(0);
-	Node	  **bmNodeP = (Node *) PG_GETARG_POINTER(1);
+	Node	  **bmNodeP = (Node **) PG_GETARG_POINTER(1);
 	TIDBitmap  *tbm;
 	GISTScanOpaque so = (GISTScanOpaque) scan->opaque;
 	int64		ntids = 0;

--- a/src/backend/access/hash/hash.c
+++ b/src/backend/access/hash/hash.c
@@ -331,7 +331,7 @@ Datum
 hashgetbitmap(PG_FUNCTION_ARGS)
 {
 	IndexScanDesc scan = (IndexScanDesc) PG_GETARG_POINTER(0);
-	Node	  **bmNodeP = (Node *) PG_GETARG_POINTER(1);
+	Node	  **bmNodeP = (Node **) PG_GETARG_POINTER(1);
 	TIDBitmap  *tbm;
 	HashScanOpaque so = (HashScanOpaque) scan->opaque;
 	bool		res;

--- a/src/backend/access/nbtree/nbtree.c
+++ b/src/backend/access/nbtree/nbtree.c
@@ -570,7 +570,7 @@ Datum
 btgetbitmap(PG_FUNCTION_ARGS)
 {
 	IndexScanDesc scan = (IndexScanDesc) PG_GETARG_POINTER(0);
-	Node	  **bmNodeP = (Node *) PG_GETARG_POINTER(1);
+	Node	  **bmNodeP = (Node **) PG_GETARG_POINTER(1);
 	TIDBitmap  *tbm;
 	BTScanOpaque so = (BTScanOpaque) scan->opaque;
 	int64		ntids = 0;

--- a/src/backend/access/spgist/spgscan.c
+++ b/src/backend/access/spgist/spgscan.c
@@ -583,7 +583,7 @@ Datum
 spggetbitmap(PG_FUNCTION_ARGS)
 {
 	IndexScanDesc scan = (IndexScanDesc) PG_GETARG_POINTER(0);
-	Node	  **bmNodeP = (Node *) PG_GETARG_POINTER(1);
+	Node	  **bmNodeP = (Node **) PG_GETARG_POINTER(1);
 	TIDBitmap  *tbm;
 	SpGistScanOpaque so = (SpGistScanOpaque) scan->opaque;
 

--- a/src/backend/utils/mmgr/mcxt.c
+++ b/src/backend/utils/mmgr/mcxt.c
@@ -927,7 +927,7 @@ MemoryContextCheck(MemoryContext context)
  * false-positive result, since the bits right before it might look like
  * a valid chunk header by chance.
  */
-static bool
+bool
 MemoryContextContains(MemoryContext context, void *pointer)
 {
 	StandardChunkHeader *header;

--- a/src/include/utils/memutils.h
+++ b/src/include/utils/memutils.h
@@ -226,6 +226,7 @@ extern void dump_memory_allocation_ctxt(FILE * ofile, void *ctxt);
 #ifdef MEMORY_CONTEXT_CHECKING
 extern void MemoryContextCheck(MemoryContext context);
 #endif
+extern bool MemoryContextContains(MemoryContext context, void *pointer);
 extern bool MemoryContextContainsGenericAllocation(MemoryContext context, void *pointer);
 
 /* Functions called only by context-type-specific memory managers... */


### PR DESCRIPTION
This commit: https://github.com/greenplum-db/gpdb/commit/699998c79460babd05d4a710e29fe74eeceae89e imported some compile warnings.

Fix them in this PR.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
