### PR TITLE
[6X] run ALTER TABLE EXPAND PARTITION PREPARE in separate transactions

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1672,6 +1672,7 @@ WHERE
             """ % (row[0])
             self.logger.debug(prepare_cmd)
             dbconn.execSQL(table_conn, prepare_cmd)
+            table_conn.commit()
 
         src_bytes_str = "0" if self.options.simple_progress else "pg_relation_size(quote_ident(n.nspname) || '.' || quote_ident(c.relname))"
 


### PR DESCRIPTION
For the current stage-1 implementation in gpexapnd, we run ALTER TABLE EXPAND PARTITION 
PREPARE in a single transaction with the database as the dimension, then when there are many 
partition tables in a database, the ALTER TABLE statement will hold a large number of locks, 
which is likely to cause shared memory exhaustion.

Therefore, we split it into multiple transactions to execute separately, this does not break existing 
processes. In a local performance test, 500 partitioned tables with 700 subtables took about 21 
minutes to complete all preparation. I think it's acceptable.