### PR TITLE
Changes to avoid gpstop errors when standby is not reachable.

### DIFF
--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -467,7 +467,7 @@ class GpStop:
             standby = self.gparray.standbyCoordinator
 
             if get_unreachable_segment_hosts([standby.hostname], 1):
-                logger.warning("Standby is unreachable, continuing to stop other segments...")
+                logger.warning("Standby is unreachable, skipping shutdown on standby")
                 return True
 
             logger.info("Stopping coordinator standby host %s mode=%s" % (standby.hostname, self.mode))

--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -34,6 +34,7 @@ try:
     from gppylib.gp_era import GpEraFile
     from gppylib.operations.utils import ParallelOperation, RemoteOperation
     from gppylib.operations.rebalanceSegments import ReconfigDetectionSQLQueryCommand
+    from gppylib.operations.detect_unreachable_hosts import get_unreachable_segment_hosts
 except ImportError as e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
 
@@ -464,6 +465,10 @@ class GpStop:
 
         if self.gparray.standbyCoordinator:
             standby = self.gparray.standbyCoordinator
+
+            if get_unreachable_segment_hosts([standby.hostname], 1):
+                logger.warning("Standby is unreachable, continuing to stop other segments...")
+                return True
 
             logger.info("Stopping coordinator standby host %s mode=%s" % (standby.hostname, self.mode))
             try:

--- a/gpMgmt/test/behave/mgmt_utils/gpstop.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstop.feature
@@ -34,6 +34,6 @@ Feature: gpstop behave tests
           And the catalog has a standby coordinator entry
          When the standby host is made unreachable
           And the user runs "gpstop -a"
-         Then gpstop should print "Standby is unreachable, continuing to stop other segments" to stdout
+         Then gpstop should print "Standby is unreachable, skipping shutdown on standby" to stdout
           And gpstop should return a return code of 0
           And the standby host is made reachable

--- a/gpMgmt/test/behave/mgmt_utils/gpstop.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstop.feature
@@ -27,3 +27,13 @@ Feature: gpstop behave tests
           And gpstop should print "There were 1 user connections at the start of the shutdown" to stdout
           And gpstop should print "'\(s\)mart_mode', '\(f\)ast_mode', '\(i\)mmediate_mode'" to stdout
          Then gpstop should return a return code of 0
+
+    @demo_cluster
+    Scenario: gpstop succeeds even if the standby host is unreachable
+        Given the database is running
+          And the catalog has a standby coordinator entry
+         When the standby host is made unreachable
+          And the user runs "gpstop -a"
+         Then gpstop should print "Standby is unreachable, continuing to stop other segments" to stdout
+          And gpstop should return a return code of 0
+          And the standby host is made reachable

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
@@ -37,29 +37,35 @@ def change_hostname(content, preferred_role, hostname):
 def impl(context):
     change_hostname(-1, 'm', 'invalid_host')
 
-    def cleanup(context):
-        """
-        Reverses the above SQL by starting up in coordinator-only utility mode. Since
-        the standby host is incorrect, a regular gpstart call won't work.
-        """
-        utils.stop_database_if_started(context)
-
-        subprocess.check_call(['gpstart', '-am'])
-        _run_sql("""
-            SET allow_system_table_mods='true';
-            UPDATE gp_segment_configuration
-               SET hostname = coordinator.hostname,
-                    address = coordinator.address
-              FROM (
-                     SELECT hostname, address
-                       FROM gp_segment_configuration
-                      WHERE content = -1 and role = 'p'
-                   ) coordinator
-             WHERE content = -1 AND role = 'm'
-        """, {'gp_role': 'utility'})
-        subprocess.check_call(['gpstop', '-am'])
-
     context.add_cleanup(cleanup, context)
+
+@when('the standby host is made reachable')
+@then('the standby host is made reachable')
+def impl(context):
+    cleanup(context)
+
+"""
+Reverses the changes done by change_hostname() function by starting up cluster in master-only utility mode. 
+Since the standby host is incorrect, a regular gpstart call won't work.
+"""
+def cleanup(context):
+
+    utils.stop_database_if_started(context)
+
+    subprocess.check_call(['gpstart', '-am'])
+    _run_sql("""
+        SET allow_system_table_mods='true';
+        UPDATE gp_segment_configuration
+           SET hostname = coordinator.hostname,
+                address = coordinator.address
+          FROM (
+                 SELECT hostname, address
+                   FROM gp_segment_configuration
+                  WHERE content = -1 and role = 'p'
+               ) coordinator
+         WHERE content = -1 AND role = 'm'
+    """, {'gp_role': 'utility'})
+    subprocess.check_call(['gpstop', '-am'])
 
 def _handle_sigpipe():
     """


### PR DESCRIPTION
Added check for standby reachability before stopping the standby to avoid gpstop failures when standby is unreachable.
Added behave test case for gpstop when standby is not reachable.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
