### PR TITLE
gpload add distribution key for staging table

### DIFF
--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_schema_and_mode.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_schema_and_mode.py
@@ -830,3 +830,36 @@ def test_544_gpload_mode_merge_update_with_update_condition():
     f.write("\\! gpload -f " + TestBase.mkpath('config/config_file2') + "\n")
     f.write("\\! psql -d reuse_gptest -c 'select * from texttable order by s1, s2, n1;'")
     f.close()
+
+
+@TestBase.prepare_before_test(num=545, times=1)
+def test_545_gpload_merge_staging_DK():
+    """545 test gpload merge using target table distribution key as
+    staging table DK as default"""
+    file = TestBase.mkpath('setup.sql')
+    TestBase.runfile(file)
+    TestBase.copy_data('external_file_04.txt', 'data_file.txt')
+    TestBase.write_config_file(mode='merge', file='data_file.txt', table='testtruncate', reuse_tables=True)
+    f = open(TestBase.mkpath('query545.sql'), 'a')
+    f.write("\\! psql -d reuse_gptest -c '\\d staging_gpload_reusable_*'")
+    f.close()
+
+
+@TestBase.prepare_before_test(num=546, times=1)
+def test_546_gpload_merge_staging_DK():
+    """546 test gpload merge using match column as staging table DK 
+    when target is DISTRIBUTED RANDOMLY"""
+    file = TestBase.mkpath('setup.sql')
+    TestBase.runfile(file)
+    TestBase.copy_data("external_file_47.txt", "data_file.txt")
+    TestBase.write_config_file(mode='insert', file='data_file.txt', table='testheaderreuse', delimiter="','", reuse_tables=False)
+    match_col = ['field1']
+    update_col = ['field2']
+    TestBase.copy_data("external_file_546.txt", "data_file1.txt")
+    TestBase.write_config_file(mode='merge', file='data_file1.txt', update_columns=update_col,delimiter="','",
+        match_columns=match_col, config='config/config_file1', table='testheaderreuse', reuse_tables=True)
+    f = open(TestBase.mkpath('query546.sql'), 'w')
+    f.write("\\! gpload -f " + TestBase.mkpath('config/config_file') + "\n")
+    f.write("\\! gpload -f " + TestBase.mkpath('config/config_file1') + "\n")
+    f.write("\\! psql -d reuse_gptest -c '\\d staging_gpload_reusable_*'")
+    f.close()

--- a/gpMgmt/bin/gpload_test/gpload2/data/external_file_47.txt
+++ b/gpMgmt/bin/gpload_test/gpload2/data/external_file_47.txt
@@ -1,0 +1,2 @@
+1,"row 1 - OK",file1
+2,"row 2 - OK",file1

--- a/gpMgmt/bin/gpload_test/gpload2/data/external_file_546.txt
+++ b/gpMgmt/bin/gpload_test/gpload2/data/external_file_546.txt
@@ -1,0 +1,3 @@
+1,"row 1 - OK",file1
+2,"row 2 - OK",newText
+3,"row 3 - new",file1

--- a/gpMgmt/bin/gpload_test/gpload2/query493.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query493.ans
@@ -40,7 +40,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 2021-01-04 15:50:37|INFO|gpload session started 2021-01-04 15:50:37
 2021-01-04 15:50:37|INFO|setting schema 'public' for table 'texttable'
 2021-01-04 15:50:37|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_target.txt" -t 30
-2021-01-04 15:50:37|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_3ae2a9f2be92595cba0cbb17b5858cd4
+2021-01-04 15:50:37|INFO|reusing staging table STAGING_GPLOAD_REUSABLE
 2021-01-04 15:50:37|INFO|reusing external table ext_gpload_reusable_881585e0_4e61_11eb_a8c6_7085c2381836
 2021-01-04 15:50:37|INFO|running time: 0.21 seconds
 2021-01-04 15:50:37|INFO|rows Inserted          = 0
@@ -67,7 +67,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 2021-01-04 16:04:50|INFO|gpload session started 2021-01-04 16:04:50
 2021-01-04 16:04:50|INFO|setting schema 'public' for table 'texttable'
 2021-01-04 16:04:50|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_target.txt" -t 30
-2021-01-04 16:04:50|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_2e83e0aacc17c6dd2601ee75a637dcc6
+2021-01-04 16:04:50|INFO|reusing staging table STAGING_GPLOAD_REUSABLE
 2021-01-04 16:04:50|INFO|reusing external table ext_gpload_reusable_8407f940_4e63_11eb_a1f4_7085c2381836
 2021-01-04 16:04:50|INFO|running time: 0.23 seconds
 2021-01-04 16:04:50|INFO|rows Inserted          = 0
@@ -94,7 +94,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 2021-01-04 15:50:38|INFO|gpload session started 2021-01-04 15:50:38
 2021-01-04 15:50:38|INFO|setting schema 'public' for table 'texttable'
 2021-01-04 15:50:38|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_target.txt" -t 30
-2021-01-04 15:50:38|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_507418e61988c1d20da1e83f9f6814c3
+2021-01-04 15:50:38|INFO|reusing staging table STAGING_GPLOAD_REUSABLE
 2021-01-04 15:50:38|INFO|reusing external table ext_gpload_reusable_881585e0_4e61_11eb_a8c6_7085c2381836
 2021-01-04 15:50:38|INFO|running time: 0.22 seconds
 2021-01-04 15:50:38|INFO|rows Inserted          = 0
@@ -121,7 +121,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 2021-01-04 15:50:39|INFO|gpload session started 2021-01-04 15:50:39
 2021-01-04 15:50:39|INFO|setting schema 'public' for table 'texttable'
 2021-01-04 15:50:39|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_target.txt" -t 30
-2021-01-04 15:50:39|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_7c4c8357d428226c0fb3e0e5abaddd17
+2021-01-04 15:50:39|INFO|reusing staging table STAGING_GPLOAD_REUSABLE
 2021-01-04 15:50:39|INFO|reusing external table ext_gpload_reusable_881585e0_4e61_11eb_a8c6_7085c2381836
 2021-01-04 15:50:39|INFO|running time: 0.20 seconds
 2021-01-04 15:50:39|INFO|rows Inserted          = 0
@@ -148,7 +148,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 2021-01-04 15:50:39|INFO|gpload session started 2021-01-04 15:50:39
 2021-01-04 15:50:40|INFO|setting schema 'public' for table 'texttable'
 2021-01-04 15:50:40|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_target.txt" -t 30
-2021-01-04 15:50:40|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_9e368b870de03019826de2219fb29f98
+2021-01-04 15:50:40|INFO|reusing staging table STAGING_GPLOAD_REUSABLE
 2021-01-04 15:50:40|INFO|reusing external table ext_gpload_reusable_881585e0_4e61_11eb_a8c6_7085c2381836
 2021-01-04 15:50:40|INFO|running time: 0.21 seconds
 2021-01-04 15:50:40|INFO|rows Inserted          = 0
@@ -175,7 +175,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 2021-01-04 15:50:40|INFO|gpload session started 2021-01-04 15:50:40
 2021-01-04 15:50:40|INFO|setting schema 'public' for table 'texttable'
 2021-01-04 15:50:40|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_target.txt" -t 30
-2021-01-04 15:50:40|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_3741945344fc4b31add2fb0738ec8581
+2021-01-04 15:50:40|INFO|reusing staging table STAGING_GPLOAD_REUSABLE
 2021-01-04 15:50:40|INFO|reusing external table ext_gpload_reusable_881585e0_4e61_11eb_a8c6_7085c2381836
 2021-01-04 15:50:40|INFO|running time: 0.21 seconds
 2021-01-04 15:50:40|INFO|rows Inserted          = 0
@@ -202,7 +202,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 2021-01-04 15:50:41|INFO|gpload session started 2021-01-04 15:50:41
 2021-01-04 15:50:41|INFO|setting schema 'public' for table 'texttable'
 2021-01-04 15:50:41|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_match_target.txt" -t 30
-2021-01-04 15:50:41|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_ba2d378b509828b502fce7fe1ddc6fbc
+2021-01-04 15:50:41|INFO|reusing staging table STAGING_GPLOAD_REUSABLE
 2021-01-04 15:50:41|INFO|reusing external table ext_gpload_reusable_881585e0_4e61_11eb_a8c6_7085c2381836
 2021-01-04 15:50:41|INFO|running time: 0.20 seconds
 2021-01-04 15:50:41|INFO|rows Inserted          = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query497.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query497.ans
@@ -3,7 +3,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 2021-01-04 16:55:52|INFO|gpload session started 2021-01-04 16:55:52
 2021-01-04 16:55:52|INFO|setting schema 'public' for table 'texttable'
 2021-01-04 16:55:52|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/external_file_01.txt" -t 30
-2021-01-04 16:55:52|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2021-01-04 16:55:52|INFO|reusing staging table STAGING_GPLOAD_REUSABLE
 2021-01-04 16:55:52|INFO|did not find an external table to reuse. creating ext_gpload_reusable_a651e6f8_4e6a_11eb_b8a4_7085c2381836
 2021-01-04 16:55:53|ERROR|unexpected error -- backtrace written to log file
 2021-01-04 16:55:53|INFO|rows Inserted          = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query506.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query506.ans
@@ -8,6 +8,8 @@ INSERT 0 1
 2021-01-07 18:26:18|INFO|gpload session started 2021-01-07 18:26:18
 2021-01-07 18:26:18|INFO|setting schema 'public' for table 'merge_test'
 2021-01-07 18:26:18|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/column_mapping_01.txt" -t 30
+2021-01-07 18:26:18|INFO|did not find a staging table to reuse. creating STAGING_GPLOAD_REUSABLE
+2021-01-07 18:26:18|INFO|did not find an external table to reuse. creating EXT_GPLOAD_REUSABLE
 2021-01-07 18:26:18|ERROR|A gpload control file processing error occurred. The configuration must contain gpload:output:match_columns
 2021-01-07 18:26:18|INFO|rows Inserted          = 0
 2021-01-07 18:26:18|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query532.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query532.ans
@@ -13,7 +13,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 2021-01-07 17:38:14|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_edcb757d70ae1c70cdd2f7d15496f54b
 2021-01-07 17:38:14|INFO|did not find an external table to reuse. creating ext_gpload_reusable_102fae3a_50cc_11eb_b6c8_7085c2381836
 2021-01-07 17:38:14|ERROR|ERROR:  column "s4" is of type integer but expression is of type text
-LINE 1: ...c70cdd2f7d15496f54b ("s1","s2","s4") SELECT c1,c3,c2 FROM ex...
+LINE 1: ...5c64da950cfbc41ff55 ("s1","s2","s4") SELECT c1,c3,c2 FROM ex...
                                                              ^
 HINT:  You will need to rewrite or cast the expression.
  encountered while running INSERT INTO staging_gpload_reusable_edcb757d70ae1c70cdd2f7d15496f54b ("s1","s2","s4") SELECT c1,c3,c2 FROM ext_gpload_reusable_102fae3a_50cc_11eb_b6c8_7085c2381836

--- a/gpMgmt/bin/gpload_test/gpload2/query533.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query533.ans
@@ -13,7 +13,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 2021-01-07 17:38:26|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_edcb757d70ae1c70cdd2f7d15496f54b
 2021-01-07 17:38:26|INFO|did not find an external table to reuse. creating ext_gpload_reusable_1777c5e2_50cc_11eb_bb05_7085c2381836
 2021-01-07 17:38:26|ERROR|ERROR:  column "s4" is of type integer but expression is of type text
-LINE 1: ...c70cdd2f7d15496f54b ("s1","s2","s4") SELECT c1,c3,c2 FROM ex...
+LINE 1: ...5c64da950cfbc41ff55 ("s1","s2","s4") SELECT c1,c3,c2 FROM ex...
                                                              ^
 HINT:  You will need to rewrite or cast the expression.
  encountered while running INSERT INTO staging_gpload_reusable_edcb757d70ae1c70cdd2f7d15496f54b ("s1","s2","s4") SELECT c1,c3,c2 FROM ext_gpload_reusable_1777c5e2_50cc_11eb_bb05_7085c2381836

--- a/gpMgmt/bin/gpload_test/gpload2/query545.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query545.ans
@@ -1,0 +1,26 @@
+2022-03-02 15:30:02|INFO|gpload session started 2022-03-02 15:30:02
+2022-03-02 15:30:02|INFO|setting schema 'public' for table 'testtruncate'
+2022-03-02 15:30:02|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2022-03-02 15:30:02|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_42f43ceb6be068ef6d5b75a3203d6a72
+2022-03-02 15:30:02|INFO|did not find an external table to reuse. creating ext_gpload_reusable_93057aa6_99fa_11ec_a6c8_0050569e2380
+2022-03-02 15:30:03|INFO|running time: 0.09 seconds
+2022-03-02 15:30:03|INFO|rows Inserted          = 15
+2022-03-02 15:30:03|INFO|rows Updated           = 1
+2022-03-02 15:30:03|INFO|data formatting errors = 0
+2022-03-02 15:30:03|INFO|gpload succeeded
+Table "public.staging_gpload_reusable_42f43ceb6be068ef6d5b75a3203d6a72"
+ Column |            Type             | Collation | Nullable | Default 
+--------+-----------------------------+-----------+----------+---------
+ s1     | text                        |           |          | 
+ s2     | text                        |           |          | 
+ s3     | text                        |           |          | 
+ dt     | timestamp without time zone |           |          | 
+ n1     | smallint                    |           |          | 
+ n2     | integer                     |           |          | 
+ n3     | bigint                      |           |          | 
+ n4     | numeric                     |           |          | 
+ n5     | numeric                     |           |          | 
+ n6     | real                        |           |          | 
+ n7     | double precision            |           |          | 
+Distributed by: (n1)
+

--- a/gpMgmt/bin/gpload_test/gpload2/query546.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query546.ans
@@ -1,0 +1,26 @@
+2022-03-02 15:44:52|INFO|gpload session started 2022-03-02 15:44:52
+2022-03-02 15:44:52|INFO|setting schema 'public' for table 'testheaderreuse'
+2022-03-02 15:44:52|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
+2022-03-02 15:44:52|INFO|running time: 0.05 seconds
+2022-03-02 15:44:52|INFO|rows Inserted          = 2
+2022-03-02 15:44:52|INFO|rows Updated           = 0
+2022-03-02 15:44:52|INFO|data formatting errors = 0
+2022-03-02 15:44:52|INFO|gpload succeeded
+2022-03-02 15:44:52|INFO|gpload session started 2022-03-02 15:44:52
+2022-03-02 15:44:52|INFO|setting schema 'public' for table 'testheaderreuse'
+2022-03-02 15:44:52|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file1.txt" -t 30
+2022-03-02 15:44:52|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_4f59b8233d181e082cf8dd2510e09cb6
+2022-03-02 15:44:52|INFO|did not find an external table to reuse. creating ext_gpload_reusable_a56de244_99fc_11ec_ae78_0050569e2380
+2022-03-02 15:44:52|INFO|running time: 0.08 seconds
+2022-03-02 15:44:52|INFO|rows Inserted          = 1
+2022-03-02 15:44:52|INFO|rows Updated           = 2
+2022-03-02 15:44:52|INFO|data formatting errors = 0
+2022-03-02 15:44:52|INFO|gpload succeeded
+Table "public.staging_gpload_reusable_4f59b8233d181e082cf8dd2510e09cb6"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ field1 | integer |           |          | 
+ field2 | text    |           |          | 
+ field3 | text    |           |          | 
+Distributed by: (field1)
+

--- a/gpMgmt/bin/gpload_test/gpload2/query68.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query68.ans
@@ -6,7 +6,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 2021-01-08 16:05:22|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_a1101b5024707ea34f55e778f329e548
 2021-01-08 16:05:22|INFO|did not find an external table to reuse. creating ext_gpload_reusable_418b1b42_5188_11eb_93db_00505698707d
 2021-01-08 16:05:22|ERROR|ERROR:  column "Field1" is of type bigint but expression is of type text
-LINE 1: ...07ea34f55e778f329e548 ("Field1","Field#2") SELECT "Field1","...
+LINE 1: ...bb31496d7e9a13bd29b90 ("Field1","Field#2") SELECT "Field1","...
                                                              ^
 HINT:  You will need to rewrite or cast the expression.
  encountered while running INSERT INTO staging_gpload_reusable_a1101b5024707ea34f55e778f329e548 ("Field1","Field#2") SELECT "Field1","Field#2" FROM ext_gpload_reusable_418b1b42_5188_11eb_93db_00505698707d

--- a/gpMgmt/bin/gpload_test/gpload2/query69.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query69.ans
@@ -6,7 +6,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 2021-01-08 16:28:20|INFO|did not find a staging table to reuse. creating staging_gpload_reusable_a1101b5024707ea34f55e778f329e548
 2021-01-08 16:28:20|INFO|did not find an external table to reuse. creating ext_gpload_reusable_770f4452_518b_11eb_98a2_00505698707d
 2021-01-08 16:28:20|ERROR|ERROR:  column "Field1" is of type bigint but expression is of type text
-LINE 1: ...07ea34f55e778f329e548 ("Field1","Field#2") SELECT "Field1","...
+LINE 1: ...bb31496d7e9a13bd29b90 ("Field1","Field#2") SELECT "Field1","...
                                                              ^
 HINT:  You will need to rewrite or cast the expression.
  encountered while running INSERT INTO staging_gpload_reusable_a1101b5024707ea34f55e778f329e548 ("Field1","Field#2") SELECT "Field1","Field#2" FROM ext_gpload_reusable_770f4452_518b_11eb_98a2_00505698707d


### PR DESCRIPTION
backport pr #13159 to master

When gpload do update and merge, it will first insert data from the external table to a staging table. And then compare the data between the staging table and the target table to do merge or update.
We add a feature to better the staging table by using the distribution key of the target table as the distribution key for the staging table.
If target table is distributed randomly, we will use the match columns as the staging table's DK.
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
