### PR TITLE
docs - add topics for btree_gin and pg_trgm modules

### DIFF
--- a/gpdb-doc/dita/ref_guide/modules/btree_gin.xml
+++ b/gpdb-doc/dita/ref_guide/modules/btree_gin.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE dita PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<dita>
+  <topic id="topic_fstrm">
+    <title>btree_gin</title>
+    <body>
+      <p>The <codeph>btree_gin</codeph> module provides sample generalized inverted index
+        (GIN) operator classes that implement B-tree equivalent behavior for certain data
+        types.</p>
+      <p>The Greenplum Database <codeph>btree_gin</codeph> module is equivalent
+        to the PostgreSQL <codeph>btree_gin</codeph> module. There are no
+        Greenplum Database or MPP-specific considerations for the module.</p>
+    </body>
+    <topic id="topic_reg">
+      <title>Installing and Registering the Module</title>
+      <body>
+        <p>The <codeph>btree_gin</codeph> module is installed when you install
+          Greenplum Database. Before you can use any of the functions defined in the
+          module, you must register the <codeph>btree_gin</codeph> extension in
+          each database in which you want to use the functions:</p>
+      <codeblock>CREATE EXTENSION btree_gin;</codeblock>
+        <p>Refer to <xref href="../../install_guide/install_modules.html"
+            format="html" scope="external">Installing Additional Supplied Modules</xref>
+          for more information.</p>
+      </body>
+    </topic>
+    <topic id="topic_issues">
+      <title>Greenplum Database Limitations</title>
+      <body>
+        <p>Because Greenplum Database provides no hash operator class for the 
+          <codeph>money</codeph> data type, using the <codeph>btree_gin</codeph> module
+          on this type is a no-op.</p>
+      </body>
+    </topic>
+    <topic id="topic_info">
+      <title>Module Documentation</title>
+      <body>
+        <p>See <xref href="https://www.postgresql.org/docs/9.4/btree-gin.html"
+          format="html" scope="external">btree_gin</xref> in the PostgreSQL
+          documentation for detailed information about the individual functions in
+          this module.</p>
+      </body>
+    </topic>
+  </topic>
+</dita>

--- a/gpdb-doc/dita/ref_guide/modules/btree_gin.xml
+++ b/gpdb-doc/dita/ref_guide/modules/btree_gin.xml
@@ -24,14 +24,6 @@
           for more information.</p>
       </body>
     </topic>
-    <topic id="topic_issues">
-      <title>Greenplum Database Limitations</title>
-      <body>
-        <p>Because Greenplum Database provides no hash operator class for the 
-          <codeph>money</codeph> data type, using the <codeph>btree_gin</codeph> module
-          on this type is a no-op.</p>
-      </body>
-    </topic>
     <topic id="topic_info">
       <title>Module Documentation</title>
       <body>

--- a/gpdb-doc/dita/ref_guide/modules/btree_gin.xml
+++ b/gpdb-doc/dita/ref_guide/modules/btree_gin.xml
@@ -24,6 +24,14 @@
           for more information.</p>
       </body>
     </topic>
+    <topic id="topic_issues">
+      <title>Greenplum Database Limitations</title>
+      <body>
+        <p>The Pivotal Query Optimizer (GPORCA) does not support queries that access an
+          index with <codeph>op_class</codeph>, such queries will fall back to the
+          Postgres Planner</p>
+      </body>
+    </topic>
     <topic id="topic_info">
       <title>Module Documentation</title>
       <body>

--- a/gpdb-doc/dita/ref_guide/modules/intro.xml
+++ b/gpdb-doc/dita/ref_guide/modules/intro.xml
@@ -17,6 +17,9 @@
         password quality checking and policy definition for Greenplum Database.</li>
       <li><codeph><xref href="auto-explain.xml#topic_fstrm"/></codeph> Provides a means for logging
         execution plans of slow statements automatically.</li>
+       <li><codeph><xref href="btree_gin.xml" format="dita"
+             >btree_gin</xref></codeph> - Provides sample generalized inverted index (GIN)
+          operator classes that implement B-tree equivalent behavior for certain data types.</li>
        <li><codeph><xref href="citext.xml" format="dita"
               >citext</xref></codeph> - Provides a case-insensitive, multibyte-aware text
           data type.</li>
@@ -44,6 +47,10 @@
        <li><codeph><xref href="pageinspect.xml" format="dita"
              >pageinspect</xref></codeph> - Provides functions for low level inspection
          of the contents of database pages; available to superusers only.</li>
+       <li><codeph><xref href="pg_trgm.xml" format="dita"
+             >pg_trgm</xref></codeph> - Provides functions and operators for determining the
+          similarity of alphanumeric text based on trigram matching. The module also
+          provides index operator classes that support fast searching for similar strings.</li>
        <li><codeph><xref href="pgcrypto.xml" format="dita"
              >pgcrypto</xref></codeph> - Provides cryptographic functions for Greenplum
          Database.</li>

--- a/gpdb-doc/dita/ref_guide/modules/modules.ditamap
+++ b/gpdb-doc/dita/ref_guide/modules/modules.ditamap
@@ -4,6 +4,7 @@
   <topicref href="intro.xml" navtitle="Additional Supplied Modules" linking="targetonly">
     <topicref href="adv_passwd_check.xml"/>
     <topicref href="auto-explain.xml"/>
+    <topicref href="btree_gin.xml"/>
     <topicref href="citext.xml"/>
     <topicref href="dblink.xml"/>
     <topicref href="diskquota.xml"/>
@@ -13,6 +14,7 @@
     <topicref href="hstore.xml"/>
     <topicref href="orafce_ref.xml"/>
     <topicref href="pageinspect.xml"/>
+    <topicref href="pg_trgm.xml"/>
     <topicref href="pgcrypto.xml"/>
     <topicref href="postgres_fdw.xml"/>
     <topicref href="sslinfo.xml"/>

--- a/gpdb-doc/dita/ref_guide/modules/pg_trgm.xml
+++ b/gpdb-doc/dita/ref_guide/modules/pg_trgm.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE dita PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<dita>
+  <topic id="topic_fstrm">
+    <title>pg_trgm</title>
+    <body>
+      <p>The <codeph>pg_trgm</codeph> module provides functions and operators for
+        determining the similarity of alphanumeric text based on trigram matching.
+        The module also provides index operator classes that support fast searching
+        for similar strings.</p>
+      <p>The Greenplum Database <codeph>pg_trgm</codeph> module is equivalent
+        to the PostgreSQL <codeph>pg_trgm</codeph> module. There are no
+        Greenplum Database or MPP-specific considerations for the module.</p>
+    </body>
+    <topic id="topic_reg">
+      <title>Installing and Registering the Module</title>
+      <body>
+        <p>The <codeph>pg_trgm</codeph> module is installed when you install
+          Greenplum Database. Before you can use any of the functions defined in the
+          module, you must register the <codeph>pg_trgm</codeph> extension in
+          each database in which you want to use the functions:</p>
+      <codeblock>CREATE EXTENSION pg_trgm;</codeblock>
+      <p>Refer to <xref href="../../install_guide/install_modules.html"
+            format="html" scope="external">Installing Additional Supplied Modules</xref>
+          for more information.</p>
+      </body>
+    </topic>
+    <topic id="topic_info">
+      <title>Module Documentation</title>
+      <body>
+        <p>See <xref href="https://www.postgresql.org/docs/9.4/pgtrgm.html"
+          format="html" scope="external">pg_trgm</xref> in the PostgreSQL
+          documentation for detailed information about the individual functions in
+          this module.</p>
+      </body>
+    </topic>
+  </topic>
+</dita>

--- a/gpdb-doc/markdown/install_guide/install_modules.html.md
+++ b/gpdb-doc/markdown/install_guide/install_modules.html.md
@@ -23,6 +23,7 @@ You can register the following modules in this manner:
 <table cellpadding="4" cellspacing="0" summary="" border="1" class="simpletable"><col style="width:33.33333333333333%" /><col style="width:33.33333333333333%" /><thead></thead><tbody><tr>
           <td style="vertical-align:top;">
             <ul class="ul" id="topic_d45_wcw_pgb__ul_tc3_nlx_wp">
+              <li class="li"><a class="xref" href="../ref_guide/modules/btree_gin.html">btree_gin</a></li>
               <li class="li"><a class="xref" href="../ref_guide/modules/citext.html">citext</a></li>
 
               <li class="li"><a class="xref" href="../ref_guide/modules/dblink.html">dblink</a></li>
@@ -45,6 +46,7 @@ You can register the following modules in this manner:
 
               <li class="li"><a class="xref" href="../ref_guide/modules/pageinspect.html">pageinspect</a></li>
 
+              <li class="li"><a class="xref" href="../ref_guide/modules/pg_trgm.html">pg_trgm</a></li>
               <li class="li"><a class="xref" href="../ref_guide/modules/pgcrypto.html">pgcrypto</a></li>
 
               <li class="li"><a class="xref" href="../ref_guide/modules/postgres_fdw.html">postgres_fdw</a></li>


### PR DESCRIPTION
docs for: https://github.com/greenplum-db/gpdb/pull/12928, https://github.com/greenplum-db/gpdb/pull/12927, https://github.com/greenplum-db/gpdb/pull/12929 (6X_STABLE)

will be backported to 6X_STABLE.

GPORCA support of these new modules is not clear to me...
