### PR TITLE
Add extension defaults to dynamic_library_path

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2879,7 +2879,7 @@ static struct config_string ConfigureNamesString[] =
 			GUC_SUPERUSER_ONLY
 		},
 		&Dynamic_library_path,
-		"$libdir",
+		"$libdir:/usr/local/madlib/Current/ports/greenplum/6/lib:/usr/local/greenplum-db-6-exts/lib",
 		NULL, NULL, NULL
 	},
 


### PR DESCRIPTION
The dynamic_library_path GUC is used by extensions to find their .so
files. It is set to $libdir as Postgres expects extensions to place
their library files in this folder. Some Greenplum extensions (MADlib,
gptext, pxf) use other folders for various reasons. There are two
options for these extensions to work.
1- They can set the module_pathname to the exact folder. However, this
interferes with pg_upgrade since the upgraded database keeps a reference
to a now incompatible library, thus highly discouraged.
2- They append their path to the dynamic_library_path GUC.
Adding the defaults for PXF, gptext, and MADlib makes it easier
to support these extensions as well as gpupgrade. As long as the user
installs the extension in its default location, they don't have to worry
about setting the GUC or passing the path to the gpupgrade.
