### PR TITLE
Fix flaky brin testcase

### DIFF
--- a/src/test/regress/expected/brin.out
+++ b/src/test/regress/expected/brin.out
@@ -304,7 +304,7 @@ BEGIN
 		END IF;
 	END LOOP;
 
-	FOR r IN SELECT colname, oper, typ, value[ordinality], matches[ordinality] FROM brinopers, unnest(op) WITH ORDINALITY AS oper order by colname, typ LOOP
+	FOR r IN SELECT colname, oper, typ, value[ordinality], matches[ordinality] FROM brinopers, unnest(op) WITH ORDINALITY AS oper order by colname, typ, oper LOOP
 
 		-- prepare the condition
 		IF r.value IS NULL THEN

--- a/src/test/regress/expected/brin_ao.out
+++ b/src/test/regress/expected/brin_ao.out
@@ -303,7 +303,7 @@ BEGIN
 		END IF;
 	END LOOP;
 
-	FOR r IN SELECT colname, oper, typ, value[ordinality], matches[ordinality] FROM brinopers_ao, unnest(op) WITH ORDINALITY AS oper order by colname, typ LOOP
+	FOR r IN SELECT colname, oper, typ, value[ordinality], matches[ordinality] FROM brinopers_ao, unnest(op) WITH ORDINALITY AS oper order by colname, typ, oper LOOP
 		mismatch := false;
 
 		-- prepare the condition

--- a/src/test/regress/expected/brin_ao_optimizer.out
+++ b/src/test/regress/expected/brin_ao_optimizer.out
@@ -303,7 +303,7 @@ BEGIN
 		END IF;
 	END LOOP;
 
-	FOR r IN SELECT colname, oper, typ, value[ordinality], matches[ordinality] FROM brinopers_ao, unnest(op) WITH ORDINALITY AS oper order by colname, typ LOOP
+	FOR r IN SELECT colname, oper, typ, value[ordinality], matches[ordinality] FROM brinopers_ao, unnest(op) WITH ORDINALITY AS oper order by colname, typ, oper LOOP
 		mismatch := false;
 
 		-- prepare the condition
@@ -408,21 +408,21 @@ WARNING:  ORCA did not produce a bitmap indexscan plan for (cidrcol,<,inet,255.2
 WARNING:  ORCA did not produce a bitmap indexscan plan for (cidrcol,<=,inet,255.255.255.255,100)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (cidrcol,>,inet,0.0.0.0,125)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (cidrcol,>=,inet,0.0.0.0,125)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>=,cidr,0.0.0.0,125)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>,cidr,0.0.0.0,125)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,<=,cidr,255.255.255.255,100)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,<,cidr,255.255.255.255,100)
+WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,<=,cidr,255.255.255.255,100)
+WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>,cidr,0.0.0.0,125)
+WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>=,cidr,0.0.0.0,125)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,<,inet,255.255.255.255,100)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,<=,inet,255.255.255.255,100)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>,inet,0.0.0.0,125)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>=,inet,0.0.0.0,125)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (lsncol,IS,pg_lsn,,25)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (lsncol,"IS NOT",pg_lsn,,100)
+WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,<,name,ZZAAAA,100)
+WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,<=,name,ZZAAAA,100)
+WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,=,name,MAAAAA,2)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,>,name,AAAAAA,100)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,>=,name,AAAAAA,100)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,=,name,MAAAAA,2)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,<=,name,ZZAAAA,100)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,<,name,ZZAAAA,100)
 -- Note: ORCA does not support all of the above operators:
 --       - standard comparison operators on inet and cidr columns
 --         because ORCA does not look at the second occurrence of a column in an index,

--- a/src/test/regress/expected/brin_aocs.out
+++ b/src/test/regress/expected/brin_aocs.out
@@ -303,7 +303,7 @@ BEGIN
 		END IF;
 	END LOOP;
 
-	FOR r IN SELECT colname, oper, typ, value[ordinality], matches[ordinality] FROM brinopers_aocs, unnest(op) WITH ORDINALITY AS oper order by colname, typ LOOP
+	FOR r IN SELECT colname, oper, typ, value[ordinality], matches[ordinality] FROM brinopers_aocs, unnest(op) WITH ORDINALITY AS oper order by colname, typ, oper LOOP
 		mismatch := false;
 
 		-- prepare the condition

--- a/src/test/regress/expected/brin_aocs_optimizer.out
+++ b/src/test/regress/expected/brin_aocs_optimizer.out
@@ -303,7 +303,7 @@ BEGIN
 		END IF;
 	END LOOP;
 
-	FOR r IN SELECT colname, oper, typ, value[ordinality], matches[ordinality] FROM brinopers_aocs, unnest(op) WITH ORDINALITY AS oper order by colname, typ LOOP
+	FOR r IN SELECT colname, oper, typ, value[ordinality], matches[ordinality] FROM brinopers_aocs, unnest(op) WITH ORDINALITY AS oper order by colname, typ, oper LOOP
 		mismatch := false;
 
 		-- prepare the condition
@@ -408,21 +408,21 @@ WARNING:  ORCA did not produce a bitmap indexscan plan for (cidrcol,<,inet,255.2
 WARNING:  ORCA did not produce a bitmap indexscan plan for (cidrcol,<=,inet,255.255.255.255,100)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (cidrcol,>,inet,0.0.0.0,125)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (cidrcol,>=,inet,0.0.0.0,125)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>=,cidr,0.0.0.0,125)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>,cidr,0.0.0.0,125)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,<=,cidr,255.255.255.255,100)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,<,cidr,255.255.255.255,100)
+WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,<=,cidr,255.255.255.255,100)
+WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>,cidr,0.0.0.0,125)
+WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>=,cidr,0.0.0.0,125)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,<,inet,255.255.255.255,100)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,<=,inet,255.255.255.255,100)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>,inet,0.0.0.0,125)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>=,inet,0.0.0.0,125)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (lsncol,IS,pg_lsn,,25)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (lsncol,"IS NOT",pg_lsn,,100)
+WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,<,name,ZZAAAA,100)
+WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,<=,name,ZZAAAA,100)
+WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,=,name,MAAAAA,2)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,>,name,AAAAAA,100)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,>=,name,AAAAAA,100)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,=,name,MAAAAA,2)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,<=,name,ZZAAAA,100)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,<,name,ZZAAAA,100)
 -- Note: ORCA does not support all of the above operators:
 --       - standard comparison operators on inet and cidr columns
 --         because ORCA does not look at the second occurrence of a column in an index,

--- a/src/test/regress/expected/brin_optimizer.out
+++ b/src/test/regress/expected/brin_optimizer.out
@@ -304,7 +304,7 @@ BEGIN
 		END IF;
 	END LOOP;
 
-	FOR r IN SELECT colname, oper, typ, value[ordinality], matches[ordinality] FROM brinopers, unnest(op) WITH ORDINALITY AS oper order by colname, typ LOOP
+	FOR r IN SELECT colname, oper, typ, value[ordinality], matches[ordinality] FROM brinopers, unnest(op) WITH ORDINALITY AS oper order by colname, typ, oper LOOP
 
 		-- prepare the condition
 		IF r.value IS NULL THEN
@@ -396,21 +396,21 @@ WARNING:  ORCA did not produce a bitmap indexscan plan for (cidrcol,<,inet,255.2
 WARNING:  ORCA did not produce a bitmap indexscan plan for (cidrcol,<=,inet,255.255.255.255,100)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (cidrcol,>,inet,0.0.0.0,125)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (cidrcol,>=,inet,0.0.0.0,125)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>=,cidr,0.0.0.0,125)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>,cidr,0.0.0.0,125)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,<=,cidr,255.255.255.255,100)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,<,cidr,255.255.255.255,100)
+WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,<=,cidr,255.255.255.255,100)
+WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>,cidr,0.0.0.0,125)
+WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>=,cidr,0.0.0.0,125)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,<,inet,255.255.255.255,100)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,<=,inet,255.255.255.255,100)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>,inet,0.0.0.0,125)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>=,inet,0.0.0.0,125)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (lsncol,IS,pg_lsn,,25)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (lsncol,"IS NOT",pg_lsn,,100)
+WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,<,name,ZZAAAA,100)
+WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,<=,name,ZZAAAA,100)
+WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,=,name,MAAAAA,2)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,>,name,AAAAAA,100)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,>=,name,AAAAAA,100)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,=,name,MAAAAA,2)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,<=,name,ZZAAAA,100)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,<,name,ZZAAAA,100)
 -- Note: ORCA does not support all of the above operators:
 --       - standard comparison operators on inet and cidr columns
 --         because ORCA does not look at the second occurrence of a column in an index,

--- a/src/test/regress/sql/brin.sql
+++ b/src/test/regress/sql/brin.sql
@@ -310,7 +310,7 @@ BEGIN
 		END IF;
 	END LOOP;
 
-	FOR r IN SELECT colname, oper, typ, value[ordinality], matches[ordinality] FROM brinopers, unnest(op) WITH ORDINALITY AS oper order by colname, typ LOOP
+	FOR r IN SELECT colname, oper, typ, value[ordinality], matches[ordinality] FROM brinopers, unnest(op) WITH ORDINALITY AS oper order by colname, typ, oper LOOP
 
 		-- prepare the condition
 		IF r.value IS NULL THEN

--- a/src/test/regress/sql/brin_ao.sql
+++ b/src/test/regress/sql/brin_ao.sql
@@ -309,7 +309,7 @@ BEGIN
 		END IF;
 	END LOOP;
 
-	FOR r IN SELECT colname, oper, typ, value[ordinality], matches[ordinality] FROM brinopers_ao, unnest(op) WITH ORDINALITY AS oper order by colname, typ LOOP
+	FOR r IN SELECT colname, oper, typ, value[ordinality], matches[ordinality] FROM brinopers_ao, unnest(op) WITH ORDINALITY AS oper order by colname, typ, oper LOOP
 		mismatch := false;
 
 		-- prepare the condition

--- a/src/test/regress/sql/brin_aocs.sql
+++ b/src/test/regress/sql/brin_aocs.sql
@@ -309,7 +309,7 @@ BEGIN
 		END IF;
 	END LOOP;
 
-	FOR r IN SELECT colname, oper, typ, value[ordinality], matches[ordinality] FROM brinopers_aocs, unnest(op) WITH ORDINALITY AS oper order by colname, typ LOOP
+	FOR r IN SELECT colname, oper, typ, value[ordinality], matches[ordinality] FROM brinopers_aocs, unnest(op) WITH ORDINALITY AS oper order by colname, typ, oper LOOP
 		mismatch := false;
 
 		-- prepare the condition


### PR DESCRIPTION
Using ORCA, CI has caught instances of brin_ao regress test failing with
following diff:
```
-WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,<=,inet,255.255.255.255,100)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>,cidr,0.0.0.0,125)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>,inet,0.0.0.0,125)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>=,cidr,0.0.0.0,125)
+WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,<=,inet,255.255.255.255,100)
+WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>,inet,0.0.0.0,125)
```

Issue appears to be due to dependency of volatile ordering. Testcase orders by
"colname" and "typ", but seems like we should add "op" as well.