### PR TITLE
Do not download VC_redist.x64.exe in windows client test

### DIFF
--- a/concourse/scripts/windows_remote_test.ps1
+++ b/concourse/scripts/windows_remote_test.ps1
@@ -1,5 +1,5 @@
 $progressPreference = 'silentlyContinue'
-Invoke-WebRequest -Uri https://aka.ms/vs/15/release/VC_redist.x64.exe -OutFile VC_redist.x64.exe
+copy C:\vcredist\VC_redist.x64.exe VC_redist.x64.exe
 Start-Process -FilePath "VC_redist.x64.exe" -ArgumentList "/passive" -Wait -Passthru
 Start-Process msiexec.exe -Wait -ArgumentList '/I greenplum-clients-x86_64.msi /quiet'
 $env:PATH="C:\Program Files\Greenplum\greenplum-clients\bin;C:\Program Files\curl-win64-mingw\bin;" + $env:PATH


### PR DESCRIPTION
VC_redist.x64.exe is downloaded and saved into Windows terraform image
snapshot. Use the local copy to avoid downloading it every time which
may fail sometimes because of network issue.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
