### PR TITLE
recalculate QE's query_mem proportionally

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -37,6 +37,7 @@
 #include "utils/faultinjector.h"
 #include "utils/resgroup.h"
 #include "utils/resource_manager.h"
+#include "utils/resgroup-ops.h"
 #include "utils/session_state.h"
 #include "utils/typcache.h"
 #include "miscadmin.h"
@@ -264,6 +265,21 @@ CdbDispatchPlan(struct QueryDesc *queryDesc,
 	if (queryDesc->extended_query)
 	{
 		verify_shared_snapshot_ready(gp_command_count);
+	}
+
+	/* In the final stage, add the resource information needed for QE by the resource group */
+	stmt->total_memory_coordinator = 0;
+	stmt->nsegments_coordinator = 0;
+
+	if (IsResGroupEnabled() && gp_resource_group_enable_recalculate_query_mem &&
+		memory_spill_ratio != RESGROUP_FALLBACK_MEMORY_SPILL_RATIO)
+	{
+		/*
+		 * We enable resource group re-calculate the query_mem on QE, and we are not in
+		 * fall back mode (use statement_mem).
+		 */
+		stmt->total_memory_coordinator = ResGroupOps_GetTotalMemory();
+		stmt->nsegments_coordinator = ResGroupGetSegmentNum();
 	}
 
 	cdbdisp_dispatchX(queryDesc, planRequiresTxn, cancelOnError);

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -75,6 +75,7 @@
 #include "utils/workfile_mgr.h"
 #include "utils/faultinjector.h"
 #include "utils/resource_manager.h"
+#include "utils/resgroup-ops.h"
 
 #include "catalog/pg_statistic.h"
 #include "catalog/pg_class.h"
@@ -225,9 +226,6 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 	if (query_info_collect_hook)
 		(*query_info_collect_hook)(METRICS_QUERY_START, queryDesc);
 
-	/**
-	 * Distribute memory to operators.
-	 */
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
 		if (!IsResManagerMemoryPolicyNone() &&
@@ -236,12 +234,75 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 			elog(GP_RESMANAGER_MEMORY_LOG_LEVEL, "query requested %.0fKB of memory",
 				 (double) queryDesc->plannedstmt->query_mem / 1024.0);
 		}
+	}
 
-		/**
-		 * There are some statements that do not go through the resource queue, so we cannot
-		 * put in a strong assert here. Someday, we should fix resource queues.
+	/**
+	 * Distribute memory to operators.
+	 *
+	 * There are some statements that do not go through the resource queue, so we cannot
+	 * put in a strong assert here. Someday, we should fix resource queues.
+	 */
+	if (queryDesc->plannedstmt->query_mem > 0)
+	{
+		/*
+		 * Whether we should skip operator memory assignment
+		 * - We should never skip operator memory assignment on QD.
+		 * - On QE, not skip in case of resource group enabled, and customer allow QE re-calculate query_mem,
+		 * as the GUC `gp_resource_group_enable_recalculate_query_mem` set to on.
 		 */
-		if (queryDesc->plannedstmt->query_mem > 0)
+		bool	should_skip_operator_memory_assign = true;
+
+		if (Gp_role == GP_ROLE_EXECUTE)
+		{
+			/*
+			 * If resource group is enabled, we should re-calculate query_mem on QE, because the memory
+			 * of the coordinator and segment nodes or the number of instance could be different.
+			 *
+			 * On QE, we only try to recalculate query_mem if resource group enabled. Otherwise, we will skip this
+			 * and the next operator memory assignment if resource queue enabled
+			 */
+			if (IsResGroupEnabled())
+			{
+				int32 	total_memory_coordinator = queryDesc->plannedstmt->total_memory_coordinator;
+				int    	nsegments_coordinator = queryDesc->plannedstmt->nsegments_coordinator;
+
+				/*
+				 * memSpill is not in fallback mode, and we enable resource group re-calculate the query_mem on QE,
+				 * then re-calculate the query_mem and re-compute operatorMemKB using this new value
+				 */
+				if (total_memory_coordinator != 0 && nsegments_coordinator != 0)
+				{
+					should_skip_operator_memory_assign = false;
+
+					/* Get total system memory on the QE in MB */
+					int32 	total_memory_segment = ResGroupOps_GetTotalMemory();
+					int 	nsegments_segment = ResGroupGetSegmentNum();
+					uint64	coordinator_query_mem = queryDesc->plannedstmt->query_mem;
+
+					/*
+					 * In the resource group environment, when we calculate query_mem, we can roughly use the following
+					 * formula:
+					 *
+					 * 	query_mem = (total_memory * gp_resource_group_memory_limit * memory_limit / nsegments) * memory_spill_ratio / concurrency
+					 *
+					 * Only total_memory and nsegments could differ between QD and QE, so query_mem is proportional to
+					 * the system's available virtual memory and inversely proportional to the number of instances.
+					 */
+					queryDesc->plannedstmt->query_mem *= (total_memory_segment * 1.0 / nsegments_segment) /
+														 (total_memory_coordinator * 1.0 / nsegments_coordinator);
+
+					elog(DEBUG1, "re-calculate query_mem, original QD's query_mem: %.0fKB, after recalculation QE's query_mem: %.0fKB",
+						 (double) coordinator_query_mem / 1024.0  , (double) queryDesc->plannedstmt->query_mem / 1024.0);
+				}
+			}
+		}
+		else
+		{
+			/* On QD, we always traverse the plan tree and compute operatorMemKB */
+			should_skip_operator_memory_assign = false;
+		}
+
+		if (!should_skip_operator_memory_assign)
 		{
 			switch(*gp_resmanager_memory_policy)
 			{

--- a/src/backend/executor/nodeSort.c
+++ b/src/backend/executor/nodeSort.c
@@ -238,6 +238,16 @@ ExecInitSort(Sort *node, EState *estate, int eflags)
 			   "initializing sort node");
 
 	/*
+	 * GPDB
+	 */
+#ifdef FAULT_INJECTOR
+	if (SIMPLE_FAULT_INJECTOR("rg_qmem_qd_qe") == FaultInjectorTypeSkip)
+	{
+		elog(NOTICE, "op_mem=%d", (int) (((Plan *) node)->operatorMemKB));
+	}
+#endif
+
+	/*
 	 * create state structure
 	 */
 	sortstate = makeNode(SortState);

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -144,6 +144,9 @@ _copyPlannedStmt(const PlannedStmt *from)
 
 	COPY_SCALAR_FIELD(query_mem);
 
+	COPY_SCALAR_FIELD(total_memory_coordinator);
+	COPY_SCALAR_FIELD(nsegments_coordinator);
+
 	COPY_NODE_FIELD(intoClause);
 	COPY_NODE_FIELD(copyIntoClause);
 	COPY_NODE_FIELD(refreshClause);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -387,6 +387,10 @@ _outPlannedStmt(StringInfo str, const PlannedStmt *node)
 	WRITE_NODE_FIELD(intoPolicy);
 
 	WRITE_UINT64_FIELD(query_mem);
+
+	WRITE_UINT_FIELD(total_memory_coordinator);
+	WRITE_INT_FIELD(nsegments_coordinator);
+
 	WRITE_NODE_FIELD(intoClause);
 	WRITE_NODE_FIELD(copyIntoClause);
 	WRITE_NODE_FIELD(refreshClause);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2458,6 +2458,10 @@ _readPlannedStmt(void)
 	READ_NODE_FIELD(intoPolicy);
 
 	READ_UINT64_FIELD(query_mem);
+
+	READ_UINT_FIELD(total_memory_coordinator);
+	READ_INT_FIELD(nsegments_coordinator);
+
 	READ_NODE_FIELD(intoClause);
 	READ_NODE_FIELD(copyIntoClause);
 	READ_NODE_FIELD(refreshClause);

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -221,6 +221,7 @@ double		gp_resource_group_cpu_limit;
 double		gp_resource_group_memory_limit;
 bool		gp_resource_group_bypass;
 bool		gp_resource_group_cpu_ceiling_enforcement;
+bool		gp_resource_group_enable_recalculate_query_mem;
 
 /* Metrics collector debug GUC */
 bool		vmem_process_interrupt = false;
@@ -2763,6 +2764,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&gp_resource_group_cpu_ceiling_enforcement,
 		false, NULL, NULL
+	},
+
+	{
+		{"gp_resource_group_enable_recalculate_query_mem", PGC_USERSET, RESOURCES,
+		 	gettext_noop("Enable resource group re-calculate the query_mem on QE"),
+		 	NULL
+		},
+		&gp_resource_group_enable_recalculate_query_mem,
+		true,
+		NULL, NULL, NULL
 	},
 
 	{

--- a/src/backend/utils/resource_manager/memquota.c
+++ b/src/backend/utils/resource_manager/memquota.c
@@ -960,8 +960,9 @@ PolicyEagerFreeAssignOperatorMemoryKB(PlannedStmt *stmt, uint64 memAvailableByte
 int64
 ResourceManagerGetQueryMemoryLimit(PlannedStmt* stmt)
 {
+	/* Returns QD's query_mem if we are on the QE, for re-calculating QE's query_mem */
 	if (Gp_role != GP_ROLE_DISPATCH)
-		return 0;
+		return stmt->query_mem;
 
 	/* no limits in single user mode. */
 	if (!IsUnderPostmaster)

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -656,6 +656,9 @@ extern int gp_workfile_bytes_to_checksum;
 
 extern bool coredump_on_memerror;
 
+/* Greenplum resource group query_mem re-calculate on QE */
+extern bool gp_resource_group_enable_recalculate_query_mem;
+
 /*
  * Autostats feature, whether or not to to automatically run ANALYZE after 
  * insert/delete/update/ctas or after ctas/copy/insert in case the target

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -144,6 +144,9 @@ typedef struct PlannedStmt
 	/* What is the memory reserved for this query's execution? */
 	uint64		query_mem;
 
+	int32		total_memory_coordinator;	/* GPDB: The total usable virtual memory on coordinator node in MB */
+	int			nsegments_coordinator;		/* GPDB: The number of primary segments on coordinator node  */
+
 	/*
 	 * GPDB: Used to keep target information for CTAS and it is needed
 	 * to be dispatched to QEs.

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -237,6 +237,7 @@
 		"gp_resource_group_cpu_ceiling_enforcement",
 		"gp_resource_group_memory_limit",
 		"gp_resource_group_queuing_timeout",
+		"gp_resource_group_enable_recalculate_query_mem",
 		"gp_resource_manager",
 		"gp_resqueue_memory_policy",
 		"gp_resqueue_priority",

--- a/src/test/isolation2/expected/resgroup/resgroup_query_mem.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_query_mem.out
@@ -1,0 +1,50 @@
+-- This test is to verify that query_mem is set correctly in QEs.
+-- Previously, resgroup does not consider that different number of
+-- segments among coordinator and segments. Now we let QEs to re-calculate
+-- query_mem in each segment locally. This test case use the following
+-- steps to verify the new method's correctness:
+-- 1. fetch available memory in coordinator and a single segment,
+--    compute the ratio
+-- 2. use fault inject and plpython invokes pygresql with notice,
+--    get a distributed plan's sort's operator memory in a QE
+-- 3. Get sort's operator memory in a pure QD's plan (catalog order by)
+-- 4. compute the ratio of two operator memorys
+-- 5. these two ratios should be the same.
+
+create extension if not exists gp_inject_fault;
+CREATE
+create or replace language plpython3u;
+CREATE
+
+create table t_qmem(a int);
+CREATE
+select gp_inject_fault('rg_qmem_qd_qe', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+create function rg_qmem_test() returns boolean as $$ from pg import DB from copy import deepcopy import re 
+# 1: get resgroup available mem in QD and QE and compute ratio sql = ("select memory_available m from " "gp_toolkit.gp_resgroup_status_per_segment " "where segment_id = %d and rsgname = 'admin_group'") qd_mem = int(plpy.execute(sql % -1)[0]["m"]) qe_mem = int(plpy.execute(sql % 0)[0]["m"]) ratio1 = int(round(float(qd_mem) / qe_mem)) 
+# 2. use notice to get qe operator mem dbname = plpy.execute("select current_database() db")[0]["db"] db = DB(dbname=dbname) qe_opmem_info = [] db.set_notice_receiver(lambda n: qe_opmem_info.append(deepcopy(n.message))) sql = "select * from t_qmem order by 1" db.query(sql) qe_opmem = int(re.findall(r"op_mem=(\d+)", qe_opmem_info[0])[0]) db.set_notice_receiver(None) 
+# 3. get qd operator mem sql = "explain analyze select * from pg_class order by relpages limit 10" db.query("set gp_resgroup_print_operator_memory_limits = on;") r = db.query(sql).getresult() for (line, ) in r: if "->  Sort" not in line: continue qd_opmem = int(re.findall(r"operatorMem: (\d+)", line)[0]) break 
+db.close() 
+ratio2 = int(round(float(qd_opmem) / qe_opmem)) 
+return ratio1 == ratio2 
+$$ language plpython3u;
+CREATE
+
+select rg_qmem_test();
+ rg_qmem_test 
+--------------
+ t            
+(1 row)
+select gp_inject_fault('rg_qmem_qd_qe', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+drop function rg_qmem_test();
+DROP
+drop table t_qmem;
+DROP

--- a/src/test/isolation2/isolation2_resgroup_schedule
+++ b/src/test/isolation2/isolation2_resgroup_schedule
@@ -11,6 +11,7 @@ test: resgroup/resgroup_name_convention
 test: resgroup/resgroup_assign_slot_fail
 test: resgroup/resgroup_unassign_entrydb
 test: resgroup/resgroup_seg_down_2pc
+test: resgroup/resgroup_query_mem
 
 # functions
 test: resgroup/resgroup_concurrency

--- a/src/test/isolation2/sql/resgroup/resgroup_query_mem.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_query_mem.sql
@@ -1,0 +1,63 @@
+-- This test is to verify that query_mem is set correctly in QEs.
+-- Previously, resgroup does not consider that different number of
+-- segments among coordinator and segments. Now we let QEs to re-calculate
+-- query_mem in each segment locally. This test case use the following
+-- steps to verify the new method's correctness:
+-- 1. fetch available memory in coordinator and a single segment,
+--    compute the ratio
+-- 2. use fault inject and plpython invokes pygresql with notice,
+--    get a distributed plan's sort's operator memory in a QE
+-- 3. Get sort's operator memory in a pure QD's plan (catalog order by)
+-- 4. compute the ratio of two operator memorys
+-- 5. these two ratios should be the same.
+
+create extension if not exists gp_inject_fault;
+create or replace language plpython3u;
+
+create table t_qmem(a int);
+select gp_inject_fault('rg_qmem_qd_qe', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+
+create function rg_qmem_test() returns boolean as $$
+from pg import DB
+from copy import deepcopy
+import re
+
+# 1: get resgroup available mem in QD and QE and compute ratio
+sql = ("select memory_available m from "
+       "gp_toolkit.gp_resgroup_status_per_segment "
+       "where segment_id = %d and rsgname = 'admin_group'")
+qd_mem = int(plpy.execute(sql % -1)[0]["m"])
+qe_mem = int(plpy.execute(sql % 0)[0]["m"])
+ratio1 = int(round(float(qd_mem) / qe_mem))
+
+# 2. use notice to get qe operator mem
+dbname = plpy.execute("select current_database() db")[0]["db"]
+db = DB(dbname=dbname)
+qe_opmem_info = []
+db.set_notice_receiver(lambda n: qe_opmem_info.append(deepcopy(n.message)))
+sql = "select * from t_qmem order by 1"
+db.query(sql)
+qe_opmem = int(re.findall(r"op_mem=(\d+)", qe_opmem_info[0])[0])
+db.set_notice_receiver(None)
+
+# 3. get qd operator mem
+sql = "explain analyze select * from pg_class order by relpages limit 10"
+db.query("set gp_resgroup_print_operator_memory_limits = on;")
+r = db.query(sql).getresult()
+for (line, ) in r:
+    if "->  Sort" not in line: continue
+    qd_opmem = int(re.findall(r"operatorMem: (\d+)", line)[0])
+    break
+
+db.close()
+
+ratio2 = int(round(float(qd_opmem) / qe_opmem))
+
+return ratio1 == ratio2
+
+$$ language plpython3u;
+
+select rg_qmem_test();
+select gp_inject_fault('rg_qmem_qd_qe', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+drop function rg_qmem_test();
+drop table t_qmem;


### PR DESCRIPTION
In the current resource group implementation, `query_mem` in the plan tree is calculated using 
QD's system memory and the number of primary segments, not QE's own system memory and 
the number of primary segments. This can result in the wrong memory being allocated at the 
execution stage eventually, which can lead to various problems such as OOM, underutilization of 
QE resources, etc.

The `query_mem` is linearly to system memory and number of primary segments if we enable 
resource group, the approximate calculation formula is as follows:

```bash
query_mem = (total_memory * gp_resource_group_memory_limit * memory_limit / nsegments) * memory_spill_ratio / concurrency
```

Only `total_memory` and `nsegments` differ between QD and QE, so we can dispatch these two 
parameters to QE, and then calculate QE's own query_mem proportionally:

![image](https://user-images.githubusercontent.com/30709931/156326671-c572c97e-b17b-452b-b68f-c1ad96360589.png)

At the same time, we use the GUC `gp_resource_group_enable_recalculate_query_mem` to let the 
client decide whether to recalculate the `query_mem` proportionally on QE and repopulate the 
`operatorMemKB` in the plan tree according to this value.