### PR TITLE
[6X] (Backport) Fix incorrect amount of memory allocated for WindowAgg.

### DIFF
--- a/src/backend/utils/sort/tuplesort.c
+++ b/src/backend/utils/sort/tuplesort.c
@@ -2795,7 +2795,7 @@ tuplesort_restorepos_pos(Tuplesortstate *state, TuplesortPos *pos)
  * printable summary information about how the sort was performed.
  * spaceUsed is measured in kilobytes.
  */
-static void
+void
 tuplesort_get_stats(Tuplesortstate *state,
 					const char **sortMethod,
 					const char **spaceType,

--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -384,8 +384,6 @@ struct Tuplesortstate_mk
 	int		   *gpmon_sort_tick;
 };
 
-static void tuplesort_get_stats_mk(Tuplesortstate_mk* state, const char **sortMethod, const char **spaceType, long *spaceUsed);
-
 static bool
 is_sortstate_rwfile(Tuplesortstate_mk *state)
 {
@@ -2704,7 +2702,7 @@ tuplesort_restorepos_mk(Tuplesortstate_mk *state)
  * printable summary information about how the sort was performed.
  * spaceUsed is measured in kilobytes.
  */
-static void
+void
 tuplesort_get_stats_mk(Tuplesortstate_mk* state,
 					   const char **sortMethod,
 					   const char **spaceType,

--- a/src/include/utils/tuplesort.h
+++ b/src/include/utils/tuplesort.h
@@ -81,6 +81,7 @@
 #define tuplesort_gettupleslot_pos tuplesort_gettupleslot_pos_pg
 #define tuplesort_flush tuplesort_flush_pg
 #define tuplesort_finalize_stats tuplesort_finalize_stats_pg
+#define tuplesort_get_stats tuplesort_get_stats_pg
 #define tuplesort_rescan_pos tuplesort_rescan_pos_pg
 #define tuplesort_markpos_pos tuplesort_markpos_pos_pg
 #define tuplesort_restorepos_pos tuplesort_restorepos_pos_pg
@@ -225,6 +226,7 @@ extern void tuplesort_restorepos(Tuplesortstate *state);
 #undef tuplesort_gettupleslot_pos
 #undef tuplesort_flush
 #undef tuplesort_finalize_stats
+#undef tuplesort_get_stats
 #undef tuplesort_rescan_pos
 #undef tuplesort_markpos_pos
 #undef tuplesort_restorepos_pos
@@ -586,6 +588,16 @@ switcheroo_tuplesort_finalize_stats(switcheroo_Tuplesortstate *state)
 }
 
 static inline void
+switcheroo_tuplesort_get_stats(switcheroo_Tuplesortstate *state, const char **sortMethod,
+								const char **spaceType, long *spaceUsed)
+{
+	if (state->is_mk_tuplesortstate)
+		tuplesort_get_stats_mk((Tuplesortstate_mk *) state, sortMethod, spaceType, spaceUsed);
+	else
+		tuplesort_get_stats_pg((Tuplesortstate_pg *) state, sortMethod, spaceType, spaceUsed);
+}
+
+static inline void
 switcheroo_tuplesort_rescan_pos(switcheroo_Tuplesortstate *state, TuplesortPos *pos)
 {
 	if (state->is_mk_tuplesortstate)
@@ -666,6 +678,7 @@ switcheroo_tuplesort_set_gpmon(switcheroo_Tuplesortstate *state,
 #define tuplesort_gettupleslot_pos switcheroo_tuplesort_gettupleslot_pos
 #define tuplesort_flush switcheroo_tuplesort_flush
 #define tuplesort_finalize_stats switcheroo_tuplesort_finalize_stats
+#define tuplesort_get_stats switcheroo_tuplesort_get_stats
 #define tuplesort_rescan_pos switcheroo_tuplesort_rescan_pos
 #define tuplesort_markpos_pos switcheroo_tuplesort_markpos_pos
 #define tuplesort_restorepos_pos switcheroo_tuplesort_restorepos_pos

--- a/src/include/utils/tuplesort_gp.h
+++ b/src/include/utils/tuplesort_gp.h
@@ -64,6 +64,8 @@ extern bool tuplesort_gettupleslot_pos(struct Tuplesortstate *state, TuplesortPo
 
 extern void tuplesort_flush(struct Tuplesortstate *state);
 extern void tuplesort_finalize_stats(struct Tuplesortstate *state);
+extern void tuplesort_get_stats(struct Tuplesortstate *state, const char **sortMethod,
+								const char **spaceType, long *spaceUsed);
 
 /*
  * These routines may only be called if randomAccess was specified 'true'.

--- a/src/include/utils/tuplesort_mk.h
+++ b/src/include/utils/tuplesort_mk.h
@@ -81,6 +81,8 @@ extern bool tuplesort_skiptuples_mk(Tuplesortstate_mk *state, int64 ntuples, boo
 extern void tuplesort_end_mk(Tuplesortstate_mk *state);
 extern void tuplesort_flush_mk(Tuplesortstate_mk *state);
 extern void tuplesort_finalize_stats_mk(Tuplesortstate_mk *state);
+extern void tuplesort_get_stats_mk(Tuplesortstate_mk *state, const char **sortMethod,
+									const char **spaceType, long *spaceUsed);
 
 
 extern void tuplesort_rescan_mk(Tuplesortstate_mk *state);

--- a/src/test/regress/expected/misc_jiras.out
+++ b/src/test/regress/expected/misc_jiras.out
@@ -1,4 +1,5 @@
 drop schema if exists misc_jiras;
+NOTICE:  schema "misc_jiras" does not exist, skipping
 create schema misc_jiras;
 --
 -- Test backward scanning of tuplestore spill files.
@@ -11,11 +12,21 @@ create schema misc_jiras;
 --
 create table misc_jiras.t1 (c1 int, c2 text, c3 smallint) distributed by (c1);
 insert into misc_jiras.t1 select i % 13, md5(i::text), i % 3
-  from generate_series(1, 20000) i;
--- tuplestore uses work_mem to control the in-memory data size, set a small
--- value to trigger the spilling.
-set work_mem to '64kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
+  from generate_series(1, 80000) i;
+-- tuplestore in windowagg uses statement_mem to control the in-memory data size,
+-- set a small value to trigger the spilling.
+set statement_mem to '1200kB';
+-- Inject fault at 'winagg_after_spool_tuples' to show that the tuplestore spills
+-- to disk.
+select gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
+  from gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
 select sum(cc) from (
     select c1
          , c2
@@ -27,10 +38,23 @@ select sum(cc) from (
       from misc_jiras.t1
      group by 1, 2
 ) tt;
+NOTICE:  winagg: tuplestore spilled to disk  (seg1 slice1 127.0.0.1:6003 pid=175883)
+NOTICE:  winagg: tuplestore spilled to disk  (seg0 slice1 127.0.0.1:6002 pid=175882)
+NOTICE:  winagg: tuplestore spilled to disk  (seg2 slice1 127.0.0.1:6004 pid=175884)
    sum   
 ---------
- 10006.5
+ 40006.5
 (1 row)
 
-reset work_mem;
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
+select gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
+  from gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+reset statement_mem;
+drop table misc_jiras.t1;
+drop schema misc_jiras;

--- a/src/test/regress/expected/statement_mem_for_windowagg.out
+++ b/src/test/regress/expected/statement_mem_for_windowagg.out
@@ -1,0 +1,269 @@
+CREATE TABLE dummy_table(x int, y int) DISTRIBUTED BY (y);
+INSERT INTO dummy_table SELECT generate_series(0, 20000), 0;
+INSERT INTO dummy_table SELECT generate_series(0, 20000), 3;
+INSERT INTO dummy_table SELECT generate_series(0, 20000), 10;
+-- 1. Test that if we set statement_mem to a larger value, the tuplestore
+-- for caching the tuples in partition used in WindowAgg is able to be fitted
+-- in memory.
+SET statement_mem TO '2048kB';
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+EXPLAIN ANALYZE SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
+NOTICE:  winagg: tuplestore fitted in memory  (seg2 slice1 127.0.0.1:6004 pid=221533)
+NOTICE:  winagg: tuplestore fitted in memory  (seg1 slice1 127.0.0.1:6003 pid=221532)
+NOTICE:  winagg: tuplestore fitted in memory  (seg0 slice1 127.0.0.1:6002 pid=221531)
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1651.86..2001.88 rows=20001 width=8) (actual time=14.724..24.775 rows=60003 loops=1)
+   ->  WindowAgg  (cost=1651.86..2001.88 rows=6667 width=8) (actual time=19.943..23.982 rows=20001 loops=1)
+         Partition By: y
+         ->  Sort  (cost=1651.86..1701.86 rows=6667 width=8) (actual time=10.407..13.232 rows=20001 loops=1)
+               Sort Key: y
+               Sort Method:  external sort  Disk: 960kB
+               ->  Seq Scan on dummy_table  (cost=0.00..223.01 rows=6667 width=8) (actual time=0.015..1.729 rows=20001 loops=1)
+ Planning time: 0.087 ms
+   (slice0)    Executor memory: 119K bytes.
+ * (slice1)    Executor memory: 2920K bytes avg x 3 workers, 2920K bytes max (seg0).  Work_mem: 1698K bytes max, 1589K bytes wanted.
+ Memory used:  2048kB
+ Memory wanted:  3376kB
+ Optimizer: Postgres query optimizer
+ Execution time: 29.057 ms
+(14 rows)
+
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+-- 2. Test that if we set statement_mem to a smaller value, the tuplestore
+-- for caching the tuples in partition used in WindowAgg will be spilled to disk.
+SET statement_mem TO '1024kB';
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+EXPLAIN ANALYZE SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
+NOTICE:  winagg: tuplestore spilled to disk  (seg2 slice1 127.0.0.1:6004 pid=221533)
+NOTICE:  winagg: tuplestore spilled to disk  (seg1 slice1 127.0.0.1:6003 pid=221532)
+NOTICE:  winagg: tuplestore spilled to disk  (seg0 slice1 127.0.0.1:6002 pid=221531)
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1651.86..2001.88 rows=20001 width=8) (actual time=16.669..40.162 rows=60003 loops=1)
+   ->  WindowAgg  (cost=1651.86..2001.88 rows=6667 width=8) (actual time=32.360..37.932 rows=20001 loops=1)
+         Partition By: y
+         ->  Sort  (cost=1651.86..1701.86 rows=6667 width=8) (actual time=12.260..15.535 rows=20001 loops=1)
+               Sort Key: y
+               Sort Method:  external sort  Disk: 960kB
+               ->  Seq Scan on dummy_table  (cost=0.00..223.01 rows=6667 width=8) (actual time=0.022..3.808 rows=20001 loops=1)
+ Planning time: 0.096 ms
+   (slice0)    Executor memory: 119K bytes.
+ * (slice1)    Executor memory: 1595K bytes avg x 3 workers, 1595K bytes max (seg0).  Work_mem: 956K bytes max, 1680K bytes wanted.
+ Memory used:  1024kB
+ Memory wanted:  3558kB
+ Optimizer: Postgres query optimizer
+ Execution time: 44.165 ms
+(14 rows)
+
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+-- 3. Test that if we set statement_mem to a smaller value, the tuplesort
+-- operation in DISTINCT-qualified WindowAgg will be spilled to disk.
+SET statement_mem TO '1024kB';
+-- MK-Sort
+SET gp_enable_mk_sort TO 'on';
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
+NOTICE:  distinct winagg sortstats: sort operation (mk-sort) spilled to disk  (seg0 slice1 127.0.0.1:6002 pid=221531)
+NOTICE:  distinct winagg sortstats: sort operation (mk-sort) spilled to disk  (seg1 slice1 127.0.0.1:6003 pid=221532)
+NOTICE:  distinct winagg sortstats: sort operation (mk-sort) spilled to disk  (seg2 slice1 127.0.0.1:6004 pid=221533)
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1651.86..2001.88 rows=20001 width=8) (actual time=27.430..102.601 rows=60003 loops=1)
+   ->  WindowAgg  (cost=1651.86..2001.88 rows=6667 width=8) (actual time=27.070..30.054 rows=20001 loops=1)
+         Partition By: y
+         ->  Sort  (cost=1651.86..1701.86 rows=6667 width=8) (actual time=5.796..7.671 rows=20001 loops=1)
+               Sort Key: y
+               Sort Method:  external sort  Disk: 960kB
+               ->  Seq Scan on dummy_table  (cost=0.00..223.01 rows=6667 width=8) (actual time=0.012..1.713 rows=20001 loops=1)
+ Planning time: 0.070 ms
+   (slice0)    Executor memory: 119K bytes.
+ * (slice1)    Executor memory: 2057K bytes avg x 3 workers, 2057K bytes max (seg0).  Work_mem: 956K bytes max, 1680K bytes wanted.
+ Memory used:  1024kB
+ Memory wanted:  3558kB
+ Optimizer: Postgres query optimizer
+ Execution time: 106.632 ms
+(14 rows)
+
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+-- PG-Sort
+SET gp_enable_mk_sort TO 'off';
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
+NOTICE:  distinct winagg sortstats: sort operation (pg-sort) spilled to disk  (seg0 slice1 127.0.0.1:6002 pid=221531)
+NOTICE:  distinct winagg sortstats: sort operation (pg-sort) spilled to disk  (seg1 slice1 127.0.0.1:6003 pid=221532)
+NOTICE:  distinct winagg sortstats: sort operation (pg-sort) spilled to disk  (seg2 slice1 127.0.0.1:6004 pid=221533)
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1651.86..2001.88 rows=20001 width=8) (actual time=26.262..40.608 rows=60003 loops=1)
+   ->  WindowAgg  (cost=1651.86..2001.88 rows=6667 width=8) (actual time=25.889..29.773 rows=20001 loops=1)
+         Partition By: y
+         ->  Sort  (cost=1651.86..1701.86 rows=6667 width=8) (actual time=7.518..9.707 rows=20001 loops=1)
+               Sort Key: y
+               Sort Method:  external sort  Disk: 960kB
+               ->  Seq Scan on dummy_table  (cost=0.00..223.01 rows=6667 width=8) (actual time=0.015..2.262 rows=20001 loops=1)
+ Planning time: 0.082 ms
+   (slice0)    Executor memory: 119K bytes.
+ * (slice1)    Executor memory: 2068K bytes avg x 3 workers, 2068K bytes max (seg0).  Work_mem: 959K bytes max, 1394K bytes wanted.
+ Memory used:  1024kB
+ Memory wanted:  2987kB
+ Optimizer: Postgres query optimizer
+ Execution time: 46.829 ms
+(14 rows)
+
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+-- 4. Test that if we set statement_mem to a larger value, the tuplesort
+-- operation in DISTINCT-qualified WindowAgg is able to be fitted in memory.
+SET statement_mem TO '2048kB';
+-- MK-Sort
+SET gp_enable_mk_sort TO 'on';
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
+NOTICE:  distinct winagg sortstats: sort operation (mk-sort) fitted in memory  (seg0 slice1 127.0.0.1:6002 pid=221531)
+NOTICE:  distinct winagg sortstats: sort operation (mk-sort) fitted in memory  (seg2 slice1 127.0.0.1:6004 pid=221533)
+NOTICE:  distinct winagg sortstats: sort operation (mk-sort) fitted in memory  (seg1 slice1 127.0.0.1:6003 pid=221532)
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1651.86..2001.88 rows=20001 width=8) (actual time=27.508..55.269 rows=60003 loops=1)
+   ->  WindowAgg  (cost=1651.86..2001.88 rows=6667 width=8) (actual time=27.094..31.712 rows=20001 loops=1)
+         Partition By: y
+         ->  Sort  (cost=1651.86..1701.86 rows=6667 width=8) (actual time=10.711..13.087 rows=20001 loops=1)
+               Sort Key: y
+               Sort Method:  external sort  Disk: 960kB
+               ->  Seq Scan on dummy_table  (cost=0.00..223.01 rows=6667 width=8) (actual time=0.015..2.219 rows=20001 loops=1)
+ Planning time: 0.088 ms
+   (slice0)    Executor memory: 119K bytes.
+ * (slice1)    Executor memory: 3696K bytes avg x 3 workers, 3696K bytes max (seg0).  Work_mem: 1698K bytes max, 1589K bytes wanted.
+ Memory used:  2048kB
+ Memory wanted:  3376kB
+ Optimizer: Postgres query optimizer
+ Execution time: 60.908 ms
+(14 rows)
+
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+-- PG-Sort
+SET gp_enable_mk_sort TO 'off';
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
+NOTICE:  distinct winagg sortstats: sort operation (pg-sort) fitted in memory  (seg1 slice1 127.0.0.1:6003 pid=221532)
+NOTICE:  distinct winagg sortstats: sort operation (pg-sort) fitted in memory  (seg0 slice1 127.0.0.1:6002 pid=221531)
+NOTICE:  distinct winagg sortstats: sort operation (pg-sort) fitted in memory  (seg2 slice1 127.0.0.1:6004 pid=221533)
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1651.86..2001.88 rows=20001 width=8) (actual time=16.602..38.618 rows=60003 loops=1)
+   ->  WindowAgg  (cost=1651.86..2001.88 rows=6667 width=8) (actual time=31.054..36.680 rows=20001 loops=1)
+         Partition By: y
+         ->  Sort  (cost=1651.86..1701.86 rows=6667 width=8) (actual time=14.152..18.670 rows=20001 loops=1)
+               Sort Key: y
+               Sort Method:  external sort  Disk: 960kB
+               ->  Seq Scan on dummy_table  (cost=0.00..223.01 rows=6667 width=8) (actual time=0.025..4.390 rows=20001 loops=1)
+ Planning time: 0.078 ms
+   (slice0)    Executor memory: 119K bytes.
+ * (slice1)    Executor memory: 3688K bytes avg x 3 workers, 3688K bytes max (seg0).  Work_mem: 1690K bytes max, 1394K bytes wanted.
+ Memory used:  2048kB
+ Memory wanted:  2987kB
+ Optimizer: Postgres query optimizer
+ Execution time: 42.928 ms
+(14 rows)
+
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+-- Do some clean-ups.
+DROP TABLE dummy_table;
+RESET statement_mem;
+RESET gp_enable_mk_sort;

--- a/src/test/regress/expected/statement_mem_for_windowagg.out
+++ b/src/test/regress/expected/statement_mem_for_windowagg.out
@@ -5,7 +5,7 @@ INSERT INTO dummy_table SELECT generate_series(0, 20000), 10;
 -- 1. Test that if we set statement_mem to a larger value, the tuplestore
 -- for caching the tuples in partition used in WindowAgg is able to be fitted
 -- in memory.
-SET statement_mem TO '2048kB';
+SET statement_mem TO '4096kB';
 SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
  gp_inject_fault 
@@ -15,27 +15,15 @@ SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
  Success:
 (3 rows)
 
-EXPLAIN ANALYZE SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
-NOTICE:  winagg: tuplestore fitted in memory  (seg2 slice1 127.0.0.1:6004 pid=221533)
-NOTICE:  winagg: tuplestore fitted in memory  (seg1 slice1 127.0.0.1:6003 pid=221532)
-NOTICE:  winagg: tuplestore fitted in memory  (seg0 slice1 127.0.0.1:6002 pid=221531)
-                                                              QUERY PLAN                                                              
---------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=1651.86..2001.88 rows=20001 width=8) (actual time=14.724..24.775 rows=60003 loops=1)
-   ->  WindowAgg  (cost=1651.86..2001.88 rows=6667 width=8) (actual time=19.943..23.982 rows=20001 loops=1)
-         Partition By: y
-         ->  Sort  (cost=1651.86..1701.86 rows=6667 width=8) (actual time=10.407..13.232 rows=20001 loops=1)
-               Sort Key: y
-               Sort Method:  external sort  Disk: 960kB
-               ->  Seq Scan on dummy_table  (cost=0.00..223.01 rows=6667 width=8) (actual time=0.015..1.729 rows=20001 loops=1)
- Planning time: 0.087 ms
-   (slice0)    Executor memory: 119K bytes.
- * (slice1)    Executor memory: 2920K bytes avg x 3 workers, 2920K bytes max (seg0).  Work_mem: 1698K bytes max, 1589K bytes wanted.
- Memory used:  2048kB
- Memory wanted:  3376kB
- Optimizer: Postgres query optimizer
- Execution time: 29.057 ms
-(14 rows)
+SELECT COUNT(*)
+  FROM (SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table) tt;
+NOTICE:  winagg: tuplestore fitted in memory  (seg1 slice1 127.0.0.1:6003 pid=237568)
+NOTICE:  winagg: tuplestore fitted in memory  (seg0 slice1 127.0.0.1:6002 pid=237567)
+NOTICE:  winagg: tuplestore fitted in memory  (seg2 slice1 127.0.0.1:6004 pid=237569)
+ count 
+-------
+ 60003
+(1 row)
 
 SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
@@ -58,27 +46,15 @@ SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
  Success:
 (3 rows)
 
-EXPLAIN ANALYZE SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
-NOTICE:  winagg: tuplestore spilled to disk  (seg2 slice1 127.0.0.1:6004 pid=221533)
-NOTICE:  winagg: tuplestore spilled to disk  (seg1 slice1 127.0.0.1:6003 pid=221532)
-NOTICE:  winagg: tuplestore spilled to disk  (seg0 slice1 127.0.0.1:6002 pid=221531)
-                                                              QUERY PLAN                                                              
---------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=1651.86..2001.88 rows=20001 width=8) (actual time=16.669..40.162 rows=60003 loops=1)
-   ->  WindowAgg  (cost=1651.86..2001.88 rows=6667 width=8) (actual time=32.360..37.932 rows=20001 loops=1)
-         Partition By: y
-         ->  Sort  (cost=1651.86..1701.86 rows=6667 width=8) (actual time=12.260..15.535 rows=20001 loops=1)
-               Sort Key: y
-               Sort Method:  external sort  Disk: 960kB
-               ->  Seq Scan on dummy_table  (cost=0.00..223.01 rows=6667 width=8) (actual time=0.022..3.808 rows=20001 loops=1)
- Planning time: 0.096 ms
-   (slice0)    Executor memory: 119K bytes.
- * (slice1)    Executor memory: 1595K bytes avg x 3 workers, 1595K bytes max (seg0).  Work_mem: 956K bytes max, 1680K bytes wanted.
- Memory used:  1024kB
- Memory wanted:  3558kB
- Optimizer: Postgres query optimizer
- Execution time: 44.165 ms
-(14 rows)
+SELECT COUNT(*)
+  FROM (SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table) tt;
+NOTICE:  winagg: tuplestore spilled to disk  (seg0 slice1 127.0.0.1:6002 pid=237567)
+NOTICE:  winagg: tuplestore spilled to disk  (seg1 slice1 127.0.0.1:6003 pid=237568)
+NOTICE:  winagg: tuplestore spilled to disk  (seg2 slice1 127.0.0.1:6004 pid=237569)
+ count 
+-------
+ 60003
+(1 row)
 
 SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
@@ -103,27 +79,15 @@ SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
  Success:
 (3 rows)
 
-EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
-NOTICE:  distinct winagg sortstats: sort operation (mk-sort) spilled to disk  (seg0 slice1 127.0.0.1:6002 pid=221531)
-NOTICE:  distinct winagg sortstats: sort operation (mk-sort) spilled to disk  (seg1 slice1 127.0.0.1:6003 pid=221532)
-NOTICE:  distinct winagg sortstats: sort operation (mk-sort) spilled to disk  (seg2 slice1 127.0.0.1:6004 pid=221533)
-                                                              QUERY PLAN                                                               
----------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=1651.86..2001.88 rows=20001 width=8) (actual time=27.430..102.601 rows=60003 loops=1)
-   ->  WindowAgg  (cost=1651.86..2001.88 rows=6667 width=8) (actual time=27.070..30.054 rows=20001 loops=1)
-         Partition By: y
-         ->  Sort  (cost=1651.86..1701.86 rows=6667 width=8) (actual time=5.796..7.671 rows=20001 loops=1)
-               Sort Key: y
-               Sort Method:  external sort  Disk: 960kB
-               ->  Seq Scan on dummy_table  (cost=0.00..223.01 rows=6667 width=8) (actual time=0.012..1.713 rows=20001 loops=1)
- Planning time: 0.070 ms
-   (slice0)    Executor memory: 119K bytes.
- * (slice1)    Executor memory: 2057K bytes avg x 3 workers, 2057K bytes max (seg0).  Work_mem: 956K bytes max, 1680K bytes wanted.
- Memory used:  1024kB
- Memory wanted:  3558kB
- Optimizer: Postgres query optimizer
- Execution time: 106.632 ms
-(14 rows)
+SELECT COUNT(*)
+  FROM (SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table) tt;
+NOTICE:  distinct winagg sortstats: sort operation (mk-sort) spilled to disk  (seg0 slice1 127.0.0.1:6002 pid=237567)
+NOTICE:  distinct winagg sortstats: sort operation (mk-sort) spilled to disk  (seg1 slice1 127.0.0.1:6003 pid=237568)
+NOTICE:  distinct winagg sortstats: sort operation (mk-sort) spilled to disk  (seg2 slice1 127.0.0.1:6004 pid=237569)
+ count 
+-------
+ 60003
+(1 row)
 
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
@@ -145,27 +109,15 @@ SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
  Success:
 (3 rows)
 
-EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
-NOTICE:  distinct winagg sortstats: sort operation (pg-sort) spilled to disk  (seg0 slice1 127.0.0.1:6002 pid=221531)
-NOTICE:  distinct winagg sortstats: sort operation (pg-sort) spilled to disk  (seg1 slice1 127.0.0.1:6003 pid=221532)
-NOTICE:  distinct winagg sortstats: sort operation (pg-sort) spilled to disk  (seg2 slice1 127.0.0.1:6004 pid=221533)
-                                                              QUERY PLAN                                                              
---------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=1651.86..2001.88 rows=20001 width=8) (actual time=26.262..40.608 rows=60003 loops=1)
-   ->  WindowAgg  (cost=1651.86..2001.88 rows=6667 width=8) (actual time=25.889..29.773 rows=20001 loops=1)
-         Partition By: y
-         ->  Sort  (cost=1651.86..1701.86 rows=6667 width=8) (actual time=7.518..9.707 rows=20001 loops=1)
-               Sort Key: y
-               Sort Method:  external sort  Disk: 960kB
-               ->  Seq Scan on dummy_table  (cost=0.00..223.01 rows=6667 width=8) (actual time=0.015..2.262 rows=20001 loops=1)
- Planning time: 0.082 ms
-   (slice0)    Executor memory: 119K bytes.
- * (slice1)    Executor memory: 2068K bytes avg x 3 workers, 2068K bytes max (seg0).  Work_mem: 959K bytes max, 1394K bytes wanted.
- Memory used:  1024kB
- Memory wanted:  2987kB
- Optimizer: Postgres query optimizer
- Execution time: 46.829 ms
-(14 rows)
+SELECT COUNT(*)
+  FROM (SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table) tt;
+NOTICE:  distinct winagg sortstats: sort operation (pg-sort) spilled to disk  (seg0 slice1 127.0.0.1:6002 pid=237567)
+NOTICE:  distinct winagg sortstats: sort operation (pg-sort) spilled to disk  (seg1 slice1 127.0.0.1:6003 pid=237568)
+NOTICE:  distinct winagg sortstats: sort operation (pg-sort) spilled to disk  (seg2 slice1 127.0.0.1:6004 pid=237569)
+ count 
+-------
+ 60003
+(1 row)
 
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
@@ -178,7 +130,7 @@ SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
 
 -- 4. Test that if we set statement_mem to a larger value, the tuplesort
 -- operation in DISTINCT-qualified WindowAgg is able to be fitted in memory.
-SET statement_mem TO '2048kB';
+SET statement_mem TO '4096kB';
 -- MK-Sort
 SET gp_enable_mk_sort TO 'on';
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
@@ -190,27 +142,15 @@ SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
  Success:
 (3 rows)
 
-EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
-NOTICE:  distinct winagg sortstats: sort operation (mk-sort) fitted in memory  (seg0 slice1 127.0.0.1:6002 pid=221531)
-NOTICE:  distinct winagg sortstats: sort operation (mk-sort) fitted in memory  (seg2 slice1 127.0.0.1:6004 pid=221533)
-NOTICE:  distinct winagg sortstats: sort operation (mk-sort) fitted in memory  (seg1 slice1 127.0.0.1:6003 pid=221532)
-                                                              QUERY PLAN                                                              
---------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=1651.86..2001.88 rows=20001 width=8) (actual time=27.508..55.269 rows=60003 loops=1)
-   ->  WindowAgg  (cost=1651.86..2001.88 rows=6667 width=8) (actual time=27.094..31.712 rows=20001 loops=1)
-         Partition By: y
-         ->  Sort  (cost=1651.86..1701.86 rows=6667 width=8) (actual time=10.711..13.087 rows=20001 loops=1)
-               Sort Key: y
-               Sort Method:  external sort  Disk: 960kB
-               ->  Seq Scan on dummy_table  (cost=0.00..223.01 rows=6667 width=8) (actual time=0.015..2.219 rows=20001 loops=1)
- Planning time: 0.088 ms
-   (slice0)    Executor memory: 119K bytes.
- * (slice1)    Executor memory: 3696K bytes avg x 3 workers, 3696K bytes max (seg0).  Work_mem: 1698K bytes max, 1589K bytes wanted.
- Memory used:  2048kB
- Memory wanted:  3376kB
- Optimizer: Postgres query optimizer
- Execution time: 60.908 ms
-(14 rows)
+SELECT COUNT(*)
+  FROM (SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table) tt;
+NOTICE:  distinct winagg sortstats: sort operation (mk-sort) fitted in memory  (seg0 slice1 127.0.0.1:6002 pid=237567)
+NOTICE:  distinct winagg sortstats: sort operation (mk-sort) fitted in memory  (seg1 slice1 127.0.0.1:6003 pid=237568)
+NOTICE:  distinct winagg sortstats: sort operation (mk-sort) fitted in memory  (seg2 slice1 127.0.0.1:6004 pid=237569)
+ count 
+-------
+ 60003
+(1 row)
 
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
@@ -232,27 +172,15 @@ SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
  Success:
 (3 rows)
 
-EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
-NOTICE:  distinct winagg sortstats: sort operation (pg-sort) fitted in memory  (seg1 slice1 127.0.0.1:6003 pid=221532)
-NOTICE:  distinct winagg sortstats: sort operation (pg-sort) fitted in memory  (seg0 slice1 127.0.0.1:6002 pid=221531)
-NOTICE:  distinct winagg sortstats: sort operation (pg-sort) fitted in memory  (seg2 slice1 127.0.0.1:6004 pid=221533)
-                                                              QUERY PLAN                                                              
---------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=1651.86..2001.88 rows=20001 width=8) (actual time=16.602..38.618 rows=60003 loops=1)
-   ->  WindowAgg  (cost=1651.86..2001.88 rows=6667 width=8) (actual time=31.054..36.680 rows=20001 loops=1)
-         Partition By: y
-         ->  Sort  (cost=1651.86..1701.86 rows=6667 width=8) (actual time=14.152..18.670 rows=20001 loops=1)
-               Sort Key: y
-               Sort Method:  external sort  Disk: 960kB
-               ->  Seq Scan on dummy_table  (cost=0.00..223.01 rows=6667 width=8) (actual time=0.025..4.390 rows=20001 loops=1)
- Planning time: 0.078 ms
-   (slice0)    Executor memory: 119K bytes.
- * (slice1)    Executor memory: 3688K bytes avg x 3 workers, 3688K bytes max (seg0).  Work_mem: 1690K bytes max, 1394K bytes wanted.
- Memory used:  2048kB
- Memory wanted:  2987kB
- Optimizer: Postgres query optimizer
- Execution time: 42.928 ms
-(14 rows)
+SELECT COUNT(*)
+  FROM (SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table) tt;
+NOTICE:  distinct winagg sortstats: sort operation (pg-sort) fitted in memory  (seg2 slice1 127.0.0.1:6004 pid=237569)
+NOTICE:  distinct winagg sortstats: sort operation (pg-sort) fitted in memory  (seg0 slice1 127.0.0.1:6002 pid=237567)
+NOTICE:  distinct winagg sortstats: sort operation (pg-sort) fitted in memory  (seg1 slice1 127.0.0.1:6003 pid=237568)
+ count 
+-------
+ 60003
+(1 row)
 
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -55,9 +55,11 @@ test: gpcopy_encoding gp_create_table gp_create_view window_views create_table_l
 # below test(s) inject faults so each of them need to be in a separate group
 test: gpcopy
 
-test: filter gp_combocid gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var gp_explain distributed_transactions explain_format misc_jiras direct_dispatch_explain_analyze
+test: filter gp_combocid gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var gp_explain distributed_transactions explain_format direct_dispatch_explain_analyze
 # below test(s) inject faults so each of them need to be in a separate group
 test: guc_gp
+test: misc_jiras
+test: statement_mem_for_windowagg
 # namespace_gp test will show diff if concurrent tests use temporary tables.
 # So run it separately.
 test: namespace_gp

--- a/src/test/regress/sql/statement_mem_for_windowagg.sql
+++ b/src/test/regress/sql/statement_mem_for_windowagg.sql
@@ -6,12 +6,13 @@ INSERT INTO dummy_table SELECT generate_series(0, 20000), 10;
 -- 1. Test that if we set statement_mem to a larger value, the tuplestore
 -- for caching the tuples in partition used in WindowAgg is able to be fitted
 -- in memory.
-SET statement_mem TO '2048kB';
+SET statement_mem TO '4096kB';
 
 SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
 
-EXPLAIN ANALYZE SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
+SELECT COUNT(*)
+  FROM (SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table) tt;
 
 SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
@@ -23,7 +24,8 @@ SET statement_mem TO '1024kB';
 SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
 
-EXPLAIN ANALYZE SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
+SELECT COUNT(*)
+  FROM (SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table) tt;
 
 SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
@@ -36,7 +38,8 @@ SET gp_enable_mk_sort TO 'on';
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
 
-EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
+SELECT COUNT(*)
+  FROM (SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table) tt;
 
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
@@ -46,20 +49,22 @@ SET gp_enable_mk_sort TO 'off';
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
 
-EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
+SELECT COUNT(*)
+  FROM (SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table) tt;
 
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
 
 -- 4. Test that if we set statement_mem to a larger value, the tuplesort
 -- operation in DISTINCT-qualified WindowAgg is able to be fitted in memory.
-SET statement_mem TO '2048kB';
+SET statement_mem TO '4096kB';
 -- MK-Sort
 SET gp_enable_mk_sort TO 'on';
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
 
-EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
+SELECT COUNT(*)
+  FROM (SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table) tt;
 
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
@@ -69,7 +74,8 @@ SET gp_enable_mk_sort TO 'off';
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
 
-EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
+SELECT COUNT(*)
+  FROM (SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table) tt;
 
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;

--- a/src/test/regress/sql/statement_mem_for_windowagg.sql
+++ b/src/test/regress/sql/statement_mem_for_windowagg.sql
@@ -1,0 +1,79 @@
+CREATE TABLE dummy_table(x int, y int) DISTRIBUTED BY (y);
+INSERT INTO dummy_table SELECT generate_series(0, 20000), 0;
+INSERT INTO dummy_table SELECT generate_series(0, 20000), 3;
+INSERT INTO dummy_table SELECT generate_series(0, 20000), 10;
+
+-- 1. Test that if we set statement_mem to a larger value, the tuplestore
+-- for caching the tuples in partition used in WindowAgg is able to be fitted
+-- in memory.
+SET statement_mem TO '2048kB';
+
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+EXPLAIN ANALYZE SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
+
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+-- 2. Test that if we set statement_mem to a smaller value, the tuplestore
+-- for caching the tuples in partition used in WindowAgg will be spilled to disk.
+SET statement_mem TO '1024kB';
+
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+EXPLAIN ANALYZE SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
+
+SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+-- 3. Test that if we set statement_mem to a smaller value, the tuplesort
+-- operation in DISTINCT-qualified WindowAgg will be spilled to disk.
+SET statement_mem TO '1024kB';
+-- MK-Sort
+SET gp_enable_mk_sort TO 'on';
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
+
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+-- PG-Sort
+SET gp_enable_mk_sort TO 'off';
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
+
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+-- 4. Test that if we set statement_mem to a larger value, the tuplesort
+-- operation in DISTINCT-qualified WindowAgg is able to be fitted in memory.
+SET statement_mem TO '2048kB';
+-- MK-Sort
+SET gp_enable_mk_sort TO 'on';
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
+
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+-- PG-Sort
+SET gp_enable_mk_sort TO 'off';
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+
+EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
+
+SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
+  FROM gp_segment_configuration WHERE role='p' AND content>=0;
+-- Do some clean-ups.
+DROP TABLE dummy_table;
+RESET statement_mem;
+RESET gp_enable_mk_sort;


### PR DESCRIPTION
This patch helps fix incorrect amount of memory allocated for WindowAgg.
Greenplum uses statement_mem rather than work_mem to control the memory
allocated to queries. Besides, test cases are attached for this patch.

This is a backport of ad8b266 from the master branch.

The differences between 6X_STABLE and master are as follows

1. Tuplesort in 6X_STABLE supports multi-key sorting so I've added some
   additional tests for it.
2. tuplesort_get_stats() in 6X_STABLE is a static function, I've made it
   visible from other translation units.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Pass `make installcheck`
