### PR TITLE
set memory allocated by malloc to 0 to fix 'error: ‘data’ may be used uninitialized'

### DIFF
--- a/src/backend/utils/hyperloglog/gp_hyperloglog.c
+++ b/src/backend/utils/hyperloglog/gp_hyperloglog.c
@@ -571,6 +571,7 @@ gp_hll_compress_dense(GpHLLCounter hloglog)
                  errmsg("out of memory"),
                  errdetail("Failed on request of size %zu.", data_rawsize)));
     }
+    bzero(data, data_rawsize);
 
     /* put all registers in a normal array  i.e. remove dense packing so
      * lz compression can work optimally */

--- a/src/backend/utils/hyperloglog/gp_hyperloglog.c
+++ b/src/backend/utils/hyperloglog/gp_hyperloglog.c
@@ -571,7 +571,7 @@ gp_hll_compress_dense(GpHLLCounter hloglog)
                  errmsg("out of memory"),
                  errdetail("Failed on request of size %zu.", data_rawsize)));
     }
-    bzero(data, data_rawsize);
+    memset(data, 0, data_rawsize);
 
     /* put all registers in a normal array  i.e. remove dense packing so
      * lz compression can work optimally */


### PR DESCRIPTION
set data with bzero in order to fix #13102 comiling error cause by GCC 11.2  [-Werror=maybe-uninitialized].
