### PR TITLE
Refactoring encoding related code and resolve related FIXMEs

### DIFF
--- a/src/backend/catalog/pg_attribute_encoding.c
+++ b/src/backend/catalog/pg_attribute_encoding.c
@@ -146,6 +146,36 @@ get_rel_attoptions(Oid relid, AttrNumber max_attno)
 }
 
 /*
+ * Given a relation, get all column encodings for that relation as a list of
+ * ColumnReferenceStorageDirective structures.
+ */
+List *
+rel_get_column_encodings(Relation rel)
+{
+	List **colencs = RelationGetUntransformedAttributeOptions(rel);
+	List *out = NIL;
+
+	if (colencs)
+	{
+		AttrNumber attno;
+
+		for (attno = 0; attno < RelationGetNumberOfAttributes(rel); attno++)
+		{
+			if (colencs[attno] && !TupleDescAttr(rel->rd_att, attno)->attisdropped)
+			{
+				ColumnReferenceStorageDirective *d =
+					makeNode(ColumnReferenceStorageDirective);
+				d->column = pstrdup(NameStr(TupleDescAttr(rel->rd_att, attno)->attname));
+				d->encoding = colencs[attno];
+		
+				out = lappend(out, d);
+			}
+		}
+	}
+	return out;
+}
+
+/*
  * Add pg_attribute_encoding entries for newrelid. Make them identical to those
  * stored for oldrelid.
  */

--- a/src/backend/catalog/pg_compression.c
+++ b/src/backend/catalog/pg_compression.c
@@ -45,15 +45,6 @@
 #include "utils/syscache.h"
 #include "utils/faultinjector.h"
 
-/*
- * GPDB_12_MERGE_FIXME:
- *		This enumaration does not fit in pg_compression. Also it should probably
- *		be treated as a new reloption kind and be unified in reloptions_gp
- */
-/* names we expect to see in ENCODING clauses */
-char *storage_directive_names[] = {"compresstype", "compresslevel",
-								   "blocksize", NULL};
-
 
 #ifdef HAVE_LIBZ
 /* Internal state for zlib */
@@ -536,85 +527,3 @@ compresstype_is_valid(char *comptype)
 	return false;
 }
 
-/*
- * GPDB_12_MERGE_FIXME:
- *		This function does not fit pg_compression and should probably be moved
- *		to pg_attribute_encoding or reloptions_gp.
- *
- *		The comment of the function does not match what the function is actually
- *		doing. Especially for blocksize, it is impossible for the value to be
- *		unset if an appendonly relation, hence the default is always ignored.
- *
- *		Currently used only in reloptions_gp.
- */
-/*
- * Make encoding (compresstype = ..., blocksize=...) based on
- * currently configured defaults.
- */
-List *
-default_column_encoding_clause(Relation rel)
-{
-	DefElem *e1, *e2, *e3;
-	const StdRdOptions *ao_opts = currentAOStorageOptions();
-	bool		appendonly;
-	int32		blocksize = -1;
-	int16		compresslevel = 0;
-	char	   *compresstype = NULL;
-	NameData	compresstype_nd;
-
-	appendonly = rel && RelationIsAppendOptimized(rel);
-	if (appendonly)
-	{
-		GetAppendOnlyEntryAttributes(RelationGetRelid(rel),
-									 &blocksize,
-									 NULL,
-									 &compresslevel,
-									 NULL,
-									 &compresstype_nd);
-		compresstype = NameStr(compresstype_nd);
-	}
-
-	if (compresstype && compresstype[0])
-		e1 = makeDefElem("compresstype", (Node *) makeString(pstrdup(compresstype)), -1);
-	else if (ao_opts->compresstype[0])
-		e1 = makeDefElem("compresstype", (Node *) makeString(pstrdup(ao_opts->compresstype)), -1);
-	else
-		e1 = makeDefElem("compresstype", (Node *) makeString("none"), -1);
-
-	if (appendonly)
-		e2 = makeDefElem("blocksize", (Node *) makeInteger(blocksize), -1);
-	else if (ao_opts->blocksize != 0)
-		e2 = makeDefElem("blocksize", (Node *) makeInteger(ao_opts->blocksize), -1);
-	else
-		e2 = makeDefElem("blocksize", (Node *) makeInteger(AO_DEFAULT_BLOCKSIZE), -1);
-
-	if (appendonly && compresslevel != 0)
-		e3 = makeDefElem("compresslevel", (Node *) makeInteger(compresslevel), -1);
-	else if (ao_opts->compresslevel != 0)
-		e3 = makeDefElem("compresslevel", (Node *) makeInteger(ao_opts->compresslevel), -1);
-	else
-		e3 = makeDefElem("compresslevel", (Node *) makeInteger(AO_DEFAULT_COMPRESSLEVEL), -1);
-
-	return list_make3(e1, e2, e3);
-}
-
-/*
- * GPDB_12_MERGE_FIXME:
- *		This function does not fit pg_compression and should probably be moved
- *		to pg_attribute_encoding or reloptions_gp.
- *
- *		Currently used only in typecmds.c
- */
-bool
-is_storage_encoding_directive(char *name)
-{
-	int i = 0;
-
-	while (storage_directive_names[i])
-	{
-		if (strcmp(name, storage_directive_names[i]) == 0)
-			return true;
-		i++;
-	}
-	return false;
-}

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -2414,12 +2414,6 @@ makeObjectName(const char *name1, const char *name2, const char *label)
 		overhead += strlen(label) + 1;
 
 	availchars = NAMEDATALEN - 1 - overhead;
-
-	/* GPDB_12_MERGE_FIXME: we're hitting this assertion with some SPLIT PARTITION
-	 * commands in regression tests.
-	 */
-	if (availchars <= 0)
-		elog(ERROR, "partition name too long");
 	Assert(availchars > 0);		/* else caller chose a bad label */
 
 	/*

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -949,50 +949,30 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId,
 	 *
 	 * This is done in dispatcher (and in utility mode). In QE, we receive
 	 * the already-processed options from the QD.
-	 *
-	 * GPDB_12_MERGE_FIXME:
-	 * 		Try to handle attribute encodings in a unified way under the same
-	 * 		interface for CREATE/ALTER statements and remove the diff footprint
-	 * 		with upstream.
-	 *
-	 *		One observed discrepancy between the two statements regarding
-	 *		precedence of, command specific options, environment (gucs), type
-	 *		specific encodings and relation wide options.
 	 */
 	if ((relkind == RELKIND_RELATION || relkind == RELKIND_MATVIEW ||
 		 relkind == RELKIND_PARTITIONED_TABLE) &&
 		Gp_role != GP_ROLE_EXECUTE)
 	{
-		bool		found_enc;
-
-		stmt->attr_encodings = transformAttributeEncoding(schema,
-														  stmt->attr_encodings,
-														  stmt->options,
-														  relkind == RELKIND_PARTITIONED_TABLE,
-														  &found_enc);
-		if (amHandlerOid != AO_COLUMN_TABLE_AM_HANDLER_OID)
-		{
-			/*
-			 * ENCODING options were specified, but the table is not
-			 * column-oriented.
-			 *
-			 * That's normally an error. But if we're creating a partition as
-			 * part of a CREATE TABLE ... PARTITION BY ... command, ignore the
-			 * ENCODING options instead. The parent table might be AOCS, while
-			 * some of the partitions are not, or vice versa, so options can
-			 * make sense for some parts of the partition hierarchy, even if
-			 * it doesn't for this partition.
-			 */
-			if (found_enc && !stmt->partbound && !stmt->partspec)
-			{
-				ereport(ERROR,
-						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						 errmsg("ENCODING clause only supported with column oriented tables")));
-			}
-
-			if (relkind != RELKIND_PARTITIONED_TABLE)
-				stmt->attr_encodings = NIL;
-		}
+		/*
+		 * Note that we disallow encoding clauses for non-AOCO table
+		 * besides only one exception: if we're creating a partition as
+		 * part of a CREATE TABLE ... PARTITION BY ... command, ignore the
+		 * ENCODING options instead. The parent table might be AOCS, while
+		 * some of the partitions are not, or vice versa, so options can
+		 * make sense for some parts of the partition hierarchy, even if
+		 * it doesn't for this partition.
+		 */
+		stmt->attr_encodings = transformColumnEncoding(NULL /* Relation */, 
+								schema,
+								stmt->attr_encodings,
+								stmt->options,
+								relkind == RELKIND_PARTITIONED_TABLE,
+								amHandlerOid != AO_COLUMN_TABLE_AM_HANDLER_OID 
+										&& !stmt->partbound 
+										&& !stmt->partspec /* errorOnEncodingClause */);
+		if (amHandlerOid != AO_COLUMN_TABLE_AM_HANDLER_OID && relkind != RELKIND_PARTITIONED_TABLE)
+			stmt->attr_encodings = NIL;
 	}
 
 	/*
@@ -6956,24 +6936,6 @@ static void
 ATPrepAddColumn(List **wqueue, Relation rel, bool recurse, bool recursing,
 				bool is_view, AlterTableCmd *cmd, LOCKMODE lockmode)
 {
-	/*
-	 * GPDB_12_MERGE_FIXME:
-	 *		This logic can possibly be moved in an encoding specific function
-	 *		during add column executiion, removing the diff with upstream.
-	 */	
-	/* 
-	 * If there's an encoding clause, this better be an append only
-	 * column oriented table.
-	 */
-	ColumnDef *def = (ColumnDef *)cmd->def;
-	if (def->encoding && !RelationIsAoCols(rel))
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("ENCODING clause not supported on non column orientated table")));
-
-	if (def->encoding)
-		def->encoding = transformStorageEncodingClause(def->encoding, true);
-
 	if (rel->rd_rel->reloftype && !recursing)
 		ereport(ERROR,
 				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
@@ -7013,6 +6975,7 @@ ATExecAddColumn(List **wqueue, AlteredTableInfo *tab, Relation rel,
 	ListCell   *child;
 	AclResult	aclresult;
 	ObjectAddress address;
+ 	List* enc;
 
 	/* At top level, permission check was done in ATPrepCmd, else do it */
 	if (recursing)
@@ -7386,45 +7349,24 @@ ATExecAddColumn(List **wqueue, AlteredTableInfo *tab, Relation rel,
 	add_column_datatype_dependency(myrelid, newattnum, attribute.atttypid);
 	add_column_collation_dependency(myrelid, newattnum, attribute.attcollation);
 
-	/*
-	 * GPDB_12_MERGE_FIXME:
-	 * 		Try to handle attribute encodings in a unified way under the same
-	 * 		interface for CREATE/ALTER statements and remove the diff footprint
-	 * 		with upstream.
-	 *
-	 *		One observed discrepancy between the two statements regarding
-	 *		precedence of, command specific options, environment (gucs), type
-	 *		specific encodings and relation wide options.
-	 */
-	if (!RelationIsAoCols(rel) && colDef->encoding)
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("ENCODING clause not supported on non column orientated table")));
-
 	/* 
+	 * Process the encoding clauses.
+	 *
 	 * For AO/CO tables, always store an encoding clause. If no encoding
 	 * clause was provided, store the default encoding clause.
+	 * If there's an encoding clause for non AO/CO tables, we'll throw an error 
+	 * in the function (indicated by errorOnEncodingClause == true).
+	 */
+	enc = transformColumnEncoding(rel, list_make1(colDef), 
+					NULL /* COLUMN ENCODING clauses is only for CREATE TABLE */, 
+					NULL /* withOptions */,
+					false /* rootpartition */, 
+					!RelationIsAoCols(rel) /* errorOnEncodingClause */);
+	/* 
+	 * Store the encoding clause for AO/CO tables.
 	 */
 	if (RelationIsAoCols(rel))
-	{
-		ColumnReferenceStorageDirective *c;
-		
-		c = makeNode(ColumnReferenceStorageDirective);
-		c->column = colDef->colname;
-
-		if (colDef->encoding)
-			c->encoding = colDef->encoding;
-		else
-		{
-			/* Use the type specific storage directive, if one exists */
-			c->encoding = TypeNameGetStorageDirective(colDef->typeName);
-			
-			if (!c->encoding)
-				c->encoding = default_column_encoding_clause(rel);
-		}
-
-		AddRelationAttributeEncodings(rel, list_make1(c));
-	}
+		AddRelationAttributeEncodings(rel, enc);
 
 	/* MPP-6929: metadata tracking */
 	if ((Gp_role == GP_ROLE_DISPATCH) && MetaTrackValidKindNsp(rel->rd_rel))
@@ -16011,46 +15953,25 @@ prebuild_temp_table(Relation rel, RangeVar *tmpname, DistributedBy *distro,
 			rel->rd_rel->relhasindex)
 			cs->buildAoBlkdir = true;
 
-		/*
-		 * GPDB_12_MERGE_FIXME:
-		 *		Try to unify the logic for encoding: adding/moving/removing etc.
-		 *		The logic is possible to not have to leak outside reloptions or
-		 *		pg_attribute_encoding common code.
+		/* 
+		 * For AO/CO tables, need to remove table level compression settings 
+		 * for the AO_COLUMN case since they're set at the column level.
 		 */
 		if (RelationIsAoCols(rel))
 		{
-			if (useExistingColumnAttributes)
+			ListCell *lc;
+
+			foreach(lc, opts)
 			{
-				/* 
-				 * Need to remove table level compression settings for the
-				 * AO_COLUMN case since they're set at the column level.
-				 */
-				ListCell *lc;
+				DefElem *de = lfirst(lc);
 
-				foreach(lc, opts)
-				{
-					DefElem *de = lfirst(lc);
-
-					if (de->defname &&
-						(strcmp("compresstype", de->defname) == 0 ||
-						 strcmp("compresslevel", de->defname) == 0 ||
-						 strcmp("blocksize", de->defname) == 0))
-						continue;
-					else
-						cs->options = lappend(cs->options, de);
-				}
-				col_encs = RelationGetUntransformedAttributeOptions(rel);
-			}
-			else
-			{
-				ListCell *lc;
-
-				foreach(lc, opts)
-				{
-					DefElem *de = lfirst(lc);
+				if (!useExistingColumnAttributes || 
+						!de->defname || 
+						!is_storage_encoding_directive(de->defname))
 					cs->options = lappend(cs->options, de);
-				}
 			}
+			if (useExistingColumnAttributes)
+				col_encs = RelationGetUntransformedAttributeOptions(rel);
 		}
 		else
 			cs->options = opts;
@@ -17298,42 +17219,6 @@ make_distributedby_for_rel(Relation rel)
 	}
 
 	return dist;
-}
-
-/*
- * GPDB_12_MERGE_FIXME:
- *		This interface does not belong here. At worst it can be moved into
- *		greenplum specific tablecmds_gp; at best into pg_attribute_encoding or
- *		reloptions_gp.
- */
-/*
- * Given a relation, get all column encodings for that relation as a list of
- * ColumnReferenceStorageDirective structures.
- */
-List *
-rel_get_column_encodings(Relation rel)
-{
-	List **colencs = RelationGetUntransformedAttributeOptions(rel);
-	List *out = NIL;
-
-	if (colencs)
-	{
-		AttrNumber attno;
-
-		for (attno = 0; attno < RelationGetNumberOfAttributes(rel); attno++)
-		{
-			if (colencs[attno] && !TupleDescAttr(rel->rd_att, attno)->attisdropped)
-			{
-				ColumnReferenceStorageDirective *d =
-					makeNode(ColumnReferenceStorageDirective);
-				d->column = pstrdup(NameStr(TupleDescAttr(rel->rd_att, attno)->attname));
-				d->encoding = colencs[attno];
-		
-				out = lappend(out, d);
-			}
-		}
-	}
-	return out;
 }
 
 /*

--- a/src/backend/commands/tablecmds_gp.c
+++ b/src/backend/commands/tablecmds_gp.c
@@ -22,6 +22,7 @@
 #include "catalog/gp_partition_template.h"
 #include "catalog/partition.h"
 #include "catalog/pg_attribute.h"
+#include "catalog/pg_attribute_encoding.h"
 #include "catalog/pg_collation.h"
 #include "catalog/pg_inherits.h"
 #include "catalog/pg_partitioned_table.h"

--- a/src/include/access/reloptions.h
+++ b/src/include/access/reloptions.h
@@ -328,10 +328,11 @@ extern void validate_and_adjust_options(StdRdOptions *result, relopt_value *opti
 										int num_options, relopt_kind kind, bool validate);
 
 /* attribute enconding specific functions */
-extern List *transformAttributeEncoding(List *aocoColumnEnconding,
-										List *tableElts, List *withOptions,
-										bool rootpartition, bool *found_enc);
+extern List *transformColumnEncoding(Relation rel, List *colDefs,
+										List *stenc, List *withOptions,
+										bool rootpartition, bool allowEncodingClause);
 extern List *transformStorageEncodingClause(List *options, bool validate);
 extern List *form_default_storage_directive(List *enc);
+extern bool is_storage_encoding_directive(char *name);
 
 #endif							/* RELOPTIONS_H */

--- a/src/include/catalog/pg_attribute_encoding.h
+++ b/src/include/catalog/pg_attribute_encoding.h
@@ -55,5 +55,6 @@ extern void AddRelationAttributeEncodings(Relation rel, List *attr_encodings);
 extern void RemoveAttributeEncodingsByRelid(Oid relid);
 extern void cloneAttributeEncoding(Oid oldrelid, Oid newrelid, AttrNumber max_attno);
 extern Datum *get_rel_attoptions(Oid relid, AttrNumber max_attno);
+extern List * rel_get_column_encodings(Relation rel);
 
 #endif   /* PG_ATTRIBUTE_ENCODING_H */

--- a/src/include/catalog/pg_compression.h
+++ b/src/include/catalog/pg_compression.h
@@ -98,8 +98,6 @@ extern void callCompressionValidator(PGFunction func, char *comptype,
 									 Oid typid);
 
 extern bool compresstype_is_valid(char *compresstype);
-extern List *default_column_encoding_clause(Relation rel);
 extern PGFunction *GetCompressionImplementation(char *comptype);
-extern bool is_storage_encoding_directive(char *name);
 
 #endif   /* PG_COMPRESSION */

--- a/src/include/catalog/pg_type.h
+++ b/src/include/catalog/pg_type.h
@@ -361,5 +361,8 @@ extern bool moveArrayTypeName(Oid typeOid, const char *typeName,
 							  Oid typeNamespace);
 
 extern void add_type_encoding(Oid typid, Datum typoptions);
+extern void remove_type_encoding(Oid typid);
+extern void update_type_encoding(Oid typid, Datum typoptions);
+extern List *get_type_encoding(TypeName *typname);
 
 #endif							/* PG_TYPE_H */

--- a/src/include/commands/tablecmds.h
+++ b/src/include/commands/tablecmds.h
@@ -113,8 +113,6 @@ extern void RangeVarCallbackOwnsRelation(const RangeVar *relation,
 extern bool PartConstraintImpliedByRelConstraint(Relation scanrel,
 												 List *partConstraint);
 
-extern List * rel_get_column_encodings(Relation rel);
-
 /* GPDB specific functions */
 extern void ATExecGPPartCmds(Relation origrel, AlterTableCmd *cmd);
 extern void GpRenameChildPartitions(Relation targetrelation,

--- a/src/include/parser/analyze.h
+++ b/src/include/parser/analyze.h
@@ -43,8 +43,6 @@ extern void applyLockingClause(Query *qry, Index rtindex,
 							   LockClauseStrength strength,
 							   LockWaitPolicy waitPolicy, bool pushedDown);
 
-extern List *TypeNameGetStorageDirective(TypeName *typname);
-
 extern List *BuildOnConflictExcludedTargetlist(Relation targetrel,
 											   Index exclRelIndex);
 

--- a/src/test/regress/expected/column_compression.out
+++ b/src/test/regress/expected/column_compression.out
@@ -435,13 +435,13 @@ create table ccddl (i int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 alter table ccddl add column j int encoding (compresstype=zlib);
-ERROR:  ENCODING clause not supported on non column orientated table
+ERROR:  ENCODING clause only supported with column oriented tables
 drop table ccddl;
 create table ccddl (i int) with (appendonly=true);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 alter table ccddl add column j int encoding (compresstype=zlib);
-ERROR:  ENCODING clause not supported on non column orientated table
+ERROR:  ENCODING clause only supported with column oriented tables
 drop table ccddl;
 -- check that we validate the encoding clause for add column
 create table ccddl (i int) with (appendonly=true, orientation=column);


### PR DESCRIPTION
This PR attempts to refactor the code around processing the encoding clauses mainly in CREATE TABLE, ALTER TABLE, CREATE TYPE and ALTER TYPE. A total of 15 related FIXMEs are removed here.

Also removed another FIXME in `makeObjectName()` that's not related to encoding but it's fairly straightforward: we added an elog(ERROR) to workaround an assert failure in the regress test. But I ran the regress test and didn't see the failure, so restored the code and removed the FIXME. If there's ever an assert failure again, we should fix the same instead of adding another FIXME.

The changes mainly include:
* Refactor encoding code for CREATE TABLE and ALTER TABLE 
  * Remove `transformAttributeEncoding()` and create `transformColumnEncoding()` to be used in both `DefineRelation()` and `ATExecAddColumn()`
  * Move encoding related code in `ATPrepAddColumn()` to `ATExecAddColumn()` so they are in one place.
  * In `transformColumnEncoding()`, correct the code to match the comment `If no default has been specified, we might create one out of the WITH clause.`
* Refactor encoding code for CREATE TYPE and ALTER TYPE
  * Simplify and unify encoding code in `DefineType()` and `AlterType()`. Move the utility functions to pg_type.c
  * After refactoring, the code should be straightforward enough (`transformStorageEncodingClause()` and then `transformRelOptions()`), so I think we don't need to over-simplify it by creating a single function interface as indicated by the FIXME.
* Refactor `prebuild_temp_table()`
  * Simplify the code. Didn't create new function as well since the current form should be good enough. The encoding related logic is not "leaked" anymore.
* Move functions to more appropriate source files
  * `rel_get_column_encodings()`, `is_storage_encoding_directive()`, `default_column_encoding_clause()`, `remove_type_encoding()`, `TypeNameGetStorageDirective()`


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
