### PR TITLE
Remove two FIXME comments in greenplumLegacyAOoptions() and checkDependencies()

### DIFF
--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -2865,7 +2865,7 @@ checkDependencies(const ObjectAddresses *objects,
 
 		findDependentObjects(thisobj,
 							 DEPFLAG_ORIGINAL,
-							 0, /* GPDB_12_MERGE_FIXME: new 'flags' field. need to pass something? */
+							 0,
 							 NULL,		/* empty stack */
 							 targetObjects,
 							 objects,

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -19668,24 +19668,6 @@ greenplumLegacyAOoptions(const char *accessMethod, List **options)
 	}
 	*options = amendedOptions;
 
-	/* GPDB_12_MERGE_FIXME: during the development of the ao_row/column tableam we
-	 * need to have this layer turned off. When removing this fixme, make
-	 * certain that any sanity checks on the options are also introduced if
-	 * needed. Such examples can be:
-	 *
-	 *  if (strcmp(elem->defname, "appendoptimized") == 0 ||
-	 *      strcmp(elem->defname, "appendonly") == 0)
-	 *  {
-	 *      if ((strVal(elem->arg), "true") == 0)
-	 *   	{ options for true }
-	 *   	else if ((strVal(elem->arg), "false") == 0)
-	 *   	{ options for false }
-	 *   	else
-	 *   	{ ereport(....
-	 *  }
-	 *
-	 */
-
 	if (!appendoptimized && is_column_oriented_found)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),

--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -49,6 +49,11 @@ CREATE TABLE tenk_ao13 (like tenk_heap) with (appendoptimized=true);
 CREATE TABLE tenk_ao14 (like tenk_heap) with (appendonly=true, appendoptimized=false);
 CREATE TABLE tenk_ao14 (like tenk_heap) with (appendoptimized=maybe);
 CREATE TABLE tenk_ao14 (like tenk_heap) with (appendoptimized=true, appendoptimized=true);
+CREATE TABLE tenk_ao14 (like tenk_heap) with (orientation=row);
+CREATE TABLE tenk_ao14 (like tenk_heap) with (appendoptimized=false, orientation=row);
+CREATE TABLE tenk_ao14 (like tenk_heap) with (appendoptimized=true, orientation=foo);
+CREATE TABLE tenk_ao14 (like tenk_heap) with (appendoptimized=true, orientation);
+CREATE TABLE tenk_ao14 (like tenk_heap) with (appendoptimized=true, orientation=row, orientation=row);
 CREATE TABLE tenk_ao15 (like tenk_heap) with (appendoptimized=true) 
 PARTITION BY RANGE(unique2)
 (

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -63,6 +63,18 @@ CREATE TABLE tenk_ao14 (like tenk_heap) with (appendoptimized=maybe);
 ERROR:  appendoptimized requires a Boolean value
 CREATE TABLE tenk_ao14 (like tenk_heap) with (appendoptimized=true, appendoptimized=true);
 ERROR:  parameter "appendonly" specified more than once
+CREATE TABLE tenk_ao14 (like tenk_heap) with (orientation=row);
+ERROR:  invalid option "orientation" for base relation
+HINT:  Table orientation only valid for Append Optimized relations, create an AO relation to use table orientation.
+CREATE TABLE tenk_ao14 (like tenk_heap) with (appendoptimized=false, orientation=row);
+ERROR:  invalid option "orientation" for base relation
+HINT:  Table orientation only valid for Append Optimized relations, create an AO relation to use table orientation.
+CREATE TABLE tenk_ao14 (like tenk_heap) with (appendoptimized=true, orientation=foo);
+ERROR:  invalid parameter value for "orientation": "foo"
+CREATE TABLE tenk_ao14 (like tenk_heap) with (appendoptimized=true, orientation);
+ERROR:  orientation requires a parameter
+CREATE TABLE tenk_ao14 (like tenk_heap) with (appendoptimized=true, orientation=row, orientation=row);
+ERROR:  parameter "orientation" specified more than once
 CREATE TABLE tenk_ao15 (like tenk_heap) with (appendoptimized=true) 
 PARTITION BY RANGE(unique2)
 (


### PR DESCRIPTION
1. In `greenplumLegacyAOoptions()` : the comment reminds us about adding sanity check for the AO options in the WITH clause. However, it seems that all the necessary sanity check should be already in place, either in greenplumLegacyAOoptions() itself or elsewhere. So here we just need to add some missing test cases and can resolve the comment.

2. In `checkDependencies()` : the flags passed to `findDependentObjects()` are for deletion only (`PERFORM_DELETION_xxx`). So it's ok here.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
