### PR TITLE
Set statement_mem to a larger value in tests to make pipelines happy.

### DIFF
--- a/src/test/regress/expected/misc_jiras.out
+++ b/src/test/regress/expected/misc_jiras.out
@@ -12,10 +12,10 @@ create schema misc_jiras;
 --
 create table misc_jiras.t1 (c1 int, c2 text, c3 smallint) distributed by (c1);
 insert into misc_jiras.t1 select i % 13, md5(i::text), i % 3
-  from generate_series(1, 20000) i;
+  from generate_series(1, 40000) i;
 -- tuplestore in windowagg uses statement_mem to control the in-memory data size,
 -- set a small value to trigger the spilling.
-set statement_mem to '512kB';
+set statement_mem to '1024kB';
 set extra_float_digits=0; -- the last decimal digits are somewhat random
 -- Inject fault at 'winagg_after_spool_tuples' to show that the tuplestore spills
 -- to disk.
@@ -44,7 +44,7 @@ NOTICE:  winagg: tuplestore spilled to disk  (seg1 slice1 127.0.0.1:7003 pid=547
 NOTICE:  winagg: tuplestore spilled to disk  (seg2 slice1 127.0.0.1:7004 pid=54721)
    sum   
 ---------
- 10006.5
+ 20006.5
 (1 row)
 
 SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)

--- a/src/test/regress/expected/statement_mem_for_windowagg.out
+++ b/src/test/regress/expected/statement_mem_for_windowagg.out
@@ -1,11 +1,11 @@
 CREATE TABLE dummy_table(x int, y int) DISTRIBUTED BY (y);
-INSERT INTO dummy_table SELECT generate_series(0, 10000), 0;
-INSERT INTO dummy_table SELECT generate_series(0, 10000), 3;
-INSERT INTO dummy_table SELECT generate_series(0, 10000), 10;
+INSERT INTO dummy_table SELECT generate_series(0, 20000), 0;
+INSERT INTO dummy_table SELECT generate_series(0, 20000), 3;
+INSERT INTO dummy_table SELECT generate_series(0, 20000), 10;
 -- 1. Test that if we set statement_mem to a larger value, the tuplestore
 -- for caching the tuples in partition used in WindowAgg is able to be fitted
 -- in memory.
-SET statement_mem TO '2048kB';
+SET statement_mem TO '4096kB';
 SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
  gp_inject_fault 
@@ -89,7 +89,7 @@ SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
 
 -- 3. Test that if we set statement_mem to a larger value, the tuplesort
 -- operation in DISTINCT-qualified WindowAgg is able to be fitted in memory.
-SET statement_mem TO '1024kB';
+SET statement_mem TO '4096kB';
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
  gp_inject_fault_infinite 
@@ -131,7 +131,7 @@ SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
 
 -- 4. Test that if we set statement_mem to a smaller value, the tuplesort
 -- operation in DISTINCT-qualified WindowAgg will be spilled to disk.
-SET statement_mem TO '128kB';
+SET statement_mem TO '1024kB';
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
  gp_inject_fault_infinite 

--- a/src/test/regress/sql/misc_jiras.sql
+++ b/src/test/regress/sql/misc_jiras.sql
@@ -13,11 +13,11 @@ create schema misc_jiras;
 
 create table misc_jiras.t1 (c1 int, c2 text, c3 smallint) distributed by (c1);
 insert into misc_jiras.t1 select i % 13, md5(i::text), i % 3
-  from generate_series(1, 20000) i;
+  from generate_series(1, 40000) i;
 
 -- tuplestore in windowagg uses statement_mem to control the in-memory data size,
 -- set a small value to trigger the spilling.
-set statement_mem to '512kB';
+set statement_mem to '1024kB';
 
 set extra_float_digits=0; -- the last decimal digits are somewhat random
 

--- a/src/test/regress/sql/statement_mem_for_windowagg.sql
+++ b/src/test/regress/sql/statement_mem_for_windowagg.sql
@@ -1,12 +1,12 @@
 CREATE TABLE dummy_table(x int, y int) DISTRIBUTED BY (y);
-INSERT INTO dummy_table SELECT generate_series(0, 10000), 0;
-INSERT INTO dummy_table SELECT generate_series(0, 10000), 3;
-INSERT INTO dummy_table SELECT generate_series(0, 10000), 10;
+INSERT INTO dummy_table SELECT generate_series(0, 20000), 0;
+INSERT INTO dummy_table SELECT generate_series(0, 20000), 3;
+INSERT INTO dummy_table SELECT generate_series(0, 20000), 10;
 
 -- 1. Test that if we set statement_mem to a larger value, the tuplestore
 -- for caching the tuples in partition used in WindowAgg is able to be fitted
 -- in memory.
-SET statement_mem TO '2048kB';
+SET statement_mem TO '4096kB';
 
 SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
@@ -30,7 +30,7 @@ SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
 
 -- 3. Test that if we set statement_mem to a larger value, the tuplesort
 -- operation in DISTINCT-qualified WindowAgg is able to be fitted in memory.
-SET statement_mem TO '1024kB';
+SET statement_mem TO '4096kB';
 
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
@@ -42,7 +42,7 @@ SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
 
 -- 4. Test that if we set statement_mem to a smaller value, the tuplesort
 -- operation in DISTINCT-qualified WindowAgg will be spilled to disk.
-SET statement_mem TO '128kB';
+SET statement_mem TO '1024kB';
 
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;


### PR DESCRIPTION
We observed greenplum built without cassert couldn't pass tests. Because
when the gpdb is configured with --enable-cassert, the minimum
statement_mem it accepts is 50kB while if it's configured without
--enable-cassert, the minimum statement_mem it accepts is 1000kB (See:
backend/utils/misc/guc_gp.c).

Some failed pipelines:
gpdb_master_without_asserts/icw_planner_rhel8: https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb_master_without_asserts/jobs/icw_planner_rhel8/builds/145
gpdb_master_without_asserts/icw_gporca_icproxy_rhel8: https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb_master_without_asserts/jobs/icw_gporca_icproxy_rhel8/builds/145

This patch is trying to make them happy.

## Here are some reminders before you submit the pull request
- [x] Pass `make installcheck`
