### PR TITLE
Fix flaky failed cases autovacuum-segment

### DIFF
--- a/src/backend/access/heap/vacuumlazy.c
+++ b/src/backend/access/heap/vacuumlazy.c
@@ -285,6 +285,11 @@ lazy_vacuum_rel_heap(Relation onerel, VacuumParams *params,
 	 */
 	if (params->is_wraparound && !aggressive)
 	{
+		if (onerel->rd_rel->relisshared)
+		{
+			vac_update_relstats(onerel, onerel->rd_rel->relpages, onerel->rd_rel->reltuples,onerel->rd_rel->relallvisible,
+					onerel->rd_rel->relhasindex, onerel->rd_rel->relfrozenxid, onerel->rd_rel->relminmxid, false, true);
+		}
 		ereport(DEBUG1,
 				(errmsg("skipping redundant vacuum to prevent wraparound of table \"%s.%s.%s\"",
 						get_database_name(MyDatabaseId),


### PR DESCRIPTION
the fault 'vacuum_update_dat_frozen_xid' injected in autovacuum-segment
was not triggred until Time-out, which makes the autovacuum-segment case
failed.
the reason why the injected fault 'vacuum_update_dat_frozen_xid' was not
triggred was some shared tables such as pg_shseclabel(it's randomly, but
must be some of critical shared tables) didn't change its frozenxid in
regression.pg_class tuple, so the database 'regression'couldn't update
its frozenxid either.
the shared table pg_shseclabel was vacuumed by a concurrent vacuum but
for other database and the relfrozenxid in relcache has been updated.
the followed autovacuum worker for database 'regression' load the newest
relcache info and find that the table has been vacuumed by others. they
just skip it to prevent redundant vacuum and return, the relcache info
is different form syscache in 'regression' database.
this commit will also update the shared table's frozenxid using relcache
info when autovacuum worker find the table has been vacuumed by other
databases,and then return.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
