### PR TITLE
Exclude gpbackup default directory from pg_basebackup and pg_rewind

### DIFF
--- a/src/backend/replication/basebackup.c
+++ b/src/backend/replication/basebackup.c
@@ -176,6 +176,9 @@ static const char *excludeDirContents[] =
 	/* Contents unique to each segment instance. */
 	"log",
 
+	/* GPDB: Default gpbackup directory (backup contents) */
+	"backups",
+
 	/* end of list */
 	NULL
 };
@@ -205,6 +208,9 @@ static const char *excludeFiles[] =
 
 	"postmaster.pid",
 	"postmaster.opts",
+
+	/* GPDB: Default gpbackup directory (top-level directory) */
+	"backups",
 
 	/* end of list */
 	NULL

--- a/src/bin/pg_rewind/filemap.c
+++ b/src/bin/pg_rewind/filemap.c
@@ -80,6 +80,9 @@ static const char *excludeDirContents[] =
 	/* GPDB: Contents unique to each segment instance. */
 	"log",
 
+	/* GPDB: Default gpbackup directory (backup contents) */
+	"backups",
+
 	/* end of list */
 	NULL
 };
@@ -110,6 +113,9 @@ static const char *excludeFiles[] =
 	"postmaster.opts",
 
 	GP_INTERNAL_AUTO_CONF_FILE_NAME,
+
+	/* GPDB: Default gpbackup directory (top-level directory) */
+	"backups",
 
 	/* end of list */
 	NULL
@@ -251,9 +257,9 @@ process_target_file(const char *path, file_type_t type, size_t size,
 	 * from the target data folder all paths which have been filtered out from
 	 * the source data folder when processing the source files.
 	 *
-	 * GPDB: GP_INTERNAL_AUTO_CONF_FILE_NAME and "log" are in the excluded
-	 * file list.  These should not be copied but also should not be
-	 * removed. In the future, if there are more files or directories that
+	 * GPDB: GP_INTERNAL_AUTO_CONF_FILE_NAME, "log", and "backups" are in the
+	 * excluded dir/file list.  These should not be copied but also should not
+	 * be removed. In the future, if there are more files or directories that
 	 * should not be copied but also should not be removed, then a separate
 	 * function for those would be better.
 	 */
@@ -266,6 +272,9 @@ process_target_file(const char *path, file_type_t type, size_t size,
 		if (strcmp(filename, GP_INTERNAL_AUTO_CONF_FILE_NAME) == 0)
 			return;
 		if (strstr(path, "log/") == path)
+			return;
+		if (strstr(path, "backups/") == path ||
+			strcmp(path, "backups") == 0)
 			return;
 	}
 

--- a/src/bin/pg_rewind/t/003_extrafiles.pl
+++ b/src/bin/pg_rewind/t/003_extrafiles.pl
@@ -55,6 +55,11 @@ sub run_test
 	  "$test_master_datadir/tst_master_dir/master_subdir/master_file3",
 	  "in master3";
 
+	# GPDB: gpbackup default directory should be ignored
+	mkdir "$test_master_datadir/backups";
+	append_to_file "$test_master_datadir/backups/master_backup_file",
+	  "backup data in master1";
+
 	RewindTest::promote_standby();
 	RewindTest::run_pg_rewind($test_mode);
 
@@ -63,13 +68,15 @@ sub run_test
 	find(
 		sub {
 			push @paths, $File::Find::name
-			  if $File::Find::name =~ m/.*tst_.*/;
+			  if $File::Find::name =~ m/.*(tst_|backups).*/;
 		},
 		$test_master_datadir);
 	@paths = sort @paths;
 	is_deeply(
 		\@paths,
 		[
+			"$test_master_datadir/backups",
+			"$test_master_datadir/backups/master_backup_file",
 			"$test_master_datadir/tst_both_dir",
 			"$test_master_datadir/tst_both_dir/both_file1",
 			"$test_master_datadir/tst_both_dir/both_file2",


### PR DESCRIPTION
First commit:
```
Exclude default gpbackup directory from pg_rewind

    When running pg_rewind, things that exist on the target segment but
    not on the source segment will be removed. In the case of HA when
    recovering the preferred primary segment (mirror is active primary),
    pg_rewind would try to delete the gpbackup default directory
    "backups". Although this directory default is not recommended, it's a
    valid path that needs to be excluded to protect backup data.

    Note: This "backups" directory follows the same special GPDB exclusion
    logic but with a unique difference. We must prevent the top-level
    directory "backups" from being processed in the target files AND
    exclude it in the source files exclusion check. This is because the
    "backups" directory could exist only on the primary segment, only on
    the mirror segment, or exist in both locations (which is different
    from "log" directory which always exists on both locations).
```

Second commit:
```
Exclude default gpbackup directory from pg_basebackup

    When running pg_basebackup, the default gpbackup directory "backups"
    was being needlessly added to the basebackup. Along with that, the
    target location's "backups" directory could be fully replaced or even
    deleted. In the case of HA, this could end up with loss of backups
    when running full recovery (gprecoverseg -F). Although this directory
    default is not recommended, it's a valid path that needs to be
    excluded to protect backup data.

    Note: This "backups" directory follows the same special GPDB exclusion
    logic but with a unique difference. We must prevent the top-level
    directory "backups" from being added to the list of
    directories/files. If we do not, we'll end up with an empty "backups"
    directory at the target location (which can result in complete loss of
    backup data). We don't use the hack in
    `src/bin/pg_basebackup/pg_basebackup.c` because we'll end up with an
    empty "backups" directory if the directory does not exist.
```