### PR TITLE
[6X] Refactor how we handle dropped column references in partition tables during major version upgrades

### DIFF
--- a/contrib/pg_upgrade/greenplum/check_gp.h
+++ b/contrib/pg_upgrade/greenplum/check_gp.h
@@ -6,18 +6,89 @@
  */
 void check_heterogeneous_partition(void);
 
-#define CHECK_PARTITION_TABLE_MATCHES_COLUMN_COUNT \
-	"SELECT parrelid, c1.relnatts, minchildnatts, maxchildnatts " \
+/*
+ * This query gathers all the root (rp) and child (cp1 and cp2) partition
+ * information necessary to detect if a partition table is a heterogeneous
+ * partition table. The WHERE filter compares the root and child partition
+ * information to exclude out the valid homogeneous partition table
+ * definitions (as documented in the check_heterogeneous_partition() header).
+ *
+ * Note: We ignore subroot partitions because they also do not have data like
+ * the root partition. We also defer partition tables where the root partition
+ * and all of its child partitions have the same dropped column reference but
+ * at least one child partition has extra dropped column references (the
+ * CHECK_PARTITION_TABLE_MATCHES_DROPPED_COLUMN_ATTRIBUTES query will catch
+ * these special problematic child partitions).
+ */
+#define CHECK_PARTITION_TABLE_DROPPED_COLUMN_REFERENCES \
+	"SELECT cp1.childnamespace, cp1.childrelname " \
 	"FROM ( " \
-	"    SELECT parrelid::regclass, min(c2.relnatts) minchildnatts, max(c2.relnatts) maxchildnatts " \
-	"    FROM pg_partition par " \
-	"    JOIN pg_partition_rule rule ON par.oid=rule.paroid AND NOT par.paristemplate " \
-	"    JOIN pg_class c2 ON parchildrelid = c2.oid GROUP BY parrelid " \
-	") t JOIN pg_class c1 ON c1.oid = parrelid WHERE c1.relnatts!=minchildnatts OR c1.relnatts!=maxchildnatts;"
+	"        SELECT p.parrelid, rule.parchildrelid, n.nspname AS childnamespace, c.relname AS childrelname, c.relnatts AS childnatts, " \
+	"               sum(CASE WHEN a.attisdropped THEN 1 ELSE 0 END) AS childnumattisdropped " \
+	"        FROM pg_catalog.pg_partition p " \
+	"            JOIN pg_catalog.pg_partition_rule rule ON p.oid=rule.paroid AND NOT p.paristemplate " \
+	"            JOIN pg_catalog.pg_class c ON rule.parchildrelid = c.oid AND NOT c.relhassubclass " \
+	"            JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace " \
+	"            JOIN pg_catalog.pg_attribute a ON rule.parchildrelid = a.attrelid AND a.attnum > 0 " \
+	"        GROUP BY p.parrelid, rule.parchildrelid, n.nspname, c.relname, c.relnatts " \
+	"    ) cp1 " \
+	"    JOIN ( " \
+	"        SELECT p.parrelid, min(c.relnatts) AS minchildnatts, max(c.relnatts) AS maxchildnatts " \
+	"        FROM pg_catalog.pg_partition p " \
+	"            JOIN pg_catalog.pg_partition_rule rule ON p.oid=rule.paroid AND NOT p.paristemplate " \
+	"            JOIN pg_catalog.pg_class c ON rule.parchildrelid = c.oid AND NOT c.relhassubclass " \
+	"        GROUP BY p.parrelid " \
+	"    ) cp2 ON cp2.parrelid = cp1.parrelid " \
+	"    JOIN ( " \
+	"        SELECT c.oid, n.nspname AS parnamespace, c.relname AS parrelname, c.relnatts AS parnatts, " \
+	"               sum(CASE WHEN a.attisdropped THEN 1 ELSE 0 END) AS parnumattisdropped " \
+	"        FROM pg_catalog.pg_partition p " \
+	"            JOIN pg_catalog.pg_class c ON p.parrelid = c.oid AND NOT p.paristemplate AND p.parlevel = 0 " \
+	"            JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace " \
+	"            JOIN pg_catalog.pg_attribute a ON c.oid = a.attrelid AND a.attnum > 0 " \
+	"        GROUP BY c.oid, n.nspname, c.relname, c.relnatts " \
+	"    ) rp ON rp.oid = cp1.parrelid " \
+	"WHERE NOT (rp.parnumattisdropped = 0 AND rp.parnatts = cp1.childnatts) AND " \
+	"      NOT (rp.parnumattisdropped > 0 AND cp2.minchildnatts = cp2.maxchildnatts AND " \
+	"           (rp.parnatts = cp1.childnatts OR cp1.childnumattisdropped = 0)) AND " \
+	"      NOT (rp.parnumattisdropped > 0 AND cp2.minchildnatts != cp2.maxchildnatts AND " \
+	"           cp2.minchildnatts < rp.parnatts AND cp1.childnumattisdropped = 0) AND " \
+	"      NOT (rp.parnumattisdropped > 0 AND cp2.minchildnatts != cp2.maxchildnatts AND " \
+	"           cp2.minchildnatts >= rp.parnatts) " \
+	"ORDER BY rp.oid, cp1.parchildrelid;"
 
-#define CHECK_PARTITION_TABLE_MATCHES_COLUMN_ATTRIBUTES \
-	"SELECT parrelid::regclass, att1.attnum, rule.parchildrelid::regclass, att1.attname attname1, att2.attname attname2, att1.attisdropped attisdropped1, att2.attisdropped attisdropped2, att1.attlen attlen1, att2.attlen attlen2, att1.atttypid atttypid1, att2.atttypid atttypid2, att1.attalign attalign1, att2.attalign attalign2 " \
-	"FROM pg_partition par join pg_partition_rule rule on par.oid=rule.paroid and not par.paristemplate  " \
-	"JOIN pg_attribute att1 ON att1.attrelid = par.parrelid " \
-	"JOIN pg_attribute att2 ON att2.attrelid = rule.parchildrelid AND att1.attnum = att2.attnum AND att1.attnum > 0 " \
-				"  AND NOT (att1.attisdropped = att2.attisdropped AND att1.attname = att2.attname AND att1.attlen = att2.attlen AND att1.atttypid = att2.atttypid AND att1.attalign = att2.attalign);"
+/*
+ * This query gathers all child partition dropped column attributes and
+ * compares them to their respective root partition's attribute list to detect
+ * any mismatched attribute names, dropped column references, types, lengths,
+ * and alignments. The comparison is done in attnum order.
+ *
+ * Note: Column name mismatches can occur due to changes in the relative order
+ * of dropped columns. For instance consider the two tables root(a, b,
+ * ...dropped...) and child(a, ...dropped..., b). In the query below, we
+ * exclude partition tables where the root partition does not have dropped
+ * column references or only the root partition has dropped column
+ * references. We also exclude subroot partitions because they also do not
+ * have data like the root partition.
+ */
+#define CHECK_PARTITION_TABLE_MATCHES_DROPPED_COLUMN_ATTRIBUTES \
+	"WITH root_dropped_attr AS ( " \
+	"    SELECT par.oid AS paroid, a.attnum, a.attisdropped, a.attname, a.attlen, a.atttypid, a.attalign " \
+	"    FROM pg_catalog.pg_partition par " \
+	"        JOIN pg_catalog.pg_attribute a ON a.attrelid = par.parrelid " \
+	"    WHERE NOT par.paristemplate AND a.attisdropped) " \
+	"SELECT DISTINCT child_dropped_attr.parchildrelid::regclass " \
+	"FROM root_dropped_attr " \
+	"    RIGHT JOIN ( " \
+	"        SELECT pr.paroid, pr.parchildrelid, a.attnum, a.attisdropped, a.attname, a.attlen, a.atttypid, a.attalign " \
+	"        FROM pg_catalog.pg_partition_rule pr " \
+	"            JOIN pg_catalog.pg_class c ON c.oid = pr.parchildrelid AND NOT c.relhassubclass " \
+	"            JOIN pg_catalog.pg_attribute a ON a.attrelid = pr.parchildrelid " \
+	"        WHERE a.attisdropped AND pr.paroid IN (SELECT DISTINCT paroid FROM root_dropped_attr) " \
+	"    ) child_dropped_attr ON child_dropped_attr.paroid = root_dropped_attr.paroid " \
+	"                            AND child_dropped_attr.attnum = root_dropped_attr.attnum " \
+	"WHERE root_dropped_attr.attisdropped IS DISTINCT FROM child_dropped_attr.attisdropped " \
+	"      OR root_dropped_attr.attname IS DISTINCT FROM child_dropped_attr.attname " \
+	"      OR root_dropped_attr.attlen IS DISTINCT FROM child_dropped_attr.attlen " \
+	"      OR root_dropped_attr.atttypid IS DISTINCT FROM child_dropped_attr.atttypid " \
+	"      OR root_dropped_attr.attalign IS DISTINCT FROM child_dropped_attr.attalign;"

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -348,6 +348,9 @@ typedef struct _tableInfo
 	bool		parparent;		/* true if the table is partition parent */
 	int			numTriggers;	/* number of triggers for table */
 	struct _triggerInfo *triggers;		/* array of TriggerInfo structs */
+
+	/* GPDB: true if need to ignore root partition's dropped columns */
+	bool		ignoreRootPartDroppedAttr;
 } TableInfo;
 
 typedef struct _attrDefInfo

--- a/src/test/regress/expected/pg_dump_binary_upgrade.out
+++ b/src/test/regress/expected/pg_dump_binary_upgrade.out
@@ -1,0 +1,127 @@
+-- Ensure that pg_dump --binary-upgrade correctly suppresses the ALTER
+-- TABLE DROP COLUMN DDL ouptut when a GPDB partition table with a
+-- dropped column reference on the root partition exists whereas the
+-- same dropped column reference does not exist on all of its child
+-- partitions. If the same dropped column reference exists on its
+-- child partitions, the ALTER TABLE DROP COLUMN DDL should be
+-- outputted. Refer to function check_heterogeneous_partition() in
+-- pg_upgrade's check_gp.c for more details on homogeneous and
+-- heterogeneous partitions.
+CREATE SCHEMA dump_this_schema;
+-- Scenario 1: Create homogeneous partition table where the root
+-- partition and ALL of its child partitions have the dropped column
+-- reference.
+CREATE TABLE dump_this_schema.dropped_column_homogeneous_partition_table (
+    a int,
+    b char,
+    c varchar(50)
+) DISTRIBUTED BY (b)
+PARTITION BY RANGE (a)
+(
+    PARTITION p1 START(1) END(5),
+    PARTITION p2 START(5)
+);
+ALTER TABLE dump_this_schema.dropped_column_homogeneous_partition_table DROP COLUMN c;
+-- All of the partition hierarchy members have the same dropped column reference
+SELECT relname, relnatts FROM pg_class WHERE relname LIKE 'dropped_column_homogeneous_partition_table%';
+                       relname                       | relnatts 
+-----------------------------------------------------+----------
+ dropped_column_homogeneous_partition_table          |        3
+ dropped_column_homogeneous_partition_table_1_prt_p1 |        3
+ dropped_column_homogeneous_partition_table_1_prt_p2 |        3
+(3 rows)
+
+SELECT c.relname, a.attname
+FROM pg_class c JOIN pg_attribute a ON c.oid = a.attrelid
+WHERE a.attisdropped = true AND relname LIKE 'dropped_column_homogeneous_partition_table%';
+                       relname                       |           attname            
+-----------------------------------------------------+------------------------------
+ dropped_column_homogeneous_partition_table_1_prt_p1 | ........pg.dropped.3........
+ dropped_column_homogeneous_partition_table_1_prt_p2 | ........pg.dropped.3........
+ dropped_column_homogeneous_partition_table          | ........pg.dropped.3........
+(3 rows)
+
+-- Scenario 2: Create homogeneous partition table where only the root
+-- partition has the dropped column reference (as defined by
+-- pg_upgrade heterogeneous partition check function).
+CREATE TABLE dump_this_schema.dropped_column_special_homogeneous_partition_table (
+    a int,
+    b char,
+    c varchar(50)
+) DISTRIBUTED BY (b)
+PARTITION BY RANGE (a)
+(
+    PARTITION p1 START(1) END(5)
+);
+ALTER TABLE dump_this_schema.dropped_column_special_homogeneous_partition_table DROP COLUMN c;
+CREATE TABLE dump_this_schema.staging_table_for_exchange_partition
+       AS SELECT * FROM dump_this_schema.dropped_column_special_homogeneous_partition_table_1_prt_p1 DISTRIBUTED BY (b);
+ALTER TABLE dump_this_schema.dropped_column_special_homogeneous_partition_table
+      EXCHANGE PARTITION p1 WITH TABLE dump_this_schema.staging_table_for_exchange_partition;
+DROP TABLE dump_this_schema.staging_table_for_exchange_partition;
+-- All of the partition hierarchy members DO NOT have the same dropped column reference
+SELECT relname, relnatts FROM pg_class WHERE relname LIKE 'dropped_column_special_homogeneous_partition_table%';
+                           relname                           | relnatts 
+-------------------------------------------------------------+----------
+ dropped_column_special_homogeneous_partition_table          |        3
+ dropped_column_special_homogeneous_partition_table_1_prt_p1 |        2
+(2 rows)
+
+SELECT c.relname, a.attname
+FROM pg_class c JOIN pg_attribute a ON c.oid = a.attrelid
+WHERE a.attisdropped = true AND relname LIKE 'dropped_column_special_homogeneous_partition_table%';
+                      relname                       |           attname            
+----------------------------------------------------+------------------------------
+ dropped_column_special_homogeneous_partition_table | ........pg.dropped.3........
+(1 row)
+
+-- Scenario 3: Create homogeneous partition table where only the root
+-- and subroot partition has the dropped column reference (as defined
+-- by pg_upgrade heterogeneous partition check function).
+CREATE TABLE dump_this_schema.dropped_column_special_homogeneous_partition_with_subpart (
+    a int,
+    b char,
+    c varchar(50)
+) DISTRIBUTED BY (b)
+PARTITION BY RANGE (a)
+SUBPARTITION BY RANGE (b)
+(
+    PARTITION sp1 START(1) END(5)
+    (
+	SUBPARTITION p1 START(1) END(3)
+    )
+);
+NOTICE:  CREATE TABLE will create partition "dropped_column_special_homogeneous_partition_with_sub_1_prt_sp1" for table "dropped_column_special_homogeneous_partition_with_subpart"
+NOTICE:  CREATE TABLE will create partition "dropped_column_special_homogeneous_partition_with_sub__2_prt_p1" for table "dropped_column_special_homogeneous_partition_with_sub_1_prt_sp1"
+ALTER TABLE dump_this_schema.dropped_column_special_homogeneous_partition_with_subpart DROP COLUMN c;
+CREATE TABLE dump_this_schema.staging_table_for_exchange_partition
+       AS SELECT * FROM dump_this_schema.dropped_column_special_homogeneous_partition_with_sub_1_prt_sp1 DISTRIBUTED BY (b);
+ALTER TABLE dump_this_schema.dropped_column_special_homogeneous_partition_with_subpart
+      ALTER PARTITION sp1 EXCHANGE PARTITION p1 WITH TABLE dump_this_schema.staging_table_for_exchange_partition;
+NOTICE:  exchanged partition "p1" of partition "sp1" of relation "dropped_column_special_homogeneous_partition_with_subpart" with relation "staging_table_for_exchange_partition"
+DROP TABLE dump_this_schema.staging_table_for_exchange_partition;
+-- All of the partition hierarchy members DO NOT have the same dropped column reference
+SELECT relname, relnatts FROM pg_class WHERE relname LIKE 'dropped_column_special_homogeneous_partition_with_subpart%';
+                          relname                          | relnatts 
+-----------------------------------------------------------+----------
+ dropped_column_special_homogeneous_partition_with_subpart |        3
+(1 row)
+
+SELECT c.relname, a.attname
+FROM pg_class c JOIN pg_attribute a ON c.oid = a.attrelid
+WHERE a.attisdropped = true AND relname LIKE 'dropped_column_special_homogeneous_partition_with_subpart%';
+                          relname                          |           attname            
+-----------------------------------------------------------+------------------------------
+ dropped_column_special_homogeneous_partition_with_subpart | ........pg.dropped.3........
+(1 row)
+
+-- Run pg_dump and expect to see an ALTER TABLE DROP COLUMN output
+-- only for the homogeneous partition table where the entire partition
+-- table has the same dropped column reference.
+\! pg_dump --binary-upgrade --schema dump_this_schema regression | grep " DROP COLUMN "
+ALTER TABLE dump_this_schema.dropped_column_homogeneous_partition_table DROP COLUMN "........pg.dropped.3........";
+DROP SCHEMA dump_this_schema CASCADE;
+NOTICE:  drop cascades to 3 other objects
+DETAIL:  drop cascades to table dump_this_schema.dropped_column_homogeneous_partition_table
+drop cascades to table dump_this_schema.dropped_column_special_homogeneous_partition_table
+drop cascades to table dump_this_schema.dropped_column_special_homogeneous_partition_with_subpart

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -15,6 +15,8 @@
 #   hitting max_connections limit on segments.
 #
 
+test: pg_dump_binary_upgrade
+
 test: gp_dispatch_keepalives
 
 # copy command

--- a/src/test/regress/sql/pg_dump_binary_upgrade.sql
+++ b/src/test/regress/sql/pg_dump_binary_upgrade.sql
@@ -1,0 +1,99 @@
+-- Ensure that pg_dump --binary-upgrade correctly suppresses the ALTER
+-- TABLE DROP COLUMN DDL ouptut when a GPDB partition table with a
+-- dropped column reference on the root partition exists whereas the
+-- same dropped column reference does not exist on all of its child
+-- partitions. If the same dropped column reference exists on its
+-- child partitions, the ALTER TABLE DROP COLUMN DDL should be
+-- outputted. Refer to function check_heterogeneous_partition() in
+-- pg_upgrade's check_gp.c for more details on homogeneous and
+-- heterogeneous partitions.
+
+CREATE SCHEMA dump_this_schema;
+
+-- Scenario 1: Create homogeneous partition table where the root
+-- partition and ALL of its child partitions have the dropped column
+-- reference.
+CREATE TABLE dump_this_schema.dropped_column_homogeneous_partition_table (
+    a int,
+    b char,
+    c varchar(50)
+) DISTRIBUTED BY (b)
+PARTITION BY RANGE (a)
+(
+    PARTITION p1 START(1) END(5),
+    PARTITION p2 START(5)
+);
+
+ALTER TABLE dump_this_schema.dropped_column_homogeneous_partition_table DROP COLUMN c;
+
+-- All of the partition hierarchy members have the same dropped column reference
+SELECT relname, relnatts FROM pg_class WHERE relname LIKE 'dropped_column_homogeneous_partition_table%';
+
+SELECT c.relname, a.attname
+FROM pg_class c JOIN pg_attribute a ON c.oid = a.attrelid
+WHERE a.attisdropped = true AND relname LIKE 'dropped_column_homogeneous_partition_table%';
+
+-- Scenario 2: Create homogeneous partition table where only the root
+-- partition has the dropped column reference (as defined by
+-- pg_upgrade heterogeneous partition check function).
+CREATE TABLE dump_this_schema.dropped_column_special_homogeneous_partition_table (
+    a int,
+    b char,
+    c varchar(50)
+) DISTRIBUTED BY (b)
+PARTITION BY RANGE (a)
+(
+    PARTITION p1 START(1) END(5)
+);
+
+ALTER TABLE dump_this_schema.dropped_column_special_homogeneous_partition_table DROP COLUMN c;
+CREATE TABLE dump_this_schema.staging_table_for_exchange_partition
+       AS SELECT * FROM dump_this_schema.dropped_column_special_homogeneous_partition_table_1_prt_p1 DISTRIBUTED BY (b);
+ALTER TABLE dump_this_schema.dropped_column_special_homogeneous_partition_table
+      EXCHANGE PARTITION p1 WITH TABLE dump_this_schema.staging_table_for_exchange_partition;
+DROP TABLE dump_this_schema.staging_table_for_exchange_partition;
+
+-- All of the partition hierarchy members DO NOT have the same dropped column reference
+SELECT relname, relnatts FROM pg_class WHERE relname LIKE 'dropped_column_special_homogeneous_partition_table%';
+
+SELECT c.relname, a.attname
+FROM pg_class c JOIN pg_attribute a ON c.oid = a.attrelid
+WHERE a.attisdropped = true AND relname LIKE 'dropped_column_special_homogeneous_partition_table%';
+
+-- Scenario 3: Create homogeneous partition table where only the root
+-- and subroot partition has the dropped column reference (as defined
+-- by pg_upgrade heterogeneous partition check function).
+CREATE TABLE dump_this_schema.dropped_column_special_homogeneous_partition_with_subpart (
+    a int,
+    b char,
+    c varchar(50)
+) DISTRIBUTED BY (b)
+PARTITION BY RANGE (a)
+SUBPARTITION BY RANGE (b)
+(
+    PARTITION sp1 START(1) END(5)
+    (
+	SUBPARTITION p1 START(1) END(3)
+    )
+);
+
+ALTER TABLE dump_this_schema.dropped_column_special_homogeneous_partition_with_subpart DROP COLUMN c;
+CREATE TABLE dump_this_schema.staging_table_for_exchange_partition
+       AS SELECT * FROM dump_this_schema.dropped_column_special_homogeneous_partition_with_sub_1_prt_sp1 DISTRIBUTED BY (b);
+ALTER TABLE dump_this_schema.dropped_column_special_homogeneous_partition_with_subpart
+      ALTER PARTITION sp1 EXCHANGE PARTITION p1 WITH TABLE dump_this_schema.staging_table_for_exchange_partition;
+DROP TABLE dump_this_schema.staging_table_for_exchange_partition;
+
+-- All of the partition hierarchy members DO NOT have the same dropped column reference
+SELECT relname, relnatts FROM pg_class WHERE relname LIKE 'dropped_column_special_homogeneous_partition_with_subpart%';
+
+SELECT c.relname, a.attname
+FROM pg_class c JOIN pg_attribute a ON c.oid = a.attrelid
+WHERE a.attisdropped = true AND relname LIKE 'dropped_column_special_homogeneous_partition_with_subpart%';
+
+-- Run pg_dump and expect to see an ALTER TABLE DROP COLUMN output
+-- only for the homogeneous partition table where the entire partition
+-- table has the same dropped column reference.
+\! pg_dump --binary-upgrade --schema dump_this_schema regression | grep " DROP COLUMN "
+
+DROP SCHEMA dump_this_schema CASCADE;


### PR DESCRIPTION
First commit:
```
Ignore partition table dropped columns for pg_dump --binary-upgrade

    When running pg_dump --binary-upgrade, dropped columns are always
    preserved to make sure the catalog matches with the physical data
    files. For GPDB partition tables, this gets very complicated because
    the root partition delegates whether or not the entire partition table
    will have dropped columns or not. If the root partition has dropped
    columns but a child partition does not, we hit a heterogeneous
    partition table scenario which requires manual user intervention. The
    current user workaround for this scenario is to do a plain CTAS on the
    entire partition table... but doing that could be extremely costly.

    To provide a less costly workaround, we simply need to ignore the
    dropped column from the partition table DDL that will be run on the
    target upgrade cluster and assume that all the child partitions will
    not have dropped columns (either it was already like that or the child
    partition has been fixed with a CTAS and exchange partition). However,
    if the root partition and all of its child partitions have the same
    dropped column reference, we will continue to output the dropped
    column in the schema dump as it is technically a homogeneous partition
    table and valid for upgrade. This solution works because the root
    partition does not store any data so now only the flagged child
    partitions (via pg_upgrade --check) need to be fixed instead of
    touching the entire partition table.

    Output format has also been minimalized to be similar to the Postgres
    check output (e.g. no "why" context). The context will be clarified
    from gpupgrade side.

    Note: This won't be a problem for GPDB 7+ because child partition DDL
    follows upstream Postgres logic where they are created separately and
    attached to the root/subroot.
```

Second commit:
```
Refactor pg_upgrade heterogeneous partition table check

    The heterogeneous partition table check would check if the attributes
    of a root partition and its child partitions were synchronized
    properly. If it detected an anomaly (e.g. root partition has dropped
    column references but a child partition does not), the partition table
    would be flagged and the user would be advised to recreate the table
    with CTAS. The workaround provided is correct but can be extremely
    costly in production clusters where partition tables can be very big.

    To lower the cost of fixing the issue, we now do much more complex
    queries and logic to determine which specific child partitions are
    problematic. We also now clearly define what heterogeneous/homogeneous
    partition tables are valid for upgrade. We then advise the user to
    CTAS only the problematic child partitions and do an exchange
    partition (the CTAS staging table would not have the dropped column
    reference). This workaround is a bit more complex and requires more
    concentrated user involvement but the time savings is pretty big
    (e.g. CTAS an entire partition table with 5000 child partitions
    vs. CTAS a couple child partitions).

    Note: This assumes that pg_dump --binary-upgrade will NOT output the
    dropped column reference in the partition table DDL schema dump if it
    detects a partition table where the root has dropped column references
    but its child partitions do not. Currently, there is a Greenplum hack
    to do specifically this.
```

Previous PR https://github.com/greenplum-db/gpdb/pull/13016 did not handle homogeneous partition tables where the root partition and all of its child partitions had the same dropped column reference (edge case regression).  This PR fixes that.