### PR TITLE
Updated CPhysicalJoin to derive the inner distribution in the case of tainted replicated

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpec.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpec.h
@@ -41,7 +41,7 @@ public:
 		EdtStrictHashed,  // same as hashed, used to force multiple slices for parallel union all. The motions mirror the distribution of the output columns.
 		EdtStrictReplicated,  // data is strictly replicated across all segments
 		EdtReplicated,	// data is strict or tainted replicated (required only)
-		EdtTaintedReplicated,  // data once-replicated, after being processed by an input-order-sensitive operator (derived only)
+		EdtTaintedReplicated,  // data once-replicated, after being processed by an input-order-sensitive operator or volatile function (derived only)
 		EdtAny,		   // data can be anywhere on the segments (required only)
 		EdtSingleton,  // data is on a single segment or the master
 		EdtStrictSingleton,	 // data is on a single segment or the master (derived only, only compatible with other singleton distributions)

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalJoin.cpp
@@ -404,6 +404,7 @@ CPhysicalJoin::PdsDerive(CMemoryPool *mp, CExpressionHandle &exprhdl) const
 	CDistributionSpec *pds;
 
 	if (CDistributionSpec::EdtStrictReplicated == pdsOuter->Edt() ||
+		CDistributionSpec::EdtTaintedReplicated == pdsOuter->Edt() ||
 		CDistributionSpec::EdtUniversal == pdsOuter->Edt())
 	{
 		// if outer is replicated/universal, return inner distribution

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -993,6 +993,195 @@ explain (costs off) select * from t_hashdist cross join (select * from t_replica
  Optimizer: Postgres query optimizer
 (9 rows)
 
+-- ORCA
+-- verify that JOIN derives the inner child distribution if the outer is tainted replicated (in this
+-- case, the inner child is the hash distributed table, but the distribution is random because the
+-- hash distribution key is not the JOIN key. we want to return the inner distribution because the
+-- JOIN key determines the distribution of the JOIN output).
+create table dist_tab (a integer, b integer) distributed by (a);
+create table rep_tab (c integer) distributed replicated;
+create index idx on dist_tab (b);
+insert into dist_tab values (1, 2), (2, 2), (2, 1), (1, 1);
+insert into rep_tab values (1), (2);
+analyze dist_tab;
+analyze rep_tab;
+set optimizer_enable_hashjoin=off;
+set enable_hashjoin=off;
+set enable_nestloop=on;
+explain select b from dist_tab where b in (select distinct c from rep_tab);
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000001.16..10000000021.44 rows=4 width=4)
+   ->  Nested Loop  (cost=10000000001.16..10000000021.39 rows=1 width=4)
+         ->  Unique  (cost=10000000001.03..10000000001.04 rows=2 width=4)
+               Group Key: rep_tab.c
+               ->  Sort  (cost=10000000001.03..10000000001.03 rows=2 width=4)
+                     Sort Key: rep_tab.c
+                     ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
+         ->  Index Only Scan using idx on dist_tab  (cost=0.13..10.16 rows=1 width=4)
+               Index Cond: (b = rep_tab.c)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select b from dist_tab where b in (select distinct c from rep_tab);
+ b 
+---
+ 1
+ 2
+ 1
+ 2
+(4 rows)
+
+reset optimizer_enable_hashjoin;
+reset enable_hashjoin;
+reset enable_nestloop;
+create table rand_tab (d integer) distributed randomly;
+insert into rand_tab values (1), (2);
+analyze rand_tab;
+-- Table	Side		Derives
+-- rep_tab	pdsOuter	EdtTaintedReplicated
+-- rep_tab	pdsInner	EdtHashed
+--
+-- join derives EdtHashed
+explain select c from rep_tab where c in (select distinct c from rep_tab);
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=20000000002.14..20000000002.14 rows=3 width=4)
+   ->  Hash Join  (cost=20000000001.08..20000000002.14 rows=3 width=4)
+         Hash Cond: (rep_tab.c = rep_tab_1.c)
+         ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
+         ->  Hash  (cost=10000000001.06..10000000001.06 rows=2 width=4)
+               ->  Unique  (cost=10000000001.03..10000000001.04 rows=2 width=4)
+                     Group Key: rep_tab_1.c
+                     ->  Sort  (cost=10000000001.03..10000000001.03 rows=2 width=4)
+                           Sort Key: rep_tab_1.c
+                           ->  Seq Scan on rep_tab rep_tab_1  (cost=10000000000.00..10000000001.02 rows=2 width=4)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select c from rep_tab where c in (select distinct c from rep_tab);
+ c 
+---
+ 1
+ 2
+(2 rows)
+
+-- Table	Side		Derives
+-- dist_tab	pdsOuter	EdtHashed
+-- rep_tab	pdsInner	EdtTaintedReplicated 
+--
+-- join derives EdtHashed
+explain select a from dist_tab where a in (select distinct c from rep_tab);
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=20000000001.08..20000000002.17 rows=4 width=4)
+   ->  Hash Join  (cost=20000000001.08..20000000002.12 rows=1 width=4)
+         Hash Cond: (dist_tab.a = rep_tab.c)
+         ->  Seq Scan on dist_tab  (cost=10000000000.00..10000000001.01 rows=1 width=4)
+         ->  Hash  (cost=10000000001.06..10000000001.06 rows=2 width=4)
+               ->  Unique  (cost=10000000001.03..10000000001.04 rows=2 width=4)
+                     Group Key: rep_tab.c
+                     ->  Sort  (cost=10000000001.03..10000000001.03 rows=2 width=4)
+                           Sort Key: rep_tab.c
+                           ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select a from dist_tab where a in (select distinct c from rep_tab);
+ a 
+---
+ 2
+ 2
+ 1
+ 1
+(4 rows)
+
+-- Table	Side		Derives
+-- rand_tab	pdsOuter	EdtRandom
+-- rep_tab	pdsInner	EdtTaintedReplicated
+--
+-- join derives EdtRandom
+explain select d from rand_tab where d in (select distinct c from rep_tab);
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=20000000001.08..20000000002.15 rows=3 width=4)
+   ->  Hash Join  (cost=20000000001.08..20000000002.11 rows=1 width=4)
+         Hash Cond: (rand_tab.d = rep_tab.c)
+         ->  Seq Scan on rand_tab  (cost=10000000000.00..10000000001.01 rows=1 width=4)
+         ->  Hash  (cost=10000000001.06..10000000001.06 rows=2 width=4)
+               ->  Unique  (cost=10000000001.03..10000000001.04 rows=2 width=4)
+                     Group Key: rep_tab.c
+                     ->  Sort  (cost=10000000001.03..10000000001.03 rows=2 width=4)
+                           Sort Key: rep_tab.c
+                           ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select d from rand_tab where d in (select distinct c from rep_tab);
+ d 
+---
+ 1
+ 2
+(2 rows)
+
+-- Table	Side		Derives
+-- rep_tab	pdsOuter	EdtTaintedReplicated
+-- dist_tab	pdsInner	EdtHashed
+--
+-- join derives EdtHashed
+explain select c from rep_tab where c in (select distinct a from dist_tab);
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=20000000001.05..20000000002.14 rows=3 width=4)
+   ->  Hash Join  (cost=20000000001.05..20000000002.09 rows=1 width=4)
+         Hash Cond: (rep_tab.c = dist_tab.a)
+         ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
+         ->  Hash  (cost=10000000001.04..10000000001.04 rows=1 width=4)
+               ->  Unique  (cost=10000000001.02..10000000001.03 rows=1 width=4)
+                     Group Key: dist_tab.a
+                     ->  Sort  (cost=10000000001.02..10000000001.03 rows=1 width=4)
+                           Sort Key: dist_tab.a
+                           ->  Seq Scan on dist_tab  (cost=10000000000.00..10000000001.01 rows=1 width=4)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select c from rep_tab where c in (select distinct a from dist_tab);
+ c 
+---
+ 1
+ 2
+(2 rows)
+
+-- Table	Side		Derives
+-- rep_tab	pdsOuter	EdtTaintedReplicated
+-- rand_tab	pdsInner	EdtHashed
+--
+-- join derives EdtHashed
+explain select c from rep_tab where c in (select distinct d from rand_tab);
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=20000000001.07..20000000002.15 rows=3 width=4)
+   ->  Hash Join  (cost=20000000001.07..20000000002.11 rows=1 width=4)
+         Hash Cond: (rep_tab.c = rand_tab.d)
+         ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
+         ->  Hash  (cost=10000000001.06..10000000001.06 rows=1 width=4)
+               ->  Unique  (cost=10000000001.04..10000000001.05 rows=1 width=4)
+                     Group Key: rand_tab.d
+                     ->  Sort  (cost=10000000001.04..10000000001.05 rows=1 width=4)
+                           Sort Key: rand_tab.d
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=10000000000.00..10000000001.03 rows=1 width=4)
+                                 Hash Key: rand_tab.d
+                                 ->  Seq Scan on rand_tab  (cost=10000000000.00..10000000001.01 rows=1 width=4)
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+select c from rep_tab where c in (select distinct d from rand_tab);
+ c 
+---
+ 1
+ 2
+(2 rows)
+
 -- start_ignore
 drop schema rpt cascade;
 NOTICE:  drop cascades to 7 other objects

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -984,6 +984,191 @@ explain (costs off) select * from t_hashdist cross join (select * from t_replica
  Optimizer: Pivotal Optimizer (GPORCA)
 (9 rows)
 
+-- ORCA
+-- verify that JOIN derives the inner child distribution if the outer is tainted replicated (in this
+-- case, the inner child is the hash distributed table, but the distribution is random because the
+-- hash distribution key is not the JOIN key. we want to return the inner distribution because the
+-- JOIN key determines the distribution of the JOIN output).
+create table dist_tab (a integer, b integer) distributed by (a);
+create table rep_tab (c integer) distributed replicated;
+create index idx on dist_tab (b);
+insert into dist_tab values (1, 2), (2, 2), (2, 1), (1, 1);
+insert into rep_tab values (1), (2);
+analyze dist_tab;
+analyze rep_tab;
+set optimizer_enable_hashjoin=off;
+set enable_hashjoin=off;
+set enable_nestloop=on;
+explain select b from dist_tab where b in (select distinct c from rep_tab);
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..443.00 rows=4 width=4)
+   ->  Nested Loop  (cost=0.00..443.00 rows=2 width=4)
+         Join Filter: true
+         ->  GroupAggregate  (cost=0.00..431.00 rows=2 width=4)
+               Group Key: rep_tab.c
+               ->  Sort  (cost=0.00..431.00 rows=2 width=4)
+                     Sort Key: rep_tab.c
+                     ->  Seq Scan on rep_tab  (cost=0.00..431.00 rows=2 width=4)
+         ->  Index Scan using idx on dist_tab  (cost=0.00..12.00 rows=1 width=4)
+               Index Cond: (b = rep_tab.c)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+select b from dist_tab where b in (select distinct c from rep_tab);
+ b 
+---
+ 1
+ 2
+ 1
+ 2
+(4 rows)
+
+reset optimizer_enable_hashjoin;
+reset enable_hashjoin;
+reset enable_nestloop;
+create table rand_tab (d integer) distributed randomly;
+insert into rand_tab values (1), (2);
+analyze rand_tab;
+-- Table	Side		Derives
+-- rep_tab	pdsOuter	EdtTaintedReplicated
+-- rep_tab	pdsInner	EdtHashed
+--
+-- join derives EdtHashed
+explain select c from rep_tab where c in (select distinct c from rep_tab);
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=4)
+   ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=4)
+         Hash Cond: (rep_tab.c = rep_tab_1.c)
+         ->  Result  (cost=0.00..431.00 rows=1 width=4)
+               ->  Seq Scan on rep_tab  (cost=0.00..431.00 rows=2 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+               ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=0.00..431.00 rows=1 width=4)
+                     Hash Key: rep_tab_1.c
+                     ->  GroupAggregate  (cost=0.00..431.00 rows=6 width=4)
+                           Group Key: rep_tab_1.c
+                           ->  Sort  (cost=0.00..431.00 rows=6 width=4)
+                                 Sort Key: rep_tab_1.c
+                                 ->  Seq Scan on rep_tab rep_tab_1  (cost=0.00..431.00 rows=6 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(14 rows)
+
+select c from rep_tab where c in (select distinct c from rep_tab);
+ c 
+---
+ 2
+ 1
+(2 rows)
+
+-- Table	Side		Derives
+-- dist_tab	pdsOuter	EdtHashed
+-- rep_tab	pdsInner	EdtTaintedReplicated 
+--
+-- join derives EdtHashed
+explain select a from dist_tab where a in (select distinct c from rep_tab);
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=4 width=4)
+   ->  Hash Semi Join  (cost=0.00..862.00 rows=2 width=4)
+         Hash Cond: (dist_tab.a = rep_tab.c)
+         ->  Seq Scan on dist_tab  (cost=0.00..431.00 rows=2 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+               ->  Seq Scan on rep_tab  (cost=0.00..431.00 rows=2 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+select a from dist_tab where a in (select distinct c from rep_tab);
+ a 
+---
+ 1
+ 1
+ 2
+ 2
+(4 rows)
+
+-- Table	Side		Derives
+-- rand_tab	pdsOuter	EdtRandom
+-- rep_tab	pdsInner	EdtTaintedReplicated
+--
+-- join derives EdtRandom
+explain select d from rand_tab where d in (select distinct c from rep_tab);
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=4)
+   ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=4)
+         Hash Cond: (rand_tab.d = rep_tab.c)
+         ->  Seq Scan on rand_tab  (cost=0.00..431.00 rows=1 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+               ->  Seq Scan on rep_tab  (cost=0.00..431.00 rows=2 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+select d from rand_tab where d in (select distinct c from rep_tab);
+ d 
+---
+ 1
+ 2
+(2 rows)
+
+-- Table	Side		Derives
+-- rep_tab	pdsOuter	EdtTaintedReplicated
+-- dist_tab	pdsInner	EdtHashed
+--
+-- join derives EdtHashed
+explain select c from rep_tab where c in (select distinct a from dist_tab);
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=4)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+         Hash Cond: (dist_tab.a = rep_tab.c)
+         ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
+               Group Key: dist_tab.a
+               ->  Sort  (cost=0.00..431.00 rows=2 width=4)
+                     Sort Key: dist_tab.a
+                     ->  Seq Scan on dist_tab  (cost=0.00..431.00 rows=2 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+               ->  Seq Scan on rep_tab  (cost=0.00..431.00 rows=2 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+select c from rep_tab where c in (select distinct a from dist_tab);
+ c 
+---
+ 1
+ 2
+(2 rows)
+
+-- Table	Side		Derives
+-- rep_tab	pdsOuter	EdtTaintedReplicated
+-- rand_tab	pdsInner	EdtHashed
+--
+-- join derives EdtHashed
+explain select c from rep_tab where c in (select distinct d from rand_tab);
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=4)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+         Hash Cond: (rand_tab.d = rep_tab.c)
+         ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
+               Group Key: rand_tab.d
+               ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                     Sort Key: rand_tab.d
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                           Hash Key: rand_tab.d
+                           ->  Seq Scan on rand_tab  (cost=0.00..431.00 rows=1 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+               ->  Seq Scan on rep_tab  (cost=0.00..431.00 rows=2 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+
+select c from rep_tab where c in (select distinct d from rand_tab);
+ c 
+---
+ 2
+ 1
+(2 rows)
+
 -- start_ignore
 drop schema rpt cascade;
 NOTICE:  drop cascades to 7 other objects

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -433,6 +433,71 @@ explain (costs off) update t_replicate_volatile set a = random();
 explain (costs off) insert into t_replicate_volatile select * from t_replicate_volatile limit random();
 explain (costs off) select * from t_hashdist cross join (select * from t_replicate_volatile limit random()) x;
 
+-- ORCA
+-- verify that JOIN derives the inner child distribution if the outer is tainted replicated (in this
+-- case, the inner child is the hash distributed table, but the distribution is random because the
+-- hash distribution key is not the JOIN key. we want to return the inner distribution because the
+-- JOIN key determines the distribution of the JOIN output).
+create table dist_tab (a integer, b integer) distributed by (a);
+create table rep_tab (c integer) distributed replicated;
+create index idx on dist_tab (b);
+insert into dist_tab values (1, 2), (2, 2), (2, 1), (1, 1);
+insert into rep_tab values (1), (2);
+analyze dist_tab;
+analyze rep_tab;
+set optimizer_enable_hashjoin=off;
+set enable_hashjoin=off;
+set enable_nestloop=on;
+explain select b from dist_tab where b in (select distinct c from rep_tab);
+select b from dist_tab where b in (select distinct c from rep_tab);
+reset optimizer_enable_hashjoin;
+reset enable_hashjoin;
+reset enable_nestloop;
+
+create table rand_tab (d integer) distributed randomly;
+insert into rand_tab values (1), (2);
+analyze rand_tab;
+
+-- Table	Side		Derives
+-- rep_tab	pdsOuter	EdtTaintedReplicated
+-- rep_tab	pdsInner	EdtHashed
+--
+-- join derives EdtHashed
+explain select c from rep_tab where c in (select distinct c from rep_tab);
+select c from rep_tab where c in (select distinct c from rep_tab);
+
+-- Table	Side		Derives
+-- dist_tab	pdsOuter	EdtHashed
+-- rep_tab	pdsInner	EdtTaintedReplicated 
+--
+-- join derives EdtHashed
+explain select a from dist_tab where a in (select distinct c from rep_tab);
+select a from dist_tab where a in (select distinct c from rep_tab);
+
+-- Table	Side		Derives
+-- rand_tab	pdsOuter	EdtRandom
+-- rep_tab	pdsInner	EdtTaintedReplicated
+--
+-- join derives EdtRandom
+explain select d from rand_tab where d in (select distinct c from rep_tab);
+select d from rand_tab where d in (select distinct c from rep_tab);
+
+-- Table	Side		Derives
+-- rep_tab	pdsOuter	EdtTaintedReplicated
+-- dist_tab	pdsInner	EdtHashed
+--
+-- join derives EdtHashed
+explain select c from rep_tab where c in (select distinct a from dist_tab);
+select c from rep_tab where c in (select distinct a from dist_tab);
+
+-- Table	Side		Derives
+-- rep_tab	pdsOuter	EdtTaintedReplicated
+-- rand_tab	pdsInner	EdtHashed
+--
+-- join derives EdtHashed
+explain select c from rep_tab where c in (select distinct d from rand_tab);
+select c from rep_tab where c in (select distinct d from rand_tab);
+
 -- start_ignore
 drop schema rpt cascade;
 -- end_ignore


### PR DESCRIPTION
This addresses https://github.com/greenplum-db/gpdb/issues/13058 (this fixes the issue described but this PR is not the backport to `6X_STABLE`)

Previously, CPhysicalJoin derived the outer distribution when it was tainted
replicated. It checked only for strict replicated and universal replicated and
returned the inner distribution in these cases (in this case, it satisfies
random). Tainted replicated wasn't considered and was causing an undercount (the
JOIN derived tainted replicated instead of random, which was causing the number
of columns to be undercounted, because it wrongly assumed that one segment
contained all output columns).
