### PR TITLE
Fix getResUsage integer overflow.

### DIFF
--- a/src/backend/utils/resgroup/resgroup_helper.c
+++ b/src/backend/utils/resgroup/resgroup_helper.c
@@ -105,7 +105,7 @@ getResUsage(ResGroupStatCtx *ctx, Oid inGroupId)
 		initStringInfo(&buffer);
 		appendStringInfo(&buffer,
 						 "SELECT groupid, cpu_usage, memory_usage "
-						 "FROM pg_resgroup_get_status(%d)",
+						 "FROM pg_resgroup_get_status(%u)",
 						 inGroupId);
 
 		CdbDispatchCommand(buffer.data, DF_WITH_SNAPSHOT, &cdb_pgresults);
@@ -133,8 +133,7 @@ getResUsage(ResGroupStatCtx *ctx, Oid inGroupId)
 			{
 				const char *result;
 				ResGroupStat *row = &ctx->groups[j];
-				Oid groupId = pg_atoi(PQgetvalue(pg_result, j, 0),
-									  sizeof(Oid), 0);
+				Oid groupId = atooid(PQgetvalue(pg_result, j, 0));
 
 				Assert(groupId == row->groupId);
 

--- a/src/test/isolation2/expected/resgroup/resgroup_large_group_id.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_large_group_id.out
@@ -1,0 +1,31 @@
+-- Test resgroup oid larger than int32.
+select gp_inject_fault('bump_oid', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+create resource group rg_large_oid with (cpu_rate_limit=20, memory_limit=10);
+CREATE
+
+select gp_inject_fault('bump_oid', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+select max(oid)::bigint > (power(2,31) + 1)::bigint from pg_resgroup;
+ ?column? 
+----------
+ t        
+(1 row)
+
+-- count(*) > 0 to run the SQL but do not display the result
+select count(*) > 0 from pg_resgroup_get_status(NULL);
+ ?column? 
+----------
+ t        
+(1 row)
+
+drop resource group rg_large_oid;
+DROP

--- a/src/test/isolation2/isolation2_resgroup_schedule
+++ b/src/test/isolation2/isolation2_resgroup_schedule
@@ -51,4 +51,7 @@ test: resgroup/resgroup_functions
 # dump info
 test: resgroup/resgroup_dumpinfo
 
+# test larget group id
+test: resgroup/resgroup_large_group_id
+
 test: resgroup/disable_resgroup

--- a/src/test/isolation2/sql/resgroup/resgroup_large_group_id.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_large_group_id.sql
@@ -1,0 +1,13 @@
+-- Test resgroup oid larger than int32.
+select gp_inject_fault('bump_oid', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+create resource group rg_large_oid with (cpu_rate_limit=20, memory_limit=10);
+
+select gp_inject_fault('bump_oid', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+select max(oid)::bigint > (power(2,31) + 1)::bigint from pg_resgroup;
+
+-- count(*) > 0 to run the SQL but do not display the result
+select count(*) > 0 from pg_resgroup_get_status(NULL);
+
+drop resource group rg_large_oid;


### PR DESCRIPTION
In the function getResUsage it will set the group Id (type Oid)'s
value from a string. Previous code use pg_atoi to do the value parse,
this is not correct because type Oid is uint, we should use
atooid. Another place is building the SQL involving group id it uses
"%d", this commits fix this by using "%u".
