### PR TITLE
New workflow for adding, moving and recovering mirrors

### DIFF
--- a/concourse/scripts/run_behave_test.sh
+++ b/concourse/scripts/run_behave_test.sh
@@ -25,5 +25,8 @@ if gpstate > /dev/null 2>&1 ; then
   gpstop -u
 fi
 
+# TODO remove this pip install. only for debugging
+gpssh -f ~/segment_host_list -e 'pip3 install coverage --user'
+
 cd /home/gpadmin/gpdb_src/gpMgmt
 make -f Makefile.behave behave flags="$BEHAVE_FLAGS"

--- a/concourse/scripts/run_behave_test.sh
+++ b/concourse/scripts/run_behave_test.sh
@@ -26,7 +26,11 @@ if gpstate > /dev/null 2>&1 ; then
 fi
 
 # TODO remove this pip install. only for debugging
-gpssh -f ~/segment_host_list -e 'pip3 install coverage --user'
+if [ -f ~/segment_host_list ]; then
+    gpssh -f ~/segment_host_list -e 'pip3 install coverage --user'
+fi
+
+ssh sdw5 'pip3 install coverage --user' > /dev/null 2>&1 || true
 
 cd /home/gpadmin/gpdb_src/gpMgmt
 make -f Makefile.behave behave flags="$BEHAVE_FLAGS"

--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -20,7 +20,6 @@ for executing this set of commands.
 from queue import Queue, Empty
 from threading import Thread
 
-import functools
 import os
 import signal
 import subprocess
@@ -644,21 +643,3 @@ def run_remote_commands(name, commands):
     pool.join()
     pool.check_results()
     return cmds
-
-
-def set_cmd_results(run_func):
-    """
-    Decorator function to run a command on the seg and set the results on the command object for that segment.
-    :param run_func: The function to run
-    :return:
-    """
-    @functools.wraps(run_func)
-    def run_and_set_output(cmd):
-        try:
-            run_func(cmd)
-        except Exception as e:
-            cmd.set_results(CommandResult(1, b'', str(e).encode(), True, False))
-        else:
-            cmd.set_results(CommandResult(0, b'', b'', True, False))
-
-    return run_and_set_output

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -985,20 +985,22 @@ class GpSegRecovery(Command):
     """
     Format gpsegrecovery call for running pg_basebackup/pg_rewind on remoteHost for the segments passed in confinfo
     """
-    def __init__(self, name, confinfo, logdir, batchSize, verbose, remoteHost, forceoverwrite):
-        cmdStr = _get_cmd_for_recovery_wrapper('gpsegrecovery', confinfo, logdir, batchSize, verbose, forceoverwrite)
+    def __init__(self, name, confinfo, logdir, batchSize, verbose, remoteHost, forceoverwrite, era):
+        cmdStr = _get_cmd_for_recovery_wrapper('gpsegrecovery', confinfo, logdir, batchSize, verbose, forceoverwrite, era)
         Command.__init__(self, name, cmdStr, REMOTE, remoteHost)
 
 
-def _get_cmd_for_recovery_wrapper(wrapper_filename, confinfo, logdir, batchSize, verbose, forceoverwrite):
+def _get_cmd_for_recovery_wrapper(wrapper_filename, confinfo, logdir, batchSize, verbose, forceoverwrite, era=None):
     cmdStr = '$GPHOME/sbin/{}.py -c {} -l {}'.format(wrapper_filename, pipes.quote(confinfo), pipes.quote(logdir))
 
     if verbose:
-        cmdStr += ' -v '
+        cmdStr += ' -v'
     if batchSize:
         cmdStr += ' -b %s' % batchSize
     if forceoverwrite:
         cmdStr += " --force-overwrite"
+    if era:
+        cmdStr += " --era={}".format(era)
 
     return cmdStr
 

--- a/gpMgmt/bin/gppylib/commands/test/unit/test_unit_base.py
+++ b/gpMgmt/bin/gppylib/commands/test/unit/test_unit_base.py
@@ -4,8 +4,7 @@
 #
 
 import unittest
-from gppylib.commands.base import Command, WorkerPool, RemoteExecutionContext, GPHOME, LocalExecutionContext,\
-    set_cmd_results
+from gppylib.commands.base import Command, WorkerPool, RemoteExecutionContext, GPHOME, LocalExecutionContext
 
 
 class WorkerPoolTestCase(unittest.TestCase):
@@ -54,43 +53,3 @@ class WorkerPoolTestCase(unittest.TestCase):
         self.subject.execute(cmd)
         self.assertEqual("bar=1 && foo=1 && ssh -o StrictHostKeyChecking=no -o ServerAliveInterval=60 localhost "
                           "\". gphome/greenplum_path.sh; bar=1 && foo=1 && ls /tmp\"", cmd.cmdStr)
-
-
-class SetCmdResultsTestCase(unittest.TestCase):
-
-    def _assert_cmd_passed(self, cmd):
-        self.assertEqual(0, cmd.get_results().rc)
-        self.assertEqual('', cmd.get_results().stdout)
-        self.assertEqual('', cmd.get_results().stderr)
-        self.assertEqual(True, cmd.get_results().completed)
-        self.assertEqual(False, cmd.get_results().halt)
-        self.assertEqual(True, cmd.get_results().wasSuccessful())
-
-    def _assert_cmd_failed(self, cmd, expected_stderr='running the cmd failed'):
-        self.assertEqual(1, cmd.get_results().rc)
-        self.assertEqual('', cmd.get_results().stdout)
-        self.assertTrue(expected_stderr in cmd.get_results().stderr)
-        self.assertEqual(True, cmd.get_results().completed)
-        self.assertEqual(False, cmd.get_results().halt)
-        self.assertEqual(False, cmd.get_results().wasSuccessful())
-
-    def test_set_cmd_results_no_exception(self):
-        @set_cmd_results
-        def test_decorator(cmd):
-            cmd.name = 'new name'
-
-        test_cmd = Command(name='original name', cmdStr='echo foo')
-        test_decorator(test_cmd)
-        self.assertEqual('new name', test_cmd.name)
-        self._assert_cmd_passed(test_cmd)
-
-    def test_set_cmd_results_catch_exception(self):
-        @set_cmd_results
-        def test_decorator(cmd):
-            cmd.name = 'new name'
-            raise Exception('running the cmd failed')
-
-        test_cmd = Command(name='original name', cmdStr='echo foo')
-        test_decorator(test_cmd)
-        self.assertEqual('new name', test_cmd.name)
-        self._assert_cmd_failed(test_cmd)

--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -248,8 +248,6 @@ class GpMirrorListToBuild:
 
         self._validate_gparray(gpArray)
 
-        self._run_recovery(gpEnv)
-
         # should use mainUtils.getProgramName but I can't make it work!
         programName = os.path.split(sys.argv[0])[-1]
 
@@ -267,6 +265,8 @@ class GpMirrorListToBuild:
         finally:
             # Re-enable Ctrl-C
             signal.signal(signal.SIGINT, signal.default_int_handler)
+
+        self._run_recovery(gpEnv)
 
         #TODO when should this return False ? when basebackup/rewind/start fail for even one segment ?
         return True

--- a/gpMgmt/bin/gppylib/operations/segment_tablespace_locations.py
+++ b/gpMgmt/bin/gppylib/operations/segment_tablespace_locations.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from contextlib import closing
 from gppylib.db import dbconn
 
 # get tablespace locations
@@ -20,7 +21,7 @@ def get_tablespace_locations(all_hosts, mirror_data_directory):
                         LATERAL gp_tablespace_location(_q1.oid)
                     ) AS t """
 
-    with dbconn.connect(dbconn.DbURL()) as conn:
+    with closing(dbconn.connect(dbconn.DbURL())) as conn:
         if all_hosts:
             tablespace_location_sql = """
                 SELECT c.hostname, t.tblspc_loc||'/'||c.dbid tblspc_loc

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
@@ -6,25 +6,20 @@ from collections import OrderedDict
 import io
 import logging
 
+
 from mock import ANY, call, patch, Mock
 from gppylib import gplog, recoveryinfo
 from gppylib.commands import base, gp
-from gppylib.commands.base import CommandResult
+from gppylib.commands.base import CommandResult, LocalExecutionContext
+
 from gppylib.gparray import Segment, GpArray
 from gppylib.mainUtils import ExceptionNoStackTraceNeeded
 from gppylib.operations.buildMirrorSegments import GpMirrorToBuild, GpMirrorListToBuild, GpStopSegmentDirectoryDirective
-from gppylib.operations.startSegments import StartSegmentsResult
 from gppylib.system import configurationInterface
-from test.unit.gp_unittest import GpTestCase
+from test.unit.gp_unittest import Contains, GpTestCase
 
 from gppylib.recoveryinfo import RecoveryInfo, RecoveryResult
 
-class Contains(str): #TODO should we move this somewhere
-    """
-    This class is used as a way to assert for partial match in unittests
-    """
-    def __eq__(self, other):
-        return self in other
 
 class BuildMirrorsTestCase(GpTestCase):
     """
@@ -42,13 +37,31 @@ class BuildMirrorsTestCase(GpTestCase):
         self.mirror = Segment(content=0, preferred_role='m', dbid=30, role='m', mode='s',
                               status='d', hostname='primaryhost', address='primaryhost-1',
                               port=3333, datadir='/primary')
+        self.default_action_name = 'recover'
+        self.actions_to_test = [
+            {
+                "action_name": "recover",
+            },
+            {
+                "action_name": "add",
+            }
+        ]
 
         gplog.get_unittest_logger()
+        self.mock_gp_era = Mock(return_value='dummy_era')
         self.apply_patches([
             patch('gppylib.operations.buildMirrorSegments.GpArray.getSegmentsByHostName'),
             patch('gppylib.operations.buildMirrorSegments.gplog.get_logger_dir', return_value='/tmp/logdir'),
-            patch('gppylib.operations.buildMirrorSegments.read_era', return_value='dummy_era'),
+            patch('gppylib.operations.buildMirrorSegments.read_era', self.mock_gp_era),
+            patch('gppylib.recoveryinfo.RecoveryResult.print_bb_rewind_and_start_errors'),
+            patch('gppylib.recoveryinfo.RecoveryResult.print_setup_recovery_errors'),
+            patch('gppylib.operations.buildMirrorSegments.dbconn')
         ])
+        self.mock_dbconn = self.get_mock_from_apply_patch('dbconn')
+        self.test_backout_map = {2: ['select gp_remove_segment_mirror(2)', 'select gp_add_segment_mirror(2)'],
+                       3: ['select gp_remove_segment_mirror(3)', 'select gp_add_segment_mirror(3)'],
+                       4: ['select gp_remove_segment_mirror(4)', 'select gp_add_segment_mirror(4)']}
+
         self.mock_get_segments_by_hostname = self.get_mock_from_apply_patch('getSegmentsByHostName')
         self.mock_logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
         self.default_build_mirrors_obj = GpMirrorListToBuild(
@@ -62,7 +75,6 @@ class BuildMirrorsTestCase(GpTestCase):
         self.progress_file_dbid3='/tmp/progress_file3'
         self.progress_file_dbid4='/tmp/progress_file4'
 
-        self.action = 'recover'
         self.gpEnv = Mock()
         self.gpArray = GpArray([self.coordinator, self.primary, self.mirror])
         self.recovery_info1 = RecoveryInfo('/datadir2', 7001, 2, 'source_host_for_dbid2', 7002, True, self.progress_file_dbid2)
@@ -72,61 +84,85 @@ class BuildMirrorsTestCase(GpTestCase):
     def tearDown(self):
         super(BuildMirrorsTestCase, self).tearDown()
 
-    def _setup_mocks(self, build_mirrors_obj):
+    #TODO too many setup functions. clean up to make it obvious
+    def _setup_build_mirrors_mocks(self, build_mirrors_obj):
         markdown_mock = Mock()
         build_mirrors_obj._wait_fts_to_mark_down_segments = markdown_mock
-        # TODO maybe remove this patch ?
-        build_mirrors_obj._run_recovery = Mock()
+        build_mirrors_obj._run_recovery = Mock(return_value=RecoveryResult('action', [], None))
         build_mirrors_obj._run_setup_recovery = Mock(return_value=RecoveryResult('action', [], None))
         build_mirrors_obj._clean_up_failed_segments = Mock()
         build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear = Mock()
         build_mirrors_obj._get_running_postgres_segments = Mock()
+        build_mirrors_obj._revert_config_update = Mock()
+        # build_mirrors_obj._run_b = Mock()
+        build_mirrors_obj._trigger_fts_probe = Mock()
         configurationInterface.getConfigurationProvider = Mock()
-        configurationInterface.getConfigurationProvider.return_value.updateSystemConfig.return_value = {} # mock backout_map
+        #TODO add test for backout_map
+        configurationInterface.getConfigurationProvider.return_value.updateSystemConfig.return_value = {} #mock backout_map
 
-    def _common_asserts_with_stop_and_logger(self, build_mirrors_obj, expected_logger_msg, expected_segs_to_stop,
-                                             expected_segs_to_markdown, expected_segs_to_update, cleanup_count,
-                                             info_call_count=3):
-        self.mock_logger.info.assert_any_call(expected_logger_msg)
-        #TODO assert all logger info msgs
-        self.assertEqual(info_call_count, self.mock_logger.info.call_count)
-
-        self.assertEqual([call(expected_segs_to_stop)], build_mirrors_obj._get_running_postgres_segments.call_args_list)
-        self._common_asserts(build_mirrors_obj,  expected_segs_to_markdown, expected_segs_to_update, cleanup_count)
-
-    def _common_asserts(self, build_mirrors_obj,  expected_segs_to_markdown, expected_segs_to_update, cleanup_count):
-        self.assertEqual([call(self.gpEnv, expected_segs_to_markdown)],
-                         build_mirrors_obj._wait_fts_to_mark_down_segments.call_args_list)
-        self.assertEqual(cleanup_count, build_mirrors_obj._clean_up_failed_segments.call_count)
-
-        self.assertEqual(1, build_mirrors_obj._run_recovery.call_count)
-        self.assertEqual([call(self.gpArray, ANY, dbIdToForceMirrorRemoveAdd=expected_segs_to_update,
-                               useUtilityMode=False, allowPrimary=False)],
-                         configurationInterface.getConfigurationProvider.return_value.updateSystemConfig.call_args_list)
-
-    def _set_run_recovery(self, host_errors=[], is_setup=False):
-
-        host1_recovery_output = gp.GpSegRecovery('test recover 1', 'dummy_info1', '/tmp/log1/', False, 1, 'host1', 'dummy_era1', True)
-        host2_recovery_output = gp.GpSegRecovery('test recover 2', 'dummy_info2', '/tmp/log2/', True, 2, 'host2', 'dummy_era2', False)
+    def _setup_recovery_mocks(self, host_errors=[]):
+        host1_recovery_output = gp.GpSegRecovery('test recover 1', 'dummy_info1', '/tmp/log1/', False, 1,
+                                                 'host1', 'dummy_era1', True)
+        host2_recovery_output = gp.GpSegRecovery('test recover 2', 'dummy_info2', '/tmp/log2/', True, 2,
+                                                 'host2', 'dummy_era2', False)
 
         host1_result = CommandResult(0, ''.encode(), ''.encode(), True, False)
         host2_result = CommandResult(0, ''.encode(), ''.encode(), True, False)
         if host_errors:
             host1_result = CommandResult(1, 'failed 1'.encode(), host_errors[0].encode(), True, False)
-            host2_result = CommandResult(1, 'failed 1'.encode(), host_errors[1].encode(), True, False)
-        host1_recovery_output.get_results = Mock(return_value = host1_result)
-        host2_recovery_output.get_results = Mock(return_value = host2_result)
-        self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear = Mock()
+            host2_result = CommandResult(1, 'failed 2'.encode(), host_errors[1].encode(), True, False)
+        host1_recovery_output.get_results = Mock(return_value=host1_result)
+        host2_recovery_output.get_results = Mock(return_value=host2_result)
 
         completed_items = [host1_recovery_output, host2_recovery_output]
-        if is_setup:
-            self.default_build_mirrors_obj._do_setup_for_recovery = Mock()
-            self.default_build_mirrors_obj._do_setup_for_recovery.return_value = completed_items
-        else:
-            self.default_build_mirrors_obj._do_setup_for_recovery = Mock(return_value=[])
-        self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.return_value = completed_items
+        self.default_build_mirrors_obj._do_setup_for_recovery = Mock(return_value=completed_items)
+        self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear = Mock(
+            return_value=completed_items)
 
-    def _run_buildMirrors(self, mirrors_to_build):
+    def _common_asserts_with_stop_and_logger(self, build_mirrors_obj, expected_logger_msg, expected_segs_to_stop,
+                                             expected_segs_to_markdown, expected_segs_to_update, cleanup_count,
+                                             action_name, info_call_count=3):
+        self.mock_logger.info.assert_any_call(expected_logger_msg)
+        #TODO assert all logger info msgs
+        self.assertEqual(info_call_count, self.mock_logger.info.call_count)
+
+        self.assertEqual([call(expected_segs_to_stop)], build_mirrors_obj._get_running_postgres_segments.call_args_list)
+        self._common_asserts(build_mirrors_obj,  expected_segs_to_markdown, expected_segs_to_update, cleanup_count,
+                             action_name)
+
+    def _common_asserts(self, build_mirrors_obj,  expected_segs_to_markdown, expected_segs_to_update, cleanup_count,
+                        action_name):
+        self.assertEqual([call(self.gpEnv, expected_segs_to_markdown)],
+                         build_mirrors_obj._wait_fts_to_mark_down_segments.call_args_list)
+        self.assertEqual(cleanup_count, build_mirrors_obj._clean_up_failed_segments.call_count)
+        self.assertEqual([call(self.default_action_name, ANY)], build_mirrors_obj._run_setup_recovery.call_args_list)
+        self.assertEqual([call(self.default_action_name, ANY, self.gpEnv)], build_mirrors_obj._run_recovery.call_args_list)
+        self.assertEqual([call(self.gpArray, ANY, dbIdToForceMirrorRemoveAdd=expected_segs_to_update,
+                               useUtilityMode=False, allowPrimary=False)],
+                         configurationInterface.getConfigurationProvider.return_value.updateSystemConfig.call_args_list)
+        self.assertEqual(1, build_mirrors_obj._trigger_fts_probe.call_count)
+
+        if action_name == 'add':
+            self.assertEqual(0, build_mirrors_obj._revert_config_update.call_count)
+        elif action_name == 'recover':
+            self.assertEqual(1, build_mirrors_obj._revert_config_update.call_count)
+
+    def _assert_setup_recovery(self):
+        self.assertEqual(1, RecoveryResult.print_setup_recovery_errors.call_count)
+        self.assertEqual(0, RecoveryResult.print_bb_rewind_and_start_errors.call_count)
+        self.assertEqual([], self.mock_logger.info.call_args_list)
+        self.assertEqual([], self.mock_logger.error.call_args_list)
+
+    def _assert_run_recovery(self,):
+        expected_info_msgs = [call(Contains('Initiating segment recovery'))]
+        self.assertEqual(expected_info_msgs, self.mock_logger.info.call_args_list)
+        self.assertEqual([], self.mock_logger.error.call_args_list)
+        self.assertEqual(0, RecoveryResult.print_setup_recovery_errors.call_count)
+        self.assertEqual(1, RecoveryResult.print_bb_rewind_and_start_errors.call_count)
+
+    def _run_buildMirrors(self, mirrors_to_build, action):
+        self.mock_logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
+
         build_mirrors_obj = GpMirrorListToBuild(
             toBuild=mirrors_to_build,
             pool=Mock(),
@@ -134,8 +170,14 @@ class BuildMirrorsTestCase(GpTestCase):
             parallelDegree=0,
             logger=self.mock_logger
         )
-        self._setup_mocks(build_mirrors_obj)
-        self.assertTrue(build_mirrors_obj.buildMirrors(self.action, self.gpEnv, self.gpArray))
+        self._setup_build_mirrors_mocks(build_mirrors_obj)
+        action_name = action['action_name']
+        self.default_action_name = action_name
+        #TODO add test for when buildMirrors returns False
+        if action_name == 'add':
+            self.assertTrue(build_mirrors_obj.add_mirrors(self.gpEnv, self.gpArray))
+        elif action_name == 'recover':
+            self.assertTrue(build_mirrors_obj.recover_mirrors(self.gpEnv, self.gpArray))
         return build_mirrors_obj
 
     def _create_primary(self, dbid='1', contentid='0', state='n', status='u', host='sdw1', unreachable=False):
@@ -148,7 +190,7 @@ class BuildMirrorsTestCase(GpTestCase):
         return Segment.initFromString('{}|{}|p|p|{}|{}|{}|{}|22000|/mirror/gpseg0'
                                       .format(dbid, contentid, state, status, host, host))
 
-    def test_buildMirrors_noMirrors(self):
+    def test_recover_mirrors_noMirrors(self):
         build_mirrors_obj = GpMirrorListToBuild(
             toBuild=[],
             pool=None,
@@ -156,180 +198,199 @@ class BuildMirrorsTestCase(GpTestCase):
             parallelDegree=0,
             logger=self.mock_logger
         )
-        self.assertTrue(build_mirrors_obj.buildMirrors(None, None, None))
-        self.assertTrue(build_mirrors_obj.buildMirrors(self.action, None, None))
+        self.assertTrue(build_mirrors_obj.recover_mirrors(None, None))
 
-        self.assertEqual([call('No segments to None'), call('No segments to recover')],
-                         self.mock_logger.info.call_args_list)
+        self.assertEqual([call('No segments to recover')], self.mock_logger.info.call_args_list)
 
-    def test_buildMirrors_no_failed_pass(self):
-        tests = [
-            {
-                "name": "no_failed_full",
-                "live": self._create_primary(),
-                "failover": self._create_mirror(),
-                "forceFull": False,
-            },
-            {
-                "name": "no_failed_full2",
-                "live": self._create_primary(dbid='3'),
-                "failover": self._create_mirror(dbid='4'),
-                "forceFull": True,
-            }
-        ]
-
-        mirrors_to_build = []
-        for test in tests:
-            with self.subTest(msg=test["name"]):
-                mirrors_to_build.append(GpMirrorToBuild(None, test["live"], test["failover"],
-                                                        test["forceFull"]))
-
-        build_mirrors_obj = self._run_buildMirrors(mirrors_to_build)
-
-        self.assertEqual(2, self.mock_logger.info.call_count)
-        self.assertEqual(0, build_mirrors_obj._get_running_postgres_segments.call_count)
-        self._common_asserts(build_mirrors_obj, [], {2: True, 4: True}, cleanup_count=1)
-
-        for test in tests:
-            self.assertEqual('n', test['live'].getSegmentMode())
-            self.assertEqual('d', test['failover'].getSegmentStatus())
-            self.assertEqual('n', test['failover'].getSegmentMode())
-
-    def test_buildMirrors_no_failover_pass(self):
-        tests = [
-            {
-                "name": "no_failover",
-                "failed": self._create_mirror(status='d'),
-                "live": self._create_primary(),
-                "forceFull": False,
-            },
-            {
-                "name": "no_failover_full",
-                "failed": self._create_mirror(status='d', dbid='4'),
-                "live": self._create_primary(),
-                "forceFull": True,
-            },
-            {
-                "name": "no_failover_failed_seg_exists_in_gparray",
-                "failed": self.mirror,
-                "live": self._create_primary(),
-                "forceFull": True,
-                "forceoverwrite": True
-            },
-            {
-                "name": "no_failover_failed_segment_is_up",
-                "failed": self._create_mirror(dbid='5'),
-                "live": self._create_primary(dbid='6'),
-                "is_failed_segment_up": True,
-                "forceFull": False,
-            }
-        ]
-        mirrors_to_build = []
-        expected_segs_to_stop = []
-        expected_segs_to_markdown = []
-
-        for test in tests:
-            with self.subTest(msg=test["name"]):
-                mirrors_to_build.append(GpMirrorToBuild(test["failed"], test["live"], None,
-                                                        test["forceFull"]))
-                expected_segs_to_stop.append(test["failed"])
-                if 'is_failed_segment_up' in test and test["is_failed_segment_up"]:
-                    expected_segs_to_markdown.append(test['failed'])
-
-        build_mirrors_obj = self._run_buildMirrors(mirrors_to_build)
-
-        self._common_asserts_with_stop_and_logger(build_mirrors_obj, "Ensuring 4 failed segment(s) are stopped",
-                                                  expected_segs_to_stop,
-                                                  expected_segs_to_markdown, {4: True, 30: True},
-                                                  1)
-        for test in tests:
-            self.assertEqual('n', test['live'].getSegmentMode())
-            self.assertEqual('d', test['failed'].getSegmentStatus())
-            self.assertEqual('n', test['failed'].getSegmentMode())
-
-    def test_buildMirrors_both_failed_failover_pass(self):
-        tests = [
-            {
-                "name": "both_failed_failover_full",
-                "failed": self._create_primary(status='d'),
-                "live": self._create_mirror(),
-                "failover": self._create_primary(status='d', host='sdw3'),
-                "forceFull": True
-            },
-            {
-                "name": "both_failed_failover_failed_segment_is_up",
-                "failed": self._create_primary(dbid='5'),
-                "live": self._create_mirror(dbid='6'),
-                "failover": self._create_primary(dbid='5', host='sdw3'),
-                "is_failed_segment_up": True,
-                "forceFull": True
-            },
-            {
-                "name": "both_failed_failover_failover_is_down_live_is_marked_as_sync",
-                "failed": self._create_primary(dbid='9', status='d'),
-                "live": self._create_mirror(dbid='10', state='s'),
-                "failover": self._create_primary(dbid='9', status='d'),
-                "forceFull": False,
-            },
-            {
-                "name": "both_failed_failover_failed_is_unreachable",
-                "failed": self._create_primary(dbid='9', status='d', unreachable=True),
-                "live": self._create_mirror(dbid='10', state='s'),
-                "failover": self._create_primary(dbid='9', status='d'),
-                "forceFull": False,
-            },
-
-        ]
-        mirrors_to_build = []
-        expected_segs_to_stop = []
-        expected_segs_to_markdown = []
-
-        for test in tests:
-            with self.subTest(msg=test["name"]):
-                mirrors_to_build.append(GpMirrorToBuild(test["failed"], test["live"], test["failover"],
-                                                        test["forceFull"]))
-                #TODO better way to check for this condition
-                if not test["failed"].unreachable:
-                    expected_segs_to_stop.append(test["failed"])
-                if 'is_failed_segment_up' in test and test["is_failed_segment_up"]:
-                    expected_segs_to_markdown.append(test['failed'])
-
-        build_mirrors_obj = self._run_buildMirrors(mirrors_to_build)
-
-        # TODO improve the logic that passes info_call_count
-        self._common_asserts_with_stop_and_logger(build_mirrors_obj, "Ensuring 3 failed segment(s) are stopped",
-                                                  expected_segs_to_stop,
-                                                  expected_segs_to_markdown, {1: True, 5: True, 9: True}, 1,
-                                                  info_call_count=4)
-
-        for test in tests:
-            self.assertEqual('n', test['live'].getSegmentMode())
-            self.assertEqual('d', test['failover'].getSegmentStatus())
-            self.assertEqual('n', test['failover'].getSegmentMode())
-
-    def test_buildMirrors_forceoverwrite_true(self):
-        failed = self._create_primary(status='d')
-        live = self._create_mirror()
-        failover = self._create_primary(host='sdw3')
-
+    def test_add_mirrors_noMirrors(self):
         build_mirrors_obj = GpMirrorListToBuild(
-            toBuild=[GpMirrorToBuild(failed, live, failover, False)],
+            toBuild=[],
             pool=None,
             quiet=True,
             parallelDegree=0,
-            logger=self.mock_logger,
-            forceoverwrite=True
+            logger=self.mock_logger
         )
-        self._setup_mocks(build_mirrors_obj)
-        self.assertTrue(build_mirrors_obj.buildMirrors(self.action, self.gpEnv, self.gpArray))
+        self.assertTrue(build_mirrors_obj.add_mirrors(None, None))
 
-        self._common_asserts_with_stop_and_logger(build_mirrors_obj, "Ensuring 1 failed segment(s) are stopped",
-                                                  [failed], [], {1: True}, 0)
-        self.assertEqual('n', live.getSegmentMode())
-        self.assertEqual('d', failover.getSegmentStatus())
-        self.assertEqual('n', failover.getSegmentMode())
+        self.assertEqual([call('No segments to add')], self.mock_logger.info.call_args_list)
 
-    def test_buildMirrors_failed_seg_in_gparray_fail(self):
+    def test_add_recover_mirrors_no_failed_pass(self):
+        for action in self.actions_to_test:
+            with self.subTest(msg=action["action_name"]):
+                tests = [
+                    {
+                        "name": "no_failed_full",
+                        "live": self._create_primary(),
+                        "failover": self._create_mirror(host='sdw2'),
+                        "forceFull": False,
+                    },
+                    {
+                        "name": "no_failed_full2",
+                        "live": self._create_primary(dbid='3'),
+                        "failover": self._create_mirror(dbid='4'),
+                        "forceFull": True,
+                    }
+                ]
+
+                mirrors_to_build = []
+                for test in tests:
+                    mirrors_to_build.append(GpMirrorToBuild(None, test["live"], test["failover"], test["forceFull"]))
+                build_mirrors_obj = self._run_buildMirrors(mirrors_to_build, action)
+
+                self.assertEqual(2, self.mock_logger.info.call_count)
+                self.assertEqual(0, build_mirrors_obj._get_running_postgres_segments.call_count)
+                self._common_asserts(build_mirrors_obj, [], {2: True, 4: True}, cleanup_count=1, action_name=action["action_name"])
+
+                for test in tests:
+                    self.assertEqual('n', test['live'].getSegmentMode())
+                    self.assertEqual('d', test['failover'].getSegmentStatus())
+                    self.assertEqual('n', test['failover'].getSegmentMode())
+
+    def test_add_recover_mirrors_no_failover_pass(self):
+        for action in self.actions_to_test:
+            with self.subTest(msg=action["action_name"]):
+                tests = [
+                    {
+                        "name": "no_failover",
+                        "failed": self._create_mirror(status='d'),
+                        "live": self._create_primary(),
+                        "forceFull": False,
+                    },
+                    {
+                        "name": "no_failover_full",
+                        "failed": self._create_mirror(status='d', dbid='4', host='sdw2'),
+                        "live": self._create_primary(),
+                        "forceFull": True,
+                    },
+                    {
+                        "name": "no_failover_failed_seg_exists_in_gparray",
+                        "failed": self.mirror,
+                        "live": self._create_primary(),
+                        "forceFull": True,
+                        "forceoverwrite": True
+                    },
+                    {
+                        "name": "no_failover_failed_segment_is_up",
+                        "failed": self._create_mirror(dbid='5'),
+                        "live": self._create_primary(dbid='6', host='sdw2'),
+                        "is_failed_segment_up": True,
+                        "forceFull": False,
+                    }
+                ]
+                mirrors_to_build = []
+                expected_segs_to_stop = []
+                expected_segs_to_markdown = []
+                for test in tests:
+                    mirrors_to_build.append(GpMirrorToBuild(test["failed"], test["live"], None,
+                                                            test["forceFull"]))
+                    expected_segs_to_stop.append(test["failed"])
+                    if 'is_failed_segment_up' in test and test["is_failed_segment_up"]:
+                        expected_segs_to_markdown.append(test['failed'])
+
+                build_mirrors_obj = self._run_buildMirrors(mirrors_to_build, action)
+
+                self._common_asserts_with_stop_and_logger(build_mirrors_obj, "Ensuring 4 failed segment(s) are stopped",
+                                                          expected_segs_to_stop,
+                                                          expected_segs_to_markdown, {4: True, 30: True}, 1,
+                                                          action["action_name"])
+                for test in tests:
+                    self.assertEqual('n', test['live'].getSegmentMode())
+                    self.assertEqual('d', test['failed'].getSegmentStatus())
+                    self.assertEqual('n', test['failed'].getSegmentMode())
+
+    def test_add_recover_mirrors_both_failed_failover_pass(self):
+        for action in self.actions_to_test:
+            with self.subTest(msg=action["action_name"]):
+                tests = [
+                    {
+                        "name": "both_failed_failover_full",
+                        "failed": self._create_primary(status='d'),
+                        "live": self._create_mirror(),
+                        "failover": self._create_primary(status='d', host='sdw3'),
+                        "forceFull": True
+                    },
+                    {
+                        "name": "both_failed_failover_failed_segment_is_up",
+                        "failed": self._create_primary(dbid='5'),
+                        "live": self._create_mirror(dbid='6'),
+                        "failover": self._create_primary(dbid='5', host='sdw3'),
+                        "is_failed_segment_up": True,
+                        "forceFull": True
+                    },
+                    {
+                        "name": "both_failed_failover_failover_is_down_live_is_marked_as_sync",
+                        "failed": self._create_primary(dbid='9', status='d'),
+                        "live": self._create_mirror(dbid='10', state='s'),
+                        "failover": self._create_primary(dbid='9', status='d'),
+                        "forceFull": False,
+                    },
+                    {
+                        "name": "both_failed_failover_failed_is_unreachable",
+                        "failed": self._create_primary(dbid='9', status='d', unreachable=True),
+                        "live": self._create_mirror(dbid='10', state='s'),
+                        "failover": self._create_primary(dbid='9', status='d'),
+                        "forceFull": False,
+                    },
+
+                ]
+                mirrors_to_build = []
+                expected_segs_to_stop = []
+                expected_segs_to_markdown = []
+
+                for test in tests:
+                    mirrors_to_build.append(GpMirrorToBuild(test["failed"], test["live"], test["failover"],
+                                                            test["forceFull"]))
+                    #TODO better way to check for this condition
+                    if not test["failed"].unreachable:
+                        expected_segs_to_stop.append(test["failed"])
+                    if 'is_failed_segment_up' in test and test["is_failed_segment_up"]:
+                        expected_segs_to_markdown.append(test['failed'])
+
+                build_mirrors_obj = self._run_buildMirrors(mirrors_to_build, action)
+
+                # TODO improve the logic that passes info_call_count
+                self._common_asserts_with_stop_and_logger(build_mirrors_obj, "Ensuring 3 failed segment(s) are stopped",
+                                                          expected_segs_to_stop,
+                                                          expected_segs_to_markdown, {1: True, 5: True, 9: True}, 1,
+                                                          action["action_name"], info_call_count=4)
+
+                for test in tests:
+                    self.assertEqual('n', test['live'].getSegmentMode())
+                    self.assertEqual('d', test['failover'].getSegmentStatus())
+                    self.assertEqual('n', test['failover'].getSegmentMode())
+
+    def test_add_recover_mirrors_forceoverwrite_true(self):
+        for action in self.actions_to_test:
+            with self.subTest(msg=action["action_name"]):
+                self.mock_logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
+                action_name = action["action_name"]
+                self.default_action_name = action_name
+                failed = self._create_primary(status='d')
+                live = self._create_mirror()
+                failover = self._create_primary(host='sdw3')
+
+                build_mirrors_obj = GpMirrorListToBuild(
+                    toBuild=[GpMirrorToBuild(failed, live, failover, False)],
+                    pool=None,
+                    quiet=True,
+                    parallelDegree=0,
+                    logger=self.mock_logger,
+                    forceoverwrite=True
+                )
+                self._setup_build_mirrors_mocks(build_mirrors_obj)
+
+                if action_name == 'add':
+                    self.assertTrue(build_mirrors_obj.add_mirrors(self.gpEnv, self.gpArray))
+                elif action_name == 'recover':
+                    self.assertTrue(build_mirrors_obj.recover_mirrors(self.gpEnv, self.gpArray))
+
+                self._common_asserts_with_stop_and_logger(build_mirrors_obj, "Ensuring 1 failed segment(s) are stopped",
+                                                          [failed], [], {1: True}, 0, action["action_name"])
+                self.assertEqual('n', live.getSegmentMode())
+                self.assertEqual('d', failover.getSegmentStatus())
+                self.assertEqual('n', failover.getSegmentMode())
+
+    def test_recover_mirrors_failed_seg_in_gparray_fail(self):
         tests = [
             {
                 "name": "failed_seg_exists_in_gparray1",
@@ -366,12 +427,12 @@ class BuildMirrorsTestCase(GpTestCase):
                 logger=self.mock_logger,
                 forceoverwrite=test['forceoverwrite']
             )
-            self._setup_mocks(build_mirrors_obj)
+            self._setup_build_mirrors_mocks(build_mirrors_obj)
             local_gp_array = GpArray([self.coordinator, test["failed"]])
             expected_error = "failed segment should not be in the new configuration if failing over to"
             with self.subTest(msg=test["name"]):
                 with self.assertRaisesRegex(Exception, expected_error):
-                    build_mirrors_obj.buildMirrors(self.action, self.gpEnv, local_gp_array)
+                    build_mirrors_obj.recover_mirrors(self.gpEnv, local_gp_array)
 
     def test_clean_up_failed_segments(self):
         failed1 = self._create_primary(status='d')
@@ -432,18 +493,46 @@ class BuildMirrorsTestCase(GpTestCase):
         self.assertEqual(0, self.mock_get_segments_by_hostname.call_count)
         self.assertEqual(0, self.mock_logger.info.call_count)
 
+    def test_run_setup_recovery_errors(self):
+        host1_error = '[{"error_type": "validation", "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}, ' \
+                      '{"error_type": "validation", "error_msg":"some error for dbid 3", "dbid": 3, "datadir": "/datadir3", "port": 7003, "progress_file": "/tmp/progress3"}]'
+        host2_error = '[{"error_type": "validation", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]'
+        self._setup_recovery_mocks([host1_error, host2_error])
+        with self.assertRaises(ExceptionNoStackTraceNeeded):
+            self.default_build_mirrors_obj._run_setup_recovery(self.default_action_name, None)
+
+        self._assert_setup_recovery()
+
+    def test_run_setup_recovery_invalid_errors(self):
+        host1_error = 'invalid error'
+        host2_error = '[{"error_type": "validation", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]'
+        self._setup_recovery_mocks([host1_error, host2_error])
+        with self.assertRaises(ExceptionNoStackTraceNeeded):
+            self.default_build_mirrors_obj._run_setup_recovery(self.default_action_name, None)
+
+        self._assert_setup_recovery()
+
+    def test_run_setup_recovery_empty_errors(self):
+        self._setup_recovery_mocks(['', ''])
+        with self.assertRaises(ExceptionNoStackTraceNeeded):
+            self.default_build_mirrors_obj._run_setup_recovery(self.default_action_name, None)
+
+        self._assert_setup_recovery()
+
     def test_run_recovery_no_errors(self):
-        recovery_info = OrderedDict() #We use ordered dict to deterministically assert the side effects of _run_recovery
+        self._setup_recovery_mocks()
+
+        recovery_info = OrderedDict()  # We use ordered dict to deterministically assert the side effects of _run_recovery
         recovery_info['host1'] = [self.recovery_info1]
         recovery_info['host2'] = [self.recovery_info2, self.recovery_info3]
-        recoveryinfo.build_recovery_info = Mock(return_value=recovery_info)
-        self._set_run_recovery()
-        self.default_build_mirrors_obj._run_recovery(self.action, recovery_info, self.gpEnv)
+        self.default_build_mirrors_obj._run_recovery(self.default_action_name, recovery_info, self.gpEnv)
+
         self.assertEqual([call(ANY, progressCmds=ANY, suppressErrorCheck=True), call(ANY, suppressErrorCheck=False)],
                          self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list)
+
         seg_recovery_cmds = self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list[0][0][0]
         progress_cmds = self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list[0][1]['progressCmds']
-        rm_cmds = self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list[1][0][0]
+        rm_progress_cmds = self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list[1][0][0]
 
         #TODO fix formatting
         expected_recovery_cmd_strs = ["""$GPHOME/sbin/gpsegrecovery.py -c '[{"target_datadir": "/datadir2", "target_port": 7001, "target_segment_dbid": 2, "source_hostname": "source_host_for_dbid2", "source_port": 7002, "is_full_recovery": true, "progress_file": "/tmp/progress_file2"}]' -l /tmp/logdir -b 64 --era=dummy_era""", """$GPHOME/sbin/gpsegrecovery.py -c '[{"target_datadir": "/datadir3", "target_port": 7003, "target_segment_dbid": 3, "source_hostname": "source_host_for_dbid3", "source_port": 7004, "is_full_recovery": true, "progress_file": "/tmp/progress_file3"}, {"target_datadir": "/datadir4", "target_port": 7005, "target_segment_dbid": 4, "source_hostname": "source_host_for_dbid4", "source_port": 7006, "is_full_recovery": true, "progress_file": "/tmp/progress_file4"}]' -l /tmp/logdir -b 64 --era=dummy_era"""]
@@ -463,224 +552,236 @@ class BuildMirrorsTestCase(GpTestCase):
         self.assertEqual('host2', progress_cmds[2].remoteHost)
         self.assertEqual("set -o pipefail; touch -a /tmp/progress_file4; tail -1 /tmp/progress_file4 | tr '\\r' '\\n' | tail -1",
                          progress_cmds[2].cmdStr)
+        self.assertEqual(1, self.mock_gp_era.call_count)
 
-        self.assertEqual(3, len(rm_cmds))
-        self.assertEqual("host1", rm_cmds[0].remoteHost)
-        self.assertEqual("rm -f /tmp/progress_file2", rm_cmds[0].cmdStr)
-        self.assertEqual("host2", rm_cmds[1].remoteHost)
-        self.assertEqual("rm -f /tmp/progress_file3", rm_cmds[1].cmdStr)
-        self.assertEqual("host2", rm_cmds[2].remoteHost)
-        self.assertEqual("rm -f /tmp/progress_file4", rm_cmds[2].cmdStr)
+        self.assertEqual(3, len(rm_progress_cmds))
+        self.assertEqual("host1", rm_progress_cmds[0].remoteHost)
+        self.assertEqual("rm -f /tmp/progress_file2", rm_progress_cmds[0].cmdStr)
+        self.assertEqual("host2", rm_progress_cmds[1].remoteHost)
+        self.assertEqual("rm -f /tmp/progress_file3", rm_progress_cmds[1].cmdStr)
+        self.assertEqual("host2", rm_progress_cmds[2].remoteHost)
+        self.assertEqual("rm -f /tmp/progress_file4", rm_progress_cmds[2].cmdStr)
 
-    def test_run_setup_recovery_errors(self):
-        recovery_info = {'host1': [self.recovery_info1, self.recovery_info2], 'host2': [self.recovery_info3]}
-        host1_error = '[{"error_type": "validation", "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}, ' \
-                      '{"error_type": "validation", "error_msg":"some error for dbid 3", "dbid": 3, "datadir": "/datadir3", "port": 7003, "progress_file": "/tmp/progress3"}]'
-        host2_error = '[{"error_type": "validation", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]'
-        self._set_run_recovery([host1_error, host2_error], is_setup=True)
-        with self.assertRaises(ExceptionNoStackTraceNeeded):
-            self.default_build_mirrors_obj._run_setup_recovery(self.action, recovery_info)
-        expected_info_msgs = [call(Contains('-----')),
-                              call('Failed to setup recovery for the following segments')]
-        expected_error_msgs = [call(Contains('hostname: host1; port: 7001; error: some error for dbid 2')),
-                              call(Contains('hostname: host1; port: 7003; error: some error for dbid 3')),
-                              call(Contains('hostname: host2; port: 7005; error: some error for dbid 4'))]
-
-        self.assertCountEqual(expected_info_msgs, self.mock_logger.info.call_args_list)
-        self.assertCountEqual(expected_error_msgs, self.mock_logger.error.call_args_list)
-
-    def test_run_setup_recovery_invalid_errors(self):
-        recovery_info = {'host1': [self.recovery_info1, self.recovery_info2], 'host2': [self.recovery_info3]}
-        host1_error = 'invalid value before error1 [{"error_type": "validation", "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}, ' \
-                      'invalid value before error2 {"error_type": "validation", "error_msg":"some error for dbid 3", "dbid": 3, "datadir": "/datadir3", "port": 7003, "progress_file": "/tmp/progress3"}]'
-        host2_error = '[{"error_type": "validation", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]'
-        self._set_run_recovery([host1_error, host2_error], is_setup=True)
-        with self.assertRaises(ExceptionNoStackTraceNeeded):
-            self.default_build_mirrors_obj._run_setup_recovery(self.action, recovery_info)
-        expected_info_msgs = [call(Contains('-----')),
-                              call('Failed to setup recovery for the following segments')]
-
-        expected_error_msgs = [call(Contains('Unable to parse recovery error. hostname: host1, error: invalid value before error1')),
-                               call(Contains('hostname: host2; port: 7005; error: some error for dbid 4'))]
-
-        self.assertEqual(expected_info_msgs, self.mock_logger.info.call_args_list)
-        self.assertCountEqual(expected_error_msgs, self.mock_logger.error.call_args_list)
-
-    def test_run_setup_recovery_empty_errors(self):
-        recovery_info = {'host1': [self.recovery_info1], 'host2': [self.recovery_info3]}
-        host1_error = ''
-        host2_error = ''
-        self._set_run_recovery([host1_error, host2_error], is_setup=True)
-        with self.assertRaises(ExceptionNoStackTraceNeeded):
-            self.default_build_mirrors_obj._run_setup_recovery(self.action, recovery_info)
-        expected_error_msgs = [call(Contains('Unable to parse recovery error. hostname: host1, error: ')),
-                               call(Contains('Unable to parse recovery error. hostname: host2, error: '))]
-        self.assertEqual([], self.mock_logger.info.call_args_list)
-        self.assertEqual(expected_error_msgs, self.mock_logger.error.call_args_list)
+        self._assert_run_recovery()
 
     def test_run_recovery_invalid_errors(self):
         recovery_info = {'host1': [self.recovery_info1, self.recovery_info2], 'host2': [self.recovery_info3]}
         host1_error = 'invalid error1'
-        host2_error = '[{"error_type": "full", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]'
-        self._set_run_recovery([host1_error, host2_error])
-        self.default_build_mirrors_obj._run_recovery(self.action, recovery_info, self.gpEnv)
-        expected_info_msgs = [call('Initiating segment recovery. Upon completion, will start the successfully recovered segments'),
-                              call(Contains('-----')),
-                              call(Contains('Failed to recover the following segments')),
-                              call(Contains(' hostname: host2; port: 7005; logfile: /tmp/progress4'))]
-
-        expected_error_msgs = [call(Contains('Unable to parse recovery error. hostname: host1, error: invalid error1'))]
-        self.assertEqual(expected_info_msgs, self.mock_logger.info.call_args_list)
-        self.assertEqual(expected_error_msgs, self.mock_logger.error.call_args_list)
-
-    def test_run_recovery_empty_errors(self):
-        recovery_info = {'host1': [self.recovery_info1, self.recovery_info2], 'host2': [self.recovery_info3]}
-        host1_error = ''
         host2_error = ''
-        self._set_run_recovery([host1_error, host2_error])
-        self.default_build_mirrors_obj._run_recovery(self.action, recovery_info, self.gpEnv)
-        expected_info_msgs = [call('Initiating segment recovery. Upon completion, will start the successfully recovered segments')]
+        self._setup_recovery_mocks([host1_error, host2_error])
+        self.default_build_mirrors_obj._run_recovery(self.default_action_name, recovery_info, self.gpEnv)
+        self._assert_run_recovery()
 
-        expected_error_msgs = [call(Contains('Unable to parse recovery error. hostname: host1, error: ')),
-                               call(Contains('Unable to parse recovery error. hostname: host2, error: '))]
-        self.assertEqual(expected_info_msgs, self.mock_logger.info.call_args_list)
-        self.assertEqual(expected_error_msgs, self.mock_logger.error.call_args_list)
-
-    # TODO remove duplicate code from run_recovery tests
     def test_run_recovery_all_dbids_fail_only_bb_rewind_errors(self):
         recovery_info = {'host1': [self.recovery_info1, self.recovery_info2], 'host2': [self.recovery_info3]}
         host1_error = '[{"error_type": "full", "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}, ' \
                       '{"error_type": "incremental", "error_msg":"some error for dbid 3", "dbid": 3, "datadir": "/datadir3", "port": 7003, "progress_file": "/tmp/progress3"}]'
         host2_error = '[{"error_type": "full", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]'
-        self._set_run_recovery([host1_error, host2_error])
+        self._setup_recovery_mocks([host1_error, host2_error])
 
-        self.default_build_mirrors_obj._run_recovery(self.action, recovery_info, self.gpEnv)
+        self.default_build_mirrors_obj._run_recovery(self.default_action_name, recovery_info, self.gpEnv)
         self.assertEqual([call(ANY, progressCmds=ANY, suppressErrorCheck=True), call(ANY, suppressErrorCheck=False)],
                          self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list)
-        rm_cmds = self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list[1][0][0]
+        rm_progress_cmds = self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list[1][0][0]
 
-        self.assertEqual(0, len(rm_cmds))
-        expected_info_msgs = [call(Contains('Initiating segment recovery')),
-                              call(Contains('-----')),
-                              call(Contains('Failed to recover the following segments')),
-                              call(Contains('hostname: host1; port: 7001; logfile: /tmp/progress2; recoverytype: full')),
-                              call(Contains('hostname: host1; port: 7003; logfile: /tmp/progress3; recoverytype: incremental')),
-                              call(Contains('hostname: host2; port: 7005; logfile: /tmp/progress4; recoverytype: full'))]
-        self.assertCountEqual(expected_info_msgs, self.mock_logger.info.call_args_list)
+        self.assertEqual(0, len(rm_progress_cmds))
 
-    def test_run_recovery_some_dbids_fail_all_recovery_errors(self):
+        self._assert_run_recovery()
+
+    def test_run_recovery_some_dbids_fail_all_bb_rewind_errors(self):
         recovery_info = {'host1': [self.recovery_info1], 'host2': [self.recovery_info2, self.recovery_info3]}
         host1_error = '[{"error_type": "full", "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}]'
         host2_error = '[{"error_type": "full", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]'
-        self._set_run_recovery([host1_error, host2_error])
+        self._setup_recovery_mocks([host1_error, host2_error])
 
-        self.default_build_mirrors_obj._run_recovery(self.action, recovery_info, self.gpEnv)
+        self.default_build_mirrors_obj._run_recovery(self.default_action_name, recovery_info, self.gpEnv)
         self.assertEqual([call(ANY, progressCmds=ANY, suppressErrorCheck=True), call(ANY, suppressErrorCheck=False)],
                          self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list)
-        rm_cmds = self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list[1][0][0]
+        rm_progress_cmds = self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list[1][0][0]
 
-        self.assertEqual(1, len(rm_cmds))
-        self.assertEqual("host2", rm_cmds[0].remoteHost)
-        self.assertEqual("rm -f /tmp/progress_file3", rm_cmds[0].cmdStr)
-        expected_info_msgs = [call(Contains('Initiating segment recovery')),
-                              call(Contains('-----')),
-                              call(Contains('Failed to recover the following segments')),
-                              call(Contains('hostname: host1; port: 7001; logfile: /tmp/progress2')),
-                              call(Contains('hostname: host2; port: 7005; logfile: /tmp/progress4'))]
-        self.assertEqual(expected_info_msgs, self.mock_logger.info.call_args_list)
+        self.assertEqual(1, len(rm_progress_cmds))
+        self.assertEqual("host2", rm_progress_cmds[0].remoteHost)
+        self.assertEqual("rm -f /tmp/progress_file3", rm_progress_cmds[0].cmdStr)
+
+        self._assert_run_recovery()
 
     def test_run_recovery_all_dbids_fail_all_start_errors(self):
         recovery_info = {'host1': [self.recovery_info1], 'host2': [self.recovery_info2, self.recovery_info3]}
         host1_error = '[{"error_type": "start", "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}, ' \
                       '{"error_type": "start", "error_msg":"some error for dbid 3", "dbid": 3, "datadir": "/datadir3", "port": 7003, "progress_file": "/tmp/progress3"}]'
         host2_error = '[{"error_type": "start", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]'
-        self._set_run_recovery([host1_error, host2_error])
-        self.default_build_mirrors_obj._run_recovery(self.action, recovery_info, self.gpEnv)
+        self._setup_recovery_mocks([host1_error, host2_error])
+        self.default_build_mirrors_obj._run_recovery(self.default_action_name, recovery_info, self.gpEnv)
         self.assertEqual([call(ANY, progressCmds=ANY, suppressErrorCheck=True), call(ANY, suppressErrorCheck=False)],
                          self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list)
         rm_cmds = self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list[1][0][0]
 
         self.assertEqual(3, len(rm_cmds))
-        expected_info_msgs = [call(Contains('Initiating segment recovery')),
-                              call(Contains('-----')),
-                              call(Contains('Failed to start the following segments')),
-                              call(Contains('hostname: host1; port: 7001; datadir: /datadir2')),
-                              call(Contains('hostname: host1; port: 7003; datadir: /datadir3')),
-                              call(Contains('hostname: host2; port: 7005; datadir: /datadir4'))]
-
-        self.assertEqual(expected_info_msgs, self.mock_logger.info.call_args_list)
+        self._assert_run_recovery()
 
     def test_run_recovery_some_dbids_fail_all_start_errors(self):
         recovery_info = {'host1': [self.recovery_info1], 'host2': [self.recovery_info2, self.recovery_info3]}
         host1_error = '[{"error_type": "start", "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}]'
         host2_error = '[{"error_type": "start", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]'
 
-        self._set_run_recovery([host1_error, host2_error])
-        self.default_build_mirrors_obj._run_recovery(self.action, recovery_info, self.gpEnv)
+        self._setup_recovery_mocks([host1_error, host2_error])
+
+        self.default_build_mirrors_obj._run_recovery(self.default_action_name, recovery_info, self.gpEnv)
         self.assertEqual([call(ANY, progressCmds=ANY, suppressErrorCheck=True), call(ANY, suppressErrorCheck=False)],
                          self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list)
-        rm_cmds = self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list[1][0][0]
+        rm_progress_cmds = self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list[1][0][0]
+        self.assertEqual(3, len(rm_progress_cmds))
 
-        self.assertEqual(3, len(rm_cmds))
-        expected_info_msgs = [call(Contains('Initiating segment recovery')),
-                              call(Contains('-----')),
-                              call(Contains('Failed to start the following segments')),
-                              call(Contains('hostname: host1; port: 7001; datadir: /datadir2')),
-                              call(Contains('hostname: host2; port: 7005; datadir: /datadir4'))]
-        self.assertEqual(expected_info_msgs, self.mock_logger.info.call_args_list)
+        self._assert_run_recovery()
 
-    def test_run_recovery_all_dbids_fail_both_recovery_and_start_errors(self):
+    def test_run_recovery_all_dbids_fail_bb_rewind_and_start_errors(self):
         recovery_info = {'host1': [self.recovery_info1, self.recovery_info2], 'host2': [self.recovery_info3]}
         host1_error = '[{"error_type": "full",  "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}, ' \
                       '{"error_type": "start",  "error_msg":"some error for dbid 3", "dbid": 3, "datadir": "/datadir3", "port": 7003, "progress_file": "/tmp/progress3"}]'
         host2_error = '[{"error_type": "full",  "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]'
-        self._set_run_recovery([host1_error, host2_error])
+        self._setup_recovery_mocks([host1_error, host2_error])
 
-        self.default_build_mirrors_obj._run_recovery(self.action, recovery_info, self.gpEnv)
+        self.default_build_mirrors_obj._run_recovery(self.default_action_name, recovery_info, self.gpEnv)
 
         self.assertEqual([call(ANY, progressCmds=ANY, suppressErrorCheck=True), call(ANY, suppressErrorCheck=False)],
                          self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list)
-        rm_cmds = self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list[1][0][0]
+        rm_progress_cmds = self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list[1][0][0]
 
         # Since start passed for dbid:3, we should have deleted it's progress file
-        self.assertEqual(1, len(rm_cmds))
-        self.assertEqual("host1", rm_cmds[0].remoteHost)
-        self.assertEqual("rm -f /tmp/progress_file3", rm_cmds[0].cmdStr)
+        self.assertEqual(1, len(rm_progress_cmds))
+        self.assertEqual("host1", rm_progress_cmds[0].remoteHost)
+        self.assertEqual("rm -f /tmp/progress_file3", rm_progress_cmds[0].cmdStr)
 
-        expected_info_msgs = [call(Contains('Initiating segment recovery')),
-                              call(Contains('-----')),
-                              call(Contains('Failed to recover the following segments')),
-                              call(Contains('hostname: host1; port: 7001; logfile: /tmp/progress2')),
-                              call(Contains('hostname: host2; port: 7005; logfile: /tmp/progress4')),
-                              call(Contains('-----')),
-                              call(Contains('Failed to start the following segments. Please check the latest logs')),
-                              call(Contains('hostname: host1; port: 7003; datadir: /datadir3'))]
-        self.assertEqual(expected_info_msgs, self.mock_logger.info.call_args_list)
+        self._assert_run_recovery()
 
-    def test_run_recovery_all_dbids_fail_both_recovery_and_default_errors(self):
-        recovery_info = {'host1': [self.recovery_info1], 'host2': [self.recovery_info2, self.recovery_info3]}
+    def test_run_recovery_all_dbids_fail_bb_rewind_and_default_errors(self):
+        recovery_info = OrderedDict()  # We use ordered dict to deterministically assert the side effects of _run_recovery
+        recovery_info['host1'] = [self.recovery_info1]
+        recovery_info['host2'] = [self.recovery_info2, self.recovery_info3]
+
+        # recovery_info = OrderedDict({'host1': [self.recovery_info1], 'host2': [self.recovery_info2, self.recovery_info3]})
         host1_error = '[{"error_type": "start",  "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}, ' \
                       '{"error_type": "default",  "error_msg":"some error for dbid 3", "dbid": 3, "datadir": "/datadir3", "port": 7003, "progress_file": "/tmp/progress3"}]'
         host2_error = '[{"error_type": "incremental",  "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]'
-        self._set_run_recovery([host1_error, host2_error])
+        self._setup_recovery_mocks([host1_error, host2_error])
 
-        self.default_build_mirrors_obj._run_recovery(self.action, recovery_info, self.gpEnv)
+        self.default_build_mirrors_obj._run_recovery(self.default_action_name, recovery_info, self.gpEnv)
 
         self.assertEqual([call(ANY, progressCmds=ANY, suppressErrorCheck=True), call(ANY, suppressErrorCheck=False)],
                          self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list)
-        rm_cmds = self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list[1][0][0]
+        rm_progress_cmds = self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list[1][0][0]
 
-        self.assertEqual(2, len(rm_cmds))
-        self.assertEqual("host1", rm_cmds[0].remoteHost)
-        self.assertEqual("rm -f /tmp/progress_file2", rm_cmds[0].cmdStr)
-        expected_info_msgs = [call(Contains('Initiating segment recovery')),
-                              call(Contains('-----')),
-                              call(Contains('Failed to recover the following segments')),
-                              call(Contains('hostname: host2; port: 7005; logfile: /tmp/progress4')),
-                              call(Contains('-----')),
-                              call(Contains('Failed to start the following segments. Please check the latest logs')),
-                              call(Contains('hostname: host1; port: 7001; datadir: /datadir2'))]
-        self.assertEqual(expected_info_msgs, self.mock_logger.info.call_args_list)
+        self.assertEqual(2, len(rm_progress_cmds))
+        self.assertEqual("host1", rm_progress_cmds[0].remoteHost)
+        self.assertEqual("host2", rm_progress_cmds[1].remoteHost)
+        self.assertEqual("rm -f /tmp/progress_file2", rm_progress_cmds[0].cmdStr)
+        self.assertEqual("rm -f /tmp/progress_file3", rm_progress_cmds[1].cmdStr)
+
+        self._assert_run_recovery()
+
+    def test_run_backout_some_dbids_have_errors(self):
+        host1_error = '[{"error_type": "full", "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}, ' \
+                      '{"error_type": "incremental", "error_msg":"some error for dbid 3", "dbid": 3, "datadir": "/datadir3", "port": 7003, "progress_file": "/tmp/progress3"}]'
+        host1_result = CommandResult(1, 'failed 1'.encode(), host1_error.encode(), True, False)
+        host2_result = CommandResult(0, b"", b"", True, False)
+        host1_recovery_output = Mock()
+        host2_recovery_output = Mock()
+        host1_recovery_output.get_results = Mock(return_value=host1_result)
+        host2_recovery_output.get_results = Mock(return_value=host2_result)
+
+        recovery_results = RecoveryResult(self.default_action_name, [host1_recovery_output, host2_recovery_output],
+                                          self.mock_logger)
+
+        self.default_build_mirrors_obj._revert_config_update(recovery_results, self.test_backout_map)
+
+        self.assertEqual([call(Contains('Some mirrors failed during basebackup')),
+                          call(Contains('Successfully reverted the gp_segment_configuration updates'))],
+                         self.mock_logger.debug.call_args_list)
+        self.assertEqual([call(ANY, "BEGIN"), call(ANY, "COMMIT")], self.mock_dbconn.execSQL.call_args_list)
+        expected_sql = 'SET allow_system_table_mods=true;\n' \
+                       'select gp_remove_segment_mirror(2);\n' \
+                       'select gp_add_segment_mirror(2);\n' \
+                       'select gp_remove_segment_mirror(3);\n' \
+                       'select gp_add_segment_mirror(3);\n'
+        self.assertEqual([call(ANY, expected_sql, 1)], self.mock_dbconn.executeUpdateOrInsert.call_args_list)
+
+    def test_run_backout_all_dbids_have_errors(self):
+        host1_error = '[{"error_type": "full", "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}, ' \
+                      '{"error_type": "incremental", "error_msg":"some error for dbid 3", "dbid": 3, "datadir": "/datadir3", "port": 7003, "progress_file": "/tmp/progress3"}]'
+        host2_error = '[{"error_type": "full", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]'
+
+        host1_result = CommandResult(1, 'failed 1'.encode(), host1_error.encode(), True, False)
+        host2_result = CommandResult(1, 'failed 2'.encode(), host2_error.encode(), True, False)
+        host1_recovery_output = Mock()
+        host2_recovery_output = Mock()
+        host1_recovery_output.get_results = Mock(return_value=host1_result)
+        host2_recovery_output.get_results = Mock(return_value=host2_result)
+
+        recovery_results = RecoveryResult(self.default_action_name, [host1_recovery_output, host2_recovery_output],
+                                          self.mock_logger)
+
+        self.default_build_mirrors_obj._revert_config_update(recovery_results, self.test_backout_map)
+
+        self.assertEqual([call(Contains('Some mirrors failed during basebackup')),
+                          call(Contains('Successfully reverted the gp_segment_configuration updates'))],
+                         self.mock_logger.debug.call_args_list)
+        self.assertEqual([call(ANY, "BEGIN"), call(ANY, "COMMIT")], self.mock_dbconn.execSQL.call_args_list)
+        expected_sql = 'SET allow_system_table_mods=true;\n' \
+                       'select gp_remove_segment_mirror(2);\n' \
+                       'select gp_add_segment_mirror(2);\n' \
+                       'select gp_remove_segment_mirror(3);\n' \
+                       'select gp_add_segment_mirror(3);\n' \
+                       'select gp_remove_segment_mirror(4);\n' \
+                       'select gp_add_segment_mirror(4);\n'
+        self.assertEqual([call(ANY, expected_sql, 1)], self.mock_dbconn.executeUpdateOrInsert.call_args_list)
+
+    def test_run_backout_all_dbids_have_incremental_errors(self):
+        host1_error = '[{"error_type": "incremental", "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}, ' \
+                      '{"error_type": "incremental", "error_msg":"some error for dbid 3", "dbid": 3, "datadir": "/datadir3", "port": 7003, "progress_file": "/tmp/progress3"}]'
+
+        host1_result = CommandResult(1, 'failed 1'.encode(), host1_error.encode(), True, False)
+        host2_result = CommandResult(0, b"", b"", True, False)
+        host1_recovery_output = Mock()
+        host2_recovery_output = Mock()
+        host1_recovery_output.get_results = Mock(return_value=host1_result)
+        host2_recovery_output.get_results = Mock(return_value=host2_result)
+
+        recovery_results = RecoveryResult(self.default_action_name, [host1_recovery_output, host2_recovery_output],
+                                          self.mock_logger)
+        self.default_build_mirrors_obj._revert_config_update(recovery_results, self.test_backout_map)
+
+        self.assertEqual(0, self.mock_logger.debug.call_count)
+        self.assertEqual(0, self.mock_dbconn.execSQL.call_count)
+        self.assertEqual(0, self.mock_dbconn.executeUpdateOrInsert.call_count)
+
+    def test_run_backout_no_errors(self):
+        host1_recovery_output = Mock()
+        host2_recovery_output = Mock()
+        host1_recovery_output.get_results = Mock(return_value=CommandResult(0, b"", b"", True, False))
+        host2_recovery_output.get_results = Mock(return_value=CommandResult(0, b"", b"", True, False))
+
+        recovery_results = RecoveryResult(self.default_action_name, [host1_recovery_output, host2_recovery_output],
+                                          self.mock_logger)
+        self.default_build_mirrors_obj._revert_config_update(recovery_results, self.test_backout_map)
+
+        self.assertEqual(0, self.mock_logger.debug.call_count)
+        self.assertEqual(0, self.mock_dbconn.execSQL.call_count)
+        self.assertEqual(0, self.mock_dbconn.executeUpdateOrInsert.call_count)
+
+    def test_run_backout_exception(self):
+        self.mock_dbconn.executeUpdateOrInsert.side_effect = Exception('running backout query failed')
+        host1_error = """[{"error_type": "full", "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2",
+                            "port": 7001, "progress_file": "/tmp/progress2"}]"""
+
+        host1_recovery_output = Mock()
+        host1_recovery_output.get_results = Mock(return_value=CommandResult(1, 'failed 1'.encode(), host1_error.encode(),
+                                                                            True, False))
+
+        recovery_results = RecoveryResult(self.default_action_name, [host1_recovery_output],
+                                          self.mock_logger)
+
+        with self.assertRaisesRegex(Exception, "running backout query failed"):
+            self.default_build_mirrors_obj._revert_config_update(recovery_results, self.test_backout_map)
 
 
 class BuildMirrorSegmentsTestCase(GpTestCase):
@@ -785,27 +886,6 @@ class BuildMirrorSegmentsTestCase(GpTestCase):
         host = 'h1'
         self.assertEqual(self.buildMirrorSegs.dereference_remote_symlink(datadir, host), '/tmp/seg0')
         self.mock_logger.warning.assert_any_call('Unable to determine if /tmp/seg0 is symlink. Assuming it is not symlink')
-
-    #TODO Do we need to move these tests now that the startAll function has been deleted
-    # @patch('gppylib.operations.buildMirrorSegments.read_era')
-    # @patch('gppylib.operations.startSegments.StartSegmentsOperation')
-    # def test_startAll_succeeds(self, mock1, mock2):
-    #     result = StartSegmentsResult()
-    #     result.getFailedSegmentObjs()
-    #     mock1.return_value.startSegments.return_value = result
-    #     self.assertTrue(result)
-    #
-    # @patch('gppylib.operations.buildMirrorSegments.read_era')
-    # @patch('gppylib.operations.startSegments.StartSegmentsOperation')
-    # def test_startAll_fails(self, mock1, mock2):
-    #     result = StartSegmentsResult()
-    #     failed_segment = Segment.initFromString(
-    #         "2|0|p|p|s|u|sdw1|sdw1|40000|/data/primary0")
-    #     result.addFailure(failed_segment, 'reason', 'reasoncode')
-    #     mock1.return_value.startSegments.return_value = result
-    #     self.assertFalse(result)
-    #     self.mock_logger.warn.assert_any_call('Failed to start segment.  The fault prober will shortly mark it as down. '
-    #                                      'Segment: sdw1:/data/primary0:content=0:dbid=2:role=p:preferred_role=p:mode=s:status=u: REASON: reason')
 
     def _createGpArrayWith2Primary2Mirrors(self):
         self.coordinator = Segment.initFromString(

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
@@ -2,18 +2,29 @@
 #
 # Copyright (c) Greenplum Inc 2008. All Rights Reserved.
 #
+from collections import OrderedDict
 import io
 import logging
-from mock import ANY, call, patch, Mock
 
-from gppylib import gplog
-from gppylib.commands import base
+from mock import ANY, call, patch, Mock
+from gppylib import gplog, recoveryinfo
+from gppylib.commands import base, gp
+from gppylib.commands.base import CommandResult
 from gppylib.gparray import Segment, GpArray
+from gppylib.mainUtils import ExceptionNoStackTraceNeeded
 from gppylib.operations.buildMirrorSegments import GpMirrorToBuild, GpMirrorListToBuild, GpStopSegmentDirectoryDirective
 from gppylib.operations.startSegments import StartSegmentsResult
 from gppylib.system import configurationInterface
 from test.unit.gp_unittest import GpTestCase
 
+from gppylib.recoveryinfo import RecoveryInfo, RecoveryResult
+
+class Contains(str): #TODO should we move this somewhere
+    """
+    This class is used as a way to assert for partial match in unittests
+    """
+    def __eq__(self, other):
+        return self in other
 
 class BuildMirrorsTestCase(GpTestCase):
     """
@@ -34,73 +45,184 @@ class BuildMirrorsTestCase(GpTestCase):
 
         gplog.get_unittest_logger()
         self.apply_patches([
-            patch('gppylib.operations.buildMirrorSegments.GpArray.getSegmentsByHostName')
+            patch('gppylib.operations.buildMirrorSegments.GpArray.getSegmentsByHostName'),
+            patch('gppylib.operations.buildMirrorSegments.gplog.get_logger_dir', return_value='/tmp/logdir'),
+            patch('gppylib.operations.buildMirrorSegments.read_era', return_value='dummy_era'),
         ])
         self.mock_get_segments_by_hostname = self.get_mock_from_apply_patch('getSegmentsByHostName')
+        self.mock_logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
+        self.default_build_mirrors_obj = GpMirrorListToBuild(
+            toBuild=Mock(),
+            pool=Mock(),
+            quiet=True,
+            parallelDegree=0,
+            logger=self.mock_logger
+        )
+        self.progress_file_dbid2='/tmp/progress_file2'
+        self.progress_file_dbid3='/tmp/progress_file3'
+        self.progress_file_dbid4='/tmp/progress_file4'
 
         self.action = 'recover'
         self.gpEnv = Mock()
         self.gpArray = GpArray([self.coordinator, self.primary, self.mirror])
-        self.mock_logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
+        self.recovery_info1 = RecoveryInfo('/datadir2', 7001, 2, 'source_host_for_dbid2', 7002, True, self.progress_file_dbid2)
+        self.recovery_info2 = RecoveryInfo('/datadir3', 7003, 3, 'source_host_for_dbid3', 7004, True, self.progress_file_dbid3)
+        self.recovery_info3 = RecoveryInfo('/datadir4', 7005, 4, 'source_host_for_dbid4', 7006, True, self.progress_file_dbid4)
 
     def tearDown(self):
         super(BuildMirrorsTestCase, self).tearDown()
 
-    def _setup_mocks(self, buildMirrorSegs_obj):
-        buildMirrorSegs_obj._GpMirrorListToBuild__startAll = Mock(return_value=True)
+    def _setup_mocks(self, build_mirrors_obj):
         markdown_mock = Mock()
-        buildMirrorSegs_obj._wait_fts_to_mark_down_segments = markdown_mock
-        buildMirrorSegs_obj._run_recovery = Mock()
-        buildMirrorSegs_obj._clean_up_failed_segments = Mock()
-        buildMirrorSegs_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear = Mock()
-        buildMirrorSegs_obj._get_running_postgres_segments = Mock()
+        build_mirrors_obj._wait_fts_to_mark_down_segments = markdown_mock
+        # TODO maybe remove this patch ?
+        build_mirrors_obj._run_recovery = Mock()
+        build_mirrors_obj._run_setup_recovery = Mock(return_value=RecoveryResult('action', [], None))
+        build_mirrors_obj._clean_up_failed_segments = Mock()
+        build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear = Mock()
+        build_mirrors_obj._get_running_postgres_segments = Mock()
         configurationInterface.getConfigurationProvider = Mock()
 
-    def _common_asserts_with_stop_and_logger(self, buildMirrorSegs_obj, expected_logger_msg, expected_segs_to_stop,
+    def _common_asserts_with_stop_and_logger(self, build_mirrors_obj, expected_logger_msg, expected_segs_to_stop,
                                              expected_segs_to_markdown, expected_segs_to_update, cleanup_count,
                                              info_call_count=3):
         self.mock_logger.info.assert_any_call(expected_logger_msg)
         #TODO assert all logger info msgs
         self.assertEqual(info_call_count, self.mock_logger.info.call_count)
 
-        self.assertEqual([call(expected_segs_to_stop)],
-                         buildMirrorSegs_obj._get_running_postgres_segments.call_args_list)
-        self._common_asserts(buildMirrorSegs_obj,  expected_segs_to_markdown,
-                             expected_segs_to_update, cleanup_count)
+        self.assertEqual([call(expected_segs_to_stop)], build_mirrors_obj._get_running_postgres_segments.call_args_list)
+        self._common_asserts(build_mirrors_obj,  expected_segs_to_markdown, expected_segs_to_update, cleanup_count)
 
-    def _common_asserts(self, buildMirrorSegs_obj,  expected_segs_to_markdown,
-                        expected_segs_to_update, cleanup_count):
+    def _common_asserts(self, build_mirrors_obj,  expected_segs_to_markdown, expected_segs_to_update, cleanup_count):
         self.assertEqual([call(self.gpEnv, expected_segs_to_markdown)],
-                         buildMirrorSegs_obj._wait_fts_to_mark_down_segments.call_args_list)
-        self.assertEqual(cleanup_count, buildMirrorSegs_obj._clean_up_failed_segments.call_count)
+                         build_mirrors_obj._wait_fts_to_mark_down_segments.call_args_list)
+        self.assertEqual(cleanup_count, build_mirrors_obj._clean_up_failed_segments.call_count)
 
-        self.assertEqual(1, buildMirrorSegs_obj._run_recovery.call_count)
-
+        self.assertEqual(1, build_mirrors_obj._run_recovery.call_count)
         self.assertEqual([call(self.gpArray, ANY, dbIdToForceMirrorRemoveAdd=expected_segs_to_update,
                                useUtilityMode=False, allowPrimary=False)],
                          configurationInterface.getConfigurationProvider.return_value.updateSystemConfig.call_args_list)
-        self.assertEqual(0, buildMirrorSegs_obj._GpMirrorListToBuild__startAll.call_count)
 
-    def _run_no_failed_tests(self, tests):
+    def _set_run_recovery(self, host_errors=[], is_setup=False):
+
+        host1_recovery_output = gp.GpSegRecovery('test recover 1', 'dummy_info1', '/tmp/log1/', False, 1, 'host1', 'dummy_era1', True)
+        host2_recovery_output = gp.GpSegRecovery('test recover 2', 'dummy_info2', '/tmp/log2/', True, 2, 'host2', 'dummy_era2', False)
+
+        host1_result = CommandResult(0, ''.encode(), ''.encode(), True, False)
+        host2_result = CommandResult(0, ''.encode(), ''.encode(), True, False)
+        if host_errors:
+            host1_result = CommandResult(1, 'failed 1'.encode(), host_errors[0].encode(), True, False)
+            host2_result = CommandResult(1, 'failed 1'.encode(), host_errors[1].encode(), True, False)
+        host1_recovery_output.get_results = Mock(return_value = host1_result)
+        host2_recovery_output.get_results = Mock(return_value = host2_result)
+        self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear = Mock()
+
+        completed_items = [host1_recovery_output, host2_recovery_output]
+        if is_setup:
+            self.default_build_mirrors_obj._do_setup_for_recovery = Mock()
+            self.default_build_mirrors_obj._do_setup_for_recovery.return_value = completed_items
+        else:
+            self.default_build_mirrors_obj._do_setup_for_recovery = Mock(return_value=[])
+        self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.return_value = completed_items
+
+    def _run_buildMirrors(self, mirrors_to_build):
+        build_mirrors_obj = GpMirrorListToBuild(
+            toBuild=mirrors_to_build,
+            pool=Mock(),
+            quiet=True,
+            parallelDegree=0,
+            logger=self.mock_logger
+        )
+        self._setup_mocks(build_mirrors_obj)
+        self.assertTrue(build_mirrors_obj.buildMirrors(self.action, self.gpEnv, self.gpArray))
+        return build_mirrors_obj
+
+    def _create_primary(self, dbid='1', contentid='0', state='n', status='u', host='sdw1', unreachable=False):
+        seg = Segment.initFromString('{}|{}|p|p|{}|{}|{}|{}|21000|/primary/gpseg0'
+                                     .format(dbid, contentid, state, status, host, host))
+        seg.unreachable = unreachable
+        return seg
+
+    def _create_mirror(self, dbid='2', contentid='0', state='n', status='u', host='sdw2'):
+        return Segment.initFromString('{}|{}|p|p|{}|{}|{}|{}|22000|/mirror/gpseg0'
+                                      .format(dbid, contentid, state, status, host, host))
+
+    def test_buildMirrors_noMirrors(self):
+        build_mirrors_obj = GpMirrorListToBuild(
+            toBuild=[],
+            pool=None,
+            quiet=True,
+            parallelDegree=0,
+            logger=self.mock_logger
+        )
+        self.assertTrue(build_mirrors_obj.buildMirrors(None, None, None))
+        self.assertTrue(build_mirrors_obj.buildMirrors(self.action, None, None))
+
+        self.assertEqual([call('No segments to None'), call('No segments to recover')],
+                         self.mock_logger.info.call_args_list)
+
+    def test_buildMirrors_no_failed_pass(self):
+        tests = [
+            {
+                "name": "no_failed_full",
+                "live": self._create_primary(),
+                "failover": self._create_mirror(),
+                "forceFull": False,
+            },
+            {
+                "name": "no_failed_full2",
+                "live": self._create_primary(dbid='3'),
+                "failover": self._create_mirror(dbid='4'),
+                "forceFull": True,
+            }
+        ]
+
         mirrors_to_build = []
-
         for test in tests:
             with self.subTest(msg=test["name"]):
                 mirrors_to_build.append(GpMirrorToBuild(None, test["live"], test["failover"],
                                                         test["forceFull"]))
 
-        buildMirrorSegs_obj = self._run_buildMirrors(mirrors_to_build)
+        build_mirrors_obj = self._run_buildMirrors(mirrors_to_build)
 
         self.assertEqual(2, self.mock_logger.info.call_count)
-        self.assertEqual(0, buildMirrorSegs_obj._get_running_postgres_segments.call_count)
-        self._common_asserts(buildMirrorSegs_obj, [], {2: True, 4: True}, 1)
+        self.assertEqual(0, build_mirrors_obj._get_running_postgres_segments.call_count)
+        self._common_asserts(build_mirrors_obj, [], {2: True, 4: True}, cleanup_count=1)
 
         for test in tests:
             self.assertEqual('n', test['live'].getSegmentMode())
             self.assertEqual('d', test['failover'].getSegmentStatus())
             self.assertEqual('n', test['failover'].getSegmentMode())
 
-    def _run_no_failover_tests(self, tests):
+    def test_buildMirrors_no_failover_pass(self):
+        tests = [
+            {
+                "name": "no_failover",
+                "failed": self._create_mirror(status='d'),
+                "live": self._create_primary(),
+                "forceFull": False,
+            },
+            {
+                "name": "no_failover_full",
+                "failed": self._create_mirror(status='d', dbid='4'),
+                "live": self._create_primary(),
+                "forceFull": True,
+            },
+            {
+                "name": "no_failover_failed_seg_exists_in_gparray",
+                "failed": self.mirror,
+                "live": self._create_primary(),
+                "forceFull": True,
+                "forceoverwrite": True
+            },
+            {
+                "name": "no_failover_failed_segment_is_up",
+                "failed": self._create_mirror(dbid='5'),
+                "live": self._create_primary(dbid='6'),
+                "is_failed_segment_up": True,
+                "forceFull": False,
+            }
+        ]
         mirrors_to_build = []
         expected_segs_to_stop = []
         expected_segs_to_markdown = []
@@ -113,9 +235,9 @@ class BuildMirrorsTestCase(GpTestCase):
                 if 'is_failed_segment_up' in test and test["is_failed_segment_up"]:
                     expected_segs_to_markdown.append(test['failed'])
 
-        buildMirrorSegs_obj = self._run_buildMirrors(mirrors_to_build)
+        build_mirrors_obj = self._run_buildMirrors(mirrors_to_build)
 
-        self._common_asserts_with_stop_and_logger(buildMirrorSegs_obj, "Ensuring 4 failed segment(s) are stopped",
+        self._common_asserts_with_stop_and_logger(build_mirrors_obj, "Ensuring 4 failed segment(s) are stopped",
                                                   expected_segs_to_stop,
                                                   expected_segs_to_markdown, {4: True, 30: True},
                                                   1)
@@ -124,7 +246,39 @@ class BuildMirrorsTestCase(GpTestCase):
             self.assertEqual('d', test['failed'].getSegmentStatus())
             self.assertEqual('n', test['failed'].getSegmentMode())
 
-    def _run_both_failed_failover_tests(self, tests):
+    def test_buildMirrors_both_failed_failover_pass(self):
+        tests = [
+            {
+                "name": "both_failed_failover_full",
+                "failed": self._create_primary(status='d'),
+                "live": self._create_mirror(),
+                "failover": self._create_primary(status='d', host='sdw3'),
+                "forceFull": True
+            },
+            {
+                "name": "both_failed_failover_failed_segment_is_up",
+                "failed": self._create_primary(dbid='5'),
+                "live": self._create_mirror(dbid='6'),
+                "failover": self._create_primary(dbid='5', host='sdw3'),
+                "is_failed_segment_up": True,
+                "forceFull": True
+            },
+            {
+                "name": "both_failed_failover_failover_is_down_live_is_marked_as_sync",
+                "failed": self._create_primary(dbid='9', status='d'),
+                "live": self._create_mirror(dbid='10', state='s'),
+                "failover": self._create_primary(dbid='9', status='d'),
+                "forceFull": False,
+            },
+            {
+                "name": "both_failed_failover_failed_is_unreachable",
+                "failed": self._create_primary(dbid='9', status='d', unreachable=True),
+                "live": self._create_mirror(dbid='10', state='s'),
+                "failover": self._create_primary(dbid='9', status='d'),
+                "forceFull": False,
+            },
+
+        ]
         mirrors_to_build = []
         expected_segs_to_stop = []
         expected_segs_to_markdown = []
@@ -139,10 +293,10 @@ class BuildMirrorsTestCase(GpTestCase):
                 if 'is_failed_segment_up' in test and test["is_failed_segment_up"]:
                     expected_segs_to_markdown.append(test['failed'])
 
-        buildMirrorSegs_obj = self._run_buildMirrors(mirrors_to_build)
+        build_mirrors_obj = self._run_buildMirrors(mirrors_to_build)
 
         # TODO improve the logic that passes info_call_count
-        self._common_asserts_with_stop_and_logger(buildMirrorSegs_obj, "Ensuring 3 failed segment(s) are stopped",
+        self._common_asserts_with_stop_and_logger(build_mirrors_obj, "Ensuring 3 failed segment(s) are stopped",
                                                   expected_segs_to_stop,
                                                   expected_segs_to_markdown, {1: True, 5: True, 9: True}, 1,
                                                   info_call_count=4)
@@ -152,117 +306,12 @@ class BuildMirrorsTestCase(GpTestCase):
             self.assertEqual('d', test['failover'].getSegmentStatus())
             self.assertEqual('n', test['failover'].getSegmentMode())
 
-    def _run_buildMirrors(self, mirrors_to_build):
-        buildMirrorSegs_obj = GpMirrorListToBuild(
-            toBuild=mirrors_to_build,
-            pool=None,
-            quiet=True,
-            parallelDegree=0,
-            logger=self.mock_logger
-        )
-        self._setup_mocks(buildMirrorSegs_obj)
-        self.assertTrue(buildMirrorSegs_obj.buildMirrors(self.action, self.gpEnv, self.gpArray))
-        return buildMirrorSegs_obj
-
-    def create_primary(self, dbid='1', contentid='0', state='n', status='u', host='sdw1', unreachable=False):
-        seg = Segment.initFromString('{}|{}|p|p|{}|{}|{}|{}|21000|/primary/gpseg0'
-                                     .format(dbid, contentid, state, status, host, host))
-        seg.unreachable = unreachable
-        return seg
-
-    def create_mirror(self, dbid='2', contentid='0', state='n', status='u', host='sdw2'):
-        return Segment.initFromString('{}|{}|p|p|{}|{}|{}|{}|22000|/mirror/gpseg0'
-                                      .format(dbid, contentid, state, status, host, host))
-
-    def test_buildMirrors_failed_null_pass(self):
-        failed_null_tests = [
-            {
-                "name": "no_failed_full",
-                "live": self.create_primary(),
-                "failover": self.create_mirror(),
-                "forceFull": False,
-            },
-            {
-                "name": "no_failed_full2",
-                "live": self.create_primary(dbid='3'),
-                "failover": self.create_mirror(dbid='4'),
-                "forceFull": True,
-            }
-        ]
-        self._run_no_failed_tests(failed_null_tests)
-
-    def test_buildMirrors_no_failover_pass(self):
-        tests = [
-            {
-                "name": "no_failover",
-                "failed": self.create_mirror(status='d'),
-                "live": self.create_primary(),
-                "forceFull": False,
-            },
-            {
-                "name": "no_failover_full",
-                "failed": self.create_mirror(status='d', dbid='4'),
-                "live": self.create_primary(),
-                "forceFull": True,
-            },
-            {
-                "name": "no_failover_failed_seg_exists_in_gparray",
-                "failed": self.mirror,
-                "live": self.create_primary(),
-                "forceFull": True,
-                "forceoverwrite": True
-            },
-            {
-                "name": "no_failover_failed_segment_is_up",
-                "failed": self.create_mirror(dbid='5'),
-                "live": self.create_primary(dbid='6'),
-                "is_failed_segment_up": True,
-                "forceFull": False,
-            }
-        ]
-        self._run_no_failover_tests(tests)
-
-    def test_buildMirrors_both_failed_failover_pass(self):
-        tests = [
-            {
-                "name": "both_failed_failover_full",
-                "failed": self.create_primary(status='d'),
-                "live": self.create_mirror(),
-                "failover": self.create_primary(status='d', host='sdw3'),
-                "forceFull": True
-            },
-            {
-                "name": "both_failed_failover_failed_segment_is_up",
-                "failed": self.create_primary(dbid='5'),
-                "live": self.create_mirror(dbid='6'),
-                "failover": self.create_primary(dbid='5', host='sdw3'),
-                "is_failed_segment_up": True,
-                "forceFull": True
-            },
-            {
-                "name": "both_failed_failover_failover_is_down_live_is_marked_as_sync",
-                "failed": self.create_primary(dbid='9', status='d'),
-                "live": self.create_mirror(dbid='10', state='s'),
-                "failover": self.create_primary(dbid='9', status='d'),
-                "forceFull": False,
-            },
-            {
-                "name": "both_failed_failover_failed_is_unreachable",
-                "failed": self.create_primary(dbid='9', status='d', unreachable=True),
-                "live": self.create_mirror(dbid='10', state='s'),
-                "failover": self.create_primary(dbid='9', status='d'),
-                "forceFull": False,
-            },
-
-        ]
-        self._run_both_failed_failover_tests(tests)
-
     def test_buildMirrors_forceoverwrite_true(self):
-        failed = self.create_primary(status='d')
-        live = self.create_mirror()
-        failover = self.create_primary(host='sdw3')
+        failed = self._create_primary(status='d')
+        live = self._create_mirror()
+        failover = self._create_primary(host='sdw3')
 
-        buildMirrorSegs_obj = GpMirrorListToBuild(
+        build_mirrors_obj = GpMirrorListToBuild(
             toBuild=[GpMirrorToBuild(failed, live, failover, False)],
             pool=None,
             quiet=True,
@@ -270,10 +319,10 @@ class BuildMirrorsTestCase(GpTestCase):
             logger=self.mock_logger,
             forceoverwrite=True
         )
-        self._setup_mocks(buildMirrorSegs_obj)
-        self.assertTrue(buildMirrorSegs_obj.buildMirrors(self.action, self.gpEnv, self.gpArray))
+        self._setup_mocks(build_mirrors_obj)
+        self.assertTrue(build_mirrors_obj.buildMirrors(self.action, self.gpEnv, self.gpArray))
 
-        self._common_asserts_with_stop_and_logger(buildMirrorSegs_obj, "Ensuring 1 failed segment(s) are stopped",
+        self._common_asserts_with_stop_and_logger(build_mirrors_obj, "Ensuring 1 failed segment(s) are stopped",
                                                   [failed], [], {1: True}, 0)
         self.assertEqual('n', live.getSegmentMode())
         self.assertEqual('d', failover.getSegmentStatus())
@@ -283,32 +332,32 @@ class BuildMirrorsTestCase(GpTestCase):
         tests = [
             {
                 "name": "failed_seg_exists_in_gparray1",
-                "failed": self.create_primary(status='d'),
-                "failover": self.create_primary(status='d'),
-                "live": self.create_mirror(),
+                "failed": self._create_primary(status='d'),
+                "failover": self._create_primary(status='d'),
+                "live": self._create_mirror(),
                 "forceFull": True,
                 "forceoverwrite": False
             },
             {
                 "name": "failed_seg_exists_in_gparray2",
-                "failed": self.create_primary(dbid='3', status='d'),
-                "failover": self.create_primary(dbid='3', status='d'),
-                "live": self.create_mirror(dbid='4'),
+                "failed": self._create_primary(dbid='3', status='d'),
+                "failover": self._create_primary(dbid='3', status='d'),
+                "live": self._create_mirror(dbid='4'),
                 "forceFull": False,
                 "forceoverwrite": False
             },
             {
                 "name": "failed_seg_exists_in_gparray2",
-                "failed": self.create_primary(dbid='3', status='d'),
-                "failover": self.create_primary(dbid='3', status='d'),
-                "live": self.create_mirror(dbid='4'),
+                "failed": self._create_primary(dbid='3', status='d'),
+                "failover": self._create_primary(dbid='3', status='d'),
+                "live": self._create_mirror(dbid='4'),
                 "forceFull": False,
                 "forceoverwrite": True
             }
         ]
         for test in tests:
             mirror_to_build = GpMirrorToBuild(test["failed"], test["live"], test["failover"], test["forceFull"])
-            buildMirrorSegs_obj = GpMirrorListToBuild(
+            build_mirrors_obj = GpMirrorListToBuild(
                 toBuild=[mirror_to_build,],
                 pool=None,
                 quiet=True,
@@ -316,33 +365,33 @@ class BuildMirrorsTestCase(GpTestCase):
                 logger=self.mock_logger,
                 forceoverwrite=test['forceoverwrite']
             )
-            self._setup_mocks(buildMirrorSegs_obj)
+            self._setup_mocks(build_mirrors_obj)
             local_gp_array = GpArray([self.coordinator, test["failed"]])
             expected_error = "failed segment should not be in the new configuration if failing over to"
             with self.subTest(msg=test["name"]):
                 with self.assertRaisesRegex(Exception, expected_error):
-                    buildMirrorSegs_obj.buildMirrors(self.action, self.gpEnv, local_gp_array)
+                    build_mirrors_obj.buildMirrors(self.action, self.gpEnv, local_gp_array)
 
     def test_clean_up_failed_segments(self):
-        failed1 = self.create_primary(status='d')
-        live1 = self.create_mirror()
+        failed1 = self._create_primary(status='d')
+        live1 = self._create_mirror()
 
-        failed2 = self.create_primary(dbid='3', status='d')
-        failover2 = self.create_primary(dbid='3', status='d')
-        live2 = self.create_mirror(dbid='4')
+        failed2 = self._create_primary(dbid='3', status='d')
+        failover2 = self._create_primary(dbid='3', status='d')
+        live2 = self._create_mirror(dbid='4')
 
-        failed3 = self.create_primary(dbid='5')
-        live3 = self.create_mirror(dbid='6')
+        failed3 = self._create_primary(dbid='5')
+        live3 = self._create_mirror(dbid='6')
 
-        failed4 = self.create_primary(dbid='5')
-        live4 = self.create_mirror(dbid='7')
+        failed4 = self._create_primary(dbid='5')
+        live4 = self._create_mirror(dbid='7')
 
         inplace_full1 = GpMirrorToBuild(failed1, live1, None, True)
         not_inplace_full = GpMirrorToBuild(failed2, live2, failover2, True)
         inplace_full2 = GpMirrorToBuild(failed3, live3, None, True)
         inplace_not_full = GpMirrorToBuild(failed4, live4, None, False)
 
-        buildMirrorSegs_obj = GpMirrorListToBuild(
+        build_mirrors_obj = GpMirrorListToBuild(
             toBuild=[inplace_full1, not_inplace_full, inplace_full2, inplace_not_full],
             pool=None,
             quiet=True,
@@ -350,25 +399,25 @@ class BuildMirrorsTestCase(GpTestCase):
             logger=self.mock_logger,
             forceoverwrite=True
         )
-        buildMirrorSegs_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear = Mock()
+        build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear = Mock()
 
-        buildMirrorSegs_obj._clean_up_failed_segments()
+        build_mirrors_obj._clean_up_failed_segments()
 
         self.mock_get_segments_by_hostname.assert_called_once_with([failed1, failed3])
         self.mock_logger.info.called_once_with('"Cleaning files from 2 segment(s)')
 
     def test_clean_up_failed_segments_no_segs_to_cleanup(self):
-        failed2 = self.create_primary(dbid='3', status='d')
-        failover2 = self.create_primary(dbid='3', status='d')
-        live2 = self.create_mirror(dbid='4')
+        failed2 = self._create_primary(dbid='3', status='d')
+        failover2 = self._create_primary(dbid='3', status='d')
+        live2 = self._create_mirror(dbid='4')
 
-        failed4 = self.create_primary(dbid='5')
-        live4 = self.create_mirror(dbid='7')
+        failed4 = self._create_primary(dbid='5')
+        live4 = self._create_mirror(dbid='7')
 
         not_inplace_full = GpMirrorToBuild(failed2, live2, failover2, True)
         inplace_not_full = GpMirrorToBuild(failed4, live4, None, False)
 
-        buildMirrorSegs_obj = GpMirrorListToBuild(
+        build_mirrors_obj = GpMirrorListToBuild(
             toBuild=[not_inplace_full, inplace_not_full],
             pool=None,
             quiet=True,
@@ -376,25 +425,261 @@ class BuildMirrorsTestCase(GpTestCase):
             logger=self.mock_logger,
             forceoverwrite=True
         )
-        buildMirrorSegs_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear = Mock()
+        build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear = Mock()
 
-        buildMirrorSegs_obj._clean_up_failed_segments()
+        build_mirrors_obj._clean_up_failed_segments()
         self.assertEqual(0, self.mock_get_segments_by_hostname.call_count)
         self.assertEqual(0, self.mock_logger.info.call_count)
 
-    def test_buildMirrors_noMirrors(self):
-        buildMirrorSegs_obj = GpMirrorListToBuild(
-            toBuild=[],
-            pool=None,
-            quiet=True,
-            parallelDegree=0,
-            logger=self.mock_logger
-        )
-        self.assertTrue(buildMirrorSegs_obj.buildMirrors(None, None, None))
-        self.assertTrue(buildMirrorSegs_obj.buildMirrors(self.action, None, None))
+    def test_run_recovery_no_errors(self):
+        recovery_info = OrderedDict() #We use ordered dict to deterministically assert the side effects of _run_recovery
+        recovery_info['host1'] = [self.recovery_info1]
+        recovery_info['host2'] = [self.recovery_info2, self.recovery_info3]
+        recoveryinfo.build_recovery_info = Mock(return_value=recovery_info)
+        self._set_run_recovery()
+        self.default_build_mirrors_obj._run_recovery(self.action, recovery_info, self.gpEnv)
+        self.assertEqual([call(ANY, progressCmds=ANY, suppressErrorCheck=True), call(ANY, suppressErrorCheck=False)],
+                         self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list)
+        seg_recovery_cmds = self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list[0][0][0]
+        progress_cmds = self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list[0][1]['progressCmds']
+        rm_cmds = self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list[1][0][0]
 
-        self.assertEqual([call('No segments to None'), call('No segments to recover')],
-                         self.mock_logger.info.call_args_list)
+        #TODO fix formatting
+        expected_recovery_cmd_strs = ["""$GPHOME/sbin/gpsegrecovery.py -c '[{"target_datadir": "/datadir2", "target_port": 7001, "target_segment_dbid": 2, "source_hostname": "source_host_for_dbid2", "source_port": 7002, "is_full_recovery": true, "progress_file": "/tmp/progress_file2"}]' -l /tmp/logdir -b 64 --era=dummy_era""", """$GPHOME/sbin/gpsegrecovery.py -c '[{"target_datadir": "/datadir3", "target_port": 7003, "target_segment_dbid": 3, "source_hostname": "source_host_for_dbid3", "source_port": 7004, "is_full_recovery": true, "progress_file": "/tmp/progress_file3"}, {"target_datadir": "/datadir4", "target_port": 7005, "target_segment_dbid": 4, "source_hostname": "source_host_for_dbid4", "source_port": 7006, "is_full_recovery": true, "progress_file": "/tmp/progress_file4"}]' -l /tmp/logdir -b 64 --era=dummy_era"""]
+        self.assertEqual(2, len(seg_recovery_cmds))
+        self.assertEqual('host1', seg_recovery_cmds[0].remoteHost)
+        self.assertEqual(sorted(expected_recovery_cmd_strs[0]), sorted(seg_recovery_cmds[0].cmdStr))
+        self.assertEqual('host2', seg_recovery_cmds[1].remoteHost)
+        self.assertEqual(sorted(expected_recovery_cmd_strs[1]), sorted(seg_recovery_cmds[1].cmdStr))
+
+        self.assertEqual(3, len(progress_cmds))
+        self.assertEqual('host1', progress_cmds[0].remoteHost)
+        self.assertEqual("set -o pipefail; touch -a /tmp/progress_file2; tail -1 /tmp/progress_file2 | tr '\\r' '\\n' | tail -1",
+                         progress_cmds[0].cmdStr)
+        self.assertEqual('host2', progress_cmds[1].remoteHost)
+        self.assertEqual("set -o pipefail; touch -a /tmp/progress_file3; tail -1 /tmp/progress_file3 | tr '\\r' '\\n' | tail -1",
+                         progress_cmds[1].cmdStr)
+        self.assertEqual('host2', progress_cmds[2].remoteHost)
+        self.assertEqual("set -o pipefail; touch -a /tmp/progress_file4; tail -1 /tmp/progress_file4 | tr '\\r' '\\n' | tail -1",
+                         progress_cmds[2].cmdStr)
+
+        self.assertEqual(3, len(rm_cmds))
+        self.assertEqual("host1", rm_cmds[0].remoteHost)
+        self.assertEqual("rm -f /tmp/progress_file2", rm_cmds[0].cmdStr)
+        self.assertEqual("host2", rm_cmds[1].remoteHost)
+        self.assertEqual("rm -f /tmp/progress_file3", rm_cmds[1].cmdStr)
+        self.assertEqual("host2", rm_cmds[2].remoteHost)
+        self.assertEqual("rm -f /tmp/progress_file4", rm_cmds[2].cmdStr)
+
+    def test_run_setup_recovery_errors(self):
+        recovery_info = {'host1': [self.recovery_info1, self.recovery_info2], 'host2': [self.recovery_info3]}
+        host1_error = '[{"error_type": "validation", "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}, ' \
+                      '{"error_type": "validation", "error_msg":"some error for dbid 3", "dbid": 3, "datadir": "/datadir3", "port": 7003, "progress_file": "/tmp/progress3"}]'
+        host2_error = '[{"error_type": "validation", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]'
+        self._set_run_recovery([host1_error, host2_error], is_setup=True)
+        with self.assertRaises(ExceptionNoStackTraceNeeded):
+            self.default_build_mirrors_obj._run_setup_recovery(self.action, recovery_info)
+        expected_info_msgs = [call(Contains('-----')),
+                              call('Failed to setup recovery for the following segments')]
+        expected_error_msgs = [call(Contains('hostname: host1; port: 7001; error: some error for dbid 2')),
+                              call(Contains('hostname: host1; port: 7003; error: some error for dbid 3')),
+                              call(Contains('hostname: host2; port: 7005; error: some error for dbid 4'))]
+
+        self.assertCountEqual(expected_info_msgs, self.mock_logger.info.call_args_list)
+        self.assertCountEqual(expected_error_msgs, self.mock_logger.error.call_args_list)
+
+    def test_run_setup_recovery_invalid_errors(self):
+        recovery_info = {'host1': [self.recovery_info1, self.recovery_info2], 'host2': [self.recovery_info3]}
+        host1_error = 'invalid value before error1 [{"error_type": "validation", "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}, ' \
+                      'invalid value before error2 {"error_type": "validation", "error_msg":"some error for dbid 3", "dbid": 3, "datadir": "/datadir3", "port": 7003, "progress_file": "/tmp/progress3"}]'
+        host2_error = '[{"error_type": "validation", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]'
+        self._set_run_recovery([host1_error, host2_error], is_setup=True)
+        with self.assertRaises(ExceptionNoStackTraceNeeded):
+            self.default_build_mirrors_obj._run_setup_recovery(self.action, recovery_info)
+        expected_info_msgs = [call(Contains('-----')),
+                              call('Failed to setup recovery for the following segments')]
+
+        expected_error_msgs = [call(Contains('Unable to parse recovery error. hostname: host1, error: invalid value before error1')),
+                               call(Contains('hostname: host2; port: 7005; error: some error for dbid 4'))]
+
+        self.assertEqual(expected_info_msgs, self.mock_logger.info.call_args_list)
+        self.assertCountEqual(expected_error_msgs, self.mock_logger.error.call_args_list)
+
+    def test_run_setup_recovery_empty_errors(self):
+        recovery_info = {'host1': [self.recovery_info1], 'host2': [self.recovery_info3]}
+        host1_error = ''
+        host2_error = ''
+        self._set_run_recovery([host1_error, host2_error], is_setup=True)
+        with self.assertRaises(ExceptionNoStackTraceNeeded):
+            self.default_build_mirrors_obj._run_setup_recovery(self.action, recovery_info)
+        expected_error_msgs = [call(Contains('Unable to parse recovery error. hostname: host1, error: ')),
+                               call(Contains('Unable to parse recovery error. hostname: host2, error: '))]
+        self.assertEqual([], self.mock_logger.info.call_args_list)
+        self.assertEqual(expected_error_msgs, self.mock_logger.error.call_args_list)
+
+    def test_run_recovery_invalid_errors(self):
+        recovery_info = {'host1': [self.recovery_info1, self.recovery_info2], 'host2': [self.recovery_info3]}
+        host1_error = 'invalid error1'
+        host2_error = '[{"error_type": "full", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]'
+        self._set_run_recovery([host1_error, host2_error])
+        self.default_build_mirrors_obj._run_recovery(self.action, recovery_info, self.gpEnv)
+        expected_info_msgs = [call('Initiating segment recovery. Upon completion, will start the successfully recovered segments'),
+                              call(Contains('-----')),
+                              call(Contains('Failed to recover the following segments')),
+                              call(Contains(' hostname: host2; port: 7005; logfile: /tmp/progress4'))]
+
+        expected_error_msgs = [call(Contains('Unable to parse recovery error. hostname: host1, error: invalid error1'))]
+        self.assertEqual(expected_info_msgs, self.mock_logger.info.call_args_list)
+        self.assertEqual(expected_error_msgs, self.mock_logger.error.call_args_list)
+
+    def test_run_recovery_empty_errors(self):
+        recovery_info = {'host1': [self.recovery_info1, self.recovery_info2], 'host2': [self.recovery_info3]}
+        host1_error = ''
+        host2_error = ''
+        self._set_run_recovery([host1_error, host2_error])
+        self.default_build_mirrors_obj._run_recovery(self.action, recovery_info, self.gpEnv)
+        expected_info_msgs = [call('Initiating segment recovery. Upon completion, will start the successfully recovered segments')]
+
+        expected_error_msgs = [call(Contains('Unable to parse recovery error. hostname: host1, error: ')),
+                               call(Contains('Unable to parse recovery error. hostname: host2, error: '))]
+        self.assertEqual(expected_info_msgs, self.mock_logger.info.call_args_list)
+        self.assertEqual(expected_error_msgs, self.mock_logger.error.call_args_list)
+
+    # TODO remove duplicate code from run_recovery tests
+    def test_run_recovery_all_dbids_fail_only_bb_rewind_errors(self):
+        recovery_info = {'host1': [self.recovery_info1, self.recovery_info2], 'host2': [self.recovery_info3]}
+        host1_error = '[{"error_type": "full", "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}, ' \
+                      '{"error_type": "incremental", "error_msg":"some error for dbid 3", "dbid": 3, "datadir": "/datadir3", "port": 7003, "progress_file": "/tmp/progress3"}]'
+        host2_error = '[{"error_type": "full", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]'
+        self._set_run_recovery([host1_error, host2_error])
+
+        self.default_build_mirrors_obj._run_recovery(self.action, recovery_info, self.gpEnv)
+        self.assertEqual([call(ANY, progressCmds=ANY, suppressErrorCheck=True), call(ANY, suppressErrorCheck=False)],
+                         self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list)
+        rm_cmds = self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list[1][0][0]
+
+        self.assertEqual(0, len(rm_cmds))
+        expected_info_msgs = [call(Contains('Initiating segment recovery')),
+                              call(Contains('-----')),
+                              call(Contains('Failed to recover the following segments')),
+                              call(Contains('hostname: host1; port: 7001; logfile: /tmp/progress2; recoverytype: full')),
+                              call(Contains('hostname: host1; port: 7003; logfile: /tmp/progress3; recoverytype: incremental')),
+                              call(Contains('hostname: host2; port: 7005; logfile: /tmp/progress4; recoverytype: full'))]
+        self.assertCountEqual(expected_info_msgs, self.mock_logger.info.call_args_list)
+
+    def test_run_recovery_some_dbids_fail_all_recovery_errors(self):
+        recovery_info = {'host1': [self.recovery_info1], 'host2': [self.recovery_info2, self.recovery_info3]}
+        host1_error = '[{"error_type": "full", "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}]'
+        host2_error = '[{"error_type": "full", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]'
+        self._set_run_recovery([host1_error, host2_error])
+
+        self.default_build_mirrors_obj._run_recovery(self.action, recovery_info, self.gpEnv)
+        self.assertEqual([call(ANY, progressCmds=ANY, suppressErrorCheck=True), call(ANY, suppressErrorCheck=False)],
+                         self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list)
+        rm_cmds = self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list[1][0][0]
+
+        self.assertEqual(1, len(rm_cmds))
+        self.assertEqual("host2", rm_cmds[0].remoteHost)
+        self.assertEqual("rm -f /tmp/progress_file3", rm_cmds[0].cmdStr)
+        expected_info_msgs = [call(Contains('Initiating segment recovery')),
+                              call(Contains('-----')),
+                              call(Contains('Failed to recover the following segments')),
+                              call(Contains('hostname: host1; port: 7001; logfile: /tmp/progress2')),
+                              call(Contains('hostname: host2; port: 7005; logfile: /tmp/progress4'))]
+        self.assertEqual(expected_info_msgs, self.mock_logger.info.call_args_list)
+
+    def test_run_recovery_all_dbids_fail_all_start_errors(self):
+        recovery_info = {'host1': [self.recovery_info1], 'host2': [self.recovery_info2, self.recovery_info3]}
+        host1_error = '[{"error_type": "start", "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}, ' \
+                      '{"error_type": "start", "error_msg":"some error for dbid 3", "dbid": 3, "datadir": "/datadir3", "port": 7003, "progress_file": "/tmp/progress3"}]'
+        host2_error = '[{"error_type": "start", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]'
+        self._set_run_recovery([host1_error, host2_error])
+        self.default_build_mirrors_obj._run_recovery(self.action, recovery_info, self.gpEnv)
+        self.assertEqual([call(ANY, progressCmds=ANY, suppressErrorCheck=True), call(ANY, suppressErrorCheck=False)],
+                         self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list)
+        rm_cmds = self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list[1][0][0]
+
+        self.assertEqual(3, len(rm_cmds))
+        expected_info_msgs = [call(Contains('Initiating segment recovery')),
+                              call(Contains('-----')),
+                              call(Contains('Failed to start the following segments')),
+                              call(Contains('hostname: host1; port: 7001; datadir: /datadir2')),
+                              call(Contains('hostname: host1; port: 7003; datadir: /datadir3')),
+                              call(Contains('hostname: host2; port: 7005; datadir: /datadir4'))]
+
+        self.assertEqual(expected_info_msgs, self.mock_logger.info.call_args_list)
+
+    def test_run_recovery_some_dbids_fail_all_start_errors(self):
+        recovery_info = {'host1': [self.recovery_info1], 'host2': [self.recovery_info2, self.recovery_info3]}
+        host1_error = '[{"error_type": "start", "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}]'
+        host2_error = '[{"error_type": "start", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]'
+
+        self._set_run_recovery([host1_error, host2_error])
+        self.default_build_mirrors_obj._run_recovery(self.action, recovery_info, self.gpEnv)
+        self.assertEqual([call(ANY, progressCmds=ANY, suppressErrorCheck=True), call(ANY, suppressErrorCheck=False)],
+                         self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list)
+        rm_cmds = self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list[1][0][0]
+
+        self.assertEqual(3, len(rm_cmds))
+        expected_info_msgs = [call(Contains('Initiating segment recovery')),
+                              call(Contains('-----')),
+                              call(Contains('Failed to start the following segments')),
+                              call(Contains('hostname: host1; port: 7001; datadir: /datadir2')),
+                              call(Contains('hostname: host2; port: 7005; datadir: /datadir4'))]
+        self.assertEqual(expected_info_msgs, self.mock_logger.info.call_args_list)
+
+    def test_run_recovery_all_dbids_fail_both_recovery_and_start_errors(self):
+        recovery_info = {'host1': [self.recovery_info1, self.recovery_info2], 'host2': [self.recovery_info3]}
+        host1_error = '[{"error_type": "full",  "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}, ' \
+                      '{"error_type": "start",  "error_msg":"some error for dbid 3", "dbid": 3, "datadir": "/datadir3", "port": 7003, "progress_file": "/tmp/progress3"}]'
+        host2_error = '[{"error_type": "full",  "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]'
+        self._set_run_recovery([host1_error, host2_error])
+
+        self.default_build_mirrors_obj._run_recovery(self.action, recovery_info, self.gpEnv)
+
+        self.assertEqual([call(ANY, progressCmds=ANY, suppressErrorCheck=True), call(ANY, suppressErrorCheck=False)],
+                         self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list)
+        rm_cmds = self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list[1][0][0]
+
+        # Since start passed for dbid:3, we should have deleted it's progress file
+        self.assertEqual(1, len(rm_cmds))
+        self.assertEqual("host1", rm_cmds[0].remoteHost)
+        self.assertEqual("rm -f /tmp/progress_file3", rm_cmds[0].cmdStr)
+
+        expected_info_msgs = [call(Contains('Initiating segment recovery')),
+                              call(Contains('-----')),
+                              call(Contains('Failed to recover the following segments')),
+                              call(Contains('hostname: host1; port: 7001; logfile: /tmp/progress2')),
+                              call(Contains('hostname: host2; port: 7005; logfile: /tmp/progress4')),
+                              call(Contains('-----')),
+                              call(Contains('Failed to start the following segments. Please check the latest logs')),
+                              call(Contains('hostname: host1; port: 7003; datadir: /datadir3'))]
+        self.assertEqual(expected_info_msgs, self.mock_logger.info.call_args_list)
+
+    def test_run_recovery_all_dbids_fail_both_recovery_and_default_errors(self):
+        recovery_info = {'host1': [self.recovery_info1], 'host2': [self.recovery_info2, self.recovery_info3]}
+        host1_error = '[{"error_type": "start",  "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}, ' \
+                      '{"error_type": "default",  "error_msg":"some error for dbid 3", "dbid": 3, "datadir": "/datadir3", "port": 7003, "progress_file": "/tmp/progress3"}]'
+        host2_error = '[{"error_type": "incremental",  "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]'
+        self._set_run_recovery([host1_error, host2_error])
+
+        self.default_build_mirrors_obj._run_recovery(self.action, recovery_info, self.gpEnv)
+
+        self.assertEqual([call(ANY, progressCmds=ANY, suppressErrorCheck=True), call(ANY, suppressErrorCheck=False)],
+                         self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list)
+        rm_cmds = self.default_build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear.call_args_list[1][0][0]
+
+        self.assertEqual(2, len(rm_cmds))
+        self.assertEqual("host1", rm_cmds[0].remoteHost)
+        self.assertEqual("rm -f /tmp/progress_file2", rm_cmds[0].cmdStr)
+        expected_info_msgs = [call(Contains('Initiating segment recovery')),
+                              call(Contains('-----')),
+                              call(Contains('Failed to recover the following segments')),
+                              call(Contains('hostname: host2; port: 7005; logfile: /tmp/progress4')),
+                              call(Contains('-----')),
+                              call(Contains('Failed to start the following segments. Please check the latest logs')),
+                              call(Contains('hostname: host1; port: 7001; datadir: /datadir2'))]
+        self.assertEqual(expected_info_msgs, self.mock_logger.info.call_args_list)
 
 
 class BuildMirrorSegmentsTestCase(GpTestCase):
@@ -418,6 +703,17 @@ class BuildMirrorSegmentsTestCase(GpTestCase):
             parallelDegree = 0,
             logger=self.mock_logger
             )
+
+    # def test_run_recovery(self):
+    #     self.buildMirrorSegs = GpMirrorListToBuild(
+    #         toBuild = [],
+    #         pool = None,
+    #         quiet = True,
+    #         parallelDegree = 0,
+    #         logger=self.mock_logger
+    #     )
+    #     self.buildMirrorSegs._run_recovery(Mock())
+    #     pass
 
     @patch('gppylib.operations.buildMirrorSegments.get_pid_from_remotehost')
     @patch('gppylib.operations.buildMirrorSegments.is_pid_postmaster')
@@ -489,27 +785,26 @@ class BuildMirrorSegmentsTestCase(GpTestCase):
         self.assertEqual(self.buildMirrorSegs.dereference_remote_symlink(datadir, host), '/tmp/seg0')
         self.mock_logger.warning.assert_any_call('Unable to determine if /tmp/seg0 is symlink. Assuming it is not symlink')
 
-    @patch('gppylib.operations.buildMirrorSegments.read_era')
-    @patch('gppylib.operations.startSegments.StartSegmentsOperation')
-    def test_startAll_succeeds(self, mock1, mock2):
-        result = StartSegmentsResult()
-        result.getFailedSegmentObjs()
-        mock1.return_value.startSegments.return_value = result
-        result = self.buildMirrorSegs._GpMirrorListToBuild__startAll(Mock(), [Mock(), Mock()], [])
-        self.assertTrue(result)
-
-    @patch('gppylib.operations.buildMirrorSegments.read_era')
-    @patch('gppylib.operations.startSegments.StartSegmentsOperation')
-    def test_startAll_fails(self, mock1, mock2):
-        result = StartSegmentsResult()
-        failed_segment = Segment.initFromString(
-            "2|0|p|p|s|u|sdw1|sdw1|40000|/data/primary0")
-        result.addFailure(failed_segment, 'reason', 'reasoncode')
-        mock1.return_value.startSegments.return_value = result
-        result = self.buildMirrorSegs._GpMirrorListToBuild__startAll(Mock(), [Mock(), Mock()], [])
-        self.assertFalse(result)
-        self.mock_logger.warn.assert_any_call('Failed to start segment.  The fault prober will shortly mark it as down. '
-                                         'Segment: sdw1:/data/primary0:content=0:dbid=2:role=p:preferred_role=p:mode=s:status=u: REASON: reason')
+    #TODO Do we need to move these tests now that the startAll function has been deleted
+    # @patch('gppylib.operations.buildMirrorSegments.read_era')
+    # @patch('gppylib.operations.startSegments.StartSegmentsOperation')
+    # def test_startAll_succeeds(self, mock1, mock2):
+    #     result = StartSegmentsResult()
+    #     result.getFailedSegmentObjs()
+    #     mock1.return_value.startSegments.return_value = result
+    #     self.assertTrue(result)
+    #
+    # @patch('gppylib.operations.buildMirrorSegments.read_era')
+    # @patch('gppylib.operations.startSegments.StartSegmentsOperation')
+    # def test_startAll_fails(self, mock1, mock2):
+    #     result = StartSegmentsResult()
+    #     failed_segment = Segment.initFromString(
+    #         "2|0|p|p|s|u|sdw1|sdw1|40000|/data/primary0")
+    #     result.addFailure(failed_segment, 'reason', 'reasoncode')
+    #     mock1.return_value.startSegments.return_value = result
+    #     self.assertFalse(result)
+    #     self.mock_logger.warn.assert_any_call('Failed to start segment.  The fault prober will shortly mark it as down. '
+    #                                      'Segment: sdw1:/data/primary0:content=0:dbid=2:role=p:preferred_role=p:mode=s:status=u: REASON: reason')
 
     def _createGpArrayWith2Primary2Mirrors(self):
         self.coordinator = Segment.initFromString(

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
@@ -82,6 +82,7 @@ class BuildMirrorsTestCase(GpTestCase):
         build_mirrors_obj._GpMirrorListToBuild__runWaitAndCheckWorkerPoolForErrorsAndClear = Mock()
         build_mirrors_obj._get_running_postgres_segments = Mock()
         configurationInterface.getConfigurationProvider = Mock()
+        configurationInterface.getConfigurationProvider.return_value.updateSystemConfig.return_value = {} # mock backout_map
 
     def _common_asserts_with_stop_and_logger(self, build_mirrors_obj, expected_logger_msg, expected_segs_to_stop,
                                              expected_segs_to_markdown, expected_segs_to_update, cleanup_count,

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_configurationImplGpdb.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_configurationImplGpdb.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+import unittest
+
+from gppylib.gparray import GpArray, Segment
+from gppylib.system.configurationImplGpdb import GpConfigurationProviderUsingGpdbCatalog
+from mock import Mock, patch
+
+class ConfigurationImplGpdbTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.maxDiff = None
+        self.configProvider = GpConfigurationProviderUsingGpdbCatalog()
+        self.conn = Mock()
+
+        self.coordinator = Segment.initFromString("1|-1|p|p|s|u|cdw|cdw|5432|/data/coordinator")
+        self.primary0 = Segment.initFromString("2|0|p|p|s|u|sdw1|sdw1|40000|/data/primary0")
+        self.primary1 = Segment.initFromString("3|1|p|p|s|u|sdw2|sdw2|40001|/data/primary1")
+        self.mirror0 = Segment.initFromString("4|0|m|m|s|u|sdw2|sdw2|50000|/data/mirror0")
+        self.acting_mirror0 = Segment.initFromString("6|0|m|p|d|n|sdw2|sdw2|50002|/data/acting_mirror0")
+        self.mirror1 = Segment.initFromString("5|1|m|m|s|u|sdw1|sdw1|50001|/data/mirror1")
+        segments = [self.coordinator,self.primary0,self.primary1,self.mirror0,self.mirror1]
+        self.gpArray = GpArray(segments)
+        self.gpArray.setSegmentsAsLoadedFromDb(segments)
+
+
+    @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', return_value=[6])
+    @patch('gppylib.db.dbconn.executeUpdateOrInsert')
+    def test_updateSystemConfigRemoveMirror_remove_acting_mirror(self, mockInsert, mockFetch):
+        addSQL = self.configProvider.updateSystemConfigRemoveMirror(self.conn, self.gpArray, self.acting_mirror0, "foo")
+        self.assertEqual(addSQL, "SELECT gp_add_segment(6::int2, 0::int2, 'm', 'p', 'n', 'd', 50002, 'sdw2', 'sdw2', '/data/acting_mirror0');\nINSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\n\tnow(),\n\t6,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 6'\n)")
+        mockFetch.assert_called_with(self.conn, "SELECT gp_remove_segment_mirror(0::int2)")
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\nnow(),\n  6,\n  'foo: removed mirror segment configuration'\n)", 1)
+
+    @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', return_value=[4])
+    @patch('gppylib.db.dbconn.executeUpdateOrInsert')
+    def test_updateSystemConfigRemoveMirror_remove_actual_mirror(self, mockInsert, mockFetch):
+        addSQL = self.configProvider.updateSystemConfigRemoveMirror(self.conn, self.gpArray, self.mirror0, "foo")
+        self.assertEqual(addSQL, "SELECT gp_add_segment(4::int2, 0::int2, 'm', 'm', 'n', 'd', 50000, 'sdw2', 'sdw2', '/data/mirror0');\nINSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\n\tnow(),\n\t4,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 4'\n)")
+        mockFetch.assert_called_with(self.conn, "SELECT gp_remove_segment_mirror(0::int2)")
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\nnow(),\n  4,\n  'foo: removed mirror segment configuration'\n)", 1)
+
+    @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', return_value=[2])
+    @patch('gppylib.db.dbconn.executeUpdateOrInsert')
+    def test_updateSystemConfigRemovePrimary(self, mockInsert, mockFetch):
+        addSQL = self.configProvider.updateSystemConfigRemovePrimary(self.conn, self.gpArray, self.primary0, "foo")
+        self.assertEqual(addSQL, "SELECT gp_add_segment(2::int2, 0::int2, 'm', 'm', 'n', 'd', 40000, 'sdw1', 'sdw1', '/data/primary0');\nINSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\n\tnow(),\n\t2,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 2'\n)")
+        mockFetch.assert_called_with(self.conn, "SELECT gp_remove_segment(2::int2)")
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\nnow(),\n  2,\n  'foo: removed primary segment configuration'\n)", 1)
+
+    @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', return_value=[6])
+    @patch('gppylib.db.dbconn.executeUpdateOrInsert')
+    def test_updateSystemConfigAddMirror_add_acting_mirror(self, mockInsert, mockFetch):
+        removeSQL = self.configProvider.updateSystemConfigAddMirror(self.conn, self.gpArray, self.acting_mirror0, "foo")
+        self.assertEqual(removeSQL, "SELECT gp_remove_segment(6::int2);\nINSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\n\tnow(),\n\t6,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 6'\n)")
+        mockFetch.assert_called_with(self.conn, "SELECT gp_add_segment(6::int2, 0::int2, 'm', 'm', 'n', 'd', 50002, 'sdw2', 'sdw2', '/data/acting_mirror0')")
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\nnow(),\n  6,\n  'foo: inserted mirror segment configuration'\n)", 1)
+
+    @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', return_value=[4])
+    @patch('gppylib.db.dbconn.executeUpdateOrInsert')
+    def test_updateSystemConfigAddMirror_add_actual_mirror(self, mockInsert, mockFetch):
+        removeSQL = self.configProvider.updateSystemConfigAddMirror(self.conn, self.gpArray, self.mirror0, "foo")
+        self.assertEqual(removeSQL, "SELECT gp_remove_segment(4::int2);\nINSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\n\tnow(),\n\t4,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 4'\n)")
+        mockFetch.assert_called_with(self.conn, "SELECT gp_add_segment(4::int2, 0::int2, 'm', 'm', 'n', 'd', 50000, 'sdw2', 'sdw2', '/data/mirror0')")
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\nnow(),\n  4,\n  'foo: inserted mirror segment configuration'\n)", 1)
+
+    @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', side_effect=[ [2], [0] ])
+    @patch('gppylib.db.dbconn.executeUpdateOrInsert')
+    def test_updateSystemConfigAddPrimary(self, mockInsert, mockFetch):
+        removeSQL = self.configProvider.updateSystemConfigAddPrimary(self.conn, self.gpArray, self.primary0, "foo", {0: self.mirror0})
+        self.assertEqual(removeSQL, "SELECT gp_remove_segment_mirror(0::int2);\nINSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\n\tnow(),\n\t2,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 2'\n)")
+        mockFetch.assert_any_call(self.conn, "SELECT content FROM pg_catalog.gp_segment_configuration WHERE dbId = 2")
+        mockFetch.assert_any_call(self.conn, "SELECT gp_add_segment(2::int2, 0::int2, 'p', 'p', 'n', 'u', 40000, 'sdw1', 'sdw1', '/data/primary0')")
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\nnow(),\n  2,\n  'foo: inserted primary segment configuration with contentid 0'\n)", 1)
+
+    @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', return_value=[6])
+    @patch('gppylib.db.dbconn.executeUpdateOrInsert')
+    def test_updateSystemConfigRemoveAddMirror_remove_acting_mirror(self, mockInsert, mockFetch):
+        addSQL, removeSQL = self.configProvider.updateSystemConfigRemoveAddMirror(self.conn, self.gpArray, self.acting_mirror0, "foo")
+        self.assertEqual(addSQL, "SELECT gp_add_segment(6::int2, 0::int2, 'm', 'p', 'n', 'd', 50002, 'sdw2', 'sdw2', '/data/acting_mirror0');\nINSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\n\tnow(),\n\t6,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 6'\n)")
+        self.assertEqual(removeSQL, "SELECT gp_remove_segment(6::int2)")
+        mockFetch.assert_any_call(self.conn, "SELECT gp_remove_segment_mirror(0::int2)")
+        mockFetch.assert_any_call(self.conn, "SELECT gp_add_segment(6::int2, 0::int2, 'm', 'm', 'n', 'd', 50002, 'sdw2', 'sdw2', '/data/acting_mirror0')")
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\nnow(),\n  6,\n  'foo: inserted segment configuration for full recovery or original dbid 6'\n)", 1)
+
+    @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', return_value=[4])
+    @patch('gppylib.db.dbconn.executeUpdateOrInsert')
+    def test_updateSystemConfigRemoveAddMirror_remove_actual_mirror(self, mockInsert, mockFetch):
+        addSQL, removeSQL = self.configProvider.updateSystemConfigRemoveAddMirror(self.conn, self.gpArray, self.mirror0, "foo")
+        self.assertEqual(addSQL, "SELECT gp_add_segment(4::int2, 0::int2, 'm', 'm', 'n', 'd', 50000, 'sdw2', 'sdw2', '/data/mirror0');\nINSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\n\tnow(),\n\t4,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 4'\n)")
+        self.assertEqual(removeSQL, "SELECT gp_remove_segment(4::int2)")
+        mockFetch.assert_any_call(self.conn, "SELECT gp_remove_segment_mirror(0::int2)")
+        mockFetch.assert_any_call(self.conn, "SELECT gp_add_segment(4::int2, 0::int2, 'm', 'm', 'n', 'd', 50000, 'sdw2', 'sdw2', '/data/mirror0')")
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\nnow(),\n  4,\n  'foo: inserted segment configuration for full recovery or original dbid 4'\n)", 1)

--- a/gpMgmt/bin/gppylib/programs/clsAddMirrors.py
+++ b/gpMgmt/bin/gppylib/programs/clsAddMirrors.py
@@ -539,7 +539,8 @@ class GpAddMirrorsProgram:
                     raise UserAbortedException()
 
             update_pg_hba_on_segments(gpArray, self.__options.hba_hostnames, self.__options.batch_size)
-            if not mirrorBuilder.buildMirrors("add", gpEnv, gpArray):
+            if not mirrorBuilder.add_mirrors(gpEnv, gpArray):
+                logger.error("gpaddmirrors failed. Please check the output for more details.")
                 return 1
 
             logger.info("******************************************************************")

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -348,6 +348,7 @@ class GpRecoverSegmentProgram:
             contentsToUpdate = [seg.getLiveSegment().getSegmentContentId() for seg in mirrorBuilder.getMirrorsToBuild()]
             update_pg_hba_on_segments(gpArray, self.__options.hba_hostnames, self.__options.parallelDegree, contentsToUpdate)
             if not mirrorBuilder.buildMirrors("recover", gpEnv, gpArray):
+                self.logger.error("gprecoverseg failed. Please check the output for more details.")
                 sys.exit(1)
 
             self.trigger_fts_probe(port=gpEnv.getCoordinatorPort())

--- a/gpMgmt/bin/gppylib/recoveryinfo.py
+++ b/gpMgmt/bin/gppylib/recoveryinfo.py
@@ -1,5 +1,5 @@
+from collections import defaultdict
 import datetime
-#TODO: check if pickle is better
 import json
 
 from gppylib import gplog
@@ -18,7 +18,7 @@ class RecoveryInfo(object):
         self.target_port = target_port
         self.target_segment_dbid = target_segment_dbid
 
-        # TODO: use address instead of hostname ?
+        # FIXME: use address instead of hostname ?
         self.source_hostname = source_hostname
         self.source_port = source_port
         self.is_full_recovery = is_full_recovery
@@ -29,15 +29,6 @@ class RecoveryInfo(object):
 
     def __eq__(self, cmp_recovery_info):
         return str(self) == str(cmp_recovery_info)
-
-
-def serialize_recovery_info_list(recovery_info_list):
-    return json.dumps(recovery_info_list, default=lambda o: o.__dict__)
-
-
-def deserialize_recovery_info_list(serialized_string):
-    deserialized_list = json.loads(serialized_string)
-    return [RecoveryInfo(**i) for i in deserialized_list]
 
 
 def build_recovery_info(mirrors_to_build):
@@ -53,24 +44,156 @@ def build_recovery_info(mirrors_to_build):
     """
     timestamp = datetime.datetime.today().strftime('%Y%m%d_%H%M%S')
 
-    recovery_info_by_host = {}
+    recovery_info_by_host = defaultdict(list)
     for to_recover in mirrors_to_build:
 
         source_segment = to_recover.getLiveSegment()
         target_segment = to_recover.getFailoverSegment() or to_recover.getFailedSegment()
 
-        # TODO: move the progress file naming to gpsegrecovery
+        # FIXME: move the progress file naming to gpsegrecovery
         process_name = 'pg_basebackup' if to_recover.isFullSynchronization() else 'pg_rewind'
         progress_file = '{}/{}.{}.dbid{}.out'.format(gplog.get_logger_dir(), process_name, timestamp,
-                                             target_segment.getSegmentDbId())
+                                                     target_segment.getSegmentDbId())
 
         hostname = target_segment.getSegmentHostName()
 
-        if hostname not in recovery_info_by_host:
-            recovery_info_by_host[hostname] = []
         recovery_info_by_host[hostname].append(RecoveryInfo(
             target_segment.getSegmentDataDirectory(), target_segment.getSegmentPort(),
             target_segment.getSegmentDbId(), source_segment.getSegmentHostName(),
             source_segment.getSegmentPort(), to_recover.isFullSynchronization(),
             progress_file))
     return recovery_info_by_host
+
+
+def serialize_list(recovery_info_list):
+    return json.dumps(recovery_info_list, default=lambda o: o.__dict__)
+
+
+#FIXME should we add a test for this function ?
+def deserialize_list(serialized_string, class_name=RecoveryInfo):
+    if not serialized_string:
+        return []
+    try:
+        deserialized_list = json.loads(serialized_string)
+    except ValueError:
+        #FIXME should we log the exception ?
+        return []
+    return [class_name(**i) for i in deserialized_list]
+
+
+class RecoveryErrorType(object):
+    VALIDATION_ERROR = 'validation'
+    REWIND_ERROR = 'incremental'
+    BASEBACKUP_ERROR = 'full'
+    START_ERROR = 'start'
+    DEFAULT_ERROR = 'default'
+
+
+class RecoveryError(object):
+    def __init__(self, error_type, error_msg, dbid, datadir, port, progress_file):
+        self.error_type = error_type if error_type else RecoveryErrorType.DEFAULT_ERROR
+        self.error_msg = error_msg
+        self.dbid = dbid
+        self.datadir = datadir
+        self.port = port
+        self.progress_file = progress_file
+
+    def __str__(self):
+        return json.dumps(self, default=lambda o: o.__dict__)
+
+    def __repr__(self):
+        return self.__str__()
+
+
+class RecoveryResult(object):
+    def __init__(self, action_name, results, logger):
+        self.action_name = action_name
+        self._logger = logger
+        self._invalid_recovery_errors = defaultdict(list)
+        self._setup_recovery_errors = defaultdict(list)
+        self._bb_errors = defaultdict(list)
+        self._rewind_errors = defaultdict(list)
+        self._dbids_that_failed_bb_rewind = set()
+        self._start_errors = defaultdict(list)
+        self._parse_results(results)
+
+    def _parse_results(self, results):
+        for host_result in results:
+            results = host_result.get_results()
+            if not results or results.wasSuccessful():
+                continue
+            errors_on_host = deserialize_list(results.stderr, class_name=RecoveryError)
+
+            if not errors_on_host:
+                self._invalid_recovery_errors[host_result.remoteHost] = results.stderr #FIXME add behave test for invalid errors
+            for error in errors_on_host:
+                if not error:
+                    continue
+                if error.error_type == RecoveryErrorType.BASEBACKUP_ERROR:
+                    self._bb_errors[host_result.remoteHost].append(error)
+                    self._dbids_that_failed_bb_rewind.add(error.dbid)
+                elif error.error_type == RecoveryErrorType.REWIND_ERROR:
+                    self._dbids_that_failed_bb_rewind.add(error.dbid)
+                    self._rewind_errors[host_result.remoteHost].append(error)
+                elif error.error_type == RecoveryErrorType.START_ERROR:
+                    self._start_errors[host_result.remoteHost].append(error)
+                elif error.error_type == RecoveryErrorType.VALIDATION_ERROR:
+                    self._setup_recovery_errors[host_result.remoteHost].append(error)
+                #FIXME what should we do for default errors ?
+
+    def _print_invalid_errors(self):
+        if self._invalid_recovery_errors:
+            for hostname, error in self._invalid_recovery_errors.items():
+                self._logger.error("Unable to parse recovery error. hostname: {}, error: {}".format(hostname, error))
+
+    def setup_successful(self):
+        return len(self._setup_recovery_errors) == 0 and len(self._invalid_recovery_errors) == 0
+
+    def full_recovery_successful(self):
+        return len(self._setup_recovery_errors) == 0 and len(self._bb_errors) == 0 and len(self._invalid_recovery_errors) == 0
+
+    def recovery_successful(self):
+        return len(self._setup_recovery_errors) == 0 and len(self._bb_errors) == 0 and len(self._rewind_errors) == 0 and \
+               len(self._start_errors) == 0 and len(self._invalid_recovery_errors) == 0
+
+    def was_bb_rewind_successful(self, dbid):
+        return dbid not in self._dbids_that_failed_bb_rewind
+
+    def print_setup_recovery_errors(self):
+        setup_recovery_error_pattern = " hostname: {}; port: {}; error: {}"
+        if len(self._setup_recovery_errors) > 0:
+            self._logger.info("----------------------------------------------------------")
+            self._logger.info("Failed to setup recovery for the following segments")
+            for hostname, errors in self._setup_recovery_errors.items():
+                for error in errors:
+                    self._logger.error(setup_recovery_error_pattern.format(hostname, error.port, error.error_msg))
+        self._print_invalid_errors()
+
+    def print_bb_rewind_and_start_errors(self):
+        bb_rewind_error_pattern = " hostname: {}; port: {}; logfile: {}; recoverytype: {}"
+        if len(self._bb_errors) > 0 or len(self._rewind_errors) > 0:
+            self._logger.info("----------------------------------------------------------")
+            if len(self._rewind_errors) > 0:
+                self._logger.info("Failed to {} the following segments. You must run gprecoverseg -F for "
+                                  "all incremental failures".format(self.action_name))
+            else:
+                self._logger.info("Failed to {} the following segments".format(self.action_name))
+            for hostname, errors in self._rewind_errors.items():
+                for error in errors:
+                    self._logger.info(bb_rewind_error_pattern.format(hostname, error.port, error.progress_file,
+                                                                     error.error_type))
+            for hostname, errors in self._bb_errors.items():
+                for error in errors:
+                    self._logger.info(bb_rewind_error_pattern.format(hostname, error.port, error.progress_file,
+                                                                 error.error_type))
+
+        start_error_pattern = " hostname: {}; port: {}; datadir: {}"
+        if len(self._start_errors) > 0:
+            self._logger.info("----------------------------------------------------------")
+            self._logger.info("Failed to start the following segments. "
+                              "Please check the latest logs located in segment's data directory")
+            for hostname, errors in self._start_errors.items():
+                for error in errors:
+                    self._logger.info(start_error_pattern.format(hostname, error.port, error.datadir))
+
+        self._print_invalid_errors()

--- a/gpMgmt/bin/gppylib/recoveryinfo.py
+++ b/gpMgmt/bin/gppylib/recoveryinfo.py
@@ -4,6 +4,7 @@ import json
 
 from gppylib import gplog
 
+
 class RecoveryInfo(object):
     """
     This class encapsulates the information needed on a segment host
@@ -33,9 +34,11 @@ class RecoveryInfo(object):
 def serialize_recovery_info_list(recovery_info_list):
     return json.dumps(recovery_info_list, default=lambda o: o.__dict__)
 
+
 def deserialize_recovery_info_list(serialized_string):
     deserialized_list = json.loads(serialized_string)
     return [RecoveryInfo(**i) for i in deserialized_list]
+
 
 def build_recovery_info(mirrors_to_build):
     """

--- a/gpMgmt/bin/gppylib/test/unit/gp_unittest.py
+++ b/gpMgmt/bin/gppylib/test/unit/gp_unittest.py
@@ -2,6 +2,12 @@ import unittest
 
 from mock import MagicMock, Mock
 
+class Contains(str):
+    """
+    This class is used as a way to assert for partial match in unittests
+    """
+    def __eq__(self, other):
+        return self in other
 
 class GpTestCase(unittest.TestCase):
     def __init__(self, methodName='runTest'):

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
@@ -84,6 +84,8 @@ class GpRecoversegTestCase(GpTestCase):
             patch('gppylib.commands.base.WorkerPool', return_value=self.pool),
             patch('gppylib.gparray.GpArray.getSegmentsByHostName', return_value={}),
             patch('gppylib.gplog.get_default_logger'),
+            patch('gppylib.operations.buildMirrorSegments.GpMirrorListToBuild.initialize_backout_directory'),
+            patch('gppylib.operations.buildMirrorSegments.GpMirrorListToBuild.remove_backout_directory'),
             patch.object(GpMirrorListToBuild, "__init__", return_value=None),
             patch.object(GpMirrorListToBuild, "buildMirrors"),
             patch.object(GpMirrorListToBuild, "getAdditionalWarnings"),

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
@@ -84,10 +84,8 @@ class GpRecoversegTestCase(GpTestCase):
             patch('gppylib.commands.base.WorkerPool', return_value=self.pool),
             patch('gppylib.gparray.GpArray.getSegmentsByHostName', return_value={}),
             patch('gppylib.gplog.get_default_logger'),
-            patch('gppylib.operations.buildMirrorSegments.GpMirrorListToBuild.initialize_backout_directory'),
-            patch('gppylib.operations.buildMirrorSegments.GpMirrorListToBuild.remove_backout_directory'),
             patch.object(GpMirrorListToBuild, "__init__", return_value=None),
-            patch.object(GpMirrorListToBuild, "buildMirrors"),
+            patch.object(GpMirrorListToBuild, "recover_mirrors"),
             patch.object(GpMirrorListToBuild, "getAdditionalWarnings"),
             patch.object(GpMirrorListToBuild, "getMirrorsToBuild"),
             patch.object(HeapChecksum, "check_segment_consistency"),
@@ -97,7 +95,7 @@ class GpRecoversegTestCase(GpTestCase):
         self.call_count = 0
         self.return_one = True
 
-        self.mock_build_mirrors = self.get_mock_from_apply_patch("buildMirrors")
+        self.mock_build_mirrors = self.get_mock_from_apply_patch("recover_mirrors")
         self.mock_get_mirrors_to_build = self.get_mock_from_apply_patch('getMirrorsToBuild')
         self.mock_heap_checksum_init = self.get_mock_from_apply_patch("__init__")
         self.mock_check_segment_consistency = self.get_mock_from_apply_patch('check_segment_consistency')
@@ -170,8 +168,8 @@ class GpRecoversegTestCase(GpTestCase):
         with self.assertRaises(SystemExit):
             # XXX Disable live FTS probes. The fact that we have to do this
             # indicates that these are not really unit tests.
-            with patch.object(self.subject, 'trigger_fts_probe'):
-                self.subject.run()
+            # with patch.object(self.subject, 'trigger_fts_probe'):
+            self.subject.run()
 
         self.subject.logger.info.assert_any_call('No checksum validation necessary when '
                                                  'there are no segments to recover.')
@@ -220,6 +218,7 @@ class GpRecoversegTestCase(GpTestCase):
         self.subject.logger.info.assert_any_call('The rebalance operation has completed with WARNINGS. '
                                                  'Please review the output in the gprecoverseg log.')
 
+    # @patch('gppylib.programs.clsRecoverSegment.GpRecoverSegmentProgram.trigger_fts_probe')
     @patch.object(TableLogger, "info")
     def test_failed_recover(self, _):
         self.gpArrayMock.get_unbalanced_segdbs.return_value = [self.primary0]
@@ -241,6 +240,7 @@ class GpRecoversegTestCase(GpTestCase):
 
         with self.assertRaises(SystemExit) as cm:
             self.subject.run()
+        # self.assertEqual(1, mock_fts_probe.call_count)
 
         self.assertEqual(cm.exception.code, 1)
 
@@ -266,8 +266,8 @@ class GpRecoversegTestCase(GpTestCase):
         with self.assertRaises(SystemExit) as cm:
             # XXX Disable live FTS probes. The fact that we have to do this
             # indicates that these are not really unit tests.
-            with patch.object(self.subject, 'trigger_fts_probe'):
-                self.subject.run()
+            # with patch.object(self.subject, 'trigger_fts_probe'):
+            self.subject.run()
 
         self.assertEqual(cm.exception.code, 0)
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegrecovery.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegrecovery.py
@@ -31,7 +31,7 @@ class IncrementalRecoveryTestCase(GpTestCase):
                                               m.getSegmentDbId(),
                                               p.getSegmentHostName(),
                                               p.getSegmentPort(),
-                                              False, '/test_progress_file')
+                                              False, '/tmp/test_progress_file')
         self.era = '1234_20211110'
 
         self.incremental_recovery_cmd = gpsegrecovery.IncrementalRecovery(
@@ -41,15 +41,21 @@ class IncrementalRecoveryTestCase(GpTestCase):
     def tearDown(self):
         super(IncrementalRecoveryTestCase, self).tearDown()
 
+    def _assert_cmd_failed(self, expected_stderr):
+        self.assertEqual(1, self.incremental_recovery_cmd.get_results().rc)
+        self.assertEqual('', self.incremental_recovery_cmd.get_results().stdout)
+        self.assertEqual(expected_stderr, self.incremental_recovery_cmd.get_results().stderr)
+        self.assertEqual(False, self.incremental_recovery_cmd.get_results().wasSuccessful())
+
     def test_incremental_run_passes(self):
         self.incremental_recovery_cmd.run()
         self.assertEqual(1, self.mock_pgrewind_init.call_count)
         expected_init_args = call('rewind dbid: 2', '/data/mirror0',
-                                  'sdw1', 40000, '/test_progress_file')
+                                  'sdw1', 40000, '/tmp/test_progress_file')
         self.assertEqual(expected_init_args, self.mock_pgrewind_init.call_args)
         self.assertEqual(1, self.mock_pgrewind_run.call_count)
         self.assertEqual(call(validateAfter=True), self.mock_pgrewind_run.call_args)
-        logger_call_args = [call('Running pg_rewind with progress output temporarily in /test_progress_file'),
+        logger_call_args = [call('Running pg_rewind with progress output temporarily in /tmp/test_progress_file'),
                             call('Successfully ran pg_rewind for dbid: 2')]
         self.assertEqual(logger_call_args, self.mock_logger.info.call_args_list)
         gpsegrecovery.start_segment.assert_called_once_with(self.seg_recovery_info, self.mock_logger, self.era)
@@ -59,13 +65,34 @@ class IncrementalRecoveryTestCase(GpTestCase):
         self.incremental_recovery_cmd.run()
         self.assertEqual(1, self.mock_pgrewind_init.call_count)
         expected_init_args = call('rewind dbid: 2', '/data/mirror0',
-                                  'sdw1', 40000, '/test_progress_file')
+                                  'sdw1', 40000, '/tmp/test_progress_file')
         self.assertEqual(expected_init_args, self.mock_pgrewind_init.call_args)
         self.assertEqual(1, self.mock_pgrewind_run.call_count)
         self.assertEqual(call(validateAfter=True), self.mock_pgrewind_run.call_args)
-        self.assertEqual([call('Running pg_rewind with progress output temporarily in /test_progress_file')],
+        self.assertEqual([call('Running pg_rewind with progress output temporarily in /tmp/test_progress_file')],
                          self.mock_logger.info.call_args_list)
         self.assertEqual(0, gpsegrecovery.start_segment.call_count)
+
+    def test_logger_info_exception(self):
+        self.mock_logger.info.side_effect = [Exception('logger exception')]
+        self.incremental_recovery_cmd.run()
+        self.assertEqual(0, self.mock_pgrewind_init.call_count)
+        self.assertEqual(0, self.mock_pgrewind_run.call_count)
+        self.assertEqual(1, self.mock_logger.info.call_count)
+        self.assertEqual(0, gpsegrecovery.start_segment.call_count)
+
+    def test_incremental_start_segment_exception(self):
+        gpsegrecovery.start_segment.side_effect = [Exception('pg_ctl start failed')]
+        self.incremental_recovery_cmd.run()
+
+        self.assertEqual(1, self.mock_pgrewind_init.call_count)
+        self.assertEqual(1, self.mock_pgrewind_run.call_count)
+        logger_call_args = [call('Running pg_rewind with progress output temporarily in /tmp/test_progress_file'),
+                            call('Successfully ran pg_rewind for dbid: 2')]
+        self.assertEqual(logger_call_args, self.mock_logger.info.call_args_list)
+        gpsegrecovery.start_segment.assert_called_once_with(self.seg_recovery_info, self.mock_logger, self.era)
+        self._assert_cmd_failed('{"error_type": "start", "error_msg": "pg_ctl start failed", "dbid": 2, ' \
+                                '"datadir": "/data/mirror0", "port": 50000, "progress_file": "/tmp/test_progress_file"}')
 
 
 class FullRecoveryTestCase(GpTestCase):
@@ -89,7 +116,7 @@ class FullRecoveryTestCase(GpTestCase):
                                               m.getSegmentDbId(),
                                               p.getSegmentHostName(),
                                               p.getSegmentPort(),
-                                              True, '/test_progress_file')
+                                              True, '/tmp/test_progress_file')
         self.era = '1234_20211110'
         self.full_recovery_cmd = gpsegrecovery.FullRecovery(
             name='test full recovery', recovery_info=self.seg_recovery_info,
@@ -124,7 +151,7 @@ class FullRecoveryTestCase(GpTestCase):
 
         expected_init_args1 = call("/data/mirror0", "sdw1", '40000', create_slot=False,
                                    replication_slot_name='internal_wal_replication_slot',
-                                   forceoverwrite=True, target_gp_dbid=2, progress_file='/test_progress_file')
+                                   forceoverwrite=True, target_gp_dbid=2, progress_file='/tmp/test_progress_file')
 
         self._assert_basebackup_runs(expected_init_args1)
         self._assert_cmd_passed()
@@ -136,7 +163,7 @@ class FullRecoveryTestCase(GpTestCase):
 
         expected_init_args1 = call("/data/mirror0", "sdw1", '40000', create_slot=False,
                                    replication_slot_name='internal_wal_replication_slot',
-                                   forceoverwrite=False, target_gp_dbid=2, progress_file='/test_progress_file')
+                                   forceoverwrite=False, target_gp_dbid=2, progress_file='/tmp/test_progress_file')
         self._assert_basebackup_runs(expected_init_args1)
         self._assert_cmd_passed()
 
@@ -147,10 +174,10 @@ class FullRecoveryTestCase(GpTestCase):
 
         expected_init_args1 = call("/data/mirror0", "sdw1", '40000', create_slot=False,
                                    replication_slot_name='internal_wal_replication_slot',
-                                   forceoverwrite=True, target_gp_dbid=2, progress_file='/test_progress_file')
+                                   forceoverwrite=True, target_gp_dbid=2, progress_file='/tmp/test_progress_file')
         expected_init_args2 = call("/data/mirror0", "sdw1", '40000', create_slot=True,
                                    replication_slot_name='internal_wal_replication_slot',
-                                   forceoverwrite=True, target_gp_dbid=2, progress_file='/test_progress_file')
+                                   forceoverwrite=True, target_gp_dbid=2, progress_file='/tmp/test_progress_file')
         self.assertEqual(2, self.mock_pgbasebackup_init.call_count)
         self.assertEqual([expected_init_args1, expected_init_args2] , self.mock_pgbasebackup_init.call_args_list)
         self.assertEqual(2, self.mock_pgbasebackup_run.call_count)
@@ -166,10 +193,10 @@ class FullRecoveryTestCase(GpTestCase):
 
         expected_init_args1 = call("/data/mirror0", "sdw1", '40000', create_slot=False,
                                    replication_slot_name='internal_wal_replication_slot',
-                                   forceoverwrite=True, target_gp_dbid=2, progress_file='/test_progress_file')
+                                   forceoverwrite=True, target_gp_dbid=2, progress_file='/tmp/test_progress_file')
         expected_init_args2 = call("/data/mirror0", "sdw1", '40000', create_slot=True,
                                    replication_slot_name='internal_wal_replication_slot',
-                                   forceoverwrite=True, target_gp_dbid=2, progress_file='/test_progress_file')
+                                   forceoverwrite=True, target_gp_dbid=2, progress_file='/tmp/test_progress_file')
         self.assertEqual(2, self.mock_pgbasebackup_init.call_count)
         self.assertEqual([expected_init_args1, expected_init_args2], self.mock_pgbasebackup_init.call_args_list)
         self.assertEqual(2, self.mock_pgbasebackup_run.call_count)
@@ -177,7 +204,8 @@ class FullRecoveryTestCase(GpTestCase):
         self.mock_logger.info.any_call('Running pg_basebackup failed: backup failed once')
         self.mock_logger.info.assert_called_with("Re-running pg_basebackup, creating the slot this time")
         self.assertEqual(0, gpsegrecovery.start_segment.call_count)
-        self._assert_cmd_failed('backup failed twice')
+        self._assert_cmd_failed('{"error_type": "full", "error_msg": "backup failed twice", "dbid": 2, ' \
+                                '"datadir": "/data/mirror0", "port": 50000, "progress_file": "/tmp/test_progress_file"}')
 
     def test_basebackup_run_no_forceoverwrite_two_exceptions(self):
         self.mock_pgbasebackup_run.side_effect = [Exception('backup failed once'),
@@ -188,17 +216,18 @@ class FullRecoveryTestCase(GpTestCase):
 
         expected_init_args1 = call("/data/mirror0", "sdw1", '40000', create_slot=False,
                                    replication_slot_name='internal_wal_replication_slot',
-                                   forceoverwrite=False, target_gp_dbid=2, progress_file='/test_progress_file')
+                                   forceoverwrite=False, target_gp_dbid=2, progress_file='/tmp/test_progress_file')
         # regardless of the passed in value, second call to pg_basebackup will always have forceoverwrite=True
         expected_init_args2 = call("/data/mirror0", "sdw1", '40000', create_slot=True,
                                    replication_slot_name='internal_wal_replication_slot',
-                                   forceoverwrite=True, target_gp_dbid=2, progress_file='/test_progress_file')
+                                   forceoverwrite=True, target_gp_dbid=2, progress_file='/tmp/test_progress_file')
         self.assertEqual(2, self.mock_pgbasebackup_init.call_count)
         self.assertEqual([expected_init_args1, expected_init_args2], self.mock_pgbasebackup_init.call_args_list)
         self.assertEqual(2, self.mock_pgbasebackup_run.call_count)
         self.assertEqual([call(validateAfter=True),call(validateAfter=True)], self.mock_pgbasebackup_run.call_args_list)
         self.assertEqual(0, gpsegrecovery.start_segment.call_count)
-        self._assert_cmd_failed('backup failed twice')
+        self._assert_cmd_failed('{"error_type": "full", "error_msg": "backup failed twice", "dbid": 2, ' \
+                                '"datadir": "/data/mirror0", "port": 50000, "progress_file": "/tmp/test_progress_file"}')
 
     def test_basebackup_init_exception(self):
         self.mock_pgbasebackup_init.side_effect = [Exception('backup init failed')]
@@ -206,17 +235,29 @@ class FullRecoveryTestCase(GpTestCase):
         self.full_recovery_cmd.run()
         expected_init_args = call("/data/mirror0", "sdw1", '40000', create_slot=False,
                                   replication_slot_name='internal_wal_replication_slot',
-                                  forceoverwrite=True, target_gp_dbid=2, progress_file='/test_progress_file')
+                                  forceoverwrite=True, target_gp_dbid=2, progress_file='/tmp/test_progress_file')
         self.assertEqual(1, self.mock_pgbasebackup_init.call_count)
         self.assertEqual(expected_init_args, self.mock_pgbasebackup_init.call_args)
         self.assertEqual(0, self.mock_pgbasebackup_run.call_count)
         self.assertEqual(0, gpsegrecovery.start_segment.call_count)
         self.assertEqual(0, self.mock_logger.exception.call_count)
-        self._assert_cmd_failed('backup init failed')
+        self._assert_cmd_failed('{"error_type": "full", "error_msg": "backup init failed", "dbid": 2, ' \
+                                '"datadir": "/data/mirror0", "port": 50000, "progress_file": "/tmp/test_progress_file"}')
+
+    def test_basebackup_start_segment_exception(self):
+        gpsegrecovery.start_segment.side_effect = [Exception('pg_ctl start failed'), Mock()]
+
+        self.full_recovery_cmd.run()
+        self.assertEqual(1, self.mock_pgbasebackup_init.call_count)
+        self.assertEqual(1, self.mock_pgbasebackup_run.call_count)
+        gpsegrecovery.start_segment.assert_called_once_with(self.seg_recovery_info, self.mock_logger, self.era)
+        self._assert_cmd_failed('{"error_type": "start", "error_msg": "pg_ctl start failed", "dbid": 2, ' \
+                                '"datadir": "/data/mirror0", "port": 50000, "progress_file": "/tmp/test_progress_file"}')
 
 
 class SegRecoveryTestCase(GpTestCase):
     def setUp(self):
+        self.maxDiff = None
         self.mock_logger = Mock(spec=['log', 'info', 'debug', 'error', 'warn', 'exception'])
         self.full_r1 = RecoveryInfo('target_data_dir1', 5001, 1, 'source_hostname1',
                                     6001, True, '/tmp/progress_file1')
@@ -242,15 +283,14 @@ class SegRecoveryTestCase(GpTestCase):
     @patch('gpsegrecovery.PgBaseBackup.__init__', return_value=None)
     @patch('gpsegrecovery.PgBaseBackup.run')
     def test_complete_workflow(self, mock_pgbasebackup_run, mock_pgbasebackup_init, mock_pgrewind_run, mock_pgrewind_init):
-        mix_confinfo = gppylib.recoveryinfo.serialize_recovery_info_list([
+        mix_confinfo = gppylib.recoveryinfo.serialize_list([
             self.full_r1, self.incr_r2])
         sys.argv = ['gpsegrecovery', '-l', '/tmp/logdir', '--era', '{}'.format(self.era), '-c {}'.format(mix_confinfo)]
         buf = io.StringIO()
         with redirect_stderr(buf):
             with self.assertRaises(SystemExit) as ex:
-                seg_recovery = SegRecovery()
-                seg_recovery.main()
-        self.assertEqual('', buf.getvalue())
+                SegRecovery().main()
+        self.assertEqual('', buf.getvalue().strip())
         self.assertEqual(0, ex.exception.code)
         self.assertEqual(1, mock_pgrewind_run.call_count)
         self.assertEqual(1, mock_pgrewind_init.call_count)
@@ -264,32 +304,38 @@ class SegRecoveryTestCase(GpTestCase):
     @patch('gpsegrecovery.PgBaseBackup.run')
     def test_complete_workflow_exception(self, mock_pgbasebackup_run, mock_pgbasebackup_init, mock_pgrewind_run,
                                          mock_pgrewind_init):
+        #TODO should we change this to basebackup exception ?
         mock_pgrewind_run.side_effect = [Exception('pg_rewind failed')]
-        mix_confinfo = gppylib.recoveryinfo.serialize_recovery_info_list([
+        mock_pgbasebackup_run.side_effect = [Exception('pg_basebackup failed once'),
+                                             Exception('pg_basebackup failed twice')]
+        mix_confinfo = gppylib.recoveryinfo.serialize_list([
             self.full_r1, self.incr_r2])
         sys.argv = ['gpsegrecovery', '-l', '/tmp/logdir', '--era={}'.format(self.era), '-c {}'.format(mix_confinfo)]
         buf = io.StringIO()
         with redirect_stderr(buf):
             with self.assertRaises(SystemExit) as ex:
-                seg_recovery = SegRecovery()
-                seg_recovery.main()
-        self.assertEqual('pg_rewind failed\n', buf.getvalue())
+                SegRecovery().main()
+
+        self.assertCountEqual('[{"error_type": "incremental", "error_msg": "pg_rewind failed", "dbid": 4, "datadir": "target_data_dir4", '
+                              '"port": 5004, "progress_file": "/tmp/progress_file4"} , '
+                              '{"error_type": "full", "error_msg": "pg_basebackup failed twice", "dbid": 1,'
+                              '"datadir": "target_data_dir1", "port": 5001, "progress_file": "/tmp/progress_file1"}]',
+                              buf.getvalue().strip())
         self.assertEqual(1, ex.exception.code)
         self.assertEqual(1, mock_pgrewind_run.call_count)
         self.assertEqual(1, mock_pgrewind_init.call_count)
-        self.assertEqual(1, mock_pgbasebackup_run.call_count)
-        self.assertEqual(1, mock_pgbasebackup_init.call_count)
+        self.assertEqual(2, mock_pgbasebackup_run.call_count)
+        self.assertEqual(2, mock_pgbasebackup_init.call_count)
         self.assertRegex(gplog.get_logfile(), '/gpsegrecovery.py_\d+\.log')
 
     @patch('recovery_base.gplog.setup_tool_logging')
     @patch('recovery_base.RecoveryBase.main')
     @patch('gpsegrecovery.SegRecovery.get_recovery_cmds')
     def test_get_recovery_cmds_is_called(self, mock_get_recovery_cmds, mock_recovery_base_main, mock_logger):
-        mix_confinfo = gppylib.recoveryinfo.serialize_recovery_info_list([self.full_r1, self.incr_r2])
+        mix_confinfo = gppylib.recoveryinfo.serialize_list([self.full_r1, self.incr_r2])
         sys.argv = ['gpsegrecovery', '-l', '/tmp/logdir', '--era={}'.format(self.era), '-f',
                     '-c {}'.format(mix_confinfo)]
-        seg_recovery = SegRecovery()
-        seg_recovery.main()
+        SegRecovery().main()
         mock_get_recovery_cmds.assert_called_once_with([self.full_r1, self.incr_r2], True, mock_logger.return_value,
                                                        self.era)
         mock_recovery_base_main.assert_called_once_with(mock_get_recovery_cmds.return_value)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_recovery_base.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_recovery_base.py
@@ -7,7 +7,7 @@ import sys
 from .gp_unittest import GpTestCase
 import gppylib
 from gpsegrecovery import FullRecovery
-from recovery_base import RecoveryBase, set_cmd_results
+from recovery_base import RecoveryBase, set_recovery_cmd_results
 from gppylib.recoveryinfo import RecoveryInfo
 from gppylib.commands.base import CommandResult, Command
 
@@ -35,7 +35,7 @@ class RecoveryBaseTestCase(GpTestCase):
         self.incr_r2 = RecoveryInfo('target_data_dir2', 5002, 2, 'source_hostname2',
                                     6002, False, '/tmp/progress_file2')
         self.confinfo = gppylib.recoveryinfo.serialize_list([self.full_r1,
-                                                                           self.incr_r2])
+                                                             self.incr_r2])
 
     def tearDown(self):
         super(RecoveryBaseTestCase, self).tearDown()
@@ -69,8 +69,6 @@ class RecoveryBaseTestCase(GpTestCase):
         self.assertEqual([call(self.mock_cmd1), call(self.mock_cmd2)],
                          mock_workerpool.return_value.addCommand.call_args_list)
         self.assertEqual(1, mock_workerpool.return_value.join.call_count)
-        #TODO remove this once we are sure we don't need check_results
-        # self.assertEqual(check_results_count, mock_workerpool.return_value.check_results.call_count)
         self.assertEqual(1, mock_workerpool.return_value.haltWork.call_count)
 
     def _assert_exception_from_parseargs(self, ex, stderr_buf, expected_stderr_message):
@@ -307,8 +305,8 @@ class SetCmdResultsTestCase(GpTestCase):
         self.assertEqual(False, cmd.get_results().halt)
         self.assertEqual(False, cmd.get_results().wasSuccessful())
 
-    def test_set_cmd_results_no_exception(self):
-        @set_cmd_results
+    def test_set_recovery_cmd_results_no_exception(self):
+        @set_recovery_cmd_results
         def test_decorator(cmd):
             cmd.name = 'new name'
 
@@ -318,8 +316,8 @@ class SetCmdResultsTestCase(GpTestCase):
         self.assertEqual('new name', test_cmd.name)
         self._assert_cmd_passed(test_cmd)
 
-    def test_set_cmd_results_catch_exception(self):
-        @set_cmd_results
+    def test_set_recovery_cmd_results_catch_exception(self):
+        @set_recovery_cmd_results
         def test_decorator(cmd):
             cmd.name = 'new name'
             cmd.error_type = 10
@@ -334,8 +332,8 @@ class SetCmdResultsTestCase(GpTestCase):
                           '"datadir": "/tmp/datadir2", "port": 7002, "progress_file": "/tmp/progress_file2"}'
         self._assert_cmd_failed(test_cmd, expected_stderr)
 
-    def test_set_cmd_results_catch_exception_none_error_type(self):
-        @set_cmd_results
+    def test_set_recovery_cmd_results_catch_exception_none_error_type(self):
+        @set_recovery_cmd_results
         def test_decorator(cmd):
             cmd.name = 'new name'
             cmd.error_type = None

--- a/gpMgmt/bin/lib/gpconfigurenewsegment
+++ b/gpMgmt/bin/lib/gpconfigurenewsegment
@@ -135,9 +135,9 @@ class ConfExpSegCmd(Command):
                                                                                 datetime.datetime.today().strftime('%Y%m%d_%H%M%S'),
                                                                                 self.dbid)
                     # Create a mirror based on the primary
-                    cmd = PgBaseBackup(pgdata=self.datadir,
-                                       host=self.syncWithSegmentHostname,
-                                       port=str(self.syncWithSegmentPort),
+                    cmd = PgBaseBackup(target_datadir=self.datadir,
+                                       source_host=self.syncWithSegmentHostname,
+                                       source_port=str(self.syncWithSegmentPort),
                                        create_slot = False,
                                        replication_slot_name=self.replicationSlotName,
                                        forceoverwrite=self.forceoverwrite,
@@ -156,9 +156,9 @@ class ConfExpSegCmd(Command):
                         #  Re-run with `create_slot`.
                         #  GPDB_12_MERGE_FIXME could we check it before? or let
                         #  pg_basebackup create slot if not exists.
-                        cmd = PgBaseBackup(pgdata=self.datadir,
-                                           host=self.syncWithSegmentHostname,
-                                           port=str(self.syncWithSegmentPort),
+                        cmd = PgBaseBackup(target_datadir=self.datadir,
+                                           source_host=self.syncWithSegmentHostname,
+                                           source_port=str(self.syncWithSegmentPort),
                                            create_slot = True,
                                            replication_slot_name=self.replicationSlotName,
                                            forceoverwrite=True,

--- a/gpMgmt/sbin/gpsegrecovery.py
+++ b/gpMgmt/sbin/gpsegrecovery.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
+from gppylib.recoveryinfo import RecoveryErrorType
 from gppylib.commands.pg import PgBaseBackup, PgRewind
-from recovery_base import RecoveryBase
-from gppylib.commands.base import set_cmd_results, Command
+from recovery_base import RecoveryBase, set_recovery_cmd_results
+from gppylib.commands.base import Command
 from gppylib.commands.gp import SegmentStart
 from gppylib.gparray import Segment
 
@@ -14,17 +15,17 @@ class FullRecovery(Command):
         self.replicationSlotName = 'internal_wal_replication_slot'
         self.forceoverwrite = forceoverwrite
         self.era = era
-        # TODO test for this cmdstr. also what should this cmdstr be ?
+        # FIXME test for this cmdstr. also what should this cmdstr be ?
         cmdStr = ''
-
         #cmdstr = 'TODO? : {} {}'.format(str(recovery_info), self.verbose)
         Command.__init__(self, self.name, cmdStr)
-        #TODO this logger has to come after the init and is duplicated in all the 4 classes
+        #FIXME this logger has to come after the init and is duplicated in all the 4 classes
         self.logger = logger
+        self.error_type = RecoveryErrorType.DEFAULT_ERROR
 
-    @set_cmd_results
+    @set_recovery_cmd_results
     def run(self):
-        # Create a mirror based on the primary
+        self.error_type = RecoveryErrorType.BASEBACKUP_ERROR
         cmd = PgBaseBackup(self.recovery_info.target_datadir,
                            self.recovery_info.source_hostname,
                            str(self.recovery_info.source_port),
@@ -55,8 +56,10 @@ class FullRecovery(Command):
             self.logger.info("Re-running pg_basebackup, creating the slot this time")
             cmd.run(validateAfter=True)
 
+        self.error_type = RecoveryErrorType.DEFAULT_ERROR
         self.logger.info("Successfully ran pg_basebackup for dbid: {}".format(
             self.recovery_info.target_segment_dbid))
+        self.error_type = RecoveryErrorType.START_ERROR
         start_segment(self.recovery_info, self.logger, self.era)
 
 
@@ -65,45 +68,40 @@ class IncrementalRecovery(Command):
         self.name = name
         self.recovery_info = recovery_info
         self.era = era
-        # TODO test for this cmdstr. also what should this cmdstr be ?
         cmdStr = ''
-
-        #cmdstr = 'TODO? : {} {}'.format(str(recovery_info), self.verbose)
         Command.__init__(self, self.name, cmdStr)
         self.logger = logger
+        self.error_type = RecoveryErrorType.DEFAULT_ERROR
 
-    @set_cmd_results
+    @set_recovery_cmd_results
     def run(self):
-        # Note the command name, we use the dbid later to
-        # correlate the command results with GpMirrorToBuild
-        # object.
         self.logger.info("Running pg_rewind with progress output temporarily in %s" % self.recovery_info.progress_file)
+        self.error_type = RecoveryErrorType.REWIND_ERROR
         cmd = PgRewind('rewind dbid: {}'.format(self.recovery_info.target_segment_dbid),
                        self.recovery_info.target_datadir, self.recovery_info.source_hostname,
                        self.recovery_info.source_port, self.recovery_info.progress_file)
         cmd.run(validateAfter=True)
-        self.logger.info("Successfully ran pg_rewind for dbid: {}".format(
-            self.recovery_info.target_segment_dbid))
+        self.logger.info("Successfully ran pg_rewind for dbid: {}".format(self.recovery_info.target_segment_dbid))
 
+        self.error_type = RecoveryErrorType.START_ERROR
         start_segment(self.recovery_info, self.logger, self.era)
 
 
 def start_segment(recovery_info, logger, era):
     seg = Segment(None, None, None, None, None, None, None, None,
                   recovery_info.target_port, recovery_info.target_datadir)
-    segStartCmd = SegmentStart(
+    cmd = SegmentStart(
         name="Starting new segment with dbid %s:" % (str(recovery_info.target_segment_dbid))
         , gpdb=seg
         , numContentsInCluster=0
         , era=era
         , mirrormode="mirror"
         , utilityMode=True)
-    #TODO is this log msg for start segment ebnough?
-    logger.info(str(segStartCmd))
-    segStartCmd.run(validateAfter=True)
+    logger.info(str(cmd))
+    cmd.run(validateAfter=True)
 
 
-#TODO we may not need this class
+#FIXME we may not need this class
 class SegRecovery(object):
     def __init__(self):
         pass
@@ -113,7 +111,6 @@ class SegRecovery(object):
         recovery_base.main(self.get_recovery_cmds(recovery_base.seg_recovery_info_list, recovery_base.options.forceoverwrite,
                                                   recovery_base.logger, recovery_base.options.era))
 
-    # TODO should we pass the recovery_base obj instead ?
     def get_recovery_cmds(self, seg_recovery_info_list, forceoverwrite, logger, era):
         cmd_list = []
         for seg_recovery_info in seg_recovery_info_list:

--- a/gpMgmt/sbin/gpsegsetuprecovery.py
+++ b/gpMgmt/sbin/gpsegsetuprecovery.py
@@ -110,7 +110,9 @@ class SegSetupRecovery(object):
         pass
 
     def main(self):
-        RecoveryBase().main(__file__, self.get_setup_cmds)
+        recovery_base = RecoveryBase(__file__)
+        recovery_base.main(self.get_setup_cmds(recovery_base.seg_recovery_info_list, recovery_base.options.forceoverwrite,
+                                               recovery_base.logger))
 
     def get_setup_cmds(self, seg_recovery_info_list, forceoverwrite, logger):
         cmd_list = []

--- a/gpMgmt/sbin/recovery_base.py
+++ b/gpMgmt/sbin/recovery_base.py
@@ -1,3 +1,5 @@
+import functools
+import json
 import os
 import sys
 
@@ -56,7 +58,7 @@ class RecoveryBase(object):
         if self.options.verbose:
             gplog.enable_verbose_logging()
 
-        self.seg_recovery_info_list = recoveryinfo.deserialize_recovery_info_list(self.options.confinfo)
+        self.seg_recovery_info_list = recoveryinfo.deserialize_list(self.options.confinfo)
         if len(self.seg_recovery_info_list) == 0:
             raise Exception('No segment configuration values found in --confinfo argument')
 
@@ -81,7 +83,6 @@ class RecoveryBase(object):
         print(e, file=sys.stderr)
         sys.exit(1)
 
-    # TODO: how to log multiple errors. New workflow reports errors from all segments.
     def run_cmd_list(self, cmd_list, logger, options, pool):
         for cmd in cmd_list:
             pool.addCommand(cmd)
@@ -90,13 +91,43 @@ class RecoveryBase(object):
         errors = []
         for item in pool.getCompletedItems():
             if not item.get_results().wasSuccessful():
-                errors.append(str(item.get_results().stderr).replace("\n", " "))
+                err_str = item.get_results().stderr
+                try:
+                    error_obj = json.loads(err_str)
+                except ValueError:
+                    #TODO Do we need this except and can we set dbid to None or should we rely on item.recovery_info?
+                    error_obj = recoveryinfo.RecoveryError(recoveryinfo.RecoveryErrorType.DEFAULT_ERROR, err_str, None,
+                                                            None, None, None)
+                errors.append(error_obj)
         if not errors:
             sys.exit(0)
 
-        str_error = "\n".join(errors)
+        str_error = recoveryinfo.serialize_list(errors)
         print(str_error, file=sys.stderr)
         if options.verbose:
             logger.exception(str_error)
         logger.error(str_error)
         sys.exit(1)
+
+
+def set_recovery_cmd_results(run_func):
+    """
+    Decorator function to run a command on the seg and set the results on the command object for that segment.
+    :param run_func: The function to run
+    :return:
+    """
+    @functools.wraps(run_func)
+    def run_and_set_output(recovery_cmd):
+        try:
+            run_func(recovery_cmd)
+        except Exception as e:
+            serialized_error = str(recoveryinfo.RecoveryError(recovery_cmd.error_type, str(e),
+                                                              recovery_cmd.recovery_info.target_segment_dbid,
+                                                              recovery_cmd.recovery_info.target_datadir,
+                                                              recovery_cmd.recovery_info.target_port,
+                                                              recovery_cmd.recovery_info.progress_file))
+            recovery_cmd.set_results(CommandResult(1, b'', serialized_error.encode(), True, False))
+        else:
+            recovery_cmd.set_results(CommandResult(0, b'', b'', True, False))
+
+    return run_and_set_output

--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -96,6 +96,9 @@ def before_scenario(context, scenario):
     if 'gpmovemirrors' in context.feature.tags:
         context.mirror_context = MirrorMgmtContext()
 
+    if 'gpaddmirrors' in context.feature.tags:
+        context.mirror_context = MirrorMgmtContext()
+
     if 'gprecoverseg' in context.feature.tags:
         context.mirror_context = MirrorMgmtContext()
 
@@ -144,7 +147,8 @@ def after_scenario(context, scenario):
 
     tags_to_cleanup = ['gpmovemirrors', 'gpssh-exkeys']
     if set(context.feature.tags).intersection(tags_to_cleanup):
-        if 'temp_base_dir' in context:
+        if 'temp_base_dir' in context and os.path.exists(context.temp_base_dir):
+            os.chmod(context.temp_base_dir, 0o700)
             shutil.rmtree(context.temp_base_dir)
 
     tags_to_not_restart_db = ['analyzedb', 'gpssh-exkeys']

--- a/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
@@ -21,7 +21,7 @@ Feature: Tests for gpaddmirrors
         Then gpaddmirrors should only spawn up to <coordinator_workers> workers in WorkerPool
         And check if gpaddmirrors ran "$GPHOME/sbin/gpsegsetuprecovery.py" 1 times with args "-b <segHost_workers>"
         And check if gpaddmirrors ran "$GPHOME/sbin/gpsegrecovery.py" 1 times with args "-b <segHost_workers>"
-        And check if gpaddmirrors ran "$GPHOME/sbin/gpsegstart.py" 1 times with args "-b <segHost_workers>"
+        And check if gpaddmirrors ran "$GPHOME/sbin/gpsegrecovery.py" 1 times with args "-b <segHost_workers>"
         And an FTS probe is triggered
         And the segments are synchronized
         And verify the database has mirrors

--- a/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
@@ -29,12 +29,26 @@ Feature: Tests for gpaddmirrors
         And user stops all primary processes
         And user can start transactions
         And the tablespace is valid
-
     Examples:
         | args      | coordinator_workers | segHost_workers |
         | -B 1 -b 1 |  1                  |  1              |
         | -B 2 -b 1 |  2                  |  1              |
         | -B 1 -b 2 |  1                  |  2              |
+
+    Scenario: gpaddmirrors fails for recovery setup errors
+        Given the cluster is generated with "3" primaries only
+        When gpaddmirrors adds 3 mirrors with one mirror's datadir not being empty
+        Then gpaddmirrors should return a return code of 2
+        And gpaddmirrors should print "Failed to setup recovery for the following segments" to stdout
+        And gpaddmirrors should print "gpaddmirrors error" to stdout
+        And gpaddmirrors should print " hostname: .*; port: .*; error: for segment with port .*: Segment directory .*" to stdout
+        And gpaddmirrors should not print "Initiating segment recovery" to stdout
+        #TODO run backout scripts before adding the mirrors again
+#        When gpaddmirrors adds 3 mirrors
+#        Then gpaddmirrors should return a return code of 0
+#        And an FTS probe is triggered
+#        And the segments are synchronized
+#        And verify the database has mirrors
 
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -47,7 +47,6 @@ Feature: gprecoverseg tests
         And gpsegsetuprecovery should only spawn up to <segHost_workers> workers in WorkerPool
         And gpsegrecovery should only spawn up to <segHost_workers> workers in WorkerPool
         And check if gprecoverseg ran "$GPHOME/sbin/gpsegstop.py" 1 times with args "-b <segHost_workers>"
-        And check if gprecoverseg ran "$GPHOME/sbin/gpsegstart.py" 1 times with args "-b <segHost_workers>"
         And the segments are synchronized
 
       Examples:
@@ -68,8 +67,9 @@ Feature: gprecoverseg tests
       And gprecoverseg should only spawn up to <coordinator_workers> workers in WorkerPool
       And gpsegsetuprecovery should only spawn up to <segHost_workers> workers in WorkerPool
       And gpsegrecovery should only spawn up to <segHost_workers> workers in WorkerPool
+      And check if gprecoverseg ran "$GPHOME/sbin/gpsegsetuprecovery.py" 1 times with args "-b <segHost_workers>"
+      And check if gprecoverseg ran "$GPHOME/sbin/gpsegrecovery.py" 1 times with args "-b <segHost_workers>"
       And check if gprecoverseg ran "$GPHOME/sbin/gpsegstop.py" 1 times with args "-b <segHost_workers>"
-      And check if gprecoverseg ran "$GPHOME/sbin/gpsegstart.py" 1 times with args "-b <segHost_workers>"
       And the segments are synchronized
 
     Examples:
@@ -84,8 +84,8 @@ Feature: gprecoverseg tests
         And user can start transactions
         When the user runs "gprecoverseg -a"
         Then gprecoverseg should return a return code of 0
-        And gprecoverseg should print "Running recovery for the required segments" to stdout
-        And gprecoverseg should print "pg_rewind: Done!" to stdout for each primary
+        And gprecoverseg should print "Running recovery and starting the required segments" to stdout
+        And gprecoverseg should print "pg_rewind: Done!" to stdout for each mirror
         And gprecoverseg should not print "Unhandled exception in thread started by <bound method Worker.__bootstrap" to stdout
         And the segments are synchronized
         When the user runs "gprecoverseg -ra"
@@ -112,17 +112,22 @@ Feature: gprecoverseg tests
       Given the database is running
       And all the segments are running
       And the segments are synchronized
+      And all files in gpAdminLogs directory are deleted
       And user immediately stops all primary processes
       And user can start transactions
-      And sql "DROP TABLE if exists t; CREATE TABLE t AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
-      And the "t" table row count in "postgres" is saved
+      And sql "DROP TABLE if exists test_mixed_recovery; CREATE TABLE test_mixed_recovery AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
+      And the "test_mixed_recovery" table row count in "postgres" is saved
       And a gprecoverseg directory under '/tmp' with mode '0700' is created
-      And a gprecoverseg input file is created for mixed recovery for 2 segments with full and 1 incremental
-      When the user runs gprecoverseg with input file and additional args "-a"
+      And a gprecoverseg input file is created
+      And edit the input file to recover mirror with content 0 to a new directory with mode 0700
+      And edit the input file to recover mirror with content 1 full inplace
+      And edit the input file to recover mirror with content 2 incremental
+      When the user runs gprecoverseg with input file and additional args "-av"
       Then gprecoverseg should return a return code of 0
-        # TODO: rewrite step to check if basebackup/rewind was run for expected dbids
-      And gprecoverseg should print "pg_basebackup: base backup completed" to stdout
-      And gprecoverseg should print "pg_rewind: Done!" to stdout
+      And gprecoverseg should print "pg_basebackup: base backup completed" to stdout for mirrors with content 0,1
+      And gprecoverseg should print "pg_rewind: Done!" to stdout for mirrors with content 2
+      And check if gprecoverseg ran gpsegsetuprecovery.py 1 times with the expected args
+      And check if gprecoverseg ran gpsegrecovery.py 1 times with the expected args
       And gpAdminLogs directory has no "pg_basebackup*" files
       And gpAdminLogs directory has no "pg_rewind*" files
       And gpAdminLogs directory has "gpsegsetuprecovery*" files
@@ -131,9 +136,135 @@ Feature: gprecoverseg tests
       And the segments are synchronized
       And the user runs "gprecoverseg -ar"
       And gprecoverseg should return a return code of 0
-      And the row count from table "t" in "postgres" is verified against the saved data
+      And the row count from table "test_mixed_recovery" in "postgres" is verified against the saved data
 
-    Scenario: gprecoverseg incremental recovery displays pg_rewind progress to the user
+  Scenario: gprecoverseg mixed recovery one basebackup fails and one rewind fails while others succeed
+      Given the database is running
+      And all the segments are running
+      And the segments are synchronized
+      And all files in gpAdminLogs directory are deleted
+      And user immediately stops all primary processes
+      And user can start transactions
+      And sql "DROP TABLE if exists test_rewind_failure; CREATE TABLE test_rewind_failure AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
+      And the "test_rewind_failure" table row count in "postgres" is saved
+      And all files in pg_wal directory are deleted from datadirectory of content 2 mirror
+      And a gprecoverseg directory under '/tmp' with mode '0700' is created
+      And a gprecoverseg input file is created
+    # TODO: add test for moving a mirror to a good directory, which updates the catalog
+      And edit the input file to recover mirror with content 0 to a new directory with mode 0000
+      And edit the input file to recover mirror with content 1 full inplace
+      And edit the input file to recover mirror with content 2 incremental
+      When the user runs gprecoverseg with input file and additional args "-a"
+      Then gprecoverseg should return a return code of 2
+      And gprecoverseg should print "pg_basebackup: error: could not access directory" to stdout for mirrors with content 0
+      And gprecoverseg should print "pg_basebackup: base backup completed" to stdout for mirrors with content 1
+      And gprecoverseg should print "pg_rewind: fatal" to stdout for mirrors with content 2
+      # TODO: this should only be 1 file ( for the failed segment)
+      And gpAdminLogs directory has "pg_basebackup*" files only for content 0,1
+      And gpAdminLogs directory has "pg_rewind*" files only for content 2
+      And gpAdminLogs directory has "gpsegsetuprecovery*" files
+      And gpAdminLogs directory has "gpsegrecovery*" files
+      And an FTS probe is triggered
+      And the mirror for content 1 are up
+      And the segments are synchronized for content 1
+      And the user runs "gprecoverseg -aF && gprecoverseg -ar"
+      And all the segments are running
+      And the segments are synchronized
+      And gprecoverseg should return a return code of 0
+      And the row count from table "test_rewind_failure" in "postgres" is verified against the saved data
+
+  Scenario: gprecoverseg mixed recovery segments come up even if one basebackup takes longer
+      Given the database is running
+      And all the segments are running
+      And the segments are synchronized
+      And all files in gpAdminLogs directory are deleted
+      And user immediately stops all primary processes
+      And user can start transactions
+      And the user suspend the walsender on the primary on content 0
+      And sql "DROP TABLE if exists test_slow_basebackup; CREATE TABLE test_slow_basebackup AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
+      And the "test_slow_basebackup" table row count in "postgres" is saved
+      And a gprecoverseg directory under '/tmp' with mode '0700' is created
+      And a gprecoverseg input file is created
+      And edit the input file to recover mirror with content 0 full inplace
+      And edit the input file to recover mirror with content 1 full inplace
+      And edit the input file to recover mirror with content 2 incremental
+      When the user asynchronously runs gprecoverseg with input file and additional args "-a" and the process is saved
+      Then the user waits until mirror on content 1 is up
+      And the user waits until mirror on content 2 is up
+      And verify that mirror on content 0 is down
+      And the user reset the walsender on the primary on content 0
+      And the user waits until saved async process is completed
+      And gpAdminLogs directory has no "pg_basebackup*" files
+      And gpAdminLogs directory has no "pg_rewind*" files
+      And gpAdminLogs directory has "gpsegsetuprecovery*" files
+      And gpAdminLogs directory has "gpsegrecovery*" files
+      And all the segments are running
+      And the segments are synchronized
+      And the user runs "gprecoverseg -ar"
+      And gprecoverseg should return a return code of 0
+      And the row count from table "test_slow_basebackup" in "postgres" is verified against the saved data
+
+  Scenario: gprecoverseg incremental recovery segments come up even if one rewind fails
+      Given the database is running
+      And all the segments are running
+      And the segments are synchronized
+      And all files in gpAdminLogs directory are deleted
+      And user immediately stops all primary processes
+      And user can start transactions
+      And sql "DROP TABLE if exists test_rewind_failure; CREATE TABLE test_rewind_failure AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
+      And the "test_rewind_failure" table row count in "postgres" is saved
+      And all files in pg_wal directory are deleted from datadirectory of content 0 mirror
+      When the user runs "gprecoverseg -a"
+      Then gprecoverseg should return a return code of 2
+      And gprecoverseg should print "pg_rewind: fatal" to stdout for mirrors with content 0
+      And gprecoverseg should print "pg_rewind: Done!" to stdout for mirrors with content 1,2
+      # TODO: this should only be 1 file ( for the failed segment)
+      And gpAdminLogs directory has "pg_rewind*" files only for content 0,1,2
+      And gpAdminLogs directory has "gpsegsetuprecovery*" files
+      And gpAdminLogs directory has "gpsegrecovery*" files
+      And an FTS probe is triggered
+      And the mirror for content 1,2 are up
+      And the segments are synchronized for content 1,2
+      And the user runs "gprecoverseg -aF && gprecoverseg -ar"
+      And gprecoverseg should return a return code of 0
+      And all the segments are running
+      And the segments are synchronized
+      And the row count from table "test_rewind_failure" in "postgres" is verified against the saved data
+
+  Scenario: gprecoverseg mixed recovery segments come up even if one pg_ctl_start fails
+      Given the database is running
+      And all the segments are running
+      And the segments are synchronized
+      And all files in gpAdminLogs directory are deleted
+      And user immediately stops all primary processes
+      And user can start transactions
+      And sql "DROP TABLE if exists test_start_failure; CREATE TABLE test_start_failure AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
+      And the "test_start_failure" table row count in "postgres" is saved
+      And a gprecoverseg directory under '/tmp' with mode '0700' is created
+      And a gprecoverseg input file is created
+      And edit the input file to recover mirror with content 0 to a new directory with mode 0755
+      And edit the input file to recover mirror with content 1 full inplace
+      And edit the input file to recover mirror with content 2 incremental
+      When the user runs gprecoverseg with input file and additional args "-a"
+      Then gprecoverseg should return a return code of 2
+      And gprecoverseg should print "pg_basebackup: base backup completed" to stdout for mirrors with content 0,1
+      And gprecoverseg should print "pg_rewind: Done!" to stdout for mirrors with content 2
+      # TODO: this should only be 1 file ( for the failed segment)
+      And gpAdminLogs directory has "pg_basebackup*" files only for content 0,1
+      And gpAdminLogs directory has "pg_rewind*" files only for content 2
+      And gpAdminLogs directory has "gpsegsetuprecovery*" files
+      And gpAdminLogs directory has "gpsegrecovery*" files
+      And an FTS probe is triggered
+      And verify that mirror on content 0 is down
+      And the mirror for content 1,2 are up
+      And the segments are synchronized for content 1,2
+      And the user runs "gprecoverseg -aF && gprecoverseg -ar"
+      And all the segments are running
+      And the segments are synchronized
+      And gprecoverseg should return a return code of 0
+      And the row count from table "test_start_failure" in "postgres" is verified against the saved data
+
+  Scenario: gprecoverseg incremental recovery displays pg_rewind progress to the user
         Given the database is running
         And all the segments are running
         And the segments are synchronized
@@ -142,7 +273,7 @@ Feature: gprecoverseg tests
         And user can start transactions
         When the user runs "gprecoverseg -a -s"
         Then gprecoverseg should return a return code of 0
-        And gprecoverseg should print "pg_rewind: Done!" to stdout for each primary
+        And gprecoverseg should print "pg_rewind: Done!" to stdout for each mirror
         And gpAdminLogs directory has no "pg_rewind*" files
       And gpAdminLogs directory has "gpsegsetuprecovery*" files
       And gpAdminLogs directory has "gpsegrecovery*" files
@@ -158,7 +289,7 @@ Feature: gprecoverseg tests
         When user can start transactions
         And the user runs "gprecoverseg -F -a --no-progress"
         Then gprecoverseg should return a return code of 0
-        And gprecoverseg should print "Running recovery for the required segments" to stdout
+        And gprecoverseg should print "Running recovery and starting the required segments" to stdout
         And gprecoverseg should not print "pg_basebackup: base backup completed" to stdout
         And gpAdminLogs directory has no "pg_basebackup*" files
         And all the segments are running
@@ -176,8 +307,8 @@ Feature: gprecoverseg tests
         And we generate the postmaster.pid file with the background pid on "primary" segment
         And the user runs "gprecoverseg -a"
         Then gprecoverseg should return a return code of 0
-        And gprecoverseg should print "Running recovery for the required segments" to stdout
-        And gprecoverseg should print "pg_rewind: no rewind required" to stdout for each primary
+        And gprecoverseg should print "Running recovery and starting the required segments" to stdout
+        And gprecoverseg should print "pg_rewind: no rewind required" to stdout for each mirror
         And gprecoverseg should not print "Unhandled exception in thread started by <bound method Worker.__bootstrap" to stdout
         And all the segments are running
         And the segments are synchronized
@@ -198,8 +329,8 @@ Feature: gprecoverseg tests
         When user can start transactions
         And we generate the postmaster.pid file with a non running pid on the same "primary" segment
         And the user runs "gprecoverseg -a"
-        And gprecoverseg should print "Running recovery for the required segments" to stdout
-        And gprecoverseg should print "pg_rewind: no rewind required" to stdout for each primary
+        And gprecoverseg should print "Running recovery and starting the required segments" to stdout
+        And gprecoverseg should print "pg_rewind: no rewind required" to stdout for each mirror
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should not print "Unhandled exception in thread started by <bound method Worker.__bootstrap" to stdout
         And all the segments are running
@@ -300,6 +431,108 @@ Feature: gprecoverseg tests
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster
 
     @concourse_cluster
+    Scenario: gprecoverseg incremental recovery segments come up even if one rewind fails
+      Given the database is running
+      And all the segments are running
+      And the segments are synchronized
+      And all files in gpAdminLogs directory are deleted on hosts mdw,sdw1,sdw2
+      And the "primary" segment information is saved
+      And user immediately stops all primary processes
+      And user can start transactions
+      And sql "DROP TABLE if exists test_rewind_failure; CREATE TABLE test_rewind_failure AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
+      And the "test_rewind_failure" table row count in "postgres" is saved
+      And all files in pg_wal directory are deleted from data directory of saved primary
+      When the user runs "gprecoverseg -a"
+      Then gprecoverseg should return a return code of 2
+      And gprecoverseg should print "pg_rewind: fatal" to stdout for mirrors with content 0
+      And gprecoverseg should print "pg_rewind: Done!" to stdout for mirrors with content 1,2,3
+          # TODO: this should only be 1 file ( for the failed segment)
+      And gpAdminLogs directory has "pg_rewind*" files on respective hosts only for content 0,1,2,3
+#      And gpAdminLogs directory has "gpsegsetuprecovery*" files
+#      And gpAdminLogs directory has "gpsegrecovery*" files
+      And an FTS probe is triggered
+      And the mirror for content 1,2,3 are up
+      And the segments are synchronized for content 1,2,3
+      And the user runs "gprecoverseg -aF && gprecoverseg -ar"
+      And gprecoverseg should return a return code of 0
+      And all the segments are running
+      And the segments are synchronized
+      And the row count from table "test_rewind_failure" in "postgres" is verified against the saved data
+
+    @concourse_cluster
+    Scenario: gprecoverseg mixed recovery segments come up even if one basebackup takes longer
+      Given the database is running
+      And all the segments are running
+      And the segments are synchronized
+      And all files in gpAdminLogs directory are deleted on hosts mdw,sdw1,sdw2
+      And user immediately stops all primary processes
+      And user can start transactions
+      And the user suspend the walsender on the primary on content 0
+      And sql "DROP TABLE if exists test_slow_basebackup; CREATE TABLE test_slow_basebackup AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
+      And the "test_slow_basebackup" table row count in "postgres" is saved
+      And a gprecoverseg directory under '/tmp' with mode '0700' is created
+      And a gprecoverseg input file is created
+      And edit the input file to recover mirror with content 0 full inplace
+      And edit the input file to recover mirror with content 1 incremental
+      And edit the input file to recover mirror with content 2 full inplace
+      And edit the input file to recover mirror with content 3 incremental
+      When the user asynchronously runs gprecoverseg with input file and additional args "-a" and the process is saved
+      Then the user waits until mirror on content 1 is up
+      And the user waits until mirror on content 2 is up
+      And the user waits until mirror on content 3 is up
+      And verify that mirror on content 0 is down
+      And the user reset the walsender on the primary on content 0
+      And the user waits until saved async process is completed
+#      And gpAdminLogs directory has no "pg_basebackup*" files
+#      And gpAdminLogs directory has no "pg_rewind*" files
+#      And gpAdminLogs directory has "gpsegsetuprecovery*" files
+#      And gpAdminLogs directory has "gpsegrecovery*" files
+      And all the segments are running
+      And the segments are synchronized
+      And the user runs "gprecoverseg -ar"
+      And gprecoverseg should return a return code of 0
+      And the row count from table "test_slow_basebackup" in "postgres" is verified against the saved data
+
+    @concourse_cluster
+    Scenario: gprecoverseg mixed recovery one basebackup fails and one rewind fails while others succeed
+      Given the database is running
+      And all the segments are running
+      And the segments are synchronized
+      And all files in gpAdminLogs directory are deleted on hosts mdw,sdw1,sdw2
+      And the "primary" segment information is saved
+      And user immediately stops all primary processes
+      And user can start transactions
+      And sql "DROP TABLE if exists test_rewind_failure; CREATE TABLE test_rewind_failure AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
+      And the "test_rewind_failure" table row count in "postgres" is saved
+      And all files in pg_wal directory are deleted from data directory of saved primary
+      And a gprecoverseg directory under '/tmp' with mode '0700' is created
+      And a gprecoverseg input file is created
+      # TODO: add test for moving a mirror to a good directory, which updates the catalog
+      And edit the input file to recover mirror with content 0 incremental
+      And edit the input file to recover mirror with content 1 full inplace
+      And edit the input file to recover mirror with content 2 incremental
+      And edit the input file to recover mirror with content 3 to a new directory on remote host with mode 0000
+      When the user runs gprecoverseg with input file and additional args "-a"
+      Then gprecoverseg should return a return code of 2
+      And gprecoverseg should print "pg_rewind: fatal" to stdout for mirrors with content 0
+      And gprecoverseg should print "pg_basebackup: base backup completed" to stdout for mirrors with content 1
+      And gprecoverseg should print "pg_rewind: Done!" to stdout for mirrors with content 2
+      And gprecoverseg should print "pg_basebackup: error: could not access directory" to stdout for mirrors with content 3
+        # TODO: this should only be 1 file ( for the failed segment)
+      And gpAdminLogs directory has "pg_basebackup*" files on respective hosts only for content 1,3
+      And gpAdminLogs directory has "pg_rewind*" files on respective hosts only for content 0,2
+#      And gpAdminLogs directory has "gpsegsetuprecovery*" files
+#      And gpAdminLogs directory has "gpsegrecovery*" files
+      And an FTS probe is triggered
+      And the mirror for content 1,2 are up
+      And the segments are synchronized for content 1,2
+      And the user runs "gprecoverseg -aF && gprecoverseg -ar"
+      And all the segments are running
+      And the segments are synchronized
+      And gprecoverseg should return a return code of 0
+      And the row count from table "test_rewind_failure" in "postgres" is verified against the saved data
+
+    @concourse_cluster
     Scenario: gprecoverseg behave test requires a cluster with at least 2 hosts
         Given the database is running
         Given database "gptest" exists
@@ -340,7 +573,7 @@ Feature: gprecoverseg tests
         Then the saved "mirror" segment is marked down in config
         When the user runs "gprecoverseg -F -a"
         Then gprecoverseg should return a return code of 0
-        And gprecoverseg should print "Running recovery for the required segments" to stdout
+        And gprecoverseg should print "Running recovery and starting the required segments" to stdout
         And gprecoverseg should print "pg_basebackup: base backup completed" to stdout
         And all the segments are running
         And the segments are synchronized

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -167,6 +167,7 @@ Feature: gprecoverseg tests
       And an FTS probe is triggered
       And the mirror for content 1 are up
       And the segments are synchronized for content 1
+      And the mode of the saved data directory is changed to 700
       And the user runs "gprecoverseg -aF && gprecoverseg -ar"
       And all the segments are running
       And the segments are synchronized
@@ -258,6 +259,7 @@ Feature: gprecoverseg tests
       And verify that mirror on content 0 is down
       And the mirror for content 1,2 are up
       And the segments are synchronized for content 1,2
+      And the mode of the saved data directory is changed to 700
       And the user runs "gprecoverseg -aF && gprecoverseg -ar"
       And all the segments are running
       And the segments are synchronized
@@ -526,7 +528,9 @@ Feature: gprecoverseg tests
       And an FTS probe is triggered
       And the mirror for content 1,2 are up
       And the segments are synchronized for content 1,2
+      And the mode of all the created data directories is changed to 0700
       And the user runs "gprecoverseg -aF && gprecoverseg -ar"
+      And gprecoverseg should return a return code of 0
       And all the segments are running
       And the segments are synchronized
       And gprecoverseg should return a return code of 0

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -84,7 +84,7 @@ Feature: gprecoverseg tests
         And user can start transactions
         When the user runs "gprecoverseg -a"
         Then gprecoverseg should return a return code of 0
-        And gprecoverseg should print "Running recovery and starting the required segments" to stdout
+        And gprecoverseg should print "Initiating segment recovery. Upon completion, will start the successfully recovered segments" to stdout
         And gprecoverseg should print "pg_rewind: Done!" to stdout for each mirror
         And gprecoverseg should not print "Unhandled exception in thread started by <bound method Worker.__bootstrap" to stdout
         And the segments are synchronized
@@ -102,6 +102,7 @@ Feature: gprecoverseg tests
         And the user runs "gprecoverseg -F -a -s"
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should print "pg_basebackup: base backup completed" to stdout for each mirror
+        And gprecoverseg should print "Segments successfully recovered" to stdout
         And gpAdminLogs directory has no "pg_basebackup*" files
         And gpAdminLogs directory has "gpsegrecovery*" files
         And gpAdminLogs directory has "gpsegsetuprecovery*" files
@@ -126,6 +127,7 @@ Feature: gprecoverseg tests
       Then gprecoverseg should return a return code of 0
       And gprecoverseg should print "pg_basebackup: base backup completed" to stdout for mirrors with content 0,1
       And gprecoverseg should print "pg_rewind: Done!" to stdout for mirrors with content 2
+      And gprecoverseg should print "Segments successfully recovered" to stdout
       And check if gprecoverseg ran gpsegsetuprecovery.py 1 times with the expected args
       And check if gprecoverseg ran gpsegrecovery.py 1 times with the expected args
       And gpAdminLogs directory has no "pg_basebackup*" files
@@ -138,43 +140,7 @@ Feature: gprecoverseg tests
       And gprecoverseg should return a return code of 0
       And the row count from table "test_mixed_recovery" in "postgres" is verified against the saved data
 
-  Scenario: gprecoverseg mixed recovery one basebackup fails and one rewind fails while others succeed
-      Given the database is running
-      And all the segments are running
-      And the segments are synchronized
-      And all files in gpAdminLogs directory are deleted
-      And user immediately stops all primary processes
-      And user can start transactions
-      And sql "DROP TABLE if exists test_rewind_failure; CREATE TABLE test_rewind_failure AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
-      And the "test_rewind_failure" table row count in "postgres" is saved
-      And all files in pg_wal directory are deleted from datadirectory of content 2 mirror
-      And a gprecoverseg directory under '/tmp' with mode '0700' is created
-      And a gprecoverseg input file is created
-    # TODO: add test for moving a mirror to a good directory, which updates the catalog
-      And edit the input file to recover mirror with content 0 to a new directory with mode 0000
-      And edit the input file to recover mirror with content 1 full inplace
-      And edit the input file to recover mirror with content 2 incremental
-      When the user runs gprecoverseg with input file and additional args "-a"
-      Then gprecoverseg should return a return code of 2
-      And gprecoverseg should print "pg_basebackup: error: could not access directory" to stdout for mirrors with content 0
-      And gprecoverseg should print "pg_basebackup: base backup completed" to stdout for mirrors with content 1
-      And gprecoverseg should print "pg_rewind: fatal" to stdout for mirrors with content 2
-      # TODO: this should only be 1 file ( for the failed segment)
-      And gpAdminLogs directory has "pg_basebackup*" files only for content 0,1
-      And gpAdminLogs directory has "pg_rewind*" files only for content 2
-      And gpAdminLogs directory has "gpsegsetuprecovery*" files
-      And gpAdminLogs directory has "gpsegrecovery*" files
-      And an FTS probe is triggered
-      And the mirror for content 1 are up
-      And the segments are synchronized for content 1
-      And the mode of the saved data directory is changed to 700
-      And the user runs "gprecoverseg -aF && gprecoverseg -ar"
-      And all the segments are running
-      And the segments are synchronized
-      And gprecoverseg should return a return code of 0
-      And the row count from table "test_rewind_failure" in "postgres" is verified against the saved data
-
-  Scenario: gprecoverseg mixed recovery segments come up even if one basebackup takes longer
+    Scenario: gprecoverseg mixed recovery segments come up even if one basebackup takes longer
       Given the database is running
       And all the segments are running
       And the segments are synchronized
@@ -205,7 +171,7 @@ Feature: gprecoverseg tests
       And gprecoverseg should return a return code of 0
       And the row count from table "test_slow_basebackup" in "postgres" is verified against the saved data
 
-  Scenario: gprecoverseg incremental recovery segments come up even if one rewind fails
+    Scenario: gprecoverseg incremental recovery segments come up even if one rewind fails
       Given the database is running
       And all the segments are running
       And the segments are synchronized
@@ -216,11 +182,13 @@ Feature: gprecoverseg tests
       And the "test_rewind_failure" table row count in "postgres" is saved
       And all files in pg_wal directory are deleted from datadirectory of content 0 mirror
       When the user runs "gprecoverseg -a"
-      Then gprecoverseg should return a return code of 2
+      Then gprecoverseg should return a return code of 1
       And gprecoverseg should print "pg_rewind: fatal" to stdout for mirrors with content 0
       And gprecoverseg should print "pg_rewind: Done!" to stdout for mirrors with content 1,2
-      # TODO: this should only be 1 file ( for the failed segment)
-      And gpAdminLogs directory has "pg_rewind*" files only for content 0,1,2
+      And gpAdminLogs directory has "pg_rewind*" files only for content 0
+      And gprecoverseg should print "Failed to recover the following segments" to stdout
+      And gprecoverseg should print "rewind" errors to stdout for content 0
+      And gprecoverseg should not print "Segments successfully recovered" to stdout
       And gpAdminLogs directory has "gpsegsetuprecovery*" files
       And gpAdminLogs directory has "gpsegrecovery*" files
       And an FTS probe is triggered
@@ -230,6 +198,45 @@ Feature: gprecoverseg tests
       And gprecoverseg should return a return code of 0
       And all the segments are running
       And the segments are synchronized
+      And the row count from table "test_rewind_failure" in "postgres" is verified against the saved data
+
+  Scenario: gprecoverseg mixed recovery one basebackup fails and one rewind fails while others succeed
+      Given the database is running
+      And all the segments are running
+      And the segments are synchronized
+      And all files in gpAdminLogs directory are deleted
+      And user immediately stops all primary processes
+      And user can start transactions
+      And sql "DROP TABLE if exists test_rewind_failure; CREATE TABLE test_rewind_failure AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
+      And the "test_rewind_failure" table row count in "postgres" is saved
+      And all files in pg_wal directory are deleted from datadirectory of content 2 mirror
+      And a gprecoverseg directory under '/tmp' with mode '0700' is created
+      And a gprecoverseg input file is created
+    # TODO: add test for moving a mirror to a good directory, which updates the catalog
+      And edit the input file to recover mirror with content 0 to a new directory with mode 0000
+      And edit the input file to recover mirror with content 1 full inplace
+      And edit the input file to recover mirror with content 2 incremental
+      When the user runs gprecoverseg with input file and additional args "-a"
+      Then gprecoverseg should return a return code of 1
+      And gprecoverseg should print "pg_basebackup: error: could not access directory" to stdout for mirrors with content 0
+      And gprecoverseg should print "pg_basebackup: base backup completed" to stdout for mirrors with content 1
+      And gprecoverseg should print "pg_rewind: fatal" to stdout for mirrors with content 2
+      And gprecoverseg should print "Failed to recover the following segments" to stdout
+      And gprecoverseg should print "basebackup" errors to stdout for content 0
+      And gprecoverseg should print "rewind" errors to stdout for content 2
+      And gprecoverseg should not print "Segments successfully recovered" to stdout
+      And gpAdminLogs directory has "pg_basebackup*" files only for content 0
+      And gpAdminLogs directory has "pg_rewind*" files only for content 2
+      And gpAdminLogs directory has "gpsegsetuprecovery*" files
+      And gpAdminLogs directory has "gpsegrecovery*" files
+      And an FTS probe is triggered
+      And the mirror for content 1 are up
+      And the segments are synchronized for content 1
+      And the mode of the saved data directory is changed to 700
+      And the user runs "gprecoverseg -aF && gprecoverseg -ar"
+      And all the segments are running
+      And the segments are synchronized
+      And gprecoverseg should return a return code of 0
       And the row count from table "test_rewind_failure" in "postgres" is verified against the saved data
 
   Scenario: gprecoverseg mixed recovery segments come up even if one pg_ctl_start fails
@@ -247,12 +254,14 @@ Feature: gprecoverseg tests
       And edit the input file to recover mirror with content 1 full inplace
       And edit the input file to recover mirror with content 2 incremental
       When the user runs gprecoverseg with input file and additional args "-a"
-      Then gprecoverseg should return a return code of 2
+      Then gprecoverseg should return a return code of 1
       And gprecoverseg should print "pg_basebackup: base backup completed" to stdout for mirrors with content 0,1
       And gprecoverseg should print "pg_rewind: Done!" to stdout for mirrors with content 2
-      # TODO: this should only be 1 file ( for the failed segment)
-      And gpAdminLogs directory has "pg_basebackup*" files only for content 0,1
-      And gpAdminLogs directory has "pg_rewind*" files only for content 2
+      And gprecoverseg should print "Failed to start the following segments" to stdout
+      And gprecoverseg should print "start" errors to stdout for content 0
+      And gprecoverseg should not print "Segments successfully recovered" to stdout
+      And gpAdminLogs directory has no "pg_basebackup*" files
+      And gpAdminLogs directory has no "pg_rewoind*" files
       And gpAdminLogs directory has "gpsegsetuprecovery*" files
       And gpAdminLogs directory has "gpsegrecovery*" files
       And an FTS probe is triggered
@@ -291,7 +300,7 @@ Feature: gprecoverseg tests
         When user can start transactions
         And the user runs "gprecoverseg -F -a --no-progress"
         Then gprecoverseg should return a return code of 0
-        And gprecoverseg should print "Running recovery and starting the required segments" to stdout
+        And gprecoverseg should print "Initiating segment recovery. Upon completion, will start the successfully recovered segments" to stdout
         And gprecoverseg should not print "pg_basebackup: base backup completed" to stdout
         And gpAdminLogs directory has no "pg_basebackup*" files
         And all the segments are running
@@ -309,7 +318,7 @@ Feature: gprecoverseg tests
         And we generate the postmaster.pid file with the background pid on "primary" segment
         And the user runs "gprecoverseg -a"
         Then gprecoverseg should return a return code of 0
-        And gprecoverseg should print "Running recovery and starting the required segments" to stdout
+        And gprecoverseg should print "Initiating segment recovery. Upon completion, will start the successfully recovered segments" to stdout
         And gprecoverseg should print "pg_rewind: no rewind required" to stdout for each mirror
         And gprecoverseg should not print "Unhandled exception in thread started by <bound method Worker.__bootstrap" to stdout
         And all the segments are running
@@ -331,7 +340,7 @@ Feature: gprecoverseg tests
         When user can start transactions
         And we generate the postmaster.pid file with a non running pid on the same "primary" segment
         And the user runs "gprecoverseg -a"
-        And gprecoverseg should print "Running recovery and starting the required segments" to stdout
+        And gprecoverseg should print "Initiating segment recovery. Upon completion, will start the successfully recovered segments" to stdout
         And gprecoverseg should print "pg_rewind: no rewind required" to stdout for each mirror
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should not print "Unhandled exception in thread started by <bound method Worker.__bootstrap" to stdout
@@ -431,36 +440,6 @@ Feature: gprecoverseg tests
 
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster
-
-    @concourse_cluster
-    Scenario: gprecoverseg incremental recovery segments come up even if one rewind fails
-      Given the database is running
-      And all the segments are running
-      And the segments are synchronized
-      And all files in gpAdminLogs directory are deleted on hosts mdw,sdw1,sdw2
-      And the "primary" segment information is saved
-      And user immediately stops all primary processes
-      And user can start transactions
-      And sql "DROP TABLE if exists test_rewind_failure; CREATE TABLE test_rewind_failure AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
-      And the "test_rewind_failure" table row count in "postgres" is saved
-      And all files in pg_wal directory are deleted from data directory of saved primary
-      When the user runs "gprecoverseg -a"
-      Then gprecoverseg should return a return code of 2
-      And gprecoverseg should print "pg_rewind: fatal" to stdout for mirrors with content 0
-      And gprecoverseg should print "pg_rewind: Done!" to stdout for mirrors with content 1,2,3
-          # TODO: this should only be 1 file ( for the failed segment)
-      And gpAdminLogs directory has "pg_rewind*" files on respective hosts only for content 0,1,2,3
-#      And gpAdminLogs directory has "gpsegsetuprecovery*" files
-#      And gpAdminLogs directory has "gpsegrecovery*" files
-      And an FTS probe is triggered
-      And the mirror for content 1,2,3 are up
-      And the segments are synchronized for content 1,2,3
-      And the user runs "gprecoverseg -aF && gprecoverseg -ar"
-      And gprecoverseg should return a return code of 0
-      And all the segments are running
-      And the segments are synchronized
-      And the row count from table "test_rewind_failure" in "postgres" is verified against the saved data
-
     @concourse_cluster
     Scenario: gprecoverseg mixed recovery segments come up even if one basebackup takes longer
       Given the database is running
@@ -485,15 +464,46 @@ Feature: gprecoverseg tests
       And verify that mirror on content 0 is down
       And the user reset the walsender on the primary on content 0
       And the user waits until saved async process is completed
-#      And gpAdminLogs directory has no "pg_basebackup*" files
-#      And gpAdminLogs directory has no "pg_rewind*" files
-#      And gpAdminLogs directory has "gpsegsetuprecovery*" files
-#      And gpAdminLogs directory has "gpsegrecovery*" files
+  #      And gpAdminLogs directory has no "pg_basebackup*" files
+  #      And gpAdminLogs directory has no "pg_rewind*" files
+  #      And gpAdminLogs directory has "gpsegsetuprecovery*" files
+  #      And gpAdminLogs directory has "gpsegrecovery*" files
       And all the segments are running
       And the segments are synchronized
       And the user runs "gprecoverseg -ar"
       And gprecoverseg should return a return code of 0
       And the row count from table "test_slow_basebackup" in "postgres" is verified against the saved data
+
+    @concourse_cluster
+    Scenario: gprecoverseg incremental recovery segments come up even if one rewind fails
+      Given the database is running
+      And all the segments are running
+      And the segments are synchronized
+      And all files in gpAdminLogs directory are deleted on hosts mdw,sdw1,sdw2
+      And the "primary" segment information is saved
+      And user immediately stops all primary processes
+      And user can start transactions
+      And sql "DROP TABLE if exists test_rewind_failure; CREATE TABLE test_rewind_failure AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
+      And the "test_rewind_failure" table row count in "postgres" is saved
+      And all files in pg_wal directory are deleted from data directory of saved primary
+      When the user runs "gprecoverseg -a"
+      Then gprecoverseg should return a return code of 1
+      And gprecoverseg should print "pg_rewind: fatal" to stdout for mirrors with content 0
+      And gprecoverseg should print "pg_rewind: Done!" to stdout for mirrors with content 1,2,3
+      And gpAdminLogs directory has "pg_rewind*" files on respective hosts only for content 0
+      And gprecoverseg should print "Failed to recover the following segments" to stdout
+      And gprecoverseg should print "rewind" errors to stdout for content 0
+      And gprecoverseg should not print "Segments successfully recovered" to stdout
+#      And gpAdminLogs directory has "gpsegsetuprecovery*" files
+#      And gpAdminLogs directory has "gpsegrecovery*" files
+      And an FTS probe is triggered
+      And the mirror for content 1,2,3 are up
+      And the segments are synchronized for content 1,2,3
+      And the user runs "gprecoverseg -aF && gprecoverseg -ar"
+      And gprecoverseg should return a return code of 0
+      And all the segments are running
+      And the segments are synchronized
+      And the row count from table "test_rewind_failure" in "postgres" is verified against the saved data
 
     @concourse_cluster
     Scenario: gprecoverseg mixed recovery one basebackup fails and one rewind fails while others succeed
@@ -515,14 +525,17 @@ Feature: gprecoverseg tests
       And edit the input file to recover mirror with content 2 incremental
       And edit the input file to recover mirror with content 3 to a new directory on remote host with mode 0000
       When the user runs gprecoverseg with input file and additional args "-a"
-      Then gprecoverseg should return a return code of 2
+      Then gprecoverseg should return a return code of 1
       And gprecoverseg should print "pg_rewind: fatal" to stdout for mirrors with content 0
       And gprecoverseg should print "pg_basebackup: base backup completed" to stdout for mirrors with content 1
       And gprecoverseg should print "pg_rewind: Done!" to stdout for mirrors with content 2
       And gprecoverseg should print "pg_basebackup: error: could not access directory" to stdout for mirrors with content 3
-        # TODO: this should only be 1 file ( for the failed segment)
-      And gpAdminLogs directory has "pg_basebackup*" files on respective hosts only for content 1,3
-      And gpAdminLogs directory has "pg_rewind*" files on respective hosts only for content 0,2
+      And gpAdminLogs directory has "pg_basebackup*" files on respective hosts only for content 3
+      And gpAdminLogs directory has "pg_rewind*" files on respective hosts only for content 0
+      And gprecoverseg should print "Failed to recover the following segments" to stdout
+      And gprecoverseg should print "basebackup" errors to stdout for content 3
+      And gprecoverseg should print "rewind" errors to stdout for content 0
+      And gprecoverseg should not print "Segments successfully recovered" to stdout
 #      And gpAdminLogs directory has "gpsegsetuprecovery*" files
 #      And gpAdminLogs directory has "gpsegrecovery*" files
       And an FTS probe is triggered
@@ -536,7 +549,9 @@ Feature: gprecoverseg tests
       And gprecoverseg should return a return code of 0
       And the row count from table "test_rewind_failure" in "postgres" is verified against the saved data
 
-    @concourse_cluster
+    #TODO Add scenario for when start fails but recovery succeeds
+
+  @concourse_cluster
     Scenario: gprecoverseg behave test requires a cluster with at least 2 hosts
         Given the database is running
         Given database "gptest" exists
@@ -577,8 +592,9 @@ Feature: gprecoverseg tests
         Then the saved "mirror" segment is marked down in config
         When the user runs "gprecoverseg -F -a"
         Then gprecoverseg should return a return code of 0
-        And gprecoverseg should print "Running recovery and starting the required segments" to stdout
+        And gprecoverseg should print "Initiating segment recovery. Upon completion, will start the successfully recovered segments" to stdout
         And gprecoverseg should print "pg_basebackup: base backup completed" to stdout
+        And gprecoverseg should print "Segments successfully recovered" to stdout
         And all the segments are running
         And the segments are synchronized
 

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg_newhost.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg_newhost.feature
@@ -30,3 +30,68 @@ Feature: gprecoverseg tests involving migrating to a new host
       | test_case      |  down        | spare | unused | used | acting_primary | gprecoverseg_cmd                              | down_sql                                              |
       | one_host_down  |  "sdw1"      | "sdw5" | "sdw6"   | sdw5 | sdw2           | "gprecoverseg -a -p sdw5 --hba-hostnames"   | "hostname='sdw1' and status='u'"                      |
       | two_hosts_down |  "sdw1,sdw3" | "sdw5,sdw6" | none   | sdw5 | sdw2           | "gprecoverseg -a -p sdw5,sdw6 --hba-hostnames" | "(hostname='sdw1' or hostname='sdw3') and status='u'" |
+
+  @concourse_cluster
+  Scenario: "gprecoverseg -p newhost" failure correctly for start failures
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And database "gptest" exists
+    And the user runs gpconfig sets guc "wal_sender_timeout" with "15s"
+    And the user runs "gpstop -air"
+    And the cluster configuration is saved for "before"
+    And segment hosts "sdw1" are disconnected from the cluster and from the spare segment hosts "sdw5"
+    And the cluster configuration has no segments where "hostname='sdw1' and status='u'"
+    And datadirs from "before" configuration for "sdw1" are created on "sdw5" with mode 755
+    When the user runs "gprecoverseg -a -p sdw5 --hba-hostnames"
+    Then gprecoverseg should return a return code of 1
+#    And pg_hba file "/data/gpdata/mirror/gpseg0/pg_hba.conf" on host "sdw2" contains entries for "sdw5"
+    And check if start failed for full recovery for mirrors with hostname sdw5
+    And gpAdminLogs directory has no "pg_basebackup*" files on all segment hosts
+    And gpAdminLogs directory has no "pg_rewind*" files on all segment hosts
+    And gpAdminLogs directory has "gpsegsetuprecovery*" files on all segment hosts
+    And gpAdminLogs directory has "gpsegrecovery*" files on all segment hosts
+    And datadirs from "before" configuration for "sdw1" are created on "sdw5" with mode 700
+    And the user runs "gprecoverseg -aF"
+    And gprecoverseg should return a return code of 0
+    And the cluster configuration is saved for "one_host_down"
+    And the "before" and "one_host_down" cluster configuration matches with the expected for gprecoverseg newhost
+    And the mirrors replicate and fail over and back correctly
+    And the cluster is rebalanced
+    And the original cluster state is recreated for "one_host_down"
+    And the cluster configuration is saved for "after_recreation"
+    And the "before" and "after_recreation" cluster configuration matches with the expected for gprecoverseg newhost
+
+  @concourse_cluster
+  Scenario: "gprecoverseg -p newhost" failure correctly for basebackup failures
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And database "gptest" exists
+    And the user runs gpconfig sets guc "wal_sender_timeout" with "15s"
+    And the user runs "gpstop -air"
+    And the cluster configuration is saved for "before"
+    And segment hosts "sdw1" are disconnected from the cluster and from the spare segment hosts "sdw5"
+    And the cluster configuration has no segments where "hostname='sdw1' and status='u'"
+    And the cluster configuration is saved for "before_recoverseg"
+    And datadirs from "before_recoverseg" configuration for "sdw1" are created on "sdw5" with mode 000
+    When the user runs "gprecoverseg -a -p sdw5 --hba-hostnames"
+    Then gprecoverseg should return a return code of 1
+#    And pg_hba file "/data/gpdata/mirror/gpseg0/pg_hba.conf" on host "sdw2" contains entries for "sdw5"
+    And check if moving the mirrors from sdw1 to sdw5 failed
+    And gprecoverseg should print "Recovery Target instance port        = 20000" to stdout
+    And gprecoverseg should print "Recovery Target instance port        = 20001" to stdout
+    And gprecoverseg should print "Recovery Target instance port        = 20002" to stdout
+    And gprecoverseg should print "Recovery Target instance port        = 20003" to stdout
+    And the cluster configuration is saved for "after_backout"
+    And the "before_recoverseg" and "after_backout" cluster configuration matches for gprecoverseg newhost
+    And datadirs from "before_recoverseg" configuration for "sdw1" are created on "sdw5" with mode 700
+    And the user runs "gprecoverseg -a -p sdw5 --hba-hostnames"
+    And gprecoverseg should return a return code of 0
+    And the cluster configuration is saved for "one_host_down"
+    And the "before" and "one_host_down" cluster configuration matches with the expected for gprecoverseg newhost
+    And the mirrors replicate and fail over and back correctly
+    And the cluster is rebalanced
+    And the original cluster state is recreated for "one_host_down"
+    And the cluster configuration is saved for "after_recreation"
+    And the "before" and "after_recreation" cluster configuration matches with the expected for gprecoverseg newhost

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -539,12 +539,12 @@ def impl(context, process_name, secs):
     run_async_command(context, command)
 
 
-@when('the user asynchronously sets up to end gpinitsystem process when {log_msg} is printed in the logs')
-def impl(context, log_msg):
+@when('the user asynchronously sets up to end {process_name} process when {log_msg} is printed in the logs')
+def impl(context, process_name, log_msg):
     command = "while sleep 0.1; " \
-              "do if egrep --quiet %s  ~/gpAdminLogs/gpinitsystem*log ; " \
-              "then ps ux | grep bin/gpinitsystem |awk '{print $2}' | xargs kill ;break 2; " \
-              "fi; done" % (log_msg)
+              "do if egrep --quiet %s  ~/gpAdminLogs/%s*log ; " \
+              "then ps ux | grep bin/%s |awk '{print $2}' | xargs kill ;break 2; " \
+              "fi; done" % (log_msg, process_name, process_name)
     run_async_command(context, command)
 
 
@@ -2497,6 +2497,7 @@ def impl(context, location):
         ])
 
 @given('all files in gpAdminLogs directory are deleted')
+@when('all files in gpAdminLogs directory are deleted')
 @then('all files in gpAdminLogs directory are deleted')
 def impl(context):
     log_dir = _get_gpAdminLogs_directory()

--- a/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
@@ -335,7 +335,7 @@ def impl(context, content, mode):
                 fd.write('{} {}\n'.format(valid_config, valid_config_new))
             break
 
-
+data_dirs_created = {}
 @given("edit the input file to recover mirror with content {content} to a new directory on remote host with mode {mode}")
 def impl(context, content, mode):
     content = int(content)
@@ -353,7 +353,19 @@ def impl(context, content, mode):
                                                  target_datadir)
             with open(context.mirror_context.input_file_path(), 'a') as fd:
                 fd.write('{} {}\n'.format(valid_config, valid_config_new))
+            data_dirs_created[seg.mirrorDB.getSegmentHostName()] = target_datadir
             break
+
+@given("the mode of all the created data directories is changed to 0700")
+@when("the mode of all the created data directories is changed to 0700")
+@then("the mode of all the created data directories is changed to 0700")
+def impl(context):
+    for hostname, data_dir in data_dirs_created.items():
+        command = 'ssh {} "chmod -R 700 {}"'.format(hostname, data_dir)
+        run_command(context, command)
+
+    data_dirs_created.clear()
+
 
 def make_temp_dir_on_remote(context, hostname, tmp_base_dir_remote, mode='700'):
     if not tmp_base_dir_remote:
@@ -405,6 +417,15 @@ def impl(context, num, parent_dir, mode):
         os.mkdir(ith_dir, int(mode,8))
         context.mirror_context.working_directory.append(ith_dir)
 
+@given("the mode of the saved data directory is changed to 700")
+@when("the mode of the saved data directory is changed to 700")
+@then("the mode of the saved data directory is changed to 700")
+def impl(context):
+    data_dir = context.mirror_context.working_directory[0]
+    print("changing mode of data dir {}".format(data_dir))
+    command = 'chmod -R 700 {}'.format(data_dir)
+    print("running command {}".format(command))
+    run_command(context, command)
 
 @given("a '{file_type}' gpmovemirrors file is created")
 def impl(context, file_type):


### PR DESCRIPTION
# Problem
Currently when a user wants to add/recover/move multiple mirrrors, we schedule jobs for pg_basebackup and pg_rewind on the failed segment host using a worker pool. 
Because of this design, we wait for everything to finish and only return when everything in the pool has finished. The current workflow starts the mirror only after all the mirrors have successfully completed the pg_basebackup/pg_rewind operation. 
This can be wasteful in cases where one or more mirrors take much longer to complete or fail during the pg_basebackup or pg_rewind operation. This prevents us from starting the mirrors for which basebackup/rewind has successfully completed.

# Expectation
We should be able to use the mirrors that have successfully completed ther pg_basebackup/pg_rewind operation without having to wait for all the other mirrors to complete their recovery process.
Also if some mirrors fail during the basebackup/rewind process, we shouldn't have to rerun recovery for those mirrors.

# Main Features in this PR:
1. Ability to start a mirror post successful recovery independently of other mirrors undergoing their recovery process
2. Improved console output in case any operation including pg_basebackup/pg_rewind or start fails for one or more mirrors
3. Ability to revert catalog updates(if any) for mirrors that fail during basebackup operation.

# Implementation in this PR
This PR fixes the problem by starting the mirror inside the recovery wrapper which runs on the segment host. This wrapper which currently runs pg_basebackup/pg_rewind will now also start the mirror once the pg_basebackup/pg_rewind operation is successfully completed for that mirror. 
Once the mirror has started, even if the main operation that triggered pg_basebackup/pg_rewind is waiting for all the mirrors to complete recovery, the mirrors that have been started will be marked as up by fts and will become usable.

**Current workflow:**
1. Coordinator runs gpsegrecovery(this is the new wrapper introduced in https://github.com/greenplum-db/gpdb/pull/12774)  in a pool on all the segment hosts that need recovery.  gpsegrecovery in turn: 
     - runs pg_basebackup or pg_rewind on the mirrors that need recovery on that host
     - If there is an error running pg_basebackup/pg_rewind for even one of the mirrors, the code will error out after all mirrors have completed running pg_basebackup/pg_rewind and the rest of the workflow won't get executed
3. Wait for all the gpsegrecovery operations to complete.
4. If needed, update the catalog(gp_segment_configuration) from the coordinator - like add_mirror, remove_mirror etc.
6. Start all recovered mirrors from coordinator- *This is why we are not able to use the mirrors that have completed recovery since we wait until this step to start the mirrors.*
7. Trigger fts probe

**New workflow:**
1. If needed, update the catalog(gp_segment_configuration) from the coordinator- like add_mirror, remove_mirror etc.
3. Coordinator runs gpsegrecovery in a pool on all the segment hosts that need recovery. gpsegrecovery in turn:
     - runs pg_basebackup or pg_rewind on the mirrors that need recovery on that host
     - starts the mirror using pg_ctl - As soon as the mirror is started, fts will try to mark the mirror as “up” and in “sync”
4. Wait for all the gpsegrecovery operations to complete
5. If there were any failures during the recovery process (including pg_basebackup/pg_rewind and start)
    - print errors to the console
    -  if the catalog was updated, revert the update for the failed mirrors. Note that we only revert if the basebackup operation failed for that mirror.
9. Trigger fts probe

Co-authored-by: Divyesh Vanjare <vanjared@vmware.com>
Co-authored-by: Jamie McAtamney <jmcatamney@vmware.com>