### PR TITLE
(WIP) Combine gp_random_dist and replicated table to improve the performance of pg_relation_size in gpexpand

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1553,6 +1553,8 @@ class gpexpand:
             self._populate_regular_tables(dbname)
             self._populate_partitioned_tables(dbname)
 
+        self._fill_status_detail_source_bytes()
+
         nowStr = datetime.datetime.now()
         statusSQL = "INSERT INTO gpexpand.status VALUES ( 'SETUP DONE', '%s' ) " % (nowStr)
         dbconn.execSQL(self.conn, statusSQL)
@@ -1566,8 +1568,35 @@ class gpexpand:
         # including new segments has been started once before so finalize
         self.finalize_prepare()
 
+    def _fill_status_detail_source_bytes(self):
+        """Combine gp_random_dist and replicated table to improve the performance of pg_relation_size"""
+
+        if self.options.simple_progress:
+            return
+
+        # 1. create a table, and insert all table_oid from status_detail into it.
+        create_oid_table_sql = "create table gpexpand.all_table_oids(table_oid oid) distributed replicated;"
+        dbconn.execSQL(self.conn, create_oid_table_sql)
+        insert_oid_table_sql = "insert into gpexpand.all_table_oids select table_oid from gpexpand.status_detail;"
+        dbconn.execSQL(self.conn, insert_oid_table_sql)
+
+        # 2. use gp_random_dist to get all relation size in one single SQL, and update status_detail.source_bytes.
+        update_status_detail_sql = """
+        update gpexpand.status_detail set source_bytes = total_bytes 
+        from (
+            select table_oid, sum(pg_relation_size(table_oid)) total_bytes 
+            from gp_dist_random('gpexpand.all_table_oids') 
+            group by table_oid
+        ) x
+        where x.table_oid = gpexpand.status_detail.table_oid;
+        """
+        dbconn.execSQL(self.conn, update_status_detail_sql)
+
+        # 3. drop table
+        drop_oid_table_sql = "drop table gpexpand.all_table_oids;"
+        dbconn.execSQL(self.conn, drop_oid_table_sql)
+
     def _populate_regular_tables(self, dbname):
-        src_bytes_str = "0" if self.options.simple_progress else "pg_relation_size(quote_ident(n.nspname) || '.' || quote_ident(c.relname))"
         sql = """SELECT
     current_database(),
     quote_ident(n.nspname) || '.' || quote_ident(c.relname) as fq_name,
@@ -1578,7 +1607,7 @@ class gpexpand:
     '%s' as undone_status,
     NULL as expansion_started,
     NULL as expansion_finished,
-    %s as source_bytes
+    0 as source_bytes
 FROM
     pg_class c
     JOIN pg_namespace n ON (c.relnamespace=n.oid)
@@ -1591,7 +1620,7 @@ WHERE
     AND n.nspname != 'gpexpand'
     AND n.nspname != 'pg_bitmapindex'
     AND c.relpersistence != 't'
-                  """ % (undone_status, src_bytes_str)
+        """ % undone_status
         self.logger.debug(sql)
         table_conn = self.connect_database(dbname)
 
@@ -1654,7 +1683,6 @@ WHERE
             self.logger.debug(prepare_cmd)
             dbconn.execSQL(table_conn, prepare_cmd, autocommit=False)
 
-        src_bytes_str = "0" if self.options.simple_progress else "pg_relation_size(c.oid)"
         get_status_detail_cmd = """
              SELECT
                 current_database(),
@@ -1666,7 +1694,7 @@ WHERE
                 '%s' as undone_status,
                 NULL as expansion_started,
                 NULL as expansion_finished,
-                %s as source_bytes
+                0 as source_bytes
             FROM
                 pg_inherits a,
                 pg_partitioned_table b,
@@ -1680,7 +1708,7 @@ WHERE
                 c.relnamespace = n.oid and
                 c.relkind != 'p' and
                 c.relkind != 'f'
-        """ % (undone_status, src_bytes_str)
+        """ % undone_status
         self.logger.debug(get_status_detail_cmd)
 
         try:


### PR DESCRIPTION
In the current gpexpand implementation, when we insert tables into status_detail, we will use 
`pg_relation_size()` to calculate the size of the table, which becomes the performance bottleneck 
of gpexpand.

`pg_relation_size('t')` is executed on the QD, and dispatch commands to the QE, collects the 
results of all QEs and summarizes them to the client. If we had 10,000 tables, the above process 
would need to be repeated 10,000 times, with a lot of network overhead.

We can combine `gp_dist_random()` and replicate table to optimize the performance of obtaining 
multiple table sizes. The basic principles are as follows:

```
# create table and insert some data
postgres=# create table t(a int);
postgres=# create table s(a int);
postgres=# insert into t select * from generate_series(1, 1000);
postgres=# insert into s select * from generate_series(1, 4000);

# get reelation size
postgres=# select pg_relation_size('t');
 pg_relation_size 
------------------
            98304
(1 row)

postgres=# select pg_relation_size('s');
 pg_relation_size 
------------------
           196608
(1 row)

# create a replicated table holds all relation oid that we need calculate total size
postgres=# create table all_oids(table_oid oid) distributed replicated;
postgres=# insert into all_oids values ('t'::regclass::oid), ('s'::regclass::oid);

# use gp_dist_random to get all relation size on QEs, and gather to QD
postgres=# select table_oid::regclass::text, sum(pg_relation_size(table_oid)) 
postgres-# from gp_dist_random('all_oids') group by table_oid;
 table_oid |  sum   
-----------+--------
 s         | 196608
 t         |  98304
(2 rows)

postgres=# explain select table_oid::regclass::text, sum(pg_relation_size(table_oid))
postgres-# from gp_dist_random('all_oids') group by table_oid;
                                              QUERY PLAN                                              
------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=635.75..654.92 rows=1000 width=68)
   ->  Finalize HashAggregate  (cost=635.75..641.58 rows=333 width=68)
         Group Key: table_oid
         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=595.75..628.25 rows=1000 width=36)
               Hash Key: table_oid
               ->  Partial HashAggregate  (cost=595.75..608.25 rows=1000 width=36)
                     Group Key: table_oid
                     ->  Seq Scan on all_oids  (cost=0.00..355.00 rows=32100 width=4)
 Optimizer: Postgres query optimizer
(9 rows)
```

A simple performance test is as follows, time for the stage-1 of gpexpand:

#### 1. 10 partition tables, each with 700 subtables, total 7000 tables

Before this change: 90s
After this change:  23s

#### 2. 50 partition tables, each with 700 subtables, total 35000 tables

Before this change: 960s
After this change:  35s