### PR TITLE
Fix query with mode() crash when QueryFinishPending is true

### DIFF
--- a/src/test/regress/expected/query_finish_pending.out
+++ b/src/test/regress/expected/query_finish_pending.out
@@ -180,3 +180,32 @@ select gp_inject_fault('fts_probe', 'reset', 1);
 
 drop table _tmp_table1;
 drop table _tmp_table2;
+-- test if a query with mode() does not crash when QueryFinishPending set to true
+create table _tmp_table3(a char, b int);
+insert into _tmp_table3 values ('a', 1), ('a', 1), ('a', 2), ('b', 1), ('b', 1), ('b', 1), ('c', 3), ('c', 3);
+select gp_inject_fault('before_tuplesort_getdatum_in_mode_final', 'finish_pending', dbid) FROM gp_segment_configuration WHERE role='p' AND content <> -1;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+-- Make sure that no fault is triggered like
+-- DETAIL:  FailedAssertion("!(pointer != ((void *)0))", File: "mcxt.c", Line: 1291)
+select b, mode() within group(order by a) from _tmp_table3 group by b order by b;
+ b | mode 
+---+------
+ 1 | 
+ 2 | 
+(2 rows)
+
+select gp_inject_fault('before_tuplesort_getdatum_in_mode_final', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content <> -1;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+drop table _tmp_table3;

--- a/src/test/regress/sql/query_finish_pending.sql
+++ b/src/test/regress/sql/query_finish_pending.sql
@@ -88,3 +88,14 @@ select gp_inject_fault('fts_probe', 'reset', 1);
 
 drop table _tmp_table1;
 drop table _tmp_table2;
+
+-- test if a query with mode() does not crash when QueryFinishPending set to true
+create table _tmp_table3(a char, b int);
+insert into _tmp_table3 values ('a', 1), ('a', 1), ('a', 2), ('b', 1), ('b', 1), ('b', 1), ('c', 3), ('c', 3);
+select gp_inject_fault('before_tuplesort_getdatum_in_mode_final', 'finish_pending', dbid) FROM gp_segment_configuration WHERE role='p' AND content <> -1;
+-- Make sure that no fault is triggered like
+-- DETAIL:  FailedAssertion("!(pointer != ((void *)0))", File: "mcxt.c", Line: 1291)
+select b, mode() within group(order by a) from _tmp_table3 group by b order by b;
+select gp_inject_fault('before_tuplesort_getdatum_in_mode_final', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content <> -1;
+
+drop table _tmp_table3;


### PR DESCRIPTION
There is an issue that query with `mode() `aggregate crashes when `QueryFinishPending` is set to true.

**Steps to reproduce:**

1. Create test table and fill it with data
```
-- test if a query with mode() does not crash when QueryFinishPending set to true
CREATE TABLE _tmp_table3(a char, b int);
INSERT INTO _tmp_table3 VALUES ('a', 1), ('a', 1), ('a', 2), ('b', 1), ('b', 1), ('b', 1), ('c', 3), ('c', 3);

```

2. Connect with gdb to any segment and set breakpoint at function `mode_final`

```
(gdb) br mode_final
Breakpoint 1 at 0xd5f4d5: file orderedsetaggs.c, line 1093.
(gdb) c
Continuing.
```

3. Execute the following query:
`
select b, mode() within group(order by a) from _tmp_table3 group by b order by b;
`

4. Switch go gdb window with breakpoint at `mode_final`, check `QueryFinishPending` flag, set to to 1 and continue:

```
Breakpoint 1, mode_final (fcinfo=0x7ffdb65ba490) at orderedsetaggs.c:1093
1093		Datum		mode_val = (Datum) 0;
(gdb) p QueryFinishPending
$1 = 0 '\000'
(gdb) set QueryFinishPending = 1
(gdb) p QueryFinishPending
$2 = 1 '\001'
(gdb) c
Continuing.
[Detaching after fork from child process 25400]

```

5. Switch to SQL window to see that query with mode() crashed:
```
postgres=# select b, mode() within group(order by a) from test_table group by b order by b;
ERROR:  Unexpected internal error (mcxt.c:1291)  (seg0 slice2 10.92.6.193:6002 pid=25185) (mcxt.c:1291)
DETAIL:  FailedAssertion("!(pointer != ((void *)0))", File: "mcxt.c", Line: 1291)
HINT:  Process 25185 will wait for gp_debug_linger=120 seconds before termination.
Note that its locks and other resources will not be released until then.
postgres=# 
```

**Analysis** 

In case of query with mode() [mode_final](https://github.com/greenplum-db/gpdb/blob/6X_STABLE/src/backend/utils/adt/orderedsetaggs.c#L1084-L1182) [scans tuples and counts
frequencies in a loop](https://github.com/greenplum-db/gpdb/blob/6X_STABLE/src/backend/utils/adt/orderedsetaggs.c#L1124-L1166) using tuplesort_getdatum to fetch tuples.

[In case of MK tuplesort state](https://github.com/greenplum-db/gpdb/blob/6X_STABLE/src/include/utils/tuplesort.h#L453-L454) `tuplesort_getdatum` ([that is switcheroo_tuplesort_getdatum](https://github.com/greenplum-db/gpdb/blob/6X_STABLE/src/include/utils/tuplesort.h#L655)) [calls](https://github.com/greenplum-db/gpdb/blob/6X_STABLE/src/include/utils/tuplesort.h#L454)
[tuplesort_getdatum_mk](https://github.com/greenplum-db/gpdb/blob/6X_STABLE/src/backend/utils/sort/tuplesort_mk.c#L1744-L1772) that uses [tuplesort_gettuple_common_pos](https://github.com/greenplum-db/gpdb/blob/6X_STABLE/src/backend/utils/sort/tuplesort_mk.c#L1473-L1662)
to fetch the next tuple.

[There is a check for QueryFinishPending flag](https://github.com/greenplum-db/gpdb/blob/6X_STABLE/src/backend/utils/sort/tuplesort_mk.c#L1488-L1495) and when it is set
to true[ return with false](https://github.com/greenplum-db/gpdb/blob/6X_STABLE/src/backend/utils/sort/tuplesort_mk.c#L1494) (no next tuple).

If `QueryFinishPending` is true [before entry to scan tuples loop](https://github.com/greenplum-db/gpdb/blob/6X_STABLE/src/backend/utils/adt/orderedsetaggs.c#L1124-L1166)
in [mode_final](https://github.com/greenplum-db/gpdb/blob/6X_STABLE/src/backend/utils/adt/orderedsetaggs.c#L1084-L1182) then no tuple value is fetched. That leaves [last_val
unchanged from init value 0](https://github.com/greenplum-db/gpdb/blob/6X_STABLE/src/backend/utils/adt/orderedsetaggs.c#L1095) and attempting to [pfree](https://github.com/greenplum-db/gpdb/blob/6X_STABLE/src/backend/utils/adt/orderedsetaggs.c#L1169) it results in
a crash.

**Solution**

This patch checks if `last_val` is a valid pointer before attempting to pfree it.

New test verifies the fix.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
