### PR TITLE
[6X]Fix flaky failed cases pg_rewind_fail_missing_xlog.

### DIFF
--- a/src/test/isolation2/expected/pg_rewind_fail_missing_xlog.out
+++ b/src/test/isolation2/expected/pg_rewind_fail_missing_xlog.out
@@ -196,6 +196,28 @@ INSERT 3
  m    | p              
  p    | m              
 (2 rows)
+-- Wait for the end of recovery CHECKPOINT completed after the mirror was promoted
+3: SELECT gp_inject_fault('checkpoint_after_redo_calculated', 'skip', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+3: SELECT gp_wait_until_triggered_fault('checkpoint_after_redo_calculated', 1, dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+3: SELECT gp_inject_fault('checkpoint_after_redo_calculated', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+3: SELECT role, preferred_role from gp_segment_configuration where content = 1;
+ role | preferred_role 
+------+----------------
+ m    | p              
+ p    | m              
+(2 rows)
 
 4: INSERT INTO tst_missing_tbl values(2),(1),(5);
 INSERT 3

--- a/src/test/isolation2/sql/pg_rewind_fail_missing_xlog.sql
+++ b/src/test/isolation2/sql/pg_rewind_fail_missing_xlog.sql
@@ -87,6 +87,11 @@ INSERT INTO tst_missing_tbl values(2),(1),(5);
 3: SELECT pg_ctl(datadir, 'stop', 'immediate') FROM gp_segment_configuration WHERE role='p' AND content = 1;
 3: SELECT gp_request_fts_probe_scan();
 3: SELECT role, preferred_role from gp_segment_configuration where content = 1;
+-- Wait for the end of recovery CHECKPOINT completed after the mirror was promoted
+3: SELECT gp_inject_fault('checkpoint_after_redo_calculated', 'skip', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 1;
+3: SELECT gp_wait_until_triggered_fault('checkpoint_after_redo_calculated', 1, dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 1;
+3: SELECT gp_inject_fault('checkpoint_after_redo_calculated', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 1;
+3: SELECT role, preferred_role from gp_segment_configuration where content = 1;
 
 4: INSERT INTO tst_missing_tbl values(2),(1),(5);
 4: SELECT gp_segment_id, count(*) from tst_missing_tbl group by gp_segment_id;


### PR DESCRIPTION
The case is tesing the bug when gp crash recovery, it calls
two checkpoints, if some checkpoint triggered removed/recylced
wal file, the gp_rewind might failed.

The flaky is due to sometimes when stoping the primary and
promoting the mirror, the end of recovery hasn't fully completed
after mirror is promoted, then insert some data will see errors
"seg is in recovery mode".

The fix is waiting for the end of recovery CHECKPOINT completed
after the mirror was promoted.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
