### PR TITLE
Fix regression about PREPARE TRANSACTION in utility-mode connections

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1783,12 +1783,11 @@ exec_simple_query(const char *query_string)
 		}
 
 		/*
-		 * If are connected in utility mode, disallow PREPARE TRANSACTION
-		 * statements.
+		 * GPDB: If we are connected in utility mode, disallow PREPARE
+		 * TRANSACTION statements.
 		 */
-		TransactionStmt *transStmt = (TransactionStmt *) parsetree;
-		if (Gp_role == GP_ROLE_UTILITY && IsA(parsetree, TransactionStmt) &&
-			transStmt->kind == TRANS_STMT_PREPARE)
+		if (Gp_role == GP_ROLE_UTILITY && IsA(parsetree->stmt, TransactionStmt) &&
+			((TransactionStmt *) parsetree->stmt)->kind == TRANS_STMT_PREPARE)
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),

--- a/src/test/recovery/t/009_twophase.pl
+++ b/src/test/recovery/t/009_twophase.pl
@@ -4,7 +4,14 @@ use warnings;
 
 use PostgresNode;
 use TestLib;
-use Test::More tests => 24;
+
+# GPDB: Effectively disable this TAP test. We cannot run PREPARE
+# TRANSACTION in utility-mode. We need at least 1 test so create a
+# dummy one.
+#use Test::More tests => 24;
+use Test::More tests => 1;
+is(-1, -1, "Disable this TAP test");
+exit;
 
 my $psql_out = '';
 my $psql_rc  = '';

--- a/src/test/recovery/t/012_subtransactions.pl
+++ b/src/test/recovery/t/012_subtransactions.pl
@@ -4,7 +4,14 @@ use warnings;
 
 use PostgresNode;
 use TestLib;
-use Test::More tests => 12;
+
+# GPDB: Effectively disable this TAP test. We cannot run PREPARE
+# TRANSACTION in utility-mode. We need at least 1 test so create a
+# dummy one.
+#use Test::More tests => 12;
+use Test::More tests => 1;
+is(-1, -1, "Disable this TAP test");
+exit;
 
 # Setup master node
 my $node_master = get_new_node("master");

--- a/src/test/regress/expected/gp_prepared_xacts.out
+++ b/src/test/regress/expected/gp_prepared_xacts.out
@@ -1,0 +1,7 @@
+-- PREPARE TRANSACTION should not work
+BEGIN;
+PREPARE TRANSACTION 'foo_prep_xact';
+ERROR:  PREPARE TRANSACTION is not yet supported in Greenplum Database
+-- PREPARE TRANSACTION should not work in utility-mode connections either
+\! PGOPTIONS='-c gp_role=utility' psql -X regression -c "BEGIN; PREPARE TRANSACTION 'foo_prep_xact';"
+ERROR:  PREPARE TRANSACTION is not supported in utility mode

--- a/src/test/regress/expected/temp.out
+++ b/src/test/regress/expected/temp.out
@@ -311,7 +311,7 @@ create function pg_temp.twophase_func() returns void as
   $$ select '2pc_func'::text $$ language sql;
 prepare transaction 'twophase_func';
 ERROR:  PREPARE TRANSACTION is not yet supported in Greenplum Database
-rollback; -- PREPARE TRANACTION is not supported in GPDB
+rollback; -- PREPARE TRANSACTION is not supported in GPDB
 -- Function drop
 create function pg_temp.twophase_func() returns void as
   $$ select '2pc_func'::text $$ language sql;
@@ -319,29 +319,29 @@ begin;
 drop function pg_temp.twophase_func();
 prepare transaction 'twophase_func';
 ERROR:  PREPARE TRANSACTION is not yet supported in Greenplum Database
-rollback; -- PREPARE TRANACTION is not supported in GPDB
+rollback; -- PREPARE TRANSACTION is not supported in GPDB
 -- Operator creation
 begin;
 create operator pg_temp.@@ (leftarg = int4, rightarg = int4, procedure = int4mi);
 prepare transaction 'twophase_operator';
 ERROR:  PREPARE TRANSACTION is not yet supported in Greenplum Database
-rollback; -- PREPARE TRANACTION is not supported in GPDB
+rollback; -- PREPARE TRANSACTION is not supported in GPDB
 -- These generate errors about temporary tables.
 begin;
 create type pg_temp.twophase_type as (a int);
 prepare transaction 'twophase_type';
 ERROR:  PREPARE TRANSACTION is not yet supported in Greenplum Database
-rollback; -- PREPARE TRANACTION is not supported in GPDB
+rollback; -- PREPARE TRANSACTION is not supported in GPDB
 begin;
 create view pg_temp.twophase_view as select 1;
 prepare transaction 'twophase_view';
 ERROR:  PREPARE TRANSACTION is not yet supported in Greenplum Database
-rollback; -- PREPARE TRANACTION is not supported in GPDB
+rollback; -- PREPARE TRANSACTION is not supported in GPDB
 begin;
 create sequence pg_temp.twophase_seq;
 prepare transaction 'twophase_sequence';
 ERROR:  PREPARE TRANSACTION is not yet supported in Greenplum Database
-rollback; -- PREPARE TRANACTION is not supported in GPDB
+rollback; -- PREPARE TRANSACTION is not supported in GPDB
 -- Temporary tables cannot be used with two-phase commit.
 create temp table twophase_tab (a int);
 begin;
@@ -352,22 +352,22 @@ select a from twophase_tab;
 
 prepare transaction 'twophase_tab';
 ERROR:  PREPARE TRANSACTION is not yet supported in Greenplum Database
-rollback; -- PREPARE TRANACTION is not supported in GPDB
+rollback; -- PREPARE TRANSACTION is not supported in GPDB
 begin;
 insert into twophase_tab values (1);
 prepare transaction 'twophase_tab';
 ERROR:  PREPARE TRANSACTION is not yet supported in Greenplum Database
-rollback; -- PREPARE TRANACTION is not supported in GPDB
+rollback; -- PREPARE TRANSACTION is not supported in GPDB
 begin;
 lock twophase_tab in access exclusive mode;
 prepare transaction 'twophase_tab';
 ERROR:  PREPARE TRANSACTION is not yet supported in Greenplum Database
-rollback; -- PREPARE TRANACTION is not supported in GPDB
+rollback; -- PREPARE TRANSACTION is not supported in GPDB
 begin;
 drop table twophase_tab;
 prepare transaction 'twophase_tab';
 ERROR:  PREPARE TRANSACTION is not yet supported in Greenplum Database
-rollback; -- PREPARE TRANACTION is not supported in GPDB
+rollback; -- PREPARE TRANSACTION is not supported in GPDB
 -- Corner case: current_schema may create a temporary schema if namespace
 -- creation is pending, so check after that.  First reset the connection
 -- to remove the temporary namespace.

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -37,7 +37,7 @@ test: instr_in_shmem_setup
 test: instr_in_shmem
 
 test: createdb
-test: gp_aggregates gp_aggregates_costs gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml shared_scan update_gp triggers_gp returning_gp resource_queue_with_rule gp_types gp_index cluster_gp combocid_gp gp_sort
+test: gp_aggregates gp_aggregates_costs gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml shared_scan update_gp triggers_gp returning_gp resource_queue_with_rule gp_types gp_index cluster_gp combocid_gp gp_sort gp_prepared_xacts
 test: spi_processed64bit
 test: gp_tablespace_with_faults
 # below test(s) inject faults so each of them need to be in a separate group

--- a/src/test/regress/sql/gp_prepared_xacts.sql
+++ b/src/test/regress/sql/gp_prepared_xacts.sql
@@ -1,0 +1,6 @@
+-- PREPARE TRANSACTION should not work
+BEGIN;
+PREPARE TRANSACTION 'foo_prep_xact';
+
+-- PREPARE TRANSACTION should not work in utility-mode connections either
+\! PGOPTIONS='-c gp_role=utility' psql -X regression -c "BEGIN; PREPARE TRANSACTION 'foo_prep_xact';"

--- a/src/test/regress/sql/temp.sql
+++ b/src/test/regress/sql/temp.sql
@@ -235,52 +235,52 @@ begin;
 create function pg_temp.twophase_func() returns void as
   $$ select '2pc_func'::text $$ language sql;
 prepare transaction 'twophase_func';
-rollback; -- PREPARE TRANACTION is not supported in GPDB
+rollback; -- PREPARE TRANSACTION is not supported in GPDB
 -- Function drop
 create function pg_temp.twophase_func() returns void as
   $$ select '2pc_func'::text $$ language sql;
 begin;
 drop function pg_temp.twophase_func();
 prepare transaction 'twophase_func';
-rollback; -- PREPARE TRANACTION is not supported in GPDB
+rollback; -- PREPARE TRANSACTION is not supported in GPDB
 -- Operator creation
 begin;
 create operator pg_temp.@@ (leftarg = int4, rightarg = int4, procedure = int4mi);
 prepare transaction 'twophase_operator';
-rollback; -- PREPARE TRANACTION is not supported in GPDB
+rollback; -- PREPARE TRANSACTION is not supported in GPDB
 
 -- These generate errors about temporary tables.
 begin;
 create type pg_temp.twophase_type as (a int);
 prepare transaction 'twophase_type';
-rollback; -- PREPARE TRANACTION is not supported in GPDB
+rollback; -- PREPARE TRANSACTION is not supported in GPDB
 begin;
 create view pg_temp.twophase_view as select 1;
 prepare transaction 'twophase_view';
-rollback; -- PREPARE TRANACTION is not supported in GPDB
+rollback; -- PREPARE TRANSACTION is not supported in GPDB
 begin;
 create sequence pg_temp.twophase_seq;
 prepare transaction 'twophase_sequence';
-rollback; -- PREPARE TRANACTION is not supported in GPDB
+rollback; -- PREPARE TRANSACTION is not supported in GPDB
 
 -- Temporary tables cannot be used with two-phase commit.
 create temp table twophase_tab (a int);
 begin;
 select a from twophase_tab;
 prepare transaction 'twophase_tab';
-rollback; -- PREPARE TRANACTION is not supported in GPDB
+rollback; -- PREPARE TRANSACTION is not supported in GPDB
 begin;
 insert into twophase_tab values (1);
 prepare transaction 'twophase_tab';
-rollback; -- PREPARE TRANACTION is not supported in GPDB
+rollback; -- PREPARE TRANSACTION is not supported in GPDB
 begin;
 lock twophase_tab in access exclusive mode;
 prepare transaction 'twophase_tab';
-rollback; -- PREPARE TRANACTION is not supported in GPDB
+rollback; -- PREPARE TRANSACTION is not supported in GPDB
 begin;
 drop table twophase_tab;
 prepare transaction 'twophase_tab';
-rollback; -- PREPARE TRANACTION is not supported in GPDB
+rollback; -- PREPARE TRANSACTION is not supported in GPDB
 
 -- Corner case: current_schema may create a temporary schema if namespace
 -- creation is pending, so check after that.  First reset the connection


### PR DESCRIPTION
In GPDB, we do not allow users to use PREPARE TRANSACTION in regular
and utility-mode connections to prevent any conflicts/issues with
GPDB's distributed transaction manager that heavily utilizes two-phase
commit. As part of the Postgres 10 merge into GPDB, a regression was
introduced that allowed PREPARE TRANSACTION to be run in utility-mode
connections. The error check was being bypassed because the
TransactionStmt was not being properly obtained. The cause of this was
due to an upstream Postgres refactor that introduced RawStmt which
would wrap the TransactionStmt so the TransactionStmt typecast was
being done on the wrong parse node (needs to be done on the
RawStmt->stmt). Added simple regression test to make sure this
regression doesn't occur again from future Postgres merges. Also
disable some recovery TAP tests which use PREPARE TRANSACTION in
utility-mode connections.

Postgres commit reference (RawStmt refactor):
https://github.com/postgres/postgres/commit/ab1f0c8225714aaa18d2f9ca4f80cd009f145421

Although the loss of the TAP tests is unfortunate, we should try to enable them in the near future by maybe having some test GUC or preferably a fault injection point to allow PREPARE TRANSACTION in utility-mode connections.