### PR TITLE
docs - rename some ANALYZE ref page varnames to clarify

### DIFF
--- a/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-root-partition.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-root-partition.xml
@@ -37,9 +37,9 @@
         there are significant changes to leaf partition data.</p>
       <p>Follow these best practices for running <codeph>ANALYZE</codeph> or <codeph>ANALYZE
           ROOTPARTITION</codeph> on partitioned tables in your system:<ul id="ul_vm4_fsn_wbb">
-          <li>Run <codeph>ANALYZE &lt;<varname>root_partition_table</varname>></codeph> on a new
+          <li>Run <codeph>ANALYZE &lt;<varname>root_partition_table_name</varname>></codeph> on a new
             partitioned table after adding initial data. Run <codeph>ANALYZE
-                &lt;<varname>leaf_partition_table</varname>></codeph> on a new leaf partition or a leaf
+                &lt;<varname>leaf_partition_table_name</varname>></codeph> on a new leaf partition or a leaf
             partition where data has changed. By default, running the command on a leaf partition
             updates the root partition statistics if the other leaf partitions have statistics.</li>
           <li>Update root partition statistics when you observe query performance regression in

--- a/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-root-partition.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-root-partition.xml
@@ -37,9 +37,9 @@
         there are significant changes to leaf partition data.</p>
       <p>Follow these best practices for running <codeph>ANALYZE</codeph> or <codeph>ANALYZE
           ROOTPARTITION</codeph> on partitioned tables in your system:<ul id="ul_vm4_fsn_wbb">
-          <li>Run <codeph>ANALYZE &lt;<varname>root_partition</varname>></codeph> on a new
+          <li>Run <codeph>ANALYZE &lt;<varname>root_partition_table</varname>></codeph> on a new
             partitioned table after adding initial data. Run <codeph>ANALYZE
-                &lt;<varname>leaf_partition</varname>></codeph> on a new leaf partition or a leaf
+                &lt;<varname>leaf_partition_table</varname>></codeph> on a new leaf partition or a leaf
             partition where data has changed. By default, running the command on a leaf partition
             updates the root partition statistics if the other leaf partitions have statistics.</li>
           <li>Update root partition statistics when you observe query performance regression in

--- a/gpdb-doc/dita/ref_guide/sql_commands/ANALYZE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ANALYZE.xml
@@ -9,9 +9,9 @@
       <title>Synopsis</title>
       <codeblock id="sql_command_synopsis">ANALYZE [VERBOSE] [<varname>table</varname> [ (<varname>column</varname> [, ...] ) ]]
 
-ANALYZE [VERBOSE] {<varname>root_partition</varname>|<varname>leaf_partition</varname>} [ (<varname>column</varname> [, ...] )] 
+ANALYZE [VERBOSE] {<varname>root_partition_table</varname>|<varname>leaf_partition_table</varname>} [ (<varname>column</varname> [, ...] )] 
 
-ANALYZE [VERBOSE] ROOTPARTITION {ALL | <varname>root_partition</varname> [ (<varname>column</varname> [, ...] )]}</codeblock>
+ANALYZE [VERBOSE] ROOTPARTITION {ALL | <varname>root_partition_table</varname> [ (<varname>column</varname> [, ...] )]}</codeblock>
     </section>
     <section id="section3">
       <title>Description</title>
@@ -55,13 +55,13 @@ ANALYZE [VERBOSE] ROOTPARTITION {ALL | <varname>root_partition</varname> [ (<var
       <title>Parameters</title>
       <parml>
         <plentry>
-          <pt>{ <varname>root_partition</varname> | <varname>leaf_partition</varname> } [
+          <pt>{ <varname>root_partition_table</varname> | <varname>leaf_partition_table</varname> } [
               (<varname>column</varname> [, ...] ) ]</pt>
           <pd>Collect statistics for partitioned tables including HLL statistics. HLL statistics are
             collected only on leaf child partitions. </pd>
-          <pd><codeph>ANALYZE <varname>root_partition</varname></codeph>, collects statistics on all
+          <pd><codeph>ANALYZE <varname>root_partition_table</varname></codeph>, collects statistics on all
             leaf child partitions and the root partition. </pd>
-          <pd><codeph>ANALYZE <varname>leaf_partition</varname></codeph>, collects statistics on the
+          <pd><codeph>ANALYZE <varname>leaf_partition_table</varname></codeph>, collects statistics on the
             leaf child partition. </pd>
           <pd>By default, if you specify a leaf child partition, and all other leaf child partitions
             have statistics, <codeph>ANALYZE</codeph> updates the root partition statistics. If not

--- a/gpdb-doc/dita/ref_guide/sql_commands/ANALYZE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/ANALYZE.xml
@@ -9,9 +9,9 @@
       <title>Synopsis</title>
       <codeblock id="sql_command_synopsis">ANALYZE [VERBOSE] [<varname>table</varname> [ (<varname>column</varname> [, ...] ) ]]
 
-ANALYZE [VERBOSE] {<varname>root_partition_table</varname>|<varname>leaf_partition_table</varname>} [ (<varname>column</varname> [, ...] )] 
+ANALYZE [VERBOSE] {<varname>root_partition_table_name</varname>|<varname>leaf_partition_table_name</varname>} [ (<varname>column</varname> [, ...] )] 
 
-ANALYZE [VERBOSE] ROOTPARTITION {ALL | <varname>root_partition_table</varname> [ (<varname>column</varname> [, ...] )]}</codeblock>
+ANALYZE [VERBOSE] ROOTPARTITION {ALL | <varname>root_partition_table_name</varname> [ (<varname>column</varname> [, ...] )]}</codeblock>
     </section>
     <section id="section3">
       <title>Description</title>
@@ -55,13 +55,13 @@ ANALYZE [VERBOSE] ROOTPARTITION {ALL | <varname>root_partition_table</varname> [
       <title>Parameters</title>
       <parml>
         <plentry>
-          <pt>{ <varname>root_partition_table</varname> | <varname>leaf_partition_table</varname> } [
+          <pt>{ <varname>root_partition_table_name</varname> | <varname>leaf_partition_table_name</varname> } [
               (<varname>column</varname> [, ...] ) ]</pt>
           <pd>Collect statistics for partitioned tables including HLL statistics. HLL statistics are
             collected only on leaf child partitions. </pd>
-          <pd><codeph>ANALYZE <varname>root_partition_table</varname></codeph>, collects statistics on all
+          <pd><codeph>ANALYZE <varname>root_partition_table_name</varname></codeph>, collects statistics on all
             leaf child partitions and the root partition. </pd>
-          <pd><codeph>ANALYZE <varname>leaf_partition_table</varname></codeph>, collects statistics on the
+          <pd><codeph>ANALYZE <varname>leaf_partition_table_name</varname></codeph>, collects statistics on the
             leaf child partition. </pd>
           <pd>By default, if you specify a leaf child partition, and all other leaf child partitions
             have statistics, <codeph>ANALYZE</codeph> updates the root partition statistics. If not


### PR DESCRIPTION
the ANALYZE sql command ref page was using the term `root_partition` to refer to the name of the root partition table.  this terminology is close enough to the ROOTPARTITION keyword to be confusing.  replace root_partition with root_partition_table (the first line of the command syntax uses table) and leaf_partition with leaf_partition_table to remove any ambiguity.  also made a similar change to gporca topic.
