### PR TITLE
[6X] make ALTER TABLE EXPAND PARTITION PREPARE reentrant

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -4755,11 +4755,12 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 				{
 					if (rel->rd_cdbpolicy->numsegments == getgpsegmentCount())
 					{
-						ereport(ERROR,
-								(errcode(ERRCODE_WRONG_OBJECT_TYPE),
-										errmsg("cannot expand partition table prepare \"%s\"",
-											   RelationGetRelationName(rel)),
-										errdetail("table has already been expanded partiton prepare")));
+						ereport(NOTICE,
+								(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+										errmsg("skipped, table \"%s\" has already been expanded partiton prepare",
+											   RelationGetRelationName(rel))));
+						pass = AT_PASS_MISC;    /* We do nothing here */
+						break;
 					}
 					if (ps != PART_STATUS_ROOT)
 					{

--- a/src/test/regress/expected/partition_expand.out
+++ b/src/test/regress/expected/partition_expand.out
@@ -99,8 +99,7 @@ select gp_segment_id, localoid::regclass, policytype, numsegments, distkey, dist
 (12 rows)
 
 alter table t_hash_partition expand partition prepare;
-ERROR:  cannot expand partition table prepare "t_hash_partition"
-DETAIL:  table has already been expanded partiton prepare
+NOTICE:  skipped, table "t_hash_partition" has already been expanded partiton prepare
 --dml of parent table
 select count(*) from t_hash_partition;
  count 
@@ -270,8 +269,7 @@ select gp_segment_id, localoid::regclass, policytype, numsegments, distkey, dist
 
 		
 alter table t_randomly_partition expand partition prepare;
-ERROR:  cannot expand partition table prepare "t_randomly_partition"
-DETAIL:  table has already been expanded partiton prepare
+NOTICE:  skipped, table "t_randomly_partition" has already been expanded partiton prepare
 --dml of parent table
 select count(*) from t_randomly_partition;
  count 
@@ -529,8 +527,7 @@ select gp_segment_id, localoid::regclass, policytype, numsegments, distkey, dist
 (30 rows)
 
 alter table t_hash_subpartition expand partition prepare;
-ERROR:  cannot expand partition table prepare "t_hash_subpartition"
-DETAIL:  table has already been expanded partiton prepare
+NOTICE:  skipped, table "t_hash_subpartition" has already been expanded partiton prepare
 --dml of parent table
 select count(*) from t_hash_subpartition;
  count 


### PR DESCRIPTION
gpexpand in partition table has two-stage:

1. if the root table is hash distributed, change the leaf tables to randomly distributed, 
that's what `ALTER TABLE EXPAND PARTITION PREPARE` does. And extract the table 
info into `gpexpand.status_detail`. 
2. perform actual expansion, moving data to correct segment.

For the current implementation, we can not re-enter `ALTER TABLE EXPAND PARTITION PREPARE` 
because it's not reentrant. So if we failed at stage-1 for some reason, like share memory 
exhausted, we cannot re-execute the expand script, it's a problem.

So this PR make `ALTER TABLE EXPAND PARTITION PREPARE` reentrant by changing the 
`ERROR` to `NOTICE`, just leave a NOTICE message instead of aborting the transaction.