### PR TITLE
Fix flaky fts_unblock_primary isolation2 test

### DIFF
--- a/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
+++ b/src/test/isolation2/expected/segwalrep/fts_unblock_primary.out
@@ -99,7 +99,8 @@ select content, role, preferred_role, mode, status from gp_segment_configuration
  2       | m    | m              | s    | u      
 (2 rows)
 
--- set mirror down grace period to zero to instantly mark mirror down
+-- set mirror down grace period to zero to instantly mark mirror down.
+-- the 2Uq and 2U pair will force a wait on the config reload.
 !\retcode gpconfig -c gp_fts_mark_mirror_down_grace_period -v 0;
 -- start_ignore
 -- end_ignore
@@ -108,7 +109,7 @@ select content, role, preferred_role, mode, status from gp_segment_configuration
 -- start_ignore
 -- end_ignore
 (exited with code 1)
-
+2Uq: ... <quitting>
 2U: show gp_fts_mark_mirror_down_grace_period;
  gp_fts_mark_mirror_down_grace_period 
 --------------------------------------
@@ -207,6 +208,8 @@ INSERT 10
  *                         
 (1 row)
 
+-- reset the mirror down grace period back to its default value.
+-- the 2Uq and 2U pair will force a wait on the config reload.
 !\retcode gpconfig -r gp_fts_mark_mirror_down_grace_period;
 -- start_ignore
 -- end_ignore
@@ -215,6 +218,7 @@ INSERT 10
 -- start_ignore
 -- end_ignore
 (exited with code 0)
+2Uq: ... <quitting>
 2U: show gp_fts_mark_mirror_down_grace_period;
  gp_fts_mark_mirror_down_grace_period 
 --------------------------------------

--- a/src/test/isolation2/sql/segwalrep/fts_unblock_primary.sql
+++ b/src/test/isolation2/sql/segwalrep/fts_unblock_primary.sql
@@ -42,10 +42,11 @@ select gp_inject_fault('fts_probe', 'reset', 1);
 select gp_request_fts_probe_scan();
 select content, role, preferred_role, mode, status from gp_segment_configuration where content=2;
 
--- set mirror down grace period to zero to instantly mark mirror down
+-- set mirror down grace period to zero to instantly mark mirror down.
+-- the 2Uq and 2U pair will force a wait on the config reload.
 !\retcode gpconfig -c gp_fts_mark_mirror_down_grace_period -v 0;
 !\retcode gpstop -u;
-
+2Uq:
 2U: show gp_fts_mark_mirror_down_grace_period;
 
 -- trigger fts probe and check to see primary marked n/u and mirror n/d
@@ -84,6 +85,9 @@ insert into fts_unblock_primary select i from generate_series(1,10)i;
 -- synchronous_standby_names should be back to its original value on the primary
 2U: show synchronous_standby_names;
 
+-- reset the mirror down grace period back to its default value.
+-- the 2Uq and 2U pair will force a wait on the config reload.
 !\retcode gpconfig -r gp_fts_mark_mirror_down_grace_period;
 !\retcode gpstop -u;
+2Uq:
 2U: show gp_fts_mark_mirror_down_grace_period;


### PR DESCRIPTION
The fts_unblock_primary isolation2 test would sometimes fail stating
that the GUC value was not updated after running `gpstop -u` to reload
from the updated postgresql.conf file. The cause of the flakiness was
due to the assumption that the SHOW command would immediately be
usable after `gpstop -u` returned. The `gpstop -u` command merely
sends SIGHUP signals to all the segments (e.g. pg_ctl reload on all
the segments) and does not do any validations. In this test, the SHOW
command was being run before the SIGHUP signal was handled which
resulted in the incorrect value being displayed. To fix this test
flake, we simply need to close our SQL connection after sending the
SIGHUP signals and open a new connection to run the SHOW command. This
solution works because the new connection will block until the config
reload has completed.

---------

Side notes:
* This test fix needs to be backported to 6X_STABLE.
* We need to check other tests to see if this same scenario could also occur.