### PR TITLE
Using poll instead of select in nodeShareInputScan

### DIFF
--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -26,6 +26,13 @@
 
 #include "postgres.h"
 
+#ifdef HAVE_POLL_H
+#include <poll.h>
+#endif
+#ifdef HAVE_SYS_POLL_H
+#include <sys/poll.h>
+#endif
+
 #include "access/xact.h"
 #include "cdb/cdbvars.h"
 #include "commands/tablespace.h"
@@ -547,6 +554,39 @@ write_retry:
 	return 0;
 }
 
+#ifdef FAULT_INJECTOR
+/**
+ * create and open many tmp files, so the next fd number is bigger.
+ **/
+static void fi_create_many_fds(int *fds, char *file_prefix, int num)
+{
+	for (int i = 0; i < num; i++)
+	{
+		char filepath[1024];
+		snprintf(filepath, sizeof(filepath), "%s/si_%d", file_prefix, i);
+		fds[i] = open(filepath, O_RDWR | O_CREAT, 0666);
+	}
+	if (fds[num-1] > 0)
+		Assert(fds[num-1] > num);
+}
+
+/**
+ * close opened fds and delete the tmp files
+ **/
+static void fi_close_created_fds(int *fds, char *file_prefix, int num)
+{
+	for (int i = 0; i < num; i++)
+	{
+		char filepath[1024];
+		snprintf(filepath, sizeof(filepath), "%s/si_%d", file_prefix, i);
+		if (fds[i] > 0) {
+			close(fds[i]);
+			unlink(filepath);
+		}
+	}
+}
+#endif
+
 /* 
  * Readiness (a) synchronization.
  *
@@ -586,36 +626,57 @@ write_retry:
 void
 shareinput_reader_waitready(void *ctxt, int share_id, PlanGenerator planGen)
 {
-	mpp_fd_set rset;
-	struct timeval tval;
-	int n;
+	struct pollfd fds[1];
+	int nfds = 0;
 	char a;
 	ShareInput_Lk_Context *pctxt = (ShareInput_Lk_Context *) ctxt;
 	RegisterXactCallbackOnce(XCallBack_ShareInput_FIFO, pctxt);
+
+#ifdef FAULT_INJECTOR
+	/**
+	 * In preivous code, use MPP_FD_SET(call select() internally) to operate FIFO,
+	 * so the FIFO's fd number cannot exceed 65536.
+	 *
+	 * After using poll() instead of select(), it can overcome this limit.
+	 * Using FAULT_INJECTOR here to test whether it works normally in this
+	 * scenario (already opened many fds).
+	 **/
+	const int num = 70000; // > 65536
+	int tmp_fds[num];
+	memset(tmp_fds, 0, sizeof(tmp_fds));
+	char tmpfile_prefix[] = "/tmp/_gpdb_fault_inject_tmp_dir/"; // need create the dir first
+	if (SIMPLE_FAULT_INJECTOR("inject_many_fds_for_shareinputscan") == FaultInjectorTypeSkip)
+		fi_create_many_fds(tmp_fds, tmpfile_prefix, num);
+#endif
 
 	create_tmp_fifo(pctxt->lkname_ready);
 	pctxt->readyfd = open(pctxt->lkname_ready, O_RDWR, 0600); 
 	if(pctxt->readyfd < 0)
 		elog(ERROR, "could not open fifo \"%s\": %m", pctxt->lkname_ready);
-	
+
 	create_tmp_fifo(pctxt->lkname_done);
 	pctxt->donefd = open(pctxt->lkname_done, O_RDWR, 0600);
 	if(pctxt->donefd < 0)
 		elog(ERROR, "could not open fifo \"%s\": %m", pctxt->lkname_done);
 
+#ifdef FAULT_INJECTOR
+	/* close opened fds */
+	fi_close_created_fds(tmp_fds, tmpfile_prefix, num);
+#endif
+
+	fds[0].fd = pctxt->readyfd;
+	fds[0].events = POLLIN;
+	nfds++;
 	while(1)
 	{
 		CHECK_FOR_INTERRUPTS();
 
-		MPP_FD_ZERO(&rset);
-		MPP_FD_SET(pctxt->readyfd, &rset);
+		int nready = 0;
+		int poll_timeout = 1000; // unit: ms
 
-		tval.tv_sec = 1;
-		tval.tv_usec = 0;
+		nready = poll(fds, nfds, poll_timeout);
 
-		n = select(pctxt->readyfd+1, (fd_set *) &rset, NULL, NULL, &tval);
-
-		if(n==1)
+		if (nready == 1)
 		{
 #if USE_ASSERT_CHECKING
 			int rwsize =
@@ -641,7 +702,7 @@ shareinput_reader_waitready(void *ctxt, int share_id, PlanGenerator planGen)
 
 			break;
 		}
-		else if(n==0)
+		else if (nready == 0)
 		{
 			elog(DEBUG1, "SISC READER (shareid=%d, slice=%d): Wait ready time out once",
 					share_id, currentSliceId);
@@ -717,22 +778,23 @@ static void
 writer_wait_for_acks(ShareInput_Lk_Context *pctxt, int share_id, int xslice)
 {
 	int ack_needed = xslice;
-	mpp_fd_set rset;
-	struct timeval tval;
+	struct pollfd fds[1];
+	int nfds = 0;
 	char b;
 
+	fds[0].fd = pctxt->donefd;
+	fds[0].events = POLLIN;
+	nfds++;
 	while(ack_needed > 0)
 	{
 		CHECK_FOR_INTERRUPTS();
 
-		MPP_FD_ZERO(&rset);
-		MPP_FD_SET(pctxt->donefd, &rset);
+		int nready = 0;
+		int poll_timeout = 1000; // unit: ms
 
-		tval.tv_sec = 1;
-		tval.tv_usec = 0;
-		int numReady = select(pctxt->donefd+1, (fd_set *) &rset, NULL, NULL, &tval);
+		nready = poll(fds, nfds, poll_timeout);
 
-		if(numReady==1)
+		if (nready == 1)
 		{
 #if USE_ASSERT_CHECKING
 			int rwsize =
@@ -752,7 +814,7 @@ writer_wait_for_acks(ShareInput_Lk_Context *pctxt, int share_id, int xslice)
 						share_id, currentSliceId, ack_needed);
 			}
 		}
-		else if(numReady==0)
+		else if (nready == 0)
 		{
 			elog(DEBUG1, "SISC WRITER (shareid=%d, slice=%d): Notify ready time out once ... ",
 					share_id, currentSliceId);
@@ -804,31 +866,31 @@ void
 shareinput_writer_waitdone(void *ctxt, int share_id, int nsharer_xslice)
 {
 	ShareInput_Lk_Context *pctxt = (ShareInput_Lk_Context *) ctxt;
+	struct pollfd fds[1];
+	int nfds = 0;
 
 	if (pctxt->donefd < 0)
 		return;
 
-	mpp_fd_set rset;
-	struct timeval tval;
-	int numReady;
 	char z;
 	int ack_needed = nsharer_xslice - pctxt->zcnt;
 
 	elog(DEBUG1, "SISC WRITER (shareid=%d, slice=%d): waiting for DONE message from %d readers",
 							share_id, currentSliceId, ack_needed);
 
+	fds[0].fd = pctxt->donefd;
+	fds[0].events = POLLIN;
+	nfds++;
 	while(ack_needed > 0)
 	{
 		CHECK_FOR_INTERRUPTS();
-	
-		MPP_FD_ZERO(&rset);
-		MPP_FD_SET(pctxt->donefd, &rset);
 
-		tval.tv_sec = 1;
-		tval.tv_usec = 0;
-		numReady = select(pctxt->donefd+1, (fd_set *) &rset, NULL, NULL, &tval);
-	
-		if(numReady==1)
+		int nready = 0;
+		int poll_timeout = 1000; // unit: ms
+
+		nready = poll(fds, nfds, poll_timeout);
+
+		if (nready == 1)
 		{
 #if USE_ASSERT_CHECKING
 			int rwsize =
@@ -840,7 +902,7 @@ shareinput_writer_waitdone(void *ctxt, int share_id, int nsharer_xslice)
 					share_id, currentSliceId);
 			--ack_needed;
 		}
-		else if(numReady==0)
+		else if (nready == 0)
 		{
 			elog(DEBUG1, "SISC WRITER (shareid=%d, slice=%d): wait done timeout once",
 					share_id, currentSliceId);

--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -641,7 +641,10 @@ shareinput_reader_waitready(void *ctxt, int share_id, PlanGenerator planGen)
 	 * Using FAULT_INJECTOR here to test whether it works normally in this
 	 * scenario (already opened many fds).
 	 **/
-	const int num = 70000; // > 65536
+	// we should use 70000(>65536) to test here, but the test env (docker)'s open files
+	// is not very big, so only using a smaller value instead.
+	// const int num = 70000;
+	const int num = 40000;
 	int tmp_fds[num];
 	memset(tmp_fds, 0, sizeof(tmp_fds));
 	char tmpfile_prefix[] = "/tmp/_gpdb_fault_inject_tmp_dir/"; // need create the dir first

--- a/src/test/regress/expected/shared_scan.out
+++ b/src/test/regress/expected/shared_scan.out
@@ -284,4 +284,3 @@ select gp_inject_fault('inject_many_fds_for_shareinputscan', 'reset', dbid) from
 (1 row)
 
 \! rm -rf /tmp/_gpdb_fault_inject_tmp_dir/
-

--- a/src/test/regress/expected/shared_scan.out
+++ b/src/test/regress/expected/shared_scan.out
@@ -2,6 +2,9 @@
 -- Queries that lead to hanging (not dead lock) when we don't handle synchronization properly in shared scan
 -- Queries that lead to wrong result when we don't finish executing the subtree below the shared scan being squelched.
 --
+-- start_ignore
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
 CREATE SCHEMA shared_scan;
 SET search_path = shared_scan;
 CREATE TABLE foo (a int, b int);
@@ -248,7 +251,9 @@ where
 (52 rows)
 
 -- Test the scenario which already opened many fds
-create extension if not exists gp_inject_fault;
+-- start_ignore
+RESET search_path;
+-- end_ignore
 \! mkdir -p /tmp/_gpdb_fault_inject_tmp_dir/
 select gp_inject_fault('inject_many_fds_for_shareinputscan', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = 0;
  gp_inject_fault 
@@ -257,7 +262,7 @@ select gp_inject_fault('inject_many_fds_for_shareinputscan', 'skip', dbid) from 
 (1 row)
 
 -- borrow the test query in gp_aggregates
-select case when ten < 5 then ten else ten * 2 end, count(distinct two), count(distinct four) from public.tenk1 group by 1;
+select case when ten < 5 then ten else ten * 2 end, count(distinct two), count(distinct four) from tenk1 group by 1;
  case | count | count 
 ------+-------+-------
     0 |     1 |     2

--- a/src/test/regress/expected/shared_scan.out
+++ b/src/test/regress/expected/shared_scan.out
@@ -247,3 +247,34 @@ where
  Optimizer: Postgres query optimizer
 (52 rows)
 
+-- Test the scenario which already opened many fds
+create extension if not exists gp_inject_fault;
+\! mkdir -p /tmp/_gpdb_fault_inject_tmp_dir/
+select gp_inject_fault('inject_many_fds_for_shareinputscan', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- borrow the test query in gp_aggregates
+select case when ten < 5 then ten else ten * 2 end, count(distinct two), count(distinct four) from public.tenk1 group by 1;
+ case | count | count 
+------+-------+-------
+    0 |     1 |     2
+    1 |     1 |     2
+    2 |     1 |     2
+    3 |     1 |     2
+    4 |     1 |     2
+   10 |     1 |     2
+   12 |     1 |     2
+   14 |     1 |     2
+   16 |     1 |     2
+   18 |     1 |     2
+(10 rows)
+
+select gp_inject_fault('inject_many_fds_for_shareinputscan', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+

--- a/src/test/regress/expected/shared_scan.out
+++ b/src/test/regress/expected/shared_scan.out
@@ -283,3 +283,5 @@ select gp_inject_fault('inject_many_fds_for_shareinputscan', 'reset', dbid) from
  Success:
 (1 row)
 
+\! rm -rf /tmp/_gpdb_fault_inject_tmp_dir/
+

--- a/src/test/regress/expected/shared_scan_optimizer.out
+++ b/src/test/regress/expected/shared_scan_optimizer.out
@@ -2,6 +2,9 @@
 -- Queries that lead to hanging (not dead lock) when we don't handle synchronization properly in shared scan
 -- Queries that lead to wrong result when we don't finish executing the subtree below the shared scan being squelched.
 --
+-- start_ignore
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
 CREATE SCHEMA shared_scan;
 SET search_path = shared_scan;
 CREATE TABLE foo (a int, b int);
@@ -259,4 +262,37 @@ where
                        ->  Result
  Optimizer: Postgres query optimizer
 (52 rows)
+
+-- Test the scenario which already opened many fds
+-- start_ignore
+RESET search_path;
+-- end_ignore
+\! mkdir -p /tmp/_gpdb_fault_inject_tmp_dir/
+select gp_inject_fault('inject_many_fds_for_shareinputscan', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- borrow the test query in gp_aggregates
+select case when ten < 5 then ten else ten * 2 end, count(distinct two), count(distinct four) from tenk1 group by 1;
+ case | count | count 
+------+-------+-------
+    0 |     1 |     2
+    1 |     1 |     2
+    2 |     1 |     2
+    3 |     1 |     2
+    4 |     1 |     2
+   10 |     1 |     2
+   12 |     1 |     2
+   14 |     1 |     2
+   16 |     1 |     2
+   18 |     1 |     2
+(10 rows)
+
+select gp_inject_fault('inject_many_fds_for_shareinputscan', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
 

--- a/src/test/regress/expected/shared_scan_optimizer.out
+++ b/src/test/regress/expected/shared_scan_optimizer.out
@@ -297,4 +297,3 @@ select gp_inject_fault('inject_many_fds_for_shareinputscan', 'reset', dbid) from
 (1 row)
 
 \! rm -rf /tmp/_gpdb_fault_inject_tmp_dir/
-

--- a/src/test/regress/expected/shared_scan_optimizer.out
+++ b/src/test/regress/expected/shared_scan_optimizer.out
@@ -296,3 +296,5 @@ select gp_inject_fault('inject_many_fds_for_shareinputscan', 'reset', dbid) from
  Success:
 (1 row)
 
+\! rm -rf /tmp/_gpdb_fault_inject_tmp_dir/
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -37,7 +37,8 @@ test: instr_in_shmem_setup
 test: instr_in_shmem
 
 test: createdb
-test: gp_aggregates gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml shared_scan update_gp returning_gp resource_queue_with_rule gp_types gp_index
+test: gp_aggregates gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml update_gp returning_gp resource_queue_with_rule gp_types gp_index
+test: shared_scan
 test: spi_processed64bit
 test: python_processed64bit
 test: gp_tablespace_with_faults

--- a/src/test/regress/sql/shared_scan.sql
+++ b/src/test/regress/sql/shared_scan.sql
@@ -135,3 +135,5 @@ select gp_inject_fault('inject_many_fds_for_shareinputscan', 'skip', dbid) from 
 -- borrow the test query in gp_aggregates
 select case when ten < 5 then ten else ten * 2 end, count(distinct two), count(distinct four) from tenk1 group by 1;
 select gp_inject_fault('inject_many_fds_for_shareinputscan', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+
+\! rm -rf /tmp/_gpdb_fault_inject_tmp_dir/

--- a/src/test/regress/sql/shared_scan.sql
+++ b/src/test/regress/sql/shared_scan.sql
@@ -121,3 +121,11 @@ where
 	and (stat.schema_name || '.' ||stat.table_name not in (select table_nm_onl_act from tbls_w_onl_actl_data))
 	or (stat.schema_name || '.' ||stat.table_name in (select table_nm_onl_act from tbls_w_onl_actl_data));
 
+-- Test the scenario which already opened many fds
+create extension if not exists gp_inject_fault;
+\! mkdir -p /tmp/_gpdb_fault_inject_tmp_dir/
+
+select gp_inject_fault('inject_many_fds_for_shareinputscan', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+-- borrow the test query in gp_aggregates
+select case when ten < 5 then ten else ten * 2 end, count(distinct two), count(distinct four) from public.tenk1 group by 1;
+select gp_inject_fault('inject_many_fds_for_shareinputscan', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;

--- a/src/test/regress/sql/shared_scan.sql
+++ b/src/test/regress/sql/shared_scan.sql
@@ -3,6 +3,10 @@
 -- Queries that lead to wrong result when we don't finish executing the subtree below the shared scan being squelched.
 --
 
+-- start_ignore
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
+
 CREATE SCHEMA shared_scan;
 
 SET search_path = shared_scan;
@@ -122,10 +126,12 @@ where
 	or (stat.schema_name || '.' ||stat.table_name in (select table_nm_onl_act from tbls_w_onl_actl_data));
 
 -- Test the scenario which already opened many fds
-create extension if not exists gp_inject_fault;
+-- start_ignore
+RESET search_path;
+-- end_ignore
 \! mkdir -p /tmp/_gpdb_fault_inject_tmp_dir/
 
 select gp_inject_fault('inject_many_fds_for_shareinputscan', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = 0;
 -- borrow the test query in gp_aggregates
-select case when ten < 5 then ten else ten * 2 end, count(distinct two), count(distinct four) from public.tenk1 group by 1;
+select case when ten < 5 then ten else ten * 2 end, count(distinct two), count(distinct four) from tenk1 group by 1;
 select gp_inject_fault('inject_many_fds_for_shareinputscan', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;


### PR DESCRIPTION
Current 6X ShareInputScan using FIFO as the notification mechanism between processes and using `select()` to detect whether the specific fd can read.
But `select()` has the "**max fd number**" limit, we can see the check logic (65535) in `MPP_FD_SET()`:
```
#define MPP_FD_SET(fd, set) do{ \
	if (fd > 65535) \
	elog(FATAL,"Internal error:  Using fd > 65535 in MPP_FD_SET"); \
	((set)->__fds_bits[MPP_FD_WORD(fd)] = ((set)->__fds_bits[MPP_FD_WORD(fd)]) | MPP_FD_BIT(fd)); \
    } while(0)
```

One error scene example is 
```
 Sequence  (cost=0.00..9854193.27 rows=149 width=205) (actual time=19477.963..20583.114 rows=456618 loops=1)
   ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=1) (actual time=15.110..15.114 rows=1 loops=1)
         ->  Materialize  (cost=0.00..431.00 rows=1 width=1) (actual time=15.080..15.080 rows=0 loops=1)
               ->  Limit  (cost=0.00..431.00 rows=1 width=7) (actual time=0.268..0.301 rows=1 loops=1)
                     ->  Gather Motion 816:1  (slice83; segments: 816)  (cost=0.00..431.00 rows=1 width=7) (actual time=0.265..0.265 rows=1 loops=1)
                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=7) (actual time=2893.051..2893.051 rows=1 loops=1)
...
```
SharedInputScan can run on QD in some plans, that means its fd number is very bigger than normal QE (QD need to access many files and socks, especially in a big cluster). When the number exceeds 65535, an error "FATAL: Internal error: Using fd > 65535 in MPP_FD_SET" happens.

Using `poll()` can avoid this issue: indeed, should use `poll()` instead of `select()` in every place.
https://man7.org/linux/man-pages/man2/select.2.html#DESCRIPTION

Note: master doesn't have this issue, it uses condition variable as the notification mechanism (so no select/poll are needed).

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
