### PR TITLE
remove gpdb_12_merge_fixme in pg_import_system_collations

### DIFF
--- a/src/backend/commands/collationcmds.c
+++ b/src/backend/commands/collationcmds.c
@@ -653,10 +653,8 @@ pg_import_system_collations(PG_FUNCTION_ARGS)
 				continue;		/* ignore locales for client-only encodings */
 			if (enc == PG_SQL_ASCII)
 				continue;		/* C/POSIX are already in the catalog */
-
-			/* GPDB_12_MERGE_FIXME: Why do we have this extra condition in GPDB? */
 			if (enc != GetDatabaseEncoding())
-				continue;
+				continue;       /* Ignore collations incompatible with database encoding */ 
 
 			/* count valid locales found in operating system */
 			nvalid++;

--- a/src/backend/commands/collationcmds.c
+++ b/src/backend/commands/collationcmds.c
@@ -653,6 +653,12 @@ pg_import_system_collations(PG_FUNCTION_ARGS)
 				continue;		/* ignore locales for client-only encodings */
 			if (enc == PG_SQL_ASCII)
 				continue;		/* C/POSIX are already in the catalog */
+            /*
+             * Greenplum specific behavior: this function in Greenplum can only be called after a full cluster is
+             * built, this is different from Postgres which might call this function during initdb. When reaching
+             * here, it must be in a database session, we can just ignore the collations not match current database's
+             * encoding because they cannot be used in this database.
+             */
 			if (enc != GetDatabaseEncoding())
 				continue;       /* Ignore collations incompatible with database encoding */ 
 


### PR DESCRIPTION
Postgres 10 added the ```pg_import_system_collations()``` UDF that will import collations from all system locales installed on the system. This function is used in initdb to import the collations on the system, or can be called by a system administrator to import newly added collations any time thereafter.

Some adaptations were made to MPP during the GreenPlum back port this UDF in https://github.com/greenplum-db/gpdb/pull/5016.
In order for collations to work correctly, we need to be sure that every collation that is created on the QD is also installed on the QEs, and that the OID matches in every database.  In upstream, collations are created during initdb, but this won't work for GPDB. Because while initdb is running there is no way to be sure that every segment has the same locales installed.

Since we no longer import collations in initdb and database administrator need to call this UDF manually after the database is created, we only need to import collations that are compatible with the current database encoding in ```pg_import_system_collations()```.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
