### PR TITLE
run ALTER TABLE EXPAND PARTITION PREPARE in separate transactions

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1652,7 +1652,7 @@ WHERE
                 ALTER TABLE %s EXPAND PARTITION PREPARE;
             """ % (row.relname)
             self.logger.debug(prepare_cmd)
-            dbconn.execSQL(table_conn, prepare_cmd, autocommit=False)
+            dbconn.execSQL(table_conn, prepare_cmd, autocommit=True)
 
         src_bytes_str = "0" if self.options.simple_progress else "pg_relation_size(c.oid)"
         get_status_detail_cmd = """


### PR DESCRIPTION
For the current stage-1 implementation in gpexpand, we run ALTER TABLE EXPAND PARTITION 
PREPARE in a single transaction with the database as the dimension, then when there are many 
partition tables in a database, the ALTER TABLE statement will hold a large number of locks, 
which is likely to cause shared memory exhaustion.

Therefore, we split it into multiple transactions to execute separately, this does not break existing 
processes. In a local performance test, 500 partitioned tables with 700 subtables took about 21 
minutes to complete all preparation. I think it's acceptable.

Here are some performance tests result between run `ALTER TABLE EXPAND PARTITION PREPARE` in a 
single transaction and in a multi transaction:

#### 10 partition tables, each with 700 subtables, total 7000:

single transaction spent: 13.754475116729736s
multi transaction spent: 13.463390111923218s

#### 50 partition tables, each with 700 subtables, total 35000:

single transaction spent: 76.02462005615234s
multi transaction spent: 69.63282895088196s

Therefore, we can get a basic conclusion that the PR does not introduce performance problems.

At the same time, there is no need to add additional tests, `gpexpand.feature` is enough to cover 
this.




