### PR TITLE
docs - greenplum can support fdw parallel writes

### DIFF
--- a/gpdb-doc/dita/admin_guide/external/g-devel-fdw.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-devel-fdw.xml
@@ -437,7 +437,7 @@ GetForeignColumnOptions(Oid relid, AttrNumber attnum);</codeblock></entry>
         wrapper examines the <codeph>mpp_execute</codeph> option value
         and uses it to determine where to request or send data - from the
         <codeph>master</codeph> (the default), <codeph>any</codeph> (master or
-        any one segment), or <codeph>all segments</codeph> segments (parallel
+        any one segment), or <codeph>all segments</codeph> (parallel
         read/write).</p>
      <p>Greenplum Database supports all <codeph>mpp_execute</codeph> settings
         for a scan.</p>

--- a/gpdb-doc/dita/admin_guide/external/g-devel-fdw.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-devel-fdw.xml
@@ -64,10 +64,12 @@
      <ul>
        <li>The Greenplum Database 6 distribution does not install any
          foreign data wrappers.</li>
-       <li>Greenplum Database uses the <codeph>mpp_execute</codeph> option value
-         for foreign table scans only. Greenplum does not honor the
-         <codeph>mpp_execute</codeph> setting when you write to, or update, a
-         foreign table; all write operations are initiated through the master.</li>
+       <li>Greenplum Database supports all values of the <codeph>mpp_execute</codeph>
+         option value for foreign table scans only. Greenplum supports parallel
+         write operations only when <codeph>mpp_execute</codeph> is set to
+         <codeph>'all segments'</codeph>; Greenplum initiates write operations
+         through the master for all other <codeph>mpp_execute</codeph> settings.
+         See <xref href="#topic5" type="topic" format="dita"/>.</li>
      </ul>
     </body>
   </topic>
@@ -259,6 +261,94 @@ EndForeignScan (ForeignScanState *node)</codeblock></entry>
           </tbody>
         </tgroup>
       </table>
+      <p>If a foreign data wrappers supports writable foreign tables, it should
+        provide the update-related callback functions that are required by the
+        capabilities of the FDW. Update-related callback functions include:</p>
+      <table id="in201681">
+        <tgroup cols="2">
+          <colspec colname="col1" colnum="1" colwidth="90*"/>
+          <colspec colname="col2" colnum="2" colwidth="163*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Callback Signature</entry>
+              <entry colname="col2">Description</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1"><codeblock>void
+AddForeignUpdateTargets (Query *parsetree,
+                         RangeTblEntry *target_rte,
+                         Relation target_relation)</codeblock></entry>
+              <entry colname="col2">Add additional information in the foreign
+                table that will be retrieved during an update or delete operation 
+                to identify the exact row on which to operate.</entry>
+            </row>
+            <row>
+              <entry colname="col1"><codeblock>List *
+PlanForeignModify (PlannerInfo *root,
+                   ModifyTable *plan,
+                   Index resultRelation,
+                   int subplan_index)</codeblock></entry>
+              <entry colname="col2">Perform additional planning actions required
+                for an insert, update, or delete operation on a foreign table,
+                and return the information generated.</entry>
+            </row>
+            <row>
+              <entry colname="col1"><codeblock>void
+BeginForeignModify (ModifyTableState *mtstate,
+                    ResultRelInfo *rinfo,
+                    List *fdw_private,
+                    int subplan_index,
+                    int eflags)</codeblock></entry>
+              <entry colname="col2">Begin executing a modify operation on a
+                foreign table. Called during executor startup.</entry>
+            </row>
+            <row>
+              <entry colname="col1"><codeblock>TupleTableSlot *
+ExecForeignInsert (EState *estate,
+                   ResultRelInfo *rinfo,
+                   TupleTableSlot *slot,
+                   TupleTableSlot *planSlot)</codeblock></entry>
+              <entry colname="col2">Insert a single tuple into the foreign table.
+                Return a slot containing the data that was actually inserted, or
+                NULL if no row was inserted.</entry>
+            </row>
+            <row>
+              <entry colname="col1"><codeblock>TupleTableSlot *
+ExecForeignUpdate (EState *estate,
+                   ResultRelInfo *rinfo,
+                   TupleTableSlot *slot,
+                   TupleTableSlot *planSlot)</codeblock></entry>
+              <entry colname="col2">Update a single tuple in the foreign table.
+                Return a slot containing the row as it was actually updated, or
+                NULL if no row was updated. </entry>
+            </row>
+            <row>
+              <entry colname="col1"><codeblock>TupleTableSlot *
+ExecForeignDelete (EState *estate,
+                   ResultRelInfo *rinfo,
+                   TupleTableSlot *slot,
+                   TupleTableSlot *planSlot)</codeblock></entry>
+              <entry colname="col2">Delete a single tuple from the foreign table.
+                Return a slot containing the row that was deleted, or NULL if no
+                row was deleted.</entry>
+            </row>
+            <row>
+              <entry colname="col1"><codeblock>void
+EndForeignModify (EState *estate,
+                  ResultRelInfo *rinfo)</codeblock></entry>
+              <entry colname="col2">End the update and release resources.</entry>
+            </row>
+            <row>
+              <entry colname="col1"><codeblock>int
+IsForeignRelUpdatable (Relation rel)</codeblock></entry>
+              <entry colname="col2">Report the update operations supported by the
+                specified foreign table.</entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
       <p>Refer to
         <xref href="https://www.postgresql.org/docs/9.4/fdw-callbacks.html" scope="external" format="html">Foreign Data Wrapper Callback Routines</xref>
         in the PostgreSQL documentation for detailed information about the inputs
@@ -344,13 +434,22 @@ GetForeignColumnOptions(Oid relid, AttrNumber attnum);</codeblock></entry>
       <p>A Greenplum Database user can specify the <codeph>mpp_execute</codeph>
         option when they create or alter a foreign table, foreign server, or
         foreign data wrapper. A Greenplum Database-compatible foreign-data
-        wrapper examines the <codeph>mpp_execute</codeph> option value on a scan
-        and uses it to determine where to request data - from the
+        wrapper examines the <codeph>mpp_execute</codeph> option value
+        and uses it to determine where to request or send data - from the
         <codeph>master</codeph> (the default), <codeph>any</codeph> (master or
-        any one segment), or <codeph>all</codeph> segments.</p>
-      <note>Write/update operations using a foreign data wrapper are always
-        performed on the Greenplum Database master, regardless of the
-        <codeph>mpp_execute</codeph> setting.</note>
+        any one segment), or <codeph>all segments</codeph> segments (parallel
+        read/write).</p>
+     <p>Greenplum Database supports all <codeph>mpp_execute</codeph> settings
+        for a scan.</p>
+     <p>Greenplum Database supports parallel write when
+        <codeph>mpp_execute 'all segments"</codeph> is set. For all other
+        <codeph>mpp_execute</codeph> settings, Greenplum Database executes
+        write/update operations initiated by a foreign data wrapper on the
+        Greenplum master node.</p>
+     <note>When <codeph>mpp_execute 'all segments'</codeph> is set, Greenplum
+        Database creates the foreign table with a random partition policy. This
+        enables a foreign data wrapper to write to a foreign table from all
+        segments.</note>
       <p>The following scan code snippet probes the <codeph>mpp_execute</codeph>
         value associated with a foreign table:</p>
         <codeblock>ForeignTable *table = GetForeignTable(foreigntableid);

--- a/gpdb-doc/dita/admin_guide/external/g-foreign.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-foreign.xml
@@ -41,7 +41,7 @@
     <body>
       <p>Most PostgreSQL foreign-data wrappers should work with Greenplum
         Database. However, PostgreSQL foreign-data wrappers connect only through 
-        the Greenplum Database master and do not access the Greenplum Database 
+        the Greenplum Database master by default and do not access the Greenplum Database 
         segment instances directly.</p>
       <p>Greenplum Database adds an <codeph>mpp_execute</codeph> option to FDW-related
         SQL commands. If the foreign-data wrapper supports it, you can specify
@@ -54,8 +54,13 @@
           <li><codeph>any</codeph>—Read data from either the master host or any one segment,
             depending on which path costs less.</li>
           <li><codeph>all segments</codeph>—Read or write data from all segments. If a foreign-data
-            wrapper supports this value, it must have a policy that matches segments to data.</li>
+            wrapper supports this value, for correct results it should have a policy that matches
+            segments to data.</li>
         </ul>
+      <p>(A PostgreSQL foreign-data wrapper may work with the various <codeph>mpp_execute</codeph>
+        option settings, but the results are not guaranteed to be correct. For example,
+        a segment may not be able to connect to the foriegn server, or segments may receive
+        overlapping results resulting in duplicate rows.)</p>
       <note>GPORCA does not support foreign tables, a query on a foreign table
         always falls back to the Postgres Planner.</note>
     </body>

--- a/gpdb-doc/dita/admin_guide/external/g-foreign.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-foreign.xml
@@ -13,13 +13,9 @@
       access details.</p>
     <p>The Greenplum Database distribution includes the
       <xref href="../../ref_guide/modules/postgres_fdw.xml" format="dita" scope="peer">postgres_fdw</xref>
-       foreign data wrapper.</p>
-    <note>Most PostgreSQL foreign-data wrappers should work with Greenplum
-      Database. However, PostgreSQL foreign-data wrappers connect only through 
-      the Greenplum Database master and do not access the Greenplum Database 
-      segment instances directly.</note>
-    <p>If none of the existing foreign-data wrappers suit your needs, you can
-      write your own as described in <xref href="g-devel-fdw.xml#topic1"/>.</p>
+       foreign-data wrapper.</p>
+    <p>If none of the existing PostgreSQL or Greenplum Database foreign-data wrappers suit
+      your needs, you can write your own as described in <xref href="g-devel-fdw.xml#topic1"/>.</p>
     <p>To access foreign data, you create a <i>foreign server</i> object,
       which defines how to connect to a particular remote data source
       according to the set of options used by its supporting foreign-data
@@ -29,8 +25,6 @@
       the Greenplum Database server. Whenever a foreign table is accessed,
       Greenplum Database asks the foreign-data wrapper to fetch data from, or
       update data in (if supported by the wrapper), the remote source.</p>
-    <note>GPORCA does not support foreign tables, a query on a foreign table
-      always falls back to the Postgres Planner.</note>
     <p>Accessing remote data may require authenticating to the remote data
       source. This information can be provided by a <i>user mapping</i>,
       which can provide additional data such as a user name and password
@@ -42,4 +36,28 @@
         and <codeph><xref href="../../ref_guide/sql_commands/CREATE_FOREIGN_TABLE.xml#topic1"/></codeph>
         SQL reference pages.</p>
   </body>
+  <topic id="greenplum">
+    <title>Using Foreign-Data Wrappers with Greenplum Database</title>
+    <body>
+      <p>Most PostgreSQL foreign-data wrappers should work with Greenplum
+        Database. However, PostgreSQL foreign-data wrappers connect only through 
+        the Greenplum Database master and do not access the Greenplum Database 
+        segment instances directly.</p>
+      <p>Greenplum Database adds an <codeph>mpp_execute</codeph> option to FDW-related
+        SQL commands. If the foreign-data wrapper supports it, you can specify
+        <codeph>mpp_execute '<i>value</i>'</codeph> in the <codeph>OPTIONS</codeph> clause
+        when you create the FDW, server, or foreign table to identify the Greenplum host
+        from which the foreign-data wrapper reads or writes data. Valid
+        <codeph><i>value</i></codeph>s are:</p>
+        <ul>
+          <li><codeph>master</codeph> (the default)—Read or write data from the master host.</li>
+          <li><codeph>any</codeph>—Read data from either the master host or any one segment,
+            depending on which path costs less.</li>
+          <li><codeph>all segments</codeph>—Read or write data from all segments. If a foreign-data
+            wrapper supports this value, it must have a policy that matches segments to data.</li>
+        </ul>
+      <note>GPORCA does not support foreign tables, a query on a foreign table
+        always falls back to the Postgres Planner.</note>
+    </body>
+  </topic>
 </topic>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FOREIGN_DATA_WRAPPER.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FOREIGN_DATA_WRAPPER.xml
@@ -51,15 +51,19 @@
                     <pt>mpp_execute { 'master' | 'any' | 'all segments' }</pt>
                     <pd>
                         <p>An option that identifies the host from which the foreign data-wrapper
-                            requests data: <ul id="ul_zcg_2vd_mgb">
-                                <li><codeph>master</codeph> (the default)—Request data from the
+                            reads or writes data: <ul id="ul_zcg_2vd_mgb">
+                                <li><codeph>master</codeph> (the default)—Read or write data from the
                                     master host.</li>
-                                <li><codeph>any</codeph>—Request data from either the master host or
+                                <li><codeph>any</codeph>—Read data from either the master host or
                                     any one segment, depending on which path costs less.</li>
-                                <li><codeph>all segments</codeph>—Request data from all segments. To
+                                <li><codeph>all segments</codeph>—Read or write data from all segments. To
                                     support this option value, the foreign data-wrapper must have a
-                                    policy that matches the segments to data.</li>
+                                    policy that matches the segments to data.
+                                  <note>Greenplum Database supports parallel writes to foreign tables
+                                   only when you set <codeph>mpp_execute 'all segments'</codeph>.</note></li>
                             </ul></p>
+                        <p>Use of the foreign table <codeph>mpp_execute</codeph> option, and the
+                            specific modes supported, is foreign data-wrapper-specific.</p>
                         <p>The <codeph>mpp_execute</codeph> option can be specified in multiple
                             commands: <codeph>CREATE FOREIGN TABLE</codeph>, <codeph>CREATE
                                 SERVER</codeph>, and <codeph>CREATE FOREIGN DATA WRAPPER</codeph>.

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FOREIGN_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FOREIGN_TABLE.xml
@@ -99,14 +99,16 @@
                     <pt>mpp_execute { 'master' | 'any' | 'all segments' }</pt>
                     <pd>
                         <p>An option that identifies the host from which the foreign data-wrapper
-                            requests data: <ul id="ul_zcg_2vd_mgb">
-                                <li><codeph>master</codeph> (the default)—Request data from the
+                            reads or writes data: <ul id="ul_zcg_2vd_mgb">
+                                <li><codeph>master</codeph> (the default)—Read or write data from the
                                     master host.</li>
-                                <li><codeph>any</codeph>—Request data from either the master host or
+                                <li><codeph>any</codeph>—Read data from either the master host or
                                     any one segment, depending on which path costs less.</li>
-                                <li><codeph>all segments</codeph>—Request data from all segments. To
+                                <li><codeph>all segments</codeph>—Read or write data from all segments. To
                                     support this option value, the foreign data-wrapper must have a
-                                    policy that matches the segments to data.</li>
+                                    policy that matches the segments to data.
+                                 <note>Greenplum Database supports parallel writes to foreign tables
+                                   only when you set <codeph>mpp_execute 'all segments'</codeph>.</note></li>
                             </ul></p>
                         <p>Use of the foreign table <codeph>mpp_execute</codeph> option, and the
                             specific modes supported, is foreign data-wrapper-specific.</p>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_SERVER.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_SERVER.xml
@@ -58,15 +58,20 @@
                     <pt>mpp_execute { 'master' | 'any' | 'all segments' }</pt>
                     <pd>
                         <p>An option that identifies the host from which the foreign data-wrapper
-                            requests data: <ul id="ul_zcg_2vd_mgb">
-                                <li><codeph>master</codeph> (the default)—Request data from the
-                                    master host.</li>
-                                <li><codeph>any</codeph>—Request data from either the master host or
+                            reads or writes data: <ul id="ul_zcg_2vd_mgb">
+                                <li><codeph>master</codeph> (the default)—Read or write data from
+                                    the master host.</li>
+                                <li><codeph>any</codeph>—Read data from either the master host or
                                     any one segment, depending on which path costs less.</li>
-                                <li><codeph>all segments</codeph>—Request data from all segments. To
-                                    support this option value, the foreign data-wrapper must have a
-                                    policy that matches the segments to data.</li>
+                                <li><codeph>all segments</codeph>—Read or write data from
+                                    all segments. To support this option value, the
+                                    foreign data-wrapper must have a policy that matches the segments
+                                     to data.
+                                 <note>Greenplum Database supports parallel writes to foreign tables
+                                   only when you set <codeph>mpp_execute 'all segments'</codeph>.</note></li>
                             </ul></p>
+                        <p>Use of the foreign table <codeph>mpp_execute</codeph> option, and the
+                            specific modes supported, is foreign data-wrapper-specific.</p> 
                         <p>The <codeph>mpp_execute</codeph> option can be specified in multiple
                             commands: <codeph>CREATE FOREIGN TABLE</codeph>, <codeph>CREATE
                                 SERVER</codeph>, and <codeph>CREATE FOREIGN DATA WRAPPER</codeph>.


### PR DESCRIPTION
docs for old PRs https://github.com/greenplum-db/gpdb/pull/9943 and https://github.com/greenplum-db/gpdb/pull/9987, greenplum supports parallel writes to foreign tables.  in this PR:
- add the fdw write callbacks to the "writing an fdw" page
- reorg the "accessing foreign tables" page (new "Using FDWs with Greenplum Database" topic) and include info about mpp_execute option
- update server/fdw/foreigntable sql ref pages

notes:  
- this PR does not include docs for new num_segments option, will submit those changes in a separate PR
- will backport to 6X_STABLE

doc review site links (behind vpn):
- accessing foreign tables page: https://docs-lisa-fdw-pwrite.sc2-04-pcf1-apps.oc.vmware.com/6-19/admin_guide/external/g-foreign.html
- writing an fdw page: https://docs-lisa-fdw-pwrite.sc2-04-pcf1-apps.oc.vmware.com/6-19/admin_guide/external/g-devel-fdw.html#topic1
- create server SQL page (other ref page updates are similar): https://docs-lisa-fdw-pwrite.sc2-04-pcf1-apps.oc.vmware.com/6-19/ref_guide/sql_commands/CREATE_SERVER.html#topic1
