### PR TITLE
Undo the banner changes on behave tests once the test has completed.

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -113,7 +113,7 @@ def before_scenario(context, scenario):
     if 'analyzedb' not in context.feature.tags:
         start_database_if_not_started(context)
         drop_database_if_exists(context, 'testdb')
-    if 'gp_bash_functions.sh' in context.feature.tags:
+    if 'gp_bash_functions.sh' in context.feature.tags or 'backup_restore_bashrc' in scenario.effective_tags:
         backup_bashrc()
 
 def after_scenario(context, scenario):
@@ -133,7 +133,7 @@ def after_scenario(context, scenario):
             And gpstart should return a return code of 0
             ''')
 
-    if 'gp_bash_functions.sh' in context.feature.tags:
+    if 'gp_bash_functions.sh' in context.feature.tags or 'backup_restore_bashrc' in scenario.effective_tags:
         restore_bashrc()
 
     # NOTE: gpconfig after_scenario cleanup is in the step `the gpconfig context is setup`

--- a/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
@@ -133,6 +133,7 @@ Feature: Tests for gpinitstandby feature
         Then gpinitstandby should return a return code of 0
         And verify that the file "pg_hba.conf" in the coordinator data directory has "no" line starting with "host.*replication.*(127.0.0.1|::1).*trust"
 
+    @backup_restore_bashrc
     Scenario: gpinitstandby should not throw error when banner exists on the host
         Given the database is running
         And the standby is not initialized

--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -255,12 +255,14 @@ Feature: gpinitsystem tests
         And the database locales "lc_ctype" match the installed UTF locale
         And the database locales "lc_messages,lc_monetary,lc_numeric,lc_time" match the system locale
 
+    @backup_restore_bashrc
     Scenario: gpinitsystem succeeds if there is banner on host
         Given the database is not running
         When the user sets banner on host
         And a demo cluster is created using gpinitsystem args " "
         And gpinitsystem should return a return code of 0
 
+    @backup_restore_bashrc
     Scenario: gpinitsystem succeeds if there is multi-line banner on host
         Given the database is not running
         When the user sets multi-line banner on host

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -241,6 +241,7 @@ Feature: gprecoverseg tests
         And the segments are synchronized
         And the cluster is rebalanced
 
+    @backup_restore_bashrc
     Scenario: gprecoverseg should not return error when banner configured on host
         Given the database is running
         And all the segments are running

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -408,10 +408,11 @@ def impl(context, content):
 
 
 def backup_bashrc():
-    file = '~/.bashrc'
-    backup_fle = '~/.bashrc.backup'
+    home_dir = os.environ.get('HOME')
+    file = home_dir + '/.bashrc'
+    backup_fle = home_dir + '/.bashrc.backup'
     if (os.path.isfile(file)):
-        command = "cp -f %s %s.backup" % (file, backup_fle)
+        command = "cp -f %s %s" % (file, backup_fle)
         result = run_cmd(command)
         if (result[0] != 0):
             raise Exception("Error while backing up bashrc file. STDERR:%s" % (result[2]))
@@ -420,10 +421,11 @@ def backup_bashrc():
 
 
 def restore_bashrc():
-    file = '~/.bashrc'
-    backup_fle = '~/.bashrc.backup'
+    home_dir = os.environ.get('HOME')
+    file = home_dir + '/.bashrc'
+    backup_fle = home_dir + '/.bashrc.backup'
     if (os.path.isfile(backup_fle)):
-        command = "mv -f %s.backup %s" % (backup_fle, file)
+        command = "mv -f %s %s" % (backup_fle, file)
     else:
         command = "rm -f %s" % (file)
     result = run_cmd(command)

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -430,7 +430,7 @@ def restore_bashrc():
         command = "rm -f %s" % (file)
     result = run_cmd(command)
     if (result[0] != 0):
-        raise Exception("Error while restoring up bashrc file. STDERR:%s" % (result[2])
+        raise Exception("Error while restoring up bashrc file. STDERR:%s" % (result[2]))
 
 
 @given('the user runs "{command}"')

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -430,7 +430,7 @@ def restore_bashrc():
         command = "rm -f %s" % (file)
     result = run_cmd(command)
     if (result[0] != 0):
-        raise Exception('Error while restoring up bashrc file. ')
+        raise Exception("Error while restoring up bashrc file. STDERR:%s" % (result[2])
 
 
 @given('the user runs "{command}"')


### PR DESCRIPTION
gpinitsystem Testcases:
	Scenario: gpinitsystem succeeds if there is banner on host

	Scenario: gpinitsystem succeeds if there is multi-line banner on host

gpinitstandby Testcase:
	Scenario: gpinitstandby should not throw error when banner exists on the host

gprecoverseg testcase:
	Scenario: gprecoverseg should not return error when banner configured on host

Added scenario tag 'backup_restore_bashrc' which will backup and restore bashrc file to undo the banner changes on host.

Changes in backup_bashrc and restore_bashrc functions to pickup the home directory from environment and other minor changes.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
