### PR TITLE
Fix ORCA crash due to nested optimization calls

### DIFF
--- a/src/backend/gpopt/CGPOptimizer.cpp
+++ b/src/backend/gpopt/CGPOptimizer.cpp
@@ -251,4 +251,12 @@ TerminateGPOPT()
 }
 }
 
+extern "C" {
+bool
+InProgressGPOPT()
+{
+	return gpos::CWorker::Self() != NULL;
+}
+}
+
 // EOF

--- a/src/backend/optimizer/plan/orca.c
+++ b/src/backend/optimizer/plan/orca.c
@@ -35,6 +35,8 @@
 /* GPORCA entry point */
 extern PlannedStmt * GPOPTOptimizedPlan(Query *parse, bool *had_unexpected_failure);
 
+extern bool InProgressGPOPT();
+
 /*
  * Logging of optimization outcome
  */
@@ -90,6 +92,14 @@ optimize_query(Query *parse, ParamListInfo boundParams)
 	List		   *invalItems;
 	ListCell	   *lc;
 	ListCell	   *lp;
+
+	/*
+	 * ORCA doesn't currently support nested optimization requests. This could
+	 * happen while evaluating a UDF used for static partition elimination.
+	 * Instead, fallback to planner.
+	 */
+	if (InProgressGPOPT())
+		return NULL;
 
 	/*
 	 * Initialize a dummy PlannerGlobal struct. ORCA doesn't use it, but the

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -73,6 +73,7 @@ static void process_startup_options(Port *port, bool am_superuser);
 #ifdef USE_ORCA
 extern void InitGPOPT();
 extern void TerminateGPOPT();
+extern void InProgressGPOPT();
 #endif
 
 

--- a/src/include/gpopt/CGPOptimizer.h
+++ b/src/include/gpopt/CGPOptimizer.h
@@ -49,6 +49,7 @@ extern PlannedStmt *GPOPTOptimizedPlan(Query *query,
 extern char *SerializeDXLPlan(Query *query);
 extern void InitGPOPT();
 extern void TerminateGPOPT();
+extern bool InProgressGPOPT();
 }
 
 #endif	// CGPOptimizer_H

--- a/src/test/regress/expected/bfv_partition.out
+++ b/src/test/regress/expected/bfv_partition.out
@@ -1934,6 +1934,66 @@ SELECT * FROM part_tbl WHERE profile_key = 99999999;
 (2 rows)
 
 DROP TABLE part_tbl;
+-- A user-defined fuction inside partition selection that needs to be
+-- optimized, should perform still SPE and should not fall back.
+-- start_ignore
+drop table if exists pt;
+NOTICE:  table "pt" does not exist, skipping
+-- end_ignore
+CREATE TABLE pt(a int) PARTITION BY RANGE(a) (START(0)  END(10) EVERY(1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_1" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_2" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_3" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_4" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_5" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_6" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_7" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_8" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_9" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_10" for table "pt"
+CREATE OR REPLACE FUNCTION to_date(integer, text) RETURNS date AS $$
+BEGIN
+   RETURN to_date($1::text, $2);
+END;
+$$ LANGUAGE PLPGSQL STABLE;
+INSERT INTO pt SELECT generate_series(0, 9);
+EXPLAIN SELECT * FROM pt WHERE a = to_number((to_date(20210120 / 1, 'yyyymmdd'))::varchar , '9');
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..265550.00 rows=963 width=4)
+   ->  Append  (cost=0.00..265550.00 rows=321 width=4)
+         ->  Seq Scan on pt_1_prt_1 pt  (cost=0.00..26555.00 rows=33 width=4)
+               Filter: a::numeric = to_number(to_date(20210120 / 1, 'yyyymmdd'::text)::character varying::text, '9'::text)
+         ->  Seq Scan on pt_1_prt_2 pt  (cost=0.00..26555.00 rows=33 width=4)
+               Filter: a::numeric = to_number(to_date(20210120 / 1, 'yyyymmdd'::text)::character varying::text, '9'::text)
+         ->  Seq Scan on pt_1_prt_3 pt  (cost=0.00..26555.00 rows=33 width=4)
+               Filter: a::numeric = to_number(to_date(20210120 / 1, 'yyyymmdd'::text)::character varying::text, '9'::text)
+         ->  Seq Scan on pt_1_prt_4 pt  (cost=0.00..26555.00 rows=33 width=4)
+               Filter: a::numeric = to_number(to_date(20210120 / 1, 'yyyymmdd'::text)::character varying::text, '9'::text)
+         ->  Seq Scan on pt_1_prt_5 pt  (cost=0.00..26555.00 rows=33 width=4)
+               Filter: a::numeric = to_number(to_date(20210120 / 1, 'yyyymmdd'::text)::character varying::text, '9'::text)
+         ->  Seq Scan on pt_1_prt_6 pt  (cost=0.00..26555.00 rows=33 width=4)
+               Filter: a::numeric = to_number(to_date(20210120 / 1, 'yyyymmdd'::text)::character varying::text, '9'::text)
+         ->  Seq Scan on pt_1_prt_7 pt  (cost=0.00..26555.00 rows=33 width=4)
+               Filter: a::numeric = to_number(to_date(20210120 / 1, 'yyyymmdd'::text)::character varying::text, '9'::text)
+         ->  Seq Scan on pt_1_prt_8 pt  (cost=0.00..26555.00 rows=33 width=4)
+               Filter: a::numeric = to_number(to_date(20210120 / 1, 'yyyymmdd'::text)::character varying::text, '9'::text)
+         ->  Seq Scan on pt_1_prt_9 pt  (cost=0.00..26555.00 rows=33 width=4)
+               Filter: a::numeric = to_number(to_date(20210120 / 1, 'yyyymmdd'::text)::character varying::text, '9'::text)
+         ->  Seq Scan on pt_1_prt_10 pt  (cost=0.00..26555.00 rows=33 width=4)
+               Filter: a::numeric = to_number(to_date(20210120 / 1, 'yyyymmdd'::text)::character varying::text, '9'::text)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(24 rows)
+
+SELECT * FROM pt WHERE a = to_number((to_date(20210120 / 1, 'yyyymmdd'))::varchar , '9');
+ a 
+---
+ 0
+(1 row)
+
 -- CLEANUP
 -- start_ignore
 drop schema if exists bfv_partition;

--- a/src/test/regress/expected/bfv_partition_optimizer.out
+++ b/src/test/regress/expected/bfv_partition_optimizer.out
@@ -1935,6 +1935,49 @@ SELECT * FROM part_tbl WHERE profile_key = 99999999;
 (2 rows)
 
 DROP TABLE part_tbl;
+-- A user-defined fuction inside partition selection that needs to be
+-- optimized, should perform still SPE and should not fall back.
+-- start_ignore
+drop table if exists pt;
+NOTICE:  table "pt" does not exist, skipping
+-- end_ignore
+CREATE TABLE pt(a int) PARTITION BY RANGE(a) (START(0)  END(10) EVERY(1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_1" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_2" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_3" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_4" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_5" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_6" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_7" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_8" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_9" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_10" for table "pt"
+CREATE OR REPLACE FUNCTION to_date(integer, text) RETURNS date AS $$
+BEGIN
+   RETURN to_date($1::text, $2);
+END;
+$$ LANGUAGE PLPGSQL STABLE;
+INSERT INTO pt SELECT generate_series(0, 9);
+EXPLAIN SELECT * FROM pt WHERE a = to_number((to_date(20210120 / 1, 'yyyymmdd'))::varchar , '9');
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+   ->  Sequence  (cost=0.00..431.00 rows=1 width=4)
+         ->  Partition Selector for pt (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+               Partitions selected: 1 (out of 10)
+         ->  Dynamic Table Scan on pt (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=4)
+               Filter: a::numeric = to_number(to_date(20210120 / 1, 'yyyymmdd'::text)::character varying::text, '9'::text)
+ Optimizer status: PQO version 3.122.0
+(7 rows)
+
+SELECT * FROM pt WHERE a = to_number((to_date(20210120 / 1, 'yyyymmdd'))::varchar , '9');
+ a 
+---
+ 0
+(1 row)
+
 -- CLEANUP
 -- start_ignore
 drop schema if exists bfv_partition;

--- a/src/test/unit/mock/gpopt_mock.c
+++ b/src/test/unit/mock/gpopt_mock.c
@@ -57,3 +57,9 @@ TerminateGPOPT ()
 {
 	elog(ERROR, "mock implementation of TerminateGPOPT called");
 }
+
+void
+InProgressGPOPT()
+{
+	elog(ERROR, "mock implementation of InProgressGPOPT called");
+}


### PR DESCRIPTION
Following SQL produced crash:

```
CREATE TABLE pt(a int) PARTITION BY RANGE(a) (START(0)  END(10) EVERY(1));
CREATE OR REPLACE FUNCTION to_date(integer, text) RETURNS DATE AS $$
    SELECT to_date($1::text,$2);
$$ LANGUAGE SQL IMMUTABLE;
SELECT * FROM pt WHERE a = to_number((to_date(20210120/1, 'yyyymmdd'))::varchar , '9');
```

In above scenario, ORCA tries to evaluate the predicate for static
partition elimination on the partitioned table. In order to do that, it
must plan, optimize, and execute the statements inside the user-defined
function. Issue is that ORCA does not allow nested optimization calls.

Fix is to fallback to planner in case of nested optimization requests. This
produces the following plan with static partition elimination:

```
                             QUERY PLAN
--------------------------------------------------------------------------
 Gather Motion 3:1
   ->  Sequence
         ->  Partition Selector for pt (dynamic scan id: 1)
               Partitions selected: 1 (out of 10)
         ->  Dynamic Table Scan on pt (dynamic scan id: 1)
               Filter: a::numeric = (to_number(((to_date(20210120 / 1, ...
 Optimizer status: PQO version 3.122.0
(7 rows)
```

--

NOTE: Issue has not been reproduced in master or 6X because preprocess_query_optimizer has been smart enough to optimize the issue away.