### PR TITLE
Fix flaky insert-conflict-toast isolation test

### DIFF
--- a/src/test/isolation/expected/insert-conflict-toast_1.out
+++ b/src/test/isolation/expected/insert-conflict-toast_1.out
@@ -5,11 +5,19 @@ pg_advisory_xact_lock
 
                
 step s2insert: 
+  select pg_advisory_xact_lock_shared(1); 
   INSERT INTO ctoast (key, val) VALUES (1, ctoast_large_val()) ON CONFLICT DO NOTHING;
  <waiting ...>
 step s3insert: 
+  select pg_advisory_xact_lock_shared(1); 
   INSERT INTO ctoast (key, val) VALUES (1, ctoast_large_val()) ON CONFLICT DO NOTHING;
  <waiting ...>
 step s1commit: COMMIT;
 step s3insert: <... completed>
+pg_advisory_xact_lock_shared
+
+               
 step s2insert: <... completed>
+pg_advisory_xact_lock_shared
+
+               


### PR DESCRIPTION
The insert-conflict-toast isolation test would sometimes fail with a
weird diff that showed one INSERT in the permutation happening before
another INSERT. From first glance, it clearly looks like a race
condition which I was able to confirm by reproducing the issue on my
local machine. Upstream Postgres has already seen this issue before
with this isolation test and has a couple fixes on top but for the
current GPDB snapshot of PG12, the solution is to have a secondary
expected output file. Weirdly enough, the secondary expected output
file already existed but was not up-to-date. Updated it and confirmed
the output race condition is now properly handled.
