### PR TITLE
Remove num_segments option from the foreign table layer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -241,6 +241,13 @@ script:
         if [ -z "$tests" ] || [ "$tests" = "installcheck" ]; then
             make -C gpAux/gpdemo cluster
             source gpAux/gpdemo/gpdemo-env.sh
+            trap look4diffs ERR
+            function look4diffs() {
+                echo ========regression.diffs========
+                cat src/test/regress/regression.diffs
+                echo ========regression.diffs========
+                exit 1
+            }
             make -C src/test/regress installcheck-small
         fi
       fi
@@ -266,6 +273,13 @@ script:
         make -s unittest-check
         make -C gpAux/gpdemo cluster
         source gpAux/gpdemo/gpdemo-env.sh
+        trap look4diffs ERR
+        function look4diffs() {
+            echo ========regression.diffs========
+            cat src/test/regress/regression.diffs
+            echo ========regression.diffs========
+            exit 1
+        }
         make -C src/test/regress installcheck-small
       fi
   - |

--- a/src/backend/commands/foreigncmds.c
+++ b/src/backend/commands/foreigncmds.c
@@ -194,7 +194,6 @@ transformGenericOptions(Oid catalogId,
 	if (catalogId != UserMappingRelationId)
 	{
 		SeparateOutMppExecute(&resultOptions);
-		SeparateOutNumSegments(&resultOptions);
 	}
 
 	if (OidIsValid(fdwvalidator))

--- a/src/backend/foreign/foreign.c
+++ b/src/backend/foreign/foreign.c
@@ -371,18 +371,11 @@ GetForeignTable(Oid relid)
 	else
 		ft->options = untransformRelOptions(datum);
 
-	ForeignServer *server = GetForeignServer(ft->serverid);
-
 	ft->exec_location = SeparateOutMppExecute(&ft->options);
 	if (ft->exec_location == FTEXECLOCATION_NOT_DEFINED)
 	{
+		ForeignServer *server = GetForeignServer(ft->serverid);
 		ft->exec_location = server->exec_location;
-	}
-
-	ft->num_segments = SeparateOutNumSegments(&ft->options);
-	if (ft->num_segments <= 0)
-	{
-		ft->num_segments = server->num_segments;
 	}
 
 	ReleaseSysCache(tp);

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -3312,13 +3312,18 @@ create_foreignscan_path(PlannerInfo *root, RelOptInfo *rel,
 	pathnode->path.total_cost = total_cost;
 	pathnode->path.pathkeys = pathkeys;
 
+	ForeignServer *server = NULL;
 	switch (rel->exec_location)
 	{
 		case FTEXECLOCATION_ANY:
 			CdbPathLocus_MakeGeneral(&(pathnode->path.locus));
 			break;
 		case FTEXECLOCATION_ALL_SEGMENTS:
-			CdbPathLocus_MakeStrewn(&(pathnode->path.locus), rel->num_segments);
+			server = GetForeignServer(rel->serverid);
+			if (server)
+				CdbPathLocus_MakeStrewn(&(pathnode->path.locus), server->num_segments);
+			else
+				CdbPathLocus_MakeStrewn(&(pathnode->path.locus), getgpsegmentCount());
 			break;
 		case FTEXECLOCATION_COORDINATOR:
 			CdbPathLocus_MakeEntry(&(pathnode->path.locus));
@@ -3377,13 +3382,18 @@ create_foreign_join_path(PlannerInfo *root, RelOptInfo *rel,
 	pathnode->path.total_cost = total_cost;
 	pathnode->path.pathkeys = pathkeys;
 
+	ForeignServer *server = NULL;
 	switch (rel->exec_location)
 	{
 		case FTEXECLOCATION_ANY:
 			CdbPathLocus_MakeGeneral(&(pathnode->path.locus));
 			break;
 		case FTEXECLOCATION_ALL_SEGMENTS:
-			CdbPathLocus_MakeStrewn(&(pathnode->path.locus), rel->num_segments);
+			server = GetForeignServer(rel->serverid);
+			if (server)
+				CdbPathLocus_MakeStrewn(&(pathnode->path.locus), server->num_segments);
+			else
+				CdbPathLocus_MakeStrewn(&(pathnode->path.locus), getgpsegmentCount());
 			break;
 		case FTEXECLOCATION_COORDINATOR:
 			CdbPathLocus_MakeEntry(&(pathnode->path.locus));

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -58,7 +58,6 @@
 
 #include "cdb/cdbappendonlyam.h"
 #include "cdb/cdbrelsize.h"
-#include "cdb/cdbutil.h"
 #include "catalog/pg_appendonly.h"
 #include "catalog/pg_foreign_server.h"
 #include "catalog/pg_inherits.h"
@@ -457,14 +456,12 @@ get_relation_info(PlannerInfo *root, Oid relationObjectId, bool inhparent,
 		rel->serverid = GetForeignServerIdByRelId(RelationGetRelid(relation));
 		rel->fdwroutine = GetFdwRoutineForRelation(relation, true);
 		rel->exec_location = GetForeignTable(RelationGetRelid(relation))->exec_location;
-		rel->num_segments = GetForeignTable(RelationGetRelid(relation))->num_segments;
 	}
 	else
 	{
 		rel->serverid = InvalidOid;
 		rel->fdwroutine = NULL;
 		rel->exec_location = FTEXECLOCATION_NOT_DEFINED;
-		rel->num_segments = getgpsegmentCount();
 	}
 
 	/* Collect info about relation's foreign keys, if relevant */

--- a/src/include/foreign/foreign.h
+++ b/src/include/foreign/foreign.h
@@ -70,7 +70,6 @@ typedef struct ForeignTable
 	Oid			serverid;		/* server Oid */
 	List	   *options;		/* ftoptions as DefElem list */
 	char		exec_location;  /* execute on COORDINATOR, ANY or ALL SEGMENTS, Greenplum MPP specific */
-	int32		num_segments;	/* the number of segments of the foreign table */
 } ForeignTable;
 
 /* Flags for GetForeignServerExtended */

--- a/src/include/nodes/pathnodes.h
+++ b/src/include/nodes/pathnodes.h
@@ -864,7 +864,6 @@ typedef struct RelOptInfo
 	Oid			userid;			/* identifies user to check access as */
 	bool		useridiscurrent;	/* join is only valid for current user */
 	char		exec_location;  /* execute on MASTER, ANY or ALL SEGMENTS, Greenplum MPP specific */
-	int32		num_segments;  /* number of segments, Greenplum MPP specific */
 	/* use "struct FdwRoutine" to avoid including fdwapi.h here */
 	struct FdwRoutine *fdwroutine;
 	void	   *fdw_private;

--- a/src/test/regress/expected/.gitignore
+++ b/src/test/regress/expected/.gitignore
@@ -56,3 +56,5 @@
 /trigger_sets_oid.out
 /workfile_mgr_test.out
 /external_table_persistent_error_log.out
+/external_table_union_all.out
+/external_table_union_all_optimizer.out

--- a/src/test/regress/expected/gp_foreign_data.out
+++ b/src/test/regress/expected/gp_foreign_data.out
@@ -26,16 +26,12 @@ CREATE FOREIGN TABLE ft3 (
 CREATE FOREIGN TABLE ft4 (
 	c1 int
 ) SERVER s0 OPTIONS (delimiter ',', mpp_execute 'all segments');
--- Test num_segments option
-CREATE SERVER s1 FOREIGN DATA WRAPPER dummy OPTIONS (num_segments '3');
-CREATE FOREIGN TABLE ft5 (
-       c1 int
-) SERVER s1 OPTIONS (delimiter ',', mpp_execute 'all segments', num_segments '5');
-\d+ ft5
-                                       Foreign table "public.ft5"
- Column |  Type   | Collation | Nullable | Default | FDW options | Storage | Stats target | Description 
---------+---------+-----------+----------+---------+-------------+---------+--------------+-------------
- c1     | integer |           |          |         |             | plain   |              | 
-Server: s1
-FDW options: (delimiter ',', mpp_execute 'all segments', num_segments '5')
+-- CREATE FOREIGN SERVER WITH num_segments
+CREATE SERVER s1 FOREIGN DATA WRAPPER dummy OPTIONS (num_segments '5');
+-- CHECK FOREIGN SERVER's OPTIONS
+SELECT srvoptions FROM pg_foreign_server WHERE srvname = 's1';
+    srvoptions    
+------------------
+ {num_segments=5}
+(1 row)
 

--- a/src/test/regress/sql/.gitignore
+++ b/src/test/regress/sql/.gitignore
@@ -55,3 +55,4 @@
 /upgrade.sql
 /workfile_mgr_test.sql
 /external_table_persistent_error_log.sql
+/external_table_union_all.sql

--- a/src/test/regress/sql/gp_foreign_data.sql
+++ b/src/test/regress/sql/gp_foreign_data.sql
@@ -3,6 +3,8 @@
 --
 
 -- start_ignore
+DROP SERVER s0 CASCADE;
+DROP SERVER s1 CASCADE;
 DROP FOREIGN DATA WRAPPER dummy CASCADE;
 -- end_ignore
 
@@ -25,9 +27,8 @@ CREATE FOREIGN TABLE ft4 (
 	c1 int
 ) SERVER s0 OPTIONS (delimiter ',', mpp_execute 'all segments');
 
--- Test num_segments option
-CREATE SERVER s1 FOREIGN DATA WRAPPER dummy OPTIONS (num_segments '3');
-CREATE FOREIGN TABLE ft5 (
-       c1 int
-) SERVER s1 OPTIONS (delimiter ',', mpp_execute 'all segments', num_segments '5');
-\d+ ft5
+-- CREATE FOREIGN SERVER WITH num_segments
+CREATE SERVER s1 FOREIGN DATA WRAPPER dummy OPTIONS (num_segments '5');
+
+-- CHECK FOREIGN SERVER's OPTIONS
+SELECT srvoptions FROM pg_foreign_server WHERE srvname = 's1';


### PR DESCRIPTION
https://github.com/greenplum-db/gpdb/commit/aa7c74cfa4734ae6d2969740a0b341d26ea4ad2e - Support num_segments option for foreign servers and tables

Commit above introduces the support of num_segments option, however in
practice the option for foreign tables confuses the user.

This commit removes it from the foreign table layer, only the foreign
servers support.