### PR TITLE
[6X] Exclude gpbackup default directory from pg_basebackup and pg_rewind

### DIFF
--- a/src/backend/replication/basebackup.c
+++ b/src/backend/replication/basebackup.c
@@ -179,6 +179,9 @@ static const char *excludeDirContents[] =
 	/* Contents unique to each segment instance. */
 	"pg_log",
 
+	/* GPDB: Default gpbackup directory (backup contents) */
+	"backups",
+
 	/* end of list */
 	NULL
 };
@@ -203,6 +206,9 @@ static const char *excludeFiles[] =
 	"postmaster.opts",
 
 	GP_INTERNAL_AUTO_CONF_FILE_NAME,
+
+	/* GPDB: Default gpbackup directory (top-level directory) */
+	"backups",
 
 	/* end of list */
 	NULL

--- a/src/bin/pg_basebackup/t/010_pg_basebackup.pl
+++ b/src/bin/pg_basebackup/t/010_pg_basebackup.pl
@@ -220,3 +220,14 @@ command_ok(
 	'pg_basebackup runs with exclude-from file');
 ok(! -f "$exclude_tempdir/exclude/0", 'excluded files were not created');
 ok(-f "$exclude_tempdir/exclude/keep", 'other files were created');
+
+# GPDB: Exclude gpbackup default directory
+my $gpbackup_test_dir = "$tempdir/gpbackup_test_dir";
+mkdir "$tempdir/pgdata/backups";
+append_to_file("$tempdir/pgdata/backups/random_backup_file", "some random backup data");
+
+command_ok([ 'pg_basebackup', '-D', $gpbackup_test_dir, '--target-gp-dbid', '123' ],
+	'pg_basebackup does not copy over \'backups/\' directory created by gpbackup');
+
+ok(! -d "$gpbackup_test_dir/backups", 'gpbackup default backup directory should be excluded');
+rmtree($gpbackup_test_dir);

--- a/src/bin/pg_rewind/expected/extrafiles.out
+++ b/src/bin/pg_rewind/expected/extrafiles.out
@@ -21,3 +21,5 @@ tst_standby_dir/standby_file1
 tst_standby_dir/standby_file2
 tst_standby_dir/standby_subdir
 tst_standby_dir/standby_subdir/standby_file3
+backups
+backups/master_backup_file

--- a/src/bin/pg_rewind/filemap.c
+++ b/src/bin/pg_rewind/filemap.c
@@ -82,6 +82,9 @@ static const char *excludeDirContents[] =
 	/* Contents unique to each segment instance. */
 	"pg_log",
 
+	/* GPDB: Default gpbackup directory (backup contents) */
+	"backups",
+
 	/* end of list */
 	NULL
 };
@@ -112,6 +115,9 @@ static const char *excludeFiles[] =
 	"postmaster.opts",
 
 	GP_INTERNAL_AUTO_CONF_FILE_NAME,
+
+	/* GPDB: Default gpbackup directory (top-level directory) */
+	"backups",
 
 	/* end of list */
 	NULL
@@ -253,11 +259,11 @@ process_target_file(const char *path, file_type_t type, size_t size,
 	 * from the target data folder all paths which have been filtered out from
 	 * the source data folder when processing the source files.
 	 *
-	 * GPDB: GP_INTERNAL_AUTO_CONF_FILE_NAME and "pg_log" are in the excluded
-	 * file list.  These should not be copied but also should not be
-	 * removed. In the future, if there are more files or directories that
-	 * should not be copied but also should not be removed, then a separate
-	 * function for those would be better.
+	 * GPDB: GP_INTERNAL_AUTO_CONF_FILE_NAME, "pg_log", and "backups" are in
+	 * the excluded dir/file list.  These should not be copied but also should
+	 * not be removed. In the future, if there are more files or directories
+	 * that should not be copied but also should not be removed, then a
+	 * separate function for those would be better.
 	 */
 	{
 		const char *filename = last_dir_separator(path);
@@ -275,6 +281,9 @@ process_target_file(const char *path, file_type_t type, size_t size,
 		 * possibility to change it externally
 		 */
 		if (strstr(path, "pg_log/") == path)
+			return;
+		if (strstr(path, "backups/") == path ||
+			strcmp(path, "backups") == 0)
 			return;
 	}
 

--- a/src/bin/pg_rewind/sql/extrafiles.sql
+++ b/src/bin/pg_rewind/sql/extrafiles.sql
@@ -35,12 +35,17 @@ function standby_following_master
   echo "in master2" > $TEST_MASTER/tst_master_dir/master_file2
   mkdir $TEST_MASTER/tst_master_dir/master_subdir/
   echo "in master3" > $TEST_MASTER/tst_master_dir/master_subdir/master_file3
+
+  # GPDB: gpbackup default directory should be ignored
+  mkdir $TEST_MASTER/backups
+  echo "backup data in master1" > $TEST_MASTER/backups/master_backup_file;
 }
 
 # See what files and directories are present after rewind.
 function after_rewind
 {
     (cd $TEST_MASTER; find tst_* | sort)
+    (cd $TEST_MASTER; find backups* | sort)
 }
 
 # Run the test

--- a/src/bin/pg_rewind/t/003_extrafiles.pl
+++ b/src/bin/pg_rewind/t/003_extrafiles.pl
@@ -51,6 +51,11 @@ sub run_test
 	  "$test_master_datadir/tst_master_dir/master_subdir/master_file3",
 	  "in master3";
 
+	# GPDB: gpbackup default directory should be ignored
+	mkdir "$test_master_datadir/backups";
+	append_to_file "$test_master_datadir/backups/master_backup_file",
+	  "backup data in master1";
+
 	RewindTest::promote_standby();
 	RewindTest::run_pg_rewind($test_mode);
 
@@ -59,13 +64,15 @@ sub run_test
 	find(
 		sub {
 			push @paths, $File::Find::name
-			  if $File::Find::name =~ m/.*tst_.*/;
+			  if $File::Find::name =~ m/.*(tst_|backups).*/;
 		},
 		$test_master_datadir);
 	@paths = sort @paths;
 	is_deeply(
 		\@paths,
-		[   "$test_master_datadir/tst_both_dir",
+		[   "$test_master_datadir/backups",
+			"$test_master_datadir/backups/master_backup_file",
+			"$test_master_datadir/tst_both_dir",
 			"$test_master_datadir/tst_both_dir/both_file1",
 			"$test_master_datadir/tst_both_dir/both_file2",
 			"$test_master_datadir/tst_both_dir/both_subdir",


### PR DESCRIPTION
First commit:
```
Exclude default gpbackup directory from pg_rewind

    When running pg_rewind, things that exist on the target segment but
    not on the source segment will be removed. In the case of HA when
    recovering the preferred primary segment (mirror is active primary),
    pg_rewind would try to delete the gpbackup default directory
    "backups". Although this directory default is not recommended, it's a
    valid path that needs to be excluded to protect backup data.

    Note: This "backups" directory follows the same special GPDB exclusion
    logic but with a unique difference. We must prevent the top-level
    directory "backups" from being processed in the target files AND
    exclude it in the source files exclusion check. This is because the
    "backups" directory could exist only on the primary segment, only on
    the mirror segment, or exist in both locations (which is different
    from "pg_log" directory which always exists on both locations).

    Backported from GPDB master branch:
    https://github.com/greenplum-db/gpdb/commit/1a1863998eeb4ed097e2566383495909af0527ba

    Merge conflict:
    The pg_rewind TAP tests are not really used so had to translate the
    TAP test change over to the regress-style pg_rewind extrafiles test.
```

Second commit:
```
Exclude default gpbackup directory from pg_basebackup

    When running pg_basebackup, the default gpbackup directory "backups"
    was being needlessly added to the basebackup. Along with that, the
    target location's "backups" directory could be fully replaced or even
    deleted. In the case of HA, this could end up with loss of backups
    when running full recovery (gprecoverseg -F). Although this directory
    default is not recommended, it's a valid path that needs to be
    excluded to protect backup data.

    Note: This "backups" directory follows the same special GPDB exclusion
    logic but with a unique difference. We must prevent the top-level
    directory "backups" from being added to the list of
    directories/files. If we do not, we'll end up with an empty "backups"
    directory at the target location (which can result in complete loss of
    backup data). We don't use the hack in
    `src/bin/pg_basebackup/pg_basebackup.c` because we'll end up with an
    empty "backups" directory if the directory does not exist.

    Backported from GPDB master branch:
    https://github.com/greenplum-db/gpdb/commit/b56a3175eaa4d5a14c653042196ead0ce8e52305
```