### PR TITLE
docs - add new guc gp_log_resqueue_priority_sleep_time to ref guide

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -3807,12 +3807,13 @@
     <title>gp_log_resqueue_priority_sleep_time</title>
     <body>
       <p>Controls the logging of per-statement sleep time when resource queue-based resource
-        management is active. You can use this information for post-query analysis of
-        statement concurrency.</p>
+        management is active. You can use this information for analysis of sleep time for
+        queries.</p>
       <p>The default value is <codeph>false</codeph>, do not log the statement sleep time.
-        When set to <codeph>true</codeph>, Greenplum Database logs the duration for which
-        each statement was put to sleep in a resource queue. The information is written to
-        the server log.</p>
+        When set to <codeph>true</codeph>, Greenplum Database:<ul>
+          <li>Logs the current amount of sleep time for a running query every two minutes.</li>
+          <li>Logs the total of sleep time duration for a query at the end of a query.</li>
+        </ul> The information is written to the server log.</p>
       <table id="table_xkm_nqr_y1b">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -3803,6 +3803,39 @@
       </table>
     </body>
   </topic>
+  <topic id="gp_log_resqueue_priority_sleep_time">
+    <title>gp_log_resqueue_priority_sleep_time</title>
+    <body>
+      <p>Controls the logging of per-statement sleep time when resource queue-based resource
+        management is active. You can use this information for post-query analysis of
+        statement concurrency.</p>
+      <p>The default value is <codeph>false</codeph>, do not log the statement sleep time.
+        When set to <codeph>true</codeph>, Greenplum Database logs the duration for which
+        each statement was put to sleep in a resource queue. The information is written to
+        the server log.</p>
+      <table id="table_xkm_nqr_y1b">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">Boolean</entry>
+              <entry colname="col2">false</entry>
+              <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
   <topic id="gp_gpperfmon_send_interval">
     <title>gp_gpperfmon_send_interval</title>
     <body>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -796,6 +796,13 @@
                   >debug_print_slice_table</xref>
               </p>
               <p>
+                <xref href="guc-list.xml#gp_log_format" type="section">gp_log_format</xref>
+              </p>
+              <p><xref href="guc-list.xml#gp_log_interconnect">gp_log_interconnect</xref>
+              </p>
+              <p><xref href="guc-list.xml#gp_log_resqueue_priority_sleep_time">gp_log_resqueue_priority_sleep_time</xref>
+              </p>
+              <p>
                 <xref href="guc-list.xml#log_autostats" type="section">log_autostats</xref>
               </p>
               <p>
@@ -805,6 +812,8 @@
                 <xref href="guc-list.xml#log_disconnections" type="section"
                   >log_disconnections</xref>
               </p>
+            </stentry>
+            <stentry>
               <p>
                 <xref href="guc-list.xml#log_dispatch_stats" type="section"
                   >log_dispatch_stats</xref>
@@ -812,16 +821,12 @@
               <p>
                 <xref href="guc-list.xml#log_duration" type="section">log_duration</xref>
               </p>
-            </stentry>
-            <stentry>
               <p>
                 <xref href="guc-list.xml#log_executor_stats" type="section"
                   >log_executor_stats</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#log_hostname" type="section">log_hostname</xref>
-              </p>
-              <p><xref href="guc-list.xml#gp_log_interconnect">gp_log_interconnect</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#log_parser_stats" type="section">log_parser_stats</xref>
@@ -841,9 +846,6 @@
               </p>
               <p>
                 <xref href="guc-list.xml#gp_debug_linger" type="section">gp_debug_linger</xref>
-              </p>
-              <p>
-                <xref href="guc-list.xml#gp_log_format" type="section">gp_log_format</xref>
               </p>
               <p>
                 <xref href="guc-list.xml#gp_reraise_signal" type="section">gp_reraise_signal</xref>
@@ -1130,6 +1132,10 @@
       <simpletable id="kh157161" frame="none">
         <strow>
           <stentry>
+            <p>
+              <xref href="guc-list.xml#gp_log_resqueue_priority_sleep_time" type="section"
+                >gp_log_resqueue_priority_sleep_time</xref>
+            </p>
             <p>
               <xref href="guc-list.xml#gp_resqueue_memory_policy" type="section"
                 >gp_resqueue_memory_policy</xref>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -137,6 +137,7 @@
             <topicref href="guc-list.xml#gp_log_fts"/>
             <topicref href="guc-list.xml#gp_log_gang"/>
             <topicref href="guc-list.xml#gp_log_interconnect"/>
+            <topicref href="guc-list.xml#gp_log_resqueue_priority_sleep_time"/>
             <topicref href="guc-list.xml#gp_max_local_distributed_cache"/>
             <topicref href="guc-list.xml#gp_max_packet_size"/>
             <topicref href="guc-list.xml#gp_max_plan_size"/>


### PR DESCRIPTION
document the new guc that logs statement sleep time in resource queues.  misc edits to arrange some gucs in alphabetic order.
