### PR TITLE
docs - new foreign server num_segments option

### DIFF
--- a/gpdb-doc/dita/admin_guide/external/g-devel-fdw.xml
+++ b/gpdb-doc/dita/admin_guide/external/g-devel-fdw.xml
@@ -62,8 +62,6 @@
      <p>The Greenplum Database 6 foreign-data wrapper implementation has
        the following known issues and limitations:</p>
      <ul>
-       <li>The Greenplum Database 6 distribution does not install any
-         foreign data wrappers.</li>
        <li>Greenplum Database supports all values of the <codeph>mpp_execute</codeph>
          option value for foreign table scans only. Greenplum supports parallel
          write operations only when <codeph>mpp_execute</codeph> is set to

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FOREIGN_DATA_WRAPPER.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FOREIGN_DATA_WRAPPER.xml
@@ -50,25 +50,25 @@
                 <plentry>
                     <pt>mpp_execute { 'master' | 'any' | 'all segments' }</pt>
                     <pd>
-                        <p>An option that identifies the host from which the foreign data-wrapper
+                        <p>An option that identifies the host from which the foreign-data wrapper
                             reads or writes data: <ul id="ul_zcg_2vd_mgb">
                                 <li><codeph>master</codeph> (the default)—Read or write data from the
                                     master host.</li>
                                 <li><codeph>any</codeph>—Read data from either the master host or
                                     any one segment, depending on which path costs less.</li>
                                 <li><codeph>all segments</codeph>—Read or write data from all segments. To
-                                    support this option value, the foreign data-wrapper must have a
+                                    support this option value, the foreign-data wrapper must have a
                                     policy that matches the segments to data.
                                   <note>Greenplum Database supports parallel writes to foreign tables
                                    only when you set <codeph>mpp_execute 'all segments'</codeph>.</note></li>
                             </ul></p>
-                        <p>Use of the foreign table <codeph>mpp_execute</codeph> option, and the
-                            specific modes supported, is foreign data-wrapper-specific.</p>
+                        <p>Support for the foreign-data wrapper <codeph>mpp_execute</codeph> option,
+                            and the specific modes, is foreign-data wrapper-specific.</p>
                         <p>The <codeph>mpp_execute</codeph> option can be specified in multiple
                             commands: <codeph>CREATE FOREIGN TABLE</codeph>, <codeph>CREATE
                                 SERVER</codeph>, and <codeph>CREATE FOREIGN DATA WRAPPER</codeph>.
                             The foreign table setting takes precedence over the foreign server
-                            setting, followed by the foreign data wrapper setting.</p>
+                            setting, followed by the foreign-data wrapper setting.</p>
                     </pd>
                 </plentry>
             </parml>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FOREIGN_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_FOREIGN_TABLE.xml
@@ -98,25 +98,26 @@
                 <plentry>
                     <pt>mpp_execute { 'master' | 'any' | 'all segments' }</pt>
                     <pd>
-                        <p>An option that identifies the host from which the foreign data-wrapper
+                        <p>A Greenplum Database-specific option that identifies the host
+                            from which the foreign-data wrapper
                             reads or writes data: <ul id="ul_zcg_2vd_mgb">
                                 <li><codeph>master</codeph> (the default)—Read or write data from the
                                     master host.</li>
                                 <li><codeph>any</codeph>—Read data from either the master host or
                                     any one segment, depending on which path costs less.</li>
                                 <li><codeph>all segments</codeph>—Read or write data from all segments. To
-                                    support this option value, the foreign data-wrapper must have a
+                                    support this option value, the foreign-data wrapper must have a
                                     policy that matches the segments to data.
                                  <note>Greenplum Database supports parallel writes to foreign tables
                                    only when you set <codeph>mpp_execute 'all segments'</codeph>.</note></li>
                             </ul></p>
-                        <p>Use of the foreign table <codeph>mpp_execute</codeph> option, and the
-                            specific modes supported, is foreign data-wrapper-specific.</p>
+                        <p>Support for the foreign table <codeph>mpp_execute</codeph> option,
+                            and the specific modes, is foreign-data wrapper-specific.</p>
                         <p>The <codeph>mpp_execute</codeph> option can be specified in multiple
                             commands: <codeph>CREATE FOREIGN TABLE</codeph>, <codeph>CREATE
                                 SERVER</codeph>, and <codeph>CREATE FOREIGN DATA WRAPPER</codeph>.
                             The foreign table setting takes precedence over the foreign server
-                            setting, followed by the foreign data wrapper setting.</p>
+                            setting, followed by the foreign-data wrapper setting.</p>
                     </pd>
                 </plentry>
             </parml>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_SERVER.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_SERVER.xml
@@ -9,7 +9,9 @@
             <title>Synopsis</title>
             <codeblock id="sql_command_synopsis">CREATE SERVER <varname>server_name</varname> [ TYPE '<varname>server_type</varname>' ] [ VERSION '<varname>server_version</varname>' ]
     FOREIGN DATA WRAPPER <varname>fdw_name</varname>
-    [ OPTIONS ( [ mpp_execute { 'master' | 'any' | 'all segments' } [, ] ] <varname>option</varname> '<varname>value</varname>' [, ... ] ) ]</codeblock>
+    [ OPTIONS ( [ mpp_execute { 'master' | 'any' | 'all segments' } [, ] ]
+                [ num_segments '<varname>num</varname>' [, ] ]
+                [ <varname>option</varname> '<varname>value</varname>' [, ... ]] ) ]</codeblock>
         </section>
         <section id="section3">
             <title>Description</title>
@@ -57,7 +59,8 @@
                 <plentry>
                     <pt>mpp_execute { 'master' | 'any' | 'all segments' }</pt>
                     <pd>
-                        <p>An option that identifies the host from which the foreign data-wrapper
+                        <p>A Greenplum Database-specific option that identifies the host
+                            from which the foreign-data wrapper
                             reads or writes data: <ul id="ul_zcg_2vd_mgb">
                                 <li><codeph>master</codeph> (the default)—Read or write data from
                                     the master host.</li>
@@ -65,18 +68,32 @@
                                     any one segment, depending on which path costs less.</li>
                                 <li><codeph>all segments</codeph>—Read or write data from
                                     all segments. To support this option value, the
-                                    foreign data-wrapper must have a policy that matches the segments
+                                    foreign-data wrapper should have a policy that matches the segments
                                      to data.
                                  <note>Greenplum Database supports parallel writes to foreign tables
                                    only when you set <codeph>mpp_execute 'all segments'</codeph>.</note></li>
                             </ul></p>
-                        <p>Use of the foreign table <codeph>mpp_execute</codeph> option, and the
-                            specific modes supported, is foreign data-wrapper-specific.</p> 
+                        <p>Support for the foreign server <codeph>mpp_execute</codeph> option,
+                            and the specific modes, is foreign-data wrapper-specific.</p> 
                         <p>The <codeph>mpp_execute</codeph> option can be specified in multiple
                             commands: <codeph>CREATE FOREIGN TABLE</codeph>, <codeph>CREATE
                                 SERVER</codeph>, and <codeph>CREATE FOREIGN DATA WRAPPER</codeph>.
                             The foreign table setting takes precedence over the foreign server
-                            setting, followed by the foreign data wrapper setting.</p>
+                            setting, followed by the foreign-data wrapper setting.</p>
+                    </pd>
+                </plentry>
+                <plentry>
+                    <pt>num_segments '<varname>num</varname>'</pt>
+                    <pd>
+                        <p>When <codeph>mpp_execute</codeph> is set to
+                          <codeph>'all segments'</codeph>, the Greenplum Database-specific
+                          <codeph>num_segments</codeph> option identifies the
+                          number of query executors that Greenplum Database spawns on the
+                          source Greenplum Database cluster. If you do not provide a value,
+                          <varname>num</varname> defaults to the number of segments in the
+                          source cluster.</p>
+                        <p>Support for the foreign server <codeph>num_segments</codeph> option
+                          is foreign-data wrapper-specific.</p>
                     </pd>
                 </plentry>
             </parml>

--- a/gpdb-doc/dita/ref_guide/sql_commands/GRANT.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/GRANT.xml
@@ -103,7 +103,7 @@ GRANT { SELECT | INSERT | ALL [PRIVILEGES] }
           below.) The owner implicitly has all grant options for the object, too.</p><p>Greenplum
           Database grants default privileges on some types of objects to <codeph>PUBLIC</codeph>. No
           privileges are granted to <codeph>PUBLIC</codeph> by default on tables, table columns,
-          sequences, foreign data wrappers, foreign servers, large objects, schemas, or tablespaces.
+          sequences, foreign-data wrappers, foreign servers, large objects, schemas, or tablespaces.
           For other types of objects, the default privileges granted to <codeph>PUBLIC</codeph> are
           as follows:</p><ul>
           <li><codeph>CONNECT</codeph> and <codeph>TEMPORARY</codeph> (create temporary tables)


### PR DESCRIPTION
update the CREATE SERVER sql ref page for https://github.com/greenplum-db/gpdb/pull/12920, https://github.com/greenplum-db/gpdb/pull/12789 (6X_STABLE, not yet merged).  PR also includes some misc edits for consistency.

will be backport to 6X_STABLE.

note:  this PR is against master.  the 6X_STABLE feature PR removes the num_segments option from foreign table.  i am assuming that this change will be forward-ported to 7/master.  let me know if that is not the case.
