### PR TITLE
Refactor how we handle dropped column references in partition tables during major version upgrades

### DIFF
--- a/contrib/pg_upgrade/greenplum/check_gp.h
+++ b/contrib/pg_upgrade/greenplum/check_gp.h
@@ -6,18 +6,10 @@
  */
 void check_heterogeneous_partition(void);
 
-#define CHECK_PARTITION_TABLE_MATCHES_COLUMN_COUNT \
-	"SELECT parrelid, c1.relnatts, minchildnatts, maxchildnatts " \
-	"FROM ( " \
-	"    SELECT parrelid::regclass, min(c2.relnatts) minchildnatts, max(c2.relnatts) maxchildnatts " \
-	"    FROM pg_partition par " \
-	"    JOIN pg_partition_rule rule ON par.oid=rule.paroid AND NOT par.paristemplate " \
-	"    JOIN pg_class c2 ON parchildrelid = c2.oid GROUP BY parrelid " \
-	") t JOIN pg_class c1 ON c1.oid = parrelid WHERE c1.relnatts!=minchildnatts OR c1.relnatts!=maxchildnatts;"
-
-#define CHECK_PARTITION_TABLE_MATCHES_COLUMN_ATTRIBUTES \
-	"SELECT parrelid::regclass, att1.attnum, rule.parchildrelid::regclass, att1.attname attname1, att2.attname attname2, att1.attisdropped attisdropped1, att2.attisdropped attisdropped2, att1.attlen attlen1, att2.attlen attlen2, att1.atttypid atttypid1, att2.atttypid atttypid2, att1.attalign attalign1, att2.attalign attalign2 " \
-	"FROM pg_partition par join pg_partition_rule rule on par.oid=rule.paroid and not par.paristemplate  " \
-	"JOIN pg_attribute att1 ON att1.attrelid = par.parrelid " \
-	"JOIN pg_attribute att2 ON att2.attrelid = rule.parchildrelid AND att1.attnum = att2.attnum AND att1.attnum > 0 " \
-				"  AND NOT (att1.attisdropped = att2.attisdropped AND att1.attname = att2.attname AND att1.attlen = att2.attlen AND att1.atttypid = att2.atttypid AND att1.attalign = att2.attalign);"
+#define CHECK_CHILD_PARTITIONS_DO_NOT_HAVE_DROPPED_COLUMNS \
+	"SELECT nsp.nspname AS child_relnamespace, c.relname AS child_relname " \
+	"FROM pg_partition_rule pr " \
+	"    JOIN pg_attribute a ON a.attrelid = pr.parchildrelid " \
+	"    JOIN pg_class c ON c.oid = a.attrelid " \
+	"    JOIN pg_namespace nsp ON c.relnamespace = nsp.oid " \
+	"WHERE a.attisdropped IS TRUE AND c.relhassubclass IS FALSE;"

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -348,6 +348,9 @@ typedef struct _tableInfo
 	bool		parparent;		/* true if the table is partition parent */
 	int			numTriggers;	/* number of triggers for table */
 	struct _triggerInfo *triggers;		/* array of TriggerInfo structs */
+
+	/* GPDB: true if need to ignore root partition's dropped columns */
+	bool		ignoreRootPartDroppedAttr;
 } TableInfo;
 
 typedef struct _attrDefInfo

--- a/src/test/regress/expected/pg_dump_binary_upgrade.out
+++ b/src/test/regress/expected/pg_dump_binary_upgrade.out
@@ -1,0 +1,23 @@
+-- Ensure that pg_dump --binary-upgrade correctly suppresses the ALTER
+-- TABLE DROP COLUMN DDL ouptut when a GPDB partition table with a
+-- dropped column reference on the root partition exists.
+CREATE SCHEMA dump_this_schema;
+CREATE TABLE dump_this_schema.dropped_column_partition_table_binary_upgrade (
+    a int,
+    b int,
+    c char,
+    d varchar(50)
+) DISTRIBUTED BY (c)
+PARTITION BY RANGE (a)
+(
+    PARTITION p1 START(1) END(5),
+    PARTITION p2 START(5)
+);
+ALTER TABLE dump_this_schema.dropped_column_partition_table_binary_upgrade DROP COLUMN d;
+\! pg_dump --binary-upgrade --schema dump_this_schema regression | grep " DROP COLUMN "
+DROP SCHEMA dump_this_schema CASCADE;
+NOTICE:  drop cascades to table dump_this_schema.dropped_column_partition_table_binary_upgrade_1_prt_p2
+NOTICE:  drop cascades to constraint dropped_column_partition_table_binary_upgrade_1_prt_p2_check on table dump_this_schema.dropped_column_partition_table_binary_upgrade_1_prt_p2
+NOTICE:  drop cascades to table dump_this_schema.dropped_column_partition_table_binary_upgrade_1_prt_p1
+NOTICE:  drop cascades to constraint dropped_column_partition_table_binary_upgrade_1_prt_p1_check on table dump_this_schema.dropped_column_partition_table_binary_upgrade_1_prt_p1
+NOTICE:  drop cascades to table dump_this_schema.dropped_column_partition_table_binary_upgrade

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -15,6 +15,8 @@
 #   hitting max_connections limit on segments.
 #
 
+test: pg_dump_binary_upgrade
+
 test: gp_dispatch_keepalives
 
 # copy command

--- a/src/test/regress/sql/pg_dump_binary_upgrade.sql
+++ b/src/test/regress/sql/pg_dump_binary_upgrade.sql
@@ -1,0 +1,22 @@
+-- Ensure that pg_dump --binary-upgrade correctly suppresses the ALTER
+-- TABLE DROP COLUMN DDL ouptut when a GPDB partition table with a
+-- dropped column reference on the root partition exists.
+
+CREATE SCHEMA dump_this_schema;
+CREATE TABLE dump_this_schema.dropped_column_partition_table_binary_upgrade (
+    a int,
+    b int,
+    c char,
+    d varchar(50)
+) DISTRIBUTED BY (c)
+PARTITION BY RANGE (a)
+(
+    PARTITION p1 START(1) END(5),
+    PARTITION p2 START(5)
+);
+
+ALTER TABLE dump_this_schema.dropped_column_partition_table_binary_upgrade DROP COLUMN d;
+
+\! pg_dump --binary-upgrade --schema dump_this_schema regression | grep " DROP COLUMN "
+
+DROP SCHEMA dump_this_schema CASCADE;


### PR DESCRIPTION
First commit:
```
Author: Jimmy Yih <jyih@vmware.com>
Date:   Fri Jan 14 12:02:25 2022 -0800

    Ignore partition table dropped columns for pg_dump --binary-upgrade

    When running pg_dump --binary-upgrade, dropped columns are always
    preserved to make sure the catalog matches with the physical data
    files. For GPDB partition tables, this gets very complicated because
    the root partition delegates whether or not the entire partition table
    will have dropped columns or not. If the root partition has dropped
    columns but a child partition does not, we hit a heterogeneous
    partition table scenario which requires manual user intervention. The
    current user workaround for this scenario is to do a plain CTAS on the
    entire partition table... but doing that could be extremely costly.

    To provide a less costly workaround, we simply need to ignore the
    dropped column from the partition table DDL that will be run on the
    target upgrade cluster and assume that all the child partitions will
    not have dropped columns (either it was already like that or the child
    partition has been fixed with a CTAS and exchange partition). This
    works because the root partition does not store any data so now only
    the flagged child partitions (via pg_upgrade --check) need to be fixed
    instead of touching the entire partition table.

    Note: This won't be a problem for GPDB 7+ because child partition DDL
    follows upstream Postgres logic where they are created separately and
    attached to the root/subroot.
```

Second commit:
```
Author: Jimmy Yih <jyih@vmware.com>
Date:   Fri Jan 14 17:09:01 2022 -0800

    Refactor pg_upgrade heterogeneous partition table check

    The heterogeneous partition table check would check if the attributes
    of a root partition and its child partitions were synchronized
    properly. If it detected an anomaly (e.g. root partition has dropped
    column references but a child partition does not), the partition table
    would be flagged and the user would be advised to recreate the table
    with CTAS. The workaround provided is correct but can be extremely
    costly in production clusters where partition tables can be very big.

    To lower the cost of fixing the issue, we now only check if the child
    partitions have any dropped column references. We then advise the user
    to CTAS only the problematic child partition(s) and do an exchange
    partition (the CTAS staging table would not have the dropped column
    reference). This workaround is a bit more complex and requires more
    concentrated user involvement but the time savings is pretty big
    (e.g. CTAS an entire partition table with 5000 child partitions
    vs. CTAS a couple child partitions).

    Note: This assumes that pg_dump --binary-upgrade will NOT output the
    dropped column reference in the partition table DDL schema
    dump. Currently, there is a Greenplum hack to ignore the dropped
    column references of the root partition which makes this pg_upgrade
    assumption correct.
```