### PR TITLE
Fix pg_basebackup integer overflow.

### DIFF
--- a/src/backend/access/transam/varsup.c
+++ b/src/backend/access/transam/varsup.c
@@ -608,16 +608,9 @@ GetNewObjectIdUnderLock(void)
 		/*
 		 * CDB: we encounter high oid issues several times, we should
 		 * have some test-utils to verify logic under larger oid.
-		 *
-		 * NOTE: we do not have undo-bump, so take care when you decide to
-		 * use this fault inject. Currently, only resgroup test job uses it,
-		 * that is safe, becase resgroup job is an independent pipeline job.
 		 */
-		Oid large_oid = (1U<<31)+5; /* this value will overflow if taken as int32 */
-		if (ShmemVariableCache->nextOid < large_oid)
-		{
-			ShmemVariableCache->nextOid = large_oid + 1;
-			result = large_oid;
+		if (result <= PG_INT32_MAX) {
+			result = PG_INT32_MAX + result % (PG_UINT32_MAX - PG_INT32_MAX) + 1;
 		}
 	}
 #endif

--- a/src/backend/replication/basebackup.c
+++ b/src/backend/replication/basebackup.c
@@ -1484,7 +1484,7 @@ sendDir(const char *path, int basepathlen, bool sizeonly, List *tablespaces,
 
 			if (!sizeonly)
 				sent = sendFile(pathbuf, pathbuf + basepathlen + 1, &statbuf,
-								true, isDbDir ? pg_atoi(lastDir + 1, sizeof(Oid), 0) : InvalidOid);
+								true, isDbDir ? atooid(lastDir + 1) : InvalidOid);
 
 			if (sent || sizeonly)
 			{

--- a/src/test/isolation2/input/pg_basebackup_large_database_oid.source
+++ b/src/test/isolation2/input/pg_basebackup_large_database_oid.source
@@ -1,0 +1,17 @@
+-- Test database oid larger than int32.
+select gp_inject_fault('bump_oid', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+create database db_large_oid;
+
+select gp_inject_fault('bump_oid', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+select max(oid)::bigint > (power(2,31) + 1)::bigint from pg_database;
+
+select pg_basebackup(address, dbid, port, true, 'some_replication_slot', '@testtablespace@/some_isolation2_pg_basebackup', false, 'stream') from gp_segment_configuration where content = 0 and role = 'p';
+
+
+drop database db_large_oid;
+
+0U: select * from pg_drop_replication_slot('some_replication_slot');
+!\retcode rm -rf @testtablespace@/some_isolation2_pg_basebackup;
+

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -211,6 +211,7 @@ test: vacuum_after_vacuum_skip_drop_column
 test: workfile_mgr_test
 test: pg_basebackup
 test: pg_basebackup_with_tablespaces
+test: pg_basebackup_large_database_oid
 test: enable_autovacuum
 
 test: segwalrep/die_commit_pending_replication

--- a/src/test/isolation2/output/pg_basebackup_large_database_oid.source
+++ b/src/test/isolation2/output/pg_basebackup_large_database_oid.source
@@ -1,0 +1,43 @@
+-- Test database oid larger than int32.
+select gp_inject_fault('bump_oid', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+create database db_large_oid;
+CREATE
+
+select gp_inject_fault('bump_oid', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+select max(oid)::bigint > (power(2,31) + 1)::bigint from pg_database;
+ ?column? 
+----------
+ t        
+(1 row)
+
+select pg_basebackup(address, dbid, port, true, 'some_replication_slot', '@testtablespace@/some_isolation2_pg_basebackup', false, 'stream') from gp_segment_configuration where content = 0 and role = 'p';
+ pg_basebackup 
+---------------
+               
+(1 row)
+
+
+drop database db_large_oid;
+DROP
+
+0U: select * from pg_drop_replication_slot('some_replication_slot');
+ pg_drop_replication_slot 
+--------------------------
+                          
+(1 row)
+!\retcode rm -rf @testtablespace@/some_isolation2_pg_basebackup;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+


### PR DESCRIPTION
In the function SendBaseBackup it will set the group Id (type Oid)'s
value from a string. Previous code use pg_atoi to do the value parse,
this is not correct because type Oid is uint, we should use
atooid.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
