### PR TITLE
Revert "Skip redundant anti-wraparound vacuums" to fix flacky case

### DIFF
--- a/src/backend/access/heap/vacuumlazy.c
+++ b/src/backend/access/heap/vacuumlazy.c
@@ -277,23 +277,6 @@ lazy_vacuum_rel_heap(Relation onerel, VacuumParams *params,
 	if (params->options & VACOPT_DISABLE_PAGE_SKIPPING)
 		aggressive = true;
 
-	/*
-	 * Normally the relfrozenxid for an anti-wraparound vacuum will be old
-	 * enough to force an aggressive vacuum.  However, a concurrent vacuum
-	 * might have already done this work that the relfrozenxid in relcache has
-	 * been updated.  If that happens this vacuum is redundant, so skip it.
-	 */
-	if (params->is_wraparound && !aggressive)
-	{
-		ereport(DEBUG1,
-				(errmsg("skipping redundant vacuum to prevent wraparound of table \"%s.%s.%s\"",
-						get_database_name(MyDatabaseId),
-						get_namespace_name(RelationGetNamespace(onerel)),
-						RelationGetRelationName(onerel))));
-		pgstat_progress_end_command();
-		return;
-	}
-
 	vacrelstats = (LVRelStats *) palloc0(sizeof(LVRelStats));
 
 	vacrelstats->old_rel_pages = onerel->rd_rel->relpages;
@@ -423,9 +406,10 @@ lazy_vacuum_rel_heap(Relation onerel, VacuumParams *params,
 			initStringInfo(&buf);
 			if (params->is_wraparound)
 			{
-				/* an anti-wraparound vacuum has to be aggressive */
-				Assert(aggressive);
-				msgfmt = _("automatic aggressive vacuum to prevent wraparound of table \"%s.%s.%s\": index scans: %d\n");
+				if (aggressive)
+					msgfmt = _("automatic aggressive vacuum to prevent wraparound of table \"%s.%s.%s\": index scans: %d\n");
+				else
+					msgfmt = _("automatic vacuum to prevent wraparound of table \"%s.%s.%s\": index scans: %d\n");
 			}
 			else
 			{


### PR DESCRIPTION
the fault 'vacuum_update_dat_frozen_xid' injected in autovacuum-segment
was not triggred until Time-out, which makes the autovacuum-segment case
failed.

the reason why the injected fault 'vacuum_update_dat_frozen_xid' was not
triggred was some shared tables such as pg_shseclabel(it's randomly, but
must be some of critical shared tables) didn't change its frozenxid in
regression.pg_class tuple, so the database 'regression' couldn't update
its frozenxid either.

This reverts commit 2aa6e33, that added a fast path to skip
anti-wraparound and non-aggressive autovacuum jobs (these have no sense
as anti-wraparound implies aggressive).  With a cluster using a high
amount of relations with a portion of them being heavily updated, this
could cause autovacuum to lock down, with autovacuum workers attempting
repeatedly those jobs on the same relations for the same database, that
just kept being skipped.  This lock down can be solved with a manual
VACUUM FREEZE.

Note that anti-wraparound and non-aggressive jobs can only be triggered
on a subset of shared catalogs:
- pg_auth_members
- pg_authid
- pg_database
- pg_shseclabel
- pg_subscription
- pg_auth_time_constraint

Reported-by: Justin King
Discussion: https://postgr.es/m/CAE39h22zPLrkH17GrkDgAYL3kbjvySYD1io+rtnAUFnaJJVS4g@mail.gmail.com

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
