### PR TITLE
Fix incorrect amount of memory allocated for WindowAgg.

### DIFF
--- a/src/backend/executor/nodeWindowAgg.c
+++ b/src/backend/executor/nodeWindowAgg.c
@@ -40,6 +40,7 @@
 #include "executor/executor.h"
 #include "executor/nodeWindowAgg.h"
 #include "miscadmin.h"
+#include "nodes/execnodes.h"
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
 #include "parser/parse_agg.h"
@@ -48,6 +49,7 @@
 #include "utils/acl.h"
 #include "utils/builtins.h"
 #include "utils/datum.h"
+#include "utils/faultinjector.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/regproc.h"
@@ -268,7 +270,7 @@ initialize_windowaggregate(WindowAggState *winstate,
 								  peraggstate->distinctLtOper,
 								  peraggstate->distinctColl,
 								  false, /* nullsFirstFlag */
-								  work_mem,
+								  PlanStateOperatorMemKB((PlanState *) winstate),
 								  NULL, /* coordinate */
 								  false);
 	}
@@ -684,6 +686,28 @@ perform_distinct_windowaggregate(WindowAggState *winstate,
 	oldcontext = MemoryContextSwitchTo(winstate->tmpcontext->ecxt_per_tuple_memory);
 
 	tuplesort_performsort(peraggstate->distinctSortState);
+
+#ifdef FAULT_INJECTOR
+	/*
+	 * This routine is used for tracing whether the sort operation of DISTINCT-qualified
+	 * WindowAgg is spilled to disk.
+	 */
+	if (SIMPLE_FAULT_INJECTOR("distinct_winagg_perform_sort") == FaultInjectorTypeSkip)
+	{
+		TuplesortInstrumentation sortstats;
+		tuplesort_get_stats(peraggstate->distinctSortState, &sortstats);
+		if (sortstats.spaceType == SORT_SPACE_TYPE_MEMORY)
+		{
+			ereport(NOTICE,
+					(errmsg("distinct winagg sortstats: sort operation fitted in memory")));
+		}
+		else
+		{
+			ereport(NOTICE,
+					(errmsg("distinct winagg sortstats: sort operation spilled to disk")));
+		}
+	}
+#endif
 
 	/* load the first tuple from spool */
 	if (tuplesort_getdatum(peraggstate->distinctSortState, true,
@@ -1359,7 +1383,9 @@ begin_partition(WindowAggState *winstate)
 	}
 
 	/* Create new tuplestore for this partition */
-	winstate->buffer = tuplestore_begin_heap(false, false, work_mem);
+	winstate->buffer =
+		tuplestore_begin_heap(false, false,
+							  PlanStateOperatorMemKB((PlanState *) winstate));
 
 	/*
 	 * Set up read pointers for the tuplestore.  The current pointer doesn't
@@ -2424,6 +2450,38 @@ ExecWindowAgg(PlanState *pstate)
 	 * already
 	 */
 	spool_tuples(winstate, winstate->currentpos);
+
+#ifdef FAULT_INJECTOR
+	/*
+	* This routine is used for testing if we have allocated enough memory
+	* for the tuplestore (winstate->buffer) in begin_partition(). If all
+	* tuples of the current partition can be fitted in the memory, we
+	* emit a notice saying 'fitted in memory'. If they cannot be fitted in
+	* the memory, we emit a notice saying 'spilled to disk'. If there're
+	* no input rows, we emit a notice saying 'no input rows'.
+	*
+	* NOTE: The fault-injector only triggers once, we emit the notice when
+	* we finishes spooling all the tuples of the first partition.
+	*/
+	if (winstate->partition_spooled &&
+		winstate->currentpos >= winstate->spooled_rows)
+	{
+		if (SIMPLE_FAULT_INJECTOR("winagg_after_spool_tuples") == FaultInjectorTypeSkip)
+		{
+			if (winstate->buffer)
+			{
+				if (tuplestore_in_memory(winstate->buffer))
+					ereport(NOTICE, (errmsg("winagg: tuplestore fitted in memory")));
+				else
+					ereport(NOTICE, (errmsg("winagg: tuplestore spilled to disk")));
+			}
+			else
+			{
+				ereport(NOTICE, (errmsg("winagg: no input rows")));
+			}
+		}
+	}
+#endif
 
 	/* Move to the next partition if we reached the end of this partition */
 	if (winstate->partition_spooled &&

--- a/src/backend/executor/nodeWindowAgg.c
+++ b/src/backend/executor/nodeWindowAgg.c
@@ -2449,16 +2449,16 @@ ExecWindowAgg(PlanState *pstate)
 
 #ifdef FAULT_INJECTOR
 	/*
-	* This routine is used for testing if we have allocated enough memory
-	* for the tuplestore (winstate->buffer) in begin_partition(). If all
-	* tuples of the current partition can be fitted in the memory, we
-	* emit a notice saying 'fitted in memory'. If they cannot be fitted in
-	* the memory, we emit a notice saying 'spilled to disk'. If there're
-	* no input rows, we emit a notice saying 'no input rows'.
-	*
-	* NOTE: The fault-injector only triggers once, we emit the notice when
-	* we finishes spooling all the tuples of the first partition.
-	*/
+	 * This routine is used for testing if we have allocated enough memory
+	 * for the tuplestore (winstate->buffer) in begin_partition(). If all
+	 * tuples of the current partition can be fitted in the memory, we
+	 * emit a notice saying 'fitted in memory'. If they cannot be fitted in
+	 * the memory, we emit a notice saying 'spilled to disk'. If there're
+	 * no input rows, we emit a notice saying 'no input rows'.
+	 *
+	 * NOTE: The fault-injector only triggers once, we emit the notice when
+	 * we finishes spooling all the tuples of the first partition.
+	 */
 	if (winstate->partition_spooled &&
 		winstate->currentpos >= winstate->spooled_rows &&
 		SIMPLE_FAULT_INJECTOR("winagg_after_spool_tuples") == FaultInjectorTypeSkip)

--- a/src/test/regress/expected/misc_jiras.out
+++ b/src/test/regress/expected/misc_jiras.out
@@ -1,4 +1,5 @@
 drop schema if exists misc_jiras;
+NOTICE:  schema "misc_jiras" does not exist, skipping
 create schema misc_jiras;
 --
 -- Test backward scanning of tuplestore spill files.
@@ -12,11 +13,21 @@ create schema misc_jiras;
 create table misc_jiras.t1 (c1 int, c2 text, c3 smallint) distributed by (c1);
 insert into misc_jiras.t1 select i % 13, md5(i::text), i % 3
   from generate_series(1, 20000) i;
--- tuplestore uses work_mem to control the in-memory data size, set a small
--- value to trigger the spilling.
-set work_mem to '64kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
+-- tuplestore in windowagg uses statement_mem to control the in-memory data size,
+-- set a small value to trigger the spilling.
+set statement_mem to '256kB';
 set extra_float_digits=0; -- the last decimal digits are somewhat random
+-- Inject fault at 'winagg_after_spool_tuples' to show that the tuplestore spills
+-- to disk.
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
 select sum(cc) from (
     select c1
          , c2
@@ -28,13 +39,24 @@ select sum(cc) from (
       from misc_jiras.t1
      group by 1, 2
 ) tt;
+NOTICE:  winagg: tuplestore spilled to disk  (seg0 slice1 127.0.0.1:7002 pid=54719)
+NOTICE:  winagg: tuplestore spilled to disk  (seg1 slice1 127.0.0.1:7003 pid=54720)
+NOTICE:  winagg: tuplestore spilled to disk  (seg2 slice1 127.0.0.1:7004 pid=54721)
    sum   
 ---------
  10006.5
 (1 row)
 
-reset work_mem;
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+reset statement_mem;
 -- non-ASCII multibyte character should show up correctly in error messages.
 select '溋' || (B'1');
 ERROR:  "溋" is not a valid binary digit

--- a/src/test/regress/expected/misc_jiras.out
+++ b/src/test/regress/expected/misc_jiras.out
@@ -15,7 +15,7 @@ insert into misc_jiras.t1 select i % 13, md5(i::text), i % 3
   from generate_series(1, 20000) i;
 -- tuplestore in windowagg uses statement_mem to control the in-memory data size,
 -- set a small value to trigger the spilling.
-set statement_mem to '256kB';
+set statement_mem to '512kB';
 set extra_float_digits=0; -- the last decimal digits are somewhat random
 -- Inject fault at 'winagg_after_spool_tuples' to show that the tuplestore spills
 -- to disk.

--- a/src/test/regress/expected/statement_mem_for_windowagg.out
+++ b/src/test/regress/expected/statement_mem_for_windowagg.out
@@ -1,0 +1,354 @@
+CREATE TABLE dummy_table(x int, y int) DISTRIBUTED BY (y);
+INSERT INTO dummy_table SELECT generate_series(0, 10000), 0;
+INSERT INTO dummy_table SELECT generate_series(0, 10000), 3;
+INSERT INTO dummy_table SELECT generate_series(0, 10000), 10;
+-- 1. Test that if we set statement_mem to a larger value, the tuplestore
+-- for caching the tuples in partition used in WindowAgg is able to be fitted
+-- in memory.
+SET statement_mem TO '2048kB';
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+EXPLAIN ANALYZE SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
+NOTICE:  winagg: tuplestore fitted in memory  (seg0 slice1 127.0.0.1:7002 pid=313121)
+NOTICE:  winagg: tuplestore fitted in memory  (seg1 slice1 127.0.0.1:7003 pid=313122)
+NOTICE:  winagg: tuplestore fitted in memory  (seg2 slice1 127.0.0.1:7004 pid=313123)
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2446.06..4096.31 rows=86100 width=36) (actual time=6.626..10.833 rows=30003 loops=1)
+   ->  WindowAgg  (cost=2446.06..2948.31 rows=28700 width=36) (actual time=6.179..7.984 rows=10001 loops=1)
+         Partition By: y
+         ->  Sort  (cost=2446.06..2517.81 rows=28700 width=8) (actual time=3.157..3.831 rows=10001 loops=1)
+               Sort Key: y
+               Sort Method:  quicksort  Memory: 5040kB
+               ->  Seq Scan on dummy_table  (cost=0.00..321.00 rows=28700 width=8) (actual time=0.027..1.881 rows=10001 loops=1)
+ Planning Time: 0.283 ms
+   (slice0)    Executor memory: 50K bytes.
+   (slice1)    Executor memory: 606K bytes avg x 3 workers, 606K bytes max (seg0).  Work_mem: 606K bytes max.
+ Memory used:  2048kB
+ Optimizer: Postgres query optimizer
+ Execution Time: 12.843 ms
+(13 rows)
+
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+-- 2. Test that if we set statement_mem to a smaller value, the tuplestore
+-- for caching the tuples in partition used in WindowAgg will be spilled to disk.
+SET statement_mem TO '1024kB';
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+EXPLAIN ANALYZE SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
+NOTICE:  winagg: tuplestore spilled to disk  (seg0 slice1 127.0.0.1:7002 pid=313121)
+NOTICE:  winagg: tuplestore spilled to disk  (seg1 slice1 127.0.0.1:7003 pid=313122)
+NOTICE:  winagg: tuplestore spilled to disk  (seg2 slice1 127.0.0.1:7004 pid=313123)
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2446.06..4096.31 rows=86100 width=36) (actual time=10.033..17.074 rows=30003 loops=1)
+   ->  WindowAgg  (cost=2446.06..2948.31 rows=28700 width=36) (actual time=9.811..11.653 rows=10001 loops=1)
+         Partition By: y
+         ->  Sort  (cost=2446.06..2517.81 rows=28700 width=8) (actual time=3.909..5.077 rows=10001 loops=1)
+               Sort Key: y
+               Sort Method:  external merge  Disk: 6144kB
+               ->  Seq Scan on dummy_table  (cost=0.00..321.00 rows=28700 width=8) (actual time=0.024..1.983 rows=10001 loops=1)
+ Planning Time: 0.108 ms
+   (slice0)    Executor memory: 39K bytes.
+   (slice1)    Executor memory: 391K bytes avg x 3 workers, 391K bytes max (seg0).  Work_mem: 391K bytes max.
+ Memory used:  1024kB
+ Optimizer: Postgres query optimizer
+ Execution Time: 20.006 ms
+(13 rows)
+
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+-- 3. Test that setting work_mem has no effect on the execution of the WindowAgg
+-- plan.
+-- a) Set work_mem to a larger value while statement_mem is a smaller value.
+SET statement_mem TO '1024kB';
+SET work_mem TO '2048kB';
+WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+EXPLAIN ANALYZE SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
+NOTICE:  winagg: tuplestore spilled to disk  (seg0 slice1 127.0.0.1:7002 pid=313121)
+NOTICE:  winagg: tuplestore spilled to disk  (seg1 slice1 127.0.0.1:7003 pid=313122)
+NOTICE:  winagg: tuplestore spilled to disk  (seg2 slice1 127.0.0.1:7004 pid=313123)
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2446.06..4096.31 rows=86100 width=36) (actual time=9.751..13.947 rows=30003 loops=1)
+   ->  WindowAgg  (cost=2446.06..2948.31 rows=28700 width=36) (actual time=9.366..11.189 rows=10001 loops=1)
+         Partition By: y
+         ->  Sort  (cost=2446.06..2517.81 rows=28700 width=8) (actual time=3.480..4.669 rows=10001 loops=1)
+               Sort Key: y
+               Sort Method:  external merge  Disk: 6144kB
+               ->  Seq Scan on dummy_table  (cost=0.00..321.00 rows=28700 width=8) (actual time=0.022..1.732 rows=10001 loops=1)
+ Planning Time: 0.094 ms
+   (slice0)    Executor memory: 39K bytes.
+   (slice1)    Executor memory: 391K bytes avg x 3 workers, 391K bytes max (seg0).  Work_mem: 391K bytes max.
+ Memory used:  1024kB
+ Optimizer: Postgres query optimizer
+ Execution Time: 15.908 ms
+(13 rows)
+
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+-- b) Set work_mem to a smaller value while statement_mem is a larger value.
+SET statement_mem TO '2048kB';
+SET work_mem TO '1024kB';
+WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+EXPLAIN ANALYZE SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
+NOTICE:  winagg: tuplestore fitted in memory  (seg0 slice1 127.0.0.1:7002 pid=313121)
+NOTICE:  winagg: tuplestore fitted in memory  (seg1 slice1 127.0.0.1:7003 pid=313122)
+NOTICE:  winagg: tuplestore fitted in memory  (seg2 slice1 127.0.0.1:7004 pid=313123)
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2446.06..4096.31 rows=86100 width=36) (actual time=5.439..8.731 rows=30003 loops=1)
+   ->  WindowAgg  (cost=2446.06..2948.31 rows=28700 width=36) (actual time=5.272..6.871 rows=10001 loops=1)
+         Partition By: y
+         ->  Sort  (cost=2446.06..2517.81 rows=28700 width=8) (actual time=2.829..3.395 rows=10001 loops=1)
+               Sort Key: y
+               Sort Method:  quicksort  Memory: 5040kB
+               ->  Seq Scan on dummy_table  (cost=0.00..321.00 rows=28700 width=8) (actual time=0.024..1.877 rows=10001 loops=1)
+ Planning Time: 0.099 ms
+   (slice0)    Executor memory: 39K bytes.
+   (slice1)    Executor memory: 606K bytes avg x 3 workers, 606K bytes max (seg0).  Work_mem: 606K bytes max.
+ Memory used:  2048kB
+ Optimizer: Postgres query optimizer
+ Execution Time: 10.444 ms
+(13 rows)
+
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+-- 4. Test that if we set statement_mem to a larger value, the tuplesort
+-- operation in DISTINCT-qualified WindowAgg is able to be fitted in memory.
+SET statement_mem TO '1024kB';
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
+NOTICE:  distinct winagg sortstats: sort operation fitted in memory  (seg0 slice1 127.0.0.1:7002 pid=313121)
+NOTICE:  distinct winagg sortstats: sort operation fitted in memory  (seg2 slice1 127.0.0.1:7004 pid=313123)
+NOTICE:  distinct winagg sortstats: sort operation fitted in memory  (seg1 slice1 127.0.0.1:7003 pid=313122)
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2446.06..4096.31 rows=86100 width=36) (actual time=10.559..14.515 rows=30003 loops=1)
+   ->  WindowAgg  (cost=2446.06..2948.31 rows=28700 width=36) (actual time=10.113..11.813 rows=10001 loops=1)
+         Partition By: y
+         ->  Sort  (cost=2446.06..2517.81 rows=28700 width=8) (actual time=3.628..4.675 rows=10001 loops=1)
+               Sort Key: y
+               Sort Method:  external merge  Disk: 6144kB
+               ->  Seq Scan on dummy_table  (cost=0.00..321.00 rows=28700 width=8) (actual time=0.025..1.849 rows=10001 loops=1)
+ Planning Time: 0.095 ms
+   (slice0)    Executor memory: 50K bytes.
+   (slice1)    Executor memory: 391K bytes avg x 3 workers, 391K bytes max (seg0).  Work_mem: 391K bytes max.
+ Memory used:  1024kB
+ Optimizer: Postgres query optimizer
+ Execution Time: 16.305 ms
+(13 rows)
+
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+-- 5. Test that if we set statement_mem to a smaller value, the tuplesort
+-- operation in DISTINCT-qualified WindowAgg will be spilled to disk.
+SET statement_mem TO '128kB';
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
+NOTICE:  distinct winagg sortstats: sort operation spilled to disk  (seg0 slice1 127.0.0.1:7002 pid=313121)
+NOTICE:  distinct winagg sortstats: sort operation spilled to disk  (seg1 slice1 127.0.0.1:7003 pid=313122)
+NOTICE:  distinct winagg sortstats: sort operation spilled to disk  (seg2 slice1 127.0.0.1:7004 pid=313123)
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2446.06..4096.31 rows=86100 width=36) (actual time=13.122..17.443 rows=30003 loops=1)
+   ->  WindowAgg  (cost=2446.06..2948.31 rows=28700 width=36) (actual time=12.762..14.595 rows=10001 loops=1)
+         Partition By: y
+         ->  Sort  (cost=2446.06..2517.81 rows=28700 width=8) (actual time=4.211..5.454 rows=10001 loops=1)
+               Sort Key: y
+               Sort Method:  external merge  Disk: 9216kB
+               ->  Seq Scan on dummy_table  (cost=0.00..321.00 rows=28700 width=8) (actual time=0.024..1.730 rows=10001 loops=1)
+ Planning Time: 0.093 ms
+   (slice0)    Executor memory: 39K bytes.
+   (slice1)    Executor memory: 275K bytes avg x 3 workers, 275K bytes max (seg0).  Work_mem: 275K bytes max.
+ Memory used:  128kB
+ Optimizer: Postgres query optimizer
+ Execution Time: 19.371 ms
+(13 rows)
+
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+-- 6. Test that setting work_mem has no effect on the sort operation in the
+-- DISTINCT-qualified WindowAgg.
+-- a) Set work_mem to a larger value while statement_mem is a smaller value.
+SET work_mem TO '1024kB';
+WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
+SET statement_mem TO '128kB';
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
+NOTICE:  distinct winagg sortstats: sort operation spilled to disk  (seg0 slice1 127.0.0.1:7002 pid=313121)
+NOTICE:  distinct winagg sortstats: sort operation spilled to disk  (seg1 slice1 127.0.0.1:7003 pid=313122)
+NOTICE:  distinct winagg sortstats: sort operation spilled to disk  (seg2 slice1 127.0.0.1:7004 pid=313123)
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2446.06..4096.31 rows=86100 width=36) (actual time=12.095..15.971 rows=30003 loops=1)
+   ->  WindowAgg  (cost=2446.06..2948.31 rows=28700 width=36) (actual time=11.695..13.364 rows=10001 loops=1)
+         Partition By: y
+         ->  Sort  (cost=2446.06..2517.81 rows=28700 width=8) (actual time=4.151..5.250 rows=10001 loops=1)
+               Sort Key: y
+               Sort Method:  external merge  Disk: 9216kB
+               ->  Seq Scan on dummy_table  (cost=0.00..321.00 rows=28700 width=8) (actual time=0.023..1.736 rows=10001 loops=1)
+ Planning Time: 0.103 ms
+   (slice0)    Executor memory: 39K bytes.
+   (slice1)    Executor memory: 275K bytes avg x 3 workers, 275K bytes max (seg0).  Work_mem: 275K bytes max.
+ Memory used:  128kB
+ Optimizer: Postgres query optimizer
+ Execution Time: 17.718 ms
+(13 rows)
+
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+-- b) Set work_mem to a smaller value while statement_mem is a larger value.
+SET work_mem TO '128kB';
+WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
+SET statement_mem TO '1024kB';
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
+NOTICE:  distinct winagg sortstats: sort operation fitted in memory  (seg0 slice1 127.0.0.1:7002 pid=313121)
+NOTICE:  distinct winagg sortstats: sort operation fitted in memory  (seg1 slice1 127.0.0.1:7003 pid=313122)
+NOTICE:  distinct winagg sortstats: sort operation fitted in memory  (seg2 slice1 127.0.0.1:7004 pid=313123)
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2446.06..4096.31 rows=86100 width=36) (actual time=10.023..14.039 rows=30003 loops=1)
+   ->  WindowAgg  (cost=2446.06..2948.31 rows=28700 width=36) (actual time=9.810..11.493 rows=10001 loops=1)
+         Partition By: y
+         ->  Sort  (cost=2446.06..2517.81 rows=28700 width=8) (actual time=3.581..4.604 rows=10001 loops=1)
+               Sort Key: y
+               Sort Method:  external merge  Disk: 6144kB
+               ->  Seq Scan on dummy_table  (cost=0.00..321.00 rows=28700 width=8) (actual time=0.026..1.811 rows=10001 loops=1)
+ Planning Time: 0.108 ms
+   (slice0)    Executor memory: 39K bytes.
+   (slice1)    Executor memory: 391K bytes avg x 3 workers, 391K bytes max (seg0).  Work_mem: 391K bytes max.
+ Memory used:  1024kB
+ Optimizer: Postgres query optimizer
+ Execution Time: 16.130 ms
+(13 rows)
+
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+-- Do some clean-ups.
+DROP TABLE dummy_table;
+RESET statement_mem;
+RESET work_mem;
+WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.

--- a/src/test/regress/expected/statement_mem_for_windowagg.out
+++ b/src/test/regress/expected/statement_mem_for_windowagg.out
@@ -16,24 +16,24 @@ SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
 (3 rows)
 
 EXPLAIN ANALYZE SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
-NOTICE:  winagg: tuplestore fitted in memory  (seg0 slice1 127.0.0.1:7002 pid=313121)
-NOTICE:  winagg: tuplestore fitted in memory  (seg1 slice1 127.0.0.1:7003 pid=313122)
-NOTICE:  winagg: tuplestore fitted in memory  (seg2 slice1 127.0.0.1:7004 pid=313123)
-                                                              QUERY PLAN                                                              
---------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=2446.06..4096.31 rows=86100 width=36) (actual time=6.626..10.833 rows=30003 loops=1)
-   ->  WindowAgg  (cost=2446.06..2948.31 rows=28700 width=36) (actual time=6.179..7.984 rows=10001 loops=1)
+NOTICE:  winagg: tuplestore fitted in memory  (seg1 slice1 127.0.0.1:7003 pid=43473)
+NOTICE:  winagg: tuplestore fitted in memory  (seg0 slice1 127.0.0.1:7002 pid=43472)
+NOTICE:  winagg: tuplestore fitted in memory  (seg2 slice1 127.0.0.1:7004 pid=43474)
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=6.520..15.872 rows=30003 loops=1)
+   ->  WindowAgg  (cost=0.00..431.00 rows=1 width=8) (actual time=10.607..13.115 rows=10001 loops=1)
          Partition By: y
-         ->  Sort  (cost=2446.06..2517.81 rows=28700 width=8) (actual time=3.157..3.831 rows=10001 loops=1)
+         ->  Sort  (cost=0.00..431.00 rows=1 width=8) (actual time=5.298..6.324 rows=10001 loops=1)
                Sort Key: y
                Sort Method:  quicksort  Memory: 5040kB
-               ->  Seq Scan on dummy_table  (cost=0.00..321.00 rows=28700 width=8) (actual time=0.027..1.881 rows=10001 loops=1)
- Planning Time: 0.283 ms
-   (slice0)    Executor memory: 50K bytes.
+               ->  Seq Scan on dummy_table  (cost=0.00..431.00 rows=1 width=8) (actual time=0.036..3.299 rows=10001 loops=1)
+ Planning Time: 5.241 ms
+   (slice0)    Executor memory: 48K bytes.
    (slice1)    Executor memory: 606K bytes avg x 3 workers, 606K bytes max (seg0).  Work_mem: 606K bytes max.
  Memory used:  2048kB
- Optimizer: Postgres query optimizer
- Execution Time: 12.843 ms
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution Time: 17.225 ms
 (13 rows)
 
 SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
@@ -58,24 +58,24 @@ SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
 (3 rows)
 
 EXPLAIN ANALYZE SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
-NOTICE:  winagg: tuplestore spilled to disk  (seg0 slice1 127.0.0.1:7002 pid=313121)
-NOTICE:  winagg: tuplestore spilled to disk  (seg1 slice1 127.0.0.1:7003 pid=313122)
-NOTICE:  winagg: tuplestore spilled to disk  (seg2 slice1 127.0.0.1:7004 pid=313123)
-                                                              QUERY PLAN                                                               
----------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=2446.06..4096.31 rows=86100 width=36) (actual time=10.033..17.074 rows=30003 loops=1)
-   ->  WindowAgg  (cost=2446.06..2948.31 rows=28700 width=36) (actual time=9.811..11.653 rows=10001 loops=1)
+NOTICE:  winagg: tuplestore spilled to disk  (seg0 slice1 127.0.0.1:7002 pid=43472)
+NOTICE:  winagg: tuplestore spilled to disk  (seg1 slice1 127.0.0.1:7003 pid=43473)
+NOTICE:  winagg: tuplestore spilled to disk  (seg2 slice1 127.0.0.1:7004 pid=43474)
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=8.784..13.923 rows=30003 loops=1)
+   ->  WindowAgg  (cost=0.00..431.00 rows=1 width=8) (actual time=8.390..9.720 rows=10001 loops=1)
          Partition By: y
-         ->  Sort  (cost=2446.06..2517.81 rows=28700 width=8) (actual time=3.909..5.077 rows=10001 loops=1)
+         ->  Sort  (cost=0.00..431.00 rows=1 width=8) (actual time=3.125..4.135 rows=10001 loops=1)
                Sort Key: y
                Sort Method:  external merge  Disk: 6144kB
-               ->  Seq Scan on dummy_table  (cost=0.00..321.00 rows=28700 width=8) (actual time=0.024..1.983 rows=10001 loops=1)
- Planning Time: 0.108 ms
-   (slice0)    Executor memory: 39K bytes.
+               ->  Seq Scan on dummy_table  (cost=0.00..431.00 rows=1 width=8) (actual time=0.032..1.589 rows=10001 loops=1)
+ Planning Time: 3.174 ms
+   (slice0)    Executor memory: 42K bytes.
    (slice1)    Executor memory: 391K bytes avg x 3 workers, 391K bytes max (seg0).  Work_mem: 391K bytes max.
  Memory used:  1024kB
- Optimizer: Postgres query optimizer
- Execution Time: 20.006 ms
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution Time: 15.235 ms
 (13 rows)
 
 SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
@@ -87,95 +87,7 @@ SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
  Success:
 (3 rows)
 
--- 3. Test that setting work_mem has no effect on the execution of the WindowAgg
--- plan.
--- a) Set work_mem to a larger value while statement_mem is a smaller value.
-SET statement_mem TO '1024kB';
-SET work_mem TO '2048kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
-SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content>=0;
- gp_inject_fault 
------------------
- Success:
- Success:
- Success:
-(3 rows)
-
-EXPLAIN ANALYZE SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
-NOTICE:  winagg: tuplestore spilled to disk  (seg0 slice1 127.0.0.1:7002 pid=313121)
-NOTICE:  winagg: tuplestore spilled to disk  (seg1 slice1 127.0.0.1:7003 pid=313122)
-NOTICE:  winagg: tuplestore spilled to disk  (seg2 slice1 127.0.0.1:7004 pid=313123)
-                                                              QUERY PLAN                                                              
---------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=2446.06..4096.31 rows=86100 width=36) (actual time=9.751..13.947 rows=30003 loops=1)
-   ->  WindowAgg  (cost=2446.06..2948.31 rows=28700 width=36) (actual time=9.366..11.189 rows=10001 loops=1)
-         Partition By: y
-         ->  Sort  (cost=2446.06..2517.81 rows=28700 width=8) (actual time=3.480..4.669 rows=10001 loops=1)
-               Sort Key: y
-               Sort Method:  external merge  Disk: 6144kB
-               ->  Seq Scan on dummy_table  (cost=0.00..321.00 rows=28700 width=8) (actual time=0.022..1.732 rows=10001 loops=1)
- Planning Time: 0.094 ms
-   (slice0)    Executor memory: 39K bytes.
-   (slice1)    Executor memory: 391K bytes avg x 3 workers, 391K bytes max (seg0).  Work_mem: 391K bytes max.
- Memory used:  1024kB
- Optimizer: Postgres query optimizer
- Execution Time: 15.908 ms
-(13 rows)
-
-SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content>=0;
- gp_inject_fault 
------------------
- Success:
- Success:
- Success:
-(3 rows)
-
--- b) Set work_mem to a smaller value while statement_mem is a larger value.
-SET statement_mem TO '2048kB';
-SET work_mem TO '1024kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
-SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content>=0;
- gp_inject_fault 
------------------
- Success:
- Success:
- Success:
-(3 rows)
-
-EXPLAIN ANALYZE SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
-NOTICE:  winagg: tuplestore fitted in memory  (seg0 slice1 127.0.0.1:7002 pid=313121)
-NOTICE:  winagg: tuplestore fitted in memory  (seg1 slice1 127.0.0.1:7003 pid=313122)
-NOTICE:  winagg: tuplestore fitted in memory  (seg2 slice1 127.0.0.1:7004 pid=313123)
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=2446.06..4096.31 rows=86100 width=36) (actual time=5.439..8.731 rows=30003 loops=1)
-   ->  WindowAgg  (cost=2446.06..2948.31 rows=28700 width=36) (actual time=5.272..6.871 rows=10001 loops=1)
-         Partition By: y
-         ->  Sort  (cost=2446.06..2517.81 rows=28700 width=8) (actual time=2.829..3.395 rows=10001 loops=1)
-               Sort Key: y
-               Sort Method:  quicksort  Memory: 5040kB
-               ->  Seq Scan on dummy_table  (cost=0.00..321.00 rows=28700 width=8) (actual time=0.024..1.877 rows=10001 loops=1)
- Planning Time: 0.099 ms
-   (slice0)    Executor memory: 39K bytes.
-   (slice1)    Executor memory: 606K bytes avg x 3 workers, 606K bytes max (seg0).  Work_mem: 606K bytes max.
- Memory used:  2048kB
- Optimizer: Postgres query optimizer
- Execution Time: 10.444 ms
-(13 rows)
-
-SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content>=0;
- gp_inject_fault 
------------------
- Success:
- Success:
- Success:
-(3 rows)
-
--- 4. Test that if we set statement_mem to a larger value, the tuplesort
+-- 3. Test that if we set statement_mem to a larger value, the tuplesort
 -- operation in DISTINCT-qualified WindowAgg is able to be fitted in memory.
 SET statement_mem TO '1024kB';
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
@@ -188,24 +100,24 @@ SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
 (3 rows)
 
 EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
-NOTICE:  distinct winagg sortstats: sort operation fitted in memory  (seg0 slice1 127.0.0.1:7002 pid=313121)
-NOTICE:  distinct winagg sortstats: sort operation fitted in memory  (seg2 slice1 127.0.0.1:7004 pid=313123)
-NOTICE:  distinct winagg sortstats: sort operation fitted in memory  (seg1 slice1 127.0.0.1:7003 pid=313122)
+NOTICE:  distinct winagg sortstats: sort operation fitted in memory  (seg0 slice1 127.0.0.1:7002 pid=43472)
+NOTICE:  distinct winagg sortstats: sort operation fitted in memory  (seg1 slice1 127.0.0.1:7003 pid=43473)
+NOTICE:  distinct winagg sortstats: sort operation fitted in memory  (seg2 slice1 127.0.0.1:7004 pid=43474)
                                                               QUERY PLAN                                                               
 ---------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=2446.06..4096.31 rows=86100 width=36) (actual time=10.559..14.515 rows=30003 loops=1)
-   ->  WindowAgg  (cost=2446.06..2948.31 rows=28700 width=36) (actual time=10.113..11.813 rows=10001 loops=1)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2446.06..4096.31 rows=86100 width=36) (actual time=10.348..16.027 rows=30003 loops=1)
+   ->  WindowAgg  (cost=2446.06..2948.31 rows=28700 width=36) (actual time=10.186..11.795 rows=10001 loops=1)
          Partition By: y
-         ->  Sort  (cost=2446.06..2517.81 rows=28700 width=8) (actual time=3.628..4.675 rows=10001 loops=1)
+         ->  Sort  (cost=2446.06..2517.81 rows=28700 width=8) (actual time=3.678..4.683 rows=10001 loops=1)
                Sort Key: y
                Sort Method:  external merge  Disk: 6144kB
-               ->  Seq Scan on dummy_table  (cost=0.00..321.00 rows=28700 width=8) (actual time=0.025..1.849 rows=10001 loops=1)
- Planning Time: 0.095 ms
+               ->  Seq Scan on dummy_table  (cost=0.00..321.00 rows=28700 width=8) (actual time=0.030..1.919 rows=10001 loops=1)
+ Planning Time: 1.695 ms
    (slice0)    Executor memory: 50K bytes.
    (slice1)    Executor memory: 391K bytes avg x 3 workers, 391K bytes max (seg0).  Work_mem: 391K bytes max.
  Memory used:  1024kB
  Optimizer: Postgres query optimizer
- Execution Time: 16.305 ms
+ Execution Time: 18.747 ms
 (13 rows)
 
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
@@ -217,7 +129,7 @@ SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
  Success:
 (3 rows)
 
--- 5. Test that if we set statement_mem to a smaller value, the tuplesort
+-- 4. Test that if we set statement_mem to a smaller value, the tuplesort
 -- operation in DISTINCT-qualified WindowAgg will be spilled to disk.
 SET statement_mem TO '128kB';
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
@@ -230,112 +142,24 @@ SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
 (3 rows)
 
 EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
-NOTICE:  distinct winagg sortstats: sort operation spilled to disk  (seg0 slice1 127.0.0.1:7002 pid=313121)
-NOTICE:  distinct winagg sortstats: sort operation spilled to disk  (seg1 slice1 127.0.0.1:7003 pid=313122)
-NOTICE:  distinct winagg sortstats: sort operation spilled to disk  (seg2 slice1 127.0.0.1:7004 pid=313123)
+NOTICE:  distinct winagg sortstats: sort operation spilled to disk  (seg0 slice1 127.0.0.1:7002 pid=43472)
+NOTICE:  distinct winagg sortstats: sort operation spilled to disk  (seg1 slice1 127.0.0.1:7003 pid=43473)
+NOTICE:  distinct winagg sortstats: sort operation spilled to disk  (seg2 slice1 127.0.0.1:7004 pid=43474)
                                                               QUERY PLAN                                                               
 ---------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=2446.06..4096.31 rows=86100 width=36) (actual time=13.122..17.443 rows=30003 loops=1)
-   ->  WindowAgg  (cost=2446.06..2948.31 rows=28700 width=36) (actual time=12.762..14.595 rows=10001 loops=1)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2446.06..4096.31 rows=86100 width=36) (actual time=13.040..19.232 rows=30003 loops=1)
+   ->  WindowAgg  (cost=2446.06..2948.31 rows=28700 width=36) (actual time=12.768..14.527 rows=10001 loops=1)
          Partition By: y
-         ->  Sort  (cost=2446.06..2517.81 rows=28700 width=8) (actual time=4.211..5.454 rows=10001 loops=1)
+         ->  Sort  (cost=2446.06..2517.81 rows=28700 width=8) (actual time=4.278..5.449 rows=10001 loops=1)
                Sort Key: y
                Sort Method:  external merge  Disk: 9216kB
-               ->  Seq Scan on dummy_table  (cost=0.00..321.00 rows=28700 width=8) (actual time=0.024..1.730 rows=10001 loops=1)
- Planning Time: 0.093 ms
+               ->  Seq Scan on dummy_table  (cost=0.00..321.00 rows=28700 width=8) (actual time=0.029..1.746 rows=10001 loops=1)
+ Planning Time: 1.509 ms
    (slice0)    Executor memory: 39K bytes.
    (slice1)    Executor memory: 275K bytes avg x 3 workers, 275K bytes max (seg0).  Work_mem: 275K bytes max.
  Memory used:  128kB
  Optimizer: Postgres query optimizer
- Execution Time: 19.371 ms
-(13 rows)
-
-SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content>=0;
- gp_inject_fault_infinite 
---------------------------
- Success:
- Success:
- Success:
-(3 rows)
-
--- 6. Test that setting work_mem has no effect on the sort operation in the
--- DISTINCT-qualified WindowAgg.
--- a) Set work_mem to a larger value while statement_mem is a smaller value.
-SET work_mem TO '1024kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
-SET statement_mem TO '128kB';
-SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content>=0;
- gp_inject_fault_infinite 
---------------------------
- Success:
- Success:
- Success:
-(3 rows)
-
-EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
-NOTICE:  distinct winagg sortstats: sort operation spilled to disk  (seg0 slice1 127.0.0.1:7002 pid=313121)
-NOTICE:  distinct winagg sortstats: sort operation spilled to disk  (seg1 slice1 127.0.0.1:7003 pid=313122)
-NOTICE:  distinct winagg sortstats: sort operation spilled to disk  (seg2 slice1 127.0.0.1:7004 pid=313123)
-                                                              QUERY PLAN                                                               
----------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=2446.06..4096.31 rows=86100 width=36) (actual time=12.095..15.971 rows=30003 loops=1)
-   ->  WindowAgg  (cost=2446.06..2948.31 rows=28700 width=36) (actual time=11.695..13.364 rows=10001 loops=1)
-         Partition By: y
-         ->  Sort  (cost=2446.06..2517.81 rows=28700 width=8) (actual time=4.151..5.250 rows=10001 loops=1)
-               Sort Key: y
-               Sort Method:  external merge  Disk: 9216kB
-               ->  Seq Scan on dummy_table  (cost=0.00..321.00 rows=28700 width=8) (actual time=0.023..1.736 rows=10001 loops=1)
- Planning Time: 0.103 ms
-   (slice0)    Executor memory: 39K bytes.
-   (slice1)    Executor memory: 275K bytes avg x 3 workers, 275K bytes max (seg0).  Work_mem: 275K bytes max.
- Memory used:  128kB
- Optimizer: Postgres query optimizer
- Execution Time: 17.718 ms
-(13 rows)
-
-SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content>=0;
- gp_inject_fault_infinite 
---------------------------
- Success:
- Success:
- Success:
-(3 rows)
-
--- b) Set work_mem to a smaller value while statement_mem is a larger value.
-SET work_mem TO '128kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
-SET statement_mem TO '1024kB';
-SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content>=0;
- gp_inject_fault_infinite 
---------------------------
- Success:
- Success:
- Success:
-(3 rows)
-
-EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
-NOTICE:  distinct winagg sortstats: sort operation fitted in memory  (seg0 slice1 127.0.0.1:7002 pid=313121)
-NOTICE:  distinct winagg sortstats: sort operation fitted in memory  (seg1 slice1 127.0.0.1:7003 pid=313122)
-NOTICE:  distinct winagg sortstats: sort operation fitted in memory  (seg2 slice1 127.0.0.1:7004 pid=313123)
-                                                              QUERY PLAN                                                               
----------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=2446.06..4096.31 rows=86100 width=36) (actual time=10.023..14.039 rows=30003 loops=1)
-   ->  WindowAgg  (cost=2446.06..2948.31 rows=28700 width=36) (actual time=9.810..11.493 rows=10001 loops=1)
-         Partition By: y
-         ->  Sort  (cost=2446.06..2517.81 rows=28700 width=8) (actual time=3.581..4.604 rows=10001 loops=1)
-               Sort Key: y
-               Sort Method:  external merge  Disk: 6144kB
-               ->  Seq Scan on dummy_table  (cost=0.00..321.00 rows=28700 width=8) (actual time=0.026..1.811 rows=10001 loops=1)
- Planning Time: 0.108 ms
-   (slice0)    Executor memory: 39K bytes.
-   (slice1)    Executor memory: 391K bytes avg x 3 workers, 391K bytes max (seg0).  Work_mem: 391K bytes max.
- Memory used:  1024kB
- Optimizer: Postgres query optimizer
- Execution Time: 16.130 ms
+ Execution Time: 22.056 ms
 (13 rows)
 
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
@@ -350,5 +174,3 @@ SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
 -- Do some clean-ups.
 DROP TABLE dummy_table;
 RESET statement_mem;
-RESET work_mem;
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -51,10 +51,12 @@ test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp li
 test: gpcopy
 
 test: orca_static_pruning orca_groupingsets_fallbacks
-test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var gp_explain distributed_transactions explain_format olap_plans misc_jiras gp_copy_dtx
+test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var gp_explain distributed_transactions explain_format olap_plans gp_copy_dtx
 # below test(s) inject faults so each of them need to be in a separate group
 test: guc_gp
 test: toast
+test: misc_jiras
+test: statement_mem_for_windowagg
 
 # namespace_gp test will show diff if concurrent tests use temporary tables.
 # So run it separately.
@@ -290,8 +292,5 @@ test: run_utility_gpexpand_phase1
 
 # check correct error message when create extension error on segment
 test: create_extension_fail
-
-# Test that we are able to tune statement_mem for WindowAgg.
-test: statement_mem_for_windowagg
 
 # end of tests

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -291,4 +291,7 @@ test: run_utility_gpexpand_phase1
 # check correct error message when create extension error on segment
 test: create_extension_fail
 
+# Test that we are able to tune statement_mem for WindowAgg.
+test: statement_mem_for_windowagg
+
 # end of tests

--- a/src/test/regress/sql/misc_jiras.sql
+++ b/src/test/regress/sql/misc_jiras.sql
@@ -17,7 +17,7 @@ insert into misc_jiras.t1 select i % 13, md5(i::text), i % 3
 
 -- tuplestore in windowagg uses statement_mem to control the in-memory data size,
 -- set a small value to trigger the spilling.
-set statement_mem to '256kB';
+set statement_mem to '512kB';
 
 set extra_float_digits=0; -- the last decimal digits are somewhat random
 

--- a/src/test/regress/sql/misc_jiras.sql
+++ b/src/test/regress/sql/misc_jiras.sql
@@ -15,11 +15,16 @@ create table misc_jiras.t1 (c1 int, c2 text, c3 smallint) distributed by (c1);
 insert into misc_jiras.t1 select i % 13, md5(i::text), i % 3
   from generate_series(1, 20000) i;
 
--- tuplestore uses work_mem to control the in-memory data size, set a small
--- value to trigger the spilling.
-set work_mem to '64kB';
+-- tuplestore in windowagg uses statement_mem to control the in-memory data size,
+-- set a small value to trigger the spilling.
+set statement_mem to '256kB';
 
 set extra_float_digits=0; -- the last decimal digits are somewhat random
+
+-- Inject fault at 'winagg_after_spool_tuples' to show that the tuplestore spills
+-- to disk.
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
 
 select sum(cc) from (
     select c1
@@ -33,7 +38,10 @@ select sum(cc) from (
      group by 1, 2
 ) tt;
 
-reset work_mem;
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+reset statement_mem;
 
 -- non-ASCII multibyte character should show up correctly in error messages.
 select '溋' || (B'1');

--- a/src/test/regress/sql/statement_mem_for_windowagg.sql
+++ b/src/test/regress/sql/statement_mem_for_windowagg.sql
@@ -1,0 +1,110 @@
+CREATE TABLE dummy_table(x int, y int) DISTRIBUTED BY (y);
+INSERT INTO dummy_table SELECT generate_series(0, 10000), 0;
+INSERT INTO dummy_table SELECT generate_series(0, 10000), 3;
+INSERT INTO dummy_table SELECT generate_series(0, 10000), 10;
+
+-- 1. Test that if we set statement_mem to a larger value, the tuplestore
+-- for caching the tuples in partition used in WindowAgg is able to be fitted
+-- in memory.
+SET statement_mem TO '2048kB';
+
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+EXPLAIN ANALYZE SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
+
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+-- 2. Test that if we set statement_mem to a smaller value, the tuplestore
+-- for caching the tuples in partition used in WindowAgg will be spilled to disk.
+SET statement_mem TO '1024kB';
+
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+EXPLAIN ANALYZE SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
+
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+-- 3. Test that setting work_mem has no effect on the execution of the WindowAgg
+-- plan.
+-- a) Set work_mem to a larger value while statement_mem is a smaller value.
+SET statement_mem TO '1024kB';
+SET work_mem TO '2048kB';
+
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+EXPLAIN ANALYZE SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
+
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+-- b) Set work_mem to a smaller value while statement_mem is a larger value.
+SET statement_mem TO '2048kB';
+SET work_mem TO '1024kB';
+
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+EXPLAIN ANALYZE SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
+
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+-- 4. Test that if we set statement_mem to a larger value, the tuplesort
+-- operation in DISTINCT-qualified WindowAgg is able to be fitted in memory.
+SET statement_mem TO '1024kB';
+
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
+
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+-- 5. Test that if we set statement_mem to a smaller value, the tuplesort
+-- operation in DISTINCT-qualified WindowAgg will be spilled to disk.
+SET statement_mem TO '128kB';
+
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
+
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+-- 6. Test that setting work_mem has no effect on the sort operation in the
+-- DISTINCT-qualified WindowAgg.
+-- a) Set work_mem to a larger value while statement_mem is a smaller value.
+SET work_mem TO '1024kB';
+SET statement_mem TO '128kB';
+
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
+
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+-- b) Set work_mem to a smaller value while statement_mem is a larger value.
+SET work_mem TO '128kB';
+SET statement_mem TO '1024kB';
+
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
+
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+-- Do some clean-ups.
+DROP TABLE dummy_table;
+RESET statement_mem;
+RESET work_mem;

--- a/src/test/regress/sql/statement_mem_for_windowagg.sql
+++ b/src/test/regress/sql/statement_mem_for_windowagg.sql
@@ -28,33 +28,7 @@ EXPLAIN ANALYZE SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
 SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
 
--- 3. Test that setting work_mem has no effect on the execution of the WindowAgg
--- plan.
--- a) Set work_mem to a larger value while statement_mem is a smaller value.
-SET statement_mem TO '1024kB';
-SET work_mem TO '2048kB';
-
-SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content>=0;
-
-EXPLAIN ANALYZE SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
-
-SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content>=0;
-
--- b) Set work_mem to a smaller value while statement_mem is a larger value.
-SET statement_mem TO '2048kB';
-SET work_mem TO '1024kB';
-
-SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content>=0;
-
-EXPLAIN ANALYZE SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
-
-SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content>=0;
-
--- 4. Test that if we set statement_mem to a larger value, the tuplesort
+-- 3. Test that if we set statement_mem to a larger value, the tuplesort
 -- operation in DISTINCT-qualified WindowAgg is able to be fitted in memory.
 SET statement_mem TO '1024kB';
 
@@ -66,35 +40,9 @@ EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
 
--- 5. Test that if we set statement_mem to a smaller value, the tuplesort
+-- 4. Test that if we set statement_mem to a smaller value, the tuplesort
 -- operation in DISTINCT-qualified WindowAgg will be spilled to disk.
 SET statement_mem TO '128kB';
-
-SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content>=0;
-
-EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
-
-SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content>=0;
-
--- 6. Test that setting work_mem has no effect on the sort operation in the
--- DISTINCT-qualified WindowAgg.
--- a) Set work_mem to a larger value while statement_mem is a smaller value.
-SET work_mem TO '1024kB';
-SET statement_mem TO '128kB';
-
-SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content>=0;
-
-EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
-
-SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
-  FROM gp_segment_configuration WHERE role='p' AND content>=0;
-
--- b) Set work_mem to a smaller value while statement_mem is a larger value.
-SET work_mem TO '128kB';
-SET statement_mem TO '1024kB';
 
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
@@ -107,4 +55,3 @@ SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
 -- Do some clean-ups.
 DROP TABLE dummy_table;
 RESET statement_mem;
-RESET work_mem;


### PR DESCRIPTION
This patch helps fix incorrect amount of memory allocated for WindowAgg.
Greenplum uses statement_mem rather than work_mem to control the memory
allocated to queries. Besides, test cases are attached for this patch.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Pass `make installcheck`
