### PR TITLE
Insert more data to make tuplestore spill in regress/misc_jiras.sql.

### DIFF
--- a/src/test/regress/expected/misc_jiras.out
+++ b/src/test/regress/expected/misc_jiras.out
@@ -12,7 +12,7 @@ create schema misc_jiras;
 --
 create table misc_jiras.t1 (c1 int, c2 text, c3 smallint) distributed by (c1);
 insert into misc_jiras.t1 select i % 13, md5(i::text), i % 3
-  from generate_series(1, 40000) i;
+  from generate_series(1, 60000) i;
 -- tuplestore in windowagg uses statement_mem to control the in-memory data size,
 -- set a small value to trigger the spilling.
 set statement_mem to '1024kB';
@@ -44,7 +44,7 @@ NOTICE:  winagg: tuplestore spilled to disk  (seg1 slice1 127.0.0.1:7003 pid=547
 NOTICE:  winagg: tuplestore spilled to disk  (seg2 slice1 127.0.0.1:7004 pid=54721)
    sum   
 ---------
- 20006.5
+ 30006.5
 (1 row)
 
 SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)

--- a/src/test/regress/sql/misc_jiras.sql
+++ b/src/test/regress/sql/misc_jiras.sql
@@ -13,7 +13,7 @@ create schema misc_jiras;
 
 create table misc_jiras.t1 (c1 int, c2 text, c3 smallint) distributed by (c1);
 insert into misc_jiras.t1 select i % 13, md5(i::text), i % 3
-  from generate_series(1, 40000) i;
+  from generate_series(1, 60000) i;
 
 -- tuplestore in windowagg uses statement_mem to control the in-memory data size,
 -- set a small value to trigger the spilling.


### PR DESCRIPTION
This is a follow-up patch for ad8b266 and a039910 to make pipelines
happy.

Previous commits are causing CI failure.
See: https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb_master_without_asserts/jobs/icw_planner_icproxy_ubuntu18.04/builds/603

## Here are some reminders before you submit the pull request
- [x] Pass `make installcheck`
