### PR TITLE
Fix ORCA crash due to wrong UDF volatility

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -407,6 +407,17 @@ gpdb::WalkExpressionTree(Node *node, bool (*walker)(), void *context)
 	return false;
 }
 
+bool
+gpdb::WalkPlanTree(Node *node, bool (*walker)(), void *context)
+{
+	GP_WRAP_START;
+	{
+		return plan_tree_walker(node, walker, context);
+	}
+	GP_WRAP_END;
+	return false;
+}
+
 Oid
 gpdb::ExprType(Node *expr)
 {
@@ -2591,6 +2602,17 @@ gpdb::GPDBMemoryContextDelete(MemoryContext context)
 		MemoryContextDelete(context);
 	}
 	GP_WRAP_END;
+}
+
+gpos::BOOL
+gpdb::IsImmutableUDFWithMutableContent(Oid funcid)
+{
+	GP_WRAP_START;
+	{
+		return is_immutable_udf_with_mutable_content(funcid);
+	}
+	GP_WRAP_END;
+	return false;
 }
 
 MemoryContext

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -489,6 +489,9 @@ bool WalkExpressionTree(Node *node, bool (*walker)(), void *context);
 bool WalkQueryOrExpressionTree(Node *node, bool (*walker)(), void *context,
 							   int flags);
 
+// plan tree walker
+bool WalkPlanTree(Node *node, bool (*walker)(), void *context);
+
 // modify a query tree
 Query *MutateQueryTree(Query *query, Node *(*mutator)(), void *context,
 					   int flags);
@@ -694,6 +697,8 @@ void *GPDBMemoryContextAlloc(MemoryContext context, Size size);
 MemoryContext GPDBAllocSetContextCreate();
 
 void GPDBMemoryContextDelete(MemoryContext context);
+
+gpos::BOOL IsImmutableUDFWithMutableContent(Oid funcid);
 
 }  //namespace gpdb
 

--- a/src/include/optimizer/clauses.h
+++ b/src/include/optimizer/clauses.h
@@ -84,6 +84,8 @@ extern bool contain_window_functions(Node *clause);
 extern bool contain_nonstrict_functions(Node *clause);
 extern Relids find_nonnullable_rels(Node *clause);
 
+extern bool is_immutable_udf_with_mutable_content(Oid funcid);
+
 extern bool is_pseudo_constant_clause(Node *clause);
 extern bool is_pseudo_constant_clause_relids(Node *clause, Relids relids);
 

--- a/src/test/regress/expected/dpe.out
+++ b/src/test/regress/expected/dpe.out
@@ -2582,3 +2582,31 @@ select 1 from dpe_bar join (select * from dpe_part join dpe_foo on i = a) t on i
         1
 (18 rows)
 
+---
+-- DPE: Ensure that when a UDF is incorrectly labeled "immutable"
+--      then we do not perform SPE and should instead perform DPE.
+--      N.B. built-in to_date() is "stable".
+---
+create function _to_date(integer, text) returns date as $$ select to_date($1::text,$2); $$ language sql immutable;
+explain select * from dpe_part where i = (_to_date(20210120 / 1, 'yyyymmdd'))::varchar::int;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..25.28 rows=1 width=4)
+   ->  Append  (cost=0.00..25.28 rows=1 width=4)
+         ->  Seq Scan on dpe_part_1_prt_dpe_part1 dpe_part  (cost=0.00..25.28 rows=1 width=4)
+               Filter: i = _to_date(20210120 / 1, 'yyyymmdd'::text)::character varying::integer
+ Settings:  optimizer=off; optimizer_nestloop_factor=1
+ Optimizer status: legacy query optimizer
+(6 rows)
+
+explain select * from dpe_part where i = to_number((_to_date(20210120 / 1, 'yyyymmdd'))::date::varchar , '999999');
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..25.28 rows=1 width=4)
+   ->  Append  (cost=0.00..25.28 rows=1 width=4)
+         ->  Seq Scan on dpe_part_1_prt_dpe_part1 dpe_part  (cost=0.00..25.28 rows=1 width=4)
+               Filter: i::numeric = to_number(_to_date(20210120 / 1, 'yyyymmdd'::text)::character varying::text, '999999'::text)
+ Settings:  optimizer=off; optimizer_nestloop_factor=1
+ Optimizer status: legacy query optimizer
+(6 rows)
+

--- a/src/test/regress/expected/dpe_optimizer.out
+++ b/src/test/regress/expected/dpe_optimizer.out
@@ -2006,3 +2006,35 @@ select 1 from dpe_bar join (select * from dpe_part join dpe_foo on i = a) t on i
         1
 (18 rows)
 
+---
+-- DPE: Ensure that when a UDF is incorrectly labeled "immutable"
+--      then we do not perform SPE and should instead perform DPE.
+--      N.B. built-in to_date() is "stable".
+---
+create function _to_date(integer, text) returns date as $$ select to_date($1::text,$2); $$ language sql immutable;
+explain select * from dpe_part where i = (_to_date(20210120 / 1, 'yyyymmdd'))::varchar::int;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=13 width=4)
+   ->  Sequence  (cost=0.00..431.00 rows=5 width=4)
+         ->  Partition Selector for dpe_part (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+               Partitions selected: 0 (out of 1)
+         ->  Dynamic Table Scan on dpe_part (dynamic scan id: 1)  (cost=0.00..431.00 rows=5 width=4)
+               Filter: i = _to_date(20210120 / 1, 'yyyymmdd'::text)::character varying::integer
+ Settings:  optimizer_nestloop_factor=1
+ Optimizer status: PQO version 3.122.0
+(8 rows)
+
+explain select * from dpe_part where i = to_number((_to_date(20210120 / 1, 'yyyymmdd'))::date::varchar , '999999');
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=13 width=4)
+   ->  Sequence  (cost=0.00..431.00 rows=5 width=4)
+         ->  Partition Selector for dpe_part (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+               Partitions selected: 0 (out of 1)
+         ->  Dynamic Table Scan on dpe_part (dynamic scan id: 1)  (cost=0.00..431.00 rows=5 width=4)
+               Filter: i::numeric = to_number(_to_date(20210120 / 1, 'yyyymmdd'::text)::character varying::text, '999999'::text)
+ Settings:  optimizer_nestloop_factor=1
+ Optimizer status: PQO version 3.122.0
+(8 rows)
+


### PR DESCRIPTION
Following SQL produced crash:
```sql
CREATE TABLE pt(a int) PARTITION BY RANGE(a) (START(0)  END(10) EVERY(1));
CREATE FUNCTION _to_date(integer, text) RETURNS date AS $$ SELECT to_date($1::text,$2); $$ LANGUAGE SQL IMMUTABLE;
EXPLAIN SELECT * FROM pt WHERE a = to_number((_to_date(20210120 / 1, 'yyyymmdd')- interval'1 day')::date::varchar , '999999');
```

Notice that _to_date() UDF is labeled "immutable" and the built-in
to_date() function is "stable". This is a user error because a UDF
cannot provide a stronger volatility guarantee than its contents.
Regardless, such an error should not cause a crash.

Issue is that ORCA evaluates "immutable" functions when performing
static partition elimiation without a guarantee that the functions are
actually "immutable".  While evaulating the UDF, ORCA must plan and
execute the "mutable" UDF statements.  However, ORCA does not support
nested optimization calls and will crash due to over-allocated worker.

Fix is to check UDF volatility before evaluating in a static partition
elimination expression. And in the case of mismatch, perform dynamic
partition elimination instead.