### PR TITLE
[6X] Close AO segment file

### DIFF
--- a/src/backend/cdb/cdbappendonlystoragewrite.c
+++ b/src/backend/cdb/cdbappendonlystoragewrite.c
@@ -503,6 +503,8 @@ AppendOnlyStorageWrite_FlushAndCloseFile(
 						storageWrite->segmentFileName,
 						storageWrite->relationName)));
 
+	FileClose(storageWrite->file);
+
 	storageWrite->file = -1;
 	storageWrite->formatVersion = -1;
 


### PR DESCRIPTION
Previously we only flushed but didn't close AO segment in
AppendOnlyStorageWrite_FlushAndCloseFile() function. It caused
file descriptors stuck in backends' cache, that could delay kernel
to free disk space after such files would be unlinked.

Back-ported from: https://github.com/greenplum-db/gpdb/commit/d3a4fa897aef820386b3cb6f2f14650aa0dcbe6c