### PR TITLE
[6X backport] ORCA: avoid returning output of a CTE producer (#12776)

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -3535,6 +3535,7 @@ CTranslatorDXLToPlStmt::TranslateDXLCTEProducerToSharedScan(
 	// create the shared input scan representing the CTE Producer
 	ShareInputScan *shared_input_scan = MakeNode(ShareInputScan);
 	shared_input_scan->share_id = cte_id;
+	shared_input_scan->discard_output = true;
 	Plan *plan = &(shared_input_scan->scan.plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
@@ -3747,6 +3748,7 @@ CTranslatorDXLToPlStmt::TranslateDXLCTEConsumerToSharedScan(
 
 	ShareInputScan *share_input_scan_cte_consumer = MakeNode(ShareInputScan);
 	share_input_scan_cte_consumer->share_id = cte_id;
+	share_input_scan_cte_consumer->discard_output = false;
 
 	Plan *plan = &(share_input_scan_cte_consumer->scan.plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();

--- a/src/backend/optimizer/plan/planshare.c
+++ b/src/backend/optimizer/plan/planshare.c
@@ -27,7 +27,7 @@ int get_plan_share_id(Plan *p)
 {
 	if(IsA(p, Material))
 		return ((Material *) p)->share_id;
-	
+
 	if(IsA(p, Sort))
 		return ((Sort *) p)->share_id;
 
@@ -52,7 +52,7 @@ ShareType get_plan_share_type(Plan *p)
 {
 	if(IsA(p, Material))
 		return ((Material *) p)->share_type;
-	
+
 	if(IsA(p, Sort))
 		return ((Sort *) p)->share_type ;
 
@@ -127,7 +127,7 @@ void incr_plan_nsharer_xslice(Plan *p)
 	}
 }
 
-static ShareInputScan *make_shareinputscan(PlannerInfo *root, Plan *inputplan) 
+static ShareInputScan *make_shareinputscan(PlannerInfo *root, Plan *inputplan)
 {
 	ShareInputScan *sisc = NULL;
 	Path sipath;
@@ -153,6 +153,7 @@ static ShareInputScan *make_shareinputscan(PlannerInfo *root, Plan *inputplan)
 	set_plan_share_type((Plan *) sisc, get_plan_share_type(inputplan));
 	set_plan_share_id((Plan *) sisc, get_plan_share_id(inputplan));
 	sisc->driver_slice = -1;
+    sisc->discard_output = false;
 
 	sisc->scan.plan.qual = NIL;
 	sisc->scan.plan.righttree = NULL;
@@ -185,7 +186,7 @@ prepare_plan_for_sharing(PlannerInfo *root, Plan *common)
 	{
 		shared = common->lefttree;
 	}
-	
+
 	else if(IsA(common, Material))
 	{
 		Material *m = (Material *) common;
@@ -220,7 +221,7 @@ prepare_plan_for_sharing(PlannerInfo *root, Plan *common)
 		shared->plan_rows = common->plan_rows;
 		shared->plan_width = common->plan_width;
 		shared->dispatch = common->dispatch;
-		shared->flow = copyObject(common->flow); 
+		shared->flow = copyObject(common->flow);
 		shared->extParam = bms_copy(common->extParam);
 		shared->allParam = bms_copy(common->allParam);
 
@@ -275,7 +276,7 @@ share_plan(PlannerInfo *root, Plan *common, int numpartners)
 /*
  * Return the total cost of sharing common numpartner times.
  * If the planner need to make a decision whether the common subplan should be shared
- * or should be duplicated, planner should compare the cost returned by this function 
+ * or should be duplicated, planner should compare the cost returned by this function
  * against common->total_cost * numpartners.
  */
 Cost cost_share_plan(Plan *common, PlannerInfo *root, int numpartners)

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -979,6 +979,9 @@ typedef struct ShareInputScan
 	ShareType 	share_type;
 	int 		share_id;
 	int 		driver_slice;   	/* slice id that will execute the underlying material/sort */
+
+    /* Discard the scan output? True for ORCA CTE producer, false otherwise. */
+    bool        discard_output;
 } ShareInputScan;
 
 /* ----------------


### PR DESCRIPTION
When dealing with queries which have CTE and result set being used
more than once, ORCA produces a plan with Sequence Node and
ShareInputScan Node. Here is an example:

explain (costs off) with tmp_t as (select id from test) select a.id from tmp_t a join tmp_t b on a.id = b.id;
```
                          QUERY PLAN
 ------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   ->  Sequence
         ->  Shared Scan (share slice:id 1:0)
               ->  Seq Scan on test
         ->  Hash Join
               Hash Cond: (share0_ref3.id = share0_ref2.id)
               ->  Shared Scan (share slice:id 1:0)
               ->  Hash
                     ->  Shared Scan (share slice:id 1:0)
 Optimizer: Pivotal Optimizer (GPORCA)
(10 rows)
```

This plan has three ShareInputScan nodes: one producer and two
consumers, all of them read from the tuplestore and return tuples to
upper node.  However, the CTE producer does not need to do so, because
the Sequence Node only receives the last subplan's output tuples.

When tuplestore is small, the extra read from the CTE producer is at
low cost, but when tuplestore is huge, this read is heavy and would
cause bad performance of the entire query.

This commit adds a flag discard_output in ShareInputScan plan node to
indicate when a ShareInputScan can avoid reading from tuplestore and
return early. The flag is set to true by ORCA when translating CTE producer,
and set to false elsewhere.

Fixes #12772

Co-authored-by: wuyuhao28 <wuyuhao28@github.com>
Co-authored-by: Alexandra Wang <walexandra@vmware.com>
Reviewed-by: Zhenghua Lyu <kainwen@gmail.com>
Reviewed-by: Shreedhar Hardikar <shardikar@vmware.com>
(cherry picked from commit 1b5be8cc5be9bf9e55d381b239cc9037c81eb340)

