### PR TITLE
pg_upgrade check feature

### DIFF
--- a/src/bin/pg_upgrade/README.gpdb
+++ b/src/bin/pg_upgrade/README.gpdb
@@ -87,3 +87,20 @@ intention is for this to be a quick test that all objects are handled by
 pg_upgrade; upgrade testing still requires the full run across all
 segments/mirrors. The smoketest can be invoked by "make check" in the
 contrib/pg_upgrade directory.
+
+GPDB Merge notice:
+------------------
+We added the gp_fatal_log() function to replace some of the pg_fatal() calls in
+check.c and check_gp.c to support --continue-check-on-fatal, which allows
+running through all the checks even if we get a fatal failure. We need to
+update any newly added checks to ensure they work with the flag by replacing
+pg_fatal function calls with gp_fatal_log calls.
+
+Note: we cannot skip few checks despite using the --continue-check-on-fatal
+flag. See gp_fatal_log() for details.
+
+For --skip-target-check flag while merging upstream, if we have new checks for
+new/target cluster, they should be skipped when the flag is enabled. See
+is_skip_target_check(). There might be new pre-check steps for the target
+cluster before we check_new_cluster(), such as get_sock_dir(), which must be
+guarded.

--- a/src/bin/pg_upgrade/check.c
+++ b/src/bin/pg_upgrade/check.c
@@ -342,19 +342,6 @@ check_cluster_versions(void)
 
 	/* cluster versions should already have been obtained */
 	Assert(old_cluster.major_version != 0);
-	Assert(new_cluster.major_version != 0);
-
-	/*
-	 * Upgrading within a major version is a handy feature of pg_upgrade, but
-	 * we don't allow it for within 4.3.x clusters, 4.3.x can only be an old
-	 * version to be upgraded from.
-	 */
-	if (GET_MAJOR_VERSION(old_cluster.major_version) == 802 &&
-		GET_MAJOR_VERSION(new_cluster.major_version) == 802)
-	{
-		pg_log(PG_FATAL,
-			   "old and new cluster cannot both be Greenplum 4.3.x installations\n");
-	}
 
 	/*
 	 * We allow upgrades from/to the same major version for alpha/beta
@@ -370,6 +357,32 @@ check_cluster_versions(void)
 	if (GET_MAJOR_VERSION(old_cluster.major_version) < 802)
 		pg_fatal("This utility can only upgrade from Greenplum version 4.3.x and later.\n");
 
+	/* Ensure binaries match the designated data directories */
+	if (GET_MAJOR_VERSION(old_cluster.major_version) !=
+		GET_MAJOR_VERSION(old_cluster.bin_version))
+		pg_fatal("Old cluster data and binary directories are from different major versions.\n");
+
+	if(is_skip_target_check())
+	{
+		check_ok();
+		return;
+	}
+
+	/* cluster versions should already have been obtained */
+	Assert(new_cluster.major_version != 0);
+
+	/*
+	 * Upgrading within a major version is a handy feature of pg_upgrade, but
+	 * we don't allow it for within 4.3.x clusters, 4.3.x can only be an old
+	 * version to be upgraded from.
+	 */
+	if (GET_MAJOR_VERSION(old_cluster.major_version) == 802 &&
+		GET_MAJOR_VERSION(new_cluster.major_version) == 802)
+	{
+		pg_log(PG_FATAL,
+			   "old and new cluster cannot both be Greenplum 4.3.x installations\n");
+	}
+
 	/* Only current PG version is supported as a target */
 	if (GET_MAJOR_VERSION(new_cluster.major_version) != GET_MAJOR_VERSION(PG_VERSION_NUM))
 		pg_fatal("This utility can only upgrade to Greenplum version %s.\n",
@@ -384,9 +397,6 @@ check_cluster_versions(void)
 		pg_fatal("This utility cannot be used to downgrade to older major Greenplum versions.\n");
 
 	/* Ensure binaries match the designated data directories */
-	if (GET_MAJOR_VERSION(old_cluster.major_version) !=
-		GET_MAJOR_VERSION(old_cluster.bin_version))
-		pg_fatal("Old cluster data and binary directories are from different major versions.\n");
 	if (GET_MAJOR_VERSION(new_cluster.major_version) !=
 		GET_MAJOR_VERSION(new_cluster.bin_version))
 		pg_fatal("New cluster data and binary directories are from different major versions.\n");
@@ -400,8 +410,12 @@ check_cluster_compatibility(bool live_check)
 {
 	/* get/check pg_control data of servers */
 	get_control_data(&old_cluster, live_check);
-	get_control_data(&new_cluster, false);
-	check_control_data(&old_cluster.controldata, &new_cluster.controldata);
+
+	if(!is_skip_target_check())
+	{
+		get_control_data(&new_cluster, false);
+		check_control_data(&old_cluster.controldata, &new_cluster.controldata);
+	}
 
 	/* We read the real port number for PG >= 9.1 */
 	if (live_check && GET_MAJOR_VERSION(old_cluster.major_version) < 901 &&
@@ -409,9 +423,12 @@ check_cluster_compatibility(bool live_check)
 		pg_fatal("When checking a pre-PG 9.1 live old server, "
 				 "you must specify the old server's port number.\n");
 
-	if (live_check && old_cluster.port == new_cluster.port)
-		pg_fatal("When checking a live server, "
-				 "the old and new port numbers must be different.\n");
+	if(!is_skip_target_check())
+	{
+		if (live_check && old_cluster.port == new_cluster.port)
+			pg_fatal("When checking a live server, "
+					 "the old and new port numbers must be different.\n");
+	}
 }
 
 

--- a/src/bin/pg_upgrade/check.c
+++ b/src/bin/pg_upgrade/check.c
@@ -240,7 +240,9 @@ report_clusters_compatible(void)
 {
 	if (user_opts.check)
 	{
-		pg_log(PG_REPORT, "\n*Clusters are compatible*\n");
+		pg_log(PG_REPORT, (get_check_fatal_occurred() ?
+			"\n*Some cluster objects are not compatible*\n" : "\n*Clusters are compatible*\n"));
+
 		/* stops new cluster */
 		stop_postmaster(false);
 		exit(0);
@@ -428,10 +430,10 @@ check_locale_and_encoding(DbInfo *olddb, DbInfo *newdb)
 				 pg_encoding_to_char(olddb->db_encoding),
 				 pg_encoding_to_char(newdb->db_encoding));
 	if (!equivalent_locale(LC_COLLATE, olddb->db_collate, newdb->db_collate))
-		pg_fatal("lc_collate values for database \"%s\" do not match:  old \"%s\", new \"%s\"\n",
+		gp_fatal_log("lc_collate values for database \"%s\" do not match:  old \"%s\", new \"%s\"\n",
 				 olddb->db_name, olddb->db_collate, newdb->db_collate);
 	if (!equivalent_locale(LC_CTYPE, olddb->db_ctype, newdb->db_ctype))
-		pg_fatal("lc_ctype values for database \"%s\" do not match:  old \"%s\", new \"%s\"\n",
+		gp_fatal_log("lc_ctype values for database \"%s\" do not match:  old \"%s\", new \"%s\"\n",
 				 olddb->db_name, olddb->db_ctype, newdb->db_ctype);
 }
 
@@ -512,7 +514,7 @@ check_new_cluster_is_empty(void)
 		{
 			/* pg_largeobject and its index should be skipped */
 			if (strcmp(rel_arr->rels[relnum].nspname, "pg_catalog") != 0)
-				pg_fatal("New cluster database \"%s\" is not empty: found relation \"%s.%s\"\n",
+				gp_fatal_log("New cluster database \"%s\" is not empty: found relation \"%s.%s\"\n",
 						 new_cluster.dbarr.dbs[dbnum].db_name,
 						 rel_arr->rels[relnum].nspname,
 						 rel_arr->rels[relnum].relname);
@@ -794,7 +796,7 @@ check_is_install_user(ClusterInfo *cluster)
 	 */
 	if (PQntuples(res) != 1 ||
 		atooid(PQgetvalue(res, 0, 1)) != BOOTSTRAP_SUPERUSERID)
-		pg_fatal("database user \"%s\" is not the install user\n",
+		gp_fatal_log("database user \"%s\" is not the install user\n",
 				 os_info.user);
 
 	PQclear(res);
@@ -805,7 +807,7 @@ check_is_install_user(ClusterInfo *cluster)
 							"WHERE rolname !~ '^pg_'");
 
 	if (PQntuples(res) != 1)
-		pg_fatal("could not determine the number of users\n");
+		gp_fatal_log("could not determine the number of users\n");
 
 	/*
 	 * We only allow the install user in the new cluster because other defined
@@ -907,9 +909,9 @@ check_for_prepared_transactions(ClusterInfo *cluster)
 	if (PQntuples(res) != 0)
 	{
 		if (cluster == &old_cluster)
-			pg_fatal("The source cluster contains prepared transactions\n");
+			gp_fatal_log("The source cluster contains prepared transactions\n");
 		else
-			pg_fatal("The target cluster contains prepared transactions\n");
+			gp_fatal_log("The target cluster contains prepared transactions\n");
 	}
 
 	PQclear(res);
@@ -997,13 +999,14 @@ check_for_isn_and_int8_passing_mismatch(ClusterInfo *cluster)
 	if (found)
 	{
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains \"contrib/isn\" functions which rely on the\n"
-				 "bigint data type.  Your old and new clusters pass bigint values\n"
-				 "differently so this cluster cannot currently be upgraded.  You can\n"
-				 "manually upgrade databases that use \"contrib/isn\" facilities and remove\n"
-				 "\"contrib/isn\" from the old cluster and restart the upgrade.  A list of\n"
-				 "the problem functions is in the file:\n"
-				 "    %s\n\n", output_path);
+		gp_fatal_log(
+				"| Your installation contains \"contrib/isn\" functions which rely on the\n"
+				"| bigint data type.  Your old and new clusters pass bigint values\n"
+				"| differently so this cluster cannot currently be upgraded.  You can\n"
+				"| manually upgrade databases that use \"contrib/isn\" facilities and remove\n"
+				"| \"contrib/isn\" from the old cluster and restart the upgrade.  A list of\n"
+				"| the problem functions is in the file:\n"
+				"|     %s\n\n", output_path);
 	}
 	else
 		check_ok();
@@ -1076,11 +1079,12 @@ check_for_tables_with_oids(ClusterInfo *cluster)
 	if (found)
 	{
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains tables declared WITH OIDS, which is not supported\n"
-				 "anymore. Consider removing the oid column using\n"
-				 "    ALTER TABLE ... SET WITHOUT OIDS;\n"
-				 "A list of tables with the problem is in the file:\n"
-				 "    %s\n\n", output_path);
+		gp_fatal_log(
+				"| Your installation contains tables declared WITH OIDS, which is not supported\n"
+				"| anymore. Consider removing the oid column using\n"
+				"|     ALTER TABLE ... SET WITHOUT OIDS;\n"
+				"| A list of tables with the problem is in the file:\n"
+				"|     %s\n\n", output_path);
 	}
 	else
 		check_ok();
@@ -1191,12 +1195,13 @@ check_for_reg_data_type_usage(ClusterInfo *cluster)
 	if (found)
 	{
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains one of the reg* data types in user tables.\n"
-				 "These data types reference system OIDs that are not preserved by\n"
-				 "pg_upgrade, so this cluster cannot currently be upgraded.  You can\n"
-				 "remove the problem tables and restart the upgrade.  A list of the problem\n"
-				 "columns is in the file:\n"
-				 "    %s\n\n", output_path);
+		gp_fatal_log(
+				"| Your installation contains one of the reg* data types in user tables.\n"
+				"| These data types reference system OIDs that are not preserved by\n"
+				"| pg_upgrade, so this cluster cannot currently be upgraded.  You can\n"
+				"| remove the problem tables and restart the upgrade.  A list of the problem\n"
+				"| columns is in the file:\n"
+				"|     %s\n\n", output_path);
 	}
 	else
 		check_ok();
@@ -1282,11 +1287,12 @@ check_for_jsonb_9_4_usage(ClusterInfo *cluster)
 	if (found)
 	{
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains the \"jsonb\" data type in user tables.\n"
-				 "The internal format of \"jsonb\" changed during 9.4 beta so this cluster cannot currently\n"
-				 "be upgraded.  You can remove the problem tables and restart the upgrade.  A list\n"
-				 "of the problem columns is in the file:\n"
-				 "    %s\n\n", output_path);
+		gp_fatal_log(
+				"| Your installation contains the \"jsonb\" data type in user tables.\n"
+				"| The internal format of \"jsonb\" changed during 9.4 beta so this cluster cannot currently\n"
+				"| be upgraded.  You can remove the problem tables and restart the upgrade.  A list\n"
+				"| of the problem columns is in the file:\n"
+				"|     %s\n\n", output_path);
 	}
 	else
 		check_ok();
@@ -1313,9 +1319,9 @@ check_for_pg_role_prefix(ClusterInfo *cluster)
 	if (PQntuples(res) != 0)
 	{
 		if (cluster == &old_cluster)
-			pg_fatal("The source cluster contains roles starting with \"pg_\"\n");
+			gp_fatal_log("The source cluster contains roles starting with \"pg_\"\n");
 		else
-			pg_fatal("The target cluster contains roles starting with \"pg_\"\n");
+			gp_fatal_log("The target cluster contains roles starting with \"pg_\"\n");
 	}
 
 	PQclear(res);

--- a/src/bin/pg_upgrade/exec.c
+++ b/src/bin/pg_upgrade/exec.c
@@ -13,6 +13,8 @@
 
 #include "pg_upgrade.h"
 
+#include "greenplum/pg_upgrade_greenplum.h"
+
 static void check_data_dir(ClusterInfo *cluster);
 static void check_bin_dir(ClusterInfo *cluster);
 static void get_bin_version(ClusterInfo *cluster);
@@ -256,8 +258,12 @@ verify_directories(void)
 
 	check_bin_dir(&old_cluster);
 	check_data_dir(&old_cluster);
-	check_bin_dir(&new_cluster);
-	check_data_dir(&new_cluster);
+
+	if(!is_skip_target_check())
+	{
+	  check_bin_dir(&new_cluster);
+	  check_data_dir(&new_cluster);
+	}
 }
 
 

--- a/src/bin/pg_upgrade/function.c
+++ b/src/bin/pg_upgrade/function.c
@@ -278,11 +278,12 @@ check_loadable_libraries(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation references loadable libraries that are missing from the\n"
-				 "new installation.  You can add these libraries to the new installation,\n"
-				 "or remove the functions using them from the old installation.  A list of\n"
-				 "problem libraries is in the file:\n"
-				 "    %s\n\n", output_path);
+		gp_fatal_log(
+				"| Your installation references loadable libraries that are missing from the\n"
+				"| new installation.  You can add these libraries to the new installation,\n"
+				"| or remove the functions using them from the old installation.  A list of\n"
+				"| problem libraries is in the file:\n"
+				"|     %s\n\n", output_path);
 	}
 	else
 		check_ok();

--- a/src/bin/pg_upgrade/greenplum/check_gp.c
+++ b/src/bin/pg_upgrade/greenplum/check_gp.c
@@ -109,7 +109,7 @@ check_online_expansion(void)
 	if (expansion)
 	{
 		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
+		gp_fatal_log(
 			   "| Your installation is in progress of online expansion,\n"
 			   "| must complete that job before the upgrade.\n\n");
 	}
@@ -200,7 +200,7 @@ check_external_partition(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
+		gp_fatal_log(
 			   "| Your installation contains partitioned tables with external\n"
 			   "| tables as partitions.  These partitions need to be removed\n"
 			   "| from the partition hierarchy before the upgrade.  A list of\n"
@@ -308,7 +308,7 @@ check_covering_aoindex(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
+		gp_fatal_log(
 			   "| Your installation contains partitioned append-only tables\n"
 			   "| with an index defined on the partition parent which isn't\n"
 			   "| present on all partition members.  These indexes must be\n"
@@ -372,7 +372,7 @@ check_orphaned_toastrels(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
+		gp_fatal_log(
 			   "| Your installation contains orphaned toast tables which\n"
 			   "| must be dropped before upgrade.\n"
 			   "| A list of the problem databases is in the file:\n"
@@ -479,7 +479,7 @@ check_partition_indexes(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
+		gp_fatal_log(
 			   "| Your installation contains partitioned tables with\n"
 			   "| indexes defined on them.  Indexes on partition parents,\n"
 			   "| as well as children, must be dropped before upgrade.\n"
@@ -557,7 +557,7 @@ check_gphdfs_external_tables(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
+		gp_fatal_log(
 			   "| Your installation contains gphdfs external tables.  These \n"
 			   "| tables need to be dropped before upgrade.  A list of\n"
 			   "| external gphdfs tables to remove is provided in the file:\n"
@@ -634,7 +634,7 @@ check_gphdfs_user_roles(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
+		gp_fatal_log(
 			   "| Your installation contains roles that have gphdfs privileges.\n"
 			   "| These privileges need to be revoked before upgrade.  A list\n"
 			   "| of roles and their corresponding gphdfs privileges that\n"
@@ -713,11 +713,9 @@ check_for_array_of_partition_table_types(ClusterInfo *cluster)
 	if (strlen(dependee_partition_report))
 	{
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal(
-			"Array types derived from partitions of a partitioned table must not have dependants.\n"
-			"OIDs of such types found and their original partitions:\n%s",
-			dependee_partition_report
-		);
+		gp_fatal_log(
+			"| Array types derived from partitions of a partitioned table must not have dependants.\n"
+			"| OIDs of such types found and their original partitions:\n%s", dependee_partition_report);
 	}
 	pfree(dependee_partition_report);
 

--- a/src/bin/pg_upgrade/greenplum/option_gp.c
+++ b/src/bin/pg_upgrade/greenplum/option_gp.c
@@ -11,6 +11,7 @@ typedef struct {
 	segmentMode segment_mode;
 	checksumMode checksum_mode;
 	bool continue_check_on_fatal;
+	bool skip_target_check;
 } GreenplumUserOpts;
 
 static GreenplumUserOpts greenplum_user_opts;
@@ -20,6 +21,8 @@ void
 initialize_greenplum_user_options(void)
 {
 	greenplum_user_opts.segment_mode = SEGMENT;
+	greenplum_user_opts.continue_check_on_fatal = false;
+	greenplum_user_opts.skip_target_check = false;
 }
 
 bool
@@ -64,6 +67,18 @@ process_greenplum_option(greenplumOption option, char *option_value)
 				exit(1);
 			}
 			break;
+
+		case GREENPLUM_SKIP_TARGET_CHECK:
+			if (user_opts.check)
+					greenplum_user_opts.skip_target_check = true;
+			else
+			{
+					pg_log(PG_FATAL,
+						"--skip-target-check: should be used with check mode (-c)\n");
+					exit(1);
+			}
+			break;
+
 		default:
 			return false;
 	}
@@ -105,4 +120,10 @@ bool
 get_check_fatal_occurred(void)
 {
 	return check_fatal_occurred;
+}
+
+bool
+is_skip_target_check(void)
+{
+	return greenplum_user_opts.skip_target_check;
 }

--- a/src/bin/pg_upgrade/greenplum/option_gp.c
+++ b/src/bin/pg_upgrade/greenplum/option_gp.c
@@ -10,9 +10,11 @@ typedef struct {
 	bool progress;
 	segmentMode segment_mode;
 	checksumMode checksum_mode;
+	bool continue_check_on_fatal;
 } GreenplumUserOpts;
 
 static GreenplumUserOpts greenplum_user_opts;
+static bool check_fatal_occurred;
 
 void
 initialize_greenplum_user_options(void)
@@ -48,6 +50,20 @@ process_greenplum_option(greenplumOption option, char *option_value)
 		case GREENPLUM_REMOVE_CHECKSUM_OPTION:        /* --remove-checksum */
 			greenplum_user_opts.checksum_mode = CHECKSUM_REMOVE;
 			break;
+
+		case GREENPLUM_CONTINUE_CHECK_ON_FATAL:
+			if (user_opts.check)
+			{
+				greenplum_user_opts.continue_check_on_fatal = true;
+				check_fatal_occurred = false;
+			}
+			else
+			{
+				pg_log(PG_FATAL,
+					"--continue-check-on-fatal: should be used with check mode (-c)\n");
+				exit(1);
+			}
+			break;
 		default:
 			return false;
 	}
@@ -73,3 +89,20 @@ is_show_progress_mode(void)
 	return greenplum_user_opts.progress;
 }
 
+bool
+is_continue_check_on_fatal(void)
+{
+	return greenplum_user_opts.continue_check_on_fatal;
+}
+
+void
+set_check_fatal_occured(void)
+{
+	check_fatal_occurred = true;
+}
+
+bool
+get_check_fatal_occurred(void)
+{
+	return check_fatal_occurred;
+}

--- a/src/bin/pg_upgrade/greenplum/pg_upgrade_greenplum.h
+++ b/src/bin/pg_upgrade/greenplum/pg_upgrade_greenplum.h
@@ -43,7 +43,8 @@ typedef enum {
 	GREENPLUM_PROGRESS_OPTION = 11,
 	GREENPLUM_ADD_CHECKSUM_OPTION = 12,
 	GREENPLUM_REMOVE_CHECKSUM_OPTION = 13,
-	GREENPLUM_CONTINUE_CHECK_ON_FATAL = 14
+	GREENPLUM_CONTINUE_CHECK_ON_FATAL = 14,
+	GREENPLUM_SKIP_TARGET_CHECK = 15
 } greenplumOption;
 
 #define GREENPLUM_OPTIONS \
@@ -51,7 +52,8 @@ typedef enum {
 	{"progress", no_argument, NULL, GREENPLUM_PROGRESS_OPTION}, \
 	{"add-checksum", no_argument, NULL, GREENPLUM_ADD_CHECKSUM_OPTION}, \
 	{"remove-checksum", no_argument, NULL, GREENPLUM_REMOVE_CHECKSUM_OPTION}, \
-	{"continue-check-on-fatal", no_argument, NULL, GREENPLUM_CONTINUE_CHECK_ON_FATAL},
+	{"continue-check-on-fatal", no_argument, NULL, GREENPLUM_CONTINUE_CHECK_ON_FATAL}, \
+	{"skip-target-check", no_argument, NULL, GREENPLUM_SKIP_TARGET_CHECK},
 
 #define GREENPLUM_USAGE "\
       --mode=TYPE               designate node type to upgrade, \"segment\" or \"dispatcher\" (default \"segment\")\n\
@@ -59,6 +61,7 @@ typedef enum {
       --remove-checksum         remove data checksums when creating new cluster\n\
       --add-checksum            add data checksumming to the new cluster\n\
       --continue-check-on-fatal continue to run through all pg_upgrade checks without upgrade. Stops on major issues\n\
+      --skip-target-check       skip all checks on new/target cluster\n\
 "
 
 /* option_gp.c */
@@ -70,6 +73,7 @@ bool is_show_progress_mode(void);
 bool is_continue_check_on_fatal(void);
 void set_check_fatal_occured(void);
 bool get_check_fatal_occurred(void);
+bool is_skip_target_check(void);
 
 /* pg_upgrade_greenplum.c */
 void freeze_master_data(void);

--- a/src/bin/pg_upgrade/greenplum/pg_upgrade_greenplum.h
+++ b/src/bin/pg_upgrade/greenplum/pg_upgrade_greenplum.h
@@ -42,20 +42,23 @@ typedef enum {
 	GREENPLUM_MODE_OPTION = 10,
 	GREENPLUM_PROGRESS_OPTION = 11,
 	GREENPLUM_ADD_CHECKSUM_OPTION = 12,
-	GREENPLUM_REMOVE_CHECKSUM_OPTION = 13
+	GREENPLUM_REMOVE_CHECKSUM_OPTION = 13,
+	GREENPLUM_CONTINUE_CHECK_ON_FATAL = 14
 } greenplumOption;
 
 #define GREENPLUM_OPTIONS \
 	{"mode", required_argument, NULL, GREENPLUM_MODE_OPTION}, \
 	{"progress", no_argument, NULL, GREENPLUM_PROGRESS_OPTION}, \
 	{"add-checksum", no_argument, NULL, GREENPLUM_ADD_CHECKSUM_OPTION}, \
-	{"remove-checksum", no_argument, NULL, GREENPLUM_REMOVE_CHECKSUM_OPTION},
+	{"remove-checksum", no_argument, NULL, GREENPLUM_REMOVE_CHECKSUM_OPTION}, \
+	{"continue-check-on-fatal", no_argument, NULL, GREENPLUM_CONTINUE_CHECK_ON_FATAL},
 
 #define GREENPLUM_USAGE "\
       --mode=TYPE               designate node type to upgrade, \"segment\" or \"dispatcher\" (default \"segment\")\n\
       --progress                enable progress reporting\n\
       --remove-checksum         remove data checksums when creating new cluster\n\
       --add-checksum            add data checksumming to the new cluster\n\
+      --continue-check-on-fatal continue to run through all pg_upgrade checks without upgrade. Stops on major issues\n\
 "
 
 /* option_gp.c */
@@ -64,6 +67,9 @@ bool process_greenplum_option(greenplumOption option, char *option_value);
 bool is_greenplum_dispatcher_mode(void);
 bool is_checksum_mode(checksumMode mode);
 bool is_show_progress_mode(void);
+bool is_continue_check_on_fatal(void);
+void set_check_fatal_occured(void);
+bool get_check_fatal_occurred(void);
 
 /* pg_upgrade_greenplum.c */
 void freeze_master_data(void);

--- a/src/bin/pg_upgrade/option.c
+++ b/src/bin/pg_upgrade/option.c
@@ -324,6 +324,7 @@ usage(void)
 	printf(_("  -v, --verbose                 enable verbose internal logging\n"));
 	printf(_("  -V, --version                 display version information, then exit\n"));
 	printf(_("  --clone                       clone instead of copying files to new cluster\n"));
+	printf(_("  --continue-check-on-fatal     goes through all pg_upgrade checks; should be used with -c\n"));
 	printf(_("  -?, --help                    show this help, then exit\n"));
 	printf(_("\n"
 			 "Before running pg_upgrade you must:\n"

--- a/src/bin/pg_upgrade/option.c
+++ b/src/bin/pg_upgrade/option.c
@@ -263,12 +263,18 @@ parseCommandLine(int argc, char *argv[])
 	/* Get values from env if not already set */
 	check_required_directory(&old_cluster.bindir, "PGBINOLD", false,
 							 "-b", _("old cluster binaries reside"));
-	check_required_directory(&new_cluster.bindir, "PGBINNEW", false,
-							 "-B", _("new cluster binaries reside"));
+
+	if(!is_skip_target_check())
+		check_required_directory(&new_cluster.bindir, "PGBINNEW", false,
+					 "-B", "new cluster binaries reside");
+
 	check_required_directory(&old_cluster.pgdata, "PGDATAOLD", false,
 							 "-d", _("old cluster data resides"));
-	check_required_directory(&new_cluster.pgdata, "PGDATANEW", false,
-							 "-D", _("new cluster data resides"));
+
+	if(!is_skip_target_check())
+		check_required_directory(&new_cluster.pgdata, "PGDATANEW", false,
+					 "-D", "new cluster data resides");
+
 	check_required_directory(&user_opts.socketdir, "PGSOCKETDIR", true,
 							 "-s", _("sockets will be created"));
 
@@ -325,6 +331,7 @@ usage(void)
 	printf(_("  -V, --version                 display version information, then exit\n"));
 	printf(_("  --clone                       clone instead of copying files to new cluster\n"));
 	printf(_("  --continue-check-on-fatal     goes through all pg_upgrade checks; should be used with -c\n"));
+	printf(_("  --skip-target-check           skip all checks and comparisons of new cluster; should be used with -c\n"));
 	printf(_("  -?, --help                    show this help, then exit\n"));
 	printf(_("\n"
 			 "Before running pg_upgrade you must:\n"

--- a/src/bin/pg_upgrade/pg_upgrade.h
+++ b/src/bin/pg_upgrade/pg_upgrade.h
@@ -556,6 +556,7 @@ void		check_ok(void);
 unsigned int str2uint(const char *str);
 uint64		str2uint64(const char *str);
 void		pg_putenv(const char *var, const char *val);
+void 		gp_fatal_log(const char *fmt,...);
 
 
 /* version.c */

--- a/src/bin/pg_upgrade/tablespace.c
+++ b/src/bin/pg_upgrade/tablespace.c
@@ -10,6 +10,7 @@
 #include "postgres_fe.h"
 
 #include "pg_upgrade.h"
+#include "greenplum/pg_upgrade_greenplum.h"
 
 static void get_tablespace_paths(void);
 static void set_tablespace_directory_suffix(ClusterInfo *cluster);
@@ -21,12 +22,16 @@ init_tablespaces(void)
 	get_tablespace_paths();
 
 	set_tablespace_directory_suffix(&old_cluster);
-	set_tablespace_directory_suffix(&new_cluster);
 
-	if (os_info.num_old_tablespaces > 0 &&
-		strcmp(old_cluster.tablespace_suffix, new_cluster.tablespace_suffix) == 0)
-		pg_fatal("Cannot upgrade to/from the same system catalog version when\n"
-				 "using tablespaces.\n");
+	if(!is_skip_target_check())
+	{
+		set_tablespace_directory_suffix(&new_cluster);
+
+		if (os_info.num_old_tablespaces > 0 &&
+		  strcmp(old_cluster.tablespace_suffix, new_cluster.tablespace_suffix) == 0)
+			pg_fatal("Cannot upgrade to/from the same system catalog version when\n"
+					"using tablespaces.\n");
+	}
 }
 
 


### PR DESCRIPTION
Adds `--skip-target-check` and `--continue-check-on-fatal` features for check mode:


### `--continue-check-on-fatal`
The  flag lets us traverse through the pg_upgrade --check list without
exiting the first error encountered. It allows the user to get a report of 
the entire list of non-upgradable objects in their cluster at one go.

Note: We canot ignore certain checks despite the flag being supplied -
they may be critical to the check process . One such example is
heck_proper_datallowconn(), which ensures that we can connect to user
databases to perform the checks themselves.  Specific checks are
multi-step, like the check to ensure that only the install user is the
sole user in the target database. If we get fatal: "could not determine
the number of users", we can't proceed with the check. Thus, in these
cases, the flag will not respect the flag.

Example:
```
pg_upgrade \
-b /usr/local/5XSTABLE/bin/ \
-B /usr/local/6XSTABLE/bin/ \
-d /data/5XStable/demoDataDir-1 \
-D /data/6XStable/demoDataDir-1 \
-p 15432 \
-P 6000 \
-c \
--continue-check-on-fatal
```

### `--skip-target-check`
The flag allows us to skip target cluster checks performed by pg_upgrade
--check. It lets users find out incompatible objects on the source
cluster without the hassle of setting up a target cluster. For instance,
it is often non-trivial to set up GPDB specific extensions, and users
invariably run into a failure in check_loadable_libraries().

- need to be used along with check flag (-c)
- when you are using the flag we don't need to provide:
  - new-bindir (-B)
  - new-datadir (-D)
  - new-port (-P)
- it can be used along with `--continue-check-on-fatal`

Example:
```
pg_upgrade \
-b /usr/local/5XSTABLE/bin/ \
-d /data/5XStable/demoDataDir-1 \
-p 15432 \
-c \
--continue-check-on-fatal \
--skip-target-check
```

Dependency: https://github.com/greenplum-db/gpdb/pull/13122