### PR TITLE
gpcheckcat orphaned_toast_tables fails when there is temp toast table…

### DIFF
--- a/gpMgmt/bin/gpcheckcat_modules/orphaned_toast_tables_check.py
+++ b/gpMgmt/bin/gpcheckcat_modules/orphaned_toast_tables_check.py
@@ -25,6 +25,7 @@ class OrphanedToastTablesCheck:
         # The following query attempts to "follow" the loop from pg_class to
         # pg_depend back to pg_class, and if the table oids don't match and/or
         # one is missing, the TOAST table is considered to be an orphan.
+        # Note: Handles toast tables <pg_toast_temp_*> which is created/used by InitTempTableNamespace().
         self.orphaned_toast_tables_query = """
 SELECT
     gp_segment_id AS content_id,
@@ -60,7 +61,7 @@ FROM (
             AND tst.oid = dep.objid
         LEFT JOIN pg_class tbl ON tst.oid = tbl.reltoastrelid
         LEFT JOIN pg_class dbl
-            ON trim('pg_toast.pg_toast_' FROM tst.oid::regclass::text)::int::regclass::oid = dbl.oid
+            ON REGEXP_REPLACE(tst.oid::regclass::text, 'pg_toast(_temp_\d+)?.pg_toast_', '')::int::regclass::oid = dbl.oid
         LEFT JOIN pg_class dbl_tst ON dbl.reltoastrelid = dbl_tst.oid
     WHERE tst.relkind='t'
         AND	(
@@ -93,7 +94,7 @@ FROM (
             AND tst.gp_segment_id = dep.gp_segment_id
         LEFT JOIN gp_dist_random('pg_class') tbl ON tst.oid = tbl.reltoastrelid AND tst.gp_segment_id = tbl.gp_segment_id
         LEFT JOIN gp_dist_random('pg_class') dbl
-            ON trim('pg_toast.pg_toast_' FROM tst.oid::regclass::text)::int::regclass::oid = dbl.oid 
+            ON REGEXP_REPLACE(tst.oid::regclass::text, 'pg_toast(_temp_\d+)?.pg_toast_', '')::int::regclass::oid = dbl.oid
             AND tst.gp_segment_id = dbl.gp_segment_id
         LEFT JOIN pg_class dbl_tst ON dbl.reltoastrelid = dbl_tst.oid AND tst.gp_segment_id = dbl_tst.gp_segment_id
     WHERE tst.relkind='t'

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -382,6 +382,15 @@ Feature: gpcheckcat tests
         Then gpcheckcat should return a return code of 0
         And the user runs "dropdb gpextension_db"
 
+    Scenario: gpcheckcat orphaned_toast_tables test should pass when there is valid temp toast table exists
+        Given database "temp_toast" is dropped and recreated
+        And the user connects to "temp_toast" with named connection "default"
+        And the user executes "CREATE TEMP TABLE temp_t1 (c1 text)" with named connection "default"
+        Then the user runs "gpcheckcat -R orphaned_toast_tables temp_toast"
+        And gpcheckcat should return a return code of 0
+        And the user drops the named connection "default"
+        And the user runs "dropdb temp_toast"
+
     Scenario: gpcheckcat should repair "bad reference" orphaned toast tables (caused by missing reltoastrelid)
         Given the database "gpcheckcat_orphans" is broken with "bad reference" orphaned toast tables
         When the user runs "gpcheckcat -R orphaned_toast_tables -g repair_dir gpcheckcat_orphans"


### PR DESCRIPTION
… exist

gpcheckcat failed to handle when there is a temp toast table exists
In current gpcheckcat orphaned_toast_tables querey include toast table with format
<pg_toast.pg_toast_>, updating querey to handle tost table with format
<pg_toast<_temp_*>.pg_toast_>.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
