### PR TITLE
Changes to avoid gpinitsystem failure when multiple address interfaces

### DIFF
--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -757,7 +757,7 @@ BUILD_COORDINATOR_PG_HBA_FILE () {
         if [ $HBA_HOSTNAMES -eq 0 ];then
             local COORDINATOR_IP_ADDRESS_NO_LOOPBACK=($("$GPHOME"/libexec/ifaddrs --no-loopback))
             if [ x"" != x"$STANDBY_HOSTNAME" ] && [ "$STANDBY_HOSTNAME" != "$COORDINATOR_HOSTNAME" ];then
-                local STANDBY_IP_ADDRESS_NO_LOOPBACK=$( REMOTE_EXECUTE_AND_GET_OUTPUT $STANDBY_HOSTNAME "'$GPHOME'/libexec/ifaddrs --no-loopback" )
+                local STANDBY_IP_ADDRESS_NO_LOOPBACK=($( REMOTE_EXECUTE_AND_GET_OUTPUT $STANDBY_HOSTNAME "'$GPHOME'/libexec/ifaddrs --no-loopback" ))
             fi
             for ADDR in "${COORDINATOR_IP_ADDRESS_NO_LOOPBACK[@]}" "${STANDBY_IP_ADDRESS_NO_LOOPBACK[@]}"
             do

--- a/gpMgmt/bin/lib/gpcreateseg.sh
+++ b/gpMgmt/bin/lib/gpcreateseg.sh
@@ -226,8 +226,8 @@ CREATE_QES_MIRROR () {
     # Add the samehost replication entry to support single-host development
     local PG_HBA_ENTRIES="${PG_HBA_ENTRIES}"$'\n'"host replication ${GP_USER} samehost trust"
     if [ $HBA_HOSTNAMES -eq 0 ];then
-        local MIRROR_ADDRESSES=$( REMOTE_EXECUTE_AND_GET_OUTPUT ${GP_HOSTADDRESS} "'${GPHOME}'/libexec/ifaddrs --no-loopback" )
-        local PRIMARY_ADDRESSES=$( REMOTE_EXECUTE_AND_GET_OUTPUT ${PRIMARY_HOSTADDRESS} "'${GPHOME}'/libexec/ifaddrs --no-loopback")
+        local MIRROR_ADDRESSES=($( REMOTE_EXECUTE_AND_GET_OUTPUT ${GP_HOSTADDRESS} "'${GPHOME}'/libexec/ifaddrs --no-loopback" ))
+        local PRIMARY_ADDRESSES=($( REMOTE_EXECUTE_AND_GET_OUTPUT ${PRIMARY_HOSTADDRESS} "'${GPHOME}'/libexec/ifaddrs --no-loopback"))
         for ADDR in "${MIRROR_ADDRESSES[@]}" "${PRIMARY_ADDRESSES[@]}"
         do
             CIDR_ADDR=$(GET_CIDRADDR $ADDR)


### PR DESCRIPTION
Fixing bug to treat command output as string instead of array which was causing gpinitsystem failure when cluster created with mirrors and hosts have multiple interfaces configured. The regression was introduced as part of commit: 248c1c740b2f5f351ef6ee6cc4c1317397c857f9

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
