### PR TITLE
gpload add distribution key for staging table

### DIFF
--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_base.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_base.py
@@ -539,7 +539,7 @@ def ModifyOutFile(file,old_str,new_str):
     os.remove(file)
     os.rename("%s.bak" % file, file)
 
-Modify_Output_Case = [44,46,51,57,65,219,260,259,76]
+Modify_Output_Case = [44,46,51,57,65,219,260,259]
 
 
 def doTest(num):
@@ -562,10 +562,9 @@ def doTest(num):
         newpat4='ext_gpload_table'
         pat5 = r'[a-zA-Z0-9/\_-]*/gpload.py'  # file location
         newpat5 = 'pathto/gpload.py'
-        pat6 = r'LINE 1: ...[a-z0-9_]*\('
-        newpat6 = 'LINE 1: ...ENCODING_STR('
-        ModifyOutFile(str(num), [pat1,pat2,pat3,pat4,pat5,pat6], [newpat1,newpat2,newpat3,newpat4,newpat5,newpat6])  # some strings in outfile are different each time, such as host and file location
+        # some strings in outfile are different each time, such as host and file location
         # we modify the out file here to make it match the ans file
+        ModifyOutFile(str(num), [pat1,pat2,pat3,pat4,pat5], [newpat1,newpat2,newpat3,newpat4,newpat5])
 
     check_result(file,num=num)
 

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_base.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_base.py
@@ -539,7 +539,7 @@ def ModifyOutFile(file,old_str,new_str):
     os.remove(file)
     os.rename("%s.bak" % file, file)
 
-Modify_Output_Case = [44,46,51,57,65,219,260,259]
+Modify_Output_Case = [44,46,51,57,65,219,260,259,76]
 
 
 def doTest(num):
@@ -562,7 +562,9 @@ def doTest(num):
         newpat4='ext_gpload_table'
         pat5 = r'[a-zA-Z0-9/\_-]*/gpload.py'  # file location
         newpat5 = 'pathto/gpload.py'
-        ModifyOutFile(str(num), [pat1,pat2,pat3,pat4,pat5], [newpat1,newpat2,newpat3,newpat4,newpat5])  # some strings in outfile are different each time, such as host and file location
+        pat6 = r'LINE 1: ...[a-z0-9_]*\('
+        newpat6 = 'LINE 1: ...ENCODING_STR('
+        ModifyOutFile(str(num), [pat1,pat2,pat3,pat4,pat5,pat6], [newpat1,newpat2,newpat3,newpat4,newpat5,newpat6])  # some strings in outfile are different each time, such as host and file location
         # we modify the out file here to make it match the ans file
 
     check_result(file,num=num)

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_schema_and_mode.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_schema_and_mode.py
@@ -884,3 +884,38 @@ def test_544_gpload_mode_merge_update_with_update_condition():
     f.write("\\! gpload -f " + TestBase.mkpath('config/config_file2') + "\n")
     f.write("\\! psql -d reuse_gptest -c 'select * from texttable order by s1, s2, n1;'")
     f.close()
+
+
+@pytest.mark.order(545)
+@TestBase.prepare_before_test(num=545, times=1)
+def test_545_gpload_merge_staging_DK():
+    """545 test gpload merge using target table distribution key as
+    staging table DK as default"""
+    file = TestBase.mkpath('setup.sql')
+    TestBase.runfile(file)
+    TestBase.copy_data('external_file_04.txt', 'data_file.txt')
+    TestBase.write_config_file(mode='merge', file='data_file.txt', table='testtruncate', reuse_tables=True)
+    f = open(TestBase.mkpath('query545.sql'), 'a')
+    f.write("\\! psql -d reuse_gptest -c '\\d staging_gpload_reusable_*'")
+    f.close()
+
+
+@pytest.mark.order(546)
+@TestBase.prepare_before_test(num=546, times=1)
+def test_546_gpload_merge_staging_DK():
+    """546 test gpload merge using match column as staging table DK 
+    when target is DISTRIBUTED RANDOMLY"""
+    file = TestBase.mkpath('setup.sql')
+    TestBase.runfile(file)
+    TestBase.copy_data("external_file_47.txt", "data_file.txt")
+    TestBase.write_config_file(mode='insert', file='data_file.txt', table='testheaderreuse', delimiter="','", reuse_tables=False)
+    match_col = ['field1']
+    update_col = ['field2']
+    TestBase.copy_data("external_file_546.txt", "data_file1.txt")
+    TestBase.write_config_file(mode='merge', file='data_file1.txt', update_columns=update_col,delimiter="','",
+        match_columns=match_col, config='config/config_file1', table='testheaderreuse', reuse_tables=True)
+    f = open(TestBase.mkpath('query546.sql'), 'w')
+    f.write("\\! gpload -f " + TestBase.mkpath('config/config_file') + "\n")
+    f.write("\\! gpload -f " + TestBase.mkpath('config/config_file1') + "\n")
+    f.write("\\! psql -d reuse_gptest -c '\\d staging_gpload_reusable_*'")
+    f.close()

--- a/gpMgmt/bin/gpload_test/gpload2/data/external_file_546.txt
+++ b/gpMgmt/bin/gpload_test/gpload2/data/external_file_546.txt
@@ -1,0 +1,3 @@
+1,"row 1 - OK",file1
+2,"row 2 - OK",newText
+3,"row 3 - new",file1

--- a/gpMgmt/bin/gpload_test/gpload2/query493.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query493.ans
@@ -1,214 +1,198 @@
 TRUNCATE TABLE
-2021-01-04 15:50:36|INFO|gpload session started 2021-01-04 15:50:36
-2021-01-04 15:50:36|INFO|setting schema 'public' for table 'texttable'
-2021-01-04 15:50:36|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_01.txt" -t 30
-2021-01-04 15:50:36|INFO|did not find an external table to reuse. creating ext_gpload_reusable_87f02318_4e61_11eb_aa6b_7085c2381836
-2021-01-04 15:50:36|INFO|running time: 0.13 seconds
-2021-01-04 15:50:36|INFO|rows Inserted          = 9
-2021-01-04 15:50:36|INFO|rows Updated           = 0
-2021-01-04 15:50:36|INFO|data formatting errors = 0
-2021-01-04 15:50:36|INFO|gpload succeeded
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 's1' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-2021-01-04 15:50:36|INFO|gpload session started 2021-01-04 15:50:36
-2021-01-04 15:50:36|INFO|setting schema 'public' for table 'texttable'
-2021-01-04 15:50:36|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_target.txt" -t 30
-2021-01-04 15:50:36|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_ea670ed2951ca1d409fee5af7147a731
-2021-01-04 15:50:36|INFO|did not find an external table to reuse. creating ext_gpload_reusable_881585e0_4e61_11eb_a8c6_7085c2381836
-2021-01-04 15:50:36|INFO|running time: 0.22 seconds
-2021-01-04 15:50:36|INFO|rows Inserted          = 0
-2021-01-04 15:50:36|INFO|rows Updated           = 9
-2021-01-04 15:50:36|INFO|data formatting errors = 0
-2021-01-04 15:50:36|INFO|gpload succeeded
+2022-02-25 15:39:37|INFO|gpload session started 2022-02-25 15:39:37
+2022-02-25 15:39:37|INFO|setting schema 'public' for table 'texttable'
+2022-02-25 15:39:37|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_01.txt" -t 30
+2022-02-25 15:39:37|INFO|did not find an external table to reuse. creating ext_gpload_reusable_1541491e_960e_11ec_9148_0050569ea4ff
+2022-02-25 15:39:37|INFO|running time: 0.05 seconds
+2022-02-25 15:39:37|INFO|rows Inserted          = 9
+2022-02-25 15:39:37|INFO|rows Updated           = 0
+2022-02-25 15:39:37|INFO|data formatting errors = 0
+2022-02-25 15:39:37|INFO|gpload succeeded
+2022-02-25 15:39:37|INFO|gpload session started 2022-02-25 15:39:37
+2022-02-25 15:39:37|INFO|setting schema 'public' for table 'texttable'
+2022-02-25 15:39:37|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_target.txt" -t 30
+2022-02-25 15:39:37|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_bf2513bc4e5c7466f3cd5abecf21f8f4
+2022-02-25 15:39:37|INFO|did not find an external table to reuse. creating ext_gpload_reusable_155b6ee8_960e_11ec_ae55_0050569ea4ff
+2022-02-25 15:39:37|INFO|running time: 0.06 seconds
+2022-02-25 15:39:37|INFO|rows Inserted          = 0
+2022-02-25 15:39:37|INFO|rows Updated           = 9
+2022-02-25 15:39:37|INFO|data formatting errors = 0
+2022-02-25 15:39:37|INFO|gpload succeeded
  count 
 -------
      9
 (1 row)
 
 TRUNCATE TABLE
-2021-01-04 15:50:37|INFO|gpload session started 2021-01-04 15:50:37
-2021-01-04 15:50:37|INFO|setting schema 'public' for table 'texttable'
-2021-01-04 15:50:37|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_01.txt" -t 30
-2021-01-04 15:50:37|INFO|reusing external table ext_gpload_reusable_87f02318_4e61_11eb_aa6b_7085c2381836
-2021-01-04 15:50:37|INFO|running time: 0.16 seconds
-2021-01-04 15:50:37|INFO|rows Inserted          = 9
-2021-01-04 15:50:37|INFO|rows Updated           = 0
-2021-01-04 15:50:37|INFO|data formatting errors = 0
-2021-01-04 15:50:37|INFO|gpload succeeded
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 's1' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-2021-01-04 15:50:37|INFO|gpload session started 2021-01-04 15:50:37
-2021-01-04 15:50:37|INFO|setting schema 'public' for table 'texttable'
-2021-01-04 15:50:37|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_target.txt" -t 30
-2021-01-04 15:50:37|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_3ae2a9f2be92595cba0cbb17b5858cd4
-2021-01-04 15:50:37|INFO|reusing external table ext_gpload_reusable_881585e0_4e61_11eb_a8c6_7085c2381836
-2021-01-04 15:50:37|INFO|running time: 0.21 seconds
-2021-01-04 15:50:37|INFO|rows Inserted          = 0
-2021-01-04 15:50:37|INFO|rows Updated           = 9
-2021-01-04 15:50:37|INFO|data formatting errors = 0
-2021-01-04 15:50:37|INFO|gpload succeeded
+2022-02-25 15:39:37|INFO|gpload session started 2022-02-25 15:39:37
+2022-02-25 15:39:37|INFO|setting schema 'public' for table 'texttable'
+2022-02-25 15:39:37|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_01.txt" -t 30
+2022-02-25 15:39:37|INFO|reusing external table ext_gpload_reusable_1541491e_960e_11ec_9148_0050569ea4ff
+2022-02-25 15:39:37|INFO|running time: 0.04 seconds
+2022-02-25 15:39:37|INFO|rows Inserted          = 9
+2022-02-25 15:39:37|INFO|rows Updated           = 0
+2022-02-25 15:39:37|INFO|data formatting errors = 0
+2022-02-25 15:39:37|INFO|gpload succeeded
+2022-02-25 15:39:37|INFO|gpload session started 2022-02-25 15:39:37
+2022-02-25 15:39:37|INFO|setting schema 'public' for table 'texttable'
+2022-02-25 15:39:37|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_target.txt" -t 30
+2022-02-25 15:39:37|INFO|reusing staging table staging_gpload_reusable_bf2513bc4e5c7466f3cd5abecf21f8f4
+2022-02-25 15:39:37|INFO|reusing external table ext_gpload_reusable_155b6ee8_960e_11ec_ae55_0050569ea4ff
+2022-02-25 15:39:37|INFO|running time: 0.06 seconds
+2022-02-25 15:39:37|INFO|rows Inserted          = 0
+2022-02-25 15:39:37|INFO|rows Updated           = 9
+2022-02-25 15:39:37|INFO|data formatting errors = 0
+2022-02-25 15:39:37|INFO|gpload succeeded
  count 
 -------
      9
 (1 row)
 
 TRUNCATE TABLE
-2021-01-04 15:50:37|INFO|gpload session started 2021-01-04 15:50:37
-2021-01-04 15:50:37|INFO|setting schema 'public' for table 'texttable'
-2021-01-04 15:50:37|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_01.txt" -t 30
-2021-01-04 15:50:37|INFO|reusing external table ext_gpload_reusable_87f02318_4e61_11eb_aa6b_7085c2381836
-2021-01-04 15:50:37|INFO|running time: 0.14 seconds
-2021-01-04 15:50:37|INFO|rows Inserted          = 9
-2021-01-04 15:50:37|INFO|rows Updated           = 0
-2021-01-04 15:50:37|INFO|data formatting errors = 0
-2021-01-04 15:50:37|INFO|gpload succeeded
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 's1' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-2021-01-04 16:04:50|INFO|gpload session started 2021-01-04 16:04:50
-2021-01-04 16:04:50|INFO|setting schema 'public' for table 'texttable'
-2021-01-04 16:04:50|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_target.txt" -t 30
-2021-01-04 16:04:50|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_2e83e0aacc17c6dd2601ee75a637dcc6
-2021-01-04 16:04:50|INFO|reusing external table ext_gpload_reusable_8407f940_4e63_11eb_a1f4_7085c2381836
-2021-01-04 16:04:50|INFO|running time: 0.23 seconds
-2021-01-04 16:04:50|INFO|rows Inserted          = 0
-2021-01-04 16:04:50|INFO|rows Updated           = 9
-2021-01-04 16:04:50|INFO|data formatting errors = 0
-2021-01-04 16:04:50|INFO|gpload succeeded
+2022-02-25 15:39:37|INFO|gpload session started 2022-02-25 15:39:37
+2022-02-25 15:39:37|INFO|setting schema 'public' for table 'texttable'
+2022-02-25 15:39:37|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_01.txt" -t 30
+2022-02-25 15:39:37|INFO|reusing external table ext_gpload_reusable_1541491e_960e_11ec_9148_0050569ea4ff
+2022-02-25 15:39:37|INFO|running time: 0.04 seconds
+2022-02-25 15:39:37|INFO|rows Inserted          = 9
+2022-02-25 15:39:37|INFO|rows Updated           = 0
+2022-02-25 15:39:37|INFO|data formatting errors = 0
+2022-02-25 15:39:37|INFO|gpload succeeded
+2022-02-25 15:39:38|INFO|gpload session started 2022-02-25 15:39:38
+2022-02-25 15:39:38|INFO|setting schema 'public' for table 'texttable'
+2022-02-25 15:39:38|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_target.txt" -t 30
+2022-02-25 15:39:38|INFO|reusing staging table staging_gpload_reusable_bf2513bc4e5c7466f3cd5abecf21f8f4
+2022-02-25 15:39:38|INFO|reusing external table ext_gpload_reusable_155b6ee8_960e_11ec_ae55_0050569ea4ff
+2022-02-25 15:39:38|INFO|running time: 0.05 seconds
+2022-02-25 15:39:38|INFO|rows Inserted          = 0
+2022-02-25 15:39:38|INFO|rows Updated           = 9
+2022-02-25 15:39:38|INFO|data formatting errors = 0
+2022-02-25 15:39:38|INFO|gpload succeeded
  count 
 -------
      9
 (1 row)
 
 TRUNCATE TABLE
-2021-01-04 15:50:38|INFO|gpload session started 2021-01-04 15:50:38
-2021-01-04 15:50:38|INFO|setting schema 'public' for table 'texttable'
-2021-01-04 15:50:38|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_01.txt" -t 30
-2021-01-04 15:50:38|INFO|reusing external table ext_gpload_reusable_87f02318_4e61_11eb_aa6b_7085c2381836
-2021-01-04 15:50:38|INFO|running time: 0.13 seconds
-2021-01-04 15:50:38|INFO|rows Inserted          = 9
-2021-01-04 15:50:38|INFO|rows Updated           = 0
-2021-01-04 15:50:38|INFO|data formatting errors = 0
-2021-01-04 15:50:38|INFO|gpload succeeded
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 's1' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-2021-01-04 15:50:38|INFO|gpload session started 2021-01-04 15:50:38
-2021-01-04 15:50:38|INFO|setting schema 'public' for table 'texttable'
-2021-01-04 15:50:38|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_target.txt" -t 30
-2021-01-04 15:50:38|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_507418e61988c1d20da1e83f9f6814c3
-2021-01-04 15:50:38|INFO|reusing external table ext_gpload_reusable_881585e0_4e61_11eb_a8c6_7085c2381836
-2021-01-04 15:50:38|INFO|running time: 0.22 seconds
-2021-01-04 15:50:38|INFO|rows Inserted          = 0
-2021-01-04 15:50:38|INFO|rows Updated           = 9
-2021-01-04 15:50:38|INFO|data formatting errors = 0
-2021-01-04 15:50:38|INFO|gpload succeeded
+2022-02-25 15:39:38|INFO|gpload session started 2022-02-25 15:39:38
+2022-02-25 15:39:38|INFO|setting schema 'public' for table 'texttable'
+2022-02-25 15:39:38|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_01.txt" -t 30
+2022-02-25 15:39:38|INFO|reusing external table ext_gpload_reusable_1541491e_960e_11ec_9148_0050569ea4ff
+2022-02-25 15:39:38|INFO|running time: 0.04 seconds
+2022-02-25 15:39:38|INFO|rows Inserted          = 9
+2022-02-25 15:39:38|INFO|rows Updated           = 0
+2022-02-25 15:39:38|INFO|data formatting errors = 0
+2022-02-25 15:39:38|INFO|gpload succeeded
+2022-02-25 15:39:38|INFO|gpload session started 2022-02-25 15:39:38
+2022-02-25 15:39:38|INFO|setting schema 'public' for table 'texttable'
+2022-02-25 15:39:38|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_target.txt" -t 30
+2022-02-25 15:39:38|INFO|reusing staging table staging_gpload_reusable_bf2513bc4e5c7466f3cd5abecf21f8f4
+2022-02-25 15:39:38|INFO|reusing external table ext_gpload_reusable_155b6ee8_960e_11ec_ae55_0050569ea4ff
+2022-02-25 15:39:38|INFO|running time: 0.05 seconds
+2022-02-25 15:39:38|INFO|rows Inserted          = 0
+2022-02-25 15:39:38|INFO|rows Updated           = 9
+2022-02-25 15:39:38|INFO|data formatting errors = 0
+2022-02-25 15:39:38|INFO|gpload succeeded
  count 
 -------
      9
 (1 row)
 
 TRUNCATE TABLE
-2021-01-04 15:50:39|INFO|gpload session started 2021-01-04 15:50:39
-2021-01-04 15:50:39|INFO|setting schema 'public' for table 'texttable'
-2021-01-04 15:50:39|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_01.txt" -t 30
-2021-01-04 15:50:39|INFO|reusing external table ext_gpload_reusable_87f02318_4e61_11eb_aa6b_7085c2381836
-2021-01-04 15:50:39|INFO|running time: 0.16 seconds
-2021-01-04 15:50:39|INFO|rows Inserted          = 9
-2021-01-04 15:50:39|INFO|rows Updated           = 0
-2021-01-04 15:50:39|INFO|data formatting errors = 0
-2021-01-04 15:50:39|INFO|gpload succeeded
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 's1' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-2021-01-04 15:50:39|INFO|gpload session started 2021-01-04 15:50:39
-2021-01-04 15:50:39|INFO|setting schema 'public' for table 'texttable'
-2021-01-04 15:50:39|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_target.txt" -t 30
-2021-01-04 15:50:39|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_7c4c8357d428226c0fb3e0e5abaddd17
-2021-01-04 15:50:39|INFO|reusing external table ext_gpload_reusable_881585e0_4e61_11eb_a8c6_7085c2381836
-2021-01-04 15:50:39|INFO|running time: 0.20 seconds
-2021-01-04 15:50:39|INFO|rows Inserted          = 0
-2021-01-04 15:50:39|INFO|rows Updated           = 9
-2021-01-04 15:50:39|INFO|data formatting errors = 0
-2021-01-04 15:50:39|INFO|gpload succeeded
+2022-02-25 15:39:38|INFO|gpload session started 2022-02-25 15:39:38
+2022-02-25 15:39:38|INFO|setting schema 'public' for table 'texttable'
+2022-02-25 15:39:38|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_01.txt" -t 30
+2022-02-25 15:39:38|INFO|reusing external table ext_gpload_reusable_1541491e_960e_11ec_9148_0050569ea4ff
+2022-02-25 15:39:38|INFO|running time: 0.04 seconds
+2022-02-25 15:39:38|INFO|rows Inserted          = 9
+2022-02-25 15:39:38|INFO|rows Updated           = 0
+2022-02-25 15:39:38|INFO|data formatting errors = 0
+2022-02-25 15:39:38|INFO|gpload succeeded
+2022-02-25 15:39:38|INFO|gpload session started 2022-02-25 15:39:38
+2022-02-25 15:39:38|INFO|setting schema 'public' for table 'texttable'
+2022-02-25 15:39:38|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_target.txt" -t 30
+2022-02-25 15:39:38|INFO|reusing staging table staging_gpload_reusable_bf2513bc4e5c7466f3cd5abecf21f8f4
+2022-02-25 15:39:38|INFO|reusing external table ext_gpload_reusable_155b6ee8_960e_11ec_ae55_0050569ea4ff
+2022-02-25 15:39:38|INFO|running time: 0.05 seconds
+2022-02-25 15:39:38|INFO|rows Inserted          = 0
+2022-02-25 15:39:38|INFO|rows Updated           = 9
+2022-02-25 15:39:38|INFO|data formatting errors = 0
+2022-02-25 15:39:38|INFO|gpload succeeded
  count 
 -------
      9
 (1 row)
 
 TRUNCATE TABLE
-2021-01-04 15:50:39|INFO|gpload session started 2021-01-04 15:50:39
-2021-01-04 15:50:39|INFO|setting schema 'public' for table 'texttable'
-2021-01-04 15:50:39|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_01.txt" -t 30
-2021-01-04 15:50:39|INFO|reusing external table ext_gpload_reusable_87f02318_4e61_11eb_aa6b_7085c2381836
-2021-01-04 15:50:39|INFO|running time: 0.15 seconds
-2021-01-04 15:50:39|INFO|rows Inserted          = 9
-2021-01-04 15:50:39|INFO|rows Updated           = 0
-2021-01-04 15:50:39|INFO|data formatting errors = 0
-2021-01-04 15:50:39|INFO|gpload succeeded
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 's1' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-2021-01-04 15:50:39|INFO|gpload session started 2021-01-04 15:50:39
-2021-01-04 15:50:40|INFO|setting schema 'public' for table 'texttable'
-2021-01-04 15:50:40|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_target.txt" -t 30
-2021-01-04 15:50:40|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_9e368b870de03019826de2219fb29f98
-2021-01-04 15:50:40|INFO|reusing external table ext_gpload_reusable_881585e0_4e61_11eb_a8c6_7085c2381836
-2021-01-04 15:50:40|INFO|running time: 0.21 seconds
-2021-01-04 15:50:40|INFO|rows Inserted          = 0
-2021-01-04 15:50:40|INFO|rows Updated           = 9
-2021-01-04 15:50:40|INFO|data formatting errors = 0
-2021-01-04 15:50:40|INFO|gpload succeeded
+2022-02-25 15:39:38|INFO|gpload session started 2022-02-25 15:39:38
+2022-02-25 15:39:38|INFO|setting schema 'public' for table 'texttable'
+2022-02-25 15:39:38|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_01.txt" -t 30
+2022-02-25 15:39:38|INFO|reusing external table ext_gpload_reusable_1541491e_960e_11ec_9148_0050569ea4ff
+2022-02-25 15:39:38|INFO|running time: 0.04 seconds
+2022-02-25 15:39:38|INFO|rows Inserted          = 9
+2022-02-25 15:39:38|INFO|rows Updated           = 0
+2022-02-25 15:39:38|INFO|data formatting errors = 0
+2022-02-25 15:39:38|INFO|gpload succeeded
+2022-02-25 15:39:39|INFO|gpload session started 2022-02-25 15:39:39
+2022-02-25 15:39:39|INFO|setting schema 'public' for table 'texttable'
+2022-02-25 15:39:39|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_target.txt" -t 30
+2022-02-25 15:39:39|INFO|reusing staging table staging_gpload_reusable_bf2513bc4e5c7466f3cd5abecf21f8f4
+2022-02-25 15:39:39|INFO|reusing external table ext_gpload_reusable_155b6ee8_960e_11ec_ae55_0050569ea4ff
+2022-02-25 15:39:39|INFO|running time: 0.05 seconds
+2022-02-25 15:39:39|INFO|rows Inserted          = 0
+2022-02-25 15:39:39|INFO|rows Updated           = 9
+2022-02-25 15:39:39|INFO|data formatting errors = 0
+2022-02-25 15:39:39|INFO|gpload succeeded
  count 
 -------
      9
 (1 row)
 
 TRUNCATE TABLE
-2021-01-04 15:50:40|INFO|gpload session started 2021-01-04 15:50:40
-2021-01-04 15:50:40|INFO|setting schema 'public' for table 'texttable'
-2021-01-04 15:50:40|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_01.txt" -t 30
-2021-01-04 15:50:40|INFO|reusing external table ext_gpload_reusable_87f02318_4e61_11eb_aa6b_7085c2381836
-2021-01-04 15:50:40|INFO|running time: 0.13 seconds
-2021-01-04 15:50:40|INFO|rows Inserted          = 9
-2021-01-04 15:50:40|INFO|rows Updated           = 0
-2021-01-04 15:50:40|INFO|data formatting errors = 0
-2021-01-04 15:50:40|INFO|gpload succeeded
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 's1' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-2021-01-04 15:50:40|INFO|gpload session started 2021-01-04 15:50:40
-2021-01-04 15:50:40|INFO|setting schema 'public' for table 'texttable'
-2021-01-04 15:50:40|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_target.txt" -t 30
-2021-01-04 15:50:40|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_3741945344fc4b31add2fb0738ec8581
-2021-01-04 15:50:40|INFO|reusing external table ext_gpload_reusable_881585e0_4e61_11eb_a8c6_7085c2381836
-2021-01-04 15:50:40|INFO|running time: 0.21 seconds
-2021-01-04 15:50:40|INFO|rows Inserted          = 0
-2021-01-04 15:50:40|INFO|rows Updated           = 9
-2021-01-04 15:50:40|INFO|data formatting errors = 0
-2021-01-04 15:50:40|INFO|gpload succeeded
+2022-02-25 15:39:39|INFO|gpload session started 2022-02-25 15:39:39
+2022-02-25 15:39:39|INFO|setting schema 'public' for table 'texttable'
+2022-02-25 15:39:39|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_01.txt" -t 30
+2022-02-25 15:39:39|INFO|reusing external table ext_gpload_reusable_1541491e_960e_11ec_9148_0050569ea4ff
+2022-02-25 15:39:39|INFO|running time: 0.04 seconds
+2022-02-25 15:39:39|INFO|rows Inserted          = 9
+2022-02-25 15:39:39|INFO|rows Updated           = 0
+2022-02-25 15:39:39|INFO|data formatting errors = 0
+2022-02-25 15:39:39|INFO|gpload succeeded
+2022-02-25 15:39:39|INFO|gpload session started 2022-02-25 15:39:39
+2022-02-25 15:39:39|INFO|setting schema 'public' for table 'texttable'
+2022-02-25 15:39:39|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_target.txt" -t 30
+2022-02-25 15:39:39|INFO|reusing staging table staging_gpload_reusable_bf2513bc4e5c7466f3cd5abecf21f8f4
+2022-02-25 15:39:39|INFO|reusing external table ext_gpload_reusable_155b6ee8_960e_11ec_ae55_0050569ea4ff
+2022-02-25 15:39:39|INFO|running time: 0.05 seconds
+2022-02-25 15:39:39|INFO|rows Inserted          = 0
+2022-02-25 15:39:39|INFO|rows Updated           = 9
+2022-02-25 15:39:39|INFO|data formatting errors = 0
+2022-02-25 15:39:39|INFO|gpload succeeded
  count 
 -------
      9
 (1 row)
 
 TRUNCATE TABLE
-2021-01-04 15:50:41|INFO|gpload session started 2021-01-04 15:50:41
-2021-01-04 15:50:41|INFO|setting schema 'public' for table 'texttable'
-2021-01-04 15:50:41|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_01.txt" -t 30
-2021-01-04 15:50:41|INFO|reusing external table ext_gpload_reusable_87f02318_4e61_11eb_aa6b_7085c2381836
-2021-01-04 15:50:41|INFO|running time: 0.16 seconds
-2021-01-04 15:50:41|INFO|rows Inserted          = 9
-2021-01-04 15:50:41|INFO|rows Updated           = 0
-2021-01-04 15:50:41|INFO|data formatting errors = 0
-2021-01-04 15:50:41|INFO|gpload succeeded
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 's1' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-2021-01-04 15:50:41|INFO|gpload session started 2021-01-04 15:50:41
-2021-01-04 15:50:41|INFO|setting schema 'public' for table 'texttable'
-2021-01-04 15:50:41|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_target.txt" -t 30
-2021-01-04 15:50:41|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_ba2d378b509828b502fce7fe1ddc6fbc
-2021-01-04 15:50:41|INFO|reusing external table ext_gpload_reusable_881585e0_4e61_11eb_a8c6_7085c2381836
-2021-01-04 15:50:41|INFO|running time: 0.20 seconds
-2021-01-04 15:50:41|INFO|rows Inserted          = 0
-2021-01-04 15:50:41|INFO|rows Updated           = 9
-2021-01-04 15:50:41|INFO|data formatting errors = 0
-2021-01-04 15:50:41|INFO|gpload succeeded
+2022-02-25 15:39:39|INFO|gpload session started 2022-02-25 15:39:39
+2022-02-25 15:39:39|INFO|setting schema 'public' for table 'texttable'
+2022-02-25 15:39:39|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_01.txt" -t 30
+2022-02-25 15:39:39|INFO|reusing external table ext_gpload_reusable_1541491e_960e_11ec_9148_0050569ea4ff
+2022-02-25 15:39:39|INFO|running time: 0.04 seconds
+2022-02-25 15:39:39|INFO|rows Inserted          = 9
+2022-02-25 15:39:39|INFO|rows Updated           = 0
+2022-02-25 15:39:39|INFO|data formatting errors = 0
+2022-02-25 15:39:39|INFO|gpload succeeded
+2022-02-25 15:39:39|INFO|gpload session started 2022-02-25 15:39:39
+2022-02-25 15:39:39|INFO|setting schema 'public' for table 'texttable'
+2022-02-25 15:39:39|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_target.txt" -t 30
+2022-02-25 15:39:39|INFO|reusing staging table staging_gpload_reusable_bf2513bc4e5c7466f3cd5abecf21f8f4
+2022-02-25 15:39:39|INFO|reusing external table ext_gpload_reusable_155b6ee8_960e_11ec_ae55_0050569ea4ff
+2022-02-25 15:39:39|INFO|running time: 0.05 seconds
+2022-02-25 15:39:39|INFO|rows Inserted          = 0
+2022-02-25 15:39:39|INFO|rows Updated           = 9
+2022-02-25 15:39:39|INFO|data formatting errors = 0
+2022-02-25 15:39:39|INFO|gpload succeeded
  count 
 -------
      9

--- a/gpMgmt/bin/gpload_test/gpload2/query497.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query497.ans
@@ -1,7 +1,7 @@
 2021-06-01 17:04:39|INFO|gpload session started 2021-06-01 17:04:39
 2021-06-01 17:04:39|INFO|setting schema 'public' for table 'texttable'
 2021-06-01 17:04:39|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/external_file_01.txt" -t 30
-2021-06-01 17:04:39|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2021-06-01 17:04:39|INFO|reusing staging table staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
 2021-06-01 17:04:39|INFO|did not find an external table to reuse. creating ext_gpload_reusable_650c1ebc_c2b8_11eb_ab9c_0050569ea4ff
 2021-06-01 17:04:39|ERROR|ERROR:  column "non_col" does not exist
 LINE 1: ...ble."s1" and into_table."s2"=from_table."s2" and  non_col = ...

--- a/gpMgmt/bin/gpload_test/gpload2/query506.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query506.ans
@@ -8,6 +8,8 @@ INSERT 0 1
 2021-01-07 18:26:18|INFO|gpload session started 2021-01-07 18:26:18
 2021-01-07 18:26:18|INFO|setting schema 'public' for table 'merge_test'
 2021-01-07 18:26:18|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_mapping_01.txt" -t 30
+2021-01-07 18:26:18|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_90380b7fa505855fb0b4b9398a280896
+2021-01-07 18:26:18|INFO|did not find an external table to reuse. creating ext_gpload_reusable_193aa2ea_960e_11ec_a721_0050569ea4ff
 2021-01-07 18:26:18|ERROR|A gpload control file processing error occurred. The configuration must contain gpload:output:match_columns
 2021-01-07 18:26:18|INFO|rows Inserted          = 0
 2021-01-07 18:26:18|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query545.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query545.ans
@@ -1,0 +1,26 @@
+2022-02-28 17:34:47|INFO|gpload session started 2022-02-28 17:34:47
+2022-02-28 17:34:47|INFO|setting schema 'public' for table 'testtruncate'
+2022-02-28 17:34:47|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2022-02-28 17:34:47|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_42f43ceb6be068ef6d5b75a3203d6a72
+2022-02-28 17:34:47|INFO|did not find an external table to reuse. creating ext_gpload_reusable_ab739780_9879_11ec_9df4_0050569ea4ff
+2022-02-28 17:34:47|INFO|running time: 0.06 seconds
+2022-02-28 17:34:47|INFO|rows Inserted          = 15
+2022-02-28 17:34:47|INFO|rows Updated           = 1
+2022-02-28 17:34:47|INFO|data formatting errors = 0
+2022-02-28 17:34:47|INFO|gpload succeeded
+Table "public.staging_gpload_reusable_42f43ceb6be068ef6d5b75a3203d6a72"
+ Column |            Type             | Modifiers 
+--------+-----------------------------+-----------
+ s1     | text                        | 
+ s2     | text                        | 
+ s3     | text                        | 
+ dt     | timestamp without time zone | 
+ n1     | smallint                    | 
+ n2     | integer                     | 
+ n3     | bigint                      | 
+ n4     | numeric                     | 
+ n5     | numeric                     | 
+ n6     | real                        | 
+ n7     | double precision            | 
+Distributed by: (n1)
+

--- a/gpMgmt/bin/gpload_test/gpload2/query546.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query546.ans
@@ -1,0 +1,26 @@
+2022-02-28 18:03:55|INFO|gpload session started 2022-02-28 18:03:55
+2022-02-28 18:03:55|INFO|setting schema 'public' for table 'testheaderreuse'
+2022-02-28 18:03:55|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2022-02-28 18:03:55|INFO|running time: 0.04 seconds
+2022-02-28 18:03:55|INFO|rows Inserted          = 2
+2022-02-28 18:03:55|INFO|rows Updated           = 0
+2022-02-28 18:03:55|INFO|data formatting errors = 0
+2022-02-28 18:03:55|INFO|gpload succeeded
+2022-02-28 18:03:55|INFO|gpload session started 2022-02-28 18:03:55
+2022-02-28 18:03:55|INFO|setting schema 'public' for table 'testheaderreuse'
+2022-02-28 18:03:55|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file1.txt" -t 30
+2022-02-28 18:03:55|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_4f59b8233d181e082cf8dd2510e09cb6
+2022-02-28 18:03:55|INFO|did not find an external table to reuse. creating ext_gpload_reusable_bd7bbfda_987d_11ec_8dd4_0050569ea4ff
+2022-02-28 18:03:55|INFO|running time: 0.06 seconds
+2022-02-28 18:03:55|INFO|rows Inserted          = 1
+2022-02-28 18:03:55|INFO|rows Updated           = 2
+2022-02-28 18:03:55|INFO|data formatting errors = 0
+2022-02-28 18:03:55|INFO|gpload succeeded
+Table "public.staging_gpload_reusable_4f59b8233d181e082cf8dd2510e09cb6"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ field1 | integer | 
+ field2 | text    | 
+ field3 | text    | 
+Distributed by: (field1)
+

--- a/gpMgmt/bin/gpload_test/gpload2/query76.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query76.ans
@@ -1,45 +1,50 @@
-2021-07-30 11:44:08|INFO|gpload session started 2021-07-30 11:44:08
-2021-07-30 11:44:08|INFO|setting schema 'public' for table 'chinese表'
-2021-07-30 11:44:08|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-07-30 11:44:08|INFO|did not find an external table to reuse. creating ext_gpload_reusable_6558efe0_f0e8_11eb_9001_0050569ea4ff
-2021-07-30 11:44:08|ERROR|could not run SQL "create external table ext_gpload_reusable_6558efe0_f0e8_11eb_9001_0050569ea4ff("列1" text,"列#2" int,"lie3" timestamp)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+2022-02-25 15:38:36|INFO|gpload session started 2022-02-25 15:38:36
+2022-02-25 15:38:36|INFO|setting schema 'public' for table 'chinese表'
+2022-02-25 15:38:36|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2022-02-25 15:38:36|INFO|did not find an external table to reuse. creating ext_gpload_table
+2022-02-25 15:38:36|ERROR|could not run SQL "create external table ext_gpload_table
 LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
                                                                  ^
  standard_conforming_strings is set to 'off', please set it to 'on' and try again 
 
-2021-07-30 11:44:08|INFO|rows Inserted          = 0
-2021-07-30 11:44:08|INFO|rows Updated           = 0
-2021-07-30 11:44:08|INFO|data formatting errors = 0
-2021-07-30 11:44:08|INFO|gpload failed
-2021-07-30 11:44:08|INFO|gpload session started 2021-07-30 11:44:08
-2021-07-30 11:44:08|INFO|setting schema 'public' for table 'chinese表'
-2021-07-30 11:44:09|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-07-30 11:44:09|INFO|reusing staging table staging_gpload_reusable_5171458efa83aaf8c5bc7004bae85d5b
-2021-07-30 11:44:09|INFO|did not find an external table to reuse. creating ext_gpload_reusable_656d1e98_f0e8_11eb_8ba3_0050569ea4ff
-2021-07-30 11:44:09|ERROR|could not run SQL "create external table ext_gpload_reusable_656d1e98_f0e8_11eb_8ba3_0050569ea4ff("列1" text,"列#2" int,"lie3" timestamp)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
+2022-02-25 15:38:36|INFO|rows Inserted          = 0
+2022-02-25 15:38:36|INFO|rows Updated           = 0
+2022-02-25 15:38:36|INFO|data formatting errors = 0
+2022-02-25 15:38:36|INFO|gpload failed
+2022-02-25 15:38:36|INFO|gpload session started 2022-02-25 15:38:36
+2022-02-25 15:38:36|INFO|setting schema 'public' for table 'chinese表'
+2022-02-25 15:38:36|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2022-02-25 15:38:36|INFO|reusing staging table staging_gpload_reusable_5171458efa83aaf8c5bc7004bae85d5b
+2022-02-25 15:38:36|INFO|did not find an external table to reuse. creating ext_gpload_table
+2022-02-25 15:38:36|ERROR|could not run SQL "create external table ext_gpload_table
 LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
                                                                  ^
  could not get standard_conforming_strings, ERROR:  current transaction is aborted, commands ignored until end of transaction block
  if standard_conforming_strings is set to 'off', please set it to 'on' and try again 
 
-2021-07-30 11:44:09|INFO|rows Inserted          = 0
-2021-07-30 11:44:09|INFO|rows Updated           = 0
-2021-07-30 11:44:09|INFO|data formatting errors = 0
-2021-07-30 11:44:09|INFO|gpload failed
-2021-07-30 11:44:09|INFO|gpload session started 2021-07-30 11:44:09
-2021-07-30 11:44:09|INFO|setting schema 'public' for table 'chinese表'
-2021-07-30 11:44:09|ERROR|no mapping for input column "'列1'" to output table
-2021-07-30 11:44:09|INFO|rows Inserted          = 0
-2021-07-30 11:44:09|INFO|rows Updated           = 0
-2021-07-30 11:44:09|INFO|data formatting errors = 0
-2021-07-30 11:44:09|INFO|gpload failed
-2021-07-30 11:44:09|INFO|gpload session started 2021-07-30 11:44:09
-2021-07-30 11:44:09|INFO|setting schema 'public' for table 'chinese表'
-2021-07-30 11:44:09|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-07-30 11:44:09|INFO|reusing staging table staging_gpload_reusable_5171458efa83aaf8c5bc7004bae85d5b
-2021-07-30 11:44:09|INFO|did not find an external table to reuse. creating ext_gpload_reusable_65931f44_f0e8_11eb_8b52_0050569ea4ff
-2021-07-30 11:44:09|ERROR|unexpected error -- backtrace written to log file
-2021-07-30 11:44:09|INFO|rows Inserted          = 0
-2021-07-30 11:44:09|INFO|rows Updated           = 0
-2021-07-30 11:44:09|INFO|data formatting errors = 0
-2021-07-30 11:44:09|INFO|gpload failed
+2022-02-25 15:38:36|INFO|rows Inserted          = 0
+2022-02-25 15:38:36|INFO|rows Updated           = 0
+2022-02-25 15:38:36|INFO|data formatting errors = 0
+2022-02-25 15:38:36|INFO|gpload failed
+2022-02-25 15:38:36|INFO|gpload session started 2022-02-25 15:38:36
+2022-02-25 15:38:36|INFO|setting schema 'public' for table 'chinese表'
+2022-02-25 15:38:36|ERROR|no mapping for input column "'列1'" to output table
+2022-02-25 15:38:36|INFO|rows Inserted          = 0
+2022-02-25 15:38:36|INFO|rows Updated           = 0
+2022-02-25 15:38:36|INFO|data formatting errors = 0
+2022-02-25 15:38:36|INFO|gpload failed
+2022-02-25 15:38:37|INFO|gpload session started 2022-02-25 15:38:37
+2022-02-25 15:38:37|INFO|setting schema 'public' for table 'chinese表'
+2022-02-25 15:38:37|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
+2022-02-25 15:38:37|INFO|reusing staging table staging_gpload_reusable_5171458efa83aaf8c5bc7004bae85d5b
+2022-02-25 15:38:37|INFO|did not find an external table to reuse. creating ext_gpload_table
+2022-02-25 15:38:37|ERROR|could not run SQL "create external table ext_gpload_table
+LINE 1: ...ENCODING_STR(列1 text,列#2 int,lie...
+                                                             ^
+ could not get standard_conforming_strings, ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ if standard_conforming_strings is set to 'off', please set it to 'on' and try again 
+
+2022-02-25 15:38:37|INFO|rows Inserted          = 0
+2022-02-25 15:38:37|INFO|rows Updated           = 0
+2022-02-25 15:38:37|INFO|data formatting errors = 0
+2022-02-25 15:38:37|INFO|gpload failed

--- a/gpMgmt/bin/gpload_test/gpload2/query76.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query76.ans
@@ -1,50 +1,45 @@
-2022-02-25 15:38:36|INFO|gpload session started 2022-02-25 15:38:36
-2022-02-25 15:38:36|INFO|setting schema 'public' for table 'chinese表'
-2022-02-25 15:38:36|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
-2022-02-25 15:38:36|INFO|did not find an external table to reuse. creating ext_gpload_table
-2022-02-25 15:38:36|ERROR|could not run SQL "create external table ext_gpload_table
+2021-07-30 11:44:08|INFO|gpload session started 2021-07-30 11:44:08
+2021-07-30 11:44:08|INFO|setting schema 'public' for table 'chinese表'
+2021-07-30 11:44:08|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-07-30 11:44:08|INFO|did not find an external table to reuse. creating ext_gpload_reusable_6558efe0_f0e8_11eb_9001_0050569ea4ff
+2021-07-30 11:44:08|ERROR|could not run SQL "create external table ext_gpload_reusable_6558efe0_f0e8_11eb_9001_0050569ea4ff("列1" text,"列#2" int,"lie3" timestamp)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
 LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
                                                                  ^
  standard_conforming_strings is set to 'off', please set it to 'on' and try again 
 
-2022-02-25 15:38:36|INFO|rows Inserted          = 0
-2022-02-25 15:38:36|INFO|rows Updated           = 0
-2022-02-25 15:38:36|INFO|data formatting errors = 0
-2022-02-25 15:38:36|INFO|gpload failed
-2022-02-25 15:38:36|INFO|gpload session started 2022-02-25 15:38:36
-2022-02-25 15:38:36|INFO|setting schema 'public' for table 'chinese表'
-2022-02-25 15:38:36|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
-2022-02-25 15:38:36|INFO|reusing staging table staging_gpload_reusable_5171458efa83aaf8c5bc7004bae85d5b
-2022-02-25 15:38:36|INFO|did not find an external table to reuse. creating ext_gpload_table
-2022-02-25 15:38:36|ERROR|could not run SQL "create external table ext_gpload_table
+2021-07-30 11:44:08|INFO|rows Inserted          = 0
+2021-07-30 11:44:08|INFO|rows Updated           = 0
+2021-07-30 11:44:08|INFO|data formatting errors = 0
+2021-07-30 11:44:08|INFO|gpload failed
+2021-07-30 11:44:08|INFO|gpload session started 2021-07-30 11:44:08
+2021-07-30 11:44:08|INFO|setting schema 'public' for table 'chinese表'
+2021-07-30 11:44:09|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-07-30 11:44:09|INFO|reusing staging table staging_gpload_reusable_5171458efa83aaf8c5bc7004bae85d5b
+2021-07-30 11:44:09|INFO|did not find an external table to reuse. creating ext_gpload_reusable_656d1e98_f0e8_11eb_8ba3_0050569ea4ff
+2021-07-30 11:44:09|ERROR|could not run SQL "create external table ext_gpload_reusable_656d1e98_f0e8_11eb_8ba3_0050569ea4ff("列1" text,"列#2" int,"lie3" timestamp)location('gpfdist://127.0.0.1:8081//home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt') format 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' ": ERROR:  syntax error at or near "UTF8"
 LINE 1: ... 'text' (delimiter ';' null '\N' escape '\') encoding'UTF8' 
                                                                  ^
  could not get standard_conforming_strings, ERROR:  current transaction is aborted, commands ignored until end of transaction block
  if standard_conforming_strings is set to 'off', please set it to 'on' and try again 
 
-2022-02-25 15:38:36|INFO|rows Inserted          = 0
-2022-02-25 15:38:36|INFO|rows Updated           = 0
-2022-02-25 15:38:36|INFO|data formatting errors = 0
-2022-02-25 15:38:36|INFO|gpload failed
-2022-02-25 15:38:36|INFO|gpload session started 2022-02-25 15:38:36
-2022-02-25 15:38:36|INFO|setting schema 'public' for table 'chinese表'
-2022-02-25 15:38:36|ERROR|no mapping for input column "'列1'" to output table
-2022-02-25 15:38:36|INFO|rows Inserted          = 0
-2022-02-25 15:38:36|INFO|rows Updated           = 0
-2022-02-25 15:38:36|INFO|data formatting errors = 0
-2022-02-25 15:38:36|INFO|gpload failed
-2022-02-25 15:38:37|INFO|gpload session started 2022-02-25 15:38:37
-2022-02-25 15:38:37|INFO|setting schema 'public' for table 'chinese表'
-2022-02-25 15:38:37|INFO|started gpfdist -p 8081 -P 8082 -f "pathto/data_file.txt" -t 30
-2022-02-25 15:38:37|INFO|reusing staging table staging_gpload_reusable_5171458efa83aaf8c5bc7004bae85d5b
-2022-02-25 15:38:37|INFO|did not find an external table to reuse. creating ext_gpload_table
-2022-02-25 15:38:37|ERROR|could not run SQL "create external table ext_gpload_table
-LINE 1: ...ENCODING_STR(列1 text,列#2 int,lie...
-                                                             ^
- could not get standard_conforming_strings, ERROR:  current transaction is aborted, commands ignored until end of transaction block
- if standard_conforming_strings is set to 'off', please set it to 'on' and try again 
-
-2022-02-25 15:38:37|INFO|rows Inserted          = 0
-2022-02-25 15:38:37|INFO|rows Updated           = 0
-2022-02-25 15:38:37|INFO|data formatting errors = 0
-2022-02-25 15:38:37|INFO|gpload failed
+2021-07-30 11:44:09|INFO|rows Inserted          = 0
+2021-07-30 11:44:09|INFO|rows Updated           = 0
+2021-07-30 11:44:09|INFO|data formatting errors = 0
+2021-07-30 11:44:09|INFO|gpload failed
+2021-07-30 11:44:09|INFO|gpload session started 2021-07-30 11:44:09
+2021-07-30 11:44:09|INFO|setting schema 'public' for table 'chinese表'
+2021-07-30 11:44:09|ERROR|no mapping for input column "'列1'" to output table
+2021-07-30 11:44:09|INFO|rows Inserted          = 0
+2021-07-30 11:44:09|INFO|rows Updated           = 0
+2021-07-30 11:44:09|INFO|data formatting errors = 0
+2021-07-30 11:44:09|INFO|gpload failed
+2021-07-30 11:44:09|INFO|gpload session started 2021-07-30 11:44:09
+2021-07-30 11:44:09|INFO|setting schema 'public' for table 'chinese表'
+2021-07-30 11:44:09|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2021-07-30 11:44:09|INFO|reusing staging table staging_gpload_reusable_5171458efa83aaf8c5bc7004bae85d5b
+2021-07-30 11:44:09|INFO|did not find an external table to reuse. creating ext_gpload_reusable_65931f44_f0e8_11eb_8b52_0050569ea4ff
+2021-07-30 11:44:09|ERROR|unexpected error -- backtrace written to log file
+2021-07-30 11:44:09|INFO|rows Inserted          = 0
+2021-07-30 11:44:09|INFO|rows Updated           = 0
+2021-07-30 11:44:09|INFO|data formatting errors = 0
+2021-07-30 11:44:09|INFO|gpload failed


### PR DESCRIPTION
When gpload do update and merge, it will first insert data from the external table to a staging table. And then compare the data between the staging table and the target table to do merge or update.
We add a feature to better the staging table by using the distribution key of the target table as the distribution key for the staging table.
If target table is distributed randomly, we will use the match columns as the staging table's DK.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
