### PR TITLE
Resolve a FIXME about not opening table in CondUpgradeRelLock() when possible

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -2825,8 +2825,8 @@ gpdb::GPDBLockRelationOid(Oid reloid, LOCKMODE lockmode)
 {
 	GP_WRAP_START;
 	{
-		bool lockUpgraded;
-		lockmode = UpgradeRelLockIfNecessary(reloid, lockmode, &lockUpgraded);
+		lockmode =
+			UpgradeRelLockAndReuseRelIfNecessary(reloid, nullptr, lockmode);
 		LockRelationOid(reloid, lockmode);
 	}
 	GP_WRAP_END;

--- a/src/include/storage/lmgr.h
+++ b/src/include/storage/lmgr.h
@@ -115,8 +115,7 @@ extern const char *GetLockNameFromTagType(uint16 locktag_type);
 /* Knowledge about which locktags describe temp objects */
 extern bool LockTagIsTemp(const LOCKTAG *tag);
 
-extern bool CondUpgradeRelLock(Oid relid);
-extern int UpgradeRelLockIfNecessary(Oid relid, int lockmode, bool *lockUpgraded);
+extern LOCKMODE UpgradeRelLockAndReuseRelIfNecessary(Oid relid, Relation *relptr, LOCKMODE lockmode);
 
 extern void GxactLockTableInsert(DistributedTransactionId xid);
 extern void GxactLockTableWait(DistributedTransactionId xid);


### PR DESCRIPTION
Currently `CondUpgradeRelLock()` always needs to open and close table to check if it's an AO table. Try to avoid that when we can pass an opened table in. 

And, modify `UpgradeRelLockIfNecessary()` too so the caller can pass opened table in, in which case if there's a need to upgrade, we will re-open the table.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
