### PR TITLE
Enable faultinject point 'fault_in_background_writer_main' in builds without assertion.

### DIFF
--- a/src/backend/postmaster/bgwriter.c
+++ b/src/backend/postmaster/bgwriter.c
@@ -243,9 +243,7 @@ BackgroundWriterMain(void)
 		bool		can_hibernate;
 		int			rc;
 
-#ifdef USE_ASSERT_CHECKING
 		SIMPLE_FAULT_INJECTOR("fault_in_background_writer_main");
-#endif
 
 		/* Clear any already-pending wakeups */
 		ResetLatch(MyLatch);


### PR DESCRIPTION
I'm trying to investigate some flaky test failure of
regress/fsync/bgwriter_checkpoint.sql and haven't made any progress so
far. However, I found that the fault injection point
'fault_in_background_writer_main' wasn't enabled in builds without
assertion. So, this patch helps fix it.

P.S. 6X_STABLE branch has the same issue.
https://github.com/greenplum-db/gpdb/blob/5a435d78e0d0f4d1779bf61d93d68d9e95c5d699/src/backend/postmaster/bgwriter.c#L263-L265

## Here are some reminders before you submit the pull request
- [x] Pass `make installcheck`
