### PR TITLE
gprecoverseg behave: Do not delete the cluster for newhost scenario

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg_newhost.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg_newhost.feature
@@ -24,12 +24,11 @@ Feature: gprecoverseg tests involving migrating to a new host
       And gprecoverseg should print "Skipping shared memory cleanup and gpsegstop on unreachable host" to stdout
       And gprecoverseg should not print "ExecutionError" to stdout
       And the mirrors replicate and fail over and back correctly
-      And segment hosts <down> are reconnected to the cluster and to the spare segment hosts "<unused>"
-      And the original cluster state is recreated after cleaning up <down> hosts
-      And database "gptest" exists
+      And the cluster is rebalanced
+      And the original cluster state is recreated for "<test_case>"
       And the cluster configuration is saved for "after_recreation"
       And the "before" and "after_recreation" cluster configuration matches with the expected for gprecoverseg newhost
       Examples:
-      | test_case      |  down        | spare       | unused | used | acting_primary | gprecoverseg_cmd                               | down_sql                                              |
-      | one_host_down  |  "sdw1"      | "sdw5,sdw6" | sdw6   | sdw5 | sdw2           | "gprecoverseg -a -p sdw5 --hba-hostnames"      | "hostname='sdw1' and status='u'"                      |
+      | test_case      |  down        | spare | unused | used | acting_primary | gprecoverseg_cmd                              | down_sql                                              |
+      | one_host_down  |  "sdw1"      | "sdw5" | "sdw6"   | sdw5 | sdw2           | "gprecoverseg -a -p sdw5 --hba-hostnames"   | "hostname='sdw1' and status='u'"                      |
       | two_hosts_down |  "sdw1,sdw3" | "sdw5,sdw6" | none   | sdw5 | sdw2           | "gprecoverseg -a -p sdw5,sdw6 --hba-hostnames" | "(hostname='sdw1' or hostname='sdw3') and status='u'" |

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1143,6 +1143,17 @@ def stop_all_primary_or_mirror_segments(context, segment_type):
     role = ROLE_PRIMARY if segment_type == 'primary' else ROLE_MIRROR
     stop_segments(context, lambda seg: seg.getSegmentRole() == role and seg.content != -1)
 
+@given('user stops all {segment_type} processes on "{hosts}"')
+@given('user stops all {segment_type} processes on "{hosts}"')
+@given('user stops all {segment_type} processes on "{hosts}"')
+def stop_all_primary_or_mirror_segments_on_hosts(context, segment_type, hosts):
+    hosts = hosts.split(',')
+    if segment_type not in ("primary", "mirror"):
+        raise Exception("Expected segment_type to be 'primary' or 'mirror', but found '%s'." % segment_type)
+    print("Stopping {} on {}".format(segment_type, hosts))
+    role = ROLE_PRIMARY if segment_type == 'primary' else ROLE_MIRROR
+    stop_segments(context, lambda seg: seg.getSegmentRole() == role and seg.content != -1 and seg.getSegmentHostName() in hosts)
+
 
 @given('the {role} on content {contentID} is stopped')
 def stop_segments_on_contentID(context, role, contentID):
@@ -1158,6 +1169,7 @@ def stop_segments(context, where_clause):
     gparray = GpArray.initFromCatalog(dbconn.DbURL())
 
     segments = filter(where_clause, gparray.getDbList())
+    print("Stopping segments: {}".format(segments))
     for seg in segments:
         # For demo_cluster tests that run on the CI gives the error 'bash: pg_ctl: command not found'
         # Thus, need to add pg_ctl to the path when ssh'ing to a demo cluster.

--- a/gpMgmt/test/behave/mgmt_utils/steps/unreachable_hosts_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/unreachable_hosts_mgmt_utils.py
@@ -1,4 +1,5 @@
 import subprocess
+import tempfile
 
 from behave import given, when, then
 
@@ -10,13 +11,19 @@ from gppylib.db import dbconn
 # tied to any particular hardware implementation, and that's mostly the case.
 
 @given('segment hosts "{disconnected}" are disconnected from the cluster and from the spare segment hosts "{spare}"')
+@when('segment hosts "{disconnected}" are disconnected from the cluster and from the spare segment hosts "{spare}"')
+@then('segment hosts "{disconnected}" are disconnected from the cluster and from the spare segment hosts "{spare}"')
 def impl(context, disconnected, spare):
     disconnected_hosts = disconnected.split(',')
-    spare_hosts = spare.split(',')
+    spare_hosts = []
+    if spare != "none":
+        spare_hosts = spare.split(',')
 
     add_or_remove_blackhole_route(disconnected_hosts, spare_hosts, disconnect=True)
 
 
+@given('segment hosts "{reconnected}" are reconnected to the cluster and to the spare segment hosts "{spare}"')
+@when('segment hosts "{reconnected}" are reconnected to the cluster and to the spare segment hosts "{spare}"')
 @then('segment hosts "{reconnected}" are reconnected to the cluster and to the spare segment hosts "{spare}"')
 def impl(context, reconnected, spare):
     reconnected_hosts = reconnected.split(',')
@@ -79,18 +86,9 @@ def _blackhole_route_helper(disconnect_host, hosts, disconnect=False):
         cmd = "sudo ip route {} {}".format(subcmd, disconnect_addr)
         subprocess.check_output(["ssh", host, cmd])
 
-
-# This step is very specific to the CCP CI cluster.
-@then('the original cluster state is recreated after cleaning up "{disconnected}" hosts')
+@given('all postgres processes are killed on "{disconnected}" hosts')
 def impl(context, disconnected):
     disconnected_hosts = disconnected.split(',')
-
-    # delete the current cluster
-    cmd = '''
-source /usr/local/greenplum-db-devel/greenplum_path.sh
-yes | gpdeletesystem -fD -d /data/gpdata/master/gpseg-1
-'''
-    subprocess.check_output(["bash", "-c", cmd])
 
     # clean up disconnected
     cmds = ["pkill -9 postgres",
@@ -101,14 +99,52 @@ yes | gpdeletesystem -fD -d /data/gpdata/master/gpseg-1
         for cmd in cmds:
             subprocess.check_output(["ssh", host, cmd])
 
-    # reinitialize the cluster...see concourse-cluster-provisioner/scripts/gpinitsystem.sh
-    cmd = '''
-source /usr/local/greenplum-db-devel/greenplum_path.sh
-if grep --quiet photon /etc/os-release
-then
-    gpinitsystem -a -n en_US.UTF-8 -c ~gpadmin/gpinitsystem_config -h ~gpadmin/segment_host_list || :
-else
-    gpinitsystem -a -c ~gpadmin/gpinitsystem_config -h ~gpadmin/segment_host_list || :
-fi
-'''
-    subprocess.check_output(["bash", "-c", cmd])
+# This step is very specific to the CCP CI cluster.
+@given('the original cluster state is recreated for "{test_case}"')
+@when('the original cluster state is recreated for "{test_case}"')
+@then('the original cluster state is recreated for "{test_case}"')
+def impl(context, test_case):
+    # We will bring the cluster back to it's original state by
+    # reconnecting the down host(s) and then making the segments on the spare host(s)
+    # fall back to their original(read down) hosts. Note that because of -p, the port numbers on the
+    # spare segment hosts are not the same as the original hosts.
+    # For one_host_down: down host is sdw1 and spare host is sdw5
+    # For two_hosts_down: down hosts are sdw1,sdw3 and spare hosts are sdw5,sdw6
+    if test_case == "one_host_down":
+        down = 'sdw1'
+        spare = 'sdw5'
+        hostname_filter = "hostname in ('sdw5')"
+        expected_config = '''sdw5|20000|/data/gpdata/primary/gpseg0 sdw1|20000|/data/gpdata/primary/gpseg0
+sdw5|20001|/data/gpdata/primary/gpseg1 sdw1|20001|/data/gpdata/primary/gpseg1
+sdw5|20002|/data/gpdata/mirror/gpseg6 sdw1|21000|/data/gpdata/mirror/gpseg6
+sdw5|20003|/data/gpdata/mirror/gpseg7 sdw1|21001|/data/gpdata/mirror/gpseg7'''
+    elif test_case == "two_hosts_down":
+        down = 'sdw1,sdw3'
+        spare = 'sdw5,sdw6'
+        hostname_filter = "hostname in ('sdw5', 'sdw6')"
+        expected_config = '''sdw5|20000|/data/gpdata/primary/gpseg0 sdw1|20000|/data/gpdata/primary/gpseg0
+sdw5|20001|/data/gpdata/primary/gpseg1 sdw1|20001|/data/gpdata/primary/gpseg1
+sdw5|20002|/data/gpdata/mirror/gpseg6 sdw1|21000|/data/gpdata/mirror/gpseg6
+sdw5|20003|/data/gpdata/mirror/gpseg7 sdw1|21001|/data/gpdata/mirror/gpseg7
+sdw6|20002|/data/gpdata/primary/gpseg4 sdw3|20000|/data/gpdata/primary/gpseg4
+sdw6|20003|/data/gpdata/primary/gpseg5 sdw3|20001|/data/gpdata/primary/gpseg5
+sdw6|20000|/data/gpdata/mirror/gpseg2 sdw3|21000|/data/gpdata/mirror/gpseg2
+sdw6|20001|/data/gpdata/mirror/gpseg3 sdw3|21001|/data/gpdata/mirror/gpseg3'''
+    else:
+        raise Exception('Invalid test case')
+
+    with tempfile.NamedTemporaryFile() as config_file:
+        config_file.write(expected_config.encode('utf-8'))
+        config_file.flush()
+
+        context.execute_steps(u"""
+            Given segment hosts "{down}" are reconnected to the cluster and to the spare segment hosts "none"
+            And all postgres processes are killed on "{down}" hosts
+            And user stops all mirror processes on "{spare}"
+            And user stops all primary processes on "{spare}"
+            And the cluster configuration has no segments where "{hostname_filter} and status='u'"
+            And the user runs "gprecoverseg -a -i {config_file_path}"
+            Then gprecoverseg should return a return code of 0
+            And all the segments are running
+            And the cluster is rebalanced""".format(down=down, spare=spare, hostname_filter=hostname_filter,
+                                                    config_file_path=config_file.name))


### PR DESCRIPTION
In order to test the `-p` functionality in gprecoverseg, we create a cluster
with spare hosts and then make one or more of the cluster hosts as unreachable
and use -p to make the segments on thost hosts failover to the spare hosts.
For this to work, we had to bring the cluster back to it's original state for
each example of the test scenario. This was done to make sure examples were not
dependent on each other and that they could start with a clean cluster. To
achieve this, we would delete the cluster using gpdeletesystem and reinitialize
it using gpinitsystem.
The problem with this approach was that any changes made to the cluster like
setting a guc would get removed because of running gpdeletesystem and
gpinitsystem. A better way is to reconnect the down hosts and then make the
segments on the spare hosts fallback to their original hosts.
