### PR TITLE
Resolve a merge FIXME for ATExecSetDistributedBy()

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -16608,12 +16608,6 @@ ATExecExpandTableCTAS(AlterTableCmd *rootCmd, Relation rel, AlterTableCmd *cmd)
  * ALTER TABLE SET DISTRIBUTED BY
  *
  * set distribution policy for rel
- *
- * GPDB_12_MERGE_FIXME: this function used to close the relation. Previously, the
- * callers expected that, but not anymore. There are supposedly comments
- * below explaining why we have to close it, but I don't understand it.
- * I changed it so that we don't close the relation here, but I wonder why it
- * was done differently before? Was there a good reason to close it?
  */
 static void
 ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)


### PR DESCRIPTION
This commit is to confirm and remove the FIXME message that we can safely stop closing relations in `ATExecSetDistributedBy()` (already done so in 8518ed4). Detailed reason as below.

In the earliest historical commit that supported `ALTER TABLE SET DISTRIBUTE`, we needed to close relations in `ATExecSetDistributedBy()`, just before swapping the original table and temp table (`swap_relation_files()`) because `swap_relation_files()` back then needed to forget the relcache entries in order to work around some dangling smgr entry issue: https://github.com/greenplum-db/gpdb/blob/5X_STABLE/src/backend/commands/cluster.c#L1249-L1263
Therefore `ATExecSetDistributedBy()` had to close the relation: https://github.com/greenplum-db/gpdb/blob/5X_STABLE/src/backend/commands/tablecmds.c#L12209-L12216
And the caller of `ATExecSetDistributedBy()` would re-open the relation.

Later PG upstream introduced an optimization which removed `RelationForgetRelation()` from `swap_relation_files()` and we've pulled it to the master branch: b9b8831ad60f6e4bd580fe6dbe9749359298a3c4

Then, closing the relation became unnecessary. But the code continued to be there until 8518ed4f425a11f1d643a0ff1a06f271974f7071

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
