### PR TITLE
[6X] Support bitmap scans on mixed heap/AO partitioned tables

### DIFF
--- a/src/backend/cdb/cdbpartindex.c
+++ b/src/backend/cdb/cdbpartindex.c
@@ -939,7 +939,8 @@ getPartConstraints(Oid partOid, Oid rootOid, List *partKey)
 		{
 			int16		key_elem = DatumGetInt16(dats[i]);
 
-			keys = lappend_int(keys, key_elem);
+			AttrNumber mapped_key_elem = attrMap(map, key_elem);
+			keys = lappend_int(keys, mapped_key_elem);
 		}
 	}
 
@@ -1589,7 +1590,7 @@ logicalIndexInfoForIndexOid(Oid rootOid, Oid indexOid)
 	TupleDesc	partTupDesc = partRel->rd_att;
 
 	char		relstorage = partRel->rd_rel->relstorage;
-	AttrNumber *attMap = varattnos_map(rootTupDesc, partTupDesc);
+	AttrNumber *attMap = varattnos_map(partTupDesc, rootTupDesc);
 
 	heap_close(rootRel, AccessShareLock);
 	heap_close(partRel, AccessShareLock);

--- a/src/backend/executor/nodeDynamicBitmapIndexscan.c
+++ b/src/backend/executor/nodeDynamicBitmapIndexscan.c
@@ -120,14 +120,22 @@ beginCurrentBitmapIndexScan(DynamicBitmapIndexScanState *node, EState *estate,
 	oldCxt = MemoryContextSwitchTo(node->partitionMemoryContext);
 
 	/*
-	 * Re-map the index columns, per the new partition, and find the correct
-	 * index.
+	 * find the root of the partition table
 	 */
 	if (!OidIsValid(node->columnLayoutOid))
 	{
-		/* Very first partition */
-		node->columnLayoutOid = rel_partition_get_root(tableOid);
+		Oid parentOid = rel_partition_get_root(tableOid);
+		while (parentOid != InvalidOid)
+		{
+			node->columnLayoutOid = parentOid;
+			parentOid = rel_partition_get_root(node->columnLayoutOid);
+		}
 	}
+
+	/*
+	 * Re-map the index columns, per the new partition, and find the correct
+	 * index.
+	 */
 	BitmapIndexScan_ReMapColumns(dbiScan, node->columnLayoutOid, tableOid);
 	node->columnLayoutOid = tableOid;
 

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -18,6 +18,7 @@
 #include "gpopt/base/CAutoOptCtxt.h"
 #include "gpopt/base/CColRef.h"
 #include "gpopt/base/CColRefSet.h"
+#include "gpopt/base/CColRefTable.h"
 #include "gpopt/base/CColumnFactory.h"
 #include "gpopt/base/CDistributionSpecAny.h"
 #include "gpopt/base/CEnfdDistribution.h"
@@ -404,7 +405,19 @@ CTranslatorDXLToExpr::PexprTranslateScalar(const CDXLNode *dxlnode,
 			ULONG *pulKey = NULL;
 			if (NULL == pdrgpul)
 			{
-				pulKey = GPOS_NEW(m_mp) ULONG(ul + 1);
+				// We only go through this code path through GetPartConstraintExpr()
+				if (colref->Ecrt() == CColRef::EcrtTable)
+				{
+					// grab the attnum from the colref to use as the key, as this attnum is later used when looking up this colref via LookupColRef
+					CColRefTable *pcolrefTable =
+						CColRefTable::PcrConvert(colref);
+					pulKey = GPOS_NEW(m_mp) ULONG(pcolrefTable->AttrNum());
+				}
+				else
+				{
+					// for generated colrefs, we can only arbitrarily assign a key
+					pulKey = GPOS_NEW(m_mp) ULONG(ul + 1);
+				}
 			}
 			else
 			{

--- a/src/backend/gporca/libnaucrates/src/md/CMDRelationGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDRelationGPDB.cpp
@@ -579,13 +579,28 @@ BOOL
 CMDRelationGPDB::IsPartialIndex(IMDId *mdid) const
 {
 	const ULONG indexes = IndexCount();
+	bool foundPartial = false;
 
+	// if the index is a bitmap index, there can exist both a partial and
+	// non-partial entry for a given MDid. In this case, we prefer the non-partial entry
 	for (ULONG ul = 0; ul < indexes; ++ul)
 	{
 		if (CMDIdGPDB::MDIdCompare(IndexMDidAt(ul), mdid))
 		{
-			return (*m_mdindex_info_array)[ul]->IsPartial();
+			if (!(*m_mdindex_info_array)[ul]->IsPartial())
+			{
+				return false;
+			}
+			else
+			{
+				foundPartial = true;
+			}
 		}
+	}
+
+	if (foundPartial)
+	{
+		return true;
 	}
 
 	// Not found

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14162,6 +14162,60 @@ SELECT gp_segment_id, * FROM result_tab;
 DROP TABLE IF EXISTS dist_tab_a;
 DROP TABLE IF EXISTS dist_tab_b;
 DROP TABLE IF EXISTS result_tab;
+-- Test if orca produces bitmap scan on mixed partitions
+create table mixed_part( a int) distributed randomly
+partition by range (a)
+( partition a1 start (1) end (100) with (appendonly='true'),
+partition a2 start (100) end (200) with (appendonly='false'));
+NOTICE:  CREATE TABLE will create partition "mixed_part_1_prt_a1" for table "mixed_part"
+NOTICE:  CREATE TABLE will create partition "mixed_part_1_prt_a2" for table "mixed_part"
+create index idx_mixed_part on mixed_part using btree(a);
+insert into mixed_part select i from generate_series(1,199)i;
+insert into mixed_part select 12 from generate_series(1,100)i;
+analyze mixed_part;
+explain select * from mixed_part where a=3;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.49 rows=2 width=4)
+   ->  Append  (cost=0.00..3.49 rows=1 width=4)
+         ->  Seq Scan on mixed_part_1_prt_a1  (cost=0.00..3.49 rows=1 width=4)
+               Filter: (a = 3)
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+select * from mixed_part where a=3;
+ a 
+---
+ 3
+(1 row)
+
+-- Test that orca still produces index scan on heap partitions
+create table heap_part( a int) distributed randomly
+partition by range (a)
+( partition a1 start (1) end (100) with (appendonly='false'),
+partition a2 start (100) end (200) with (appendonly='false'));
+NOTICE:  CREATE TABLE will create partition "heap_part_1_prt_a1" for table "heap_part"
+NOTICE:  CREATE TABLE will create partition "heap_part_1_prt_a2" for table "heap_part"
+create index idx_heap_part on heap_part using btree(a);
+insert into heap_part select i from generate_series(1,199)i;
+insert into heap_part select 12 from generate_series(1,100)i;
+analyze heap_part;
+explain select * from heap_part where a=3;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..5.49 rows=2 width=4)
+   ->  Append  (cost=0.00..5.49 rows=1 width=4)
+         ->  Seq Scan on heap_part_1_prt_a1  (cost=0.00..5.49 rows=1 width=4)
+               Filter: (a = 3)
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+select * from heap_part where a=3;
+ a 
+---
+ 3
+(1 row)
+
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 NOTICE:  drop cascades to 167 other objects

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14216,6 +14216,46 @@ select * from heap_part where a=3;
  3
 (1 row)
 
+-- Generate bitmap scan for mixed index types
+create table part_table13(a int, b int, c int)
+partition by range(b)
+(
+partition p1 start(1) end(10),
+partition p2 start(10) end (20) with (appendonly=true),
+partition p3 start(20) end (30) with (appendonly=true,orientation=column),
+partition p4 start(30) end (40)
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "part_table13_1_prt_p1" for table "part_table13"
+NOTICE:  CREATE TABLE will create partition "part_table13_1_prt_p2" for table "part_table13"
+NOTICE:  CREATE TABLE will create partition "part_table13_1_prt_p3" for table "part_table13"
+NOTICE:  CREATE TABLE will create partition "part_table13_1_prt_p4" for table "part_table13"
+create index part_table13_1_idx on part_table13_1_prt_p1 using btree(c);
+create index part_table13_2_idx on part_table13_1_prt_p2 using btree(c);
+create index part_table13_3_idx on part_table13_1_prt_p3 using bitmap(c);
+create index part_table13_4_idx on part_table13_1_prt_p4 using bitmap(c);
+explain select * from part_table13 where c=7;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4295.00 rows=312 width=12)
+   ->  Append  (cost=0.00..4295.00 rows=104 width=12)
+         ->  Seq Scan on part_table13_1_prt_p1  (cost=0.00..1073.75 rows=26 width=12)
+               Filter: (c = 7)
+         ->  Seq Scan on part_table13_1_prt_p2  (cost=0.00..1073.75 rows=26 width=12)
+               Filter: (c = 7)
+         ->  Seq Scan on part_table13_1_prt_p3  (cost=0.00..1073.75 rows=26 width=12)
+               Filter: (c = 7)
+         ->  Seq Scan on part_table13_1_prt_p4  (cost=0.00..1073.75 rows=26 width=12)
+               Filter: (c = 7)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select * from part_table13 where c=7;
+ a | b | c 
+---+---+---
+(0 rows)
+
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 NOTICE:  drop cascades to 167 other objects

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14417,6 +14417,66 @@ SELECT gp_segment_id, * FROM result_tab;
 DROP TABLE IF EXISTS dist_tab_a;
 DROP TABLE IF EXISTS dist_tab_b;
 DROP TABLE IF EXISTS result_tab;
+-- Test if orca produces bitmap scan on mixed partitions
+create table mixed_part( a int) distributed randomly
+partition by range (a)
+( partition a1 start (1) end (100) with (appendonly='true'),
+partition a2 start (100) end (200) with (appendonly='false'));
+NOTICE:  CREATE TABLE will create partition "mixed_part_1_prt_a1" for table "mixed_part"
+NOTICE:  CREATE TABLE will create partition "mixed_part_1_prt_a2" for table "mixed_part"
+create index idx_mixed_part on mixed_part using btree(a);
+insert into mixed_part select i from generate_series(1,199)i;
+insert into mixed_part select 12 from generate_series(1,100)i;
+analyze mixed_part;
+explain select * from mixed_part where a=3;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..391.30 rows=1 width=4)
+   ->  Sequence  (cost=0.00..391.30 rows=1 width=4)
+         ->  Partition Selector for mixed_part (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+               Partitions selected: 1 (out of 2)
+         ->  Dynamic Bitmap Heap Scan on mixed_part (dynamic scan id: 1)  (cost=0.00..391.30 rows=1 width=4)
+               Recheck Cond: (a = 3)
+               ->  Dynamic Bitmap Index Scan on idx_mixed_part  (cost=0.00..0.00 rows=0 width=0)
+                     Index Cond: (a = 3)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+select * from mixed_part where a=3;
+ a 
+---
+ 3
+(1 row)
+
+-- Test that orca still produces index scan on heap partitions
+create table heap_part( a int) distributed randomly
+partition by range (a)
+( partition a1 start (1) end (100) with (appendonly='false'),
+partition a2 start (100) end (200) with (appendonly='false'));
+NOTICE:  CREATE TABLE will create partition "heap_part_1_prt_a1" for table "heap_part"
+NOTICE:  CREATE TABLE will create partition "heap_part_1_prt_a2" for table "heap_part"
+create index idx_heap_part on heap_part using btree(a);
+insert into heap_part select i from generate_series(1,199)i;
+insert into heap_part select 12 from generate_series(1,100)i;
+analyze heap_part;
+explain select * from heap_part where a=3;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=4)
+   ->  Sequence  (cost=0.00..6.00 rows=1 width=4)
+         ->  Partition Selector for heap_part (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+               Partitions selected: 1 (out of 2)
+         ->  Dynamic Index Scan on heap_part (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=4)
+               Index Cond: (a = 3)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+select * from heap_part where a=3;
+ a 
+---
+ 3
+(1 row)
+
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 NOTICE:  drop cascades to 167 other objects

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14477,6 +14477,44 @@ select * from heap_part where a=3;
  3
 (1 row)
 
+-- Generate bitmap scan for mixed index types
+create table part_table13(a int, b int, c int)
+partition by range(b)
+(
+partition p1 start(1) end(10),
+partition p2 start(10) end (20) with (appendonly=true),
+partition p3 start(20) end (30) with (appendonly=true,orientation=column),
+partition p4 start(30) end (40)
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "part_table13_1_prt_p1" for table "part_table13"
+NOTICE:  CREATE TABLE will create partition "part_table13_1_prt_p2" for table "part_table13"
+NOTICE:  CREATE TABLE will create partition "part_table13_1_prt_p3" for table "part_table13"
+NOTICE:  CREATE TABLE will create partition "part_table13_1_prt_p4" for table "part_table13"
+create index part_table13_1_idx on part_table13_1_prt_p1 using btree(c);
+create index part_table13_2_idx on part_table13_1_prt_p2 using btree(c);
+create index part_table13_3_idx on part_table13_1_prt_p3 using bitmap(c);
+create index part_table13_4_idx on part_table13_1_prt_p4 using bitmap(c);
+explain select * from part_table13 where c=7;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..391.30 rows=1 width=12)
+   ->  Sequence  (cost=0.00..391.30 rows=1 width=12)
+         ->  Partition Selector for part_table13 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+               Partitions selected: 4 (out of 4)
+         ->  Dynamic Bitmap Heap Scan on part_table13 (dynamic scan id: 1)  (cost=0.00..391.30 rows=1 width=12)
+               Recheck Cond: (c = 7)
+               ->  Dynamic Bitmap Index Scan on part_table13_1_idx  (cost=0.00..0.00 rows=0 width=0)
+                     Index Cond: (c = 7)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+select * from part_table13 where c=7;
+ a | b | c 
+---+---+---
+(0 rows)
+
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 NOTICE:  drop cascades to 167 other objects

--- a/src/test/regress/expected/qp_dropped_cols.out
+++ b/src/test/regress/expected/qp_dropped_cols.out
@@ -15817,8 +15817,11 @@ EXPLAIN SELECT * FROM table_with_leaf_containing_dropped_column_between_index_co
  Optimizer: Postgres query optimizer
 (7 rows)
 
--- FIXME: Test fails on ORCA
--- SELECT * FROM table_with_leaf_containing_dropped_column_between_index_columns WHERE a>42 and z<42;
+SELECT * FROM table_with_leaf_containing_dropped_column_between_index_columns WHERE a>42 and z<42;
+ a | b | z 
+---+---+---
+(0 rows)
+
 EXPLAIN SELECT * FROM leaf_containing_dropped_col_index_part1 WHERE a>42 and z<42;
                                              QUERY PLAN                                             
 ----------------------------------------------------------------------------------------------------
@@ -15880,8 +15883,11 @@ EXPLAIN SELECT * FROM table_with_root_containing_dropped_columns WHERE a>42 and 
  Optimizer: Postgres query optimizer
 (7 rows)
 
--- FIXME: Test fails on ORCA
--- SELECT * FROM table_with_root_containing_dropped_columns WHERE a>42 and z<42;
+SELECT * FROM table_with_root_containing_dropped_columns WHERE a>42 and z<42;
+ a | b | z 
+---+---+---
+(0 rows)
+
 EXPLAIN SELECT * FROM leaf_with_root_containing_dropped_columns_part1 WHERE a>42 and z<42;
                                                  QUERY PLAN                                                 
 ------------------------------------------------------------------------------------------------------------
@@ -15944,8 +15950,11 @@ EXPLAIN SELECT * FROM table_with_both_containing_dropped_column WHERE a>42 and z
  Optimizer: Postgres query optimizer
 (7 rows)
 
--- FIXME: Test fails on ORCA
--- SELECT * FROM table_with_both_containing_dropped_column WHERE a>42 and z<42;
+SELECT * FROM table_with_both_containing_dropped_column WHERE a>42 and z<42;
+ a | b | z 
+---+---+---
+(0 rows)
+
 EXPLAIN SELECT * FROM leaf_with_dropped_cols_index_part1 WHERE a>42 and z<42;
                                           QUERY PLAN                                           
 -----------------------------------------------------------------------------------------------
@@ -15972,6 +15981,209 @@ EXPLAIN SELECT * FROM leaf_with_dropped_cols_index_part2 WHERE a>42 and z<42;
 SELECT * FROM leaf_with_dropped_cols_index_part2 WHERE a>42 and z<42;
  a | b | z 
 ---+---+---
+(0 rows)
+
+-- multi-level-partition with dropped root cols and exchanged partition
+drop table if exists multi_dropped_cols_root;
+NOTICE:  table "multi_dropped_cols_root" does not exist, skipping
+CREATE TABLE multi_dropped_cols_root (trans_id int, to_be_dropped1 int, date date, amount 
+decimal(9,2), to_be_dropped2 int, region text) 
+DISTRIBUTED BY (trans_id)
+PARTITION BY RANGE (date)
+SUBPARTITION BY LIST (region)
+SUBPARTITION TEMPLATE
+( SUBPARTITION usa VALUES ('usa'), 
+  SUBPARTITION asia VALUES ('asia'))
+  (START (date '2011-01-01') INCLUSIVE
+   END (date '2011-04-01') EXCLUSIVE
+   EVERY (INTERVAL '3 month'));
+NOTICE:  CREATE TABLE will create partition "multi_dropped_cols_root_1_prt_1" for table "multi_dropped_cols_root"
+NOTICE:  CREATE TABLE will create partition "multi_dropped_cols_root_1_prt_1_2_prt_usa" for table "multi_dropped_cols_root_1_prt_1"
+NOTICE:  CREATE TABLE will create partition "multi_dropped_cols_root_1_prt_1_2_prt_asia" for table "multi_dropped_cols_root_1_prt_1"
+alter table multi_dropped_cols_root drop column to_be_dropped1;
+alter table multi_dropped_cols_root drop column to_be_dropped2;
+drop table if exists multi_dropped_cols_root_exchange_part;
+NOTICE:  table "multi_dropped_cols_root_exchange_part" does not exist, skipping
+create table multi_dropped_cols_root_exchange_part (trans_id int, date date, amount 
+decimal(9,2), region text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'trans_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ALTER TABLE multi_dropped_cols_root 
+ALTER PARTITION FOR (RANK(1))
+EXCHANGE PARTITION FOR ('usa') WITH TABLE multi_dropped_cols_root_exchange_part ;
+NOTICE:  exchanged partition "usa" of partition for rank 1 of relation "multi_dropped_cols_root" with relation "multi_dropped_cols_root_exchange_part"
+create index idx_sales_date on multi_dropped_cols_root(date);
+explain select * from multi_dropped_cols_root where date = '2011-01-01' and region = 'usa';
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..683.50 rows=2 width=54)
+   ->  Append  (cost=0.00..683.50 rows=1 width=54)
+         ->  Seq Scan on multi_dropped_cols_root_1_prt_1_2_prt_usa  (cost=0.00..683.50 rows=1 width=54)
+               Filter: ((date = '2011-01-01'::date) AND (region = 'usa'::text))
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+select * from multi_dropped_cols_root where date = '2011-01-01' and region = 'usa';
+ trans_id | date | amount | region 
+----------+------+--------+--------
+(0 rows)
+
+-- multi-level-partition with dropped leaf cols and exchanged partition
+CREATE TABLE multi_dropped_cols_leaf (trans_id int, date date, amount 
+decimal(9,2), region text) 
+DISTRIBUTED BY (trans_id)
+PARTITION BY RANGE (date)
+SUBPARTITION BY LIST (region)
+SUBPARTITION TEMPLATE
+( SUBPARTITION usa VALUES ('usa'), 
+  SUBPARTITION asia VALUES ('asia'))
+  (START (date '2011-01-01') INCLUSIVE
+   END (date '2011-04-01') EXCLUSIVE
+   EVERY (INTERVAL '3 month'));
+NOTICE:  CREATE TABLE will create partition "multi_dropped_cols_leaf_1_prt_1" for table "multi_dropped_cols_leaf"
+NOTICE:  CREATE TABLE will create partition "multi_dropped_cols_leaf_1_prt_1_2_prt_usa" for table "multi_dropped_cols_leaf_1_prt_1"
+NOTICE:  CREATE TABLE will create partition "multi_dropped_cols_leaf_1_prt_1_2_prt_asia" for table "multi_dropped_cols_leaf_1_prt_1"
+drop table if exists multi_dropped_cols_leaf_exchange_part;
+NOTICE:  table "multi_dropped_cols_leaf_exchange_part" does not exist, skipping
+create table multi_dropped_cols_leaf_exchange_part (trans_id int, to_be_dropped1, date date, amount 
+decimal(9,2), to_be_dropped2, region text);
+ERROR:  syntax error at or near ","
+LINE 1: ...s_leaf_exchange_part (trans_id int, to_be_dropped1, date dat...
+                                                             ^
+alter table multi_dropped_cols_leaf_exchange_part drop column to_be_dropped1;
+ERROR:  relation "multi_dropped_cols_leaf_exchange_part" does not exist
+alter table multi_dropped_cols_leaf_exchange_part drop column to_be_dropped2;
+ERROR:  relation "multi_dropped_cols_leaf_exchange_part" does not exist
+ALTER TABLE multi_dropped_cols_leaf 
+ALTER PARTITION FOR (RANK(1))
+EXCHANGE PARTITION FOR ('usa') WITH TABLE sales_exchange_part ;
+ERROR:  relation "sales_exchange_part" does not exist
+create index idx_multi_dropped_cols_leaf_date on multi_dropped_cols_leaf(date);
+explain select * from multi_dropped_cols_leaf where date = '2011-01-01' and region = 'usa';
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..683.50 rows=2 width=54)
+   ->  Append  (cost=0.00..683.50 rows=1 width=54)
+         ->  Seq Scan on multi_dropped_cols_leaf_1_prt_1_2_prt_usa  (cost=0.00..683.50 rows=1 width=54)
+               Filter: ((date = '2011-01-01'::date) AND (region = 'usa'::text))
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+select * from multi_dropped_cols_leaf where date = '2011-01-01' and region = 'usa';
+ trans_id | date | amount | region 
+----------+------+--------+--------
+(0 rows)
+
+-- multi-level-partition with btree index with mid level not having dropped column for added partition
+CREATE TABLE multi_part_mid_btree (trans_id int, to_be_dropped1 int, date date, amount 
+decimal(9,2), to_be_dropped2 int, region text) 
+DISTRIBUTED BY (trans_id)
+PARTITION BY RANGE (date)
+SUBPARTITION BY LIST (region)
+SUBPARTITION TEMPLATE
+( SUBPARTITION usa VALUES ('usa'), 
+  SUBPARTITION asia VALUES ('asia'))
+  (START (date '2011-01-01') INCLUSIVE
+   END (date '2011-04-01') EXCLUSIVE
+   EVERY (INTERVAL '3 month'));
+NOTICE:  CREATE TABLE will create partition "multi_part_mid_btree_1_prt_1" for table "multi_part_mid_btree"
+NOTICE:  CREATE TABLE will create partition "multi_part_mid_btree_1_prt_1_2_prt_usa" for table "multi_part_mid_btree_1_prt_1"
+NOTICE:  CREATE TABLE will create partition "multi_part_mid_btree_1_prt_1_2_prt_asia" for table "multi_part_mid_btree_1_prt_1"
+alter table multi_part_mid_btree drop column to_be_dropped1;
+alter table multi_part_mid_btree drop column to_be_dropped2;
+-- Create the exchange candidate without dropped columns
+drop table if exists multi_part_mid_btree_exchange_part;
+NOTICE:  table "multi_part_mid_btree_exchange_part" does not exist, skipping
+create table multi_part_mid_btree_exchange_part (trans_id int, date date, amount 
+decimal(9,2), region text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'trans_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Exchange
+ALTER TABLE multi_part_mid_btree 
+ALTER PARTITION FOR (RANK(1))
+EXCHANGE PARTITION FOR ('usa') WITH TABLE multi_part_mid_btree_exchange_part ;
+NOTICE:  exchanged partition "usa" of partition for rank 1 of relation "multi_part_mid_btree" with relation "multi_part_mid_btree_exchange_part"
+ALTER TABLE multi_part_mid_btree ADD PARTITION 
+            START (date '2017-02-01') INCLUSIVE 
+            END (date '2017-03-01') EXCLUSIVE;
+NOTICE:  CREATE TABLE will create partition "multi_part_mid_btree_1_prt_r1910462130" for table "multi_part_mid_btree"
+NOTICE:  CREATE TABLE will create partition "multi_part_mid_btree_1_prt_r1910462130_2_prt_usa" for table "multi_part_mid_btree_1_prt_r1910462130"
+NOTICE:  CREATE TABLE will create partition "multi_part_mid_btree_1_prt_r1910462130_2_prt_asia" for table "multi_part_mid_btree_1_prt_r1910462130"
+create index idx_multi_part_mid_btree on multi_part_mid_btree(date);
+-- Since we have arbitrarily named partitions here, we can't match the plan
+-- output for planner. It should still generate a dynamic bitmap scan for Orca.
+-- start_ignore
+explain select * from multi_part_mid_btree where date = '2017-02-05' and region = 'usa';
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1367.00 rows=3 width=54)
+   ->  Append  (cost=0.00..1367.00 rows=1 width=54)
+         ->  Seq Scan on multi_part_mid_btree_1_prt_1_2_prt_usa  (cost=0.00..683.50 rows=1 width=54)
+               Filter: ((date = '2017-02-05'::date) AND (region = 'usa'::text))
+         ->  Seq Scan on multi_part_mid_btree_1_prt_r1544653164_2_prt_usa  (cost=0.00..683.50 rows=1 width=54)
+               Filter: ((date = '2017-02-05'::date) AND (region = 'usa'::text))
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+-- end_ignore
+select * from multi_part_mid_btree where date = '2017-02-05' and region = 'usa';
+ trans_id | date | amount | region 
+----------+------+--------+--------
+(0 rows)
+
+-- multi-level-partition with bitmap index with mid level not having dropped column for added partition
+CREATE TABLE multi_part_mid_bitmap (trans_id int, to_be_dropped1 int, date date, amount 
+decimal(9,2), to_be_dropped2 int, region text) 
+DISTRIBUTED BY (trans_id)
+PARTITION BY RANGE (date)
+SUBPARTITION BY LIST (region)
+SUBPARTITION TEMPLATE
+( SUBPARTITION usa VALUES ('usa'), 
+  SUBPARTITION asia VALUES ('asia'))
+  (START (date '2011-01-01') INCLUSIVE
+   END (date '2011-04-01') EXCLUSIVE
+   EVERY (INTERVAL '3 month'));
+NOTICE:  CREATE TABLE will create partition "multi_part_mid_bitmap_1_prt_1" for table "multi_part_mid_bitmap"
+NOTICE:  CREATE TABLE will create partition "multi_part_mid_bitmap_1_prt_1_2_prt_usa" for table "multi_part_mid_bitmap_1_prt_1"
+NOTICE:  CREATE TABLE will create partition "multi_part_mid_bitmap_1_prt_1_2_prt_asia" for table "multi_part_mid_bitmap_1_prt_1"
+alter table multi_part_mid_bitmap drop column to_be_dropped1;
+alter table multi_part_mid_bitmap drop column to_be_dropped2;
+drop table if exists multi_part_mid_bitmap_exchange_part;
+NOTICE:  table "multi_part_mid_bitmap_exchange_part" does not exist, skipping
+create table multi_part_mid_bitmap_exchange_part (trans_id int, date date, amount 
+decimal(9,2), region text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'trans_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ALTER TABLE multi_part_mid_bitmap 
+ALTER PARTITION FOR (RANK(1))
+EXCHANGE PARTITION FOR ('usa') WITH TABLE multi_part_mid_bitmap_exchange_part ;
+NOTICE:  exchanged partition "usa" of partition for rank 1 of relation "multi_part_mid_bitmap" with relation "multi_part_mid_bitmap_exchange_part"
+ALTER TABLE multi_part_mid_bitmap ADD PARTITION 
+            START (date '2017-02-01') INCLUSIVE 
+            END (date '2017-03-01') EXCLUSIVE;
+NOTICE:  CREATE TABLE will create partition "multi_part_mid_bitmap_1_prt_r640350246" for table "multi_part_mid_bitmap"
+NOTICE:  CREATE TABLE will create partition "multi_part_mid_bitmap_1_prt_r640350246_2_prt_usa" for table "multi_part_mid_bitmap_1_prt_r640350246"
+NOTICE:  CREATE TABLE will create partition "multi_part_mid_bitmap_1_prt_r640350246_2_prt_asia" for table "multi_part_mid_bitmap_1_prt_r640350246"
+create index idx_multi_part_mid_bitmap on multi_part_mid_bitmap using bitmap(date);
+-- Since we have arbitrarily named partitions here, we can't match the plan
+-- output for planner. It should still generate a dynamic bitmap scan for Orca.
+-- start_ignore
+explain select * from multi_part_mid_bitmap where date = '2017-02-05' and region = 'usa';
+                                                  QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1367.00 rows=3 width=54)
+   ->  Append  (cost=0.00..1367.00 rows=1 width=54)
+         ->  Seq Scan on multi_part_mid_bitmap_1_prt_1_2_prt_usa  (cost=0.00..683.50 rows=1 width=54)
+               Filter: ((date = '2017-02-05'::date) AND (region = 'usa'::text))
+         ->  Seq Scan on multi_part_mid_bitmap_1_prt_r640350246_2_prt_usa  (cost=0.00..683.50 rows=1 width=54)
+               Filter: ((date = '2017-02-05'::date) AND (region = 'usa'::text))
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+-- end_ignore
+select * from multi_part_mid_bitmap where date = '2017-02-05' and region = 'usa';
+ trans_id | date | amount | region 
+----------+------+--------+--------
 (0 rows)
 
 -- As of this writing, pg_dump creates an invalid dump for some of the tables

--- a/src/test/regress/expected/qp_dropped_cols_optimizer.out
+++ b/src/test/regress/expected/qp_dropped_cols_optimizer.out
@@ -15724,8 +15724,11 @@ EXPLAIN SELECT * FROM table_with_leaf_containing_dropped_column_between_index_co
  Optimizer: Pivotal Optimizer (GPORCA)
 (8 rows)
 
--- FIXME: Test fails on ORCA
--- SELECT * FROM table_with_leaf_containing_dropped_column_between_index_columns WHERE a>42 and z<42;
+SELECT * FROM table_with_leaf_containing_dropped_column_between_index_columns WHERE a>42 and z<42;
+ a | b | z 
+---+---+---
+(0 rows)
+
 EXPLAIN SELECT * FROM leaf_containing_dropped_col_index_part1 WHERE a>42 and z<42;
                                            QUERY PLAN                                           
 ------------------------------------------------------------------------------------------------
@@ -15789,8 +15792,11 @@ EXPLAIN SELECT * FROM table_with_root_containing_dropped_columns WHERE a>42 and 
  Optimizer: Pivotal Optimizer (GPORCA)
 (8 rows)
 
--- FIXME: Test fails on ORCA
--- SELECT * FROM table_with_root_containing_dropped_columns WHERE a>42 and z<42;
+SELECT * FROM table_with_root_containing_dropped_columns WHERE a>42 and z<42;
+ a | b | z 
+---+---+---
+(0 rows)
+
 EXPLAIN SELECT * FROM leaf_with_root_containing_dropped_columns_part1 WHERE a>42 and z<42;
                                                QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------
@@ -15855,8 +15861,11 @@ EXPLAIN SELECT * FROM table_with_both_containing_dropped_column WHERE a>42 and z
  Optimizer: Pivotal Optimizer (GPORCA)
 (8 rows)
 
--- FIXME: Test fails on ORCA
--- SELECT * FROM table_with_both_containing_dropped_column WHERE a>42 and z<42;
+SELECT * FROM table_with_both_containing_dropped_column WHERE a>42 and z<42;
+ a | b | z 
+---+---+---
+(0 rows)
+
 EXPLAIN SELECT * FROM leaf_with_dropped_cols_index_part1 WHERE a>42 and z<42;
                                         QUERY PLAN                                         
 -------------------------------------------------------------------------------------------
@@ -15884,6 +15893,219 @@ EXPLAIN SELECT * FROM leaf_with_dropped_cols_index_part2 WHERE a>42 and z<42;
 SELECT * FROM leaf_with_dropped_cols_index_part2 WHERE a>42 and z<42;
  a | b | z 
 ---+---+---
+(0 rows)
+
+-- multi-level-partition with dropped root cols and exchanged partition
+drop table if exists multi_dropped_cols_root;
+NOTICE:  table "multi_dropped_cols_root" does not exist, skipping
+CREATE TABLE multi_dropped_cols_root (trans_id int, to_be_dropped1 int, date date, amount 
+decimal(9,2), to_be_dropped2 int, region text) 
+DISTRIBUTED BY (trans_id)
+PARTITION BY RANGE (date)
+SUBPARTITION BY LIST (region)
+SUBPARTITION TEMPLATE
+( SUBPARTITION usa VALUES ('usa'), 
+  SUBPARTITION asia VALUES ('asia'))
+  (START (date '2011-01-01') INCLUSIVE
+   END (date '2011-04-01') EXCLUSIVE
+   EVERY (INTERVAL '3 month'));
+NOTICE:  CREATE TABLE will create partition "multi_dropped_cols_root_1_prt_1" for table "multi_dropped_cols_root"
+NOTICE:  CREATE TABLE will create partition "multi_dropped_cols_root_1_prt_1_2_prt_usa" for table "multi_dropped_cols_root_1_prt_1"
+NOTICE:  CREATE TABLE will create partition "multi_dropped_cols_root_1_prt_1_2_prt_asia" for table "multi_dropped_cols_root_1_prt_1"
+alter table multi_dropped_cols_root drop column to_be_dropped1;
+alter table multi_dropped_cols_root drop column to_be_dropped2;
+drop table if exists multi_dropped_cols_root_exchange_part;
+NOTICE:  table "multi_dropped_cols_root_exchange_part" does not exist, skipping
+create table multi_dropped_cols_root_exchange_part (trans_id int, date date, amount 
+decimal(9,2), region text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'trans_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ALTER TABLE multi_dropped_cols_root 
+ALTER PARTITION FOR (RANK(1))
+EXCHANGE PARTITION FOR ('usa') WITH TABLE multi_dropped_cols_root_exchange_part ;
+NOTICE:  exchanged partition "usa" of partition for rank 1 of relation "multi_dropped_cols_root" with relation "multi_dropped_cols_root_exchange_part"
+create index idx_sales_date on multi_dropped_cols_root(date);
+explain select * from multi_dropped_cols_root where date = '2011-01-01' and region = 'usa';
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=24)
+   ->  Sequence  (cost=0.00..6.00 rows=1 width=24)
+         ->  Partition Selector for multi_dropped_cols_root (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+               Partitions selected: 1 (out of 2)
+         ->  Dynamic Index Scan on multi_dropped_cols_root (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=24)
+               Index Cond: (date = '2011-01-01'::date)
+               Filter: ((date = '2011-01-01'::date) AND (region = 'usa'::text))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+select * from multi_dropped_cols_root where date = '2011-01-01' and region = 'usa';
+ trans_id | date | amount | region 
+----------+------+--------+--------
+(0 rows)
+
+-- multi-level-partition with dropped leaf cols and exchanged partition
+CREATE TABLE multi_dropped_cols_leaf (trans_id int, date date, amount 
+decimal(9,2), region text) 
+DISTRIBUTED BY (trans_id)
+PARTITION BY RANGE (date)
+SUBPARTITION BY LIST (region)
+SUBPARTITION TEMPLATE
+( SUBPARTITION usa VALUES ('usa'), 
+  SUBPARTITION asia VALUES ('asia'))
+  (START (date '2011-01-01') INCLUSIVE
+   END (date '2011-04-01') EXCLUSIVE
+   EVERY (INTERVAL '3 month'));
+NOTICE:  CREATE TABLE will create partition "multi_dropped_cols_leaf_1_prt_1" for table "multi_dropped_cols_leaf"
+NOTICE:  CREATE TABLE will create partition "multi_dropped_cols_leaf_1_prt_1_2_prt_usa" for table "multi_dropped_cols_leaf_1_prt_1"
+NOTICE:  CREATE TABLE will create partition "multi_dropped_cols_leaf_1_prt_1_2_prt_asia" for table "multi_dropped_cols_leaf_1_prt_1"
+drop table if exists multi_dropped_cols_leaf_exchange_part;
+NOTICE:  table "multi_dropped_cols_leaf_exchange_part" does not exist, skipping
+create table multi_dropped_cols_leaf_exchange_part (trans_id int, to_be_dropped1, date date, amount 
+decimal(9,2), to_be_dropped2, region text);
+ERROR:  syntax error at or near ","
+LINE 1: ...s_leaf_exchange_part (trans_id int, to_be_dropped1, date dat...
+                                                             ^
+alter table multi_dropped_cols_leaf_exchange_part drop column to_be_dropped1;
+ERROR:  relation "multi_dropped_cols_leaf_exchange_part" does not exist
+alter table multi_dropped_cols_leaf_exchange_part drop column to_be_dropped2;
+ERROR:  relation "multi_dropped_cols_leaf_exchange_part" does not exist
+ALTER TABLE multi_dropped_cols_leaf 
+ALTER PARTITION FOR (RANK(1))
+EXCHANGE PARTITION FOR ('usa') WITH TABLE sales_exchange_part ;
+ERROR:  relation "sales_exchange_part" does not exist
+create index idx_multi_dropped_cols_leaf_date on multi_dropped_cols_leaf(date);
+explain select * from multi_dropped_cols_leaf where date = '2011-01-01' and region = 'usa';
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=24)
+   ->  Sequence  (cost=0.00..6.00 rows=1 width=24)
+         ->  Partition Selector for multi_dropped_cols_leaf (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+               Partitions selected: 1 (out of 2)
+         ->  Dynamic Index Scan on multi_dropped_cols_leaf (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=24)
+               Index Cond: (date = '2011-01-01'::date)
+               Filter: ((date = '2011-01-01'::date) AND (region = 'usa'::text))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+select * from multi_dropped_cols_leaf where date = '2011-01-01' and region = 'usa';
+ trans_id | date | amount | region 
+----------+------+--------+--------
+(0 rows)
+
+-- multi-level-partition with btree index with mid level not having dropped column for added partition
+CREATE TABLE multi_part_mid_btree (trans_id int, to_be_dropped1 int, date date, amount 
+decimal(9,2), to_be_dropped2 int, region text) 
+DISTRIBUTED BY (trans_id)
+PARTITION BY RANGE (date)
+SUBPARTITION BY LIST (region)
+SUBPARTITION TEMPLATE
+( SUBPARTITION usa VALUES ('usa'), 
+  SUBPARTITION asia VALUES ('asia'))
+  (START (date '2011-01-01') INCLUSIVE
+   END (date '2011-04-01') EXCLUSIVE
+   EVERY (INTERVAL '3 month'));
+NOTICE:  CREATE TABLE will create partition "multi_part_mid_btree_1_prt_1" for table "multi_part_mid_btree"
+NOTICE:  CREATE TABLE will create partition "multi_part_mid_btree_1_prt_1_2_prt_usa" for table "multi_part_mid_btree_1_prt_1"
+NOTICE:  CREATE TABLE will create partition "multi_part_mid_btree_1_prt_1_2_prt_asia" for table "multi_part_mid_btree_1_prt_1"
+alter table multi_part_mid_btree drop column to_be_dropped1;
+alter table multi_part_mid_btree drop column to_be_dropped2;
+-- Create the exchange candidate without dropped columns
+drop table if exists multi_part_mid_btree_exchange_part;
+NOTICE:  table "multi_part_mid_btree_exchange_part" does not exist, skipping
+create table multi_part_mid_btree_exchange_part (trans_id int, date date, amount 
+decimal(9,2), region text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'trans_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Exchange
+ALTER TABLE multi_part_mid_btree 
+ALTER PARTITION FOR (RANK(1))
+EXCHANGE PARTITION FOR ('usa') WITH TABLE multi_part_mid_btree_exchange_part ;
+NOTICE:  exchanged partition "usa" of partition for rank 1 of relation "multi_part_mid_btree" with relation "multi_part_mid_btree_exchange_part"
+ALTER TABLE multi_part_mid_btree ADD PARTITION 
+            START (date '2017-02-01') INCLUSIVE 
+            END (date '2017-03-01') EXCLUSIVE;
+NOTICE:  CREATE TABLE will create partition "multi_part_mid_btree_1_prt_r1108536696" for table "multi_part_mid_btree"
+NOTICE:  CREATE TABLE will create partition "multi_part_mid_btree_1_prt_r1108536696_2_prt_usa" for table "multi_part_mid_btree_1_prt_r1108536696"
+NOTICE:  CREATE TABLE will create partition "multi_part_mid_btree_1_prt_r1108536696_2_prt_asia" for table "multi_part_mid_btree_1_prt_r1108536696"
+create index idx_multi_part_mid_btree on multi_part_mid_btree(date);
+-- Since we have arbitrarily named partitions here, we can't match the plan
+-- output for planner. It should still generate a dynamic bitmap scan for Orca.
+-- start_ignore
+explain select * from multi_part_mid_btree where date = '2017-02-05' and region = 'usa';
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=24)
+   ->  Sequence  (cost=0.00..6.00 rows=1 width=24)
+         ->  Partition Selector for multi_part_mid_btree (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+               Partitions selected: 1 (out of 4)
+         ->  Dynamic Index Scan on multi_part_mid_btree (dynamic scan id: 1)  (cost=0.00..6.00 rows=1 width=24)
+               Index Cond: (date = '2017-02-05'::date)
+               Filter: ((date = '2017-02-05'::date) AND (region = 'usa'::text))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+-- end_ignore
+select * from multi_part_mid_btree where date = '2017-02-05' and region = 'usa';
+ trans_id | date | amount | region 
+----------+------+--------+--------
+(0 rows)
+
+-- multi-level-partition with bitmap index with mid level not having dropped column for added partition
+CREATE TABLE multi_part_mid_bitmap (trans_id int, to_be_dropped1 int, date date, amount 
+decimal(9,2), to_be_dropped2 int, region text) 
+DISTRIBUTED BY (trans_id)
+PARTITION BY RANGE (date)
+SUBPARTITION BY LIST (region)
+SUBPARTITION TEMPLATE
+( SUBPARTITION usa VALUES ('usa'), 
+  SUBPARTITION asia VALUES ('asia'))
+  (START (date '2011-01-01') INCLUSIVE
+   END (date '2011-04-01') EXCLUSIVE
+   EVERY (INTERVAL '3 month'));
+NOTICE:  CREATE TABLE will create partition "multi_part_mid_bitmap_1_prt_1" for table "multi_part_mid_bitmap"
+NOTICE:  CREATE TABLE will create partition "multi_part_mid_bitmap_1_prt_1_2_prt_usa" for table "multi_part_mid_bitmap_1_prt_1"
+NOTICE:  CREATE TABLE will create partition "multi_part_mid_bitmap_1_prt_1_2_prt_asia" for table "multi_part_mid_bitmap_1_prt_1"
+alter table multi_part_mid_bitmap drop column to_be_dropped1;
+alter table multi_part_mid_bitmap drop column to_be_dropped2;
+drop table if exists multi_part_mid_bitmap_exchange_part;
+NOTICE:  table "multi_part_mid_bitmap_exchange_part" does not exist, skipping
+create table multi_part_mid_bitmap_exchange_part (trans_id int, date date, amount 
+decimal(9,2), region text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'trans_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ALTER TABLE multi_part_mid_bitmap 
+ALTER PARTITION FOR (RANK(1))
+EXCHANGE PARTITION FOR ('usa') WITH TABLE multi_part_mid_bitmap_exchange_part ;
+NOTICE:  exchanged partition "usa" of partition for rank 1 of relation "multi_part_mid_bitmap" with relation "multi_part_mid_bitmap_exchange_part"
+ALTER TABLE multi_part_mid_bitmap ADD PARTITION 
+            START (date '2017-02-01') INCLUSIVE 
+            END (date '2017-03-01') EXCLUSIVE;
+NOTICE:  CREATE TABLE will create partition "multi_part_mid_bitmap_1_prt_r799946243" for table "multi_part_mid_bitmap"
+NOTICE:  CREATE TABLE will create partition "multi_part_mid_bitmap_1_prt_r799946243_2_prt_usa" for table "multi_part_mid_bitmap_1_prt_r799946243"
+NOTICE:  CREATE TABLE will create partition "multi_part_mid_bitmap_1_prt_r799946243_2_prt_asia" for table "multi_part_mid_bitmap_1_prt_r799946243"
+create index idx_multi_part_mid_bitmap on multi_part_mid_bitmap using bitmap(date);
+-- Since we have arbitrarily named partitions here, we can't match the plan
+-- output for planner. It should still generate a dynamic bitmap scan for Orca.
+-- start_ignore
+explain select * from multi_part_mid_bitmap where date = '2017-02-05' and region = 'usa';
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..391.30 rows=1 width=24)
+   ->  Sequence  (cost=0.00..391.30 rows=1 width=24)
+         ->  Partition Selector for multi_part_mid_bitmap (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+               Partitions selected: 1 (out of 4)
+         ->  Dynamic Bitmap Heap Scan on multi_part_mid_bitmap (dynamic scan id: 1)  (cost=0.00..391.30 rows=1 width=24)
+               Recheck Cond: (date = '2017-02-05'::date)
+               Filter: ((date = '2017-02-05'::date) AND (region = 'usa'::text))
+               ->  Dynamic Bitmap Index Scan on idx_multi_part_mid_bitmap  (cost=0.00..0.00 rows=0 width=0)
+                     Index Cond: (date = '2017-02-05'::date)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+-- end_ignore
+select * from multi_part_mid_bitmap where date = '2017-02-05' and region = 'usa';
+ trans_id | date | amount | region 
+----------+------+--------+--------
 (0 rows)
 
 -- As of this writing, pg_dump creates an invalid dump for some of the tables

--- a/src/test/regress/output/partindex_test.source
+++ b/src/test/regress/output/partindex_test.source
@@ -50,7 +50,8 @@ select nColumns, indKey, indUnique, indPred, indExprs, partCons, defaultLevels, 
  ncolumns | indkey | indunique | indpred | indexprs | partcons | defaultlevels | indtype 
 ----------+--------+-----------+---------+----------+----------+---------------+---------
         1 | 1      | f         |         |          |          |               |       0
-(1 row)
+        1 | 1      | f         |         |          |          |               |       1
+(2 rows)
 
 -- partial index on all part
 -- output shows 1 logical index with partial predicate 
@@ -63,7 +64,8 @@ where indpred is NOT NULL;
  indkey |           pg_get_expr            | partcons 
 --------+----------------------------------+----------
  1      | (part_key >= 1), (part_key < 10) | 
-(1 row)
+ 1      | (part_key >= 1), (part_key < 10) | 
+(2 rows)
 
 -- add a new part - index automatically created 
 alter table part_table1 add partition part4 start('31') end ('40');
@@ -72,7 +74,7 @@ NOTICE:  CREATE TABLE will create partition "part_table1_1_prt_part4" for table 
 select count(*) from gp_build_logical_index('part_table1'::regclass);
  count 
 -------
-     2
+     4
 (1 row)
 
 select indKey, pg_get_expr(indpred, 'part_table1'::regclass), partCons from gp_build_logical_index('part_table1'::regclass)
@@ -80,7 +82,8 @@ where indpred is NOT NULL;
  indkey |           pg_get_expr            | partcons 
 --------+----------------------------------+----------
  1      | (part_key >= 1), (part_key < 10) | 
-(1 row)
+ 1      | (part_key >= 1), (part_key < 10) | 
+(2 rows)
 
 -- create index on just 1 part
 create index rp_i2 on part_table1_1_prt_part4(part_key, content);
@@ -88,7 +91,7 @@ create index rp_i2 on part_table1_1_prt_part4(part_key, content);
 select count(*) from gp_build_logical_index('part_table1'::regclass);
  count 
 -------
-     3
+     6
 (1 row)
 
 select indKey, defaultLevels, partCons from gp_build_logical_index('part_table1'::regclass)
@@ -96,7 +99,8 @@ where partcons is NOT NULL;
  indkey | defaultlevels |                partcons                
 --------+---------------+----------------------------------------
  1 2    |               | ((part_key >= 31) AND (part_key < 40))
-(1 row)
+ 1 2    |               | ((part_key >= 31) AND (part_key < 40))
+(2 rows)
 
 -- split a part into 2 parts - index created on both the parts
 -- the existing part4 along with indexes is dropped 
@@ -112,7 +116,9 @@ select indKey, defaultLevels, partCons from gp_build_logical_index('part_table1'
 --------+---------------+----------
  1      |               | 
  1      |               | 
-(2 rows)
+ 1      |               | 
+ 1      |               | 
+(4 rows)
 
 --
 -- ************************************************************
@@ -144,7 +150,8 @@ where indExprs is NOT NULL;
  indkey |  pg_get_expr   |                partcons                
 --------+----------------+----------------------------------------
  0      | lower(content) | ((part_key >= 11) AND (part_key < 20))
-(1 row)
+ 0      | lower(content) | ((part_key >= 11) AND (part_key < 20))
+(2 rows)
 
 --
 -- ************************************************************
@@ -304,7 +311,8 @@ select indKey, defaultLevels, partCons from gp_build_logical_index('part_table2'
  indkey | defaultlevels | partcons 
 --------+---------------+----------
  1      |               | 
-(1 row)
+ 1      |               | 
+(2 rows)
 
 -- create a partial index on part_table2 (will be created on all parts/subparts)
 create index second_index on part_table2(trans_id)  
@@ -380,7 +388,8 @@ where indPred is NOT NULL;
  indkey |              pg_get_expr              | defaultlevels | partcons 
 --------+---------------------------------------+---------------+----------
  1      | (trans_id >= 1000), (trans_id < 2000) |               | 
-(1 row)
+ 1      | (trans_id >= 1000), (trans_id < 2000) |               | 
+(2 rows)
 
 -- create index on expression on all parts
 create index third_index on part_table2(lower(region));
@@ -455,7 +464,8 @@ where indExprs is NOT NULL;
  indkey | indpred |  pg_get_expr  | partcons 
 --------+---------+---------------+----------
  0      |         | lower(region) | 
-(1 row)
+ 0      |         | lower(region) | 
+(2 rows)
 
 -- create indexes on all leaf parts of a mid-level partition
 -- logical index should be pulled up to the mid-level partition.
@@ -470,10 +480,14 @@ order by indKey;
  indkey |                            partcons                            
 --------+----------------------------------------------------------------
  0      | 
+ 0      | 
+ 1      | 
+ 1      | 
  1      | 
  1      | 
  2      | ((date >= '10-01-2008'::date) AND (date < '11-01-2008'::date))
-(4 rows)
+ 2      | ((date >= '10-01-2008'::date) AND (date < '11-01-2008'::date))
+(8 rows)
 
 -- Create an index on the mid-level -- internal part -- will not show up
 -- in the result.  Adding indexes to mid-level/internal root partitions will
@@ -488,10 +502,14 @@ order by indKey;
  indkey | defaultlevels |                            partcons                            
 --------+---------------+----------------------------------------------------------------
  0      |               | 
+ 0      |               | 
+ 1      |               | 
+ 1      |               | 
  1      |               | 
  1      |               | 
  2      |               | ((date >= '10-01-2008'::date) AND (date < '11-01-2008'::date))
-(4 rows)
+ 2      |               | ((date >= '10-01-2008'::date) AND (date < '11-01-2008'::date))
+(8 rows)
 
 -- create an index on a default part
 -- result should show this as an extra row
@@ -503,11 +521,16 @@ order by indKey;
  indkey | defaultlevels |                            partcons                            
 --------+---------------+----------------------------------------------------------------
  0      |               | 
+ 0      |               | 
  1      |               | 
  1      |               | 
+ 1      |               | 
+ 1      |               | 
+ 2      | (i 1)         | ((date >= '07-01-2008'::date) AND (date < '08-01-2008'::date))
  2      |               | ((date >= '10-01-2008'::date) AND (date < '11-01-2008'::date))
  2      | (i 1)         | ((date >= '07-01-2008'::date) AND (date < '08-01-2008'::date))
-(5 rows)
+ 2      |               | ((date >= '10-01-2008'::date) AND (date < '11-01-2008'::date))
+(10 rows)
 
 -- create an index on a bunch of default partitions 
 create index subset_index1 on part_table2_1_prt_7_2_prt_other_regions(upper(region));
@@ -518,12 +541,17 @@ where partcons is NOT NULL
 order by partcons;
   pg_get_expr  | defaultlevels |                            partcons                            
 ---------------+---------------+----------------------------------------------------------------
-               |               | ((date >= '10-01-2008'::date) AND (date < '11-01-2008'::date))
-               | (i 1)         | ((date >= '07-01-2008'::date) AND (date < '08-01-2008'::date))
  upper(region) | (i 1)         | ((date >= '06-01-2008'::date) AND (date < '07-01-2008'::date))
+ upper(region) | (i 1)         | ((date >= '06-01-2008'::date) AND (date < '07-01-2008'::date))
+               | (i 1)         | ((date >= '07-01-2008'::date) AND (date < '08-01-2008'::date))
+               | (i 1)         | ((date >= '07-01-2008'::date) AND (date < '08-01-2008'::date))
+ upper(region) | (i 1)         | ((date >= '08-01-2008'::date) AND (date < '09-01-2008'::date))
  upper(region) | (i 1)         | ((date >= '08-01-2008'::date) AND (date < '09-01-2008'::date))
  upper(region) | (i 1)         | ((date >= '10-01-2008'::date) AND (date < '11-01-2008'::date))
-(5 rows)
+               |               | ((date >= '10-01-2008'::date) AND (date < '11-01-2008'::date))
+               |               | ((date >= '10-01-2008'::date) AND (date < '11-01-2008'::date))
+ upper(region) | (i 1)         | ((date >= '10-01-2008'::date) AND (date < '11-01-2008'::date))
+(10 rows)
 
 create index subset_index4 on part_table2_1_prt_7_2_prt_other_regions(upper(region));
 create index subset_index5 on part_table2_1_prt_outlying_years_2_prt_other_regions(upper(region));
@@ -532,12 +560,17 @@ where partcons is NOT NULL
 order by partcons;
   pg_get_expr  | defaultlevels |                            partcons                            
 ---------------+---------------+----------------------------------------------------------------
-               |               | ((date >= '10-01-2008'::date) AND (date < '11-01-2008'::date))
-               | (i 1)         | ((date >= '07-01-2008'::date) AND (date < '08-01-2008'::date))
  upper(region) | (i 1)         | ((date >= '06-01-2008'::date) AND (date < '07-01-2008'::date))
+ upper(region) | (i 1)         | ((date >= '06-01-2008'::date) AND (date < '07-01-2008'::date))
+               | (i 1)         | ((date >= '07-01-2008'::date) AND (date < '08-01-2008'::date))
+               | (i 1)         | ((date >= '07-01-2008'::date) AND (date < '08-01-2008'::date))
+ upper(region) | (i 1)         | ((date >= '08-01-2008'::date) AND (date < '09-01-2008'::date))
  upper(region) | (i 1)         | ((date >= '08-01-2008'::date) AND (date < '09-01-2008'::date))
  upper(region) | (i 1)         | ((date >= '10-01-2008'::date) AND (date < '11-01-2008'::date))
-(5 rows)
+               |               | ((date >= '10-01-2008'::date) AND (date < '11-01-2008'::date))
+               |               | ((date >= '10-01-2008'::date) AND (date < '11-01-2008'::date))
+ upper(region) | (i 1)         | ((date >= '10-01-2008'::date) AND (date < '11-01-2008'::date))
+(10 rows)
 
 --
 -- ************************************************************
@@ -594,7 +627,8 @@ select indKey, defaultLevels, partCons from gp_build_logical_index('part_table3'
  indkey | defaultlevels | partcons 
 --------+---------------+----------
  1 4    |               | 
-(1 row)
+ 1 4    |               | 
+(2 rows)
 
 -- truncate partitions until table is empty
 select * from part_table3;
@@ -645,7 +679,8 @@ select indKey, defaultLevels, partCons from gp_build_logical_index('part_table3'
  indkey | defaultlevels | partcons 
 --------+---------------+----------
  1 4    |               | 
-(1 row)
+ 1 4    |               | 
+(2 rows)
 
 -- the index i1 on this part has atts - 1 3
 alter table part_table3 add partition part3 start(date '2010-01-01') end (date '2011-01-01')
@@ -657,7 +692,8 @@ select indKey, defaultLevels, partCons from gp_build_logical_index('part_table3'
  indkey | defaultlevels | partcons 
 --------+---------------+----------
  1 4    |               | 
-(1 row)
+ 1 4    |               | 
+(2 rows)
 
 -- extra row just on the default part show up
 create index i2 on part_table3(region);
@@ -675,8 +711,10 @@ order by nColumns;
  indkey | defaultlevels | partcons 
 --------+---------------+----------
  2      |               | 
+ 2      |               | 
  1 4    |               | 
-(2 rows)
+ 1 4    |               | 
+(4 rows)
 
 -- create an index on ALL subparts of 2 parts (part3 no dropped col)
 -- on part3 index is on attnum 3
@@ -690,9 +728,12 @@ order by indKey;
  indkey | defaultlevels |                                                              partcons                                                              
 --------+---------------+------------------------------------------------------------------------------------------------------------------------------------
  1 4    |               | 
+ 1 4    |               | 
+ 2      |               | 
  2      |               | 
  4      |               | (((date >= '01-01-2008'::date) AND (date < '01-01-2009'::date)) OR ((date >= '01-01-2010'::date) AND (date < '01-01-2011'::date)))
-(3 rows)
+ 4      |               | (((date >= '01-01-2008'::date) AND (date < '01-01-2009'::date)) OR ((date >= '01-01-2010'::date) AND (date < '01-01-2011'::date)))
+(6 rows)
 
 -- dropped cols in the ind expr 
 -- index expr varno are different
@@ -706,7 +747,8 @@ order by indKey;
  pg_get_expr  |                            partcons                            
 --------------+----------------------------------------------------------------
  ceil(amount) | ((date >= '01-01-2009'::date) AND (date < '01-01-2011'::date))
-(1 row)
+ ceil(amount) | ((date >= '01-01-2009'::date) AND (date < '01-01-2011'::date))
+(2 rows)
 
 -- dropped cols in the ind pred
 create index i52 on part_table3_1_prt_part2_2_prt_usa(amount) where amount < 1000;
@@ -718,7 +760,8 @@ order by indKey;
  indpred | pg_get_expr  | defaultlevels |                            partcons                            
 ---------+--------------+---------------+----------------------------------------------------------------
          | ceil(amount) |               | ((date >= '01-01-2009'::date) AND (date < '01-01-2011'::date))
-(1 row)
+         | ceil(amount) |               | ((date >= '01-01-2009'::date) AND (date < '01-01-2011'::date))
+(2 rows)
 
 --
 -- ************************************************************
@@ -871,7 +914,8 @@ where defaultLevels is NULL and partcons is NULL;
  pg_get_expr | indexprs | partcons 
 -------------+----------+----------
  (c1 < 100)  |          | 
-(1 row)
+ (c1 < 100)  |          | 
+(2 rows)
 
 -- returns 1 row with index on whole table
 select pg_get_expr(indPred, 'part_table5'::regclass) from gp_build_logical_index('part_table5'::regclass)
@@ -879,7 +923,8 @@ where partCons is NULL;
  pg_get_expr 
 -------------
  (c1 < 100)
-(1 row)
+ (c1 < 100)
+(2 rows)
 
 -- returns 1 row with index on default part
 select pg_get_expr(indExprs, 'part_table5'::regclass), defaultLevels from gp_build_logical_index('part_table5'::regclass)
@@ -887,7 +932,8 @@ where defaultLevels is NOT NULL;
  pg_get_expr | defaultlevels 
 -------------+---------------
  abs(c1)     | (i 0)
-(1 row)
+ abs(c1)     | (i 0)
+(2 rows)
 
 -- ************************************************************
 -- * Scenario 7
@@ -1006,32 +1052,38 @@ select 'part_table6', partCons, defaultLevels from gp_build_logical_index('part_
   ?column?   | partcons | defaultlevels 
 -------------+----------+---------------
  part_table6 | (a <= 3) | 
-(1 row)
+ part_table6 | (a <= 3) | 
+(2 rows)
 
 select 'part_table7', partCons, defaultLevels from gp_build_logical_index('part_table7'::regclass);
   ?column?   | partcons | defaultlevels 
 -------------+----------+---------------
  part_table7 | (a > 2)  | 
-(1 row)
+ part_table7 | (a > 2)  | 
+(2 rows)
 
 select 'part_table8', partCons, defaultLevels from gp_build_logical_index('part_table8'::regclass);
   ?column?   | partcons | defaultlevels 
 -------------+----------+---------------
  part_table8 |          | 
-(1 row)
+ part_table8 |          | 
+(2 rows)
 
 select 'part_table9', partCons, defaultLevels from gp_build_logical_index('part_table9'::regclass);
   ?column?   |               partcons               | defaultlevels 
 -------------+--------------------------------------+---------------
- part_table9 | ((a <= 1) OR ((a > 2) AND (a <= 3))) | 
  part_table9 | ((a > 1) AND (a <= 2))               | 
-(2 rows)
+ part_table9 | ((a > 1) AND (a <= 2))               | 
+ part_table9 | ((a <= 1) OR ((a > 2) AND (a <= 3))) | 
+ part_table9 | ((a <= 1) OR ((a > 2) AND (a <= 3))) | 
+(4 rows)
 
 select 'part_table10', partCons, defaultLevels from gp_build_logical_index('part_table10'::regclass);
    ?column?   |                     partcons                      | defaultlevels 
 --------------+---------------------------------------------------+---------------
  part_table10 | (((a > 1) AND (a < 2)) OR ((a > 2) AND (a <= 3))) | 
-(1 row)
+ part_table10 | (((a > 1) AND (a < 2)) OR ((a > 2) AND (a <= 3))) | 
+(2 rows)
 
 -- AO partitioned tables: Orca treats them as bitmap indexes
 create table part_table11(a int, b int, c int) with (appendonly=true) partition by list(b) (partition p1 values(1), partition p2 values(2));
@@ -1070,7 +1122,7 @@ select 'part_table12', partCons, defaultLevels, indType from gp_build_logical_in
    ?column?   |       partcons       | defaultlevels | indtype 
 --------------+----------------------+---------------+---------
  part_table12 | ((b = 1) OR (b = 4)) |               |       0
- part_table12 | ((b = 2) OR (b = 3)) |               |       1
+ part_table12 |                      |               |       1
 (2 rows)
 
 -- ************************************************************
@@ -1102,10 +1154,10 @@ create index part_table13_3_idx on part_table13_1_prt_p3 using bitmap(c);
 -- heap/bitmap
 create index part_table13_4_idx on part_table13_1_prt_p4 using bitmap(c); 
 select 'part_table13', partCons, defaultLevels, indType from gp_build_logical_index('part_table13'::regclass);
-   ?column?   |         partcons         | defaultlevels | indtype 
---------------+--------------------------+---------------+---------
- part_table13 | ((b >= 1) AND (b < 10))  |               |       0
- part_table13 | ((b >= 10) AND (b < 40)) |               |       1
+   ?column?   |        partcons         | defaultlevels | indtype 
+--------------+-------------------------+---------------+---------
+ part_table13 | ((b >= 1) AND (b < 10)) |               |       0
+ part_table13 |                         |               |       1
 (2 rows)
 
 --

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3195,6 +3195,25 @@ analyze heap_part;
 
 explain select * from heap_part where a=3;
 select * from heap_part where a=3;
+
+-- Generate bitmap scan for mixed index types
+create table part_table13(a int, b int, c int)
+partition by range(b)
+(
+partition p1 start(1) end(10),
+partition p2 start(10) end (20) with (appendonly=true),
+partition p3 start(20) end (30) with (appendonly=true,orientation=column),
+partition p4 start(30) end (40)
+);
+
+create index part_table13_1_idx on part_table13_1_prt_p1 using btree(c);
+create index part_table13_2_idx on part_table13_1_prt_p2 using btree(c);
+create index part_table13_3_idx on part_table13_1_prt_p3 using bitmap(c);
+create index part_table13_4_idx on part_table13_1_prt_p4 using bitmap(c);
+
+explain select * from part_table13 where c=7;
+select * from part_table13 where c=7;
+
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 -- end_ignore


### PR DESCRIPTION
In Orca, we currently only support index/bitmap scans if the entire partitioned table has the 
same index storage type in most cases.

For Orca, indexes on partitioned tables are marked as partial or non-partial. It is partial if
there is not a homogenous index on all partitions. This can occur if
there are not indexes on some partitions, or if there are different
index types on some partitions. When we create a btree index on an AO
partition, we mark this internally as a bitmap index, as the executor cannot run an index
scan on an AO table. This is a bit of a hack, as the underlying storage
is still a btree index, and we build the bitmap index during the scan.
This way, GPDB is still able to perform a bitmap scan on a btree index.

The goal of this PR is to support bitmap scans on partitioned tables
containing both heap and AO partitions.

When constructing "logical" indexes for the root partition, we now
populate a "bitmap" index for heap partitions containing a btree index.
This way, when constructing this root index, we'll see that the heap
partitions also have a bitmap index and can create a bitmap alternative.
When selecting an index OID to use, we'll prefer the btree index if it
exists for the case where all partitions are heap, otherwise we'll use
the bitmap index.

 In gpdb master, we don't support partial scans and all of this logic was 
ripped out and replaced during the partitioning rewrite. We already support
bitmap scans on mixed AO/heap tables as a result in gpdb master.

