### PR TITLE
Resolve GPDB_12_MERGE_FIXME in catalog/*.dat

### DIFF
--- a/src/backend/utils/adt/pivot.c
+++ b/src/backend/utils/adt/pivot.c
@@ -235,10 +235,13 @@ static Datum oid_pivot_accum(FunctionCallInfo fcinfo, Oid type)
 	else
 	{
 		int elsize, size, nelem;
+		Oid eltype = type;
 
 		switch (type) {
 			case INT4OID:
-				elsize = 4;
+				/* addition of two int4 should be int8, otherwise it may cause overflow in addition*/
+				elsize = 8;
+				eltype = INT8OID;
 				break;
 			case INT8OID:
 			case FLOAT8OID:
@@ -254,7 +257,7 @@ static Datum oid_pivot_accum(FunctionCallInfo fcinfo, Oid type)
 		SET_VARSIZE(data, size);
 		data->ndim = 1;
 		data->dataoffset = 0;
-		data->elemtype = type;
+		data->elemtype = eltype;
 		ARR_DIMS(data)[0] = nelem;
 		ARR_LBOUND(data)[0] = 1;
 		memset(ARR_DATA_PTR(data), 0, nelem * elsize);
@@ -268,7 +271,7 @@ static Datum oid_pivot_accum(FunctionCallInfo fcinfo, Oid type)
 	switch (type) {
 		case INT4OID:
 		{
-			int32 *datap = (int32*) ARR_DATA_PTR(data);
+			int64 *datap = (int64*) ARR_DATA_PTR(data);
 			int32  value = PG_GETARG_INT32(3);
 			datap[i] += value;
 			break;

--- a/src/include/catalog/pg_aggregate.dat
+++ b/src/include/catalog/pg_aggregate.dat
@@ -613,10 +613,9 @@
   aggcombinefn => 'float8_matrix_accum(_float8,_float8)',
   aggtranstype => '_float8' },
 
-# GPDB_12_MERGE_FIXME: is transtype really _int4? does that work with int8_matrix_accum?
-{ aggfnoid => 'pivot_sum(_text,text,int4)', aggtransfn => 'int4_pivot_accum(_int4,_text,text,int4)', aggkind => 'n',
+{ aggfnoid => 'pivot_sum(_text,text,int4)', aggtransfn => 'int4_pivot_accum(_int8,_text,text,int4)', aggkind => 'n',
   aggcombinefn => 'int8_matrix_accum(_int8,_int8)',
-  aggtranstype => '_int4' },
+  aggtranstype => '_int8' },
 
 { aggfnoid => 'pivot_sum(_text,text,int8)', aggtransfn => 'int8_pivot_accum(_int8,_text,text,int8)', aggkind => 'n',
   aggcombinefn => 'int8_matrix_accum(_int8,_int8)',

--- a/src/include/catalog/pg_cast.dat
+++ b/src/include/catalog/pg_cast.dat
@@ -527,7 +527,7 @@
   castcontext => 'e', castmethod => 'b' },
 { castsource => 'complex', casttarget => 'point', castfunc => '0',
   castcontext => 'e', castmethod => 'b' },
-{ castsource => 'numeric', casttarget => 'complex', castfunc => 'numeric2point(numeric)',
+{ castsource => 'numeric', casttarget => 'complex', castfunc => 'numeric2complex(numeric)',
   castcontext => 'i', castmethod => 'f' },
 
 ]

--- a/src/include/catalog/pg_operator.dat
+++ b/src/include/catalog/pg_operator.dat
@@ -3328,8 +3328,7 @@
 { oid => '6474', descr => 'subtract',
   oprname => '-', oprkind => 'b', oprcanmerge => 'f', oprcanhash => 'f', oprleft => 'complex',
   oprright => 'complex', oprresult => 'complex', oprcode => 'complex_mi' },
-# GPDB_12_MERGE_FIXME: the description 'subtract' doesn't seem right for the unary -
-{ oid => '6475', descr => 'subtract',
+{ oid => '6475', descr => 'minus',
   oprname => '-', oprkind => 'l', oprcanmerge => 'f', oprcanhash => 'f', oprleft => '0',
   oprright => 'complex', oprresult => 'complex', oprcode => 'complex_um' },
 { oid => '6476', descr => 'multiply',

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -10890,7 +10890,7 @@
 
 
 # contrib/adminpack functions, brought to core in GPDB.
-# GPDB_12_MERGE_FIXME: Why?
+# the new version functions which using the GRANT system to control access instead of having hard-coded superuser checks
 { oid => 6045, descr => 'Read text from a file',
    proname => 'pg_file_read', provolatile => 'v', prorettype => 'text', proargtypes => 'text int8 int8', prosrc => 'pg_read_file' },
 
@@ -10898,16 +10898,16 @@
    proname => 'pg_logfile_rotate', provolatile => 'v', prorettype => 'bool', proargtypes => '', prosrc => 'pg_rotate_logfile' },
 
 { oid => 6047, descr => 'Write text to a file',
-   proname => 'pg_file_write', provolatile => 'v', prorettype => 'int8', proargtypes => 'text text bool', prosrc => 'pg_file_write' },
+   proname => 'pg_file_write', provolatile => 'v', prorettype => 'int8', proargtypes => 'text text bool', prosrc => 'pg_file_write_v1_1' },
 
 { oid => 6048, descr => 'Rename a file',
-   proname => 'pg_file_rename', proisstrict => 'f', provolatile => 'v', prorettype => 'bool', proargtypes => 'text text text', prosrc => 'pg_file_rename' },
+   proname => 'pg_file_rename', proisstrict => 'f', provolatile => 'v', prorettype => 'bool', proargtypes => 'text text text', prosrc => 'pg_file_rename_v1_1' },
 
 { oid => 6049, descr => 'Delete (unlink) a file',
-   proname => 'pg_file_unlink', provolatile => 'v', prorettype => 'bool', proargtypes => 'text', prosrc => 'pg_file_unlink' },
+   proname => 'pg_file_unlink', provolatile => 'v', prorettype => 'bool', proargtypes => 'text', prosrc => 'pg_file_unlink_v1_1' },
 
 { oid => 6050, descr => 'ls the log dir',
-   proname => 'pg_logdir_ls', prorows => '1000', proretset => 't', provolatile => 'v', prorettype => 'record', proargtypes => '', prosrc => 'pg_logdir_ls' },
+   proname => 'pg_logdir_ls', prorows => '1000', proretset => 't', provolatile => 'v', prorettype => 'record', proargtypes => '', prosrc => 'pg_logdir_ls_v1_1' },
 
 { oid => 6051, descr => 'Get the length of a file (via stat)',
    proname => 'pg_file_length', provolatile => 'v', prorettype => 'int8', proargtypes => 'text', prosrc => 'pg_file_length' },
@@ -10954,11 +10954,11 @@
 
 # 3220 - reserved for sum(numeric[]) 
 { oid => 6225, descr => 'aggregate transition function',
-   proname => 'int4_pivot_accum', proisstrict => 'f', prorettype => '_int4', proargtypes => '_int4 _text text int4', prosrc => 'int4_pivot_accum' },
+   proname => 'int4_pivot_accum', proisstrict => 'f', prorettype => '_int8', proargtypes => '_int8 _text text int4', prosrc => 'int4_pivot_accum' },
 
 { oid => 6226, descr => 'pivot sum aggregate',
    proname => 'pivot_sum', prokind => 'a', proisstrict => 'f',
-   prorettype => '_int4', proargtypes => '_text text int4',
+   prorettype => '_int8', proargtypes => '_text text int4',
    prosrc => 'aggregate_dummy' },
 
 { oid => 6227, descr => 'aggregate transition function',
@@ -11341,9 +11341,8 @@
 { oid => 5064, descr => 'cube root',
    proname => 'cbrt', prorettype => 'complex', proargtypes => 'complex', prosrc => 'complex_cbrt' },
 
-# GPDB_12_MERGE_FIXME: Why is this function called "numeric2point" ?
 { oid => 7597, descr => '(internal) type cast from numeric to complex',
-   proname => 'numeric2point', prorettype => 'complex', proargtypes => 'numeric', prosrc => 'numeric2complex' },
+   proname => 'numeric2complex', prorettype => 'complex', proargtypes => 'numeric', prosrc => 'numeric2complex' },
 
 { oid => 7598, descr => 'implementation of << operator',
    proname => 'complex_lt', prorettype => 'bool', proargtypes => 'complex complex', prosrc => 'complex_lt' },

--- a/src/test/regress/expected/opr_sanity.out
+++ b/src/test/regress/expected/opr_sanity.out
@@ -1595,10 +1595,9 @@ WHERE a.aggcombinefn = p.oid AND
      p.prorettype != p.proargtypes[0] OR
      p.prorettype != p.proargtypes[1] OR
      NOT binary_coercible(a.aggtranstype, p.proargtypes[0]));
-       aggfnoid       |      proname      
-----------------------+-------------------
- pg_catalog.pivot_sum | int8_matrix_accum
-(1 row)
+ aggfnoid | proname 
+----------+---------
+(0 rows)
 
 -- Check that no combine function for an INTERNAL transtype is strict.
 SELECT a.aggfnoid, p.proname


### PR DESCRIPTION
1.remove GPDB_12_MERGE_FIXME in pg_operator.dat:change the description 
to 'minus' for the unary operator.
2.remove GPDB_12_MERGE_FIXME(brought adminpack functions to core in GPDB)
 in pg_proc.dat: in 6X_STABLE branch,adminpack functions has added to
GPDB and the extension adminpack is not compiled, the extension
adminpack shouldn't be used anymore.  upgrade the adminpack functions to 
new version which using the GRANT system to control access instead of 
having hard-coded superuser checks.
3.resolve GPDB_12_MERGE_FIXME in pg_proc.dat: rename 'numeric2point' to
'numeric2complex',although point and complex have same struct,but i
don't find any other functions has the format '*2point'.
4.resolve GPDB_12_MERGE_FIXME in pg_aggregate.dat: alter the transition
type to _int8 and alter return type, argument type of int4_pivot_accum,
because the sum of int4 may be out of 32bit range. it may cause a
overflow fault if transtype is _int4.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
