### PR TITLE
gpstate -e : Display ongoing recovery progress

### DIFF
--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
@@ -2,12 +2,15 @@
 #
 # Copyright (c) Greenplum Inc 2008. All Rights Reserved.
 #
+import os
 from collections import OrderedDict
 import io
 import logging
+import shutil
+import tempfile
 
 
-from mock import ANY, call, patch, Mock
+from mock import ANY, call, patch, Mock, mock_open
 from gppylib import gplog, recoveryinfo
 from gppylib.commands import base, gp
 from gppylib.commands.base import CommandResult, LocalExecutionContext
@@ -939,21 +942,34 @@ class SegmentProgressTestCase(GpTestCase):
             parallelDegree=0,
             logger=Mock(spec=logging.Logger)
         )
+        self.tmp_log_dir = tempfile.mkdtemp()
+        self.apply_patches([
+            patch('recoveryinfo.gplog.get_logger_dir', return_value=self.tmp_log_dir),
+            patch('gppylib.operations.buildMirrorSegments.os.remove')
+        ])
+        self.mock_os_remove = self.get_mock_from_apply_patch("remove")
+        self.combined_progress_file = "{}/recovery_progress.file".format(self.tmp_log_dir)
+
+    def tearDown(self):
+        super(SegmentProgressTestCase, self).tearDown()
+        shutil.rmtree(self.tmp_log_dir)
+
+    def create_command(self, remoteHost, dbid, filepath, stdout=None, stderr=None):
+            cmd = Mock(spec=GpMirrorListToBuild.ProgressCommand)
+            cmd.remoteHost = remoteHost
+            cmd.dbid = dbid
+            cmd.filePath = filepath
+            cmd.get_results.return_value.stdout = stdout
+            cmd.get_results.return_value.stderr = stderr
+            return cmd
 
     def test_command_output_is_displayed_once_after_worker_pool_completes(self):
-        cmd = Mock(spec=base.Command)
-        cmd.remoteHost = 'localhost'
-        cmd.dbid = 2
-        cmd.get_results.return_value.stdout = "string 1\n"
-
-        cmd2 = Mock(spec=base.Command)
-        cmd2.remoteHost = 'host2'
-        cmd2.dbid = 4
-        cmd2.get_results.return_value.stdout = "string 2\n"
+        cmd1 = self.create_command('localhost', 2, './pg_basebackup.23432', "string 1\n")
+        cmd2 = self.create_command('host2', 4, './pg_basebackup.234324', "string 2\n")
 
         outfile = io.StringIO()
         self.pool.join.return_value = True
-        self.buildMirrorSegs._join_and_show_segment_progress([cmd, cmd2], outfile=outfile)
+        self.buildMirrorSegs._join_and_show_segment_progress([cmd1, cmd2], outfile=outfile)
 
         results = outfile.getvalue()
         self.assertEqual(results, (
@@ -962,9 +978,7 @@ class SegmentProgressTestCase(GpTestCase):
         ))
 
     def test_command_output_is_displayed_once_for_every_blocked_join(self):
-        cmd = Mock(spec=base.Command)
-        cmd.remoteHost = 'localhost'
-        cmd.dbid = 2
+        cmd = self.create_command('localhost', 2, './pg_basebackup.23432', "string 1\n")
 
         cmd.get_results.side_effect = [Mock(stdout="string 1"), Mock(stdout="string 2")]
 
@@ -979,19 +993,16 @@ class SegmentProgressTestCase(GpTestCase):
         ))
 
     def test_inplace_display_uses_ansi_escapes_to_overwrite_previous_output(self):
-        cmd = Mock(spec=base.Command)
-        cmd.remoteHost = 'localhost'
-        cmd.dbid = 2
-        cmd.get_results.side_effect = [Mock(stdout="string 1"), Mock(stdout="string 2")]
+        cmd1 = self.create_command('localhost', 2, './pg_basebackup.234324', "string 1\n")
+        cmd2 = self.create_command('host2', 4, './pg_basebackup.234324', "string 2\n")
 
-        cmd2 = Mock(spec=base.Command)
-        cmd2.remoteHost = 'host2'
-        cmd2.dbid = 4
+        cmd1.get_results.side_effect = [Mock(stdout="string 1"), Mock(stdout="string 2")]
+
         cmd2.get_results.side_effect = [Mock(stdout="string 3"), Mock(stdout="string 4")]
 
         outfile = io.StringIO()
         self.pool.join.side_effect = [False, True]
-        self.buildMirrorSegs._join_and_show_segment_progress([cmd, cmd2], inplace=True, outfile=outfile)
+        self.buildMirrorSegs._join_and_show_segment_progress([cmd1, cmd2], inplace=True, outfile=outfile)
 
         results = outfile.getvalue()
         self.assertEqual(results, (
@@ -1003,21 +1014,15 @@ class SegmentProgressTestCase(GpTestCase):
         ))
 
     def test_errors_during_command_execution_are_displayed(self):
-        cmd = Mock(spec=base.Command)
-        cmd.remoteHost = 'localhost'
-        cmd.dbid = 2
-        cmd.get_results.return_value.stderr = "some error\n"
-        cmd.run.side_effect = base.ExecutionError("Some exception", cmd)
+        cmd1 = self.create_command('localhost', 2, './pg_basebackup.234324', stderr="some error\n")
+        cmd2 = self.create_command('host2', 4, './pg_basebackup.234324', stderr='')
 
-        cmd2 = Mock(spec=base.Command)
-        cmd2.remoteHost = 'host2'
-        cmd2.dbid = 4
-        cmd2.get_results.return_value.stderr = ''
+        cmd1.run.side_effect = base.ExecutionError("Some exception", cmd1)
         cmd2.run.side_effect = base.ExecutionError("Some exception", cmd2)
 
         outfile = io.StringIO()
         self.pool.join.return_value = True
-        self.buildMirrorSegs._join_and_show_segment_progress([cmd, cmd2], outfile=outfile)
+        self.buildMirrorSegs._join_and_show_segment_progress([cmd1, cmd2], outfile=outfile)
 
         results = outfile.getvalue()
         self.assertEqual(results, (
@@ -1025,6 +1030,92 @@ class SegmentProgressTestCase(GpTestCase):
             'host2 (dbid 4): \n'
         ))
 
+    def test_successful_command_execution_should_delete_the_recovery_progress_file(self):
+        cmd1 = self.create_command('host1', 1, './pg_basebackup.23432', "1164848/1371715 kB (84%)\n")
+        cmd2 = self.create_command('host2', 2, './pg_rewind.23432', "1164858/1371715 kB (90%)\n")
+
+
+        outfile = io.StringIO()
+        self.pool.join.return_value = True
+        self.buildMirrorSegs._join_and_show_segment_progress([cmd1, cmd2], outfile=outfile)
+        self.mock_os_remove.assert_called_once_with(self.combined_progress_file)
+
+    def test_error_during_command_execution_should_delete_the_recovery_progress_file(self):
+        cmd1 = self.create_command('host1', 1, './pg_basebackup.23432', stderr="some error\n")
+        cmd2 = self.create_command('host2', 2, './pg_rewind.23432', stderr='')
+
+        cmd1.run.side_effect = Exception("Some exception1")
+        cmd2.run.side_effect = Exception("Some exception2")
+
+
+        outfile = io.StringIO()
+        self.pool.join.return_value = True
+        with self.assertRaisesRegex(Exception, "Some exception1"):
+            self.buildMirrorSegs._join_and_show_segment_progress([cmd1, cmd2], outfile=outfile)
+        self.mock_os_remove.assert_called_once_with(self.combined_progress_file)
+
+    def test_join_and_show_segment_progress_writes_progress_file(self):
+
+        cmd1 = self.create_command('host1', 1, './pg_basebackup.23432', "1164848/1371715 kB (84%)\n")
+        cmd2 = self.create_command('host2', 2, './pg_rewind.23432', "1164858/1371715 kB (90%)\n")
+
+        outfile = io.StringIO()
+        self.pool.join.return_value = True
+
+        self.buildMirrorSegs._join_and_show_segment_progress([cmd1, cmd2], outfile=outfile)
+
+        self.mock_os_remove.assert_called_once_with(self.combined_progress_file)
+
+        with open(self.combined_progress_file, 'r') as f:
+            results = f.readlines()
+        self.assertEqual(results, [
+            'full:1:1164848/1371715 kB (84%)\n',
+            'incremental:2:1164858/1371715 kB (90%)\n'
+        ])
+
+    def test_join_and_show_segment_progress_overwrites(self):
+        cmd1 = self.create_command('host1', 1, './pg_basebackup.23432', "1164848/1371715 kB (84%)\n")
+        cmd2 = self.create_command('host2', 2, './pg_rewind.23432', "1164858/1371715 kB (90%)\n")
+
+        outfile = io.StringIO()
+        self.pool.join.return_value = True
+
+        self.buildMirrorSegs._join_and_show_segment_progress([cmd1, cmd2], outfile=outfile)
+
+        self.mock_os_remove.assert_called_once_with(self.combined_progress_file)
+
+        with open(self.combined_progress_file, 'r') as f:
+            results = f.readlines()
+        self.assertEqual(results, [
+            'full:1:1164848/1371715 kB (84%)\n',
+            'incremental:2:1164858/1371715 kB (90%)\n'
+        ])
+
+        cmd1 = self.create_command('host11', 11, './pg_rewind.23432', "9964858/9971715 kB (1%)\n")
+        cmd2 = self.create_command('host22', 22, './pg_basebackup.23432', "9964848/9971715 kB (45%)\n")
+        self.buildMirrorSegs._join_and_show_segment_progress([cmd1, cmd2], outfile=outfile)
+
+        with open(self.combined_progress_file, 'r') as f:
+            results = f.readlines()
+            self.assertEqual(results, [
+                'incremental:11:9964858/9971715 kB (1%)\n',
+                'full:22:9964848/9971715 kB (45%)\n'
+            ])
+
+    def test_verify_recovery_progress_file_when_command_results_are_not_in_expected_format(self):
+            cmd1 = self.create_command('host1', 1, './pg_basebackup.23432', "string 1\n")
+            cmd2 = self.create_command('host2', 2, './pg_basebackup.23432', "string 2\n")
+
+
+            outfile = io.StringIO()
+            self.pool.join.return_value = True
+            self.buildMirrorSegs._join_and_show_segment_progress([cmd1, cmd2], outfile=outfile)
+
+            self.mock_os_remove.assert_called_once_with(self.combined_progress_file)
+
+            with open(self.combined_progress_file, 'r') as f:
+                results = f.readlines()
+            self.assertEqual(results, [])
 
 if __name__ == '__main__':
     run_tests()

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
@@ -1,6 +1,28 @@
+from behave import given, when, then
+import os
 import re
 
-from behave import given, when, then
+from gppylib.db import dbconn
+from gppylib.gparray import GpArray, ROLE_MIRROR
+from test.behave_utils.utils import check_stdout_msg, check_string_not_present_stdout
+
+@then('a sample recovery_progress.file is created from saved lines')
+def impl(context):
+    with open('{}/gpAdminLogs/recovery_progress.file'.format(os.path.expanduser("~")), 'w+') as fp:
+        fp.writelines(context.recovery_lines)
+
+@given('a sample recovery_progress.file is created with ongoing recoveries in gpAdminLogs')
+def impl(context):
+    with open('{}/gpAdminLogs/recovery_progress.file'.format(os.path.expanduser("~")), 'w+') as fp:
+        fp.write("full:5: 1164848/1371715 kB (84%), 0/1 tablespace (...t1/demoDataDir0/base/16384/40962)\n")
+        fp.write("incremental:6: 1/1371875 kB (1%)")
+
+@given('a sample recovery_progress.file is created with completed recoveries in gpAdminLogs')
+def impl(context):
+    with open('{}/gpAdminLogs/recovery_progress.file'.format(os.path.expanduser("~")), 'w+') as fp:
+        fp.write("incremental:5: pg_rewind: Done!\n")
+        fp.write("full:6: 1164848/1371715 kB (84%), 0/1 tablespace (...t1/demoDataDir0/base/16384/40962)\n")
+        fp.write("full:7: pg_basebackup: completed")
 
 @then('gpstate output looks like')
 def impl(context):
@@ -10,6 +32,31 @@ def impl(context):
 
     check_rows_exist(context)
 
+@then('gpstate output contains "{recovery_types}" entries for mirrors of content {contents}')
+def impl(context, recovery_types, contents):
+    recovery_types = recovery_types.split(',')
+    contents = [int(c) for c in contents.split(',')]
+    contents = set(contents)
+
+    all_segments = GpArray.initFromCatalog(dbconn.DbURL()).getDbList()
+    segments_to_display = []
+    segments_to_not_display = []
+    for seg in all_segments:
+        if seg.getSegmentContentId() in contents and seg.getSegmentRole() == ROLE_MIRROR:
+            segments_to_display.append(seg)
+        else:
+            segments_to_not_display.append(seg)
+
+    for index, seg_to_display in enumerate(segments_to_display):
+        hostname = seg_to_display.getSegmentHostName()
+        port = seg_to_display.getSegmentPort()
+        expected_msg = "{}[ \t]+{}[ \t]+{}[ \t]+[0-9]+[ \t]+[0-9]+[ \t]+[0-9]+\%".format(hostname, port,
+                                                                                         recovery_types[index])
+        check_stdout_msg(context, expected_msg)
+
+    #TODO assert that only segments_to_display are printed to the console
+    # for seg_to_not_display in segments_to_not_display:
+    #     check_string_not_present_stdout(context, str(seg_to_not_display.getSegmentPort()))
 
 @then('gpstate output has rows')
 def impl(context):

--- a/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
@@ -532,11 +532,14 @@ def impl(context, filename, content):
 
 
 
-@when('the user waits until mirror on content {content} is {expected_status}')
-@then('the user waits until mirror on content {content} is {expected_status}')
-def impl(context, content, expected_status):
-    query = "SELECT gp_request_fts_probe_scan(); SELECT status FROM gp_segment_configuration where role = 'm' and content = {};".format(content)
-    wait_for_desired_query_result(dbconn.DbURL(), query, 'u' if expected_status == 'up' else 'd')
+@given('the user waits until mirror on content {content_ids} is {expected_status}')
+@when('the user waits until mirror on content {content_ids} is {expected_status}')
+@then('the user waits until mirror on content {content_ids} is {expected_status}')
+def impl(context, content_ids, expected_status):
+    contents = content_ids.split(',')
+    for content in contents:
+        query = "SELECT gp_request_fts_probe_scan(); SELECT status FROM gp_segment_configuration where role = 'm' and content = {};".format(content)
+        wait_for_desired_query_result(dbconn.DbURL(), query, 'u' if expected_status == 'up' else 'd')
 
 
 @then('the contents {contents} should have their original data directory in the system configuration')

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -131,8 +131,7 @@ def run_gpcommand(context, command, cmd_prefix=''):
 def run_gpcommand_async(context, command):
     cmd = Command(name='run %s' % command, cmdStr='$GPHOME/bin/%s' % (command))
     asyncproc = cmd.runNoWait()
-    if 'asyncproc' not in context:
-        context.asyncproc = asyncproc
+    context.asyncproc = asyncproc
 
 
 def check_stdout_msg(context, msg, escapeStr = False):


### PR DESCRIPTION
Added new section under gpstate -e, which displays progress of segments in recovery

-Edited buildMirrorSegments to create new file (recovery_progress.file) and updates
the current recovery progress, deletes the file after recoveries are completed.
-Added new section under gpstate -e to display progress of segments in recovery
-Added _parse_recovery_progress_data(), which will look for the recovery_progress.file
and populate the required fields
-Added behave and unit tests for above scenario

```
Sample output:
-----------------------------------------------------
Segments in recovery
Segment                     Port   Recovery type   Completed bytes (kB)   Total bytes (kB)   Percentage completed
hmaddileti-a01.vmware.com   7002   full            1164848                1371715            84%
hmaddileti-a01.vmware.com   7003   incremental     1171384                1371875            85%
hmaddileti-a01.vmware.com   7004   full            116488                 1371715            60%
```

Co-authored-by: Divyesh Vanjare <vanjared@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
