### PR TITLE
Some gp wrapper function should not execute on entrydb QE

### DIFF
--- a/src/backend/catalog/cdb_schema.sql
+++ b/src/backend/catalog/cdb_schema.sql
@@ -46,4 +46,62 @@ GRANT SELECT ON pg_catalog.gp_distributed_log TO PUBLIC;
 
 ALTER RESOURCE QUEUE pg_default WITH (priority=medium, memory_limit='-1');
 
+
+-- pg_tablespace_location wrapper functions to see Greenplum cluster-wide tablespace locations
+CREATE FUNCTION gp_tablespace_segment_location (IN tblspc_oid oid, OUT gp_segment_id int, OUT tblspc_loc text)
+RETURNS SETOF RECORD AS
+$$
+DECLARE
+  seg_id int;
+BEGIN
+  EXECUTE 'select pg_catalog.gp_execution_segment()' INTO seg_id;
+  -- check if execute in entrydb QE to prevent giving wrong results
+  IF seg_id = -1 THEN
+    RAISE EXCEPTION 'Cannot execute in entrydb, this query is not currently supported by GPDB.';
+  END IF;
+  RETURN QUERY SELECT pg_catalog.gp_execution_segment() as gp_segment_id, *
+    FROM pg_catalog.pg_tablespace_location($1);
+END;
+$$ LANGUAGE plpgsql EXECUTE ON ALL SEGMENTS;
+
+
+CREATE FUNCTION gp_tablespace_location (IN tblspc_oid oid, OUT gp_segment_id int, OUT tblspc_loc text)
+RETURNS SETOF RECORD
+AS
+  'SELECT * FROM pg_catalog.gp_tablespace_segment_location($1)
+   UNION ALL
+   SELECT pg_catalog.gp_execution_segment() as gp_segment_id, * FROM pg_catalog.pg_tablespace_location($1)'
+LANGUAGE SQL EXECUTE ON COORDINATOR;
+
+-- pg_switch_wal wrapper functions to switch WAL segment files on Greenplum cluster-wide
+CREATE FUNCTION gp_switch_wal_on_all_segments (OUT gp_segment_id int, OUT pg_switch_wal pg_lsn)
+RETURNS SETOF RECORD AS
+$$
+DECLARE
+  seg_id int;
+BEGIN
+  EXECUTE 'select pg_catalog.gp_execution_segment()' INTO seg_id;
+  -- check if execute in entrydb QE to prevent giving wrong results
+  IF seg_id = -1 THEN
+    RAISE EXCEPTION 'Cannot execute in entrydb, this query is not currently supported by GPDB.';
+  END IF;
+  RETURN QUERY SELECT pg_catalog.gp_execution_segment() as gp_segment_id, * FROM pg_catalog.pg_switch_wal();
+END;
+$$ LANGUAGE plpgsql EXECUTE ON ALL SEGMENTS;
+
+CREATE FUNCTION gp_switch_wal (OUT gp_segment_id int, OUT pg_switch_wal pg_lsn)
+RETURNS SETOF RECORD
+AS
+  'SELECT * FROM pg_catalog.gp_switch_wal_on_all_segments()
+   UNION ALL
+   SELECT pg_catalog.gp_execution_segment() as gp_segment_id, * FROM pg_catalog.pg_switch_wal()'
+LANGUAGE SQL EXECUTE ON COORDINATOR;
+
+COMMENT ON FUNCTION pg_catalog.gp_switch_wal_on_all_segments() IS 'Switch WAL segment files on all primary segments';
+COMMENT ON FUNCTION pg_catalog.gp_switch_wal() IS 'Switch WAL segment files on all segments';
+
+REVOKE EXECUTE ON FUNCTION gp_switch_wal_on_all_segments() FROM public;
+REVOKE EXECUTE ON FUNCTION gp_switch_wal() FROM public;
+
+
 RESET log_min_messages;

--- a/src/backend/catalog/system_views.sql
+++ b/src/backend/catalog/system_views.sql
@@ -1617,61 +1617,6 @@ LANGUAGE INTERNAL
 STRICT IMMUTABLE PARALLEL SAFE
 AS 'jsonb_set';
 
--- pg_tablespace_location wrapper functions to see Greenplum cluster-wide tablespace locations
-CREATE FUNCTION gp_tablespace_segment_location (IN tblspc_oid oid, OUT gp_segment_id int, OUT tblspc_loc text)
-RETURNS SETOF RECORD AS
-$$
-DECLARE
-  seg_id int;
-BEGIN
-  EXECUTE 'select pg_catalog.gp_execution_segment()' INTO seg_id;
-  -- check if execute in entrydb QE to prevent giving wrong results
-  IF seg_id = -1 THEN
-    RAISE EXCEPTION 'Cannot execute in entrydb, this query is not currently supported by GPDB.';
-  END IF;
-  RETURN QUERY SELECT pg_catalog.gp_execution_segment() as gp_segment_id, *
-    FROM pg_catalog.pg_tablespace_location($1);
-END;
-$$ LANGUAGE plpgsql EXECUTE ON ALL SEGMENTS;
-
-
-CREATE FUNCTION gp_tablespace_location (IN tblspc_oid oid, OUT gp_segment_id int, OUT tblspc_loc text)
-RETURNS SETOF RECORD
-AS
-  'SELECT * FROM pg_catalog.gp_tablespace_segment_location($1)
-   UNION ALL
-   SELECT pg_catalog.gp_execution_segment() as gp_segment_id, * FROM pg_catalog.pg_tablespace_location($1)'
-LANGUAGE SQL EXECUTE ON COORDINATOR;
-
--- pg_switch_wal wrapper functions to switch WAL segment files on Greenplum cluster-wide
-CREATE FUNCTION gp_switch_wal_on_all_segments (OUT gp_segment_id int, OUT pg_switch_wal pg_lsn)
-RETURNS SETOF RECORD AS
-$$
-DECLARE
-  seg_id int;
-BEGIN
-  EXECUTE 'select pg_catalog.gp_execution_segment()' INTO seg_id;
-  -- check if execute in entrydb QE to prevent giving wrong results
-  IF seg_id = -1 THEN
-    RAISE EXCEPTION 'Cannot execute in entrydb, this query is not currently supported by GPDB.';
-  END IF;
-  RETURN QUERY SELECT pg_catalog.gp_execution_segment() as gp_segment_id, * FROM pg_catalog.pg_switch_wal();
-END;
-$$ LANGUAGE plpgsql EXECUTE ON ALL SEGMENTS;
-
-CREATE FUNCTION gp_switch_wal (OUT gp_segment_id int, OUT pg_switch_wal pg_lsn)
-RETURNS SETOF RECORD
-AS
-  'SELECT * FROM pg_catalog.gp_switch_wal_on_all_segments()
-   UNION ALL
-   SELECT pg_catalog.gp_execution_segment() as gp_segment_id, * FROM pg_catalog.pg_switch_wal()'
-LANGUAGE SQL EXECUTE ON COORDINATOR;
-
-COMMENT ON FUNCTION pg_catalog.gp_switch_wal_on_all_segments() IS 'Switch WAL segment files on all primary segments';
-COMMENT ON FUNCTION pg_catalog.gp_switch_wal() IS 'Switch WAL segment files on all segments';
-
-REVOKE EXECUTE ON FUNCTION gp_switch_wal_on_all_segments() FROM public;
-REVOKE EXECUTE ON FUNCTION gp_switch_wal() FROM public;
 
 CREATE OR REPLACE FUNCTION
   parse_ident(str text, strict boolean DEFAULT true)

--- a/src/test/regress/expected/db_size_functions.out
+++ b/src/test/regress/expected/db_size_functions.out
@@ -113,12 +113,14 @@ create temp table t1 as select pg_relation_size('pg_tables') from pg_class limit
 ERROR:  This query is not currently supported by GPDB.
 create temp table t1 as select pg_total_relation_size('pg_tables') from pg_class limit 1;
 ERROR:  This query is not currently supported by GPDB.
-
 create temp table t1 as select gp_segment_id as seg_id from gp_tablespace_location((SELECT oid FROM pg_tablespace WHERE spcname='pg_default'));
 ERROR:  Cannot execute in entrydb, this query is not currently supported by GPDB.
+CONTEXT:  PL/pgSQL function gp_tablespace_segment_location(oid) line 8 at RAISE
+SQL function "gp_tablespace_location" statement 1
 create temp table t1 as select gp_segment_id as seg_id from gp_switch_wal();
 ERROR:  Cannot execute in entrydb, this query is not currently supported by GPDB.
-
+CONTEXT:  PL/pgSQL function gp_switch_wal_on_all_segments() line 8 at RAISE
+SQL function "gp_switch_wal" statement 1
 --
 -- Tests on the table and index size variants.
 --

--- a/src/test/regress/expected/db_size_functions.out
+++ b/src/test/regress/expected/db_size_functions.out
@@ -108,11 +108,17 @@ select pg_total_relation_size('pg_tables');
                       0
 (1 row)
 
--- Test that run pg_relation_size, pg_total_relation_size on entryDB is not supported.
+-- Test on functions are not allowed to run on entryDB.
 create temp table t1 as select pg_relation_size('pg_tables') from pg_class limit 1;
 ERROR:  This query is not currently supported by GPDB.
 create temp table t1 as select pg_total_relation_size('pg_tables') from pg_class limit 1;
 ERROR:  This query is not currently supported by GPDB.
+
+create temp table t1 as select gp_segment_id as seg_id from gp_tablespace_location((SELECT oid FROM pg_tablespace WHERE spcname='pg_default'));
+ERROR:  Cannot execute in entrydb, this query is not currently supported by GPDB.
+create temp table t1 as select gp_segment_id as seg_id from gp_switch_wal();
+ERROR:  Cannot execute in entrydb, this query is not currently supported by GPDB.
+
 --
 -- Tests on the table and index size variants.
 --

--- a/src/test/regress/sql/db_size_functions.sql
+++ b/src/test/regress/sql/db_size_functions.sql
@@ -38,9 +38,12 @@ select pg_table_size('pg_tables');
 select pg_indexes_size('pg_tables');
 select pg_total_relation_size('pg_tables');
 
--- Test that run pg_relation_size, pg_total_relation_size on entryDB is not supported.
+-- Test on functions are not allowed to run on entryDB.
 create temp table t1 as select pg_relation_size('pg_tables') from pg_class limit 1;
 create temp table t1 as select pg_total_relation_size('pg_tables') from pg_class limit 1;
+
+create temp table t1 as select gp_segment_id as seg_id from gp_tablespace_location((SELECT oid FROM pg_tablespace WHERE spcname='pg_default'));
+create temp table t1 as select gp_segment_id as seg_id from gp_switch_wal();
 
 --
 -- Tests on the table and index size variants.

--- a/src/test/regress/sql/db_size_functions.sql
+++ b/src/test/regress/sql/db_size_functions.sql
@@ -41,7 +41,6 @@ select pg_total_relation_size('pg_tables');
 -- Test on functions are not allowed to run on entryDB.
 create temp table t1 as select pg_relation_size('pg_tables') from pg_class limit 1;
 create temp table t1 as select pg_total_relation_size('pg_tables') from pg_class limit 1;
-
 create temp table t1 as select gp_segment_id as seg_id from gp_tablespace_location((SELECT oid FROM pg_tablespace WHERE spcname='pg_default'));
 create temp table t1 as select gp_segment_id as seg_id from gp_switch_wal();
 


### PR DESCRIPTION
There are some gp functions (e.g. `gp_tablespace_location`) in src/backend/catalog/system_views.sql. They are designed to run on master and dispatch internal logic to segment.

But in some situations, they are executed on the entrydb QE, it will cause error result.

For example:
the definition of `gp_tablespace_location`
```
-- pg_tablespace_location wrapper functions to see Greenplum cluster-wide tablespace locations
CREATE FUNCTION gp_tablespace_segment_location (IN tblspc_oid oid, OUT gp_segment_id int, OUT tblspc_loc text)
AS 'SELECT pg_catalog.gp_execution_segment() as gp_segment_id, * FROM pg_catalog.pg_tablespace_location($1)'
LANGUAGE SQL EXECUTE ON ALL SEGMENTS;

CREATE FUNCTION gp_tablespace_location (IN tblspc_oid oid, OUT gp_segment_id int, OUT tblspc_loc text)
RETURNS SETOF RECORD
AS
  'SELECT * FROM pg_catalog.gp_tablespace_segment_location($1)
   UNION ALL
   SELECT pg_catalog.gp_execution_segment() as gp_segment_id, * FROM pg_catalog.pg_tablespace_location($1)'
LANGUAGE SQL EXECUTE ON COORDINATOR;
```
an error result repo
```
create table test (gp_segment_idd int, tblspc_loc text);

# get all tablespace location in DBs
issues=# select * from gp_tablespace_location(1663);
 gp_segment_id | tblspc_loc
---------------+------------
             1 |
             2 |
             0 |
            -1 |
(4 rows)

# but only two tuple here
issues=# insert into test select * from gp_tablespace_location(1663);
INSERT 0 2
issues=# select * from test;
 gp_segment_idd | tblspc_loc
----------------+------------
             -1 |
             -1 |
(2 rows)

```

Checked the plan:
```
issues=# explain insert into test select * from gp_tablespace_location(1663);
                                         QUERY PLAN
--------------------------------------------------------------------------------------------
 Insert on test  (cost=0.25..23.58 rows=333 width=36)
   ->  Redistribute Motion 1:3  (slice1)  (cost=0.25..23.58 rows=333 width=36)
         Hash Key: gp_tablespace_location.gp_segment_id
         ->  Function Scan on gp_tablespace_location  (cost=0.25..10.25 rows=1000 width=36)
 Optimizer: Postgres query optimizer
(5 rows)
```
The reason is the select operation runs in the entryDB QE, so cannot dispatch its internal logic.

So we should report an error message to user, follow the previous similar case: https://github.com/greenplum-db/gpdb/pull/11178.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
