### PR TITLE
Add tests for GUC of PGC_STRING type value rollback

### DIFF
--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -61,7 +61,6 @@
 #include "cdb/cdbvars.h"
 #include "cdb/memquota.h"
 #include "utils/metrics_utils.h"
-#include "utils/faultinjector.h"
 
 typedef struct
 {
@@ -325,14 +324,6 @@ ExecCreateTableAs(CreateTableAsStmt *stmt, const char *queryString,
 			return InvalidObjectAddress;
 		}
 	}
-#ifdef FAULT_INJECTOR
-	if (SIMPLE_FAULT_INJECTOR("change_string_guc") == FaultInjectorTypeSkip)
-	{
-		(void) set_config_option("search_path", "public",
-						 PGC_USERSET, PGC_S_SESSION,
-						 GUC_ACTION_SAVE, true, 0, false);
-	}
-#endif
 	/*
 	 * Create the tuple receiver object and insert info it will need
 	 */

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1631,10 +1631,6 @@ restore_guc_to_QE(void )
 		}
 		PG_CATCH();
 		{
-
-#ifdef FAULT_INJECTOR
-			SIMPLE_FAULT_INJECTOR("restore_string_guc");
-#endif
 			/* if some guc can not restore successful
 			 * we can not keep alive gang anymore.
 			 */

--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -408,52 +408,324 @@ SHOW search_path;
 (1 row)
 
 RESET search_path;
--- when the original string guc is empty, we change the guc to new value during executing a command.
--- this guc will be added to gp_guc_restore_list, and they will be restored
--- to original value to qe when the next command is executed.
--- however, the dispatch command is "set xxx to ;" that is wrong.
-create extension if not exists gp_inject_fault;
-create table public.restore_guc_test(tc1 int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'tc1' as the Greenplum Database data distribution key for this table.
+-- Test single query default_tablespace GUC rollback
+-- Function just to save default_tablespace GUC to gp_guc_restore_list
+CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
+AS $$
+BEGIN
+    EXECUTE 'SELECT 1;';
+END;
+$$ LANGUAGE plpgsql
+SET default_tablespace TO '';
+-- Create temp table to create temp schema
+CREATE TEMP TABLE just_a_temp_table (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
--- inject fault to change the value of search_path during creating materialized view
-SELECT gp_inject_fault('change_string_guc', 'skip', 1);
- gp_inject_fault 
------------------
- Success:
+-- Temp schema should be created for each segment
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+ count 
+-------
+     6
 (1 row)
 
--- inject fault when dispatch guc restore command occur errors, we throw an error.
-SELECT gp_inject_fault('restore_string_guc', 'error', 1);
- gp_inject_fault 
------------------
- Success:
-(1 row)
-
--- set search_path to '';
-SELECT pg_catalog.set_config('search_path', '', false);
- set_config 
-------------
+-- Save default_tablespace GUC to gp_guc_restore_list
+SELECT set_conf_param();
+ set_conf_param 
+----------------
  
 (1 row)
 
--- trigger inject fault of change_string_guc, and add this guc to gp_guc_restore_list
-create MATERIALIZED VIEW public.view_restore_guc_test as select * from public.restore_guc_test;
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
---we should restore gucs in gp_guc_restore_list to qe, no error occurs.
-drop MATERIALIZED VIEW public.view_restore_guc_test;
-drop table public.restore_guc_test;
---cleanup
-reset search_path;
-SELECT gp_inject_fault('change_string_guc', 'reset', 1);
- gp_inject_fault 
------------------
- Success:
+-- Trigger default_tablespace GUC restore from gp_guc_restore_list
+SELECT 1;
+ ?column? 
+----------
+        1
 (1 row)
 
-SELECT gp_inject_fault('restore_string_guc', 'reset', 1);
- gp_inject_fault 
------------------
- Success:
+-- When default_tablespace GUC is restored from gp_guc_restore_list
+-- successfully no RemoveTempRelationsCallback is called.
+-- So check that segments still have temp schemas
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+ count 
+-------
+     6
 (1 row)
 
+-- Cleanup
+DROP TABLE just_a_temp_table;
+-- Test single query gp_default_storage_options GUC rollback
+-- Function just to save gp_default_storage_options to gp_guc_restore_list
+CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
+AS $$
+BEGIN
+    EXECUTE 'SELECT 1;';
+END;
+$$ LANGUAGE plpgsql
+SET gp_default_storage_options TO 'blocksize=32768,compresstype=none,checksum=false';
+-- Create temp table to create temp schema
+CREATE TEMP TABLE just_a_temp_table (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Temp schema should be created for each segment
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+ count 
+-------
+     6
+(1 row)
+
+-- Save gp_default_storage_options GUC to gp_guc_restore_list
+SELECT set_conf_param();
+ set_conf_param 
+----------------
+ 
+(1 row)
+
+-- Trigger gp_default_storage_options GUC restore from gp_guc_restore_list
+SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+-- When gp_default_storage_options GUC is restored from gp_guc_restore_list
+-- successfully no RemoveTempRelationsCallback is called.
+-- So check that segments still have temp schemas
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+ count 
+-------
+     6
+(1 row)
+
+-- Cleanup
+DROP TABLE just_a_temp_table;
+-- Test single query lc_numeric GUC rollback
+-- Set lc_numeric to value that has to be quoted due to dot
+SET lc_numeric TO 'en_US.utf8';
+-- Function just to save lc_numeric GUC to gp_guc_restore_list
+CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
+AS $$
+BEGIN
+    EXECUTE 'SELECT 1;';
+END;
+$$ LANGUAGE plpgsql
+SET lc_numeric TO 'en_US.utf8';
+-- Create temp table to create temp schema
+CREATE TEMP TABLE just_a_temp_table (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Temp schema should be created for each segment
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+ count 
+-------
+     6
+(1 row)
+
+-- Save lc_numeric GUC to gp_guc_restore_list
+SELECT set_conf_param();
+ set_conf_param 
+----------------
+ 
+(1 row)
+
+-- Trigger lc_numeric GUC restore from gp_guc_restore_list
+SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+-- When lc_numeric GUC is restored from gp_guc_restore_list
+-- successfully no RemoveTempRelationsCallback is called.
+-- So check that segments still have temp schemas
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+ count 
+-------
+     6
+(1 row)
+
+-- Cleanup
+DROP TABLE just_a_temp_table;
+-- Test single query pljava_classpath GUC rollback
+-- Function just to save pljava_classpath GUC to gp_guc_restore_list
+CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
+AS $$
+BEGIN
+    EXECUTE 'SELECT 1;';
+END;
+$$ LANGUAGE plpgsql
+SET pljava_classpath TO '';
+-- Create temp table to create temp schema
+CREATE TEMP TABLE just_a_temp_table (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Temp schema should be created for each segment
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+ count 
+-------
+     6
+(1 row)
+
+-- Save pljava_classpath GUC to gp_guc_restore_list
+SELECT set_conf_param();
+ set_conf_param 
+----------------
+ 
+(1 row)
+
+-- Trigger pljava_classpath GUC restore from gp_guc_restore_list
+SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+-- When pljava_classpath GUC is restored from gp_guc_restore_list
+-- successfully no RemoveTempRelationsCallback is called.
+-- So check that segments still have temp schemas
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+ count 
+-------
+     6
+(1 row)
+
+-- Cleanup
+DROP TABLE just_a_temp_table;
+-- Test single query pljava_vmoptions GUC rollback
+-- Function just to save pljava_vmoptions GUC to gp_guc_restore_list
+CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
+AS $$
+BEGIN
+    EXECUTE 'SELECT 1;';
+END;
+$$ LANGUAGE plpgsql
+SET pljava_vmoptions TO '';
+-- Create temp table to create temp schema
+CREATE TEMP TABLE just_a_temp_table (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Temp schema should be created for each segment
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+ count 
+-------
+     6
+(1 row)
+
+-- Save pljava_vmoptions GUC to gp_guc_restore_list
+SELECT set_conf_param();
+ set_conf_param 
+----------------
+ 
+(1 row)
+
+-- Trigger pljava_vmoptions GUC restore from gp_guc_restore_list
+SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+-- When pljava_vmoptions GUC is restored from gp_guc_restore_list
+-- successfully no RemoveTempRelationsCallback is called.
+-- So check that segments still have temp schemas
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+ count 
+-------
+     6
+(1 row)
+
+-- Cleanup
+DROP TABLE just_a_temp_table;
+-- Test single query GUC TimeZone rollback
+-- Set TimeZone to value that has to be quoted due to slash
+SET TimeZone TO 'Africa/Mbabane';
+-- Function just to save TimeZone to gp_guc_restore_list
+CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
+AS $$
+BEGIN
+    EXECUTE 'SELECT 1;';
+END;
+$$ LANGUAGE plpgsql
+SET TimeZone TO 'UTC';
+-- Create temp table to create temp schema
+CREATE TEMP TABLE just_a_temp_table (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Temp schema should be created for each segment
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+ count 
+-------
+     6
+(1 row)
+
+-- Save TimeZone GUC to gp_guc_restore_list
+SELECT set_conf_param();
+ set_conf_param 
+----------------
+ 
+(1 row)
+
+-- Trigger TimeZone GUC restore from gp_guc_restore_list
+SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+-- When TimeZone GUC is restored from gp_guc_restore_list
+-- successfully no RemoveTempRelationsCallback is called.
+-- So check that segments still have temp schemas
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+ count 
+-------
+     6
+(1 row)
+
+-- Cleanup
+DROP TABLE just_a_temp_table;
+-- Test single query search_path GUC rollback
+-- Add empty value to search_path that caused issues before
+-- to verify that rollback it it will be successful.
+SET search_path TO public, '';
+-- Function just to save default_tablespace GUC to gp_guc_restore_list
+CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
+AS $$
+BEGIN
+    EXECUTE 'SELECT 1;';
+END;
+$$ LANGUAGE plpgsql
+SET search_path TO "public";
+-- Create temp table to create temp schema
+CREATE TEMP TABLE just_a_temp_table (a int);
+-- Temp schema should be created for each segment
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+ count 
+-------
+     6
+(1 row)
+
+-- Save default_tablespace GUC to gp_guc_restore_list
+SELECT set_conf_param();
+ set_conf_param 
+----------------
+ 
+(1 row)
+
+-- Trigger default_tablespace GUC restore from gp_guc_restore_list
+SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+-- When search_path GUC is restored from gp_guc_restore_list
+-- successfully no RemoveTempRelationsCallback is called.
+-- So check that segments still have temp schemas
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+ count 
+-------
+     6
+(1 row)
+
+-- Cleanup
+DROP TABLE just_a_temp_table;
+RESET search_path;

--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -499,8 +499,8 @@ SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg
 -- Cleanup
 DROP TABLE just_a_temp_table;
 -- Test single query lc_numeric GUC rollback
--- Set lc_numeric to value that has to be quoted due to dot
-SET lc_numeric TO 'en_US.utf8';
+-- Set lc_numeric to OS-friendly value
+SET lc_numeric TO 'C';
 -- Function just to save lc_numeric GUC to gp_guc_restore_list
 CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
 AS $$
@@ -508,7 +508,7 @@ BEGIN
     EXECUTE 'SELECT 1;';
 END;
 $$ LANGUAGE plpgsql
-SET lc_numeric TO 'en_US.utf8';
+SET lc_numeric TO 'C';
 -- Create temp table to create temp schema
 CREATE TEMP TABLE just_a_temp_table (a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/sql/guc_gp.sql
+++ b/src/test/regress/sql/guc_gp.sql
@@ -244,28 +244,181 @@ SET search_path = '\path';
 SHOW search_path;
 RESET search_path;
 
--- when the original string guc is empty, we change the guc to new value during executing a command.
--- this guc will be added to gp_guc_restore_list, and they will be restored
--- to original value to qe when the next command is executed.
--- however, the dispatch command is "set xxx to ;" that is wrong.
-create extension if not exists gp_inject_fault;
-create table public.restore_guc_test(tc1 int);
+-- Test single query default_tablespace GUC rollback
+-- Function just to save default_tablespace GUC to gp_guc_restore_list
+CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
+AS $$
+BEGIN
+    EXECUTE 'SELECT 1;';
+END;
+$$ LANGUAGE plpgsql
+SET default_tablespace TO '';
+-- Create temp table to create temp schema
+CREATE TEMP TABLE just_a_temp_table (a int);
+-- Temp schema should be created for each segment
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+-- Save default_tablespace GUC to gp_guc_restore_list
+SELECT set_conf_param();
+-- Trigger default_tablespace GUC restore from gp_guc_restore_list
+SELECT 1;
+-- When default_tablespace GUC is restored from gp_guc_restore_list
+-- successfully no RemoveTempRelationsCallback is called.
+-- So check that segments still have temp schemas
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+-- Cleanup
+DROP TABLE just_a_temp_table;
 
--- inject fault to change the value of search_path during creating materialized view
-SELECT gp_inject_fault('change_string_guc', 'skip', 1);
--- inject fault when dispatch guc restore command occur errors, we throw an error.
-SELECT gp_inject_fault('restore_string_guc', 'error', 1);
+-- Test single query gp_default_storage_options GUC rollback
+-- Function just to save gp_default_storage_options to gp_guc_restore_list
+CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
+AS $$
+BEGIN
+    EXECUTE 'SELECT 1;';
+END;
+$$ LANGUAGE plpgsql
+SET gp_default_storage_options TO 'blocksize=32768,compresstype=none,checksum=false';
+-- Create temp table to create temp schema
+CREATE TEMP TABLE just_a_temp_table (a int);
+-- Temp schema should be created for each segment
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+-- Save gp_default_storage_options GUC to gp_guc_restore_list
+SELECT set_conf_param();
+-- Trigger gp_default_storage_options GUC restore from gp_guc_restore_list
+SELECT 1;
+-- When gp_default_storage_options GUC is restored from gp_guc_restore_list
+-- successfully no RemoveTempRelationsCallback is called.
+-- So check that segments still have temp schemas
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+-- Cleanup
+DROP TABLE just_a_temp_table;
 
--- set search_path to '';
-SELECT pg_catalog.set_config('search_path', '', false);
--- trigger inject fault of change_string_guc, and add this guc to gp_guc_restore_list
-create MATERIALIZED VIEW public.view_restore_guc_test as select * from public.restore_guc_test;
+-- Test single query lc_numeric GUC rollback
+-- Set lc_numeric to value that has to be quoted due to dot
+SET lc_numeric TO 'en_US.utf8';
+-- Function just to save lc_numeric GUC to gp_guc_restore_list
+CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
+AS $$
+BEGIN
+    EXECUTE 'SELECT 1;';
+END;
+$$ LANGUAGE plpgsql
+SET lc_numeric TO 'en_US.utf8';
+-- Create temp table to create temp schema
+CREATE TEMP TABLE just_a_temp_table (a int);
+-- Temp schema should be created for each segment
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+-- Save lc_numeric GUC to gp_guc_restore_list
+SELECT set_conf_param();
+-- Trigger lc_numeric GUC restore from gp_guc_restore_list
+SELECT 1;
+-- When lc_numeric GUC is restored from gp_guc_restore_list
+-- successfully no RemoveTempRelationsCallback is called.
+-- So check that segments still have temp schemas
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+-- Cleanup
+DROP TABLE just_a_temp_table;
 
---we should restore gucs in gp_guc_restore_list to qe, no error occurs.
-drop MATERIALIZED VIEW public.view_restore_guc_test;
-drop table public.restore_guc_test;
+-- Test single query pljava_classpath GUC rollback
+-- Function just to save pljava_classpath GUC to gp_guc_restore_list
+CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
+AS $$
+BEGIN
+    EXECUTE 'SELECT 1;';
+END;
+$$ LANGUAGE plpgsql
+SET pljava_classpath TO '';
+-- Create temp table to create temp schema
+CREATE TEMP TABLE just_a_temp_table (a int);
+-- Temp schema should be created for each segment
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+-- Save pljava_classpath GUC to gp_guc_restore_list
+SELECT set_conf_param();
+-- Trigger pljava_classpath GUC restore from gp_guc_restore_list
+SELECT 1;
+-- When pljava_classpath GUC is restored from gp_guc_restore_list
+-- successfully no RemoveTempRelationsCallback is called.
+-- So check that segments still have temp schemas
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+-- Cleanup
+DROP TABLE just_a_temp_table;
 
---cleanup
-reset search_path;
-SELECT gp_inject_fault('change_string_guc', 'reset', 1);
-SELECT gp_inject_fault('restore_string_guc', 'reset', 1);
+-- Test single query pljava_vmoptions GUC rollback
+-- Function just to save pljava_vmoptions GUC to gp_guc_restore_list
+CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
+AS $$
+BEGIN
+    EXECUTE 'SELECT 1;';
+END;
+$$ LANGUAGE plpgsql
+SET pljava_vmoptions TO '';
+-- Create temp table to create temp schema
+CREATE TEMP TABLE just_a_temp_table (a int);
+-- Temp schema should be created for each segment
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+-- Save pljava_vmoptions GUC to gp_guc_restore_list
+SELECT set_conf_param();
+-- Trigger pljava_vmoptions GUC restore from gp_guc_restore_list
+SELECT 1;
+-- When pljava_vmoptions GUC is restored from gp_guc_restore_list
+-- successfully no RemoveTempRelationsCallback is called.
+-- So check that segments still have temp schemas
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+-- Cleanup
+DROP TABLE just_a_temp_table;
+
+-- Test single query GUC TimeZone rollback
+-- Set TimeZone to value that has to be quoted due to slash
+SET TimeZone TO 'Africa/Mbabane';
+-- Function just to save TimeZone to gp_guc_restore_list
+CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
+AS $$
+BEGIN
+    EXECUTE 'SELECT 1;';
+END;
+$$ LANGUAGE plpgsql
+SET TimeZone TO 'UTC';
+-- Create temp table to create temp schema
+CREATE TEMP TABLE just_a_temp_table (a int);
+-- Temp schema should be created for each segment
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+-- Save TimeZone GUC to gp_guc_restore_list
+SELECT set_conf_param();
+-- Trigger TimeZone GUC restore from gp_guc_restore_list
+SELECT 1;
+-- When TimeZone GUC is restored from gp_guc_restore_list
+-- successfully no RemoveTempRelationsCallback is called.
+-- So check that segments still have temp schemas
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+-- Cleanup
+DROP TABLE just_a_temp_table;
+
+-- Test single query search_path GUC rollback
+-- Add empty value to search_path that caused issues before
+-- to verify that rollback it it will be successful.
+SET search_path TO public, '';
+-- Function just to save default_tablespace GUC to gp_guc_restore_list
+CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
+AS $$
+BEGIN
+    EXECUTE 'SELECT 1;';
+END;
+$$ LANGUAGE plpgsql
+SET search_path TO "public";
+
+-- Create temp table to create temp schema
+CREATE TEMP TABLE just_a_temp_table (a int);
+-- Temp schema should be created for each segment
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+-- Save default_tablespace GUC to gp_guc_restore_list
+SELECT set_conf_param();
+-- Trigger default_tablespace GUC restore from gp_guc_restore_list
+SELECT 1;
+
+-- When search_path GUC is restored from gp_guc_restore_list
+-- successfully no RemoveTempRelationsCallback is called.
+-- So check that segments still have temp schemas
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+-- Cleanup
+DROP TABLE just_a_temp_table;
+RESET search_path;
+

--- a/src/test/regress/sql/guc_gp.sql
+++ b/src/test/regress/sql/guc_gp.sql
@@ -293,8 +293,8 @@ SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg
 DROP TABLE just_a_temp_table;
 
 -- Test single query lc_numeric GUC rollback
--- Set lc_numeric to value that has to be quoted due to dot
-SET lc_numeric TO 'en_US.utf8';
+-- Set lc_numeric to OS-friendly value
+SET lc_numeric TO 'C';
 -- Function just to save lc_numeric GUC to gp_guc_restore_list
 CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
 AS $$
@@ -302,7 +302,7 @@ BEGIN
     EXECUTE 'SELECT 1;';
 END;
 $$ LANGUAGE plpgsql
-SET lc_numeric TO 'en_US.utf8';
+SET lc_numeric TO 'C';
 -- Create temp table to create temp schema
 CREATE TEMP TABLE just_a_temp_table (a int);
 -- Temp schema should be created for each segment


### PR DESCRIPTION
GUC values of PGC_STRING type should be quoted or parsing
at GUC value rollback will fail otherwise.

As failed SET command leads to transaction abort that leads to
backend exit that triggers RemoveTempRelationsCallback to remove
temp relations, the new tests verify that after GUC PGC_STRING value
rollback no temp relation is removed.

Test for empty search_path GUC value from 620bdbda7ac40016f9bbd49941f70c4247ca2637
replaced with new one that required no Fault Injector and keeps the
source code clean.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
