### PR TITLE
[6X] Adds feature flags for check cluster: `continue-check-on-fatal` and `skip-target-check`

### DIFF
--- a/contrib/pg_upgrade/check.c
+++ b/contrib/pg_upgrade/check.c
@@ -234,7 +234,8 @@ report_clusters_compatible(void)
 {
 	if (user_opts.check)
 	{
-		pg_log(PG_REPORT, "\n*Clusters are compatible*\n");
+		pg_log(PG_REPORT, (get_check_error() ?
+				"\n*Clusters are NOT compatible*\n" : "\n*Clusters are compatible*\n"));
 		/* stops new cluster */
 		stop_postmaster(false);
 		exit(0);
@@ -343,8 +344,7 @@ check_cluster_versions(void)
 	if (GET_MAJOR_VERSION(old_cluster.major_version) == 802 &&
 		GET_MAJOR_VERSION(new_cluster.major_version) == 802)
 	{
-		pg_log(PG_FATAL,
-			   "old and new cluster cannot both be Greenplum 4.3.x installations\n");
+		pg_fatal("old and new cluster cannot both be Greenplum 4.3.x installations\n");
 	}
 
 	/*
@@ -1008,13 +1008,14 @@ check_for_isn_and_int8_passing_mismatch(ClusterInfo *cluster)
 	if (found)
 	{
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains \"contrib/isn\" functions which rely on the\n"
-		  "bigint data type.  Your old and new clusters pass bigint values\n"
-		"differently so this cluster cannot currently be upgraded.  You can\n"
-				 "manually upgrade databases that use \"contrib/isn\" facilities and remove\n"
-				 "\"contrib/isn\" from the old cluster and restart the upgrade.  A list of\n"
-				 "the problem functions is in the file:\n"
-				 "    %s\n\n", output_path);
+		gp_fatal_log(
+				"| Your installation contains \"contrib/isn\" functions which rely on the\n"
+				"| bigint data type.  Your old and new clusters pass bigint values\n"
+				"| differently so this cluster cannot currently be upgraded.  You can\n"
+				"| manually upgrade databases that use \"contrib/isn\" facilities and remove\n"
+				"| \"contrib/isn\" from the old cluster and restart the upgrade.  A list of\n"
+				"| the problem functions is in the file:\n"
+				"|     %s\n\n", output_path);
 	}
 	else
 		check_ok();
@@ -1115,12 +1116,13 @@ check_for_reg_data_type_usage(ClusterInfo *cluster)
 	if (found)
 	{
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains one of the reg* data types in user tables.\n"
-		 "These data types reference system OIDs that are not preserved by\n"
-		"pg_upgrade, so this cluster cannot currently be upgraded.  You can\n"
-				 "remove the problem tables and restart the upgrade.  A list of the problem\n"
-				 "columns is in the file:\n"
-				 "    %s\n\n", output_path);
+		gp_fatal_log(
+				"| Your installation contains one of the reg* data types in user tables.\n"
+				"| These data types reference system OIDs that are not preserved by\n"
+				"| pg_upgrade, so this cluster cannot currently be upgraded.  You can\n"
+				"| remove the problem tables and restart the upgrade.  A list of the problem\n"
+				"| columns is in the file:\n"
+				"|     %s\n\n", output_path);
 	}
 	else
 		check_ok();
@@ -1206,11 +1208,12 @@ check_for_jsonb_9_4_usage(ClusterInfo *cluster)
 	if (found)
 	{
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains one of the JSONB data types in user tables.\n"
-		 "The internal format of JSONB changed during 9.4 beta so this cluster cannot currently\n"
-				 "be upgraded.  You can remove the problem tables and restart the upgrade.  A list\n"
-				 "of the problem columns is in the file:\n"
-				 "    %s\n\n", output_path);
+		gp_fatal_log(
+				"| Your installation contains one of the JSONB data types in user tables.\n"
+				"| The internal format of JSONB changed during 9.4 beta so this cluster cannot currently\n"
+				"| be upgraded.  You can remove the problem tables and restart the upgrade.  A list\n"
+				"| of the problem columns is in the file:\n"
+				"|     %s\n\n", output_path);
 	}
 	else
 		check_ok();

--- a/contrib/pg_upgrade/exec.c
+++ b/contrib/pg_upgrade/exec.c
@@ -14,6 +14,8 @@
 #include <fcntl.h>
 #include <sys/types.h>
 
+#include "greenplum/pg_upgrade_greenplum.h"
+
 static void check_data_dir(const char *pg_data);
 static void check_bin_dir(ClusterInfo *cluster);
 static void validate_exec(const char *dir, const char *cmdName);
@@ -217,8 +219,12 @@ verify_directories(void)
 
 	check_bin_dir(&old_cluster);
 	check_data_dir(old_cluster.pgdata);
-	check_bin_dir(&new_cluster);
-	check_data_dir(new_cluster.pgdata);
+
+	if(!is_skip_target_check())
+	{
+	  check_bin_dir(&new_cluster);
+	  check_data_dir(new_cluster.pgdata);
+	}
 }
 
 

--- a/contrib/pg_upgrade/greenplum/check_gp.c
+++ b/contrib/pg_upgrade/greenplum/check_gp.c
@@ -131,7 +131,7 @@ check_online_expansion(void)
 	if (expansion)
 	{
 		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
+		gp_fatal_log(
 			   "| Your installation is in progress of online expansion,\n"
 			   "| must complete that job before the upgrade.\n\n");
 	}
@@ -193,7 +193,7 @@ check_unique_primary_constraint(void)
 			found = true;
 
 			if (script == NULL && (script = fopen(output_path, "w")) == NULL)
-				pg_log(PG_FATAL, "Could not create necessary upgrade report file:  %s\n",
+				pg_fatal("Could not create necessary upgrade report file:  %s\n",
 					   output_path);
 
 			for (rowno = 0; rowno < ntups; rowno++)
@@ -216,7 +216,7 @@ check_unique_primary_constraint(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
+		gp_fatal_log(
 			   "| Your installation contains unique or primary key constraints\n"
 			   "| on tables.  These constraints need to be removed\n"
 			   "| from the tables before the upgrade.  A list of\n"
@@ -279,7 +279,7 @@ check_external_partition(void)
 			found = true;
 
 			if (script == NULL && (script = fopen(output_path, "w")) == NULL)
-				pg_log(PG_FATAL, "Could not create necessary file:  %s\n",
+				pg_fatal("Could not create necessary file:  %s\n",
 					   output_path);
 
 			for (rowno = 0; rowno < ntups; rowno++)
@@ -297,7 +297,7 @@ check_external_partition(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
+		gp_fatal_log(
 			   "| Your installation contains partitioned tables with external\n"
 			   "| tables as partitions.  These partitions need to be removed\n"
 			   "| from the partition hierarchy before the upgrade.  A list of\n"
@@ -386,7 +386,7 @@ check_covering_aoindex(void)
 			found = true;
 
 			if (script == NULL && (script = fopen(output_path, "w")) == NULL)
-				pg_log(PG_FATAL, "Could not create necessary file:  %s\n",
+				pg_fatal("Could not create necessary file:  %s\n",
 					   output_path);
 
 			for (rowno = 0; rowno < ntups; rowno++)
@@ -405,7 +405,7 @@ check_covering_aoindex(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
+		gp_fatal_log(
 			   "| Your installation contains partitioned append-only tables\n"
 			   "| with an index defined on the partition parent which isn't\n"
 			   "| present on all partition members.  These indexes must be\n"
@@ -456,7 +456,7 @@ check_orphaned_toastrels(void)
 		{
 			found = true;
 			if (script == NULL && (script = fopen(output_path, "w")) == NULL)
-				pg_log(PG_FATAL, "Could not create necessary file:  %s\n", output_path);
+				pg_fatal("Could not create necessary file:  %s\n", output_path);
 
 			fprintf(script, "Database \"%s\" has %d orphaned toast tables\n", active_db->db_name, ntups);
 		}
@@ -469,7 +469,7 @@ check_orphaned_toastrels(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
+		gp_fatal_log(
 			   "| Your installation contains orphaned toast tables which\n"
 			   "| must be dropped before upgrade.\n"
 			   "| A list of the problem databases is in the file:\n"
@@ -586,7 +586,7 @@ check_heterogeneous_partition(void)
 	if (found)
 	{
 		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
+		gp_fatal_log(
 			   "| Your installation contains heterogenous partitioned tables\n"
 			   "| where the root partition does not match one or more child\n"
 			   "| partitions' on disk representation. In order to make the\n"
@@ -664,7 +664,7 @@ check_partition_indexes(void)
 		{
 			found = true;
 			if (script == NULL && (script = fopen(output_path, "w")) == NULL)
-				pg_log(PG_FATAL, "Could not create necessary file:  %s\n", output_path);
+				pg_fatal("Could not create necessary file:  %s\n", output_path);
 			if (!db_used)
 			{
 				fprintf(script, "Database:  %s\n", active_db->db_name);
@@ -684,7 +684,7 @@ check_partition_indexes(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
+		gp_fatal_log(
 			   "| Your installation contains partitioned tables with\n"
 			   "| indexes defined on them.  Indexes on partition parents,\n"
 			   "| as well as children, must be dropped before upgrade.\n"
@@ -744,7 +744,7 @@ check_gphdfs_external_tables(void)
 			found = true;
 
 			if (script == NULL && (script = fopen(output_path, "w")) == NULL)
-				pg_log(PG_FATAL, "Could not create necessary file:  %s\n",
+				pg_fatal("Could not create necessary file:  %s\n",
 					   output_path);
 
 			for (rowno = 0; rowno < ntups; rowno++)
@@ -762,7 +762,7 @@ check_gphdfs_external_tables(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
+		gp_fatal_log(
 			   "| Your installation contains gphdfs external tables.  These \n"
 			   "| tables need to be dropped before upgrade.  A list of\n"
 			   "| external gphdfs tables to remove is provided in the file:\n"
@@ -811,7 +811,7 @@ check_gphdfs_user_roles(void)
 	if (ntups > 0)
 	{
 		if ((script = fopen(output_path, "w")) == NULL)
-			pg_log(PG_FATAL, "Could not create necessary file:  %s\n",
+			pg_fatal("Could not create necessary file:  %s\n",
 					output_path);
 
 		i_hdfs_read = PQfnumber(res, "hdfs_read");
@@ -839,7 +839,7 @@ check_gphdfs_user_roles(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
+		gp_fatal_log(
 			   "| Your installation contains roles that have gphdfs privileges.\n"
 			   "| These privileges need to be revoked before upgrade.  A list\n"
 			   "| of roles and their corresponding gphdfs privileges that\n"
@@ -906,9 +906,9 @@ check_for_array_of_partition_table_types(ClusterInfo *cluster)
 	if (strlen(dependee_partition_report))
 	{
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal(
-			"Array types derived from partitions of a partitioned table must not have dependants.\n"
-			"OIDs of such types found and their original partitions:\n%s",
+		gp_fatal_log(
+			"| Array types derived from partitions of a partitioned table must not have dependants.\n"
+			"| OIDs of such types found and their original partitions:\n%s",
 			dependee_partition_report
 		);
 	}
@@ -982,13 +982,13 @@ check_partition_schemas(void)
 	if (found)
 	{
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal(
-			"Your installation contains partitioned tables where one or more\n"
-			"child partitions are not in the same schema as the root partition.\n"
-			"ALTER TABLE ... SET SCHEMA must be performed on the child partitions\n"
-			"to match them before upgrading. A list of problem tables is in the\n"
-			"file:\n"
-			"    %s\n\n", output_path);
+		gp_fatal_log(
+			"| Your installation contains partitioned tables where one or more\n"
+			"| child partitions are not in the same schema as the root partition.\n"
+			"| ALTER TABLE ... SET SCHEMA must be performed on the child partitions\n"
+			"| to match them before upgrading. A list of problem tables is in the\n"
+			"| file:\n"
+			"|     %s\n\n", output_path);
 	}
 	else
 		check_ok();
@@ -1042,10 +1042,11 @@ check_large_objects(void)
 	if (found)
 	{
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains large objects.  These objects are not supported\n"
-				 "by the new cluster and must be dropped.\n"
-				 "A list of databases which contains large objects is in the file:\n"
-				 "\t%s\n\n", output_path);
+		gp_fatal_log(
+			"| Your installation contains large objects.  These objects are not supported\n"
+			"| by the new cluster and must be dropped.\n"
+			"| A list of databases which contains large objects is in the file:\n"
+			"| \t%s\n\n", output_path);
 	}
 	else
 		check_ok();
@@ -1121,10 +1122,11 @@ check_invalid_indexes(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains invalid indexes.  These indexes either \n"
-			     "need to be dropped or reindexed before proceeding to upgrade.\n"
-			     "A list of invalid indexes is provided in the file:\n"
-		         "\t%s\n\n", output_path);
+		gp_fatal_log(
+			"| Your installation contains invalid indexes.  These indexes either \n"
+			"| need to be dropped or reindexed before proceeding to upgrade.\n"
+			"| A list of invalid indexes is provided in the file:\n"
+		  "|  \t%s\n\n", output_path);
 	}
 	else
 		check_ok();
@@ -1190,11 +1192,12 @@ check_foreign_key_constraints_on_root_partition(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains foreign key constraint on root \n"
-				 "partition tables. These constraints need to be dropped before \n"
-				 "proceeding to upgrade. A list of foreign key constraints is \n"
-				 "in the file:\n"
-				 "\t%s\n\n", output_path);
+		gp_fatal_log(
+			"| Your installation contains foreign key constraint on root \n"
+			"| partition tables. These constraints need to be dropped before \n"
+			"| proceeding to upgrade. A list of foreign key constraints is \n"
+			"| in the file:\n"
+			"| \t%s\n\n", output_path);
 	}
 	else
 		check_ok();
@@ -1262,11 +1265,12 @@ check_views_with_unsupported_lag_lead_function(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains views using lag or lead \n"
-				 "functions with the second parameter as bigint. These views \n"
-				 "need to be dropped before proceeding to upgrade. \n"
-				 "A list of views is in the file:\n"
-				 "\t%s\n\n", output_path);
+		gp_fatal_log(
+			"| Your installation contains views using lag or lead \n"
+			"| functions with the second parameter as bigint. These views \n"
+			"| need to be dropped before proceeding to upgrade. \n"
+			"| A list of views is in the file:\n"
+			"| \t%s\n\n", output_path);
 	}
 	else
 		check_ok();
@@ -1337,12 +1341,13 @@ check_views_with_fabricated_anyarray_casts()
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains views having anyarray\n"
-				 "casts. Drop the view or recreate the view without explicit \n"
-				 "array-type type casts before running the upgrade. Alternatively, drop the view \n"
-				 "before the upgrade and recreate the view after the upgrade. \n"
-				 "A list of views is in the file:\n"
-				 "\t%s\n\n", output_path);
+		gp_fatal_log(
+			"| Your installation contains views having anyarray\n"
+			"| casts. Drop the view or recreate the view without explicit \n"
+			"| array-type type casts before running the upgrade. Alternatively, drop the view \n"
+			"| before the upgrade and recreate the view after the upgrade. \n"
+			"| A list of views is in the file:\n"
+			"| \t%s\n\n", output_path);
 	}
 	else
 		check_ok();
@@ -1413,11 +1418,12 @@ check_views_with_fabricated_unknown_casts()
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains views having unknown\n"
-				 "casts. Drop the view or recreate the view without explicit \n"
-				 "unknown::cstring type casts before running the upgrade.\n"
-				 "A list of views is in the file:\n"
-				 "\t%s\n\n", output_path);
+		gp_fatal_log(
+			"| Your installation contains views having unknown\n"
+			"| casts. Drop the view or recreate the view without explicit \n"
+			"| unknown::cstring type casts before running the upgrade.\n"
+			"| A list of views is in the file:\n"
+			"| \t%s\n\n", output_path);
 	}
 	else
 		check_ok();
@@ -1497,12 +1503,13 @@ check_views_referencing_deprecated_tables()
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains views referencing catalog\n"
-				 "tables that no longer exist in the target cluster.\n"
-				 "Drop these views before running the upgrade. Please refer to\n"
-				 "the documentation for a complete list of deprecated tables.\n"
-				 "A list of such views is in the file:\n"
-				 "\t%s\n\n", output_path);
+		gp_fatal_log(
+			"| Your installation contains views referencing catalog\n"
+			"| tables that no longer exist in the target cluster.\n"
+			"| Drop these views before running the upgrade. Please refer to\n"
+			"| the documentation for a complete list of deprecated tables.\n"
+			"| A list of such views is in the file:\n"
+			"| \t%s\n\n", output_path);
 	}
 	else
 		check_ok();
@@ -1582,12 +1589,13 @@ check_views_referencing_deprecated_columns()
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains views referencing columns\n"
-				 "in catalog tables that no longer exist in the target cluster.\n"
-				 "Drop these views before running the upgrade. Please refer to\n"
-				 "the documentation for a complete list of deprecated columns.\n"
-				 "A list of such views is in the file:\n"
-				 "\t%s\n\n", output_path);
+		gp_fatal_log(
+			"| Your installation contains views referencing columns\n"
+			"| in catalog tables that no longer exist in the target cluster.\n"
+			"| Drop these views before running the upgrade. Please refer to\n"
+			"| the documentation for a complete list of deprecated columns.\n"
+			"| A list of such views is in the file:\n"
+			"| \t%s\n\n", output_path);
 	}
 	else
 		check_ok();

--- a/contrib/pg_upgrade/greenplum/pg_upgrade_greenplum.h
+++ b/contrib/pg_upgrade/greenplum/pg_upgrade_greenplum.h
@@ -49,7 +49,8 @@ typedef enum {
 	GREENPLUM_OLD_GP_DBID = 5,
 	GREENPLUM_NEW_GP_DBID = 6,
 	GREENPLUM_OLD_TABLESPACES_FILE = 7,
-	GREENPLUM_CONTINUE_CHECK_ON_FATAL = 8
+	GREENPLUM_CONTINUE_CHECK_ON_FATAL = 8,
+	GREENPLUM_SKIP_TARGET_CHECK = 9
 } greenplumOption;
 
 
@@ -61,7 +62,8 @@ typedef enum {
 	{"old-gp-dbid", required_argument, NULL, GREENPLUM_OLD_GP_DBID}, \
 	{"new-gp-dbid", required_argument, NULL, GREENPLUM_NEW_GP_DBID}, \
 	{"old-tablespaces-file", required_argument, NULL, GREENPLUM_OLD_TABLESPACES_FILE}, \
-	{"continue-check-on-fatal", no_argument, NULL, GREENPLUM_CONTINUE_CHECK_ON_FATAL},
+	{"continue-check-on-fatal", no_argument, NULL, GREENPLUM_CONTINUE_CHECK_ON_FATAL}, \
+     {"skip-target-check", no_argument, NULL, GREENPLUM_SKIP_TARGET_CHECK},
 
 #define GREENPLUM_USAGE "\
       --mode=TYPE               designate node type to upgrade, \"segment\" or \"dispatcher\" (default \"segment\")\n\
@@ -72,6 +74,7 @@ typedef enum {
       --new-gp-dbid             greenplum database id of the new segment\n\
       --old-tablespaces-file    file containing the tablespaces from an old gpdb five cluster\n\
 	 --continue-check-on-fatal goes through all pg_upgrade checks, without upgrade\n\
+      --skip-target-check       skip checks all checks for new cluster\n\
 "
 
 /* option_gp.c */
@@ -81,6 +84,7 @@ bool is_greenplum_dispatcher_mode(void);
 bool is_checksum_mode(checksumMode mode);
 bool is_show_progress_mode(void);
 bool is_continue_check_on_fatal(void);
+bool is_skip_target_check(void);
 void check_error_occured(void);
 bool get_check_error(void);
 void validate_greenplum_options(void);

--- a/contrib/pg_upgrade/greenplum/pg_upgrade_greenplum.h
+++ b/contrib/pg_upgrade/greenplum/pg_upgrade_greenplum.h
@@ -48,7 +48,8 @@ typedef enum {
 	GREENPLUM_REMOVE_CHECKSUM_OPTION = 4,
 	GREENPLUM_OLD_GP_DBID = 5,
 	GREENPLUM_NEW_GP_DBID = 6,
-	GREENPLUM_OLD_TABLESPACES_FILE = 7
+	GREENPLUM_OLD_TABLESPACES_FILE = 7,
+	GREENPLUM_CONTINUE_CHECK_ON_FATAL = 8
 } greenplumOption;
 
 
@@ -59,7 +60,8 @@ typedef enum {
 	{"remove-checksum", no_argument, NULL, GREENPLUM_REMOVE_CHECKSUM_OPTION}, \
 	{"old-gp-dbid", required_argument, NULL, GREENPLUM_OLD_GP_DBID}, \
 	{"new-gp-dbid", required_argument, NULL, GREENPLUM_NEW_GP_DBID}, \
-	{"old-tablespaces-file", required_argument, NULL, GREENPLUM_OLD_TABLESPACES_FILE},
+	{"old-tablespaces-file", required_argument, NULL, GREENPLUM_OLD_TABLESPACES_FILE}, \
+	{"continue-check-on-fatal", no_argument, NULL, GREENPLUM_CONTINUE_CHECK_ON_FATAL},
 
 #define GREENPLUM_USAGE "\
       --mode=TYPE               designate node type to upgrade, \"segment\" or \"dispatcher\" (default \"segment\")\n\
@@ -69,6 +71,7 @@ typedef enum {
       --old-gp-dbid             greenplum database id of the old segment\n\
       --new-gp-dbid             greenplum database id of the new segment\n\
       --old-tablespaces-file    file containing the tablespaces from an old gpdb five cluster\n\
+	 --continue-check-on-fatal goes through all pg_upgrade checks, without upgrade\n\
 "
 
 /* option_gp.c */
@@ -77,6 +80,9 @@ bool process_greenplum_option(greenplumOption option);
 bool is_greenplum_dispatcher_mode(void);
 bool is_checksum_mode(checksumMode mode);
 bool is_show_progress_mode(void);
+bool is_continue_check_on_fatal(void);
+void check_error_occured(void);
+bool get_check_error(void);
 void validate_greenplum_options(void);
 
 /* pg_upgrade_greenplum.c */

--- a/contrib/pg_upgrade/option.c
+++ b/contrib/pg_upgrade/option.c
@@ -234,12 +234,17 @@ parseCommandLine(int argc, char *argv[])
 	/* Get values from env if not already set */
 	check_required_directory(&old_cluster.bindir, "PGBINOLD", false,
 							 "-b", "old cluster binaries reside");
-	check_required_directory(&new_cluster.bindir, "PGBINNEW", false,
-							 "-B", "new cluster binaries reside");
 	check_required_directory(&old_cluster.pgdata, "PGDATAOLD", false,
 							 "-d", "old cluster data resides");
-	check_required_directory(&new_cluster.pgdata, "PGDATANEW", false,
+
+	if(!is_skip_target_check())
+	{
+			check_required_directory(&new_cluster.pgdata, "PGDATANEW", false,
 							 "-D", "new cluster data resides");
+			check_required_directory(&new_cluster.bindir, "PGBINNEW", false,
+							 "-B", "new cluster binaries reside");
+	}
+
 	check_required_directory(&user_opts.socketdir, "PGSOCKETDIR", true,
 							 "-s", "sockets will be created");
 

--- a/contrib/pg_upgrade/pg_upgrade.c
+++ b/contrib/pg_upgrade/pg_upgrade.c
@@ -120,7 +120,8 @@ main(int argc, char **argv)
 	get_restricted_token(os_info.progname);
 
 	adjust_data_dir(&old_cluster);
-	adjust_data_dir(&new_cluster);
+	if(!is_skip_target_check())
+  	adjust_data_dir(&new_cluster);
 
 	setup(argv[0], &live_check);
 
@@ -132,15 +133,18 @@ main(int argc, char **argv)
 	get_sock_dir(&old_cluster, live_check);
 	get_sock_dir(&new_cluster, false);
 
-	check_cluster_compatibility(live_check);
+	if(!is_skip_target_check())
+		check_cluster_compatibility(live_check);
 
 	check_and_dump_old_cluster(live_check, &sequence_script_file_name);
 
+	if (!is_skip_target_check())
+	{
+	  /* -- NEW -- */
+	  start_postmaster(&new_cluster, true);
+	  check_new_cluster();
+	}
 
-	/* -- NEW -- */
-	start_postmaster(&new_cluster, true);
-
-	check_new_cluster();
 	log_with_timing(&t, "\nPerforming Consistency Checks took");
 	report_clusters_compatible();
 

--- a/contrib/pg_upgrade/pg_upgrade.h
+++ b/contrib/pg_upgrade/pg_upgrade.h
@@ -437,6 +437,7 @@ void		check_cluster_versions(void);
 void		check_cluster_compatibility(bool live_check);
 void		create_script_for_old_cluster_deletion(char **deletion_script_file_name);
 void		create_script_for_cluster_analyze(char **analyze_script_file_name);
+void 		gp_fatal_log(const char *fmt,...);
 
 
 /* controldata.c */

--- a/contrib/pg_upgrade/util.c
+++ b/contrib/pg_upgrade/util.c
@@ -176,6 +176,27 @@ pg_fatal(const char *fmt,...)
 	exit(1);
 }
 
+/*
+ * wrapper around pg_fatal to continue check when running in check mode
+ * with --continue-check-on-fatal
+ */
+void
+gp_fatal_log(const char *fmt,...)
+{
+	va_list		args;
+	eLogType error_type = PG_FATAL;
+
+	if(is_continue_check_on_fatal())
+	{
+		check_error_occured();
+		error_type = PG_WARNING;
+	}
+
+	va_start(args, fmt);
+	pg_log_v(error_type, fmt, args);
+	va_end(args);
+}
+
 
 void
 check_ok(void)


### PR DESCRIPTION
Adds `--skip-target-check` and `--continue-check-on-fatal` features for check mode:

- `--continue-check-on-fatal` flag allows to parse through the
  checklist without erroring out in case of failure.
   - Need to be used along with check flag `-c`
   - Indent log messages for proper output rendering
   
- `--skip-target-check` allows to skip checks on new cluster
     - when you are using --skip-target-check along with check flag (-c) we
  dont need to provide
      - new-bindir (-B)
      - new-datadir (-D)
      - new-port (-P)
      - new-gp-dbid
   - it can be used along with `--continue-check-on-fatal`

Example:
`--continue-check-on-fatal`
```
pg_upgrade \
-b /usr/local/5XSTABLE/bin/ \
-B /usr/local/6XSTABLE/bin/ \
-d /data/5XStable/demoDataDir-1 \
-D /data/6XStable/demoDataDir-1 \
-p 15432 \
-P 6000 \
--old-gp-dbid=1 \
--new-gp-dbid=1 \
-c --continue-check-on-fatal
```

`--skip-target-check`
```
pg_upgrade \
-b /usr/local/5XSTABLE/bin/ \
-d /data/5XStable/demoDataDir-1 \
-p 15432 \
--old-gp-dbid=1 \
-c --skip-target-check
```

Co-authored-by: Gaurab Dey <gaurabd@vmware.com>
Co-authored-by: Bhuvnesh Chaudhary <bchaudhary@vmware.com>