### PR TITLE
(Backport to 6X) Make svec_l2_eq strict function to handle NULL properly.

### DIFF
--- a/gpcontrib/Makefile
+++ b/gpcontrib/Makefile
@@ -85,11 +85,6 @@ installcheck:
 		$(MAKE) -C gpmapreduce installcheck; \
 	fi
 	if [ "$(enable_orafce)" = "yes" ]; then $(MAKE) -C orafce installcheck; fi
-
-ifeq "$(with_zstd)" "yes"
-	$(MAKE) -C zstd installcheck
-endif
-
-ifeq "$(with_quicklz)" "yes"
-	$(MAKE) -C quicklz installcheck
-endif
+	if [ "$(with_zstd)" = "yes" ]; then $(MAKE) -C zstd installcheck; fi
+	if [ "$(with_quicklz)" = "yes" ]; then $(MAKE) -C quicklz installcheck; fi
+	$(MAKE) -C gp_sparse_vector installcheck

--- a/gpcontrib/gp_sparse_vector/expected/gp_svec.out
+++ b/gpcontrib/gp_sparse_vector/expected/gp_svec.out
@@ -249,5 +249,38 @@ SELECT vec_median('{9960,9926,10053,9993,10080,10050,9938,9941,10030,10029}:{1,9
           5
 (1 row)
 
+-- Test operator == as a joining condition when this column could be null. (See issue #12986)
+SELECT DISTINCT a.table_name, a.character_maximum_length
+FROM information_schema.columns a INNER JOIN information_schema.columns b ON a.table_name=b.table_name AND a.column_name=b.column_name 
+WHERE a.character_maximum_length == b.character_maximum_length ORDER BY a.table_name;
+            table_name             | character_maximum_length 
+-----------------------------------+--------------------------
+ administrable_role_authorizations |                        3
+ applicable_roles                  |                        3
+ attributes                        |                        3
+ column_privileges                 |                        3
+ columns                           |                        3
+ domain_constraints                |                        3
+ parameters                        |                        3
+ role_column_grants                |                        3
+ role_routine_grants               |                        3
+ role_table_grants                 |                        3
+ role_udt_grants                   |                        3
+ role_usage_grants                 |                        3
+ routine_privileges                |                        3
+ routines                          |                        3
+ sequences                         |                        3
+ sql_features                      |                        3
+ sql_packages                      |                        3
+ sql_parts                         |                        3
+ table_constraints                 |                        3
+ table_privileges                  |                        3
+ tables                            |                        3
+ udt_privileges                    |                        3
+ usage_privileges                  |                        3
+ user_defined_types                |                        3
+ views                             |                        3
+(25 rows)
+
 DROP EXTENSION gp_sparse_vector;
-SET search_path TO DEFAULT;
+RESET search_path;

--- a/gpcontrib/gp_sparse_vector/gp_sparse_vector--1.0.1.sql
+++ b/gpcontrib/gp_sparse_vector/gp_sparse_vector--1.0.1.sql
@@ -320,13 +320,13 @@ CREATE AGGREGATE median_inmemory (float8) (
 );
 
 -- Comparisons based on L2 Norm
-CREATE OR REPLACE FUNCTION svec_l2_lt(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_lt' LANGUAGE C IMMUTABLE;
-CREATE OR REPLACE FUNCTION svec_l2_le(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_le' LANGUAGE C IMMUTABLE;
-CREATE OR REPLACE FUNCTION svec_l2_eq(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_eq' LANGUAGE C IMMUTABLE;
-CREATE OR REPLACE FUNCTION svec_l2_ne(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_ne' LANGUAGE C IMMUTABLE;
-CREATE OR REPLACE FUNCTION svec_l2_gt(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_gt' LANGUAGE C IMMUTABLE;
-CREATE OR REPLACE FUNCTION svec_l2_ge(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_ge' LANGUAGE C IMMUTABLE;
-CREATE OR REPLACE FUNCTION svec_l2_cmp(svec,svec) RETURNS integer AS 'gp_svec.so', 'svec_l2_cmp' LANGUAGE C IMMUTABLE;
+CREATE OR REPLACE FUNCTION svec_l2_lt(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_lt' STRICT LANGUAGE C IMMUTABLE;
+CREATE OR REPLACE FUNCTION svec_l2_le(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_le' STRICT LANGUAGE C IMMUTABLE;
+CREATE OR REPLACE FUNCTION svec_l2_eq(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_eq' STRICT LANGUAGE C IMMUTABLE;
+CREATE OR REPLACE FUNCTION svec_l2_ne(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_ne' STRICT LANGUAGE C IMMUTABLE;
+CREATE OR REPLACE FUNCTION svec_l2_gt(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_gt' STRICT LANGUAGE C IMMUTABLE;
+CREATE OR REPLACE FUNCTION svec_l2_ge(svec,svec) RETURNS bool AS 'gp_svec.so', 'svec_l2_ge' STRICT LANGUAGE C IMMUTABLE;
+CREATE OR REPLACE FUNCTION svec_l2_cmp(svec,svec) RETURNS integer AS 'gp_svec.so', 'svec_l2_cmp' STRICT LANGUAGE C IMMUTABLE;
 
 CREATE OPERATOR < (
 	leftarg = svec, rightarg = svec, procedure = svec_l2_lt,

--- a/gpcontrib/gp_sparse_vector/sql/gp_svec.sql
+++ b/gpcontrib/gp_sparse_vector/sql/gp_svec.sql
@@ -82,5 +82,10 @@ SELECT array_agg(a) FROM (SELECT trunc(7) a,generate_series(1,100000) ORDER BY a
 SELECT vec_median('{9960,9926,10053,9993,10080,10050,9938,9941,10030,10029}:{1,9,8,7,6,5,4,3,2,0}'::svec);
 SELECT vec_median('{9960,9926,10053,9993,10080,10050,9938,9941,10030,10029}:{1,9,8,7,6,5,4,3,2,0}'::svec::float8[]);
 
+-- Test operator == as a joining condition when this column could be null. (See issue #12986)
+SELECT DISTINCT a.table_name, a.character_maximum_length
+FROM information_schema.columns a INNER JOIN information_schema.columns b ON a.table_name=b.table_name AND a.column_name=b.column_name 
+WHERE a.character_maximum_length == b.character_maximum_length ORDER BY a.table_name;
+
 DROP EXTENSION gp_sparse_vector;
-SET search_path TO DEFAULT;
+RESET search_path;

--- a/src/backend/optimizer/plan/orca.c
+++ b/src/backend/optimizer/plan/orca.c
@@ -132,7 +132,7 @@ optimize_query(Query *parse, ParamListInfo boundParams)
 	 * glob->invalItems, for any functions that are inlined or eliminated
 	 * away. (We will find dependencies to other objects later, after planning).
 	 */
-	pqueryCopy = preprocess_query_optimizer(root, pqueryCopy, boundParams);
+	pqueryCopy = fold_constants(root, pqueryCopy, boundParams, GPOPT_MAX_FOLDED_CONSTANT_SIZE);
 
 	/* Ok, invoke ORCA. */
 	result = GPOPTOptimizedPlan(pqueryCopy, &fUnexpectedFailure);

--- a/src/backend/optimizer/plan/transform.c
+++ b/src/backend/optimizer/plan/transform.c
@@ -50,19 +50,10 @@ static bool safe_to_replace_sirvf_rte(Query *query);
 Query *
 preprocess_query_optimizer(PlannerInfo *root, Query *query, ParamListInfo boundParams)
 {
-#ifdef USE_ASSERT_CHECKING
-	Query *qcopy = (Query *) copyObject(query);
-#endif
-
 	/* fold all constant expressions */
 	Query *res = fold_constants(root, query, boundParams, GPOPT_MAX_FOLDED_CONSTANT_SIZE);
 
-#ifdef USE_ASSERT_CHECKING
-	Assert(equal(qcopy, query) && "Preprocessing should not modify original query object");
-#endif
-
 	return res;
-
 }
 
 /**

--- a/src/backend/optimizer/plan/transform.c
+++ b/src/backend/optimizer/plan/transform.c
@@ -45,18 +45,6 @@ static bool safe_to_replace_sirvf_tle(Query *query);
 static bool safe_to_replace_sirvf_rte(Query *query);
 
 /**
- * Preprocess query structure for consumption by the optimizer
- */
-Query *
-preprocess_query_optimizer(PlannerInfo *root, Query *query, ParamListInfo boundParams)
-{
-	/* fold all constant expressions */
-	Query *res = fold_constants(root, query, boundParams, GPOPT_MAX_FOLDED_CONSTANT_SIZE);
-
-	return res;
-}
-
-/**
  * Normalize query before planning.
  */
 Query *

--- a/src/include/gpopt/utils/gpdbdefs.h
+++ b/src/include/gpopt/utils/gpdbdefs.h
@@ -69,8 +69,6 @@ extern "C" {
 #include "utils/typcache.h"
 #include "utils/uri.h"
 
-extern Query *preprocess_query_optimizer(Query *query,
-										 ParamListInfo boundParams);
 
 extern List *pg_parse_and_rewrite(const char *query_string, Oid *paramTypes,
 								  int iNumParams);

--- a/src/include/optimizer/transform.h
+++ b/src/include/optimizer/transform.h
@@ -21,6 +21,4 @@
 
 extern Query *normalize_query(Query *query);
 
-/* preprocess the query for the optimizer */
-extern Query *preprocess_query_optimizer(PlannerInfo *root, Query *query, ParamListInfo boundParams);
 #endif /* TRANSFORM_H */


### PR DESCRIPTION

This is a re-commit of #12987 due to ICW pieline's installcheck tests failure at orca build. The root cause has been analyzed with details at the end of this PR.

 I appended a commit to disable assert checking between the tweaked query and origin query object, so the behavior is aligned with master. In master branch, this assert check is only performed in `normalizeQuery` stage, but never in `optimizeQuery` stage.


As #12986 mentioned, some binary operators function definition in GP extension `gp_sparse_vector` is not `strict`, which cannot properly handle NULL rows, may cause SIGSEV memory crush as follow:

```
#0  0x00007fdf3f7d74fb in raise () from /data/logs/298723/packcore-postgres.626108.181669.core/lib64/libpthread.so.0

#1  0x0000000000bf8260 in StandardHandlerForSigillSigsegvSigbus_OnMainThread (processName=<optimized out>, postgres_signal_arg=11) at elog.c:5579

#2  <signal handler called>

#3  pg_detoast_datum (datum=0x0) at fmgr.c:2209

#4  0x00007fdf183bec11 in svec_l2_eq () from /data/logs/298723/packcore-postgres.626108.181669.core/ms/dist/gpdb/PROJ/ds/6.17.7/.exec/@sys/lib/postgresql/gp_svec.so

#5  0x00000000008c590b in ExecMakeFunctionResultNoSets (fcache=0x33d19d8, econtext=0x33ddf38, isNull=0x7ffdeb86392f "", isDone=<optimized out>) at execQual.c:2161

#6  0x00000000008c4dc6 in ExecEvalOr (orExpr=<optimized out>, econtext=0x33ddf38, isNull=0x7ffdeb86392f "", isDone=<optimized out>) at execQual.c:3292

#7  0x00000000008c4f2d in ExecEvalCase (caseExpr=0x33d18b8, econtext=0x33ddf38, isNull=0x8a3e252 "", isDone=0x8a3e400) at execQual.c:3498

#8  0x00000000008cf662 in ExecTargetList (isDone=0x0, itemIsDone=0x8a3e3f8, isnull=0x8a3e250 "", values=0x8a3e220, econtext=0x33ddf38, targetlist=0x8a3e368) at execQual.c:6333

#9  ExecProject (projInfo=<optimized out>, isDone=isDone@entry=0x0) at execQual.c:6548

#10 0x00000000008e3ed7 in ExecHashJoin_guts (node=node@entry=0x8a5a100) at nodeHashjoin.c:489

#11 ExecHashJoin (node=node@entry=0x33ddad8) at nodeHashjoin.c:520

#12 0x00000000008c20f8 in ExecProcNode (node=node@entry=0x33ddad8) at execProcnode.c:1078

#13 0x00000000008f0fc0 in ExecSort (node=node@entry=0x33dd3c0) at nodeSort.c:185

#14 0x00000000008c20d8 in ExecProcNode (node=node@entry=0x33dd3c0) at execProcnode.c:1089

#15 0x00000000008b9489 in ExecutePlan (estate=estate@entry=0x33dd0a8, planstate=0x33dd3c0, operati
```

If the operand is a NULL row, pg_detoast_datum will hit a memory segmentation fault. 
This PR fixed this issue and added some test.

This is a backport to 6X branch of PR: #12988

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community


## PR #12987 CI Failure RCA

### RCA

In `src/backend/optimizer/plan/transform.c`, if we enable the `USE_ASSERT_CHECKING`, we need to guarantee we don't modify original query object during the `fold_constants` transform process during query optimizer optimization:

```
/**
 * Preprocess query structure for consumption by the optimizer
 */
Query *
preprocess_query_optimizer(PlannerInfo *root, Query *query, ParamListInfo boundParams)
{
#ifdef USE_ASSERT_CHECKING
	Query *qcopy = (Query *) copyObject(query);
#endif

	/* fold all constant expressions */
	Query *res = fold_constants(root, query, boundParams, GPOPT_MAX_FOLDED_CONSTANT_SIZE);

#ifdef USE_ASSERT_CHECKING
	Assert(equal(qcopy, query) && "Preprocessing should not modify original query object");
#endif

	return res;

}
```

But if the `fold_constants` transform modified the original query, the assert will fail.

### Why Master pipeline doesn't fail?

In master branch, the `fole_constants` transform is performed on the copy of original query, so without mutation the query object, and no check will not fail the assertion:

```
/* create a local copy to hand to the optimizer */
	pqueryCopy = (Query *) copyObject(parse);

/*
	* Pre-process the Query tree before calling optimizer.
	*
	* Constant folding will add dependencies to functions or relations in
	* glob->invalItems, for any functions that are inlined or eliminated
	* away. (We will find dependencies to other objects later, after planning).
	*/
pqueryCopy = fold_constants(root, pqueryCopy, boundParams, GPOPT_MAX_FOLDED_CONSTANT_SIZE);
```

### Why only orca-enabled build failed in 6x pipeline?

See RCA, the `optimize_query` is called in ORCA which performed a `preprocess_query_optimizer` inside:

```
#ifdef USE_ORCA

extern PlannedStmt * optimize_query(Query *parse, ParamListInfo boundParams);

/* create a local copy to hand to the optimizer */
	pqueryCopy = (Query *) copyObject(parse);

	/*
	 * Pre-process the Query tree before calling optimizer. Currently, this
	 * performs only constant folding.
	 *
	 * Constant folding will add dependencies to functions or relations in
	 * glob->invalItems, for any functions that are inlined or eliminated
	 * away. (We will find dependencies to other objects later, after planning).
	 */
	pqueryCopy = preprocess_query_optimizer(root, pqueryCopy, boundParams);
```

And inside the `preprocess_query_optimizer`, there is a check we do not modify the original query object. But in fact, the mutation of query does not matter because it's only a copy instead of original object, see `pqueryCopy` passed above.

# How did the extension modified the original?

```
/*
 * This routine supplies a pointer to a SparseData derived from an SvecType.
 * The SvecType is a serialized structure with fixed memory allocations, so
 * care must be taken not to append to the embedded StringInfo structs
 * without re-serializing the SparseData into the SvecType.
 */
static inline SparseData sdata_from_svec(SvecType *svec)
{
	char *sdataptr   = SVEC_SDATAPTR(svec);
	SparseData sdata = (SparseData)sdataptr;
	sdata->vals  = (StringInfo)SDATA_DATA_SINFO(sdataptr);
	sdata->index = (StringInfo)SDATA_INDEX_SINFO(sdataptr);
	sdata->vals->data   = SVEC_VALS_PTR(svec);
	if (sdata->index->maxlen == 0)
	{
		sdata->index->data = NULL;
	} else
	{
		sdata->index->data  = SVEC_INDEX_PTR(svec);
	}
	return(sdata);
}
```

This function manipulated directly on the original pointer, and multiple pointer type casting performed, what is vital is several fields of original object got written after that, such as `sdata->vals`, `sdata->index` , `sdata->vals->data` and `sdata->index->data`.

### How to fix?

There are several solutions:

1. Rewrite the `sdata_from_svec` function to a copy-object way, instead of pointer type cast in-place.
2. Just remove the `Assert(equal(qcopy, query) && "Preprocessing should not modify original query object");` assertion, as the transform is performed on a copied object of query, the modification doesn't matter.
3. Turn off ORCA in the test at start : `set optimizer= off;` The assertion will not affect ultimate user query.

