### PR TITLE
Remove unnecessary stale checks in pg_dump

### DIFF
--- a/src/bin/pg_dump/common.c
+++ b/src/bin/pg_dump/common.c
@@ -183,11 +183,8 @@ getSchemaData(Archive *fout, int *numTablesPtr)
 	oprinfo = getOperators(fout, &numOperators);
 	oprinfoindex = buildIndexArray(oprinfo, numOperators, sizeof(OprInfo));
 
-	if (testExtProtocolSupport(fout))
-	{
-		pg_log_info("reading user-defined external protocols");
-		getExtProtocols(fout, &numExtProtocols);
-	}
+	pg_log_info("reading user-defined external protocols");
+	getExtProtocols(fout, &numExtProtocols);
 
 	pg_log_info("reading user-defined access methods");
 	getAccessMethods(fout, &numAccessMethods);

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -798,7 +798,6 @@ extern TypeStorageOptions *getTypeStorageOptions(Archive *fout, int *numTypes);
 extern ExtProtInfo *getExtProtocols(Archive *fout, int *numExtProtocols);
 extern BinaryUpgradeInfo *getBinaryUpgradeObjects(void);
 
-extern bool	testExtProtocolSupport(Archive *fout);
 /* END MPP ADDITION */
 
 #endif							/* PG_DUMP_H */


### PR DESCRIPTION
Partitioning, pg_attribute_encoding and pg_extprotocol existed in GPDB
from long time (4.2 and before). So, no reason to check for existence
of these features as for sure not planning to pg_dump versions older
than these. Removing check for these feature existence and instead can
expect these to exist.

Fixes https://github.com/greenplum-db/gpdb/issues/5170.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
