### PR TITLE
remove work_mem in WindowAgg

### DIFF
--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -2418,7 +2418,7 @@ uint64 PlanStateOperatorMemKB(const PlanState *ps)
 		 * There are some statements that do not go through the resource queue and these
 		 * plans dont get decorated with the operatorMemKB. Someday, we should fix resource queues.
 		 */
-		result = work_mem;
+		result = statement_mem;
 	}
 	else
 	{

--- a/src/backend/executor/nodeWindowAgg.c
+++ b/src/backend/executor/nodeWindowAgg.c
@@ -276,7 +276,7 @@ initialize_windowaggregate(WindowAggState *winstate,
 								  peraggstate->distinctLtOper,
 								  peraggstate->distinctColl,
 								  false, /* nullsFirstFlag */
-								  work_mem, false);
+								  PlanStateOperatorMemKB((PlanState *)winstate), false);
 	}
 }
 
@@ -1313,7 +1313,10 @@ begin_partition(WindowAggState *winstate)
 	}
 
 	/* Create new tuplestore for this partition */
-	winstate->buffer = tuplestore_begin_heap(false, false, work_mem);
+	winstate->buffer = tuplestore_begin_heap(
+		false,
+		false,
+		PlanStateOperatorMemKB((PlanState *)winstate));
 
 	/*
 	 * Set up read pointers for the tuplestore.  The current pointer doesn't


### PR DESCRIPTION
Basically, the GUC `work_mem` is deprecated and will be removed in the future. However, there are still many usages of `work_mem` in the code, which should be treated as legacy issues. Some of them have complex code paths and need to change existing interfaces, so I decide to update only the code path of WindowAgg for now, which is related to customer issue.

The change is straightforward: replace `work_mem` with calling of `PlanStateOperatorMemKB()` which returns the memory count for a specific operator. Inside `PlanStateOperatorMemKB()`, use `statement_mem` instead of `work_mem` when `plan->operatorMemKB` is not assigned. After the change, we can use `statement_mem` instead of `work_mem` to control the memory usage of operators.

The scenario of WindowAgg has been covered by existing tests. The code change does not change any existing behavior except impacting the performance of WindowAgg.

No doc change is needed since the GUC `work_mem` has been removed in doc.
