### PR TITLE
Optimize retrieving indexes on partitions within Orca

### DIFF
--- a/src/backend/cdb/cdbpartindex.c
+++ b/src/backend/cdb/cdbpartindex.c
@@ -560,6 +560,7 @@ recordIndexesOnLeafPart(PartitionIndexNode **pNodePtr,
 	char	   *partIndexHashKey;
 	bool		foundPartIndexHash;
 	bool		foundLogicalIndexHash;
+	bool 		computeAttMapping = true;
 	AttrNumber *attmap = NULL;
 	struct IndexInfo *ii = NULL;
 	PartitionIndexHashEntry *partIndexHashEntry;
@@ -607,7 +608,7 @@ recordIndexesOnLeafPart(PartitionIndexNode **pNodePtr,
 		 * when constructing hash key, we need to map attnums in part indexes
 		 * to root attnums. Get the attMap needed for mapping.
 		 */
-		if (!attmap)
+		if (computeAttMapping && !attmap)
 		{
 			Relation	rootRel = heap_open(rootOid, AccessShareLock);
 
@@ -618,6 +619,9 @@ recordIndexesOnLeafPart(PartitionIndexNode **pNodePtr,
 
 			/* can we close here ? */
 			heap_close(rootRel, AccessShareLock);
+
+			// only compute this mapping for the first index, then it can be reused, as varattnos_map can be expensive
+			computeAttMapping = false;
 		}
 
 		/* populate index info structure */

--- a/src/backend/cdb/cdbpartindex.c
+++ b/src/backend/cdb/cdbpartindex.c
@@ -608,7 +608,7 @@ recordIndexesOnLeafPart(PartitionIndexNode **pNodePtr,
 		 * when constructing hash key, we need to map attnums in part indexes
 		 * to root attnums. Get the attMap needed for mapping.
 		 */
-		if (computeAttMapping && !attmap)
+		if (computeAttMapping)
 		{
 			Relation	rootRel = heap_open(rootOid, AccessShareLock);
 


### PR DESCRIPTION
This PR is for 6X only. This code no longer exists in gpdb master,
and this issue isn't present there.

This PR optimizes the remapping of leaf partitions to root
partitions for use in Orca. In recordIndexesOnLeafPart, we don't need to
recompute the attamp for each index, we just need to do it once. For one
query with many indexes and columns on a partitioned table, this brought
the planning time from 7.5s to .85s using Orca.

In varattnos_map, we would check each attribute of the old and new tuple
descriptor in an n^2 fashion. This is necessary to handle dropped/moved
columns. However, instead we'll do a first iteration through all the
columns, if they're equal and nothing has been dropped/moved, we don't
need to do this additional n^2 logic. This brings the planning time for
this query down from .85s to .4s and this attmap remapping portion to
<50ms. This optimizes the common case, though if there are any dropped/remapped
performance will be the same as before (.85s).