### PR TITLE
Docs - dita cleanup in preparation to convert to markdown

### DIFF
--- a/gpdb-doc/dita/best_practices/analyze.xml
+++ b/gpdb-doc/dita/best_practices/analyze.xml
@@ -10,11 +10,11 @@
       is out of date, the planner can generate inefficient plans.</p>
     <section>
       <title>Generating Statistics Selectively</title>
-      <p>Running <codeph><xref href="../ref_guide/sql_commands/ANALYZE.xml">ANALYZE</xref></codeph>
+      <p>Running <xref href="../ref_guide/sql_commands/ANALYZE.xml">ANALYZE</xref>
         with no arguments updates statistics for all tables in the database. This can be a very
         long-running process and it is not recommended. You should <codeph>ANALYZE</codeph> tables
-        selectively when data has changed or use the <codeph><xref
-            href="../utility_guide/ref/analyzedb.xml">analyzedb</xref></codeph> utility. </p>
+        selectively when data has changed or use the <xref
+            href="../utility_guide/ref/analyzedb.xml">analyzedb</xref> utility. </p>
       <p>Running <codeph>ANALYZE</codeph> on a large table can take a long time. If it is not
         feasible to run <codeph>ANALYZE</codeph> on all columns of a very large table, you can
         generate statistics for selected columns only using <codeph>ANALYZE table(column,

--- a/gpdb-doc/dita/best_practices/analyze.xml
+++ b/gpdb-doc/dita/best_practices/analyze.xml
@@ -28,7 +28,7 @@
         sub-partitioned tables store no data or statistics, so running <codeph>ANALYZE</codeph> on
         them does not work. You can find the names of the partition tables in the
           <codeph>pg_partitions</codeph> system
-        catalog:<codeblock>SELECT partitiontablename from pg_partitions WHERE tablename='<i>parent_table</i>';</codeblock></p>
+        catalog:<codeblock>SELECT partitiontablename from pg_partitions WHERE tablename='parent_table';</codeblock></p>
     </section>
     <section>
       <title>Improving Statistics Quality</title>

--- a/gpdb-doc/dita/best_practices/bloat.xml
+++ b/gpdb-doc/dita/best_practices/bloat.xml
@@ -54,9 +54,9 @@
       <p>The statistics collected by the <codeph>ANALYZE</codeph> statement can be used to calculate
         the expected number of disk pages required to store a table. The difference between the
         expected number of pages and the actual number of pages is a measure of bloat. The
-          <codeph>gp_toolkit</codeph> schema provides the <codeph><xref
+          <codeph>gp_toolkit</codeph> schema provides the <xref
             href="../ref_guide/gp_toolkit.xml#topic3" type="topic" format="dita"
-            class="- topic/xref "/></codeph> view that identifies table bloat by comparing the ratio
+            class="- topic/xref "/> view that identifies table bloat by comparing the ratio
         of expected to actual pages. To use it, make sure statistics are up to date for all of the
         tables in the database, then run the following
         SQL:<codeblock>gpadmin=# SELECT * FROM gp_toolkit.gp_bloat_diag;

--- a/gpdb-doc/dita/best_practices/data_loading.xml
+++ b/gpdb-doc/dita/best_practices/data_loading.xml
@@ -175,7 +175,7 @@ Segment 12 - gpfdist 4</screen></p>
         <li>Recheck for segment skew in the table after loading a large amount of data. You can use
           a query like the following to check for
           skew:<codeblock outputclass="language-sql">SELECT gp_segment_id, count(*) 
-FROM <i>schema.table</i> 
+FROM schema.table 
 GROUP BY gp_segment_id ORDER BY 2;</codeblock></li>
         <li>By default, <codeph>gpfdist</codeph> assumes a maximum record size of 32K. To load data
           records larger than 32K, you must increase the maximum row size parameter by specifying

--- a/gpdb-doc/dita/best_practices/encryption.xml
+++ b/gpdb-doc/dita/best_practices/encryption.xml
@@ -209,7 +209,7 @@ Please select what kind of key you want:
  (2) DSA and Elgamal
  (3) DSA (sign only)
  (4) RSA (sign only)
-Your selection? <b>1</b></codeblock></li>
+Your selection? 1</codeblock></li>
         <li>Respond to the prompts and follow the instructions, as shown in this
           example:<codeblock>RSA keys may be between 1024 and 4096 bits long.
 What keysize do you want? (2048) Press enter to accept default key size
@@ -220,21 +220,21 @@ Please specify how long the key should be valid.
  &lt;n&gt;w = key expires in n weeks
  &lt;n&gt;m = key expires in n months
  &lt;n&gt;y = key expires in n years
- Key is valid for? (0) <b>365</b>
+ Key is valid for? (0) 365
 Key expires at Wed 13 Jan 2016 10:35:39 AM PST
-Is this correct? (y/N) <b>y</b>
+Is this correct? (y/N) y
 
 GnuPG needs to construct a user ID to identify your key.
 
-Real name: <b>John Doe</b>
-Email address: <b>jdoe@email.com</b>
+Real name: John Doe
+Email address: jdoe@email.com
 Comment: 
 You selected this USER-ID:
  "John Doe &lt;jdoe@email.com&gt;"
 
-Change (N)ame, (C)omment, (E)mail or (O)kay/(Q)uit? <b>O</b>
+Change (N)ame, (C)omment, (E)mail or (O)kay/(Q)uit? O
 You need a Passphrase to protect your secret key.
-<i>(For this demo the passphrase is blank.)</i>
+(For this demo the passphrase is blank.)
 can't connect to `/root/.gnupg/S.gpg-agent': No such file or directory
 You don't want a passphrase - this is probably a *bad* idea!
 I will do it anyway.  You can change your passphrase at any time,

--- a/gpdb-doc/dita/best_practices/ha.xml
+++ b/gpdb-doc/dita/best_practices/ha.xml
@@ -217,9 +217,9 @@
             </li>
             <li dir="ltr">
               <p dir="ltr">Use the <codeph>gpbackup</codeph> command to specify only the schema and
-                tables that you want backed up. See the <codeph><xref
+                tables that you want backed up. See the <xref
                     href="https://gpdb.docs.pivotal.io/latest/utility_guide/ref/gpbackup.html"
-                    format="html" scope="external">gpbackup</xref></codeph> reference for more
+                    format="html" scope="external">gpbackup</xref> reference for more
                 information.</p>
             </li>
             <li dir="ltr">
@@ -269,12 +269,12 @@
           <li><xref href="../admin_guide/managing/monitor.xml"/></li>
           <li><xref href="../admin_guide/highavail/topics/g-recovering-from-segment-failures.xml"/></li>
         </ul><p><i>Greenplum Database Utility Guide</i>:<ul id="ul_fk2_hyl_v4">
-            <li><codeph><xref href="../utility_guide/ref/gpstate.xml">gpstate</xref></codeph> - view
+            <li><xref href="../utility_guide/ref/gpstate.xml">gpstate</xref> - view
               state of the Greenplum system</li>
-            <li><codeph><xref href="../utility_guide/ref/gprecoverseg.xml"
-                >gprecoverseg</xref></codeph> - recover a failed segment</li>
-            <li><codeph><xref href="../utility_guide/ref/gpactivatestandby.xml"
-                  >gpactivatestandby</xref></codeph> - make the standby master the active
+            <li><xref href="../utility_guide/ref/gprecoverseg.xml"
+                >gprecoverseg</xref> - recover a failed segment</li>
+            <li><xref href="../utility_guide/ref/gpactivatestandby.xml"
+                  >gpactivatestandby</xref> - make the standby master the active
               master</li>
           </ul></p><p><xref href="http://tools.ietf.org/html/rfc1697" format="html" scope="external"
             >RDBMS MIB Specification</xref></p></section>
@@ -310,16 +310,16 @@
       <p>The two standard mirroring arrangements are <i>group mirroring</i> and <i>spread
           mirroring</i>:<ul id="ul_uwr_gkv_tt">
           <li><b>Group mirroring</b> — Each host mirrors another host's primary segments. This is
-            the default for <codeph><xref href="../utility_guide/ref/gpinitsystem.xml"
-                >gpinitsystem</xref></codeph> and <codeph><xref
-                href="../utility_guide/ref/gpaddmirrors.xml">gpaddmirrors</xref></codeph>.</li>
+            the default for <xref href="../utility_guide/ref/gpinitsystem.xml"
+                >gpinitsystem</xref> and <xref
+                href="../utility_guide/ref/gpaddmirrors.xml">gpaddmirrors</xref>.</li>
           <li><b>Spread mirroring</b> — Mirrors are spread across the available hosts. This requires
             that the number of hosts in the cluster is greater than the number of segments per
             host.</li>
         </ul></p>
       <p>You can design a custom mirroring configuration and use the Greenplum
-          <codeph>gpaddmirrors</codeph> or <codeph><xref
-            href="../utility_guide/ref/gpmovemirrors.xml">gpmovemirrors</xref></codeph> utilities to
+          <codeph>gpaddmirrors</codeph> or <xref
+            href="../utility_guide/ref/gpmovemirrors.xml">gpmovemirrors</xref> utilities to
         set up the configuration.</p>
       <p><i>Block mirroring</i> is a custom mirror configuration that divides hosts in the cluster
         into equally sized blocks and distributes mirrors evenly to hosts within the block. If a

--- a/gpdb-doc/dita/best_practices/ha.xml
+++ b/gpdb-doc/dita/best_practices/ha.xml
@@ -235,7 +235,7 @@
               <p dir="ltr">If backups are saved to NFS mounts, use a scale-out NFS solution such as
                 Dell EMC Isilon to prevent IO bottlenecks.</p>
             </li>
-            <li dir="ltr" otherprops="pivotal">Consider streaming backups to the Dell EMC Data Domain enterprise backup platform.</li>
+            <li dir="ltr">Tanzuy Greenplum customers should consider streaming backups to the Dell EMC Data Domain enterprise backup platform.</li>
           </ul>
         </p>
       </section>

--- a/gpdb-doc/dita/best_practices/resgroups.xml
+++ b/gpdb-doc/dita/best_practices/resgroups.xml
@@ -142,7 +142,7 @@
           group for the workload and the time of day.</li>
         <li>Use the <codeph>gp_toolkit</codeph> views to examine resource group resource
             usage and to monitor how the groups are working.</li>
-        <li otherprops="pivotal">Consider using Tanzu Greenplum Command Center
+        <li>Consider using Tanzu Greenplum Command Center
           to create and manage resource groups, and to define the criteria under which
           Command Center dynamically assigns a transaction to a resource group.</li>
       </ul>


### PR DESCRIPTION
Un-nesting various DITA tagging to facilitate markdown conversion for the best practices guide. Will backport to 6X_STABLE.