### PR TITLE
[6X] (Backport) Enable faultinject point 'fault_in_background_writer_main' in builds without assertion.

### DIFF
--- a/src/backend/postmaster/bgwriter.c
+++ b/src/backend/postmaster/bgwriter.c
@@ -260,9 +260,7 @@ BackgroundWriterMain(void)
 		bool		can_hibernate;
 		int			rc;
 
-#ifdef USE_ASSERT_CHECKING
 		SIMPLE_FAULT_INJECTOR("fault_in_background_writer_main");
-#endif
 
 		/* Clear any already-pending wakeups */
 		ResetLatch(&MyProc->procLatch);


### PR DESCRIPTION
This is backport of #13175

I'm trying to investigate some flaky test failure of
regress/fsync/bgwriter_checkpoint.sql and haven't made any progress so
far. However, I found that the fault injection point
'fault_in_background_writer_main' wasn't enabled in builds without
assertion. So, this patch helps fix it.

## Here are some reminders before you submit the pull request
- [x] Pass `make installcheck`
