### PR TITLE
upgrade: pg_strdup should not be run on the bool params

### DIFF
--- a/src/bin/pg_upgrade/greenplum/option_gp.c
+++ b/src/bin/pg_upgrade/greenplum/option_gp.c
@@ -21,7 +21,7 @@ initialize_greenplum_user_options(void)
 }
 
 bool
-process_greenplum_option(greenplumOption option, char *option_value)
+process_greenplum_option(greenplumOption option)
 {
 	switch (option)
 	{

--- a/src/bin/pg_upgrade/greenplum/pg_upgrade_greenplum.h
+++ b/src/bin/pg_upgrade/greenplum/pg_upgrade_greenplum.h
@@ -60,7 +60,7 @@ typedef enum {
 
 /* option_gp.c */
 void initialize_greenplum_user_options(void);
-bool process_greenplum_option(greenplumOption option, char *option_value);
+bool process_greenplum_option(greenplumOption option);
 bool is_greenplum_dispatcher_mode(void);
 bool is_checksum_mode(checksumMode mode);
 bool is_show_progress_mode(void);

--- a/src/bin/pg_upgrade/option.c
+++ b/src/bin/pg_upgrade/option.c
@@ -217,7 +217,7 @@ parseCommandLine(int argc, char *argv[])
 				break;
 
 			default:
-				if (!process_greenplum_option(option, pg_strdup(optarg)))
+				if (!process_greenplum_option(option))
 				{
 					fprintf(stderr, _("Try \"%s --help\" for more information.\n"),
 							os_info.progname);


### PR DESCRIPTION
optarg is a global and is not required to be passed to
process_greenplum_option. Also, for bool parameters pg_strdup must not
be called else it will fail with cannot duplicate null pointer (internal error)

Forward-ported from 6X_STABLE: 18224693a18db5243ec76e0d99c2ab2e3ed17ee5
- unmerged paths are deleted; code patch added to correct files
- pg_upgrade code moved from `contrib` to `src/bin/` directory in master

Co-authored-by: Gaurab Dey <gaurabd@vmware.com>
Co-authored-by: Bhuvnesh Chaudhary <bchaudhary@vmware.com>