### PR TITLE
Allow const expression eval on division op expr

### DIFF
--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -2115,17 +2115,6 @@ eval_const_expressions_mutator(Node *node,
 		 * to this extent.
 		 */
 		set_opfuncid(expr);
-		
-		/*
-		 * CDB: don't optimize divide, because we might hit a divide by zero in
-		 * an expression that won't necessarily get executed later.  2006-01-09
-		 */
-		if ((expr->opfuncid >=153 && expr->opfuncid <=157) ||
-			(expr->opfuncid >=172 && expr->opfuncid <=176))
-		{
-			simple = NULL;
-		}
-		else
 
 		/*
 		 * Code for op/func reduction is pretty bulky, so split it out as a

--- a/src/test/regress/expected/bfv_partition.out
+++ b/src/test/regress/expected/bfv_partition.out
@@ -1934,6 +1934,66 @@ SELECT * FROM part_tbl WHERE profile_key = 99999999;
 (2 rows)
 
 DROP TABLE part_tbl;
+-- A user-defined fuction inside partition selection that needs to be
+-- optimized, should perform still SPE and should not fall back.
+-- start_ignore
+drop table if exists pt;
+NOTICE:  table "pt" does not exist, skipping
+-- end_ignore
+CREATE TABLE pt(a int) PARTITION BY RANGE(a) (START(0)  END(10) EVERY(1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_1" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_2" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_3" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_4" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_5" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_6" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_7" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_8" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_9" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_10" for table "pt"
+CREATE OR REPLACE FUNCTION to_date(integer, text) RETURNS date AS $$
+BEGIN
+   RETURN to_date($1::text, $2);
+END;
+$$ LANGUAGE PLPGSQL STABLE;
+INSERT INTO pt SELECT generate_series(0, 9);
+EXPLAIN SELECT * FROM pt WHERE a = to_number((to_date(20210120 / 1, 'yyyymmdd'))::varchar , '9');
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..265550.00 rows=963 width=4)
+   ->  Append  (cost=0.00..265550.00 rows=321 width=4)
+         ->  Seq Scan on pt_1_prt_1 pt  (cost=0.00..26555.00 rows=33 width=4)
+               Filter: a::numeric = to_number(to_date(20210120 / 1, 'yyyymmdd'::text)::character varying::text, '9'::text)
+         ->  Seq Scan on pt_1_prt_2 pt  (cost=0.00..26555.00 rows=33 width=4)
+               Filter: a::numeric = to_number(to_date(20210120 / 1, 'yyyymmdd'::text)::character varying::text, '9'::text)
+         ->  Seq Scan on pt_1_prt_3 pt  (cost=0.00..26555.00 rows=33 width=4)
+               Filter: a::numeric = to_number(to_date(20210120 / 1, 'yyyymmdd'::text)::character varying::text, '9'::text)
+         ->  Seq Scan on pt_1_prt_4 pt  (cost=0.00..26555.00 rows=33 width=4)
+               Filter: a::numeric = to_number(to_date(20210120 / 1, 'yyyymmdd'::text)::character varying::text, '9'::text)
+         ->  Seq Scan on pt_1_prt_5 pt  (cost=0.00..26555.00 rows=33 width=4)
+               Filter: a::numeric = to_number(to_date(20210120 / 1, 'yyyymmdd'::text)::character varying::text, '9'::text)
+         ->  Seq Scan on pt_1_prt_6 pt  (cost=0.00..26555.00 rows=33 width=4)
+               Filter: a::numeric = to_number(to_date(20210120 / 1, 'yyyymmdd'::text)::character varying::text, '9'::text)
+         ->  Seq Scan on pt_1_prt_7 pt  (cost=0.00..26555.00 rows=33 width=4)
+               Filter: a::numeric = to_number(to_date(20210120 / 1, 'yyyymmdd'::text)::character varying::text, '9'::text)
+         ->  Seq Scan on pt_1_prt_8 pt  (cost=0.00..26555.00 rows=33 width=4)
+               Filter: a::numeric = to_number(to_date(20210120 / 1, 'yyyymmdd'::text)::character varying::text, '9'::text)
+         ->  Seq Scan on pt_1_prt_9 pt  (cost=0.00..26555.00 rows=33 width=4)
+               Filter: a::numeric = to_number(to_date(20210120 / 1, 'yyyymmdd'::text)::character varying::text, '9'::text)
+         ->  Seq Scan on pt_1_prt_10 pt  (cost=0.00..26555.00 rows=33 width=4)
+               Filter: a::numeric = to_number(to_date(20210120 / 1, 'yyyymmdd'::text)::character varying::text, '9'::text)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(24 rows)
+
+SELECT * FROM pt WHERE a = to_number((to_date(20210120 / 1, 'yyyymmdd'))::varchar , '9');
+ a 
+---
+ 0
+(1 row)
+
 -- CLEANUP
 -- start_ignore
 drop schema if exists bfv_partition;

--- a/src/test/regress/expected/bfv_partition_optimizer.out
+++ b/src/test/regress/expected/bfv_partition_optimizer.out
@@ -1935,6 +1935,49 @@ SELECT * FROM part_tbl WHERE profile_key = 99999999;
 (2 rows)
 
 DROP TABLE part_tbl;
+-- A user-defined fuction inside partition selection that needs to be
+-- optimized, should perform still SPE and should not fall back.
+-- start_ignore
+drop table if exists pt;
+NOTICE:  table "pt" does not exist, skipping
+-- end_ignore
+CREATE TABLE pt(a int) PARTITION BY RANGE(a) (START(0)  END(10) EVERY(1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_1" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_2" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_3" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_4" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_5" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_6" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_7" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_8" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_9" for table "pt"
+NOTICE:  CREATE TABLE will create partition "pt_1_prt_10" for table "pt"
+CREATE OR REPLACE FUNCTION to_date(integer, text) RETURNS date AS $$
+BEGIN
+   RETURN to_date($1::text, $2);
+END;
+$$ LANGUAGE PLPGSQL STABLE;
+INSERT INTO pt SELECT generate_series(0, 9);
+EXPLAIN SELECT * FROM pt WHERE a = to_number((to_date(20210120 / 1, 'yyyymmdd'))::varchar , '9');
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+   ->  Sequence  (cost=0.00..431.00 rows=1 width=4)
+         ->  Partition Selector for pt (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+               Partitions selected: 1 (out of 10)
+         ->  Dynamic Table Scan on pt (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=4)
+               Filter: a::numeric = to_number(to_date(20210120 / 1, 'yyyymmdd'::text)::character varying::text, '9'::text)
+ Optimizer status: PQO version 3.122.0
+(7 rows)
+
+SELECT * FROM pt WHERE a = to_number((to_date(20210120 / 1, 'yyyymmdd'))::varchar , '9');
+ a 
+---
+ 0
+(1 row)
+
 -- CLEANUP
 -- start_ignore
 drop schema if exists bfv_partition;

--- a/src/test/regress/output/query_info_hook_test.source
+++ b/src/test/regress/output/query_info_hook_test.source
@@ -18,12 +18,6 @@ WARNING:  Query done
 
 -- Test Error case
 SELECT * FROM generate_series(1, 3/0);
-WARNING:  Query submit
-WARNING:  Query start
-WARNING:  Plan node initializing
-WARNING:  Plan node executing node_type: FUNCTIONSCAN
-WARNING:  Query Error
-WARNING:  Query Error
 ERROR:  division by zero
 -- Test query abort
 select pg_cancel_backend(pg_backend_pid());


### PR DESCRIPTION
A safeguard existed in GPDB to prevent divide-by-zero while evaluating
const expressions. It does not appear to be relavent anymore as Postgres
has since added its own safeguards for the same (see commits https://github.com/greenplum-db/gpdb/commit/56423c1 and
https://github.com/greenplum-db/gpdb/commit/24aad03).

Issue is that if we skip evaluating const expressions for division op
expr then we may prevent function inlining. That can lead to multiple
optimization calls, which is not supported in ORCA.

Following SQL demonstrated issue:

```sql
CREATE TABLE pt(a int) PARTITION BY RANGE(a) (START(0)  END(10) EVERY(1));
CREATE OR REPLACE FUNCTION to_date(integer, text) RETURNS DATE AS $$
    SELECT to_date($1::text,$2);
$$ LANGUAGE SQL IMMUTABLE;
SELECT * FROM pt WHERE a = to_number((to_date(20210120/1, 'yyyymmdd'))::varchar , '9');
```

Here the "/1" in the argument passed to to_date UDF that prevents
function inlining.