### PR TITLE
Trying to make parallel_retrieve_cursor/fault_inject stable.

### DIFF
--- a/src/test/isolation2/input/parallel_retrieve_cursor/fault_inject.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/fault_inject.source
@@ -114,8 +114,8 @@ insert into t1 select generate_series(1,100);
 1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'reset', 2);
 1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'reset', 3);
 1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'reset', 4);
-1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'sleep', '', '', '', 5, 6, 3, 2::smallint);
-1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'sleep', '', '', '', 5, 6, 3, 4::smallint);
+1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'suspend', '', '', '', 5, 5, 0, 2::smallint);
+1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'suspend', '', '', '', 5, 5, 0, 4::smallint);
 1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'interrupt', '', '', '', 5, 5, 0, 3::smallint);
 
 1: BEGIN;
@@ -132,7 +132,13 @@ insert into t1 select generate_series(1,100);
 1U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
 1R: @pre_run 'set_endpoint_variable @ENDPOINT5': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT5";
 
+SELECT gp_wait_until_triggered_fault('fetch_tuples_from_endpoint', 1, 2);
+SELECT gp_wait_until_triggered_fault('fetch_tuples_from_endpoint', 1, 4);
+
 1<:
+
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'resume', 2);
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'resume', 4);
 
 0R<:
 2R<:
@@ -144,9 +150,9 @@ insert into t1 select generate_series(1,100);
 1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'reset', 4);
 
 -- Test6: close PARALLEL RETRIEVE CURSOR during retrieve
-1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'sleep', '', '', '', 5, 6, 3, 2::smallint);
-1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'sleep', '', '', '', 5, 6, 3, 4::smallint);
-1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'sleep', '', '', '', 5, 6, 3, 3::smallint);
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'suspend', '', '', '', 5, 5, 0, 2::smallint);
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'suspend', '', '', '', 5, 5, 0, 4::smallint);
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'suspend', '', '', '', 5, 5, 0, 3::smallint);
 
 1: BEGIN;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * from t1;
@@ -163,6 +169,10 @@ insert into t1 select generate_series(1,100);
 
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', 0);
 1: CLOSE c1;
+
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'resume', 2);
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'resume', 3);
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'resume', 4);
 
 0R<:
 1R<:
@@ -181,22 +191,22 @@ DROP TABLE IF EXISTS t2;
 CREATE TABLE t2 (a INT) DISTRIBUTED by (a);
 insert into t2 select generate_series(1,10000);
 
-1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'reset', dbid)
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'reset', dbid)
     FROM gp_segment_configuration
     WHERE content=1 AND role='p';
-1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'interrupt', '', '', '', 1000, 1000, 0, dbid)
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'interrupt', '', '', '', 1000, 1000, 0, dbid)
     FROM gp_segment_configuration
     WHERE content=1 AND role='p';
-1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'reset', dbid)
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'reset', dbid)
     FROM gp_segment_configuration
     WHERE content=0 AND role='p';
-1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'sleep', '', '', '', 900, 900, 2, dbid)
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'suspend', '', '', '', 900, 900, 0, dbid)
     FROM gp_segment_configuration
     WHERE content=0 AND role='p';
-1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'reset', dbid)
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'reset', dbid)
     FROM gp_segment_configuration
     WHERE content=2 AND role='p';
-1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'sleep', '', '', '', 800, 800, 2, dbid)
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'suspend', '', '', '', 800, 800, 0, dbid)
     FROM gp_segment_configuration
     WHERE content=2 AND role='p';
 
@@ -215,6 +225,13 @@ insert into t2 select generate_series(1,10000);
 1R: @pre_run 'set_endpoint_variable @ENDPOINT6': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT6";
 
 1<:
+
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'resume', dbid)
+    FROM gp_segment_configuration
+    WHERE content=0 AND role='p';
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'resume', dbid)
+    FROM gp_segment_configuration
+    WHERE content=2 AND role='p';
 
 0R<:
 2R<:

--- a/src/test/isolation2/output/parallel_retrieve_cursor/fault_inject.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/fault_inject.source
@@ -457,12 +457,12 @@ ROLLBACK
 -----------------
  Success:        
 (1 row)
-1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'sleep', '', '', '', 5, 6, 3, 2::smallint);
+1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'suspend', '', '', '', 5, 5, 0, 2::smallint);
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
-1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'sleep', '', '', '', 5, 6, 3, 4::smallint);
+1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'suspend', '', '', '', 5, 5, 0, 4::smallint);
  gp_inject_fault 
 -----------------
  Success:        
@@ -506,8 +506,30 @@ DECLARE
 1R: @pre_run 'set_endpoint_variable @ENDPOINT5': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT5";
 ERROR:  canceling statement due to user request
 
+SELECT gp_wait_until_triggered_fault('fetch_tuples_from_endpoint', 1, 2);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+SELECT gp_wait_until_triggered_fault('fetch_tuples_from_endpoint', 1, 4);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
 1<:  <... completed>
 ERROR:  canceling MPP operation: "Endpoint retrieve statement aborted"
+
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'resume', 2);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'resume', 4);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
 
 0R<:  <... completed>
 ERROR:  endpoint is not available because the parallel retrieve cursor was aborted (cdbendpointretrieve.c:245)
@@ -535,17 +557,17 @@ ROLLBACK
 (1 row)
 
 -- Test6: close PARALLEL RETRIEVE CURSOR during retrieve
-1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'sleep', '', '', '', 5, 6, 3, 2::smallint);
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'suspend', '', '', '', 5, 5, 0, 2::smallint);
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
-1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'sleep', '', '', '', 5, 6, 3, 4::smallint);
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'suspend', '', '', '', 5, 5, 0, 4::smallint);
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
-1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'sleep', '', '', '', 5, 6, 3, 3::smallint);
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'suspend', '', '', '', 5, 5, 0, 3::smallint);
  gp_inject_fault 
 -----------------
  Success:        
@@ -590,6 +612,22 @@ DECLARE
 1: CLOSE c1;
 CLOSE
 
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'resume', 2);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'resume', 3);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'resume', 4);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
 0R<:  <... completed>
 ERROR:  endpoint is not available because the parallel retrieve cursor was aborted (cdbendpointretrieve.c:245)
 1R<:  <... completed>
@@ -628,32 +666,32 @@ CREATE
 insert into t2 select generate_series(1,10000);
 INSERT 10000
 
-1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'reset', dbid) FROM gp_segment_configuration WHERE content=1 AND role='p';
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'reset', dbid) FROM gp_segment_configuration WHERE content=1 AND role='p';
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
-1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'interrupt', '', '', '', 1000, 1000, 0, dbid) FROM gp_segment_configuration WHERE content=1 AND role='p';
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'interrupt', '', '', '', 1000, 1000, 0, dbid) FROM gp_segment_configuration WHERE content=1 AND role='p';
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
-1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'reset', dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'reset', dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
-1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'sleep', '', '', '', 900, 900, 2, dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'suspend', '', '', '', 900, 900, 0, dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
-1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'reset', dbid) FROM gp_segment_configuration WHERE content=2 AND role='p';
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'reset', dbid) FROM gp_segment_configuration WHERE content=2 AND role='p';
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
-1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'sleep', '', '', '', 800, 800, 2, dbid) FROM gp_segment_configuration WHERE content=2 AND role='p';
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'suspend', '', '', '', 800, 800, 0, dbid) FROM gp_segment_configuration WHERE content=2 AND role='p';
  gp_inject_fault 
 -----------------
  Success:        
@@ -694,6 +732,17 @@ ERROR:  canceling statement due to user request
 
 1<:  <... completed>
 ERROR:  canceling MPP operation: "Endpoint retrieve statement aborted"
+
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'resume', dbid) FROM gp_segment_configuration WHERE content=0 AND role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'resume', dbid) FROM gp_segment_configuration WHERE content=2 AND role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
 
 0R<:  <... completed>
 ERROR:  endpoint is not available because the parallel retrieve cursor was aborted (cdbendpointretrieve.c:245)


### PR DESCRIPTION
This patch is trying to make isolation2/parallel_retrieve_cursor/fault_inject
stable by replacing 'sleep' fault with 'suspend' fault.

I can reproduce the failure with my machine by running installcheck multiple
times and I cannot reproduce it with this patch being applied. 

Below is the regression.diffs file fetched from the PR pipeline.

```diff
diff -I HINT: -I CONTEXT: -I GP_IGNORE: -U3 /tmp/build/d62a0504/gpdb_src/src/test/isolation2/expected/parallel_retrieve_cursor/fault_inject.out /tmp/build/d62a0504/gpdb_src/src/test/isolation2/results/parallel_retrieve_cursor/fault_inject.out
--- /tmp/build/d62a0504/gpdb_src/src/test/isolation2/expected/parallel_retrieve_cursor/fault_inject.out	2022-02-24 16:18:00.128491568 +0000
+++ /tmp/build/d62a0504/gpdb_src/src/test/isolation2/results/parallel_retrieve_cursor/fault_inject.out	2022-02-24 16:18:00.940556278 +0000
@@ -684,6 +684,3256 @@
  READY
 (1 row)
 2R&: @pre_run 'set_endpoint_variable @ENDPOINT6': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT6";  <waiting ...>
+FAILED:  Forked command is not blocking; got output: a
+-------
+ 5
+ 6
+ 9
+ ...
+ 9999
+ 10000
+(3247 rows)

 1U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
  state
@@ -699,7 +3949,7 @@
 0R<:  <... completed>
 ERROR:  endpoint is not available because the parallel retrieve cursor was aborted (cdbendpointretrieve.c:LINE_NUM)
 2R<:  <... completed>
-ERROR:  endpoint is not available because the parallel retrieve cursor was aborted (cdbendpointretrieve.c:LINE_NUM)
+FAILED:  Execution failed

 1<:  <... completed>
 FAILED:  Execution failed
```
