### PR TITLE
(6x backport) Fix getResUsage integer overflow.

### DIFF
--- a/src/backend/access/transam/varsup.c
+++ b/src/backend/access/transam/varsup.c
@@ -22,6 +22,7 @@
 #include "postmaster/autovacuum.h"
 #include "storage/pmsignal.h"
 #include "storage/proc.h"
+#include "utils/faultinjector.h"
 #include "utils/guc.h"
 #include "utils/syscache.h"
 
@@ -528,6 +529,26 @@ GetNewObjectIdUnderLock(void)
 
 	(ShmemVariableCache->nextOid)++;
 	(ShmemVariableCache->oidCount)--;
+
+#ifdef FAULT_INJECTOR
+	if (SIMPLE_FAULT_INJECTOR("bump_oid") == FaultInjectorTypeSkip)
+	{
+		/*
+		 * CDB: we encounter high oid issues several times, we should
+		 * have some test-utils to verify logic under larger oid.
+		 *
+		 * NOTE: we do not have undo-bump, so take care when you decide to
+		 * use this fault inject. Currently, only resgroup test job uses it,
+		 * that is safe, becase resgroup job is an independent pipeline job.
+		 */
+		Oid large_oid = (1U<<31)+5; /* this value will overflow if taken as int32 */
+		if (ShmemVariableCache->nextOid < large_oid)
+		{
+			ShmemVariableCache->nextOid = large_oid + 1;
+			result = large_oid;
+		}
+	}
+#endif
 
 	return result;
 }

--- a/src/backend/utils/resgroup/resgroup_helper.c
+++ b/src/backend/utils/resgroup/resgroup_helper.c
@@ -26,6 +26,8 @@
 #include "utils/resgroup-ops.h"
 #include "utils/resource_manager.h"
 
+#define atooid(x)  ((Oid) strtoul((x), NULL, 10))
+
 typedef struct ResGroupStat
 {
 	Datum groupId;
@@ -104,7 +106,7 @@ getResUsage(ResGroupStatCtx *ctx, Oid inGroupId)
 		initStringInfo(&buffer);
 		appendStringInfo(&buffer,
 						 "SELECT groupid, cpu_usage, memory_usage "
-						 "FROM pg_resgroup_get_status(%d)",
+						 "FROM pg_resgroup_get_status(%u)",
 						 inGroupId);
 
 		CdbDispatchCommand(buffer.data, DF_WITH_SNAPSHOT, &cdb_pgresults);
@@ -132,8 +134,7 @@ getResUsage(ResGroupStatCtx *ctx, Oid inGroupId)
 			{
 				const char *result;
 				ResGroupStat *row = &ctx->groups[j];
-				Oid groupId = pg_atoi(PQgetvalue(pg_result, j, 0),
-									  sizeof(Oid), 0);
+				Oid groupId = atooid(PQgetvalue(pg_result, j, 0));
 
 				Assert(groupId == row->groupId);
 

--- a/src/test/isolation2/expected/resgroup/resgroup_large_group_id.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_large_group_id.out
@@ -1,0 +1,34 @@
+-- Test resgroup oid larger than int32.
+create extension if not exists gp_inject_fault;
+CREATE
+
+select gp_inject_fault('bump_oid', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+create resource group rg_large_oid with (cpu_rate_limit=20, memory_limit=10);
+CREATE
+
+select gp_inject_fault('bump_oid', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+select max(oid)::bigint > (power(2,31) + 1)::bigint from pg_resgroup;
+ ?column? 
+----------
+ t        
+(1 row)
+
+-- count(*) > 0 to run the SQL but do not display the result
+select count(*) > 0 from pg_resgroup_get_status(NULL);
+ ?column? 
+----------
+ t        
+(1 row)
+
+drop resource group rg_large_oid;
+DROP

--- a/src/test/isolation2/isolation2_resgroup_schedule
+++ b/src/test/isolation2/isolation2_resgroup_schedule
@@ -51,4 +51,7 @@ test: resgroup/resgroup_functions
 # dump info
 test: resgroup/resgroup_dumpinfo
 
+# test larget group id
+test: resgroup/resgroup_large_group_id
+
 test: resgroup/disable_resgroup

--- a/src/test/isolation2/sql/resgroup/resgroup_large_group_id.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_large_group_id.sql
@@ -1,0 +1,15 @@
+-- Test resgroup oid larger than int32.
+create extension if not exists gp_inject_fault;
+
+select gp_inject_fault('bump_oid', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+create resource group rg_large_oid with (cpu_rate_limit=20, memory_limit=10);
+
+select gp_inject_fault('bump_oid', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+select max(oid)::bigint > (power(2,31) + 1)::bigint from pg_resgroup;
+
+-- count(*) > 0 to run the SQL but do not display the result
+select count(*) > 0 from pg_resgroup_get_status(NULL);
+
+drop resource group rg_large_oid;


### PR DESCRIPTION
In the function getResUsage it will set the group Id (type Oid)'s
value from a string. Previous code use pg_atoi to do the value parse,
this is not correct because type Oid is uint, we should use
atooid. Another place is building the SQL involving group id it uses
"%d", this commits fix this by using "%u".

(cherry picked from commit 29a9f92fcbb3fd21ddbd7fe0bb61c9abb0d28457)