### PR TITLE
Resolve GPDB_12_MERGE_FIXMEs: TOAST for AO_ROW Table

### DIFF
--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -2602,10 +2602,11 @@ appendonly_insert_init(Relation rel, int segno)
 	 * This GUC must have the same value on write and read.
 	 */
 /* 	aoInsertDesc->useNoToast = aoentry->notoast; */
+
 	/*
-	 * GPDB_12_MERGE_FIXME: we should simply never use toast for AO, variable
-	 * length blocks of AO should be able to accommodate variable length
-	 * datums.
+	 * Although variable length blocks of AO should be able to accommodate variable length
+	 * datums, we still need to keep TOAST for AO_ROW to benefit to performance when query
+	 * in-line data.
 	 */
 	aoInsertDesc->useNoToast = !(rel->rd_tableam->relation_needs_toast_table(rel));
 


### PR DESCRIPTION
Resolve GPDB_12_MERGE_FIXMEs: TOAST for AO_ROW Table
    
This is intended to keep TOAST enabled for AO_ROW table.
Although large contents of attributes can be fully stored
in AO_ROW table, it is still necessary to keep TOAST capability
for AO_ROW to deal with out-of-line data storage case.
Queries (like select pg_relation_size()) will get better
performance for skipping fetching the out-of-line data unless
it is required. It is a good way of keeping tables being stored
locally and compactly.

However, for AOCS tables, we removed TOAST long time ago, because
there is meaningless to store a column data outside the column
storage itself. Long length content for a single column is not
a problem and no row-like overflow situation in column oriented
storage. Queries on AOCS tables always return all data without
differentiating in/out line mode. So TOAST is not used for AOCS
or column orientated table naturally by design.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
