### PR TITLE
fix gpload occasional error to count formatting error

### DIFF
--- a/gpMgmt/bin/gpload_test/.gitignore
+++ b/gpMgmt/bin/gpload_test/.gitignore
@@ -9,6 +9,7 @@ gpload2/data_file.txt.gz
 gpload2/data_file1.txt
 gpload2/data_file1.txt.bz2
 gpload2/data_file2.txt
+gpload2/data_file.csv
 GPTest.pm
 gpstringsubs.pl
 gpdiff.pl

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_legacy.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_legacy.py
@@ -182,23 +182,22 @@ def test_21_gpload_formatOpts_escape():
     copy_data('external_file_01.txt','data_file.txt')
     write_config_file(reuse_tables=True, format='text', file='data_file.txt',table='texttable',escape="E'\\\\'")
 
-# case 22 is flaky on concourse. It may report: Fatal Python error: GC object already tracked during testing.
-# This is seldom issue. we can't reproduce it locally, so we disable it, in order to not blocking others
-#def test_22_gpload_error_count(self):
-#    "22  gpload error count"
-#    f = open(mkpath('query22.sql'),'a')
-#    f.write("\\! psql -d reuse_gptest -c 'select count(*) from csvtable;'")
-#    f.close()
-#    f = open(mkpath('data/large_file.csv'),'w')
-#    for i in range(0, 10000):
-#        if i % 2 == 0:
-#            f.write('1997,Ford,E350,"ac, abs, moon",3000.00,a\n')
-#        else:
-#            f.write('1997,Ford,E350,"ac, abs, moon",3000.00\n')
-#    f.close()
-#    copy_data('large_file.csv','data_file.csv')
-#    write_config_file(reuse_flag='true',formatOpts='csv',file='data_file.csv',table='csvtable',format='csv',delimiter="','",log_errors=True,error_limit='90000000')
-#   self.doTest(22)
+@pytest.mark.order(22)
+@prepare_before_test(num=22)
+def test_22_gpload_error_count():
+   "22  gpload error count"
+   f = open(mkpath('query22.sql'),'a')
+   f.write("\\! psql -d reuse_gptest -c 'select count(*) from csvtable;'")
+   f.close()
+   f = open(mkpath('large_file.csv'),'w')
+   for i in range(0, 10000):
+       if i % 2 == 0:
+           f.write('1997,Ford,E350,"ac, abs, moon",3000.00,a\n')
+       else:
+           f.write('1997,Ford,E350,"ac, abs, moon",3000.00\n')
+   f.close()
+   copy_data('../large_file.csv','data_file.csv')
+   write_config_file(reuse_tables=True,format='csv',file='data_file.csv',table='csvtable',delimiter="','",log_errors=True,error_limit='90000000')
 
 @pytest.mark.order(23)
 @prepare_before_test(num=23)

--- a/gpMgmt/bin/pythonSrc/PyGreSQL-4.0/pgmodule.c
+++ b/gpMgmt/bin/pythonSrc/PyGreSQL-4.0/pgmodule.c
@@ -2903,6 +2903,8 @@ static char pg_notices__doc__[] =
 static void 
 notice_processor(void *arg, const char *message)
 {
+	/* require a GIL to avoid multi threads access this code */
+	PyGILState_STATE gstate = PyGILState_Ensure();
 	pgobject *self = (pgobject *) arg;
 	PyObject *pymsg;
 
@@ -2920,6 +2922,7 @@ notice_processor(void *arg, const char *message)
 	/* If we are at capacity, remove the head element */
 	if (PyList_Size(self->notices) > MAX_BUFFERED_NOTICES)
 		PySequence_DelItem(self->notices, 0);
+	PyGILState_Release(gstate);
 }
  
 static PyObject *


### PR DESCRIPTION
1. Recover gpload test case 22. It was a flaky case about gpload count formatting errors.

2. Ask for a GIL (global interpreter lock) during function notice_processor()
In CPython, GIL is a mutex that prevents multiple native threads from executing Python bytecodes at once. Threads created by low-level C codes also need GIL to do something to python objects.
Pygresql will fork a thread to process notices and call notice_processor() after finishing the query. So we need to ask for GIL to process notices and store them in python objects.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
