### PR TITLE
Fix shared snapshot collision 

### DIFF
--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -723,40 +723,25 @@ DisconnectAndDestroyAllGangs(bool resetSession)
  * Destroy all idle (i.e available) QEs.
  * It is always safe to get rid of the reader QEs.
  *
- * If we are not in a transaction and we do not have a TempNamespace, destroy
- * writer QEs as well.
- *
  * call only from an idle session.
  */
 void DisconnectAndDestroyUnusedQEs(void)
 {
-	if (IsTransactionOrTransactionBlock() || TempNamespaceOidIsValid())
-	{
-		/*
-		 * If we are in a transaction, we can't release the writer gang,
-		 * as this will abort the transaction.
-		 *
-		 * If we have a TempNameSpace, we can't release the writer gang, as this
-		 * would drop any temp tables we own.
-		 *
-		 * Since we are idle, any reader gangs will be available but not allocated.
-		 */
-		cdbcomponent_cleanupIdleQEs(false);
-	}
-	else
-	{
-		/*
-		 * Get rid of ALL gangs... Readers and primary writer.
-		 * After this, we have no resources being consumed on the segDBs at all.
-		 *
-		 * Our session wasn't destroyed due to an fatal error or FTS action, so
-		 * we don't need to do anything special.  Specifically, we DON'T want
-		 * to act like we are now in a new session, since that would be confusing
-		 * in the log.
-		 *
-		 */
-		cdbcomponent_cleanupIdleQEs(true);
-	}
+	/*
+	 * Only release reader gangs, never writer gang. This helps to avoid the
+	 * shared snapshot collision error on next gang creation from hitting if
+	 * QE processes are slow to exit due to this cleanup.
+	 *
+	 * If we are in a transaction, we can't release the writer gang also, as
+	 * this will abort the transaction.
+	 *
+	 * If we have a TempNameSpace, we can't release the writer gang also, as
+	 * this would drop any temp tables we own.
+	 *
+	 * Since we are idle, any reader gangs will be available but not
+	 * allocated.
+	 */
+	cdbcomponent_cleanupIdleQEs(false);
 }
 
 /*

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -987,6 +987,8 @@ ProcKill(int code, Datum arg)
 
 	Assert(MyProc != NULL);
 
+	SIMPLE_FAULT_INJECTOR("proc_kill");
+
 	/* Make sure we're out of the sync rep lists */
 	SyncRepCleanupAtProcExit();
 

--- a/src/backend/utils/time/sharedsnapshot.c
+++ b/src/backend/utils/time/sharedsnapshot.c
@@ -379,7 +379,10 @@ retry:
 		SharedSnapshotSlot *testSlot = &arrayP->slots[i];
 
 		if (testSlot->slotindex > arrayP->maxSlots)
+		{
+			LWLockRelease(SharedSnapshotLock);
 			elog(ERROR, "Shared Local Snapshots Array appears corrupted: %s", SharedSnapshotDump());
+		}
 
 		if (testSlot->slotid == slotId)
 		{
@@ -403,8 +406,10 @@ retry:
 		}
 		else
 		{
+			char *slot_dump = SharedSnapshotDump();
+			LWLockRelease(SharedSnapshotLock);
 			elog(ERROR, "writer segworker group shared snapshot collision on id %d. Slot array dump: %s",
-				 slotId, SharedSnapshotDump());
+				 slotId, slot_dump);
 		}
 	}
 

--- a/src/test/isolation2/input/idle_gang_cleaner.source
+++ b/src/test/isolation2/input/idle_gang_cleaner.source
@@ -1,0 +1,35 @@
+-- This test is used to test if the writer gangs will be 
+-- reused and reader gangs will be cleaned after 
+-- gp_vmem_idle_resource_timeout. Since we no longer 
+-- clean up the idle writer gangs after the timeout, 
+-- no snapshot collision error should occur.
+
+CREATE OR REPLACE FUNCTION cleanupAllGangs() RETURNS BOOL
+AS '@abs_builddir@/../regress/regress.so', 'cleanupAllGangs' LANGUAGE C;
+set gp_vmem_idle_resource_timeout to '0.5s';
+set gp_snapshotadd_timeout to 0;
+
+create table target_session_id_t(target_session_id int) DISTRIBUTED REPLICATED;
+insert into target_session_id_t values(current_setting('gp_session_id')::int);
+
+create table idle_gang_cleaner_t (c1 int, c2 int);
+select cleanupAllGangs();
+
+0U: select gp_inject_fault('proc_kill', 'suspend', 2, target_session_id) from target_session_id_t;
+
+select count(*) from idle_gang_cleaner_t a
+  join idle_gang_cleaner_t b using (c2)
+;
+-- Start a new session to wait_until_triggered, avoid wait_until_triggered blocking IdleGangTimeoutHandler.
+0U: select gp_inject_fault('proc_kill', 'wait_until_triggered', '','','', 1, 1, 1, 2 ,target_session_id) from target_session_id_t;
+
+select count(*) from idle_gang_cleaner_t a
+  join idle_gang_cleaner_t b using (c2)
+;
+
+0U: select gp_inject_fault('proc_kill', 'reset', 2, target_session_id) from target_session_id_t;
+
+drop table target_session_id_t;
+drop table idle_gang_cleaner_t;
+reset gp_vmem_idle_resource_timeout;
+reset gp_snapshotadd_timeout;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -213,6 +213,7 @@ test: pg_basebackup
 test: pg_basebackup_with_tablespaces
 test: pg_basebackup_large_database_oid
 test: enable_autovacuum
+test: idle_gang_cleaner
 
 test: segwalrep/die_commit_pending_replication
 

--- a/src/test/isolation2/output/idle_gang_cleaner.source
+++ b/src/test/isolation2/output/idle_gang_cleaner.source
@@ -1,0 +1,64 @@
+-- This test is used to test if the writer gangs will be
+-- reused and reader gangs will be cleaned after
+-- gp_vmem_idle_resource_timeout. Since we no longer
+-- clean up the idle writer gangs after the timeout,
+-- no snapshot collision error should occur.
+
+CREATE OR REPLACE FUNCTION cleanupAllGangs() RETURNS BOOL AS '@abs_builddir@/../regress/regress@DLSUFFIX@', 'cleanupAllGangs' LANGUAGE C;
+CREATE
+set gp_vmem_idle_resource_timeout to '0.5s';
+SET
+set gp_snapshotadd_timeout to 0;
+SET
+
+create table target_session_id_t(target_session_id int) DISTRIBUTED REPLICATED;
+CREATE
+insert into target_session_id_t values(current_setting('gp_session_id')::int);
+INSERT 1
+
+create table idle_gang_cleaner_t (c1 int, c2 int);
+CREATE
+select cleanupAllGangs();
+ cleanupallgangs 
+-----------------
+ t               
+(1 row)
+
+0U: select gp_inject_fault('proc_kill', 'suspend', 2, target_session_id) from target_session_id_t;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+select count(*) from idle_gang_cleaner_t a join idle_gang_cleaner_t b using (c2) ;
+ count 
+-------
+ 0     
+(1 row)
+-- Start a new session to wait_until_triggered, avoid wait_until_triggered blocking IdleGangTimeoutHandler.
+0U: select gp_inject_fault('proc_kill', 'wait_until_triggered', '','','', 1, 1, 1, 2 ,target_session_id) from target_session_id_t;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+select count(*) from idle_gang_cleaner_t a join idle_gang_cleaner_t b using (c2) ;
+ count 
+-------
+ 0     
+(1 row)
+
+0U: select gp_inject_fault('proc_kill', 'reset', 2, target_session_id) from target_session_id_t;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+drop table target_session_id_t;
+DROP
+drop table idle_gang_cleaner_t;
+DROP
+reset gp_vmem_idle_resource_timeout;
+RESET
+reset gp_snapshotadd_timeout;
+RESET


### PR DESCRIPTION
* Fix shared snapshot collision (cherry picked from commit https://github.com/greenplum-db/gpdb/commit/cc58ac6afec2587ae7afb489f59fc7c1d1949325)

> FATAL "writer segworker group shared snapshot collision" happens when
gp_vmem_idle_time reached, the QD will clean the idle writer and
reader gang and close the connection to the QE, QE will quit in an
async way. QD processes remain. If QE cannot quit before QD starts a
new command, it will find the same session id in the shared snapshot
and collision will happen. QE session quit may take time due to
ProcArrayLock contention.

> Hence, this commit only cleans up reader gangs and not writer gang
during idle cleanup session timeout. This way no need to remove and
readd shared snapshot slot on QEs and hence avoids the collision
possibility.

* add testcase for commit https://github.com/greenplum-db/gpdb/commit/cc58ac6afec2587ae7afb489f59fc7c1d1949325



## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
