### PR TITLE
Fix typo in DeserializeResGroupInfo()

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -2539,7 +2539,7 @@ DeserializeResGroupInfo(struct ResGroupCaps *capsOut,
 	cpuset_len = ntohl(itmp);
 	if (cpuset_len >= sizeof(capsOut->cpuset))
 		elog(ERROR, "malformed serialized resource group info");
-	memcpy(capsOut->cpuset, ptr, len); ptr += cpuset_len;
+	memcpy(capsOut->cpuset, ptr, cpuset_len); ptr += cpuset_len;
 	capsOut->cpuset[cpuset_len] = '\0';
 
 	memcpy(&itmp, ptr, sizeof(int32)); ptr += sizeof(int32);


### PR DESCRIPTION
len was used instead of cpuset_len. In most of cases this resulted in
garbage being copied. But rare out-of-page reads could cause a crash.
Forward-patching for main branch from #13044
