### PR TITLE
Fix index corruption when invalid snapshot used with AO tables. (#12797)

### DIFF
--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -856,6 +856,11 @@ DefineIndex(Oid relationId,
 		/* make sure the QE uses the same index name that we chose */
 		stmt->idxname = indexRelationName;
 		stmt->oldNode = InvalidOid;
+		/*
+		 * Please note, top snapshot dispatched here was taken before lock
+		 * acquiring, but it's OK since with don't use it - see IndexBuildScan
+		 * for used snapshots and more.
+		 */
 		CdbDispatchUtilityStatement((Node *) stmt,
 									DF_CANCEL_ON_ERROR |
 									DF_WITH_SNAPSHOT |

--- a/src/test/isolation2/input/uao/snapshot_index_corruption.source
+++ b/src/test/isolation2/input/uao/snapshot_index_corruption.source
@@ -1,0 +1,34 @@
+-- @Description Test index corruption when invalid snapshot used.
+--
+-- Create AO table, insert few rows on it.
+drop table if exists test_ao;
+create table test_ao(i bigint) with (appendonly=true, orientation=@orientation@) distributed by (i);
+insert into test_ao select generate_series(1,100);
+-- Test 1
+-- Begin single-insert transaction.
+1: begin;
+1: insert into test_ao values(101);
+-- Try to create index, it should hold on lock before commit below.
+2&: create index test_ao_idx on test_ao(i);
+-- Commit single-insert transaction, so index continues creation.
+1: commit;
+-- Force index usage and check row is here (false before fix).
+2<:
+2: set optimizer=off;
+2: set enable_seqscan=off;
+2: explain (costs off) select i from test_ao where i = 101;
+2: select i from test_ao where i = 101;
+
+-- Test 2
+-- Drop incomplete index
+1: drop index test_ao_idx;
+-- Start repeatable read transaction and check row is here.
+2: begin;
+2: set transaction isolation level repeatable read;
+2: select i from test_ao where i = 100;
+-- Update row selected above and create new index
+1: update test_ao set i = 200 where i = 100;
+1: create index test_ao_idx on test_ao(i);
+-- For the repeatable read isolation level row still there (false before fix).
+2: explain (costs off) select i from test_ao where i = 100;
+2: select i from test_ao where i = 100;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -147,6 +147,7 @@ test: uao/selectinsert_while_vacuum_row
 test: uao/selectinsertupdate_while_vacuum_row
 test: uao/selectupdate_while_vacuum_row
 test: uao/snapshot_eof_row
+test: uao/snapshot_index_corruption_row
 test: uao/update_while_vacuum_row
 test: uao/vacuum_self_serializable_row
 test: uao/vacuum_self_serializable2_row
@@ -198,6 +199,7 @@ test: uao/selectinsert_while_vacuum_column
 test: uao/selectinsertupdate_while_vacuum_column
 test: uao/selectupdate_while_vacuum_column
 test: uao/snapshot_eof_column
+test: uao/snapshot_index_corruption_column
 test: uao/update_while_vacuum_column
 test: uao/vacuum_self_serializable_column
 test: uao/vacuum_self_serializable2_column

--- a/src/test/isolation2/output/uao/snapshot_index_corruption.source
+++ b/src/test/isolation2/output/uao/snapshot_index_corruption.source
@@ -1,0 +1,78 @@
+-- @Description Test index corruption when invalid snapshot used.
+--
+-- Create AO table, insert few rows on it.
+drop table if exists test_ao;
+DROP
+create table test_ao(i bigint) with (appendonly=true, orientation=@orientation@) distributed by (i);
+CREATE
+insert into test_ao select generate_series(1,100);
+INSERT 100
+-- Test 1
+-- Begin single-insert transaction.
+1: begin;
+BEGIN
+1: insert into test_ao values(101);
+INSERT 1
+-- Try to create index, it should hold on lock before commit below.
+2&: create index test_ao_idx on test_ao(i);  <waiting ...>
+-- Commit single-insert transaction, so index continues creation.
+1: commit;
+COMMIT
+-- Force index usage and check row is here (false before fix).
+2<:  <... completed>
+CREATE
+2: set optimizer=off;
+SET
+2: set enable_seqscan=off;
+SET
+2: explain (costs off) select i from test_ao where i = 101;
+ QUERY PLAN                                   
+----------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)     
+   ->  Bitmap Heap Scan on test_ao            
+         Recheck Cond: (i = 101)              
+         ->  Bitmap Index Scan on test_ao_idx 
+               Index Cond: (i = 101)          
+ Optimizer: Postgres query optimizer          
+(6 rows)
+2: select i from test_ao where i = 101;
+ i   
+-----
+ 101 
+(1 row)
+
+-- Test 2
+-- Drop incomplete index
+1: drop index test_ao_idx;
+DROP
+-- Start repeatable read transaction and check row is here.
+2: begin;
+BEGIN
+2: set transaction isolation level repeatable read;
+SET
+2: select i from test_ao where i = 100;
+ i   
+-----
+ 100 
+(1 row)
+-- Update row selected above and create new index
+1: update test_ao set i = 200 where i = 100;
+UPDATE 1
+1: create index test_ao_idx on test_ao(i);
+CREATE
+-- For the repeatable read isolation level row still there (false before fix).
+2: explain (costs off) select i from test_ao where i = 100;
+ QUERY PLAN                                   
+----------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)     
+   ->  Bitmap Heap Scan on test_ao            
+         Recheck Cond: (i = 100)              
+         ->  Bitmap Index Scan on test_ao_idx 
+               Index Cond: (i = 100)          
+ Optimizer: Postgres query optimizer          
+(6 rows)
+2: select i from test_ao where i = 100;
+ i   
+-----
+ 100 
+(1 row)


### PR DESCRIPTION
This is a resubmission of 44dc41a212b98b7b60c470f8f85ffc72894526fe (#12797) which introduced a compile error because uninitialized `OldestXmin` in some code path. The fix is simple but since the error is blocking release 6.19.3 currently and it takes time to verify the fix on pipeline, we've just reverted the original commit and re-submitted this PR which has the `OldestXmin` been fixed.

For some reason, this PR didn't trigger any pipeline job. Manually started a dev pipeline to verify: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/index-fix-compile-error
(_update: all tests passed_)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
