### PR TITLE
[6X] Existing reloption shouldn't affect redistribution in SET DISTRIBUTE BY

### DIFF
--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -1466,3 +1466,53 @@ select *, gp_segment_id from reorg_leaf_1_prt_p0;
  1 | 1 | 1 |             1
 (5 rows)
 
+-- When reorganize=false, we won't reorganize and this shouldn't be affected by the existing reloptions.
+CREATE TABLE public.t_reorganize_false (
+a integer,
+b integer
+) with (appendonly=false, autovacuum_enabled=false) DISTRIBUTED BY (a);
+-- Insert values which will all be on one segment
+INSERT INTO t_reorganize_false VALUES (0, generate_series(1,100));
+SELECT gp_segment_id,count(*)￼ from t_reorganize_false GROUP BY 1;
+ gp_segment_id |  ￼  
+---------------+-----
+             1 | 100
+(1 row)
+
+-- Change the distribution policy but because REORGANIZE=false, it should NOT be re-distributed 
+ALTER TABLE t_reorganize_false SET WITH (REORGANIZE=false) DISTRIBUTED RANDOMLY;
+SELECT gp_segment_id,count(*)￼ from t_reorganize_false GROUP BY 1;
+ gp_segment_id |  ￼  
+---------------+-----
+             1 | 100
+(1 row)
+
+DROP TABLE t_reorganize_false;
+-- Same rule should apply to partitioned table too
+CREATE TABLE public.t_reorganize_false (
+a integer,
+b integer
+)
+DISTRIBUTED BY (a) PARTITION BY RANGE(b)
+(
+PARTITION "00" START (0) END (1000) WITH (tablename='t_reorganize_false_0', appendonly='false', autovacuum_enabled=false),
+PARTITION "01" START (1000) END (2000) WITH (tablename='t_reorganize_false_1', appendonly='false', autovacuum_enabled=false),
+DEFAULT PARTITION def WITH (tablename='t_reorganize_false_def', appendonly='false', autovacuum_enabled=false)
+);
+-- Insert values which will all be on one segment
+INSERT INTO t_reorganize_false VALUES (0, generate_series(1,100));
+SELECT gp_segment_id,count(*) from t_reorganize_false GROUP BY 1;
+ gp_segment_id | count 
+---------------+-------
+             1 |   100
+(1 row)
+
+-- Should NOT be re-distributed
+ALTER TABLE t_reorganize_false SET WITH (REORGANIZE=false) DISTRIBUTED RANDOMLY;
+SELECT gp_segment_id,count(*) from t_reorganize_false GROUP BY 1;
+ gp_segment_id | count 
+---------------+-------
+             1 |   100
+(1 row)
+
+DROP TABLE t_reorganize_false;

--- a/src/test/regress/sql/alter_distribution_policy.sql
+++ b/src/test/regress/sql/alter_distribution_policy.sql
@@ -447,3 +447,34 @@ alter table reorg_leaf_1_prt_p0_2_prt_1 set with (reorganize=true) distributed b
 select *, gp_segment_id from reorg_leaf_1_prt_p0;
 alter table reorg_leaf_1_prt_p0_2_prt_1 set with (reorganize=true);
 select *, gp_segment_id from reorg_leaf_1_prt_p0;
+
+-- When reorganize=false, we won't reorganize and this shouldn't be affected by the existing reloptions.
+CREATE TABLE public.t_reorganize_false (
+a integer,
+b integer
+) with (appendonly=false, autovacuum_enabled=false) DISTRIBUTED BY (a);
+-- Insert values which will all be on one segment
+INSERT INTO t_reorganize_false VALUES (0, generate_series(1,100));
+SELECT gp_segment_id,count(*)￼ from t_reorganize_false GROUP BY 1;
+-- Change the distribution policy but because REORGANIZE=false, it should NOT be re-distributed 
+ALTER TABLE t_reorganize_false SET WITH (REORGANIZE=false) DISTRIBUTED RANDOMLY;
+SELECT gp_segment_id,count(*)￼ from t_reorganize_false GROUP BY 1;
+DROP TABLE t_reorganize_false;
+-- Same rule should apply to partitioned table too
+CREATE TABLE public.t_reorganize_false (
+a integer,
+b integer
+)
+DISTRIBUTED BY (a) PARTITION BY RANGE(b)
+(
+PARTITION "00" START (0) END (1000) WITH (tablename='t_reorganize_false_0', appendonly='false', autovacuum_enabled=false),
+PARTITION "01" START (1000) END (2000) WITH (tablename='t_reorganize_false_1', appendonly='false', autovacuum_enabled=false),
+DEFAULT PARTITION def WITH (tablename='t_reorganize_false_def', appendonly='false', autovacuum_enabled=false)
+);
+-- Insert values which will all be on one segment
+INSERT INTO t_reorganize_false VALUES (0, generate_series(1,100));
+SELECT gp_segment_id,count(*) from t_reorganize_false GROUP BY 1;
+-- Should NOT be re-distributed
+ALTER TABLE t_reorganize_false SET WITH (REORGANIZE=false) DISTRIBUTED RANDOMLY;
+SELECT gp_segment_id,count(*) from t_reorganize_false GROUP BY 1;
+DROP TABLE t_reorganize_false;


### PR DESCRIPTION
Backporting #13092
No major merge conflict. Code change exactly the same.

-------------

This fixes an issue where existing reloptions would cause a reorganize in
situations that it should not. We used to allow ALTER TABLE SET DISTRIBUTE WITH
clause to have additional storage options, and when they are present, we
will re-distribute data over the segments.

However since 50f2e3bbb88, we don't allow new reloptions to be supplied in the
ALTER TABLE SET DISTRIBUTED WITH clause. So this commit is really a follow-up,
removing redistribution decision making logic based on reloptions.
Also renamed new_rel_opts() to get_rel_opts() accordingly.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
