### PR TITLE
fix gpload yaml staging_table when it has capital letters

### DIFF
--- a/gpMgmt/bin/gpload_test/gpload2/TEST.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST.py
@@ -679,10 +679,11 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
         file = mkpath('setup.sql')
         runfile(file)
         f = open(mkpath('query25.sql'),'a')
-        f.write("\! psql -d reuse_gptest -c 'select count(*) from csvtable;'")
+        f.write("\! psql -d reuse_gptest -c 'select count(*) from csvtable;'\n")
+        f.write("\\! psql -d reuse_gptest -c \"SELECT count(*) from pg_class WHERE relname = 'Staging_table';\"")
         f.close()
         copy_data('external_file_13.csv','data_file.csv')
-        write_config_file(reuse_flag='true',formatOpts='csv',file='data_file.csv',table='csvtable',format='csv',delimiter="','",log_errors=True,error_limit='10',staging_table='staging_table')
+        write_config_file(reuse_flag='true',formatOpts='csv',file='data_file.csv',table='csvtable',format='csv',delimiter="','",log_errors=True,error_limit='10',staging_table='\'"Staging_table"\'')
         self.doTest(25)
     def test_26_gpload_ext_staging_table_with_externalschema(self):
         "26  gpload reuse ext_staging_table if it is configured with externalschema"
@@ -692,17 +693,18 @@ class GPLoad_FormatOpts_TestCase(unittest.TestCase):
         f.write("\! psql -d reuse_gptest -c 'select count(*) from csvtable;'")
         f.close()
         copy_data('external_file_13.csv','data_file.csv')
-        write_config_file(reuse_flag='true',formatOpts='csv',file='data_file.csv',table='csvtable',format='csv',delimiter="','",log_errors=True,error_limit='10',staging_table='staging_table',externalSchema='test')
+        write_config_file(reuse_flag='true',formatOpts='csv',file='data_file.csv',table='csvtable',format='csv',delimiter="','",log_errors=True,error_limit='10',staging_table='staging_table',externalSchema='\'"Test"\'')
         self.doTest(26)
     def test_27_gpload_ext_staging_table_with_externalschema(self):
         "27  gpload reuse ext_staging_table if it is configured with externalschema"
         file = mkpath('setup.sql')
         runfile(file)
         f = open(mkpath('query27.sql'),'a')
-        f.write("\! psql -d reuse_gptest -c 'select count(*) from test.csvtable;'")
+        f.write("\! psql -d reuse_gptest -c 'select count(*) from test.csvtable;'\n")
+        f.write('\! psql -d reuse_gptest -c "select * from pg_tables where schemaname = \'test\' and tablename = \'staging_table\';"\n')
         f.close()
         copy_data('external_file_13.csv','data_file.csv')
-        write_config_file(reuse_flag='true',formatOpts='csv',file='data_file.csv',table='test.csvtable',format='csv',delimiter="','",log_errors=True,error_limit='10',staging_table='staging_table',externalSchema="'%'")
+        write_config_file(reuse_flag='true',formatOpts='csv',file='data_file.csv',table='test.csvtable',format='csv',delimiter="','",log_errors=True,error_limit='10',staging_table='"Staging_table"',externalSchema="'%'")
         self.doTest(27)
     def test_28_gpload_ext_staging_table_with_dot(self):
         "28  gpload reuse ext_staging_table if it is configured with dot"

--- a/gpMgmt/bin/gpload_test/gpload2/query25.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query25.ans
@@ -9,7 +9,7 @@
 2018-01-17 21:31:13|INFO|gpload session started 2018-01-17 21:31:13
 2018-01-17 21:31:13|INFO|setting schema 'public' for table 'csvtable'
 2018-01-17 21:31:13|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/lhl/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.csv" -t 30
-2018-01-17 21:31:13|INFO|reusing external staging table staging_table
+2018-01-17 21:31:13|INFO|reusing external staging table "Staging_table"
 2018-01-17 21:31:13|INFO|running time: 0.08 seconds
 2018-01-17 21:31:13|INFO|rows Inserted          = 2
 2018-01-17 21:31:13|INFO|rows Updated           = 0
@@ -18,5 +18,10 @@
  count 
 -------
      4
+(1 row)
+
+ count 
+-------
+     1
 (1 row)
 

--- a/gpMgmt/bin/gpload_test/gpload2/query26.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query26.ans
@@ -9,7 +9,7 @@
 2018-01-17 21:36:48|INFO|gpload session started 2018-01-17 21:36:48
 2018-01-17 21:36:48|INFO|setting schema 'public' for table 'csvtable'
 2018-01-17 21:36:48|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/lhl/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.csv" -t 30
-2018-01-17 21:36:48|INFO|reusing external staging table test.staging_table
+2018-01-17 21:36:48|INFO|reusing external staging table "Test".staging_table
 2018-01-17 21:36:48|INFO|running time: 0.08 seconds
 2018-01-17 21:36:48|INFO|rows Inserted          = 2
 2018-01-17 21:36:48|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query27.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query27.ans
@@ -7,7 +7,7 @@
 2018-01-17 21:43:21|INFO|gpload succeeded
 2018-01-17 21:43:21|INFO|gpload session started 2018-01-17 21:43:21
 2018-01-17 21:43:22|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/lhl/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.csv" -t 30
-2018-01-17 21:43:22|INFO|reusing external staging table test.staging_table
+2018-01-17 21:43:22|INFO|reusing external staging table "test".Staging_table
 2018-01-17 21:43:22|INFO|running time: 0.08 seconds
 2018-01-17 21:43:22|INFO|rows Inserted          = 2
 2018-01-17 21:43:22|INFO|rows Updated           = 0
@@ -16,5 +16,10 @@
  count 
 -------
      4
+(1 row)
+
+ schemaname |   tablename   | tableowner | tablespace | hasindexes | hasrules | hastriggers
+------------+---------------+------------+------------+------------+----------+-------------
+ test       | staging_table | gpadmin    |            | f          | f        | f
 (1 row)
 

--- a/gpMgmt/bin/gpload_test/gpload2/setup.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/setup.ans
@@ -3,6 +3,8 @@ DROP DATABASE
 CREATE DATABASE reuse_gptest;
 CREATE DATABASE
 You are now connected to database "reuse_gptest" as user "gpadmin".
+CREATE SCHEMA "Test";
+CREATE SCHEMA
 CREATE SCHEMA test;
 CREATE SCHEMA
 DROP EXTERNAL TABLE IF EXISTS temp_gpload_staging_table;

--- a/gpMgmt/bin/gpload_test/gpload2/setup.sql
+++ b/gpMgmt/bin/gpload_test/gpload2/setup.sql
@@ -4,6 +4,7 @@ CREATE DATABASE reuse_gptest;
 
 \c reuse_gptest
 
+CREATE SCHEMA "Test";
 CREATE SCHEMA test;
 
 DROP EXTERNAL TABLE IF EXISTS temp_gpload_staging_table;


### PR DESCRIPTION
gpload yaml should like:
'''
GPLOAD:
  PRELOAD:
    - STAGING_TABLE: '"Staging_table"'
'''
 gpload should recognize capital letters table name in '" and "' 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
