### PR TITLE
(6x only) Fix ERRORDATA_STACK_SIZE exceeded issue.

### DIFF
--- a/src/backend/cdb/cdbhash.c
+++ b/src/backend/cdb/cdbhash.c
@@ -392,9 +392,30 @@ cdb_default_distribution_opclass_for_type(Oid typeoid)
 
 /*
  * Look up the hash function, for given datatype, in given op family.
+ * It will throw an error if not found.
  */
 Oid
 cdb_hashproc_in_opfamily(Oid opfamily, Oid typeoid)
+{
+	Oid    hashfunc;
+
+	hashfunc = cdb_hashproc_in_opfamily_no_error(opfamily, typeoid);
+
+	if (!OidIsValid(hashfunc))
+	{
+		 elog(ERROR, "could not find hash function for type %u in operator family %u",
+			   typeoid, opfamily);
+	}
+
+	return hashfunc;
+}
+
+/*
+ * Look up the hash function, for given datatype, in given op family.
+ * Return InvalidOid instead of throwing error if not found.
+ */
+Oid
+cdb_hashproc_in_opfamily_no_error(Oid opfamily, Oid typeoid)
 {
 	Oid			hashfunc;
 	CatCList   *catlist;
@@ -432,10 +453,6 @@ cdb_hashproc_in_opfamily(Oid opfamily, Oid typeoid)
 	}
 
 	ReleaseSysCacheList(catlist);
-
-	if (!hashfunc)
-		elog(ERROR, "could not find hash function for type %u in operator family %u",
-			 typeoid, opfamily);
 
 	return hashfunc;
 }

--- a/src/backend/cdb/cdbpullup.c
+++ b/src/backend/cdb/cdbpullup.c
@@ -24,7 +24,7 @@
 #include "parser/parsetree.h"	/* get_tle_by_resno() */
 #include "utils/lsyscache.h"	/* get_opfamily_member() */
 
-#include "cdb/cdbhash.h"		/* cdb_hashproc_in_opfamily */
+#include "cdb/cdbhash.h"		/* cdb_hashproc_in_opfamily_no_error */
 #include "cdb/cdbpullup.h"		/* me */
 
 /*
@@ -316,22 +316,10 @@ cdbpullup_findEclassInTargetList(EquivalenceClass *eclass, List *targetlist,
 			 * there are binary compatible types, e.g. varchar and text.
 			 *
 			 * See Issue: https://github.com/greenplum-db/gpdb/issues/12700 for a detailed case.
-			 *
-			 * Since cdb_hashproc_in_opfamily might raise error, so we enclose the call by PG_TRY.
-			 * Error means we find nothing. Auto Variable hash_proc (without volatile in declartion)
-			 * is set in both Try clause and Catch clause.
 			 */
 			Oid hash_proc;
 
-			PG_TRY();
-			{
-				hash_proc = cdb_hashproc_in_opfamily(hashOpFamily, em->em_datatype);
-			}
-			PG_CATCH();
-			{
-				hash_proc = InvalidOid;
-			}
-			PG_END_TRY();
+			hash_proc = cdb_hashproc_in_opfamily_no_error(hashOpFamily, em->em_datatype);
 
 			if (!OidIsValid(hash_proc))
 				continue;

--- a/src/include/cdb/cdbhash.h
+++ b/src/include/cdb/cdbhash.h
@@ -78,6 +78,7 @@ extern Oid cdb_get_opclass_for_column_def(List *opclass, Oid attrType);
 extern Oid cdb_default_distribution_opfamily_for_type(Oid typid);
 extern Oid cdb_default_distribution_opclass_for_type(Oid typid);
 extern Oid cdb_hashproc_in_opfamily(Oid opfamily, Oid typeoid);
+extern Oid cdb_hashproc_in_opfamily_no_error(Oid opfamily, Oid typeoid);
 extern Oid cdb_eqop_in_hash_opfamily(Oid opfamily, Oid typeoid);
 
 /* prototypes and other things, from cdblegacyhash.c */

--- a/src/test/regress/expected/bfv_planner.out
+++ b/src/test/regress/expected/bfv_planner.out
@@ -785,6 +785,56 @@ drop table t2_12146;
 drop table t3_12146;
 drop table t4_12146;
 reset allow_system_table_mods;
+-- Test for ERRORDATA_STACK_SIZE exceeded issue
+-- The following test is copied from the commit 17c19c3f
+-- since that commit tests the code path that hash op
+-- not found in the opfamily (cdbpullup.c:cdbpullup_findEclassInTargetList).
+-- Commit 49ea956f refactor the cdbpullup.c:cdbpullup_findEclassInTargetList
+-- a bit and introduces a bug during the code path same as above. The bug
+-- is that it might leak ERRORDATA_STACK_SIZE.
+CREATE TABLE gp_timestamp_err_stack1
+(a int, d1 timestamp, e1 timestamptz,
+        d2 timestamp, e2 timestamptz,
+	d3 timestamp, e3 timestamptz,
+	d4 timestamp, e4 timestamptz,
+	d5 timestamp, e5 timestamptz,
+	d6 timestamp, e6 timestamptz,
+	d7 timestamp, e7 timestamptz,
+	d8 timestamp, e8 timestamptz,
+	d9 timestamp, e9 timestamptz,
+	d10 timestamp, e10 timestamptz,
+	d11 timestamp, e11 timestamptz)
+DISTRIBUTED BY (a, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11);
+CREATE TABLE gp_timestamp_err_stack2
+(c int, f1 timestamp, g1 timestamptz,
+        f2 timestamp, g2 timestamptz,
+	f3 timestamp, g3 timestamptz,
+	f4 timestamp, g4 timestamptz,
+	f5 timestamp, g5 timestamptz,
+	f6 timestamp, g6 timestamptz,
+	f7 timestamp, g7 timestamptz,
+	f8 timestamp, g8 timestamptz,
+	f9 timestamp, g9 timestamptz,
+	f10 timestamp, g10 timestamptz,
+	f11 timestamp, g11 timestamptz)
+DISTRIBUTED BY (c, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11);
+SELECT 1 FROM gp_timestamp_err_stack1 JOIN gp_timestamp_err_stack2
+ON a = c
+AND d1 = g1 AND f1 = e1 AND e1 = timestamp '2016/11/11'
+AND d2 = g2 AND f2 = e2 AND e2 = timestamp '2017/11/11'
+AND d3 = g3 AND f3 = e3 AND e3 = timestamp '2018/11/11'
+AND d4 = g4 AND f4 = e4 AND e4 = timestamp '2019/11/11'
+AND d5 = g5 AND f5 = e5 AND e5 = timestamp '2006/11/11'
+AND d6 = g6 AND f6 = e6 AND e6 = timestamp '2007/11/11'
+AND d7 = g7 AND f7 = e7 AND e7 = timestamp '2008/11/11'
+AND d8 = g8 AND f8 = e8 AND e8 = timestamp '2009/11/11'
+AND d9 = g9 AND f9 = e9 AND e9 = timestamp '2010/11/11'
+AND d10 = g10 AND f10 = e10 AND e10 = timestamp '2016/10/11'
+AND d11 = g11 AND f11 = e11 AND e11 = timestamp '2016/09/11';
+ ?column? 
+----------
+(0 rows)
+
 -- start_ignore
 drop table if exists bfv_planner_x;
 drop table if exists testbadsql;
@@ -792,4 +842,6 @@ drop table if exists bfv_planner_foo;
 drop table if exists testmedian;
 drop table if exists bfv_planner_t1;
 drop table if exists bfv_planner_t2;
+drop table if exists gp_timestamp_err_stack1;
+drop table if exists gp_timestamp_err_stack2;
 -- end_ignore

--- a/src/test/regress/sql/bfv_planner.sql
+++ b/src/test/regress/sql/bfv_planner.sql
@@ -441,6 +441,54 @@ drop table t4_12146;
 
 reset allow_system_table_mods;
 
+-- Test for ERRORDATA_STACK_SIZE exceeded issue
+-- The following test is copied from the commit 17c19c3f
+-- since that commit tests the code path that hash op
+-- not found in the opfamily (cdbpullup.c:cdbpullup_findEclassInTargetList).
+-- Commit 49ea956f refactor the cdbpullup.c:cdbpullup_findEclassInTargetList
+-- a bit and introduces a bug during the code path same as above. The bug
+-- is that it might leak ERRORDATA_STACK_SIZE.
+CREATE TABLE gp_timestamp_err_stack1
+(a int, d1 timestamp, e1 timestamptz,
+        d2 timestamp, e2 timestamptz,
+	d3 timestamp, e3 timestamptz,
+	d4 timestamp, e4 timestamptz,
+	d5 timestamp, e5 timestamptz,
+	d6 timestamp, e6 timestamptz,
+	d7 timestamp, e7 timestamptz,
+	d8 timestamp, e8 timestamptz,
+	d9 timestamp, e9 timestamptz,
+	d10 timestamp, e10 timestamptz,
+	d11 timestamp, e11 timestamptz)
+DISTRIBUTED BY (a, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11);
+CREATE TABLE gp_timestamp_err_stack2
+(c int, f1 timestamp, g1 timestamptz,
+        f2 timestamp, g2 timestamptz,
+	f3 timestamp, g3 timestamptz,
+	f4 timestamp, g4 timestamptz,
+	f5 timestamp, g5 timestamptz,
+	f6 timestamp, g6 timestamptz,
+	f7 timestamp, g7 timestamptz,
+	f8 timestamp, g8 timestamptz,
+	f9 timestamp, g9 timestamptz,
+	f10 timestamp, g10 timestamptz,
+	f11 timestamp, g11 timestamptz)
+DISTRIBUTED BY (c, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11);
+
+SELECT 1 FROM gp_timestamp_err_stack1 JOIN gp_timestamp_err_stack2
+ON a = c
+AND d1 = g1 AND f1 = e1 AND e1 = timestamp '2016/11/11'
+AND d2 = g2 AND f2 = e2 AND e2 = timestamp '2017/11/11'
+AND d3 = g3 AND f3 = e3 AND e3 = timestamp '2018/11/11'
+AND d4 = g4 AND f4 = e4 AND e4 = timestamp '2019/11/11'
+AND d5 = g5 AND f5 = e5 AND e5 = timestamp '2006/11/11'
+AND d6 = g6 AND f6 = e6 AND e6 = timestamp '2007/11/11'
+AND d7 = g7 AND f7 = e7 AND e7 = timestamp '2008/11/11'
+AND d8 = g8 AND f8 = e8 AND e8 = timestamp '2009/11/11'
+AND d9 = g9 AND f9 = e9 AND e9 = timestamp '2010/11/11'
+AND d10 = g10 AND f10 = e10 AND e10 = timestamp '2016/10/11'
+AND d11 = g11 AND f11 = e11 AND e11 = timestamp '2016/09/11';
+
 -- start_ignore
 drop table if exists bfv_planner_x;
 drop table if exists testbadsql;
@@ -448,4 +496,6 @@ drop table if exists bfv_planner_foo;
 drop table if exists testmedian;
 drop table if exists bfv_planner_t1;
 drop table if exists bfv_planner_t2;
+drop table if exists gp_timestamp_err_stack1;
+drop table if exists gp_timestamp_err_stack2;
 -- end_ignore


### PR DESCRIPTION
Previous commit 87b9c8f9d introduces a bug in the following code
in the function cdbpullup_findEclassInTargetList:

	Oid hash_proc;

	PG_TRY();
	{
		hash_proc = cdb_hashproc_in_opfamily(hashOpFamily, em->em_datatype);
	}
	PG_CATCH();
	{
		hash_proc = InvalidOid;
	}
	PG_END_TRY();

However, cdb_hashproc_in_opfamily might throw error and the
PG_CATCH does not clean up thus might lead to ERRORDATA_STACK_SIZE
exceeded.

This commit fixes the issue by introducing a version of cdb_hashproc_in_opfamily
that returns InvalidOid instead of throwing error when not found. This
new API let the caller to decide what to do and seems useful.