### PR TITLE
Revert changes for `process_greenplum_option`

### DIFF
--- a/src/bin/pg_upgrade/greenplum/option_gp.c
+++ b/src/bin/pg_upgrade/greenplum/option_gp.c
@@ -21,7 +21,7 @@ initialize_greenplum_user_options(void)
 }
 
 bool
-process_greenplum_option(greenplumOption option, char *option_value)
+process_greenplum_option(greenplumOption option)
 {
 	switch (option)
 	{

--- a/src/bin/pg_upgrade/greenplum/pg_upgrade_greenplum.h
+++ b/src/bin/pg_upgrade/greenplum/pg_upgrade_greenplum.h
@@ -60,7 +60,7 @@ typedef enum {
 
 /* option_gp.c */
 void initialize_greenplum_user_options(void);
-bool process_greenplum_option(greenplumOption option, char *option_value);
+bool process_greenplum_option(greenplumOption option);
 bool is_greenplum_dispatcher_mode(void);
 bool is_checksum_mode(checksumMode mode);
 bool is_show_progress_mode(void);

--- a/src/bin/pg_upgrade/option.c
+++ b/src/bin/pg_upgrade/option.c
@@ -217,7 +217,7 @@ parseCommandLine(int argc, char *argv[])
 				break;
 
 			default:
-				if (!process_greenplum_option(option, pg_strdup(optarg)))
+				if (!process_greenplum_option(option))
 				{
 					fprintf(stderr, _("Try \"%s --help\" for more information.\n"),
 							os_info.progname);


### PR DESCRIPTION
- we are not using the `option_value` from argument
- we need to add addition check for options with no arguments; currently
  with code changes it will cause `pg_strdup` to error out with "cannot
  duplicate null pointer" with no arguments
- we should check for argument based on each flag similar to `option.c`

Authored-by: Gaurab Dey <gaurabd@vmware.com>