### PR TITLE
[6X] Free disk space for dropped relations on commit.

### DIFF
--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -466,6 +466,41 @@ mdunlink(RelFileNodeBackend rnode, ForkNumber forkNum, bool isRedo, char relstor
 		mdunlinkfork(rnode, forkNum, isRedo, relstorage);
 }
 
+/*
+ * Truncate a file to release disk space.
+ */
+static int
+do_truncate(const char *path)
+{
+	int			save_errno;
+	int			ret;
+	int			fd;
+
+	/* truncate(2) would be easier here, but Windows hasn't got it */
+	fd = OpenTransientFile((char *) path, O_RDWR | PG_BINARY, 0);
+	if (fd >= 0)
+	{
+		ret = ftruncate(fd, 0);
+		save_errno = errno;
+		CloseTransientFile(fd);
+		errno = save_errno;
+	}
+	else
+		ret = -1;
+
+	/* Log a warning here to avoid repetition in callers. */
+	if (ret < 0 && errno != ENOENT)
+	{
+		save_errno = errno;
+		ereport(WARNING,
+				(errcode_for_file_access(),
+				 errmsg("could not truncate file \"%s\": %m", path)));
+		errno = save_errno;
+	}
+
+	return ret;
+}
+
 static void
 mdunlinkfork(RelFileNodeBackend rnode, ForkNumber forkNum, bool isRedo, char relstorage)
 {
@@ -479,33 +514,28 @@ mdunlinkfork(RelFileNodeBackend rnode, ForkNumber forkNum, bool isRedo, char rel
 	 */
 	if (isRedo || forkNum != MAIN_FORKNUM || RelFileNodeBackendIsTemp(rnode))
 	{
-		ret = unlink(path);
-		if (ret < 0 && errno != ENOENT)
-			ereport(WARNING,
-					(errcode_for_file_access(),
-					 errmsg("could not remove file \"%s\": %m", path)));
+		if (!RelFileNodeBackendIsTemp(rnode))
+		{
+			/* Prevent other backends' fds from holding on to the disk space */
+			ret = do_truncate(path);
+		}
+		else
+			ret = 0;
+
+		/* Next unlink the file, unless it was already found to be missing */
+		if (ret == 0 || errno != ENOENT)
+		{
+			ret = unlink(path);
+			if (ret < 0 && errno != ENOENT)
+				ereport(WARNING,
+						(errcode_for_file_access(),
+						 errmsg("could not remove file \"%s\": %m", path)));
+		}
 	}
 	else
 	{
-		/* truncate(2) would be easier here, but Windows hasn't got it */
-		int			fd;
-
-		fd = OpenTransientFile(path, O_RDWR | PG_BINARY, 0);
-		if (fd >= 0)
-		{
-			int			save_errno;
-
-			ret = ftruncate(fd, 0);
-			save_errno = errno;
-			CloseTransientFile(fd);
-			errno = save_errno;
-		}
-		else
-			ret = -1;
-		if (ret < 0 && errno != ENOENT)
-			ereport(WARNING,
-					(errcode_for_file_access(),
-					 errmsg("could not truncate file \"%s\": %m", path)));
+		/* Prevent other backends' fds from holding on to the disk space */
+		ret = do_truncate(path);
 
 		/* Register request to unlink first segment later */
 		register_unlink(rnode);
@@ -533,6 +563,17 @@ mdunlinkfork(RelFileNodeBackend rnode, ForkNumber forkNum, bool isRedo, char rel
 		for (segno = 1;; segno++)
 		{
 			sprintf(segpath, "%s.%u", path, segno);
+
+			if (!RelFileNodeBackendIsTemp(rnode))
+			{
+				/*
+				 * Prevent other backends' fds from holding on to the disk
+				 * space.
+				 */
+				if (do_truncate(segpath) < 0 && errno == ENOENT)
+					break;
+			}
+
 			if (unlink(segpath) < 0)
 			{
 				/* ENOENT is expected after the last segment... */


### PR DESCRIPTION
When committing a transaction that dropped a relation, we previously
truncated only the first segment file to free up disk space (the one
that won't be unlinked until the next checkpoint).

Truncate higher numbered segments too, even though we unlink them on
commit.  This frees the disk space immediately, even if other backends
have open file descriptors and might take a long time to get around to
handling shared invalidation events and closing them.  Also extend the
same behavior to the first segment, in recovery.

Back-patch to all supported releases.

Bug: #16663
Reported-by: Denis Patron <denis.patron@previnet.it>
Reviewed-by: Pavel Borisov <pashkin.elfe@gmail.com>
Reviewed-by: Neil Chen <carpenter.nail.cz@gmail.com>
Reviewed-by: David Zhang <david.zhang@highgo.ca>
Discussion: https://postgr.es/m/16663-fe97ccf9932fc800%40postgresql.org

See Greenplum PR #11988 for more details.

Backported from GPDB master:
https://github.com/greenplum-db/gpdb/commit/d9d15d3b7b77ff3df3e2451ceff00adafad71c26

GPDB merge conflicts:
There was a conflict where the original patch assumed that we had pending
sync request refactor which introduced the function
`register_forget_request`. GPDB 6X_STABLE does the sync request cancel
before the truncate. See this stackflow for more information:
CommitTransaction => smgrDoPendingDeletes => smgrdounlinkall => mdunlink
=> ForgetRelationFsyncRequests


---
We reproduced the issue following the steps from this pgsql-hacker thread:
https://www.postgresql.org/message-id/160624299337.7563.13562988821961887884.pgcf%40coridan.postgresql.org


### Without fix
```
gaurabd-a03:12812 gaurabd$ du -sh 16387*
  0B    16387
gaurabd-a03:12812 gaurabd$ lsof -nP | grep 16387 | grep dbfast1
postgres  68415 gaurabd    6u      REG                1,5          0            52173285 /Users/gaurabd/workspace/gpdb-6xstable/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0/base/12812/16387
postgres  68415 gaurabd    8u      REG                1,5  710541312            52176159 /Users/gaurabd/workspace/gpdb-6xstable/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0/base/12812/16387.1
```

### With fix
```
gaurabd-a03:12812 gaurabd$ du -sh 16391*
  0B    16391
gaurabd-a03:12812 gaurabd$ lsof -nP | grep 16391 | grep dbfast1
postgres  79219 gaurabd   12u      REG                1,5          0            52180035 /Users/gaurabd/workspace/gpdb-6xstable/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0/base/12812/16391
postgres  79219 gaurabd   13u      REG                1,5          0            52181277 /Users/gaurabd/workspace/gpdb-6xstable/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0/base/12812/16391.1
gaurabd-a03:12812 gaurabd$
```