### PR TITLE
"New options" shouldn't affect redistribution in ALTER TABLE ... DISTRIBUTE BY

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -15891,8 +15891,11 @@ build_ctas_with_dist(Relation rel, DistributedBy *dist_clause,
 	return queryDesc;
 }
 
+/*
+ * GPDB: Convenience function to get reloptions for a given relation.
+ */
 static Datum
-new_rel_opts(Relation rel)
+get_rel_opts(Relation rel)
 {
 	Datum newOptions = PointerGetDatum(NULL);
 
@@ -16452,7 +16455,6 @@ static void
 ATExecExpandTableCTAS(AlterTableCmd *rootCmd, Relation rel, AlterTableCmd *cmd)
 {
 	RangeVar			*tmprv;
-	Datum				newOptions;
 	Oid					tmprelid;
 	Oid					relid = RelationGetRelid(rel);
 
@@ -16492,10 +16494,8 @@ ATExecExpandTableCTAS(AlterTableCmd *rootCmd, Relation rel, AlterTableCmd *cmd)
 		distby = make_distributedby_for_rel(rel);
 		distby->numsegments = getgpsegmentCount();
 
-		newOptions = new_rel_opts(rel);
-
 		queryDesc = build_ctas_with_dist(rel, distby,
-						untransformRelOptions(newOptions),
+						untransformRelOptions(get_rel_opts(rel)),
 						&tmprv,
 						true);
 
@@ -16631,7 +16631,6 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 	bool        rand_pol = false;
 	bool        rep_pol = false;
 	bool        force_reorg = false;
-	Datum		newOptions = PointerGetDatum(NULL);
 	bool		need_reorg;
 	bool		change_policy = false;
 	int			numsegments;
@@ -16722,8 +16721,6 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 			lwith = nlist;
 		}
 
-		newOptions = new_rel_opts(rel);
-
 		if (ldistro)
 			change_policy = true;
 
@@ -16766,8 +16763,8 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 
 				cmd->policy = policy;
 
-				/* only need to rebuild if have new storage options */
-				if (!(DatumGetPointer(newOptions) || force_reorg))
+				/* no need to rebuild if REORGANIZE=false*/
+				if (!force_reorg)
 					goto l_distro_fini;
 			}
 		}
@@ -16786,12 +16783,9 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 
 			policy = createReplicatedGpPolicy(ldistro->numsegments);
 
-			/* rebuild if have new storage options or policy changed */
-			if (!DatumGetPointer(newOptions) &&
-				GpPolicyIsReplicated(rel->rd_cdbpolicy))
-			{
+			/* rebuild only if policy changed */
+			if (GpPolicyIsReplicated(rel->rd_cdbpolicy))
 				goto l_distro_fini;
-			}
 
 			/*
 			 * system columns is not visiable to users for replicated table,
@@ -16894,11 +16888,9 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 													 ldistro->numsegments);
 
 				/*
-				 * See if the old policy is the same as the new one but
-				 * remember, we still might have to rebuild if there are new
-				 * storage options.
+				 * See if the old policy is the same as the new one.
 				 */
-				if (!DatumGetPointer(newOptions) && !force_reorg &&
+				if (!force_reorg &&
 					(policy->nattrs == rel->rd_cdbpolicy->nattrs))
 				{
 					int i;
@@ -17019,7 +17011,7 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 
 			/* Step (b) - build CTAS */
 			queryDesc = build_ctas_with_dist(rel, ldistro,
-											 untransformRelOptions(newOptions),
+											 untransformRelOptions(get_rel_opts(rel)),
 											 &tmprv,
 											 true);
 
@@ -17110,7 +17102,6 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 		backend_id = cmd->backendId - 1;
 		tmprv = make_temp_table_name(rel, backend_id);
 
-		newOptions = new_rel_opts(rel);
 		need_reorg = true;
 	}
 
@@ -17149,58 +17140,8 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 							ReadNextMultiXactId(),
 							NULL);
 
-		/*
-		 * Make changes from swapping relation files visible before updating
-		 * options below or else we get an already updated tuple error.
-		 */
+		/* Make changes from swapping relation files visible. */
 		CommandCounterIncrement();
-
-		if (DatumGetPointer(newOptions))
-		{
-			Datum		repl_val[Natts_pg_class];
-			bool		repl_null[Natts_pg_class];
-			bool		repl_repl[Natts_pg_class];
-			HeapTuple	newOptsTuple;
-			HeapTuple	tuple;
-			Relation	relationRelation;
-
-			/*
-			 * All we need do here is update the pg_class row; the new
-			 * options will be propagated into relcaches during
-			 * post-commit cache inval.
-			 */
-			MemSet(repl_val, 0, sizeof(repl_val));
-			MemSet(repl_null, false, sizeof(repl_null));
-			MemSet(repl_repl, false, sizeof(repl_repl));
-
-			if (newOptions != (Datum) 0)
-				repl_val[Anum_pg_class_reloptions - 1] = newOptions;
-			else
-				repl_null[Anum_pg_class_reloptions - 1] = true;
-
-			repl_repl[Anum_pg_class_reloptions - 1] = true;
-
-			relationRelation = table_open(RelationRelationId, RowExclusiveLock);
-			tuple = SearchSysCache1(RELOID, ObjectIdGetDatum(tarrelid));
-
-			Assert(HeapTupleIsValid(tuple));
-			newOptsTuple = heap_modify_tuple(tuple, RelationGetDescr(relationRelation),
-											 repl_val, repl_null, repl_repl);
-
-			CatalogTupleUpdate(relationRelation, &tuple->t_self, newOptsTuple);
-
-			heap_freetuple(newOptsTuple);
-
-			ReleaseSysCache(tuple);
-
-			table_close(relationRelation, RowExclusiveLock);
-
-			/*
-			 * Increment cmd counter to make updates visible; this is
-			 * needed because the same tuple has to be updated again
-			 */
-			CommandCounterIncrement();
-		}
 
 		/* now, reindex */
 		reindex_relation(tarrelid, 0, 0);

--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -1433,3 +1433,53 @@ select *, gp_segment_id from reorg_leaf_1_prt_p0;
  1 | 1 | 1 |             1
 (5 rows)
 
+-- When reorganize=false, we won't reorganize and this shouldn't be affected by the existing reloptions.
+CREATE TABLE public.t_reorganize_false (
+a integer,
+b integer
+) with (appendonly=false, autovacuum_enabled=false) DISTRIBUTED BY (a);
+-- Insert values which will all be on one segment
+INSERT INTO t_reorganize_false VALUES (0, generate_series(1,100));
+SELECT gp_segment_id,count(*)￼ from t_reorganize_false GROUP BY 1;
+ gp_segment_id |  ￼  
+---------------+-----
+             1 | 100
+(1 row)
+
+-- Change the distribution policy but because REORGANIZE=false, it should NOT be re-distributed 
+ALTER TABLE t_reorganize_false SET WITH (REORGANIZE=false) DISTRIBUTED RANDOMLY;
+SELECT gp_segment_id,count(*)￼ from t_reorganize_false GROUP BY 1;
+ gp_segment_id |  ￼  
+---------------+-----
+             1 | 100
+(1 row)
+
+DROP TABLE t_reorganize_false;
+-- Same rule should apply to partitioned table too
+CREATE TABLE public.t_reorganize_false (
+a integer,
+b integer
+)
+DISTRIBUTED BY (a) PARTITION BY RANGE(b)
+(
+PARTITION "00" START (0) END (1000) WITH (tablename='t_reorganize_false_0', appendonly='false', autovacuum_enabled=false),
+PARTITION "01" START (1000) END (2000) WITH (tablename='t_reorganize_false_1', appendonly='false', autovacuum_enabled=false),
+DEFAULT PARTITION def WITH (tablename='t_reorganize_false_def', appendonly='false', autovacuum_enabled=false)
+);
+-- Insert values which will all be on one segment
+INSERT INTO t_reorganize_false VALUES (0, generate_series(1,100));
+SELECT gp_segment_id,count(*) from t_reorganize_false GROUP BY 1;
+ gp_segment_id | count 
+---------------+-------
+             1 |   100
+(1 row)
+
+-- Should NOT be re-distributed
+ALTER TABLE t_reorganize_false SET WITH (REORGANIZE=false) DISTRIBUTED RANDOMLY;
+SELECT gp_segment_id,count(*) from t_reorganize_false GROUP BY 1;
+ gp_segment_id | count 
+---------------+-------
+             1 |   100
+(1 row)
+
+DROP TABLE t_reorganize_false;

--- a/src/test/regress/sql/alter_distribution_policy.sql
+++ b/src/test/regress/sql/alter_distribution_policy.sql
@@ -454,3 +454,34 @@ alter table reorg_leaf_1_prt_p0_2_prt_1 set with (reorganize=true) distributed b
 select *, gp_segment_id from reorg_leaf_1_prt_p0;
 alter table reorg_leaf_1_prt_p0_2_prt_1 set with (reorganize=true);
 select *, gp_segment_id from reorg_leaf_1_prt_p0;
+
+-- When reorganize=false, we won't reorganize and this shouldn't be affected by the existing reloptions.
+CREATE TABLE public.t_reorganize_false (
+a integer,
+b integer
+) with (appendonly=false, autovacuum_enabled=false) DISTRIBUTED BY (a);
+-- Insert values which will all be on one segment
+INSERT INTO t_reorganize_false VALUES (0, generate_series(1,100));
+SELECT gp_segment_id,count(*)￼ from t_reorganize_false GROUP BY 1;
+-- Change the distribution policy but because REORGANIZE=false, it should NOT be re-distributed 
+ALTER TABLE t_reorganize_false SET WITH (REORGANIZE=false) DISTRIBUTED RANDOMLY;
+SELECT gp_segment_id,count(*)￼ from t_reorganize_false GROUP BY 1;
+DROP TABLE t_reorganize_false;
+-- Same rule should apply to partitioned table too
+CREATE TABLE public.t_reorganize_false (
+a integer,
+b integer
+)
+DISTRIBUTED BY (a) PARTITION BY RANGE(b)
+(
+PARTITION "00" START (0) END (1000) WITH (tablename='t_reorganize_false_0', appendonly='false', autovacuum_enabled=false),
+PARTITION "01" START (1000) END (2000) WITH (tablename='t_reorganize_false_1', appendonly='false', autovacuum_enabled=false),
+DEFAULT PARTITION def WITH (tablename='t_reorganize_false_def', appendonly='false', autovacuum_enabled=false)
+);
+-- Insert values which will all be on one segment
+INSERT INTO t_reorganize_false VALUES (0, generate_series(1,100));
+SELECT gp_segment_id,count(*) from t_reorganize_false GROUP BY 1;
+-- Should NOT be re-distributed
+ALTER TABLE t_reorganize_false SET WITH (REORGANIZE=false) DISTRIBUTED RANDOMLY;
+SELECT gp_segment_id,count(*) from t_reorganize_false GROUP BY 1;
+DROP TABLE t_reorganize_false;


### PR DESCRIPTION
We used to allow `ALTER TABLE ... DISTRIBUTE BY` statement to have additional storage options, and when they are present, we will re-distribute data over the segments.

However, now we have [disallowed that syntax](https://docs.greenplum.org/6-16/ref_guide/sql_commands/ALTER_TABLE.html) and only allowed one option to be passed in `ALTER TABLE ... DISTRIBUTE BY` which is the `REORGANIZE` option. 

Therefore, it makes no more sense to keep checking "new options" for making decision for re-distribution. The only place to use the "new options" (i.e. variable `newOptions` in `ATExecSetDistributedBy()`, which btw has been reduced to just getting the existing `pg_class.reloptions` of the table) is for building CTAS statement.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
