### PR TITLE
[6X] be-gssapi-common.h: Introduce configure guard

### DIFF
--- a/src/include/libpq/be-gssapi-common.h
+++ b/src/include/libpq/be-gssapi-common.h
@@ -14,6 +14,7 @@
 #ifndef BE_GSSAPI_COMMON_H
 #define BE_GSSAPI_COMMON_H
 
+#ifdef ENABLE_GSS
 #if defined(HAVE_GSSAPI_H)
 #include <gssapi.h>
 #else
@@ -23,7 +24,10 @@
 #endif
 #endif
 
+
 void		pg_GSS_error_be(int severity, const char *errmsg,
 						 OM_uint32 maj_stat, OM_uint32 min_stat);
 void		pg_store_proxy_credential(gss_cred_id_t cred);
+#endif
+
 #endif							/* BE_GSSAPI_COMMON_H */


### PR DESCRIPTION
c2e56adb5b46e0c95aa7a1970d92cacca4cf0548 introduced kerberos delegation
in libpq. It missed the ENABLE_GSS guard rail in be-gssapi-common.h.
Without this patch, even if we are building without the --with-gssapi
flag, we would run into the following error (reported on Ubuntu 20.04.4
LTS) if we don't have dependencies installed:

../../../src/include/libpq/be-gssapi-common.h:20:10: fatal error: gssapi/gssapi.h: No such file or directory
   20 | #include <gssapi/gssapi.h>
      |          ^~~~~~~~~~~~~~~~~
compilation terminated.
