### PR TITLE
Backport PARALLEL RETRIEVE CURSOR changes

### DIFF
--- a/doc/src/sgml/ref/allfiles.sgml
+++ b/doc/src/sgml/ref/allfiles.sgml
@@ -170,6 +170,7 @@ Complete list of usable sgml source files in this directory.
 <!ENTITY reindex            SYSTEM "reindex.sgml">
 <!ENTITY releaseSavepoint   SYSTEM "release_savepoint.sgml">
 <!ENTITY reset              SYSTEM "reset.sgml">
+<!ENTITY retrieve           SYSTEM "retrieve.sgml">
 <!ENTITY revoke             SYSTEM "revoke.sgml">
 <!ENTITY rollback           SYSTEM "rollback.sgml">
 <!ENTITY rollbackPrepared   SYSTEM "rollback_prepared.sgml">

--- a/doc/src/sgml/ref/declare.sgml
+++ b/doc/src/sgml/ref/declare.sgml
@@ -21,13 +21,13 @@ PostgreSQL documentation
 
  <refnamediv>
   <refname>DECLARE</refname>
-  <refpurpose>define a cursor</refpurpose>
+  <refpurpose>define a cursor or a parallel retrieve cursor</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
 <synopsis>
 DECLARE <replaceable class="parameter">name</replaceable> [ BINARY ] [ INSENSITIVE ] [ [ NO ] SCROLL ]
-    CURSOR [ { WITH | WITHOUT } HOLD ] FOR <replaceable class="parameter">query</replaceable>
+  [ PARALLEL RETRIEVE ] CURSOR [ { WITH | WITHOUT } HOLD ] FOR <replaceable class="parameter">query</replaceable>
 </synopsis>
  </refsynopsisdiv>
 
@@ -40,6 +40,22 @@ DECLARE <replaceable class="parameter">name</replaceable> [ BINARY ] [ INSENSITI
    a small number of rows at a time out of a larger query.
    After the cursor is created, rows are fetched from it using
    <xref linkend="sql-fetch"/>.
+  </para>
+
+  <para>
+    Like a normal cursor, user can declare a parallel retrieve cursor on
+    coordinator, then retrieve the query results on each segment directly.
+  </para>
+
+  <para>
+    Parallel retrieve cursor has similar declaration and syntax as normal cursor
+    does. However, some cursor operations are not supported in parallel retrieve
+    cursor(e.g. MOVE).
+  </para>
+
+  <para>
+    NOTE: Orca doesn't support PARALLEL RETRIEVE CURSOR for now. It would fall
+    back to postgres optimizer automatically.
   </para>
 
   <note>
@@ -102,6 +118,10 @@ DECLARE <replaceable class="parameter">name</replaceable> [ BINARY ] [ INSENSITI
       <literal>SCROLL</literal>. See <xref linkend="sql-declare-notes"
       endterm="sql-declare-notes-title"/> for details.
      </para>
+
+     <para>
+      PARALLEL RETRIEVE CURSOR with <literal>WITH SCROLL</literal> is not supported.
+     </para>
     </listitem>
    </varlistentry>
 
@@ -116,6 +136,10 @@ DECLARE <replaceable class="parameter">name</replaceable> [ BINARY ] [ INSENSITI
       created it. If neither <literal>WITHOUT HOLD</literal> nor
       <literal>WITH HOLD</literal> is specified, <literal>WITHOUT
       HOLD</literal> is the default.
+     </para>
+
+     <para>
+      PARALLEL RETRIEVE CURSOR with <literal>WITH HOLD</literal> is not supported.
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/retrieve.sgml
+++ b/doc/src/sgml/ref/retrieve.sgml
@@ -1,0 +1,89 @@
+<!--
+doc/src/sgml/ref/retrieve.sgml
+PostgreSQL documentation
+-->
+
+<refentry id="sql-retrieve">
+ <indexterm zone="sql-retrieve">
+  <primary>RETRIEVE</primary>
+ </indexterm>
+
+ <refmeta>
+  <refentrytitle>RETRIEVE</refentrytitle>
+  <manvolnum>7</manvolnum>
+  <refmiscinfo>SQL - Language Statements</refmiscinfo>
+ </refmeta>
+
+ <refnamediv>
+  <refname>RETRIEVE</refname>
+  <refpurpose>retrieve from endpoint</refpurpose>
+ </refnamediv>
+
+ <refsynopsisdiv>
+<synopsis>
+RETRIEVE { ALL | <replaceable class="parameter">count</replaceable> } FROM ENDPOINT <replaceable class="parameter">endpoint_name</replaceable>;
+
+</synopsis>
+ </refsynopsisdiv>
+
+ <refsect1>
+  <title>Description</title>
+
+  <para>
+   <command>RETRIEVE</command> retrieves data from endpoint.
+  </para>
+
+  <para>
+    In each retrieve session, the query result on that segment can be
+    retrieved by using statement "RETRIEVE" and its corresponding endpoint
+    name.
+  </para>
+
+  <para>
+    An empty set will be returned if no more
+    tuples for the endpoint.
+  </para>
+ </refsect1>
+
+ <refsect1>
+  <title>Parameters</title>
+
+  <variablelist>
+   <varlistentry>
+    <term><replaceable class="parameter">count</replaceable></term>
+    <listitem>
+     <para>
+      a positive integer value needs to be provided as the "count" to
+        specify how many rows to retrieve.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><literal>ALL</literal></term>
+    <listitem>
+     <para>
+      Parameter "ALL" means to retrieve all the results from the endpoint.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><replaceable class="PARAMETER">endpoint_name</replaceable></term>
+    <listitem>
+     <para>
+      The endpoint to retrieve data from, endpoint names can be listed from function gp_get_endpoints().
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1>
+  <title>See Also</title>
+
+  <simplelist type="inline">
+   <member><xref linkend="sql-declare"></member>
+  </simplelist>
+ </refsect1>
+</refentry>

--- a/src/backend/catalog/system_views.sql
+++ b/src/backend/catalog/system_views.sql
@@ -1782,15 +1782,24 @@ CREATE OR REPLACE VIEW gp_stat_archiver AS
     UNION
     SELECT gp_execution_segment() AS gp_segment_id, * FROM gp_dist_random('pg_stat_archiver');
 
-CREATE FUNCTION gp_session_endpoints (OUT gp_segment_id int, OUT auth_token text,
-									  OUT cursorname text, OUT sessionid int, OUT hostname text,
-									  OUT port int, OUT userid oid, OUT state text,
+CREATE FUNCTION gp_get_session_endpoints (OUT gp_segment_id int, OUT auth_token text,
+									  OUT cursorname text, OUT sessionid int, OUT hostname varchar(64),
+									  OUT port int, OUT username text, OUT state text,
 									  OUT endpointname text)
 RETURNS SETOF RECORD AS
 $$
-   SELECT * FROM gp_endpoints()
+   SELECT * FROM pg_catalog.gp_get_endpoints()
 	WHERE sessionid = (SELECT setting FROM pg_settings WHERE name = 'gp_session_id')::int4
 $$
 LANGUAGE SQL EXECUTE ON COORDINATOR;
 
-COMMENT ON FUNCTION pg_catalog.gp_session_endpoints() IS 'All endpoints in this session that are visible to the current user.';
+COMMENT ON FUNCTION pg_catalog.gp_get_session_endpoints() IS 'All endpoints in this session that are visible to the current user.';
+
+CREATE VIEW pg_catalog.gp_endpoints AS
+    SELECT * FROM pg_catalog.gp_get_endpoints();
+
+CREATE VIEW pg_catalog.gp_segment_endpoints AS
+    SELECT * FROM pg_catalog.gp_get_segment_endpoints();
+
+CREATE VIEW pg_catalog.gp_session_endpoints AS
+    SELECT * FROM pg_catalog.gp_get_session_endpoints();

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -44,7 +44,7 @@
 #include "commands/sequence.h"
 #include "access/xact.h"
 #include "utils/timestamp.h"
-#define DISPATCH_WAIT_TIMEOUT_MSEC 1000
+#define DISPATCH_WAIT_TIMEOUT_MSEC 2000
 
 /*
  * Ideally, we should set timeout to zero to cancel QEs as soon as possible,
@@ -52,6 +52,13 @@
  * as many finishing QEs as possible before cancelling
  */
 #define DISPATCH_WAIT_CANCEL_TIMEOUT_MSEC 100
+
+/*
+ * DISPATCH_NO_WAIT means return immediate when there's no more data,
+ * DISPATCH_WAIT_UNTIL_FINISH means wait until all dispatch works are completed.
+ */
+#define DISPATCH_NO_WAIT 0
+#define DISPATCH_WAIT_UNTIL_FINISH -1
 
 typedef struct CdbDispatchCmdAsync
 {
@@ -74,9 +81,9 @@ typedef struct CdbDispatchCmdAsync
 	volatile DispatchWaitMode waitMode;
 
 	/*
-	 * When waitMode is set to DISPATCH_WAIT_ACK_ROOT/DISPATCH_WAIT_ACK_ALL,
-	 * the expected acknowledge message from QE should be specified. This field
-	 * stores the expected acknowledge message.
+	 * When waitMode is set to DISPATCH_WAIT_ACK_ROOT,
+	 * the expected acknowledge message from QE should be specified.
+	 * This field stores the expected acknowledge message.
 	 */
 	const char	*ackMessage;
 
@@ -155,7 +162,7 @@ cdbdisp_checkForCancel_async(struct CdbDispatcherState *ds)
 {
 	Assert(ds);
 
-	checkDispatchResult(ds, 0);
+	checkDispatchResult(ds, DISPATCH_NO_WAIT);
 	return cdbdisp_checkResultsErrcode(ds->primaryResults);
 }
 
@@ -399,7 +406,7 @@ cdbdisp_checkDispatchResult_async(struct CdbDispatcherState *ds,
 	if (waitMode != DISPATCH_WAIT_NONE)
 		pParms->waitMode = waitMode;
 
-	checkDispatchResult(ds, -1);
+	checkDispatchResult(ds, DISPATCH_WAIT_UNTIL_FINISH);
 
 	/*
 	 * It looks like everything went fine, make sure we don't miss a user
@@ -438,6 +445,9 @@ cdbdisp_makeDispatchParams_async(int maxSlices, int largestGangSize, char *query
 
 /*
  * Receive and process results from all running QEs.
+ * timeout_sec: the second that the dispatcher waits for the ack messages at most.
+ *              DISPATCH_NO_WAIT(0): return immediate when there's no more data.
+ *              DISPATCH_WAIT_UNTIL_FINISH(-1): wait until all dispatch works are completed.
  *
  * Don't throw out error, instead, append the error message to
  * CdbDispatchResult.error_message.
@@ -457,6 +467,7 @@ checkDispatchResult(CdbDispatcherState *ds, int timeout_sec)
 	uint8 ftsVersion = 0;
 	struct timeval start_ts, now;
 	int64		diff_us;
+	bool		cancelRequested = false;
 
 	db_count = pParms->dispatchCount;
 	fds = (struct pollfd *) palloc(db_count * sizeof(struct pollfd));
@@ -481,12 +492,22 @@ checkDispatchResult(CdbDispatcherState *ds, int timeout_sec)
 		if (proc_exit_inprogress)
 			break;
 
+		PG_TRY();
+		{
+			CHECK_FOR_INTERRUPTS();
+		}
+		PG_CATCH();
+		{
+			cancelRequested = true;
+		}
+		PG_END_TRY();
+
 		/*
-		 * escalate waitMode to cancel if: - user interrupt has occurred, - or
-		 * an error has been reported by any QE, - in case the caller wants
+		 * escalate waitMode to cancel if: - user cancel request has occurred, 
+		 * - or an error has been reported by any QE, - in case the caller wants
 		 * cancelOnError
 		 */
-		if ((InterruptPending || meleeResults->errcode) && meleeResults->cancelOnError)
+		if ((cancelRequested || meleeResults->errcode) && meleeResults->cancelOnError)
 			pParms->waitMode = DISPATCH_WAIT_CANCEL;
 
 		/*
@@ -636,6 +657,9 @@ checkDispatchResult(CdbDispatcherState *ds, int timeout_sec)
 	}
 
 	pfree(fds);
+
+	if (cancelRequested)
+		PG_RE_THROW();
 }
 
 /*

--- a/src/backend/cdb/endpoint/README
+++ b/src/backend/cdb/endpoint/README
@@ -1,6 +1,6 @@
 src/backend/cdb/endpoint/README
 
-With the size of greenplum cluster increasing, the performance bottleneck on
+With the size of Greenplum cluster increasing, the performance bottleneck on
 the coordinator node becomes more and more obvious.
 
 The parallel retrieve cursor feature is designed to reduce the heavy burdens of
@@ -20,14 +20,15 @@ Parallel retrieve cursor has similar declaration and syntax as normal cursor
 does. However, some cursor operations are not supported in parallel retrieve
 cursor(e.g. MOVE).
 
-#NOTE: Orca doesn't support PARALLEL RETRIEVE CURSOR for now. It would fall
-back to postgres optimizer automatically.
+#NOTE: Orca doesn't support PARALLEL RETRIEVE CURSOR for now. Greenplum would
+fall back to postgres optimizer automatically.
 
 Endpoint
 ========
 
 Once a parallel retrieve cursor has been declared on QD, a corresponding
-endpoint will be created on each QE which contains the query result.  Then,
+endpoint will be created on the same segment whose QE contains the query
+result. These endpoints are backed by individual backends on each QE. Then,
 those endpoints can be used as the source, and results can be retrieved from
 them in parallel on each QE.
 
@@ -56,26 +57,26 @@ List Parallel Retrieve Cursors and their endpoints
 
 To retrieve the query results of a parallel retrieve cursor, the related
 endpoint information is needed before start a retrieve session on QEs. The UDF
-gp_endpoints() can be used to list parallel retrieve cursors and their
+gp_get_endpoints() can be used to list parallel retrieve cursors and their
 endpoints information. This UDF could be run on the coordinator only.
 
 For a superuser, it can list all endpoints information of all users', but for
 non-superuser, it can only list the current user's endpoints information for
 security reason.
 
-Definition: gp_endpoints()
+Definition: gp_get_endpoints()
 
-gp_endpoints Columns:
+gp_get_endpoints() Columns:
 |-------------+-----------+------------------------------------------|
 | Column Name | Data Type | Description                              |
 |-------------+-----------+------------------------------------------|
 | dbid        | integer   | The QE's dbid                            |
 |-------------+-----------+------------------------------------------|
-| auth_token  | text      | Retrieve session authentication token    |
+| auth_token  | text      | Retrieve-session authentication token    |
 |-------------+-----------+------------------------------------------|
 | cursorname  | text      | Parallel retrieve cursor name            |
 |-------------+-----------+------------------------------------------|
-| sessionid   | integer   | The session where the cursor created in  |
+| sessionid   | integer   | The session where the cursor was created |
 |-------------+-----------+------------------------------------------|
 | hostname    | text      | The host to retrieve from                |
 |-------------+-----------+------------------------------------------|
@@ -104,7 +105,7 @@ gp_endpoints Columns:
 
 Examples:
 
-postgres=# select * from gp_endpoints();
+postgres=# select * from gp_get_endpoints();
  dbid |            auth_token            | cursorname | sessionid | hostname | port | userid | state |    endpointname
 ------+----------------------------------+------------+-----------+----------+------+--------+-------+--------------------
     2 | 75ebe7b49c3e09f35e017fc0181c62cf | c3         |       105 | host67   | 7002 |     10 | READY | c30000006900000005
@@ -113,13 +114,14 @@ postgres=# select * from gp_endpoints();
 (3 rows)
 
 The userid of the endpoint is the session user, not the current user. For
-example, if login the database with user1, then set role to another user
-user2 and declare a parallel retrieve cursor.  The userid of these endpoints
-is user1's oid, not user2's oid. The session user should be used to start a
-retrieve connection. This is typically due to the security concern, e.g. if
-user2 is nologin, we surely do not expect to retrieive using user2.
+example, if a user logs in to the database as user1, then uses set role to
+switch to another user (e.g., user2) and declare a parallel retrieve cursor.
+The userid of these endpoints is user1's oid, not user2's oid. The session user
+(i.e., user1) should be used to start a retrieve connection. This is typically
+due to the security concern, e.g. if user2 is nologin, we should not be able to
+retrieve using user2.
 
-There is another similar gp_session_endpoints() that shows the endpoint
+There is another similar gp_get_session_endpoints() that shows the endpoint
 informations that belong to this session only.
 
 Start A Retrieve Session
@@ -180,13 +182,13 @@ List Endpoints In Utility Session On Endpoint QE
 
 It is possible to list all sessions' endpoints in the UTILITY connection to
 specific endpoint (coordinator or segment node) by using UDF
-gp_segment_endpoints(). Same as the UDF gp_endpoints(), a superuser can see the
+gp_get_segment_endpoints(). Same as the UDF gp_get_endpoints(), a superuser can see the
 endpoint information of all users, but non-superuser can see its endpoints
 information only for security reason.
 
-Definition: gp_segment_endpoints()
+Definition: gp_get_segment_endpoints()
 
-gp_segment_endpoints Columns:
+gp_get_segment_endpoints() Columns:
 |--------------+-----------+------------------------------------------|
 | Column Name  | Data Type | Description                              |
 |--------------+-----------+------------------------------------------|
@@ -201,7 +203,7 @@ gp_segment_endpoints Columns:
 |              |           | received on                              |
 |--------------+-----------+------------------------------------------|
 | state        | text      | The state of the endpoint                |
-|              |           | See gp_endpoints() for more details      |
+|              |           | See gp_get_endpoints() for more details  |
 |--------------+-----------+------------------------------------------|
 | dbid         | integer   | The QE's dbid                            |
 |--------------+-----------+------------------------------------------|
@@ -219,7 +221,7 @@ Examples:
 # Connect the segment in utility mode
 $> PGOPTIONS="-c gp_role=utility" psql -h host67 -p 7002 -d postgres
 
-postgres=# select * from gp_segment_endpoints();
+postgres=# select * from gp_get_segment_endpoints();
             auth_token            | databaseid | senderpid | receiverpid | state | dbid | sessionid | userid |    endpointname    | cursorname
 ----------------------------------+------------+-----------+-------------+-------+------+-----------+--------+--------------------+------------
  75ebe7b49c3e09f35e017fc0181c62cf |      13361 |      3854 |          -1 | READY |    2 |       105 |     10 | c30000006900000005 | c3
@@ -228,7 +230,7 @@ postgres=# select * from gp_segment_endpoints();
 Wait Parallel Retrieve Cursor To Be Fully Retrieved
 ===================================================
 
-UDF gp_wait_parallel_retrieve_cursor(text) is designed to block until all the
+UDF gp_wait_parallel_retrieve_cursor() is designed to block until all the
 endpoints have been fully retrieved for the given parallel retrieve cursor
 until timeout happens. It will block the coordinator session until all the
 relevant endpoints are fully retrieved unless timeout or error happens. When
@@ -246,7 +248,7 @@ an error message will be thrown.
 
 Examples:
 
-postgres=# SELECT gp_wait_parallel_retrieve_cursor('c3'); <waiting...>
+postgres=# SELECT gp_wait_parallel_retrieve_cursor('c3', -1); <waiting...>
  gp_wait_parallel_retrieve_cursor
 -----------------------------------
  t
@@ -315,7 +317,7 @@ DECLARE
 
 -- List endpoints to get the needed information to start retrieving
 -- sessions on segments
-postgres=# SELECT * FROM gp_endpoints();
+postgres=# SELECT * FROM gp_get_endpoints();
  dbid |            auth_token            | cursorname | sessionid | hostname | port | userid | state |    endpointname
 ------+----------------------------------+------------+-----------+----------+------+--------+-------+--------------------
     2 | c5c116a13e2fdb8b436cdbc8e1bc7365 | c1         |        22 | host67   | 7002 |     10 | READY | c1000000160000000a
@@ -342,7 +344,7 @@ Now the state of endpoint c1000000160000000a for dbid 2 (host67:7002) should
 become "FINISHED" since all results on the segment have been retrieved.
 
 -- List endpoints on coordinator to check
-postgres=# SELECT * FROM gp_endpoints();
+postgres=# SELECT * FROM gp_get_endpoints();
  dbid |            auth_token            | cursorname | sessionid | hostname | port | userid |  state   |    endpointname
 ------+----------------------------------+------------+-----------+----------+------+--------+----------+--------------------
     2 | c5c116a13e2fdb8b436cdbc8e1bc7365 | c1         |        22 | host67   | 7002 |     10 | FINISHED | c1000000160000000a
@@ -370,7 +372,7 @@ has been attached by a receiver. If the receiver has retrieved all the data
 from the endpoint, the state becomes FINISHED.
 
 -- List endpoints on coordinator to check
-postgres=# SELECT * FROM gp_endpoints();
+postgres=# SELECT * FROM gp_get_endpoints();
  dbid |            auth_token            | cursorname | sessionid | hostname | port | userid |  state   |    endpointname
 ------+----------------------------------+------------+-----------+----------+------+--------+----------+--------------------
     2 | c5c116a13e2fdb8b436cdbc8e1bc7365 | c1         |        22 | host67   | 7002 |     10 | FINISHED | c1000000160000000a
@@ -392,7 +394,7 @@ postgres=# CLOSE c1;
 CLOSE CURSOR
 
 -- All endpoints are gone
-postgres=# SELECT * FROM gp_endpoints();
+postgres=# SELECT * FROM gp_get_endpoints();
  dbid | auth_token | cursorname | sessionid | hostname | port | userid | state | endpointname
 ------+------------+------------+-----------+----------+------+--------+-------+--------------
 (0 rows)

--- a/src/backend/cdb/endpoint/cdbendpoint.c
+++ b/src/backend/cdb/endpoint/cdbendpoint.c
@@ -5,10 +5,10 @@
  * dedicated QE. One parallel retrieve cursor could have multiple endpoints
  * on different QEs to allow retrieving in parallel.
  *
- * This file implements the sender part of endpoint.
+ * This file implements the sender part of an endpoint.
  *
- * Endpoint may exist on the coordinator or segments, depends on the query of
- * the PARALLEL RETRIEVE CURSOR:
+ * Endpoints may exist on the coordinator or segments, depending on the query
+ * of the PARALLEL RETRIEVE CURSOR:
  * (1) An endpoint is on QD only if the query of the parallel cursor needs to
  *     be finally gathered by the master. e.g.:
  *     > DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM T1 ORDER BY C1;
@@ -23,9 +23,9 @@
  * will be created first on QEs. An instance of Endpoint struct in the shared
  * memory represents the endpoint. Through the Endpoint, the client could know
  * the endpoint's identification (endpoint name), location (dbid, host, port
- * and session id), and the state for the retrieve session. All of those
- * information can be obtained on QD by UDF gp_endpoints() via dispatching
- * endpoint queries or on QE's retrieve session by UDF gp_segment_endpoints().
+ * and session id), and the state for the retrieve session. All of this
+ * information can be obtained on QD by UDF gp_get_endpoints() via dispatching
+ * endpoint queries or on QE's retrieve session by UDF gp_get_segment_endpoints().
  *
  * Instead of returning the query result to QD through a normal dest receiver,
  * endpoints write the results to TQueueDestReceiver which is a shared memory
@@ -34,9 +34,9 @@
  * is also stored in the Endpoint so that the retrieve session on the same QE
  * can know.
  *
- * The token is stored in a different structure SessionInfoEntry to make the
- * tokens same for all endpoints in the same session. The token is created on
- * each QE after plan get dispatched.
+ * The token is stored in a different structure EndpointTokenEntry to make the
+ * tokens same for all backends within the same session under the same postmaster.
+ * The token is created on each QE after plan get dispatched.
  *
  * DECLARE returns only when endpoint and token are ready and query starts
  * execution. See WaitEndpointsReady().
@@ -63,6 +63,7 @@
 #include "access/session.h"
 #include "access/tupdesc.h"
 #include "access/xact.h"
+#include "commands/async.h"
 #include "libpq-fe.h"
 #include "libpq/libpq.h"
 #include "libpq/pqformat.h"
@@ -80,7 +81,7 @@
 #include "cdb/cdbsrlz.h"
 #include "cdb/cdbvars.h"
 
-#define WAIT_ENDPOINT_TIMEOUT				100
+#define WAIT_ENDPOINT_TIMEOUT_MS	100
 
 /*
  * The size of endpoint tuple queue in bytes.
@@ -96,32 +97,32 @@
 #define DUMMY_CURSOR_NAME	"DUMMYCURSORNAME"
 #endif
 
-static EndpointExecState * CurrEndpointExecState;
+static EndpointExecState * CurrentEndpointExecState;
 
-typedef struct SessionTokenTag
+typedef struct EndpointTokenTag
 {
 	int			sessionID;
 	Oid			userID;
-}			SessionTokenTag;
+}			EndpointTokenTag;
 
 /*
- * sharedSessionInfoHash is located in shared memory on each segment for
+ * EndpointTokenHash is located in shared memory on each segment for
  * authentication purpose.
  */
-typedef struct SessionInfoEntry
+typedef struct EndpointTokenEntry
 {
-	SessionTokenTag tag;
+	EndpointTokenTag tag;
 
 	/* The auth token for this session. */
-	int8		token[ENDPOINT_TOKEN_HEX_LEN];
+	int8		token[ENDPOINT_TOKEN_ARR_LEN];
 
 	/* How many endpoints are referred to this entry. */
 	uint16		refCount;
 
-}			SessionInfoEntry;
+}			EndpointTokenEntry;
 
 /* Shared hash table for session infos */
-static HTAB *sharedSessionInfoHash = NULL;
+static HTAB *EndpointTokenHash = NULL;
 
 /* Point to Endpoint entries in shared memory */
 static struct EndpointData *sharedEndpoints = NULL;
@@ -130,24 +131,21 @@ static struct EndpointData *sharedEndpoints = NULL;
 static void InitSharedEndpoints(void);
 
 /* Token utility functions */
-static const int8 *get_or_create_token(void);
+static const int8 *create_endpoint_token(void);
 
 /* Endpoint helper function */
-static void EndpointNotifyQD(const char *message);
-static Endpoint alloc_endpoint(const char *cursorName, dsm_handle dsmHandle);
-static void free_endpoint(Endpoint endpoint);
+static Endpoint *alloc_endpoint(const char *cursorName, dsm_handle dsmHandle);
+static void free_endpoint(Endpoint *endpoint);
 static void create_and_connect_mq(TupleDesc tupleDesc,
 								  dsm_segment **mqSeg /* out */ ,
 								  shm_mq_handle **mqHandle /* out */ );
 static void detach_mq(dsm_segment *dsmSeg);
-static void setup_session_info_entry(void);
-static void wait_receiver(EndpointExecState * state);
-static void unset_endpoint_sender_pid(Endpoint endPoint);
-static void abort_endpoint(EndpointExecState * state);
+static void setup_endpoint_token_entry(void);
+static void wait_receiver(void);
+static void unset_endpoint_sender_pid(Endpoint *endPoint);
+static void abort_endpoint(void);
 static void wait_parallel_retrieve_close(void);
 
-/* utility */
-static void generate_endpoint_name(char *name, const char *cursorName);
 
 /*
  * Calculate the shared memory size for PARALLEL RETRIEVE CURSOR execute.
@@ -164,7 +162,7 @@ EndpointShmemSize(void)
 	 * the maximum endpoint number, so use MAX_ENDPOINT_SIZE here.
 	 */
 	size = add_size(
-					size, hash_estimate_size(MAX_ENDPOINT_SIZE, sizeof(SessionInfoEntry)));
+					size, hash_estimate_size(MAX_ENDPOINT_SIZE, sizeof(EndpointTokenEntry)));
 	return size;
 }
 
@@ -177,7 +175,7 @@ EndpointShmemInit(void)
 	bool		found;
 	HASHCTL		hctl;
 
-	sharedEndpoints = (Endpoint)
+	sharedEndpoints = (Endpoint *)
 		ShmemInitStruct(SHMEM_ENDPOINTS_ENTRIES,
 						MAXALIGN(mul_size(MAX_ENDPOINT_SIZE, sizeof(struct EndpointData))),
 						&found);
@@ -185,10 +183,10 @@ EndpointShmemInit(void)
 		InitSharedEndpoints();
 
 	MemSet(&hctl, 0, sizeof(hctl));
-	hctl.keysize = sizeof(SessionTokenTag);
-	hctl.entrysize = sizeof(SessionInfoEntry);
+	hctl.keysize = sizeof(EndpointTokenTag);
+	hctl.entrysize = sizeof(EndpointTokenEntry);
 	hctl.hash = tag_hash;
-	sharedSessionInfoHash =
+	EndpointTokenHash =
 		ShmemInitHash(SHMEM_ENPOINTS_SESSION_INFO, MAX_ENDPOINT_SIZE,
 					  MAX_ENDPOINT_SIZE, &hctl, HASH_ELEM | HASH_FUNCTION);
 }
@@ -199,7 +197,7 @@ EndpointShmemInit(void)
 static void
 InitSharedEndpoints()
 {
-	Endpoint	endpoints = sharedEndpoints;
+	Endpoint	*endpoints = sharedEndpoints;
 
 	for (int i = 0; i < MAX_ENDPOINT_SIZE; ++i)
 	{
@@ -257,17 +255,18 @@ WaitEndpointsReady(EState *estate)
  * Get or create a authentication token for current session.
  */
 static const int8 *
-get_or_create_token(void)
+create_endpoint_token(void)
 {
 	static int	sessionId = InvalidEndpointSessionId;
-	static int8 currentToken[ENDPOINT_TOKEN_HEX_LEN] = {0};
+	static int8 currentToken[ENDPOINT_TOKEN_ARR_LEN] = {0};
 
+	/* Generate a new token only if gp_session_id has changed */
 	if (sessionId != gp_session_id)
 	{
 		sessionId = gp_session_id;
-		if (!pg_strong_random(currentToken, ENDPOINT_TOKEN_HEX_LEN))
+		if (!pg_strong_random(currentToken, ENDPOINT_TOKEN_ARR_LEN))
 			ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
-							errmsg("failed to generate a new random token")));
+							errmsg("failed to generate a new random token for session id %d", sessionId)));
 	}
 	return currentToken;
 }
@@ -275,16 +274,11 @@ get_or_create_token(void)
 /*
  * Send acknowledge message to QD.
  */
-static void
+void
 EndpointNotifyQD(const char *message)
 {
-	StringInfoData buf;
+	NotifyMyFrontEnd(CDB_NOTIFY_ENDPOINT_ACK, message, MyProcPid);
 
-	pq_beginmessage(&buf, 'A');
-	pq_sendint(&buf, MyProcPid, sizeof(int32));
-	pq_sendstring(&buf, CDB_NOTIFY_ENDPOINT_ACK);
-	pq_sendstring(&buf, message);
-	pq_endmessage(&buf);
 	pq_flush();
 }
 
@@ -295,31 +289,28 @@ EndpointNotifyQD(const char *message)
  */
 void
 SetupEndpointExecState(TupleDesc tupleDesc, const char *cursorName,
-					   EndpointExecState * state)
+						CmdType operation, DestReceiver **endpointDest)
 {
 	shm_mq_handle *shmMqHandle;
-	DestReceiver *endpointDest;
+
+	allocEndpointExecState();
 
 	/*
 	 * The message queue needs to be created first since the dsm_handle has to
 	 * be ready when create EndpointDesc entry.
 	 */
-	create_and_connect_mq(tupleDesc, &state->dsmSeg, &shmMqHandle);
+	create_and_connect_mq(tupleDesc, &(CurrentEndpointExecState->dsmSeg), &shmMqHandle);
 
 	/*
 	 * Alloc endpoint and set it as the active one for sender.
 	 */
-	state->endpoint =
-		alloc_endpoint(cursorName, dsm_segment_handle(state->dsmSeg));
-	setup_session_info_entry();
+	CurrentEndpointExecState->endpoint =
+		alloc_endpoint(cursorName, dsm_segment_handle(CurrentEndpointExecState->dsmSeg));
+	setup_endpoint_token_entry();
 
-	/*
-	 * Once the endpoint has been created in shared memory, send acknowledge
-	 * message to QD so DECLARE PARALLEL RETRIEVE CURSOR statement can finish.
-	 */
-	EndpointNotifyQD(ENDPOINT_READY_ACK_MSG);
-	endpointDest = CreateTupleQueueDestReceiver(shmMqHandle);
-	state->dest = endpointDest;
+	CurrentEndpointExecState->dest = CreateTupleQueueDestReceiver(shmMqHandle);
+	(CurrentEndpointExecState->dest->rStartup)(CurrentEndpointExecState->dest, operation, tupleDesc);
+	*endpointDest = CurrentEndpointExecState->dest;
 }
 
 /*
@@ -333,19 +324,19 @@ SetupEndpointExecState(TupleDesc tupleDesc, const char *cursorName,
  * Should also clean all other endpoint info here.
  */
 void
-DestroyEndpointExecState(EndpointExecState * state)
+DestroyEndpointExecState()
 {
-	DestReceiver *endpointDest = state->dest;
+	DestReceiver *endpointDest = CurrentEndpointExecState->dest;
 
-	Assert(state->endpoint);
-	Assert(state->dsmSeg);
+	Assert(CurrentEndpointExecState->endpoint);
+	Assert(CurrentEndpointExecState->dsmSeg);
 
 	/*
 	 * wait for receiver to start tuple retrieving. ackDone latch will be
 	 * reset to be re-used when retrieving finished. See notify_sender()
 	 * callers.
 	 */
-	wait_receiver(state);
+	wait_receiver();
 
 	/*
 	 * tqueueShutdownReceiver() (rShutdown callback) will call
@@ -354,17 +345,17 @@ DestroyEndpointExecState(EndpointExecState * state)
 	 */
 	(*endpointDest->rShutdown) (endpointDest);
 	(*endpointDest->rDestroy) (endpointDest);
-	state->dest = NULL;
+	CurrentEndpointExecState->dest = NULL;
 
 	/*
 	 * Wait until all data is retrieved by receiver. This is needed because
 	 * when the endpoint sends all data to shared message queue. The retrieve
 	 * session may still not get all data.
 	 */
-	wait_receiver(state);
+	wait_receiver();
 
 	LWLockAcquire(ParallelCursorEndpointLock, LW_EXCLUSIVE);
-	unset_endpoint_sender_pid(state->endpoint);
+	unset_endpoint_sender_pid(CurrentEndpointExecState->endpoint);
 	LWLockRelease(ParallelCursorEndpointLock);
 	/* Notify QD */
 	EndpointNotifyQD(ENDPOINT_FINISHED_ACK_MSG);
@@ -373,20 +364,20 @@ DestroyEndpointExecState(EndpointExecState * state)
 	 * If all data get sent, hang the process and wait for QD to close it. The
 	 * purpose is to not clean up Endpoint entry until CLOSE/COMMIT/ABORT
 	 * (i.e. PortalCleanup get executed). So user can still see the finished
-	 * endpoint status through the gp_endpoints() UDF. This is needed because
+	 * endpoint status through the gp_get_endpoints() UDF. This is needed because
 	 * pg_cursor view can still see the PARALLEL RETRIEVE CURSOR
 	 */
 	wait_parallel_retrieve_close();
 
 	LWLockAcquire(ParallelCursorEndpointLock, LW_EXCLUSIVE);
-	free_endpoint(state->endpoint);
+	free_endpoint(CurrentEndpointExecState->endpoint);
 	LWLockRelease(ParallelCursorEndpointLock);
-	state->endpoint = NULL;
+	CurrentEndpointExecState->endpoint = NULL;
 
-	detach_mq(state->dsmSeg);
-	state->dsmSeg = NULL;
+	detach_mq(CurrentEndpointExecState->dsmSeg);
+	CurrentEndpointExecState->dsmSeg = NULL;
 
-	CurrEndpointExecState = NULL;
+	CurrentEndpointExecState = NULL;
 }
 
 /*
@@ -396,11 +387,11 @@ DestroyEndpointExecState(EndpointExecState * state)
  * dsmHandle  - dsm handle of shared memory message queue.
  */
 static Endpoint
-alloc_endpoint(const char *cursorName, dsm_handle dsmHandle)
+*alloc_endpoint(const char *cursorName, dsm_handle dsmHandle)
 {
 	int			i;
 	int			foundIdx = -1;
-	Endpoint	ret = NULL;
+	Endpoint	*ret = NULL;
 	dsm_handle	session_dsm_handle;
 
 	session_dsm_handle = GetSessionDsmHandle();
@@ -461,7 +452,7 @@ alloc_endpoint(const char *cursorName, dsm_handle dsmHandle)
 
 	if (foundIdx == -1)
 		ereport(ERROR, (errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
-						errmsg("failed to allocate endpoint")));
+						errmsg("failed to allocate endpoint for session id %d", gp_session_id)));
 
 	generate_endpoint_name(sharedEndpoints[i].name, cursorName);
 	StrNCpy(sharedEndpoints[i].cursorName, cursorName, NAMEDATALEN);
@@ -522,6 +513,7 @@ create_and_connect_mq(TupleDesc tupleDesc, dsm_segment **mqSeg /* out */ ,
 
 	/* Create dsm and initialize toc. */
 	*mqSeg = dsm_create(tocSize, 0);
+	/* Make sure the dsm sticks around up until session exit */
 	dsm_pin_mapping(*mqSeg);
 
 	toc = shm_toc_create(ENDPOINT_MSG_QUEUE_MAGIC, dsm_segment_address(*mqSeg),
@@ -540,28 +532,29 @@ create_and_connect_mq(TupleDesc tupleDesc, dsm_segment **mqSeg /* out */ ,
 	shm_toc_insert(toc, ENDPOINT_KEY_TUPLE_QUEUE, mq);
 	shm_mq_set_sender(mq, MyProc);
 	*mqHandle = shm_mq_attach(mq, *mqSeg, NULL);
+	if (*mqHandle == NULL)
+		ereport(ERROR, (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+						errmsg("attach to endpoint shared message queue failed")));
 }
 
 /*
- * Create/reuse SessionInfoEntry for current session in shared memory.
- * SessionInfoEntry is used for authentication in the retrieve sessions.
+ * Create/reuse EndpointTokenEntry for current session in shared memory.
+ * EndpointTokenEntry is used for authentication in the retrieve sessions.
  */
 static void
-setup_session_info_entry()
+setup_endpoint_token_entry()
 {
-	SessionInfoEntry *infoEntry = NULL;
+	EndpointTokenEntry *infoEntry = NULL;
 	bool		found = false;
-	SessionTokenTag tag;
+	EndpointTokenTag tag;
 	const int8 *token = NULL;
 
 	tag.sessionID = gp_session_id;
 	tag.userID = GetSessionUserId();
 
 	LWLockAcquire(ParallelCursorEndpointLock, LW_EXCLUSIVE);
-	infoEntry = (SessionInfoEntry *) hash_search(sharedSessionInfoHash, &tag,
-												 HASH_ENTER, &found);
-	elog(DEBUG3, "CDB_ENDPOINT: Finish endpoint init. Found SessionInfoEntry? %d",
-		 found);
+	infoEntry = (EndpointTokenEntry *) hash_search(EndpointTokenHash, &tag, HASH_ENTER, &found);
+	elog(DEBUG3, "CDB_ENDPOINT: Finish endpoint init. Found EndpointTokenEntry? %d", found);
 
 	/*
 	 * Save the token if it is the first time we create endpoint in current
@@ -569,8 +562,8 @@ setup_session_info_entry()
 	 */
 	if (!found)
 	{
-		token = get_or_create_token();
-		memcpy(infoEntry->token, token, ENDPOINT_TOKEN_HEX_LEN);
+		token = create_endpoint_token();
+		memcpy(infoEntry->token, token, ENDPOINT_TOKEN_ARR_LEN);
 		infoEntry->refCount = 0;
 	}
 
@@ -627,8 +620,10 @@ checkQDConnectionAlive()
  * from the queue, the queue will be not available for receiver.
  */
 static void
-wait_receiver(EndpointExecState * state)
+wait_receiver(void)
 {
+	EndpointExecState * state = CurrentEndpointExecState;
+
 	elog(DEBUG3, "CDB_ENDPOINTS: wait receiver");
 	while (true)
 	{
@@ -643,7 +638,7 @@ wait_receiver(EndpointExecState * state)
 		wr = WaitLatchOrSocket(&state->endpoint->ackDone,
 							   WL_LATCH_SET | WL_POSTMASTER_DEATH | WL_TIMEOUT | WL_SOCKET_READABLE,
 							   MyProcPort->sock,
-							   WAIT_ENDPOINT_TIMEOUT,
+							   WAIT_ENDPOINT_TIMEOUT_MS,
 							   PG_WAIT_PARALLEL_RETRIEVE_CURSOR);
 
 		if (wr & WL_SOCKET_READABLE)
@@ -652,14 +647,14 @@ wait_receiver(EndpointExecState * state)
 			{
 				ereport(LOG,
 						(errmsg("CDB_ENDPOINT: sender found that the connection to QD is broken")));
-				abort_endpoint(state);
+				abort_endpoint();
 				proc_exit(0);
 			}
 		}
 
 		if (wr & WL_POSTMASTER_DEATH)
 		{
-			abort_endpoint(state);
+			abort_endpoint();
 			ereport(LOG,
 					(errmsg("CDB_ENDPOINT: postmaster exit, close shared memory message queue")));
 			proc_exit(0);
@@ -697,15 +692,10 @@ detach_mq(dsm_segment *dsmSeg)
  * Needs to be called with exclusive lock on ParallelCursorEndpointLock.
  */
 static void
-unset_endpoint_sender_pid(Endpoint endpoint)
+unset_endpoint_sender_pid(Endpoint *endpoint)
 {
-	SessionTokenTag tag;
-
-	tag.sessionID = gp_session_id;
-	tag.userID = GetSessionUserId();
-
-	if (endpoint == NULL || endpoint->empty)
-		return;
+	Assert(endpoint);
+	Assert(!endpoint->empty);
 
 	elog(DEBUG3, "CDB_ENDPOINT: unset endpoint sender pid");
 
@@ -715,18 +705,19 @@ unset_endpoint_sender_pid(Endpoint endpoint)
 	 */
 	Assert(MyProcPid == endpoint->senderPid ||
 		   endpoint->senderPid == InvalidPid);
-	if (MyProcPid == endpoint->senderPid)
-	{
-		endpoint->senderPid = InvalidPid;
-	}
+	Assert(!am_cursor_retrieve_handler);
+
+	endpoint->senderPid = InvalidPid;
 }
 
 /*
  * abort_endpoint - xact abort routine for endpoint
  */
 static void
-abort_endpoint(EndpointExecState * state)
+abort_endpoint(void)
 {
+	EndpointExecState * state = CurrentEndpointExecState;
+
 	if (state->dest)
 	{
 		/*
@@ -796,7 +787,7 @@ wait_parallel_retrieve_close(void)
 		wr = WaitLatchOrSocket(&MyProc->procLatch,
 							   WL_LATCH_SET | WL_POSTMASTER_DEATH | WL_TIMEOUT | WL_SOCKET_READABLE,
 							   MyProcPort->sock,
-							   WAIT_ENDPOINT_TIMEOUT,
+							   WAIT_ENDPOINT_TIMEOUT_MS,
 							   PG_WAIT_PARALLEL_RETRIEVE_CURSOR);
 
 		if (wr & WL_POSTMASTER_DEATH)
@@ -827,10 +818,11 @@ wait_parallel_retrieve_close(void)
  * Needs to be called with exclusive lock on ParallelCursorEndpointLock.
  */
 static void
-free_endpoint(Endpoint endpoint)
+free_endpoint(Endpoint *endpoint)
 {
-	SessionTokenTag tag;
-	SessionInfoEntry *infoEntry = NULL;
+	EndpointTokenTag tag;
+	EndpointTokenEntry *infoEntry = NULL;
+	bool	found;
 
 	Assert(endpoint);
 	Assert(!endpoint->empty);
@@ -848,20 +840,20 @@ free_endpoint(Endpoint endpoint)
 
 	tag.sessionID = endpoint->sessionID;
 	tag.userID = endpoint->userID;
-	infoEntry = (SessionInfoEntry *) hash_search(
-												 sharedSessionInfoHash, &tag, HASH_FIND, NULL);
-	if (infoEntry)
-	{
-		infoEntry->refCount--;
-		if (infoEntry->refCount == 0)
-			hash_search(sharedSessionInfoHash, &tag, HASH_REMOVE, NULL);
-	}
+	infoEntry = (EndpointTokenEntry *) hash_search(
+												 EndpointTokenHash, &tag, HASH_FIND, &found);
+	Assert(found);
+
+	infoEntry->refCount--;
+	if (infoEntry->refCount == 0)
+		hash_search(EndpointTokenHash, &tag, HASH_REMOVE, NULL);
+
 	endpoint->sessionID = InvalidEndpointSessionId;
 	endpoint->userID = InvalidOid;
 }
 
 Endpoint
-get_endpointdesc_by_index(int index)
+*get_endpointdesc_by_index(int index)
 {
 	Assert(index > -1 && index < MAX_ENDPOINT_SIZE);
 	return &sharedEndpoints[index];
@@ -879,11 +871,13 @@ get_endpointdesc_by_index(int index)
  * The caller is responsible for acquiring ParallelCursorEndpointLock lock.
  */
 Endpoint
-find_endpoint(const char *endpointName, int sessionID)
+*find_endpoint(const char *endpointName, int sessionID)
 {
-	Endpoint	res = NULL;
+	Endpoint	*res = NULL;
 
-	Assert(endpointName);
+	Assert(endpointName && strlen(endpointName) > 0);
+	Assert(LWLockHeldByMe(ParallelCursorEndpointLock));
+	Assert(sessionID != InvalidEndpointSessionId);
 
 	for (int i = 0; i < MAX_ENDPOINT_SIZE; ++i)
 	{
@@ -906,21 +900,21 @@ find_endpoint(const char *endpointName, int sessionID)
 void
 get_token_from_session_hashtable(int sessionId, Oid userID, int8 *token /* out */ )
 {
-	SessionInfoEntry *infoEntry = NULL;
-	SessionTokenTag tag;
+	EndpointTokenEntry *infoEntry = NULL;
+	EndpointTokenTag tag;
 
 	tag.sessionID = sessionId;
 	tag.userID = userID;
 
 	LWLockAcquire(ParallelCursorEndpointLock, LW_SHARED);
 
-	infoEntry = (SessionInfoEntry *) hash_search(sharedSessionInfoHash, &tag,
+	infoEntry = (EndpointTokenEntry *) hash_search(EndpointTokenHash, &tag,
 												 HASH_FIND, NULL);
 	if (infoEntry == NULL)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 						errmsg("token for user id: %u, session: %d doesn't exist",
 							   tag.userID, sessionId)));
-	memcpy(token, infoEntry->token, ENDPOINT_TOKEN_HEX_LEN);
+	memcpy(token, infoEntry->token, ENDPOINT_TOKEN_ARR_LEN);
 
 	LWLockRelease(ParallelCursorEndpointLock);
 }
@@ -932,12 +926,12 @@ int
 get_session_id_from_token(Oid userID, const int8 *token)
 {
 	int			sessionId = InvalidEndpointSessionId;
-	SessionInfoEntry *infoEntry = NULL;
+	EndpointTokenEntry *infoEntry = NULL;
 	HASH_SEQ_STATUS status;
 
 	LWLockAcquire(ParallelCursorEndpointLock, LW_SHARED);
-	hash_seq_init(&status, sharedSessionInfoHash);
-	while ((infoEntry = (SessionInfoEntry *) hash_seq_search(&status)) != NULL)
+	hash_seq_init(&status, EndpointTokenHash);
+	while ((infoEntry = (EndpointTokenEntry *) hash_seq_search(&status)) != NULL)
 	{
 		if (endpoint_token_hex_equals(infoEntry->token, token) &&
 			userID == infoEntry->tag.userID)
@@ -953,74 +947,36 @@ get_session_id_from_token(Oid userID, const int8 *token)
 }
 
 /*
- * Generate the endpoint name.
- */
-static void
-generate_endpoint_name(char *name, const char *cursorName)
-{
-	int			len,
-				cursorLen;
-
-	len = 0;
-
-	/* part1: cursor name */
-	cursorLen = strlen(cursorName);
-	if (cursorLen > ENDPOINT_NAME_CURSOR_LEN)
-		cursorLen = ENDPOINT_NAME_CURSOR_LEN;
-	memcpy(name, cursorName, cursorLen);
-	len += cursorLen;
-
-	/* part2: gp_session_id */
-	snprintf(name + len, ENDPOINT_NAME_SESSIONID_LEN + 1, "%08x", gp_session_id);
-	len += ENDPOINT_NAME_SESSIONID_LEN;
-
-	/*
-	 * part3: gp_command_count In theory cursor name + gp_session_id is
-	 * enough, but we'd keep this part to avoid confusion or potential issues
-	 * for the scenario that in the same session (thus same gp_session_id),
-	 * two endpoints with same cursor names (happens the cursor is
-	 * dropped/rollbacked and then recreated) and retrieve the endpoints would
-	 * be confusing for users that in the same retrieve connection.
-	 */
-	snprintf(name + len, ENDPOINT_NAME_COMMANDID_LEN + 1, "%08x", gp_command_count);
-	len += ENDPOINT_NAME_COMMANDID_LEN;
-
-	name[len] = '\0';
-}
-
-/*
  * Called during xaction abort.
  */
 void
 AtAbort_EndpointExecState()
 {
-	EndpointExecState *state = CurrEndpointExecState;
+	EndpointExecState *state = CurrentEndpointExecState;
 
 	if (state != NULL)
 	{
-		abort_endpoint(state);
+		abort_endpoint();
 		pfree(state);
 
-		CurrEndpointExecState = NULL;
+		CurrentEndpointExecState = NULL;
 	}
 }
 
-EndpointExecState *
+/* allocate new EndpointExecState and set it to CurrentEndpointExecState */
+void
 allocEndpointExecState()
 {
 	EndpointExecState *endpointExecState;
 	MemoryContext oldcontext;
 
-	if (unlikely(CurrEndpointExecState != NULL))
-		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
-						errmsg("previous endpoint estate is not cleaned up")));
+	/* Previous endpoint estate should be cleaned up. */
+	Assert(!CurrentEndpointExecState);
 
 	oldcontext = MemoryContextSwitchTo(TopMemoryContext);
 
 	endpointExecState = palloc0(sizeof(EndpointExecState));
-	CurrEndpointExecState = endpointExecState;
+	CurrentEndpointExecState = endpointExecState;
 
 	MemoryContextSwitchTo(oldcontext);
-
-	return endpointExecState;
 }

--- a/src/backend/cdb/endpoint/cdbendpoint_private.h
+++ b/src/backend/cdb/endpoint/cdbendpoint_private.h
@@ -17,8 +17,8 @@
 #define CDBENDPOINTINTERNAL_H
 
 #define MAX_ENDPOINT_SIZE				1024
-#define ENDPOINT_TOKEN_HEX_LEN			16
-#define ENDPOINT_TOKEN_STR_LEN			(ENDPOINT_TOKEN_HEX_LEN<<1)
+#define ENDPOINT_TOKEN_ARR_LEN			16
+#define ENDPOINT_TOKEN_STR_LEN			(ENDPOINT_TOKEN_ARR_LEN<<1)
 #define InvalidEndpointSessionId		(-1)	/* follows invalid
 												 * gp_session_id */
 
@@ -34,8 +34,6 @@
  */
 
 /* ACK NOTICE MESSAGE FROM ENDPOINT QE/Entry DB to QD */
-#define ENDPOINT_READY_ACK_MSG			"ENDPOINT_READY"
-#define ENDPOINT_FINISHED_ACK_MSG		"ENDPOINT_FINISHED"
 #define ENDPOINT_NAME_SESSIONID_LEN	8
 #define ENDPOINT_NAME_COMMANDID_LEN 8
 #define ENDPOINT_NAME_CURSOR_LEN   (NAMEDATALEN - 1 - ENDPOINT_NAME_SESSIONID_LEN - ENDPOINT_NAME_COMMANDID_LEN)
@@ -43,16 +41,16 @@
 extern void check_parallel_retrieve_cursor_errors(EState *estate);
 
 /* Endpoint shared memory utility functions in "cdbendpoint.c" */
-extern Endpoint get_endpointdesc_by_index(int index);
-extern Endpoint find_endpoint(const char *endpointName, int sessionID);
+extern Endpoint *get_endpointdesc_by_index(int index);
+extern Endpoint *find_endpoint(const char *endpointName, int sessionID);
 extern void get_token_from_session_hashtable(int sessionId, Oid userID, int8 *token /* out */ );
 extern int	get_session_id_from_token(Oid userID, const int8 *token);
 
 /* utility functions in "cdbendpointutilities.c" */
 extern bool endpoint_token_hex_equals(const int8 *token1, const int8 *token2);
 extern bool endpoint_name_equals(const char *name1, const char *name2);
-extern void endpoint_token_str2hex(int8 *token, const char *tokenStr);
-extern void endpoint_token_hex2str(const int8 *token, char *tokenStr);
+extern void endpoint_token_str2arr(const char *tokenStr, int8 *token);
+extern void endpoint_token_arr2str(const int8 *token, char *tokenStr);
 extern char *state_enum_to_string(EndpointState state);
 
 #endif							/* CDBENDPOINTINTERNAL_H */

--- a/src/backend/cdb/endpoint/cdbendpointretrieve.c
+++ b/src/backend/cdb/endpoint/cdbendpointretrieve.c
@@ -72,7 +72,7 @@ typedef struct RetrieveExecEntry
 	/* The name of endpoint to be retrieved, also behave as hash key */
 	char		endpointName[NAMEDATALEN];
 	/* The endpoint to be retrieved */
-	Endpoint	endpoint;
+	Endpoint	*endpoint;
 	/* The dsm handle which contains shared memory message queue */
 	dsm_segment *mqSeg;
 	/* Shared memory message queue */
@@ -94,7 +94,7 @@ typedef struct RetrieveControl
 	 * Track current retrieve entry in executor. Multiple entries are allowed
 	 * to be in one retrieve session but only one entry is active.
 	 */
-	RetrieveExecEntry *entry;
+	RetrieveExecEntry *current_entry;
 
 	/*
 	 * Hash table to cache tuple descriptors for all endpoint_names which have
@@ -115,21 +115,21 @@ static RetrieveControl RetrieveCtl =
 };
 
 static void init_retrieve_exec_entry(RetrieveExecEntry * entry);
-static Endpoint get_endpoint_from_retrieve_exec_entry(RetrieveExecEntry * entry, bool noError);
-static RetrieveExecEntry * start_retrieve(const char *endpointName);
-static void validate_retrieve_endpoint(Endpoint endpointDesc, const char *endpointName);
-static void finish_retrieve(RetrieveExecEntry * entry, bool resetPID);
-static void attach_receiver_mq(RetrieveExecEntry * entry, dsm_handle dsmHandle);
-static void detach_receiver_mq(RetrieveExecEntry * entry);
-static void notify_sender(RetrieveExecEntry * entry, bool finished);
-static void retrieve_cancel_action(RetrieveExecEntry * entry, char *msg);
+static Endpoint *get_endpoint_from_retrieve_exec_entry(RetrieveExecEntry *entry, bool noError);
+static void start_retrieve(const char *endpointName);
+static void validate_retrieve_endpoint(Endpoint *endpointDesc, const char *endpointName);
+static void finish_retrieve(bool resetPID);
+static void attach_receiver_mq(dsm_handle dsmHandle);
+static void detach_receiver_mq(RetrieveExecEntry *entry);
+static void notify_sender(bool finished);
+static void retrieve_cancel_action(RetrieveExecEntry *entry, char *msg);
 static void retrieve_exit_callback(int code, Datum arg);
 static void retrieve_xact_callback(XactEvent ev, void *arg);
 static void retrieve_subxact_callback(SubXactEvent event,
 									  SubTransactionId mySubid,
 									  SubTransactionId parentSubid,
 									  void *arg);
-static TupleTableSlot *receive_tuple_slot(RetrieveExecEntry * entry);
+static TupleTableSlot *retrieve_next_tuple(void);
 
 /*
  * AuthEndpoint - Authenticate for retrieve connection.
@@ -140,9 +140,9 @@ bool
 AuthEndpoint(Oid userID, const char *tokenStr)
 {
 	bool		found = false;
-	int8		token[ENDPOINT_TOKEN_HEX_LEN] = {0};
+	int8		token[ENDPOINT_TOKEN_ARR_LEN] = {0};
 
-	endpoint_token_str2hex(token, tokenStr);
+	endpoint_token_str2arr(tokenStr, token);
 
 	RetrieveCtl.sessionID = get_session_id_from_token(userID, token);
 	if (RetrieveCtl.sessionID != InvalidEndpointSessionId)
@@ -165,9 +165,9 @@ AuthEndpoint(Oid userID, const char *tokenStr)
 TupleDesc
 GetRetrieveStmtTupleDesc(const RetrieveStmt * stmt)
 {
-	RetrieveCtl.entry = start_retrieve(stmt->endpoint_name);
+	start_retrieve(stmt->endpoint_name);
 
-	return RetrieveCtl.entry->retrieveTs->tts_tupleDescriptor;
+	return RetrieveCtl.current_entry->retrieveTs->tts_tupleDescriptor;
 }
 
 /*
@@ -175,16 +175,16 @@ GetRetrieveStmtTupleDesc(const RetrieveStmt * stmt)
  *
  * This function tries to use the endpoint name in the RetrieveStmt to find the
  * attached endpoint in this retrieve session. If the endpoint can be found,
- * then read from the message queue to feed the given DestReceiver. And mark
- * the endpoint as detached before returning.
+ * then read from the message queue to feed the active portal's tuplestore. And
+ * mark the endpoint as detached before returning.
  */
 void
-ExecRetrieveStmt(const RetrieveStmt * stmt, DestReceiver *dest)
+ExecRetrieveStmt(const RetrieveStmt *stmt, DestReceiver *dest)
 {
 	TupleTableSlot *result = NULL;
 	int64		retrieveCount = 0;
 
-	if (RetrieveCtl.entry == NULL)
+	if (RetrieveCtl.current_entry == NULL)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 						errmsg("endpoint %s is not attached",
 							   stmt->endpoint_name)));
@@ -196,11 +196,14 @@ ExecRetrieveStmt(const RetrieveStmt * stmt, DestReceiver *dest)
 							   "count should not be: %ld",
 							   retrieveCount)));
 
-	if (RetrieveCtl.entry->retrieveState < RETRIEVE_STATE_FINISHED)
+	Assert(dest->mydest == DestTuplestore);
+	Assert(RetrieveCtl.current_entry->retrieveState > RETRIEVE_STATE_INIT);
+
+	if (RetrieveCtl.current_entry->retrieveState < RETRIEVE_STATE_FINISHED)
 	{
 		while (stmt->is_all || retrieveCount > 0)
 		{
-			result = receive_tuple_slot(RetrieveCtl.entry);
+			result = retrieve_next_tuple();
 			if (!result)
 				break;
 
@@ -209,8 +212,12 @@ ExecRetrieveStmt(const RetrieveStmt * stmt, DestReceiver *dest)
 				retrieveCount--;
 		}
 	}
+	else
+	{
+		/* All tuples have already been retrieved. Nothing to do */
+	}
 
-	finish_retrieve(RetrieveCtl.entry, false);
+	finish_retrieve(false);
 }
 
 /*
@@ -235,7 +242,7 @@ init_retrieve_exec_entry(RetrieveExecEntry * entry)
  * if there is something wrong during validation, warn or error out, depending
  * on the parameter noError.
  */
-static Endpoint
+static Endpoint*
 get_endpoint_from_retrieve_exec_entry(RetrieveExecEntry * entry, bool noError)
 {
 	Assert(LWLockHeldByMe(ParallelCursorEndpointLock));
@@ -268,6 +275,26 @@ get_endpoint_from_retrieve_exec_entry(RetrieveExecEntry * entry, bool noError)
 }
 
 /*
+ * Initialize a hashtable, its key is the endpoint's name, its value is
+ * RetrieveExecEntry
+*/
+void InitRetrieveCtl(void)
+{
+		HASHCTL		ctl;
+
+		if (RetrieveCtl.RetrieveExecEntryHTB)
+			return;
+
+		MemSet(&ctl, 0, sizeof(ctl));
+		ctl.keysize = NAMEDATALEN;
+		ctl.entrysize = sizeof(RetrieveExecEntry);
+		ctl.hash = string_hash;
+		RetrieveCtl.RetrieveExecEntryHTB = hash_create("retrieve hash", MAX_ENDPOINT_SIZE, &ctl,
+													   (HASH_ELEM | HASH_FUNCTION));
+		RetrieveCtl.current_entry = NULL;
+}
+
+/*
  * start_retrieve - start to retrieve an endpoint.
  *
  * Initialize current retrieve RetrieveExecEntry for the given
@@ -279,35 +306,17 @@ get_endpoint_from_retrieve_exec_entry(RetrieveExecEntry * entry, bool noError)
  * When call RETRIEVE statement in PQprepare() & PQexecPrepared(), this func will
  * be called 2 times.
  */
-static RetrieveExecEntry *
+static void
 start_retrieve(const char *endpointName)
 {
-	HTAB	   *entryHTB;
+	HTAB	   *entryHTB = RetrieveCtl.RetrieveExecEntryHTB;
 	RetrieveExecEntry *entry = NULL;
 	bool		found = false;
-	Endpoint	endpoint;
+	Endpoint	*endpoint;
 	dsm_handle	handle = DSM_HANDLE_INVALID;
 
-	/*
-	 * Initialize a hashtable, its key is the endpoint's name, its value is
-	 * RetrieveExecEntry
-	 */
-	entryHTB = RetrieveCtl.RetrieveExecEntryHTB;
-	if (entryHTB == NULL)
-	{
-		HASHCTL		ctl;
 
-		MemSet(&ctl, 0, sizeof(ctl));
-		ctl.keysize = NAMEDATALEN;
-		ctl.entrysize = sizeof(RetrieveExecEntry);
-		ctl.hash = string_hash;
-		RetrieveCtl.RetrieveExecEntryHTB = hash_create("retrieve hash", MAX_ENDPOINT_SIZE, &ctl,
-													   (HASH_ELEM | HASH_FUNCTION));
-		entryHTB = RetrieveCtl.RetrieveExecEntryHTB;
-		found = false;
-	}
-	else
-		entry = hash_search(entryHTB, endpointName, HASH_FIND, &found);
+	entry = hash_search(entryHTB, endpointName, HASH_FIND, &found);
 
 	LWLockAcquire(ParallelCursorEndpointLock, LW_EXCLUSIVE);
 
@@ -318,8 +327,8 @@ start_retrieve(const char *endpointName)
 		endpoint = find_endpoint(endpointName, RetrieveCtl.sessionID);
 		if (!endpoint)
 			ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-							errmsg("the endpoint %s does not exist in the session",
-								   endpointName)));
+							errmsg("the endpoint %s does not exist for session id %d",
+								   endpointName, RetrieveCtl.sessionID)));
 		validate_retrieve_endpoint(endpoint, endpointName);
 		endpoint->receiverPid = MyProcPid;
 		handle = endpoint->mqDsmHandle;
@@ -339,13 +348,14 @@ start_retrieve(const char *endpointName)
 	LWLockRelease(ParallelCursorEndpointLock);
 
 	entry->endpoint = endpoint;
+
+	RetrieveCtl.current_entry = entry;
+
 	if (!found)
-		attach_receiver_mq(entry, handle);
+		attach_receiver_mq(handle);
 
 	if (CurrentSession->segment == NULL)
 		AttachSession(endpoint->sessionDsmHandle);
-
-	return entry;
 }
 
 /*
@@ -353,7 +363,7 @@ start_retrieve(const char *endpointName)
  * validate whether it meets the requirement.
  */
 static void
-validate_retrieve_endpoint(Endpoint endpoint, const char *endpointName)
+validate_retrieve_endpoint(Endpoint *endpoint, const char *endpointName)
 {
 	Assert(endpoint->mqDsmHandle != DSM_HANDLE_INVALID);
 
@@ -402,18 +412,19 @@ validate_retrieve_endpoint(Endpoint endpoint, const char *endpointName)
  * Attach to the endpoint's shared memory message queue.
  */
 static void
-attach_receiver_mq(RetrieveExecEntry * entry, dsm_handle dsmHandle)
+attach_receiver_mq(dsm_handle dsmHandle)
 {
 	TupleDesc	td;
 	TupleDescNode *tupdescnode;
-	dsm_segment *dsmSeg;
 	MemoryContext oldcontext;
 	shm_toc    *toc;
 	void	   *lookup_space;
 	int			td_len;
+	RetrieveExecEntry *entry = RetrieveCtl.current_entry;
 
 	Assert(!entry->mqSeg);
 	Assert(!entry->mqHandle);
+	Assert(entry->retrieveState == RETRIEVE_STATE_INIT);
 
 	/*
 	 * Store the result slot all the retrieve mode QE life cycle, we only have
@@ -423,14 +434,17 @@ attach_receiver_mq(RetrieveExecEntry * entry, dsm_handle dsmHandle)
 
 	elog(DEBUG3, "CDB_ENDPOINTS: init message queue conn for receiver");
 
-	dsmSeg = dsm_attach(dsmHandle);
-	if (dsmSeg == NULL)
-		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
-						errmsg("attach to shared message queue failed")));
-	entry->mqSeg = dsmSeg;
+	entry->mqSeg = dsm_attach(dsmHandle);
+	if (entry->mqSeg == NULL)
+		ereport(ERROR, (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+						errmsg("attach to endpoint shared message queue failed")));
 
-	dsm_pin_mapping(dsmSeg);
-	toc = shm_toc_attach(ENDPOINT_MSG_QUEUE_MAGIC, dsm_segment_address(dsmSeg));
+	dsm_pin_mapping(entry->mqSeg);
+	toc = shm_toc_attach(ENDPOINT_MSG_QUEUE_MAGIC, dsm_segment_address(entry->mqSeg));
+	if (toc == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("invalid magic number in dynamic shared memory segment")));
 
 	/*
 	 * Find the shared mq for tuple receiving from 'toc' and set up the
@@ -439,7 +453,7 @@ attach_receiver_mq(RetrieveExecEntry * entry, dsm_handle dsmHandle)
 	shm_mq	   *mq = shm_toc_lookup(toc, ENDPOINT_KEY_TUPLE_QUEUE, false);
 
 	shm_mq_set_receiver(mq, MyProc);
-	entry->mqHandle = shm_mq_attach(mq, dsmSeg, NULL);
+	entry->mqHandle = shm_mq_attach(mq, entry->mqSeg, NULL);
 
 	/*
 	 * Find the tuple descritpr information from 'toc' and set the tuple
@@ -481,12 +495,12 @@ detach_receiver_mq(RetrieveExecEntry * entry)
  * If current endpoint get freed, it means the endpoint aborted.
  */
 static void
-notify_sender(RetrieveExecEntry * entry, bool finished)
+notify_sender(bool finished)
 {
-	Endpoint	endpoint;
+	Endpoint	*endpoint;
 
 	LWLockAcquire(ParallelCursorEndpointLock, LW_SHARED);
-	endpoint = get_endpoint_from_retrieve_exec_entry(entry, false);
+	endpoint = get_endpoint_from_retrieve_exec_entry(RetrieveCtl.current_entry, false);
 	if (finished)
 		endpoint->state = ENDPOINTSTATE_FINISHED;
 	SetLatch(&endpoint->ackDone);
@@ -499,11 +513,12 @@ notify_sender(RetrieveExecEntry * entry, bool finished)
  * When reading all tuples, should tell sender that retrieve is done.
  */
 static TupleTableSlot *
-receive_tuple_slot(RetrieveExecEntry * entry)
+retrieve_next_tuple()
 {
 	TupleTableSlot *result = NULL;
 	HeapTuple	tup = NULL;
 	bool		readerdone = false;
+	RetrieveExecEntry *entry = RetrieveCtl.current_entry;
 
 	CHECK_FOR_INTERRUPTS();
 
@@ -523,8 +538,8 @@ receive_tuple_slot(RetrieveExecEntry * entry)
 		 * wait_receiver()
 		 */
 		elog(DEBUG3, "CDB_ENDPOINT: receiver notifies sender in "
-			 "receive_tuple_slot() when retrieving data for the first time");
-		notify_sender(entry, false);
+			 "retrieve_next_tuple() when retrieving data for the first time");
+		notify_sender(false);
 	}
 
 	SIMPLE_FAULT_INJECTOR("fetch_tuples_from_endpoint");
@@ -556,7 +571,7 @@ receive_tuple_slot(RetrieveExecEntry * entry)
 		 * the transient record tuples.
 		 */
 		entry->retrieveState = RETRIEVE_STATE_FINISHED;
-		notify_sender(entry, true);
+		notify_sender(true);
 		return NULL;
 	}
 
@@ -574,9 +589,6 @@ receive_tuple_slot(RetrieveExecEntry * entry)
 /*
  * finish_retrieve - Finish a retrieve statement.
  *
- * When finishing retrieve statement, if this process have not yet finished this
- * message queue reading, then don't reset its pid.
- *
  * If current retrieve statement retrieve all tuples from endpoint. Set
  * endpoint state to ENDPOINTSTATE_FINISHED.  Otherwise, set endpoint's status
  * from ENDPOINTSTATE_RETRIEVING to ENDPOINTSTATE_ATTACHED.
@@ -585,9 +597,10 @@ receive_tuple_slot(RetrieveExecEntry * entry)
  * Errors in these function is not expected to be raised.
  */
 static void
-finish_retrieve(RetrieveExecEntry * entry, bool resetPID)
+finish_retrieve(bool resetPID)
 {
-	Endpoint	endpoint = NULL;
+	Endpoint	*endpoint = NULL;
+	RetrieveExecEntry *entry = RetrieveCtl.current_entry;
 
 	Assert(entry);
 
@@ -600,9 +613,15 @@ finish_retrieve(RetrieveExecEntry * entry, bool resetPID)
 		 * the retrieve abort stage, sender cleaned the Endpoint entry. And
 		 * another endpoint gets allocated just after the cleanup, which will
 		 * occupy current endpoint entry.
+		 * remove the entry from RetrieveCtl.RetrieveExecEntryHTB also.
+		 * to avoid next statement in start_retrieve can get entry from RetrieveCtl.RetrieveExecEntryHTB,
+		 * however, can not get endpoint through get_endpoint_from_retrieve_exec_entry.
 		 */
 		LWLockRelease(ParallelCursorEndpointLock);
-		RetrieveCtl.entry = NULL;
+		elog(DEBUG3, "the Endpoint entry %s has already been cleaned, \
+			  remove from RetrieveCtl.RetrieveExecEntryHTB hash table.", entry->endpointName);
+		hash_search(RetrieveCtl.RetrieveExecEntryHTB, entry->endpointName, HASH_REMOVE, NULL);
+		RetrieveCtl.current_entry = NULL;
 		return;
 	}
 
@@ -633,7 +652,7 @@ finish_retrieve(RetrieveExecEntry * entry, bool resetPID)
 	}
 
 	LWLockRelease(ParallelCursorEndpointLock);
-	RetrieveCtl.entry = NULL;
+	RetrieveCtl.current_entry = NULL;
 }
 
 /*
@@ -643,7 +662,7 @@ finish_retrieve(RetrieveExecEntry * entry, bool resetPID)
 static void
 retrieve_cancel_action(RetrieveExecEntry * entry, char *msg)
 {
-	Endpoint	endpoint;
+	Endpoint	*endpoint;
 
 	Assert(entry);
 
@@ -715,8 +734,8 @@ retrieve_exit_callback(int code, Datum arg)
 		return;
 
 	/* If the current retrieve statement has not fnished in this run. */
-	if (RetrieveCtl.entry)
-		finish_retrieve(RetrieveCtl.entry, true);
+	if (RetrieveCtl.current_entry)
+		finish_retrieve(true);
 
 	/* Cancel all partially retrieved endpoints in this session. */
 	hash_seq_init(&status, entryHTB);
@@ -750,12 +769,13 @@ retrieve_xact_callback(XactEvent ev, void *arg pg_attribute_unused())
 	{
 		elog(DEBUG3, "CDB_ENDPOINT: retrieve xact abort callback");
 		if (RetrieveCtl.sessionID != InvalidEndpointSessionId &&
-			RetrieveCtl.entry)
+			RetrieveCtl.current_entry)
 		{
-			if (RetrieveCtl.entry->retrieveState != RETRIEVE_STATE_FINISHED)
-				retrieve_cancel_action(RetrieveCtl.entry,
+			if (RetrieveCtl.current_entry->retrieveState != RETRIEVE_STATE_FINISHED)
+				retrieve_cancel_action(RetrieveCtl.current_entry,
 									   "Endpoint retrieve statement aborted");
-			finish_retrieve(RetrieveCtl.entry, true);
+			finish_retrieve(true);
+
 		}
 	}
 

--- a/src/backend/cdb/endpoint/cdbendpointutils.c
+++ b/src/backend/cdb/endpoint/cdbendpointutils.c
@@ -25,16 +25,16 @@
 #include "cdb/cdbutil.h"
 #include "cdb/cdbvars.h"
 
-/* The two struct are used by gp_endpoints(). */
+/* These two structures are containers for the columns returned by the UDFs. */
 
 typedef struct
 {
 	char		name[NAMEDATALEN];
 	char		cursorName[NAMEDATALEN];
-	int8		token[ENDPOINT_TOKEN_HEX_LEN];
-	int			dbid;
+	int8		token[ENDPOINT_TOKEN_ARR_LEN];
+	int			segmentIndex;
 	EndpointState state;
-	Oid			userId;
+	char			userName[NAMEDATALEN];
 	int			sessionId;
 }			EndpointInfo;
 
@@ -49,26 +49,27 @@ typedef struct
 static EndpointState state_string_to_enum(const char *state);
 
 /*
- * Convert the string-format token to int (e.g. "123456789" to 0x123456789).
+ * Convert the string-format token to array
+ * (e.g. "123456789ABCDEF0" to [1,2,3,4,5,6,7,8,9,A,B,C,D,E,F,0]).
  */
 void
-endpoint_token_str2hex(int8 *token, const char *tokenStr)
+endpoint_token_str2arr(const char *tokenStr, int8 *token)
 {
 	if (strlen(tokenStr) == ENDPOINT_TOKEN_STR_LEN)
 		hex_decode(tokenStr, ENDPOINT_TOKEN_STR_LEN, (char *) token);
 	else
-		ereport(FATAL,
-				(errcode(ERRCODE_INVALID_PASSWORD),
+		ereport(FATAL, (errcode(ERRCODE_INVALID_PASSWORD),
 				 errmsg("retrieve auth token is invalid")));
 }
 
 /*
- * Convert the hex-format token to string (e.g. 0x123456789 to "123456789").
+ * Convert the array-format token to string
+ * (e.g. [1,2,3,4,5,6,7,8,9,A,B,C,D,E,F,0] to "123456789ABCDEF0").
  */
 void
-endpoint_token_hex2str(const int8 *token, char *tokenStr)
+endpoint_token_arr2str(const int8 *token, char *tokenStr)
 {
-	hex_encode((const char *) token, ENDPOINT_TOKEN_HEX_LEN, tokenStr);
+	hex_encode((const char *) token, ENDPOINT_TOKEN_ARR_LEN, tokenStr);
 	tokenStr[ENDPOINT_TOKEN_STR_LEN] = 0;
 }
 
@@ -82,7 +83,7 @@ endpoint_token_hex_equals(const int8 *token1, const int8 *token2)
 	 * memcmp should be good enough. Timing attack would not be a concern
 	 * here.
 	 */
-	return memcmp(token1, token2, ENDPOINT_TOKEN_HEX_LEN) == 0;
+	return memcmp(token1, token2, ENDPOINT_TOKEN_ARR_LEN) == 0;
 }
 
 bool
@@ -162,7 +163,7 @@ check_parallel_retrieve_cursor_errors(EState *estate)
 }
 
 /*
- * On QD, display all the endpoints information in shared memory.
+ * On QD, display all the endpoints information is in shared memory.
  *
  * Note:
  * As a superuser, it can list all endpoints info of all users', but for
@@ -170,11 +171,11 @@ check_parallel_retrieve_cursor_errors(EState *estate)
  * security reason.
  */
 Datum
-gp_endpoints(PG_FUNCTION_ARGS)
+gp_get_endpoints(PG_FUNCTION_ARGS)
 {
 	if (Gp_role != GP_ROLE_DISPATCH)
 		ereport(ERROR, (errcode(ERRCODE_GP_COMMAND_ERROR),
-						errmsg("gp_endpoints() can be called on query dispatcher only")));
+						errmsg("gp_get_endpoints() could only be called on QD")));
 
 	FuncCallContext *funcctx;
 	AllEndpointsInfo *all_info;
@@ -197,13 +198,13 @@ gp_endpoints(PG_FUNCTION_ARGS)
 		TupleDesc	tupdesc =
 		CreateTemplateTupleDesc(9);
 
-		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "dbid", INT4OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "gp_segment_id", INT4OID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "auth_token", TEXTOID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 3, "cursorname", TEXTOID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 4, "sessionid", INT4OID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 5, "hostname", TEXTOID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 6, "port", INT4OID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 7, "userid", OIDOID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 7, "username", TEXTOID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 8, "state", TEXTOID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 9, "endpointname", TEXTOID, -1, 0);
 
@@ -216,27 +217,28 @@ gp_endpoints(PG_FUNCTION_ARGS)
 
 		CdbPgResults cdb_pgresults = {NULL, 0};
 
-		CdbDispatchCommand("SELECT endpointname,cursorname,auth_token,dbid,"
-						   "state,userid, sessionid"
-						   " FROM pg_catalog.gp_segment_endpoints()",
+		CdbDispatchCommand("SELECT endpointname,cursorname,auth_token,gp_segment_id,"
+						   "state,username,sessionid"
+						   " FROM pg_catalog.gp_get_segment_endpoints()",
 						   DF_WITH_SNAPSHOT | DF_CANCEL_ON_ERROR, &cdb_pgresults);
 
 		if (cdb_pgresults.numResults == 0)
 		{
 			ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
-							errmsg("gp_segment_endpoints didn't get back any data "
-								   "from the segDBs")));
+					errmsg("gp_get_segment_endpoints() failed to fetch data from segDBs")));
 		}
 
 		res_number = 0;
 		for (int i = 0; i < cdb_pgresults.numResults; i++)
 		{
-			if (PQresultStatus(cdb_pgresults.pg_results[i]) != PGRES_TUPLES_OK)
+			ExecStatusType result_status = PQresultStatus(cdb_pgresults.pg_results[i]);
+			if (result_status != PGRES_TUPLES_OK)
 			{
 				cdbdisp_clearCdbPgResults(&cdb_pgresults);
 				ereport(ERROR,
 					(errcode(ERRCODE_INTERNAL_ERROR),
-					 errmsg("gp_segment_endpoints(): resultStatus is not TUPLES_OK")));
+					 errmsg("gp_get_segment_endpoints(): resultStatus is %s",
+						PQresStatus(result_status))));
 			}
 			res_number += PQntuples(cdb_pgresults.pg_results[i]);
 		}
@@ -255,10 +257,10 @@ gp_endpoints(PG_FUNCTION_ARGS)
 				{
 					StrNCpy(all_info->infos[idx].name, PQgetvalue(result, j, 0), NAMEDATALEN);
 					StrNCpy(all_info->infos[idx].cursorName, PQgetvalue(result, j, 1), NAMEDATALEN);
-					endpoint_token_str2hex(all_info->infos[idx].token, PQgetvalue(result, j, 2));
-					all_info->infos[idx].dbid = atoi(PQgetvalue(result, j, 3));
+					endpoint_token_str2arr(PQgetvalue(result, j, 2), all_info->infos[idx].token);
+					all_info->infos[idx].segmentIndex = atoi(PQgetvalue(result, j, 3));
 					all_info->infos[idx].state = state_string_to_enum(PQgetvalue(result, j, 4));
-					all_info->infos[idx].userId = (Oid) strtoul(PQgetvalue(result, j, 5), NULL, 10);
+					StrNCpy(all_info->infos[idx].userName, PQgetvalue(result, j, 5), NAMEDATALEN);
 					all_info->infos[idx].sessionId = atoi(PQgetvalue(result, j, 6));
 					idx++;
 				}
@@ -271,9 +273,9 @@ gp_endpoints(PG_FUNCTION_ARGS)
 
 		for (int i = 0; i < MAX_ENDPOINT_SIZE; i++)
 		{
-			const		Endpoint entry = get_endpointdesc_by_index(i);
+			const		Endpoint *entry = get_endpointdesc_by_index(i);
 
-			if (!entry->empty && (superuser() || entry->userID == GetUserId()))
+			if (!entry->empty && entry->databaseID == MyDatabaseId && (superuser() || entry->userID == GetUserId()))
 				cnt++;
 		}
 		if (cnt != 0)
@@ -295,7 +297,7 @@ gp_endpoints(PG_FUNCTION_ARGS)
 
 			for (int i = 0; i < MAX_ENDPOINT_SIZE; i++)
 			{
-				const		Endpoint entry = get_endpointdesc_by_index(i);
+				const		Endpoint *entry = get_endpointdesc_by_index(i);
 
 				/*
 				 * Only allow current user to get own endpoints. Or let
@@ -305,17 +307,14 @@ gp_endpoints(PG_FUNCTION_ARGS)
 				{
 					EndpointInfo *info = &all_info->infos[idx];
 
-					info->dbid =
-						contentid_get_dbid(MASTER_CONTENT_ID,
-										   GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY,
-										   false);
+					info->segmentIndex = MASTER_CONTENT_ID;
 					get_token_from_session_hashtable(entry->sessionID, entry->userID,
 													 info->token);
 					StrNCpy(info->name, entry->name, NAMEDATALEN);
 					StrNCpy(info->cursorName, entry->cursorName, NAMEDATALEN);
 					info->state = entry->state;
 					info->sessionId = entry->sessionID;
-					info->userId = entry->userID;
+					StrNCpy(info->userName, GetUserNameFromId(entry->userID, false), NAMEDATALEN);
 					idx++;
 				}
 			}
@@ -334,19 +333,20 @@ gp_endpoints(PG_FUNCTION_ARGS)
 		Datum		result;
 		char		tokenStr[ENDPOINT_TOKEN_STR_LEN + 1];
 		EndpointInfo *info = &all_info->infos[all_info->cur_idx++];
-		GpSegConfigEntry *segCnfInfo = dbid_get_dbinfo(info->dbid);
+		int16 dbid = contentid_get_dbid(info->segmentIndex, GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY, false);
+		GpSegConfigEntry *segCnfInfo = dbid_get_dbinfo(dbid);
 
 		MemSet(values, 0, sizeof(values));
 		MemSet(nulls, 0, sizeof(nulls));
 
-		values[0] = Int32GetDatum(info->dbid);
-		endpoint_token_hex2str(info->token, tokenStr);
+		values[0] = Int32GetDatum(info->segmentIndex);
+		endpoint_token_arr2str(info->token, tokenStr);
 		values[1] = CStringGetTextDatum(tokenStr);
 		values[2] = CStringGetTextDatum(info->cursorName);
 		values[3] = Int32GetDatum(info->sessionId);
 		values[4] = CStringGetTextDatum(segCnfInfo->hostname);
 		values[5] = Int32GetDatum(segCnfInfo->port);
-		values[6] = ObjectIdGetDatum(info->userId);
+		values[6] = CStringGetTextDatum(info->userName);
 		values[7] = CStringGetTextDatum(state_enum_to_string(info->state));
 		values[8] = CStringGetTextDatum(info->name);
 
@@ -365,8 +365,12 @@ gp_endpoints(PG_FUNCTION_ARGS)
  * Or only show current user's endpoints on this segment.
  */
 Datum
-gp_segment_endpoints(PG_FUNCTION_ARGS)
+gp_get_segment_endpoints(PG_FUNCTION_ARGS)
 {
+	if (Gp_role != GP_ROLE_EXECUTE && Gp_role != GP_ROLE_UTILITY)
+		ereport(ERROR, (errcode(ERRCODE_GP_COMMAND_ERROR),
+				errmsg("gp_get_segment_endpoints() could only be called on QE")));
+
 	FuncCallContext *funcctx;
 	MemoryContext oldcontext;
 	Datum		values[10];
@@ -386,13 +390,13 @@ gp_segment_endpoints(PG_FUNCTION_ARGS)
 		TupleDesc	tupdesc = CreateTemplateTupleDesc(10);
 
 		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "auth_token", TEXTOID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "databaseid", INT4OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "databaseid", OIDOID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 3, "senderpid", INT4OID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 4, "receiverpid", INT4OID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 5, "state", TEXTOID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 6, "dbid", INT4OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 6, "gp_segment_id", INT4OID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 7, "sessionid", INT4OID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 8, "userid", OIDOID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 8, "username", TEXTOID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 9, "endpointname", TEXTOID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 10, "cursorname", TEXTOID, -1, 0);
 
@@ -412,7 +416,7 @@ gp_segment_endpoints(PG_FUNCTION_ARGS)
 	while (*endpoint_idx < MAX_ENDPOINT_SIZE)
 	{
 		Datum		result;
-		const		Endpoint entry = get_endpointdesc_by_index(*endpoint_idx);
+		const		Endpoint *entry = get_endpointdesc_by_index(*endpoint_idx);
 
 		MemSet(values, 0, sizeof(values));
 		MemSet(nulls, 0, sizeof(nulls));
@@ -421,23 +425,23 @@ gp_segment_endpoints(PG_FUNCTION_ARGS)
 		 * Only allow current user to list his/her own endpoints, or let
 		 * superuser list all endpoints.
 		 */
-		if (!entry->empty && (superuser() || entry->userID == GetUserId()))
+		if (!entry->empty && entry->databaseID == MyDatabaseId && (superuser() || entry->userID == GetUserId()))
 		{
 			char	   *state = NULL;
-			int8		token[ENDPOINT_TOKEN_HEX_LEN];
+			int8		token[ENDPOINT_TOKEN_ARR_LEN];
 			char		tokenStr[ENDPOINT_TOKEN_STR_LEN + 1];
 
 			get_token_from_session_hashtable(entry->sessionID, entry->userID, token);
-			endpoint_token_hex2str(token, tokenStr);
+			endpoint_token_arr2str(token, tokenStr);
 			values[0] = CStringGetTextDatum(tokenStr);
-			values[1] = Int32GetDatum(entry->databaseID);
+			values[1] = ObjectIdGetDatum(entry->databaseID);
 			values[2] = Int32GetDatum(entry->senderPid);
 			values[3] = Int32GetDatum(entry->receiverPid);
 			state = state_enum_to_string(entry->state);
 			values[4] = CStringGetTextDatum(state);
-			values[5] = Int32GetDatum(GpIdentity.dbid);
+			values[5] = Int32GetDatum(GpIdentity.segindex);
 			values[6] = Int32GetDatum(entry->sessionID);
-			values[7] = ObjectIdGetDatum(entry->userID);
+			values[7] = CStringGetTextDatum(GetUserNameFromId(entry->userID, false));
 			values[8] = CStringGetTextDatum(entry->name);
 			values[9] = CStringGetTextDatum(entry->cursorName);
 
@@ -509,6 +513,42 @@ state_string_to_enum(const char *state)
 	else
 	{
 		ereport(ERROR, (errmsg("unknown endpoint state %s", state)));
-		return ENDPOINTSTATE_INVALID;
+		return ENDPOINTSTATE_INVALID; /* make the compiler happy */
 	}
+}
+
+/*
+ * Generate the endpoint name.
+ */
+void
+generate_endpoint_name(char *name, const char *cursorName)
+{
+	int                     len,
+							cursorLen;
+
+	len = 0;
+
+	/* part1: cursor name */
+	cursorLen = strlen(cursorName);
+	if (cursorLen > ENDPOINT_NAME_CURSOR_LEN)
+		cursorLen = ENDPOINT_NAME_CURSOR_LEN;
+	memcpy(name, cursorName, cursorLen);
+	len += cursorLen;
+
+	/* part2: gp_session_id */
+	snprintf(name + len, ENDPOINT_NAME_SESSIONID_LEN + 1, "%08x", gp_session_id);
+	len += ENDPOINT_NAME_SESSIONID_LEN;
+
+	/*
+	 * part3: gp_command_count In theory cursor name + gp_session_id is
+	 * enough, but we'd keep this part to avoid confusion or potential issues
+	 * for the scenario that in the same session (thus same gp_session_id),
+	 * two endpoints with same cursor names (happens the cursor is
+	 * dropped/rollbacked and then recreated) and retrieve the endpoints would
+	 * be confusing for users that in the same retrieve connection.
+	 */
+	snprintf(name + len, ENDPOINT_NAME_COMMANDID_LEN + 1, "%08x", gp_command_count);
+	len += ENDPOINT_NAME_COMMANDID_LEN;
+
+	name[len] = '\0';
 }

--- a/src/backend/commands/async.c
+++ b/src/backend/commands/async.c
@@ -2098,6 +2098,10 @@ ProcessIncomingNotify(void)
 
 /*
  * Send NOTIFY message to my front end.
+ *
+ * GPDB: We have exposed this function globally for our dispatch-notify
+ * mechanism. We overload the srcPid field to pass in the gp_session_id
+ * from GPDB specific callsites.
  */
 void
 NotifyMyFrontEnd(const char *channel, const char *payload, int32 srcPid)

--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -33,6 +33,7 @@
 #include "catalog/objectaccess.h"
 #include "catalog/pg_sequence.h"
 #include "catalog/pg_type.h"
+#include "commands/async.h"
 #include "commands/defrem.h"
 #include "commands/sequence.h"
 #include "commands/tablecmds.h"
@@ -2122,7 +2123,7 @@ seq_mask(char *page, BlockNumber blkno)
 /*
  * CDB: forward a nextval request from qExec to the QD
  */
-void
+static void
 cdb_sequence_nextval_qe(Relation	seqrel,
 						int64   *plast,
 						int64   *pcached,
@@ -2151,11 +2152,7 @@ cdb_sequence_nextval_qe(Relation	seqrel,
 	 */
 	char payload[128];
 	snprintf(payload, sizeof(payload), "%d:%d", dbid, seq_oid);
-	pq_beginmessage(&buf, 'A');
-	pq_sendint(&buf, gp_session_id, sizeof(int32));
-	pq_sendstring(&buf, "nextval"); /* channel */
-	pq_sendstring(&buf, payload);
-	pq_endmessage(&buf);
+	NotifyMyFrontEnd("nextval", payload, gp_session_id);
 	pq_flush();
 
 	/*

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -108,6 +108,9 @@
 #include "cdb/cdbutil.h"
 #include "cdb/cdbendpoint.h"
 
+#define IS_PARALLEL_RETRIEVE_CURSOR(queryDesc)	(queryDesc->ddesc &&	\
+										queryDesc->ddesc->parallelCursorName &&	\
+										strlen(queryDesc->ddesc->parallelCursorName) > 0)
 
 /* Hooks for plugins to get control in ExecutorStart/Run/Finish/End */
 ExecutorStart_hook_type ExecutorStart_hook = NULL;
@@ -791,7 +794,7 @@ standard_ExecutorRun(QueryDesc *queryDesc,
 	DestReceiver *dest;
 	bool		sendTuples;
 	MemoryContext oldcontext;
-	EndpointExecState *endpointExecState = NULL;
+	bool		endpointCreated = false;
 
 	/*
 	 * NOTE: Any local vars that are set in the PG_TRY block and examined in the
@@ -912,12 +915,7 @@ standard_ExecutorRun(QueryDesc *queryDesc,
 		}
 		else if (exec_identity == GP_ROOT_SLICE)
 		{
-			bool isParallelRetrieveCursor = false;
-			DestReceiver *endpointDest = NULL;
-
-			isParallelRetrieveCursor = (queryDesc->ddesc &&
-										queryDesc->ddesc->parallelCursorName &&
-										queryDesc->ddesc->parallelCursorName[0]);
+			DestReceiver *endpointDest;
 
 			/*
 			 * When run a root slice, and it is a PARALLEL RETRIEVE CURSOR, it means
@@ -928,32 +926,49 @@ standard_ExecutorRun(QueryDesc *queryDesc,
 			 * For the scenario: endpoint on QE, the query plan is changed,
 			 * the root slice also exists on QE.
 			 */
-			if (isParallelRetrieveCursor)
+			if (IS_PARALLEL_RETRIEVE_CURSOR(queryDesc))
 			{
-				endpointExecState = allocEndpointExecState();
 				SetupEndpointExecState(queryDesc->tupDesc,
 									   queryDesc->ddesc->parallelCursorName,
-									   endpointExecState);
-				endpointDest = endpointExecState->dest;
-				(endpointDest->rStartup)(endpointDest, operation, queryDesc->tupDesc);
-			}
+									   operation,
+									   &endpointDest);
+				endpointCreated = true;
 
-			/*
-			 * Run a root slice
-			 * It corresponds to the "normal" path through the executor
-			 * in that we enter the plan at the top and count on the
-			 * motion nodes at the fringe of the top slice to return
-			 * without ever calling nodes below them.
-			 */
-			ExecutePlan(estate,
-						queryDesc->planstate,
-						queryDesc->plannedstmt->parallelModeNeeded,
-						operation,
-						isParallelRetrieveCursor ? true : sendTuples,
-						count,
-						direction,
-						isParallelRetrieveCursor? endpointDest : dest,
-						execute_once);
+				/*
+				 * Once the endpoint has been created in shared memory, send acknowledge
+				 * message to QD so DECLARE PARALLEL RETRIEVE CURSOR statement can finish.
+				 */
+				EndpointNotifyQD(ENDPOINT_READY_ACK_MSG);
+
+				ExecutePlan(estate,
+							queryDesc->planstate,
+							queryDesc->plannedstmt->parallelModeNeeded,
+							operation,
+							true,
+							count,
+							direction,
+							endpointDest,
+							execute_once);
+			}
+			else
+			{
+				/*
+				 * Run a root slice
+				 * It corresponds to the "normal" path through the executor
+				 * in that we enter the plan at the top and count on the
+				 * motion nodes at the fringe of the top slice to return
+				 * without ever calling nodes below them.
+				 */
+				ExecutePlan(estate,
+							queryDesc->planstate,
+							queryDesc->plannedstmt->parallelModeNeeded,
+							operation,
+							sendTuples,
+							count,
+							direction,
+							dest,
+							execute_once);
+			}
 		}
 		else
 		{
@@ -999,8 +1014,8 @@ standard_ExecutorRun(QueryDesc *queryDesc,
 	/*
 	 * shutdown tuple receiver, if we started it
 	 */
-	if (endpointExecState != NULL)
-		DestroyEndpointExecState(endpointExecState);
+	if (endpointCreated)
+		DestroyEndpointExecState();
 
 	if (sendTuples)
 		dest->rShutdown(dest);

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -3312,9 +3312,12 @@ create_foreignscan_path(PlannerInfo *root, RelOptInfo *rel,
 	pathnode->path.total_cost = total_cost;
 	pathnode->path.pathkeys = pathkeys;
 
-	ForeignServer *server = NULL;
-	switch (rel->exec_location)
+	if (Gp_role == GP_ROLE_DISPATCH)
 	{
+		ForeignServer *server = NULL;
+
+		switch (rel->exec_location)
+		{
 		case FTEXECLOCATION_ANY:
 			CdbPathLocus_MakeGeneral(&(pathnode->path.locus));
 			break;
@@ -3330,6 +3333,12 @@ create_foreignscan_path(PlannerInfo *root, RelOptInfo *rel,
 			break;
 		default:
 			elog(ERROR, "unrecognized exec_location '%c'", rel->exec_location);
+		}
+	}
+	else
+	{
+		/* make entry locus for utility role */
+		CdbPathLocus_MakeEntry(&(pathnode->path.locus));
 	}
 
 	pathnode->fdw_outerpath = fdw_outerpath;

--- a/src/backend/storage/ipc/shm_toc.c
+++ b/src/backend/storage/ipc/shm_toc.c
@@ -252,6 +252,7 @@ shm_toc_lookup(shm_toc *toc, uint64 key, bool noError)
 	if (!noError)
 		elog(ERROR, "could not find key " UINT64_FORMAT " in shm TOC at %p",
 			 key, toc);
+
 	return NULL;
 }
 

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -5134,9 +5134,19 @@ PostgresMain(int argc, char *argv[],
 		 */
 		if (send_ready_for_query)
 		{
+			char activity[50];
+			memset(activity, 0, sizeof(activity));
+			int remain = sizeof(activity);
+
+			if (am_cursor_retrieve_handler)
+			{
+				strncpy(activity, "[retrieve] ", sizeof(activity));
+				remain -= strlen(activity);
+			}
 			if (IsAbortedTransactionBlockState())
 			{
-				set_ps_display("idle in transaction (aborted)", false);
+				strncat(activity, "idle in transaction (aborted)", remain);
+				set_ps_display(activity, false);
 				pgstat_report_activity(STATE_IDLEINTRANSACTION_ABORTED, NULL);
 
 				/* Start the idle-in-transaction timer */
@@ -5149,7 +5159,8 @@ PostgresMain(int argc, char *argv[],
 			}
 			else if (IsTransactionOrTransactionBlock())
 			{
-				set_ps_display("idle in transaction", false);
+				strncat(activity, "idle in transaction", remain);
+				set_ps_display(activity, false);
 				pgstat_report_activity(STATE_IDLEINTRANSACTION, NULL);
 
 				/* Start the idle-in-transaction timer */
@@ -5166,7 +5177,8 @@ PostgresMain(int argc, char *argv[],
 				pgstat_report_stat(false);
 				pgstat_report_queuestat();
 
-				set_ps_display("idle", false);
+				strncat(activity, "idle", remain);
+				set_ps_display(activity, false);
 				pgstat_report_activity(STATE_IDLE, NULL);
 			}
 

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -1201,6 +1201,7 @@ InitPostgres(const char *in_dbname, Oid dboid, const char *username,
 			ereport(FATAL,
 					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 					 errmsg("retrieve connection was not authenticated for unknown reason")));
+		InitRetrieveCtl();
 	}
 
 	/*

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -10985,10 +10985,10 @@
    proname => 'get_ao_compression_ratio', provolatile => 'v', proparallel => 'u', prorettype => 'float8', proargtypes => 'regclass', prosrc => 'get_ao_compression_ratio', prodataaccess => 'r' },
 
 { oid => 7180, descr => 'endpoints information on the cluster visible to the user',
-   proname => 'gp_endpoints', prorows => '1000', proretset => 't', provolatile => 'v', proparallel => 'u', prorettype => 'record', proargtypes => '', proallargtypes => '{int4,text,text,int4,text,int4,oid,text,text}', proargmodes => '{o,o,o,o,o,o,o,o,o}', proargnames => '{dbid,auth_token,cursorname,sessionid,hostname,port,userid,state,endpointname}', prosrc => 'gp_endpoints', proexeclocation => 'c' },
+   proname => 'gp_get_endpoints', prorows => '1000', proretset => 't', provolatile => 'v', proparallel => 'u', prorettype => 'record', proargtypes => '', proallargtypes => '{int4,text,text,int4,varchar,int4,text,text,text}', proargmodes => '{o,o,o,o,o,o,o,o,o}', proargnames => '{gp_segment_id,auth_token,cursorname,sessionid,hostname,port,username,state,endpointname}', prosrc => 'gp_get_endpoints', proexeclocation => 'c' },
 
 { oid => 7181, descr => 'endpoints information on the segment visible to the user',
-   proname => 'gp_segment_endpoints', prorows => '1000', proretset => 't', provolatile => 'v', proparallel => 'u', prorettype => 'record', proargtypes => '', proallargtypes => '{text,int4,int4,int4,text,int4,int4,oid,text,text}', proargmodes => '{o,o,o,o,o,o,o,o,o,o}', proargnames => '{auth_token,databaseid,senderpid,receiverpid,state,dbid,sessionid,userid,endpointname,cursorname}', prosrc => 'gp_segment_endpoints' },
+   proname => 'gp_get_segment_endpoints', prorows => '1000', proretset => 't', provolatile => 'v', proparallel => 'u', prorettype => 'record', proargtypes => '', proallargtypes => '{text,oid,int4,int4,text,int4,int4,text,text,text}', proargmodes => '{o,o,o,o,o,o,o,o,o,o}', proargnames => '{auth_token,databaseid,senderpid,receiverpid,state,gp_segment_id,sessionid,username,endpointname,cursorname}', prosrc => 'gp_get_segment_endpoints' },
 
 { oid => 7182, descr => 'wait until all endpoint of this parallel retrieve cursor has been retrieved finished',
    proname => 'gp_wait_parallel_retrieve_cursor', provolatile => 'v', proparallel => 'u', prorettype => 'bool', proargtypes => 'text int4', proallargtypes => '{text,int4,bool}', proargmodes => '{i,i,o}', proargnames => '{cursorname,timeout_sec,finished}', prosrc => 'gp_wait_parallel_retrieve_cursor', proexeclocation => 'c' },

--- a/src/include/cdb/cdbdisp.h
+++ b/src/include/cdb/cdbdisp.h
@@ -132,7 +132,7 @@ cdbdisp_waitDispatchFinish(struct CdbDispatcherState *ds);
  *       0 means checking immediately, and -1 means waiting until all ack
  *       messages are received.
  *
- * QEs should call cdbdisp_sendAckMessageToQD to send acknowledge messages to QD.
+ * QEs should call EndpointNotifyQD to send acknowledge messages to QD.
  */
 bool
 cdbdisp_checkDispatchAckMessage(struct CdbDispatcherState *ds, const char *message,
@@ -195,13 +195,6 @@ CdbDispatcherState * cdbdisp_makeDispatcherState(bool isExtendedQuery);
  * Free dispatcher memory context.
  */
 void cdbdisp_destroyDispatcherState(CdbDispatcherState *ds);
-
-/*
- * cdbdisp_sendAckMessageToQD - send acknowledge message to QD (runs on QE).
- *
- * QD uses cdbdisp_checkDispatchAckMessage() to wait QE acknowledge message.
- */
-void cdbdisp_sendAckMessageToQD(const char *message);
 
 void
 cdbdisp_makeDispatchParams(CdbDispatcherState *ds,

--- a/src/include/commands/async.h
+++ b/src/include/commands/async.h
@@ -53,5 +53,6 @@ extern void HandleNotifyInterrupt(void);
 
 /* process interrupts */
 extern void ProcessNotifyInterrupt(void);
+extern void NotifyMyFrontEnd(const char *channel, const char *payload, int32 srcPid);
 
 #endif							/* ASYNC_H */

--- a/src/test/examples/test_parallel_retrieve_cursor_nowait.c
+++ b/src/test/examples/test_parallel_retrieve_cursor_nowait.c
@@ -248,13 +248,13 @@ main(int argc, char **argv)
 	/*
 	 * get the endpoints info of this PARALLEL RETRIEVE CURSOR
 	 */
-	const char *sql1 = "select hostname,port,auth_token,endpointname from gp_endpoints() where cursorname='myportal';";
+	const char *sql1 = "select hostname,port,auth_token,endpointname from gp_get_endpoints() where cursorname='myportal';";
 
 	printf("\nExec SQL on Master:\n\t> %s\n", sql1);
 	res1 = PQexec(master_conn, sql1);
 	if (PQresultStatus(res1) != PGRES_TUPLES_OK)
 	{
-		fprintf(stderr, "select gp_endpoints view didn't return tuples properly\n");
+		fprintf(stderr, "select gp_get_endpoints view didn't return tuples properly\n");
 		PQclear(res1);
 		goto LABEL_ERR;
 	}
@@ -263,7 +263,7 @@ main(int argc, char **argv)
 
 	if (ntup <= 0)
 	{
-		fprintf(stderr, "select gp_endpoints view doesn't return rows\n");
+		fprintf(stderr, "select gp_get_endpoints view doesn't return rows\n");
 		goto LABEL_ERR;
 	}
 

--- a/src/test/examples/test_parallel_retrieve_cursor_wait.c
+++ b/src/test/examples/test_parallel_retrieve_cursor_wait.c
@@ -211,13 +211,13 @@ main(int argc, char **argv)
 	/*
 	 * get the endpoints info of this PARALLEL RETRIEVE CURSOR
 	 */
-	const char *sql1 = "select hostname,port,auth_token,endpointname from gp_endpoints() where cursorname='myportal';";
+	const char *sql1 = "select hostname,port,auth_token,endpointname from gp_get_endpoints() where cursorname='myportal';";
 
 	printf("\nExec SQL on Master:\n\t> %s\n", sql1);
 	res1 = PQexec(master_conn, sql1);
 	if (PQresultStatus(res1) != PGRES_TUPLES_OK)
 	{
-		fprintf(stderr, "select gp_endpoints view didn't return tuples properly\n");
+		fprintf(stderr, "select gp_get_endpoints view didn't return tuples properly\n");
 		PQclear(res1);
 		goto LABEL_ERR;
 	}
@@ -226,7 +226,7 @@ main(int argc, char **argv)
 
 	if (ntup <= 0)
 	{
-		fprintf(stderr, "select gp_endpoints view doesn't return rows\n");
+		fprintf(stderr, "select gp_get_endpoints view doesn't return rows\n");
 		goto LABEL_ERR;
 	}
 

--- a/src/test/isolation2/.gitignore
+++ b/src/test/isolation2/.gitignore
@@ -11,6 +11,8 @@ sql/fts_manual_probe.sql
 expected/fts_manual_probe.out
 sql/workfile_mgr_test.sql
 expected/workfile_mgr_test.out
+expected/idle_gang_cleaner.out
+sql/idle_gang_cleaner.sql
 
 -- ignore generated pg_basebackup tests
 /sql/pg_basebackup*.sql

--- a/src/test/isolation2/Makefile
+++ b/src/test/isolation2/Makefile
@@ -54,8 +54,8 @@ pg_isolation2_regress$(X): isolation2_main.o pg_regress.o submake-libpq submake-
 	$(CC) $(CFLAGS) $(filter %.o,$^) $(libpq_pgport) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@
 
 clean distclean:
-	rm -f pg_isolation2_regress$(X) $(OBJS) isolation2_main.o
-	rm -f pg_regress.o
+	rm -f pg_isolation2_regress$(X) $(OBJS) isolation2_main.o isolation2_regress.so
+	rm -f pg_regress.o test_parallel_retrieve_cursor_extended_query test_parallel_retrieve_cursor_extended_query_error
 	rm -f gpstringsubs.pl gpdiff.pl atmsort.pm explain.pm
 	rm -f data
 	rm -rf $(pg_regress_clean_files)

--- a/src/test/isolation2/init_file_parallel_retrieve_cursor
+++ b/src/test/isolation2/init_file_parallel_retrieve_cursor
@@ -3,6 +3,10 @@
 m/^ERROR: .* (seg\d+ [0-9.]+:\d+ pid=\d+)/
 s/seg\d+ [0-9.]+:\d+ pid=\d+/SEG IP:PORT pid=PID/
 
+# Ignore session id in fatal error message
+m/for session id -?[0-9]+/
+s/for session id -?[0-9]+/for session id xxx/
+
 # skip specific PID in: ERROR:  end point token_id3 already attached by receiver(pid: 50938)
 m/^ERROR:.*\(pid: \d+\)/
 s/\(pid: \d+\)/\(pid: PID\)/

--- a/src/test/isolation2/input/parallel_retrieve_cursor/corner.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/corner.source
@@ -18,12 +18,12 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- Test1: close not executed PARALLEL RETRIEVE CURSOR
 1: BEGIN;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 1 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 1 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
 1: CLOSE c1;
 -- check no endpoint info
-1: SELECT auth_token,state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT auth_token,state FROM gp_get_endpoints() WHERE cursorname='c1';
 -- check no token info on QE after close PARALLEL RETRIEVE CURSOR
-*U: @pre_run 'set_endpoint_variable @ENDPOINT1': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT1';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT1': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT1';
 
 -- error out for closed cursor
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
@@ -32,12 +32,12 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- test for a large table
 1: BEGIN;
 1: DECLARE c11 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t11;
-1: @post_run 'parse_endpoint_info 11 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c11';
+1: @post_run 'parse_endpoint_info 11 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c11';
 1: CLOSE c11;
 -- check no endpoint info
-1: SELECT auth_token,state FROM gp_endpoints() WHERE cursorname='c11';
+1: SELECT auth_token,state FROM gp_get_endpoints() WHERE cursorname='c11';
 -- check no token info on QE after close PARALLEL RETRIEVE CURSOR
-*U: @pre_run 'set_endpoint_variable @ENDPOINT11': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT11';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT11': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT11';
 
 -- error out for closed cursor
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c11', -1);
@@ -58,7 +58,7 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 1: DECLARE c11 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 1: ROLLBACK;
 -- check no endpoint info
-1: SELECT auth_token,state FROM gp_endpoints();
+1: SELECT auth_token,state FROM gp_get_endpoints();
 
 -- Test3: execute non-existing PARALLEL RETRIEVE CURSOR
 1: BEGIN;
@@ -70,7 +70,7 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', 0);
 1: ROLLBACK;
 -- check no endpoint info
-1: SELECT auth_token,state FROM gp_endpoints();
+1: SELECT auth_token,state FROM gp_get_endpoints();
 
 -- Test4: execute one of PARALLEL RETRIEVE CURSORs
 1: BEGIN;
@@ -85,21 +85,21 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 1: DECLARE c9 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 1: DECLARE c10 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 1: DECLARE c11 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c2';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c2';
 -- test check and wait in normal way
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', 0);
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', -1);
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
 
 1<:
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', 0);
 -- check all endpoint state
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
 1: ROLLBACK;
 -- check no endpoint info
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
 -- cleanup retrieve connections
 *Rq:
 
@@ -108,21 +108,21 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 1: DECLARE c1 CURSOR FOR SELECT * FROM t1;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 -- check no endpoint info
-1: SELECT auth_token,state FROM gp_endpoints();
+1: SELECT auth_token,state FROM gp_get_endpoints();
 1: ROLLBACK;
 
 1: BEGIN;
 1: DECLARE c1 CURSOR FOR SELECT * FROM t1;
 1: DECLARE c2 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c2';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c2';
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', -1);
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
 
 1<:
 -- check no endpoint info
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
 1: ROLLBACK;
 -- cleanup retrieve connections
 *Rq:
@@ -130,16 +130,16 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- Test6: select order by limit
 1: BEGIN;
 1: DECLARE c2 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1 ORDER BY a LIMIT 10;
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c2';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c2';
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
 
 -- test check and wait after finished retrieving
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', 0);
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', -1);
 -- check no endpoint info
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
 1: ROLLBACK;
 -- cleanup retrieve connections
 *Rq:
@@ -147,17 +147,17 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- Test7: select order by limit 0
 1: BEGIN;
 1: DECLARE c2 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1 ORDER BY a LIMIT 0;
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c2';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c2';
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', 0);
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', -1);
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
 
 1<:
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', 0);
 -- check no endpoint info
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
 1: ROLLBACK;
 -- cleanup retrieve connections
 *Rq:
@@ -165,17 +165,17 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- Test8: select empty table
 1: BEGIN;
 1: DECLARE c2 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t2;
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c2';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c2';
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', 0);
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', -1);
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
 
 1<:
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', 0);
 -- check no endpoint info
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
 1: ROLLBACK;
 -- cleanup retrieve connections
 *Rq:
@@ -183,17 +183,17 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- Test9: select table with text column
 1: BEGIN;
 1: DECLARE c2 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t3;
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c2';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c2';
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', 0);
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', -1);
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
 
 1<:
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', 0);
 -- check no endpoint info
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
 1: ROLLBACK;
 -- cleanup retrieve connections
 *Rq:
@@ -201,17 +201,17 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- Test10: select empty table with text column
 1: BEGIN;
 1: DECLARE c2 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t4;
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c2';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c2';
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', 0);
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', -1);
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
 
 1<:
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', 0);
 -- check no endpoint info
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
 1: ROLLBACK;
 -- cleanup retrieve connections
 *Rq:
@@ -219,17 +219,17 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- Test11: endpoints on one segment.
 1: BEGIN;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1 WHERE a = 50;
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', 0);
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
 
-1U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+1U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
 1R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
 
 1<:
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', 0);
 -- check no endpoint info
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c1';
 1: ROLLBACK;
 -- cleanup retrieve connections
 1Rq:
@@ -237,16 +237,16 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- Test12: PARALLEL RETRIEVE CURSOR for aggregate function: sum
 1: BEGIN;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT SUM(a) FROM t1;
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', 0);
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
 
--1U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+-1U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
 -1R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
 
 1<:
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', 0);
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c1';
 1: ROLLBACK;
 -- cleanup retrieve connections
 -1Rq:
@@ -254,14 +254,14 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- Test13: PARALLEL RETRIEVE CURSOR for aggregate function: avg
 1: BEGIN;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT AVG(a) FROM t1;
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
 
--1U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+-1U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
 -1R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
 
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', 0);
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c1';
 1: ROLLBACK;
 -- cleanup retrieve connections
 -1Rq:
@@ -269,14 +269,14 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- Test14: PARALLEL RETRIEVE CURSOR for count(*)
 1: BEGIN;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT COUNT(*) FROM t1;
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
 
--1U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+-1U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
 -1R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
 
 1<:
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c1';
 1: ROLLBACK;
 -- cleanup retrieve connections
 -1Rq:
@@ -284,13 +284,13 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- Test15: PARALLEL RETRIEVE CURSOR for two tables' join;
 1: BEGIN;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1, t5 where t1.a = t5.b;
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
 
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
 
 1<:
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c1';
 1: ROLLBACK;
 -- cleanup retrieve connections
 *Rq:
@@ -298,13 +298,13 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- Test16: PARALLEL RETRIEVE CURSOR for the count of two tables' join;
 1: BEGIN;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT COUNT(*) FROM t1, t5 where t1.a = t5.b;
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
 
 -1R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
 
 1<:
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c1';
 1: ROLLBACK;
 -- cleanup retrieve connections
 -1Rq:
@@ -312,23 +312,23 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- Test17: re-execute a PARALLEL RETRIEVE CURSOR and retrieve in same sessions.
 1: BEGIN;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * from t1;
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
 
 1<:
 1: CLOSE c1;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * from t1;
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
 
 1<:
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c1';
 1: ROLLBACK;
 -- cleanup retrieve connections
 *Rq:
@@ -336,10 +336,10 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- Test18: re-execute a PARALLEL RETRIEVE CURSOR and retrieve in different sessions.
 1: BEGIN;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * from t1;
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
 
 0Rq:
@@ -349,14 +349,14 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 1<:
 1: CLOSE c1;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * from t1;
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
 
 1<:
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c1';
 1: ROLLBACK;
 -- cleanup retrieve connections
 *Rq:
@@ -365,9 +365,9 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 1: BEGIN;
 1: SAVEPOINT s1;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * from t1;
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
 1: ROLLBACK TO s1;
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c1';
 
 1: ROLLBACK;
 
@@ -384,11 +384,11 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 1q:
 1: BEGIN;
 1: DECLARE c21a PARALLEL RETRIEVE CURSOR FOR SELECT COUNT(*) from t1;
-1: @post_run 'get_tuple_cell TOKEN21a 1 1 ; create_match_sub $TOKEN21a token21a' : SELECT auth_token FROM gp_endpoints() WHERE cursorname='c21a';
+1: @post_run 'get_tuple_cell TOKEN21a 1 1 ; create_match_sub $TOKEN21a token21a' : SELECT auth_token FROM gp_get_endpoints() WHERE cursorname='c21a';
 -- Declare more cursors in the same session should not change the first one's token
 1: DECLARE c21b PARALLEL RETRIEVE CURSOR FOR SELECT COUNT(*) from t1;
 1: DECLARE c21c PARALLEL RETRIEVE CURSOR FOR SELECT * from t1;
-1: SELECT auth_token FROM gp_endpoints() WHERE cursorname='c21a';
+1: SELECT auth_token FROM gp_get_endpoints() WHERE cursorname='c21a';
 1: COMMIT;
 1q:
 *Rq:
@@ -396,16 +396,16 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- Test22: UDF plan should be able to run on entry db.
 1: BEGIN;
 1: DECLARE c22 PARALLEL RETRIEVE CURSOR WITHOUT HOLD FOR SELECT * FROM generate_series(1,10);
-1: @post_run 'parse_endpoint_info 22 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c22';
+1: @post_run 'parse_endpoint_info 22 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c22';
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c22', 0);
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT22': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT22';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT22': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT22';
 *R: @pre_run 'set_endpoint_variable @ENDPOINT22': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT22";
 
 -- test check and wait after finished retrieving
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c22', -1);
 -- check no endpoint info
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c22';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c22';
 1: ROLLBACK;
 1q:
 -1Rq:
@@ -415,16 +415,16 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- Test23: Catalog scan plan should be able to run on entry db.
 1: BEGIN;
 1: DECLARE c23 PARALLEL RETRIEVE CURSOR WITHOUT HOLD FOR SELECT relname FROM pg_class where relname='pg_class';
-1: @post_run 'parse_endpoint_info 23 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c23';
+1: @post_run 'parse_endpoint_info 23 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c23';
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c23', 0);
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT23': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT23';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT23': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT23';
 *R: @pre_run 'set_endpoint_variable @ENDPOINT23': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT23";
 
 -- test check and wait after finished retrieving
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c23', -1);
 -- check no endpoint info
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c23';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c23';
 1: ROLLBACK;
 -- cleanup retrieve connections
 *Rq:
@@ -434,9 +434,9 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 1: DECLARE "x12345678901234567890123456789012345678901234567890123456789x" PARALLEL RETRIEVE CURSOR WITHOUT HOLD FOR SELECT * FROM t5;
 1: DECLARE "x123456789012345678901234567890123456789012345678901234567890123456789x" PARALLEL RETRIEVE CURSOR WITHOUT HOLD FOR SELECT * FROM t5;
 1: DECLARE "x1234567890123456789012345678901234567890123456789012345678901x" PARALLEL RETRIEVE CURSOR WITHOUT HOLD FOR SELECT * FROM t5;
-1: @post_run 'parse_endpoint_info 24 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='x12345678901234567890123456789012345678901234567890123456789x';
-1: @post_run 'parse_endpoint_info 24_1 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='x12345678901234567890123456789012345678901234567890123456789012';
-1: @post_run 'parse_endpoint_info 24_2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='x1234567890123456789012345678901234567890123456789012345678901x';
+1: @post_run 'parse_endpoint_info 24 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='x12345678901234567890123456789012345678901234567890123456789x';
+1: @post_run 'parse_endpoint_info 24_1 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='x12345678901234567890123456789012345678901234567890123456789012';
+1: @post_run 'parse_endpoint_info 24_2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='x1234567890123456789012345678901234567890123456789012345678901x';
 *R: @pre_run 'set_endpoint_variable @ENDPOINT24': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT24";
 *R: @pre_run 'set_endpoint_variable @ENDPOINT24_1': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT24_1";
 *R: @pre_run 'set_endpoint_variable @ENDPOINT24_2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT24_2";
@@ -453,7 +453,7 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- Test26: Retrieve one endpoint and quit the session, then connect the segment again and retrieve twice. No crash should happen.
 1: BEGIN;
 1: DECLARE c2 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t5;
-1: @post_run 'parse_endpoint_info 26 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c2';
+1: @post_run 'parse_endpoint_info 26 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c2';
 
 2R: @pre_run 'set_endpoint_variable @ENDPOINT26' : RETRIEVE ALL FROM ENDPOINT "@ENDPOINT26";
 2Rq:
@@ -470,16 +470,16 @@ INSERT INTO t5 SELECT GENERATE_SERIES(1, 10);
 -- Test27: General locus should run on entry db. Test23 tested Entry locus.
 1: BEGIN;
 1: DECLARE c27 PARALLEL RETRIEVE CURSOR FOR SELECT generate_series(1,10);
-1: @post_run 'parse_endpoint_info 27 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c27';
+1: @post_run 'parse_endpoint_info 27 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c27';
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c27', 0);
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT27': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT27';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT27': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT27';
 *R: @pre_run 'set_endpoint_variable @ENDPOINT27': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT27";
 
 -- test check and wait after finished retrieving
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c27', -1);
 -- check no endpoint info
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c27';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c27';
 -- cleanup retrieve connections
 *Rq:
 

--- a/src/test/isolation2/input/parallel_retrieve_cursor/fault_inject.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/fault_inject.source
@@ -22,18 +22,18 @@ insert into t1 select generate_series(1,100);
 --should work as normal
 1: BEGIN;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
 
-*U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1' or endpointname='DUMMYENDPOINTNAME';
+*U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1' or endpointname='DUMMYENDPOINTNAME';
 *R: @pre_run 'set_endpoint_variable @ENDPOINT1': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT1";
 
 1<:
 1: CLOSE c1;
 -- check no endpoint info
-1: SELECT auth_token,state FROM gp_endpoints() WHERE cursorname='c1' or endpointname='DUMMYENDPOINTNAME';
+1: SELECT auth_token,state FROM gp_get_endpoints() WHERE cursorname='c1' or endpointname='DUMMYENDPOINTNAME';
 -- check no token info on QE after close PARALLEL RETRIEVE CURSOR
-*U: SELECT * FROM gp_segment_endpoints() WHERE cursorname='c1' or endpointname='DUMMYENDPOINTNAME';
+*U: SELECT * FROM gp_get_segment_endpoints() WHERE cursorname='c1' or endpointname='DUMMYENDPOINTNAME';
 
 1: ROLLBACK;
 
@@ -43,23 +43,23 @@ insert into t1 select generate_series(1,100);
 
 1: BEGIN;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * from t1;
-1: @post_run 'parse_endpoint_info 2 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
 
-0U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+0U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
 0R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
 
 1<:
 
-1U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+1U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
 1R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
 
-2U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+2U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
 2R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
 
 1<:
 1: ROLLBACK;
-1: SELECT auth_token,state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT auth_token,state FROM gp_get_endpoints() WHERE cursorname='c1';
 1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'reset', 2);
 
 -- Test3: fault inject at the 5th time while retrieving tuples from endpoint
@@ -68,23 +68,23 @@ insert into t1 select generate_series(1,100);
 
 1: BEGIN;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * from t1;
-1: @post_run 'parse_endpoint_info 3 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 3 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
 
-1U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+1U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
 1R: @pre_run 'set_endpoint_variable @ENDPOINT3': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT3";
 
 1<:
 
-0U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+0U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
 0R: @pre_run 'set_endpoint_variable @ENDPOINT3': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT3";
 
-2U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+2U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
 2R: @pre_run 'set_endpoint_variable @ENDPOINT3': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT3";
 
 1<:
 1: ROLLBACK;
-1: SELECT auth_token,state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT auth_token,state FROM gp_get_endpoints() WHERE cursorname='c1';
 1: SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'reset', 3);
 
 -- Test4: error inject at the 5th time while retrieving tuples from endpoint
@@ -92,18 +92,18 @@ insert into t1 select generate_series(1,100);
 
 1: BEGIN;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * from t1;
-1: @post_run 'parse_endpoint_info 4 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 4 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
 
-1U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+1U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
 1R: @pre_run 'set_endpoint_variable @ENDPOINT4': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT4";
 
-0U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+0U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
 0R: @pre_run 'set_endpoint_variable @ENDPOINT4': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT4";
 
 1<:
 
-2U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+2U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
 2R: @pre_run 'set_endpoint_variable @ENDPOINT4': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT4";
 
 1<:
@@ -120,16 +120,16 @@ insert into t1 select generate_series(1,100);
 
 1: BEGIN;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * from t1;
-1: @post_run 'parse_endpoint_info 5 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 5 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
 
-0U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+0U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
 0R&: @pre_run 'set_endpoint_variable @ENDPOINT5': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT5";
 
-2U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+2U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
 2R&: @pre_run 'set_endpoint_variable @ENDPOINT5': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT5";
 
-1U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+1U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
 1R: @pre_run 'set_endpoint_variable @ENDPOINT5': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT5";
 
 SELECT gp_wait_until_triggered_fault('fetch_tuples_from_endpoint', 1, 2);
@@ -156,15 +156,15 @@ SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'suspend', '', '', '', 5, 5
 
 1: BEGIN;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * from t1;
-1: @post_run 'parse_endpoint_info 7 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 7 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
 
-0U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+0U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
 0R&: @pre_run 'set_endpoint_variable @ENDPOINT7': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT7";
 
-1U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+1U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
 1R&: @pre_run 'set_endpoint_variable @ENDPOINT7': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT7";
 
-2U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+2U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
 2R&: @pre_run 'set_endpoint_variable @ENDPOINT7': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT7";
 
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', 0);
@@ -212,16 +212,16 @@ SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'suspend', '', '', '', 800,
 
 1: BEGIN;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * from t2;
-1: @post_run 'parse_endpoint_info 6 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 6 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
 
-0U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+0U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
 0R&: @pre_run 'set_endpoint_variable @ENDPOINT6': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT6";
 
-2U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+2U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
 2R&: @pre_run 'set_endpoint_variable @ENDPOINT6': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT6";
 
-1U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+1U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
 1R: @pre_run 'set_endpoint_variable @ENDPOINT6': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT6";
 
 1<:

--- a/src/test/isolation2/input/parallel_retrieve_cursor/privilege.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/privilege.source
@@ -25,7 +25,7 @@ RESET SESSION AUTHORIZATION;
 1: SELECT SESSION_USER, CURRENT_USER;
 1: BEGIN;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
 1: SET SESSION AUTHORIZATION u1;
 1: SELECT SESSION_USER, CURRENT_USER;
 --- c2 is declared by u1
@@ -33,22 +33,22 @@ RESET SESSION AUTHORIZATION;
 --- c12 is declared by u1 on entry db
 1: DECLARE c12 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM generate_series(1,10);
 --- u1 is able to see all endpoints created by himself.
-1: SELECT DISTINCT(cursorname), usename FROM gp_endpoints() AS e, pg_user AS u where e.userid = u.usesysid;
+1: SELECT DISTINCT(cursorname), username FROM gp_get_endpoints();
 
 --- adminuser should be able to see all the endpoints declared by u1 with state READY
 2: SET SESSION AUTHORIZATION adminuser;
 2: SELECT SESSION_USER, CURRENT_USER;
-2: @post_run 'parse_endpoint_info 2 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c2';
-2: @post_run 'parse_endpoint_info 12 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c12';
-2: SELECT DISTINCT(cursorname), usename FROM gp_endpoints() AS e, pg_user AS u where e.userid = u.usesysid;
+2: @post_run 'parse_endpoint_info 2 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c2';
+2: @post_run 'parse_endpoint_info 12 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c12';
+2: SELECT DISTINCT(cursorname), username FROM gp_get_endpoints();
 
 --- adminuser should be able to see the cursor state change to READY
-2: SELECT auth_token, usename, state FROM gp_endpoints() endpoints, pg_user WHERE endpoints.userid = pg_user.usesysid order by usename;
+2: SELECT auth_token, username, state FROM gp_get_endpoints() endpoints order by username;
 
 --- adminuser should be able to see all endpoints declared by u1 in utility mode
 3: @pre_run 'export CURRENT_ENDPOINT_POSTFIX=1 ; export RETRIEVE_USER="adminuser"; echo $RAW_STR ' : SELECT 1;
 0R: SELECT SESSION_USER, CURRENT_USER;
-0U: SELECT auth_token, usename FROM gp_segment_endpoints() AS e, pg_user AS u where e.userid = u.usesysid;
+0U: SELECT auth_token, username FROM gp_get_segment_endpoints();
 0R: @pre_run 'set_endpoint_variable @ENDPOINT1': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT1";
 0Rq:
 3: @pre_run 'export CURRENT_ENDPOINT_POSTFIX=2 ; export RETRIEVE_USER="u1"; echo $RAW_STR ' : SELECT 1;
@@ -59,10 +59,10 @@ RESET SESSION AUTHORIZATION;
 1: SET ROLE uu1;
 1: SELECT SESSION_USER, CURRENT_USER;
 1: DECLARE c3 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-2: @post_run 'parse_endpoint_info 3 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c3';
+2: @post_run 'parse_endpoint_info 3 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c3';
 --- uu1 can not see u1's endpoints.
-1: SELECT DISTINCT(cursorname), usename FROM gp_endpoints() AS e, pg_user AS u where e.userid = u.usesysid;
-2: SELECT DISTINCT(cursorname), usename FROM gp_endpoints() AS e, pg_user AS u where e.userid = u.usesysid;
+1: SELECT DISTINCT(cursorname), username FROM gp_get_endpoints();
+2: SELECT DISTINCT(cursorname), username FROM gp_get_endpoints();
 
 3: @pre_run 'export RETRIEVE_USER="uu1"; echo $RAW_STR ' : SELECT 1;
 --- Login as uu1 and retrieve, only u1 can retrieve
@@ -91,9 +91,9 @@ RESET SESSION AUTHORIZATION;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
 
-2: @post_run 'parse_endpoint_info 40 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c0';
+2: @post_run 'parse_endpoint_info 40 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c0';
 
-2: @post_run 'parse_endpoint_info 4 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+2: @post_run 'parse_endpoint_info 4 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
 
 --- adminuser should NOT be able to retrieve from other's PARALLEL RETRIEVE CURSOR
 3: @pre_run 'export CURRENT_ENDPOINT_POSTFIX=40 ; export RETRIEVE_USER="adminuser"; echo $RAW_STR ' : SELECT 1;
@@ -130,15 +130,15 @@ RESET SESSION AUTHORIZATION;
 1: BEGIN;
 -- Used to let super login to retrieve session so then it can change user in session.
 1: DECLARE c0 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 50 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c0';
+1: @post_run 'parse_endpoint_info 50 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c0';
 1: SET SESSION AUTHORIZATION u1;
 --- c4 is declared and executed by u1
 1: DECLARE c4 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 5 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c4';
+1: @post_run 'parse_endpoint_info 5 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c4';
 
 --- u2 is not able to see u1's endpoints on master
 1: SET SESSION AUTHORIZATION u2;
-1: SELECT * from gp_endpoints();
+1: SELECT * from gp_get_endpoints();
 
 --- execute the cursor by u1
 1: SET SESSION AUTHORIZATION u1;
@@ -146,7 +146,7 @@ RESET SESSION AUTHORIZATION;
 
 --- u2 is not able to see u1's endpoints in RETRIEVE mode
 *R: @pre_run 'export CURRENT_ENDPOINT_POSTFIX=50 ; export RETRIEVE_USER="adminuser" ; echo $RAW_STR' : SET SESSION AUTHORIZATION u2;
-*U: SELECT auth_token, usename FROM gp_segment_endpoints() AS e, pg_user AS u where e.userid = u.usesysid;
+*U: SELECT auth_token, username FROM gp_get_segment_endpoints();
 
 --- u2 is not able to retrieve from u1's endpoints in RETRIEVE mode
 *R: @pre_run 'set_endpoint_variable @ENDPOINT5': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT5";

--- a/src/test/isolation2/input/parallel_retrieve_cursor/replicated_table.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/replicated_table.source
@@ -7,12 +7,12 @@ insert into rt1 select generate_series(1,100);
 --------- Test1: Basic test for PARALLEL RETRIEVE CURSOR on replicated table
 
 -- Replicated table will execute on seg id: session_id % segment_number
--- Declare a cursor and check gp_endpoints(), we can find out the real
+-- Declare a cursor and check gp_get_endpoints(), we can find out the real
 -- segment id by joining gp_segment_configuration. This should equal to
 -- session_id % 3 (size of demo cluster).
 1: BEGIN;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1;
-1: SELECT sc.content = current_setting('gp_session_id')::int % 3 AS diff FROM gp_endpoints() ep, gp_segment_configuration sc WHERE ep.dbid = sc.dbid;
+1: SELECT sc.content = current_setting('gp_session_id')::int % 3 AS diff FROM gp_get_endpoints() ep, gp_segment_configuration sc WHERE ep.gp_segment_id = sc.content;
 1: ROLLBACK;
 1q:
 
@@ -34,17 +34,17 @@ insert into rt1 select generate_series(1,100);
 -- Just declare & CHECK PARALLEL RETRIEVE CURSORs in all segment_number (i.e. 3) sessions,
 -- so that there should have specific session: MOD(sessionid,3)=1;
 -- Get token only in specific session id and retrieve this token.
-7: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE MOD(sessionid,3)=1 LIMIT 1;
+7: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE MOD(sessionid,3)=1 LIMIT 1;
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
 2&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', -1);
 3&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c3', -1);
 4&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c4', -1);
 5&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c5', -1);
 6&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c6', -1);
-*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT2";
 -- cancel all 6 sessions
-7: select pg_cancel_backend(pid) from pg_stat_activity, gp_endpoints() where sess_id = sessionid AND (cursorname ='c1' or cursorname='c2' or cursorname='c3' or cursorname ='c4' or cursorname='c5' or cursorname='c6');
+7: select pg_cancel_backend(pid) from pg_stat_activity, gp_get_endpoints() where sess_id = sessionid AND (cursorname ='c1' or cursorname='c2' or cursorname='c3' or cursorname ='c4' or cursorname='c5' or cursorname='c6');
 1<:
 2<:
 3<:
@@ -91,17 +91,17 @@ insert into rt1 select generate_series(1,100);
 -- Just declare & CHECK PARALLEL RETRIEVE CURSORs in all segment_number (i.e. 3) sessions,
 -- so that there should have specific session: MOD(sessionid,3)=1;
 -- Get token only in specific session id and retrieve this token.
-7: @post_run 'parse_endpoint_info 3 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE MOD(sessionid,3)=1 LIMIT 1;
+7: @post_run 'parse_endpoint_info 3 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE MOD(sessionid,3)=1 LIMIT 1;
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
 2&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', -1);
 3&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c3', -1);
 4&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c4', -1);
 5&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c5', -1);
 6&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c6', -1);
-*U: @pre_run 'set_endpoint_variable @ENDPOINT3': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT3';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT3': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT3';
 *R: @pre_run 'set_endpoint_variable @ENDPOINT3': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT3";
 -- cancel all 6 sessions
-7: select pg_cancel_backend(pid) from pg_stat_activity, gp_endpoints() where sess_id = sessionid AND (cursorname ='c1' or cursorname='c2' or cursorname='c3' or cursorname ='c4' or cursorname='c5' or cursorname='c6');
+7: select pg_cancel_backend(pid) from pg_stat_activity, gp_get_endpoints() where sess_id = sessionid AND (cursorname ='c1' or cursorname='c2' or cursorname='c3' or cursorname ='c4' or cursorname='c5' or cursorname='c6');
 1<:
 2<:
 3<:
@@ -148,17 +148,17 @@ insert into rt1 select generate_series(1,100);
 -- Just declare & CHECK PARALLEL RETRIEVE CURSORs in all segment_number (i.e. 3) sessions,
 -- so that there should have specific session: MOD(sessionid,3)=1;
 -- Get token only in specific session id and retrieve this token.
-7: @post_run 'parse_endpoint_info 4 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE MOD(sessionid,3)=1 LIMIT 1;
+7: @post_run 'parse_endpoint_info 4 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE MOD(sessionid,3)=1 LIMIT 1;
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
 2&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', -1);
 3&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c3', -1);
 4&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c4', -1);
 5&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c5', -1);
 6&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c6', -1);
-*U: @pre_run 'set_endpoint_variable @ENDPOINT4': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT4';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT4': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT4';
 *R: @pre_run 'set_endpoint_variable @ENDPOINT4': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT4";
 -- cancel all 6 sessions
-7: select pg_cancel_backend(pid) from pg_stat_activity, gp_endpoints() where sess_id = sessionid AND (cursorname ='c1' or cursorname='c2' or cursorname='c3' or cursorname ='c4' or cursorname='c5' or cursorname='c6');
+7: select pg_cancel_backend(pid) from pg_stat_activity, gp_get_endpoints() where sess_id = sessionid AND (cursorname ='c1' or cursorname='c2' or cursorname='c3' or cursorname ='c4' or cursorname='c5' or cursorname='c6');
 1<:
 2<:
 3<:

--- a/src/test/isolation2/input/parallel_retrieve_cursor/retrieve_quit_check.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/retrieve_quit_check.source
@@ -10,9 +10,9 @@ insert into t1 select generate_series(1,100);
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 1: DECLARE c2 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 1: DECLARE c3 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
-1: @post_run 'parse_endpoint_info 2 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c2';
-1: @post_run 'parse_endpoint_info 3 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c3';
+1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c2';
+1: @post_run 'parse_endpoint_info 3 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c3';
 
 -- in one retrieve session, retrieve multiple tokens (begin retrieving, finished retrieving, not yet retrieve)
 0R: @pre_run 'set_endpoint_variable @ENDPOINT1' : RETRIEVE 10 FROM ENDPOINT "@ENDPOINT1";
@@ -25,9 +25,9 @@ insert into t1 select generate_series(1,100);
 3R: @pre_run 'set_endpoint_variable @ENDPOINT2' : RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
 3R: @pre_run 'set_endpoint_variable @ENDPOINT3' : RETRIEVE 10 FROM ENDPOINT "@ENDPOINT3";
 
-2: SELECT cursorname, state FROM gp_endpoints();
+2: SELECT cursorname, state FROM gp_get_endpoints();
 -- verify endpoints on seg0 for c2 has been finishied
-0U: SELECT cursorname,senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints();
+0U: SELECT cursorname,senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints();
 -- quit the first retrieve session
 0Rq:
 
@@ -41,21 +41,21 @@ insert into t1 select generate_series(1,100);
 -- by this retrieve process should be cancelled.
 -- The endpoint on seg0 for c1 should firstly become to RELEASED (the retrieve process set it),
 -- and then was removed (during the endpoint QE cancelled)
-2: SELECT cursorname, state FROM gp_endpoints();
+2: SELECT cursorname, state FROM gp_get_endpoints();
 
 -- verify endpoints for c1 is gone
-0U: SELECT cursorname, senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints();
+0U: SELECT cursorname, senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints();
 
 -- Now check on c1 will trigger the error, all endpoints should be aborted since the transaction
 -- will be terminated.
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', 0);
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', 0);
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c3', 0);
-2: SELECT cursorname, state FROM gp_endpoints();
+2: SELECT cursorname, state FROM gp_get_endpoints();
 
 1: END;
 
-2: SELECT cursorname, state FROM gp_endpoints();
+2: SELECT cursorname, state FROM gp_get_endpoints();
 
 -- quit all sessions
 1q:

--- a/src/test/isolation2/input/parallel_retrieve_cursor/retrieve_quit_wait.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/retrieve_quit_wait.source
@@ -10,14 +10,14 @@ insert into t1 select generate_series(1,100);
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 1: DECLARE c2 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 1: DECLARE c3 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
-1: @post_run 'parse_endpoint_info 2 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c2';
-1: @post_run 'parse_endpoint_info 3 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c3';
+1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c2';
+1: @post_run 'parse_endpoint_info 3 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c3';
 
 -- Wait until the c2 has been fully retrieved
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', -1);
 
-2: SELECT cursorname, state FROM gp_endpoints();
+2: SELECT cursorname, state FROM gp_get_endpoints();
 
 -- in all retrieve sessions, retrieve multiple tokens (begin retrieving, finished retrieving, not yet retrieve)
 *R: @pre_run 'set_endpoint_variable @ENDPOINT1' : RETRIEVE 10 FROM ENDPOINT "@ENDPOINT1";
@@ -27,7 +27,7 @@ insert into t1 select generate_series(1,100);
 -- Retrieving on C2 finished.
 1<:
 
-0U: SELECT cursorname,senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints();
+0U: SELECT cursorname,senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints();
 -- quit the retrieve session
 0Rq:
 -- Now the interrupt is checked using WaitLatch() for time: WAIT_NORMAL_TIMEOUT,
@@ -38,12 +38,12 @@ insert into t1 select generate_series(1,100);
 -- by this retrieve process should be cancelled.
 -- The endpoint on seg0 for c1 should firstly become to RELEASED (the retrieve process set it),
 -- and then was removed (during the endpoint QE cancelled)
-2: SELECT cursorname, state FROM gp_endpoints();
+2: SELECT cursorname, state FROM gp_get_endpoints();
 
 -- Since c1 has been only partially retrieved, an error will be raised when transaction ends.
 1: END;
 
-2: SELECT cursorname, state FROM gp_endpoints();
+2: SELECT cursorname, state FROM gp_get_endpoints();
 
 --------- Test2: test for wait for quit partially retrieving session will abort all endpoints in the transaction.
 
@@ -51,9 +51,9 @@ insert into t1 select generate_series(1,100);
 1: DECLARE c4 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 1: DECLARE c5 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 1: DECLARE c6 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 4 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c4';
-1: @post_run 'parse_endpoint_info 5 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c5';
-1: @post_run 'parse_endpoint_info 6 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c6';
+1: @post_run 'parse_endpoint_info 4 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c4';
+1: @post_run 'parse_endpoint_info 5 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c5';
+1: @post_run 'parse_endpoint_info 6 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c6';
 
 -- Wait until retrieving session for c4 quits
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c4', -1);
@@ -63,14 +63,14 @@ insert into t1 select generate_series(1,100);
 *R: @pre_run 'set_endpoint_variable @ENDPOINT5' : RETRIEVE ALL FROM ENDPOINT "@ENDPOINT5";
 -- skip TOKEN3 in this session
 
-0U: SELECT cursorname,senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints();
+0U: SELECT cursorname,senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints();
 0Rq:
 
 -- Since retrieving session abort, waiting should be interrupted.
 1<:
 
 -- All endpoints should be removed since error happened.
-2: SELECT cursorname, state FROM gp_endpoints();
+2: SELECT cursorname, state FROM gp_get_endpoints();
 
 -- quit all sessions
 1q:

--- a/src/test/isolation2/input/parallel_retrieve_cursor/security.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/security.source
@@ -16,7 +16,7 @@ $$ LANGUAGE SQL;
 -- Test: Declare a cursor
 1: BEGIN;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
 
 -- Test: Should not change gp_role in retrieve mode
 0R: set gp_role to 'utility';

--- a/src/test/isolation2/input/parallel_retrieve_cursor/special_query.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/special_query.source
@@ -11,12 +11,12 @@ SELECT make_record(x) FROM t1;
 
 1: BEGIN;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT make_record(x) FROM t1;
-1: @post_run 'parse_endpoint_info 1 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 1 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
 
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', 0);
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT1': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT1';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT1': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT1';
 *R: @pre_run 'set_endpoint_variable @ENDPOINT1': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT1";
 
 1<:
@@ -45,7 +45,7 @@ SET gp_interconnect_queue_depth=1;
 2: BEGIN;
 2: SHOW gp_max_packet_size;
 2: DECLARE c2 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t2 join t2 t12 on true;
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
 2: CLOSE c2;
 2: END;
 

--- a/src/test/isolation2/input/parallel_retrieve_cursor/status_check.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/status_check.source
@@ -1,4 +1,4 @@
--- @Description Tests the state for pg_endpoints AND gp_segment_endpoints(), focus in nowait mode
+-- @Description Tests the state for pg_endpoints AND gp_get_segment_endpoints(), focus in nowait mode
 -- need to fault injection to gp_wait_parallel_retrieve_cursor()
 --
 DROP TABLE IF EXISTS t1;
@@ -8,18 +8,18 @@ insert into t1 select generate_series(1,100);
 --------- Test1: Basic test for parallel retrieve interface & close cursor
 1: BEGIN;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', 0);
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT1': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT1';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT1': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT1';
 *R: @pre_run 'set_endpoint_variable @ENDPOINT1': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT1";
 
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', 0);
 1: CLOSE c1;
 -- check no endpoint info
-1: SELECT auth_token,state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT auth_token,state FROM gp_get_endpoints() WHERE cursorname='c1';
 -- check no token info on QE after close PARALLEL RETRIEVE CURSOR
-*U: SELECT * FROM gp_segment_endpoints() WHERE cursorname='c1';
+*U: SELECT * FROM gp_get_segment_endpoints() WHERE cursorname='c1';
 
 -- error out for closed cursor
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', 0);
@@ -28,33 +28,33 @@ insert into t1 select generate_series(1,100);
 ---------- Test2: enhanced test for parallel retrieve interface state & cursor auto closed when transaction closed
 1: BEGIN;
 1: DECLARE c2 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 2 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c2';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c2';
 -- test RETRIEVE success on seg1
 0R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT2";
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', 0);
 
 -- check initial state after "CHECK PARALLEL RETRIEVE CURSOR"
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c2';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c2';
 -- check state if some endpoint retrieve partial results, some endpoint finished retrieving, some endpoint not start retrieving
 0R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT2";
 1R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c2';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c2';
 -- return 0 row instead of reporting error if finished retrieving data from this endpoint, while other endpoint have not finished retrieving.
 1R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
 -- finished retrieving all endpoints and check state
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c2';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c2';
 
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', 0);
 1: COMMIT;
 -- check the cursor auto closed when transaction closed
 -- check no endpoint info
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
 -- check no token info on QE after close PARALLEL RETRIEVE CURSOR
-*U: SELECT * FROM gp_segment_endpoints() WHERE cursorname='c2';
+*U: SELECT * FROM gp_get_segment_endpoints() WHERE cursorname='c2';
 
 -- error out for closed cursor
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', 0);
@@ -63,7 +63,7 @@ insert into t1 select generate_series(1,100);
 ---------- Test3: 2 retrieving sessions connect to the same endpoint report error & cancel QE exec backend
 1: BEGIN;
 1: DECLARE c3 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 3 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c3';
+1: @post_run 'parse_endpoint_info 3 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c3';
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c3', 0);
 0R: @pre_run 'set_endpoint_variable @ENDPOINT3': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT3";
 -- a new retrieve session should report error
@@ -73,33 +73,33 @@ insert into t1 select generate_series(1,100);
 -- some endpoint retrieve partial results, some endpoint finished retrieving, some endpoint not start retrieving
 1R: @pre_run 'set_endpoint_variable @ENDPOINT3': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT3";
 -- get senderpid which is endpoint execution backend
-0U: @post_run 'get_tuple_cell PID31 1 1 ; create_sub "$PID31[ \t]*" senderpid31': SELECT senderpid, receiverpid<>-1, state FROM gp_segment_endpoints();
+0U: @post_run 'get_tuple_cell PID31 1 1 ; create_sub "$PID31[ \t]*" senderpid31': SELECT senderpid, receiverpid<>-1, state FROM gp_get_segment_endpoints();
 -- run 'kill -s INT senderpid' to cancel the endpoint execution backend, retrieve session still can work
 42: @pre_run 'kill -s INT ${PID31} && echo "${RAW_STR}" ': SELECT 1;
 -- check it can cancel the "gp_wait_parallel_retrieve_cursor"
 1: SELECT pg_sleep(0.4);
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c3';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c3';
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c3', 0);
 -- check no endpoint info left
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c3';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c3';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c3';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c3';
 -- report error for EXECUTE canceled PARALLEL RETRIEVE CURSOR
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c3', 0);
 1: ROLLBACK;
 -- check no endpoint info
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c3';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c3';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c3';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c3';
 
 ---------- Test4: terminate (using signal QUIT) QE exec backend
 1: BEGIN;
 1: DECLARE c4 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 4 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c4';
+1: @post_run 'parse_endpoint_info 4 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c4';
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c4', 0);
 -- some endpoint retrieve partial results, some endpoint finished retrieving, some endpoint not start retrieving
 0R: @pre_run 'set_endpoint_variable @ENDPOINT4': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT4";
 1R: @pre_run 'set_endpoint_variable @ENDPOINT4': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT4";
 -- get senderpid which is endpoint execution backend
-0U: @post_run 'get_tuple_cell PID41 1 1 ; create_sub "${PID41}[ \t]*" senderpid41': SELECT senderpid, receiverpid<>-1, state FROM gp_segment_endpoints();
+0U: @post_run 'get_tuple_cell PID41 1 1 ; create_sub "${PID41}[ \t]*" senderpid41': SELECT senderpid, receiverpid<>-1, state FROM gp_get_segment_endpoints();
 -- run 'kill -s QUIT senderpid' to cancel the endpoint execution backend, retrieve session still can work
 42: @pre_run 'kill -s QUIT ${PID41} && echo "${RAW_STR}" ': SELECT 1;
 -- exit this session because the connection closed, so that it will re-connect next time use this session.
@@ -107,24 +107,24 @@ insert into t1 select generate_series(1,100);
 0Uq:
 -- check it can cancel the "gp_wait_parallel_retrieve_cursor"
 1: SELECT pg_sleep(0.4);
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c4';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c4';
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c4', 0);
 -- check no endpoint info left
 2q:
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c4';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c4';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c4';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c4';
 -- report error for EXECUTE canceled PARALLEL RETRIEVE CURSOR
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c4', 0);
 1: ROLLBACK;
 -- check no endpoint info
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c4';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c4';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c4';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c4';
 2Rq:
 
 ---------- Test5: terminate (using signal TERM) QE exec backend
 1: BEGIN;
 1: DECLARE c5 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 5 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c5';
+1: @post_run 'parse_endpoint_info 5 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c5';
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c5', 0);
 -- some endpoint retrieve partial results, some endpoint finished retrieving, some endpoint not start retrieving
 0R: @pre_run 'set_endpoint_variable @ENDPOINT5': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT5";
@@ -134,22 +134,22 @@ insert into t1 select generate_series(1,100);
 1Rq:
 1R: @pre_run 'set_endpoint_variable @ENDPOINT5': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT5";
 -- get senderpid which is endpoint execution backend
-0U: @post_run 'get_tuple_cell PID51 1 1 ; create_sub "${PID51}[ \t]*" senderpid51': SELECT senderpid, receiverpid<>-1, state FROM gp_segment_endpoints();
+0U: @post_run 'get_tuple_cell PID51 1 1 ; create_sub "${PID51}[ \t]*" senderpid51': SELECT senderpid, receiverpid<>-1, state FROM gp_get_segment_endpoints();
 -- run 'kill -s TERM senderpid' to cancel the endpoint execution backend, retrieve session still can work
 42: @pre_run 'kill -s TERM ${PID51} && echo "${RAW_STR}" ': SELECT 1;
 -- check it can cancel the "gp_wait_parallel_retrieve_cursor"
 1: SELECT pg_sleep(0.4);
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c5';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c5';
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c5', 0);
 -- check no endpoint info left
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c5';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c5';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c5';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c5';
 -- report error for EXECUTE canceled PARALLEL RETRIEVE CURSOR
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c5', 0);
 1: ROLLBACK;
 -- check no endpoint info
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c5';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c5';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c5';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c5';
 
 ---------- Test6: Cancel (using signal INT) the process of 'CHECK PARALLEL RETRIEVE CURSOR'
 -- faul injection on QD
@@ -157,7 +157,7 @@ insert into t1 select generate_series(1,100);
 1: SELECT gp_inject_fault('gp_wait_parallel_retrieve_cursor_after_udf', 'sleep', '', '', '', 1, 1, 1, 1::smallint);
 1: BEGIN;
 1: DECLARE c6 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 6 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c6';
+1: @post_run 'parse_endpoint_info 6 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c6';
 -- get backend pid of this session which run 'gp_wait_parallel_retrieve_cursor'
 1: @post_run 'get_tuple_cell PID61 1 1 ; create_sub "${PID61}[ \t]*" QDPid61': select pg_backend_pid();
 -- some endpoint retrieve partial results, some endpoint finished retrieving, some endpoint not start retrieving
@@ -170,14 +170,14 @@ insert into t1 select generate_series(1,100);
 -- check it can cancel the "gp_wait_parallel_retrieve_cursor"
 1<:
 -- check no endpoint info left
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c6';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c6';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c6';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c6';
 -- report error for EXECUTE canceled PARALLEL RETRIEVE CURSOR
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c6', 0);
 1: ROLLBACK;
 -- check no endpoint info
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c6';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c6';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c6';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c6';
 
 ---------- Test6.1: Cancel (using signal INT) the process of 'CHECK PARALLEL RETRIEVE CURSOR' without rollback
 -- faul injection on QD
@@ -185,7 +185,7 @@ insert into t1 select generate_series(1,100);
 1: SELECT gp_inject_fault('gp_wait_parallel_retrieve_cursor_after_udf', 'sleep', '', '', '', 1, 1, 1, 1::smallint);
 1: BEGIN;
 1: DECLARE c61 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 61 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c61';
+1: @post_run 'parse_endpoint_info 61 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c61';
 -- get backend pid of this session which run 'gp_wait_parallel_retrieve_cursor'
 1: @post_run 'get_tuple_cell PID611 1 1 ; create_sub "${PID611}[ \t]*" QDPid611': select pg_backend_pid();
 -- some endpoint retrieve partial results, some endpoint finished retrieving, some endpoint not start retrieving
@@ -198,13 +198,13 @@ insert into t1 select generate_series(1,100);
 -- check it can cancel the "gp_wait_parallel_retrieve_cursor"
 1<:
 -- check no endpoint info left
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c61';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c61';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c61';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c61';
 -- quit the session of 'CHECK PARALLEL RETRIEVE CURSOR' and keep other session connected
 1q:
 -- check no endpoint info
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c61';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c61';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c61';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c61';
 0Rq:
 1Rq:
 
@@ -213,13 +213,13 @@ insert into t1 select generate_series(1,100);
 1: SELECT gp_inject_fault('gp_wait_parallel_retrieve_cursor_after_udf', 'sleep', '', '', '', 1, 1, 1, 1::smallint);
 1: BEGIN;
 1: DECLARE c7 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 7 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c7';
+1: @post_run 'parse_endpoint_info 7 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c7';
 -- get backend pid of this session which run 'gp_wait_parallel_retrieve_cursor'
 1: @post_run 'get_tuple_cell PID71 1 1 ; create_sub "${PID71}[ \t]*" QDPid71': select pg_backend_pid();
 -- some endpoint retrieve partial results, some endpoint finished retrieving, some endpoint not start retrieving
 0R: @pre_run 'set_endpoint_variable @ENDPOINT7': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT7";
 1R: @pre_run 'set_endpoint_variable @ENDPOINT7': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT7";
-2U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c7';
+2U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c7';
 -- run 'kill -s QUIT QDPid' to cancel the endpoint execution backend, retrieve session still can work
 -- here need to sleep sometime to wait for endpoint QE backend to detect QD connection lost.
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c7', 0);
@@ -231,25 +231,25 @@ insert into t1 select generate_series(1,100);
 2q:
 -1Uq:
 -- check no endpoint info left
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c7';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c7';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c7';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c7';
 -- report error for EXECUTE canceled PARALLEL RETRIEVE CURSOR
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c7', -1);
 1: ROLLBACK;
 -- check no endpoint info
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c7';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c7';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c7';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c7';
 
 ---------- Test8: Status visibilities for different sessions
 1: BEGIN;
 1: DECLARE c8 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'get_tuple_cell SESSION81 1 1 ; create_match_sub_with_spaces $SESSION81 session81' : SELECT sessionid,state FROM gp_session_endpoints() WHERE cursorname='c8';
+1: @post_run 'get_tuple_cell SESSION81 1 1 ; create_match_sub_with_spaces $SESSION81 session81' : SELECT sessionid,state FROM gp_get_session_endpoints() WHERE cursorname='c8';
 -- Session 2 can only see its own cursors by default.
 2: BEGIN;
 2: DECLARE c8 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-2: @post_run 'get_tuple_cell SESSION82 1 1 ; create_match_sub_with_spaces $SESSION82 session82' : SELECT sessionid,state FROM gp_session_endpoints() WHERE cursorname='c8';
--- Session 2 can see all cursors with gp_endpoints().
-2: SELECT sessionid,state FROM gp_endpoints() WHERE cursorname='c8' order by sessionid;
+2: @post_run 'get_tuple_cell SESSION82 1 1 ; create_match_sub_with_spaces $SESSION82 session82' : SELECT sessionid,state FROM gp_get_session_endpoints() WHERE cursorname='c8';
+-- Session 2 can see all cursors with gp_get_endpoints().
+2: SELECT sessionid,state FROM gp_get_endpoints() WHERE cursorname='c8' order by sessionid;
 
 1: CLOSE c8;
 1: END;

--- a/src/test/isolation2/input/parallel_retrieve_cursor/status_wait.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/status_wait.source
@@ -1,4 +1,4 @@
--- @Description Tests the state for pg_endpoints AND gp_segment_endpoints(), focus in wait mode
+-- @Description Tests the state for pg_endpoints AND gp_get_segment_endpoints(), focus in wait mode
 --
 DROP TABLE IF EXISTS t1;
 CREATE TABLE t1 (a INT) DISTRIBUTED by (a);
@@ -7,18 +7,18 @@ insert into t1 select generate_series(1,100);
 --------- Test1: Basic test for parallel retrieve interface & close cursor
 1: BEGIN;
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT1': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT1';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT1': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT1';
 *R: @pre_run 'set_endpoint_variable @ENDPOINT1': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT1";
 
 1<:
 1: CLOSE c1;
 -- check no endpoint info
-1: SELECT auth_token,state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT auth_token,state FROM gp_get_endpoints() WHERE cursorname='c1';
 -- check no token info on QE after close PARALLEL RETRIEVE CURSOR
-*U: SELECT * FROM gp_segment_endpoints() WHERE cursorname='c1';
+*U: SELECT * FROM gp_get_segment_endpoints() WHERE cursorname='c1';
 
 -- error out for closed cursor
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', 0);
@@ -27,33 +27,33 @@ insert into t1 select generate_series(1,100);
 ---------- Test2: enhanced test for parallel retrieve interface state & cursor auto closed when transaction closed
 1: BEGIN;
 1: DECLARE c2 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 2 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c2';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c2';
 -- test RETRIEVE success on seg1
 0R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT2";
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', -1);
 
 -- check initial state after "CHECK PARALLEL RETRIEVE CURSOR"
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c2';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c2';
 -- check state if some endpoint retrieve partial results, some endpoint finished retrieving, some endpoint not start retrieving
 0R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT2";
 1R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c2';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c2';
 -- return 0 row instead of reporting error if finished retrieving data from this endpoint, while other endpoint have not finished retrieving.
 1R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
 -- finished retrieving all endpoints and check state
 *R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c2';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c2';
 
 1<:
 1: COMMIT;
 -- check the cursor auto closed when transaction closed
 -- check no endpoint info
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
 -- check no token info on QE after close PARALLEL RETRIEVE CURSOR
-*U: SELECT * FROM gp_segment_endpoints() WHERE cursorname='c2';
+*U: SELECT * FROM gp_get_segment_endpoints() WHERE cursorname='c2';
 
 -- error out for closed cursor
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', 0);
@@ -62,7 +62,7 @@ insert into t1 select generate_series(1,100);
 ---------- Test3: 2 retrieving sessions connect to the same endpoint report error & cancel QE exec backend
 1: BEGIN;
 1: DECLARE c3 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 3 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c3';
+1: @post_run 'parse_endpoint_info 3 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c3';
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c3', -1);
 0R: @pre_run 'set_endpoint_variable @ENDPOINT3': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT3";
 -- a new retrieve session should report error
@@ -72,31 +72,31 @@ insert into t1 select generate_series(1,100);
 -- some endpoint retrieve partial results, some endpoint finished retrieving, some endpoint not start retrieving
 1R: @pre_run 'set_endpoint_variable @ENDPOINT3': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT3";
 -- get senderpid which is endpoint execution backend
-0U: @post_run 'get_tuple_cell PID31 1 1 ; create_sub "$PID31[ \t]*" senderpid31': SELECT senderpid, receiverpid<>-1, state FROM gp_segment_endpoints();
+0U: @post_run 'get_tuple_cell PID31 1 1 ; create_sub "$PID31[ \t]*" senderpid31': SELECT senderpid, receiverpid<>-1, state FROM gp_get_segment_endpoints();
 -- run 'kill -s INT senderpid' to cancel the endpoint execution backend, retrieve session still can work
 42: @pre_run 'kill -s INT ${PID31} && echo "${RAW_STR}" ': SELECT 1;
 -- check it can cancel the "gp_wait_parallel_retrieve_cursor"
 1<:
 -- check no endpoint info left
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c3';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c3';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c3';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c3';
 -- report error for EXECUTE canceled PARALLEL RETRIEVE CURSOR
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c3', -1);
 1: ROLLBACK;
 -- check no endpoint info
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c3';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c3';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c3';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c3';
 
 ---------- Test4: terminate (using signal QUIT) QE exec backend
 1: BEGIN;
 1: DECLARE c4 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 4 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c4';
+1: @post_run 'parse_endpoint_info 4 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c4';
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c4', -1);
 -- some endpoint retrieve partial results, some endpoint finished retrieving, some endpoint not start retrieving
 0R: @pre_run 'set_endpoint_variable @ENDPOINT4': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT4";
 1R: @pre_run 'set_endpoint_variable @ENDPOINT4': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT4";
 -- get senderpid which is endpoint execution backend
-0U: @post_run 'get_tuple_cell PID41 1 1 ; create_sub "${PID41}[ \t]*" senderpid41': SELECT senderpid, receiverpid<>-1, state FROM gp_segment_endpoints();
+0U: @post_run 'get_tuple_cell PID41 1 1 ; create_sub "${PID41}[ \t]*" senderpid41': SELECT senderpid, receiverpid<>-1, state FROM gp_get_segment_endpoints();
 -- run 'kill -s QUIT senderpid' to cancel the endpoint execution backend, retrieve session still can work
 42: @pre_run 'kill -s QUIT ${PID41} && echo "${RAW_STR}" ': SELECT 1;
 -- exit this session because the connection closed, so that it will re-connect next time use this session.
@@ -106,20 +106,20 @@ insert into t1 select generate_series(1,100);
 1<:
 -- check no endpoint info left
 2q:
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c4';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c4';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c4';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c4';
 -- report error for EXECUTE canceled PARALLEL RETRIEVE CURSOR
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c4', -1);
 1: ROLLBACK;
 -- check no endpoint info
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c4';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c4';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c4';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c4';
 2Rq:
 
 ---------- Test5: terminate (using signal TERM) QE exec backend
 1: BEGIN;
 1: DECLARE c5 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 5 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c5';
+1: @post_run 'parse_endpoint_info 5 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c5';
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c5', -1);
 -- some endpoint retrieve partial results, some endpoint finished retrieving, some endpoint not start retrieving
 0R: @pre_run 'set_endpoint_variable @ENDPOINT5': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT5";
@@ -129,25 +129,25 @@ insert into t1 select generate_series(1,100);
 1Rq:
 1R: @pre_run 'set_endpoint_variable @ENDPOINT5': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT5";
 -- get senderpid which is endpoint execution backend
-0U: @post_run 'get_tuple_cell PID51 1 1 ; create_sub "${PID51}[ \t]*" senderpid51': SELECT senderpid, receiverpid<>-1, state FROM gp_segment_endpoints();
+0U: @post_run 'get_tuple_cell PID51 1 1 ; create_sub "${PID51}[ \t]*" senderpid51': SELECT senderpid, receiverpid<>-1, state FROM gp_get_segment_endpoints();
 -- run 'kill -s TERM senderpid' to cancel the endpoint execution backend, retrieve session still can work
 42: @pre_run 'kill -s TERM ${PID51} && echo "${RAW_STR}" ': SELECT 1;
 -- check it can cancel the "gp_wait_parallel_retrieve_cursor"
 1<:
 -- check no endpoint info left
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c5';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c5';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c5';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c5';
 -- report error for EXECUTE canceled PARALLEL RETRIEVE CURSOR
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c5', -1);
 1: ROLLBACK;
 -- check no endpoint info
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c5';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c5';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c5';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c5';
 
 ---------- Test6: Cancel (using signal INT) the process of 'CHECK PARALLEL RETRIEVE CURSOR'
 1: BEGIN;
 1: DECLARE c6 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 6 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c6';
+1: @post_run 'parse_endpoint_info 6 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c6';
 -- get backend pid of this session which run 'gp_wait_parallel_retrieve_cursor'
 1: @post_run 'get_tuple_cell PID61 1 1 ; create_sub "${PID61}[ \t]*" QDPid61': select pg_backend_pid();
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c6', -1);
@@ -159,19 +159,19 @@ insert into t1 select generate_series(1,100);
 -- check it can cancel the "gp_wait_parallel_retrieve_cursor"
 1<:
 -- check no endpoint info left
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c6';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c6';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c6';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c6';
 -- report error for EXECUTE canceled PARALLEL RETRIEVE CURSOR
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c6', -1);
 1: ROLLBACK;
 -- check no endpoint info
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c6';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c6';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c6';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c6';
 
 ---------- Test6.1: Cancel (using signal INT) the process of 'CHECK PARALLEL RETRIEVE CURSOR' without rollback
 1: BEGIN;
 1: DECLARE c61 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 61 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c61';
+1: @post_run 'parse_endpoint_info 61 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c61';
 -- get backend pid of this session which run 'gp_wait_parallel_retrieve_cursor'
 1: @post_run 'get_tuple_cell PID611 1 1 ; create_sub "${PID611}[ \t]*" QDPid611': select pg_backend_pid();
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c61', -1);
@@ -183,27 +183,27 @@ insert into t1 select generate_series(1,100);
 -- check it can cancel the "gp_wait_parallel_retrieve_cursor"
 1<:
 -- check no endpoint info left
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c61';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c61';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c61';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c61';
 -- quit the session of 'CHECK PARALLEL RETRIEVE CURSOR' and keep other session connected
 1q:
 -- check no endpoint info
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c61';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c61';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c61';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c61';
 0Rq:
 1Rq:
 
 ---------- Test7: terminate (using signal QUIT) the process of 'CHECK PARALLEL RETRIEVE CURSOR'
 1: BEGIN;
 1: DECLARE c7 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'parse_endpoint_info 7 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c7';
+1: @post_run 'parse_endpoint_info 7 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c7';
 -- get backend pid of this session which run 'gp_wait_parallel_retrieve_cursor'
 1: @post_run 'get_tuple_cell PID71 1 1 ; create_sub "${PID71}[ \t]*" QDPid71': select pg_backend_pid();
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c7', -1);
 -- some endpoint retrieve partial results, some endpoint finished retrieving, some endpoint not start retrieving
 0R: @pre_run 'set_endpoint_variable @ENDPOINT7': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT7";
 1R: @pre_run 'set_endpoint_variable @ENDPOINT7': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT7";
-2U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c7';
+2U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c7';
 -- run 'kill -s QUIT QDPid' to cancel the endpoint execution backend, retrieve session still can work
 -- here need to sleep sometime to wait for endpoint QE backend to detect QD connection lost.
 0U: @pre_run 'kill -s QUIT ${PID71}&& sleep 5 && echo "${RAW_STR}" ': SELECT 1;
@@ -214,28 +214,77 @@ insert into t1 select generate_series(1,100);
 2q:
 -1Uq:
 -- check no endpoint info left
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c7';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c7';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c7';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c7';
 -- report error for EXECUTE canceled PARALLEL RETRIEVE CURSOR
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c7', -1);
 1: ROLLBACK;
 -- check no endpoint info
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c7';
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c7';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c7';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c7';
 
 ---------- Test8: Status visibilities for different sessions
 1: BEGIN;
 1: DECLARE c8 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-1: @post_run 'get_tuple_cell SESSION81 1 1 ; create_match_sub_with_spaces $SESSION81 session81': SELECT sessionid,state FROM gp_session_endpoints() WHERE cursorname='c8';
+1: @post_run 'get_tuple_cell SESSION81 1 1 ; create_match_sub_with_spaces $SESSION81 session81': SELECT sessionid,state FROM gp_get_session_endpoints() WHERE cursorname='c8';
 -- Session 2 can only see its own cursors by default.
 2: BEGIN;
 2: DECLARE c8 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-2: @post_run 'get_tuple_cell SESSION82 1 1 ; create_match_sub_with_spaces $SESSION82 session82': SELECT sessionid,state FROM gp_session_endpoints() WHERE cursorname='c8';
--- Session 2 can see all cursors with gp_endpoints().
-2: SELECT sessionid,state FROM gp_endpoints() WHERE cursorname='c8' order by sessionid;
+2: @post_run 'get_tuple_cell SESSION82 1 1 ; create_match_sub_with_spaces $SESSION82 session82': SELECT sessionid,state FROM gp_get_session_endpoints() WHERE cursorname='c8';
+-- Session 2 can see all cursors with gp_get_endpoints().
+2: SELECT sessionid,state FROM gp_get_endpoints() WHERE cursorname='c8' order by sessionid;
 
 1: CLOSE c8;
 1: END;
 2: CLOSE c8;
 2: END;
 
+---------- Test9: Cancel (using pg_cancel_backend(pid)) the process of 'CHECK PARALLEL RETRIEVE CURSOR'
+1: BEGIN;
+1: DECLARE c9 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
+1: @post_run 'parse_endpoint_info 9 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c9';
+
+1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c9', -1);
+-- some endpoint retrieve partial results, some endpoint finished retrieving, some endpoint not start retrieving
+0R: @pre_run 'set_endpoint_variable @ENDPOINT9': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT9";
+1R: @pre_run 'set_endpoint_variable @ENDPOINT9': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT9";
+-- run pg_cancel_backend(pid) to cancel the endpoint execution backend, retrieve session still can work
+2: select pg_cancel_backend(pid) from pg_stat_activity where query like 'SELECT * FROM gp_wait_parallel_retrieve_cursor(''c9'', -1);';
+-- check it can cancel the "gp_wait_parallel_retrieve_cursor"
+1<:
+-- check no endpoint info left
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c9';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c9';
+-- report error for EXECUTE canceled PARALLEL RETRIEVE CURSOR
+1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c9', -1);
+1: ROLLBACK;
+-- check no endpoint info
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c9';
+
+---------- Test10: terminate (using pg_terminate_backend(pid)) the process of 'CHECK PARALLEL RETRIEVE CURSOR'
+1: BEGIN;
+1: DECLARE c10 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
+1: @post_run 'parse_endpoint_info 10 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c10';
+1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c10', -1);
+-- some endpoint retrieve partial results, some endpoint finished retrieving, some endpoint not start retrieving
+0R: @pre_run 'set_endpoint_variable @ENDPOINT10': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT10";
+1R: @pre_run 'set_endpoint_variable @ENDPOINT10': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT10";
+2U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c10';
+-- run ' pg_terminate_backend(pid)' to cancel the endpoint execution backend, retrieve session still can work
+-- here need to sleep sometime to wait for endpoint QE backend to detect QD connection lost.
+2: select pg_terminate_backend(pid) from pg_stat_activity where query like 'SELECT * FROM gp_wait_parallel_retrieve_cursor(''c10'', -1);';
+-- check it can cancel the "gp_wait_parallel_retrieve_cursor"
+1<:
+-- quit all sessions on the master, because connect lost
+1q:
+2q:
+-1Uq:
+-- check no endpoint info left
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c10';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c10';
+-- report error for EXECUTE canceled PARALLEL RETRIEVE CURSOR
+1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c10', -1);
+1: ROLLBACK;
+-- check no endpoint info
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c10';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c10';

--- a/src/test/isolation2/output/parallel_retrieve_cursor/corner.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/corner.source
@@ -36,7 +36,7 @@ INSERT 10
 BEGIN
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 1 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 1 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id1 | token_id | host_id | port_id | READY
  endpoint_id1 | token_id | host_id | port_id | READY
  endpoint_id1 | token_id | host_id | port_id | READY
@@ -44,12 +44,12 @@ DECLARE
 1: CLOSE c1;
 CLOSE
 -- check no endpoint info
-1: SELECT auth_token,state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT auth_token,state FROM gp_get_endpoints() WHERE cursorname='c1';
  auth_token | state 
 ------------+-------
 (0 rows)
 -- check no token info on QE after close PARALLEL RETRIEVE CURSOR
-*U: @pre_run 'set_endpoint_variable @ENDPOINT1': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT1';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT1': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT1';
  state 
 -------
 (0 rows)
@@ -77,7 +77,7 @@ ROLLBACK
 BEGIN
 1: DECLARE c11 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t11;
 DECLARE
-1: @post_run 'parse_endpoint_info 11 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c11';
+1: @post_run 'parse_endpoint_info 11 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c11';
  endpoint_id11 | token_id | host_id | port_id | READY
  endpoint_id11 | token_id | host_id | port_id | READY
  endpoint_id11 | token_id | host_id | port_id | READY
@@ -85,12 +85,12 @@ DECLARE
 1: CLOSE c11;
 CLOSE
 -- check no endpoint info
-1: SELECT auth_token,state FROM gp_endpoints() WHERE cursorname='c11';
+1: SELECT auth_token,state FROM gp_get_endpoints() WHERE cursorname='c11';
  auth_token | state 
 ------------+-------
 (0 rows)
 -- check no token info on QE after close PARALLEL RETRIEVE CURSOR
-*U: @pre_run 'set_endpoint_variable @ENDPOINT11': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT11';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT11': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT11';
  state 
 -------
 (0 rows)
@@ -141,7 +141,7 @@ DECLARE
 1: ROLLBACK;
 ROLLBACK
 -- check no endpoint info
-1: SELECT auth_token,state FROM gp_endpoints();
+1: SELECT auth_token,state FROM gp_get_endpoints();
  auth_token | state 
 ------------+-------
 (0 rows)
@@ -164,7 +164,7 @@ ERROR:  cursor "c2" does not exist
 1: ROLLBACK;
 ROLLBACK
 -- check no endpoint info
-1: SELECT auth_token,state FROM gp_endpoints();
+1: SELECT auth_token,state FROM gp_get_endpoints();
  auth_token | state 
 ------------+-------
 (0 rows)
@@ -194,7 +194,7 @@ DECLARE
 DECLARE
 1: DECLARE c11 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c2';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c2';
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
@@ -207,7 +207,7 @@ DECLARE
 (1 row)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', -1);  <waiting ...>
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
  state 
 -------
 (0 rows)
@@ -353,7 +353,7 @@ DECLARE
  t        
 (1 row)
 -- check all endpoint state
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
  state    
 ----------
  FINISHED 
@@ -363,7 +363,7 @@ DECLARE
 1: ROLLBACK;
 ROLLBACK
 -- check no endpoint info
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
  state 
 -------
 (0 rows)
@@ -381,7 +381,7 @@ DECLARE
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 ERROR:  cursor "c1" already exists
 -- check no endpoint info
-1: SELECT auth_token,state FROM gp_endpoints();
+1: SELECT auth_token,state FROM gp_get_endpoints();
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 1: ROLLBACK;
 ROLLBACK
@@ -392,14 +392,14 @@ BEGIN
 DECLARE
 1: DECLARE c2 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c2';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c2';
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
 (3 rows)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', -1);  <waiting ...>
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
  state 
 -------
 (0 rows)
@@ -540,7 +540,7 @@ DECLARE
  t        
 (1 row)
 -- check no endpoint info
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
  state    
 ----------
  FINISHED 
@@ -560,11 +560,11 @@ ROLLBACK
 BEGIN
 1: DECLARE c2 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1 ORDER BY a LIMIT 10;
 DECLARE
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c2';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c2';
  endpoint_id2 | token_id | host_id | port_id | READY
 (1 row)
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
  state 
 -------
  READY 
@@ -617,7 +617,7 @@ DECLARE
  t        
 (1 row)
 -- check no endpoint info
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
  state    
 ----------
  FINISHED 
@@ -635,7 +635,7 @@ Sessions not started cannot be quit
 BEGIN
 1: DECLARE c2 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1 ORDER BY a LIMIT 0;
 DECLARE
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c2';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c2';
  endpoint_id2 | token_id | host_id | port_id | READY
 (1 row)
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', 0);
@@ -645,7 +645,7 @@ DECLARE
 (1 row)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', -1);  <waiting ...>
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
  state 
 -------
  READY 
@@ -687,7 +687,7 @@ DECLARE
  t        
 (1 row)
 -- check no endpoint info
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
  state    
 ----------
  FINISHED 
@@ -705,7 +705,7 @@ Sessions not started cannot be quit
 BEGIN
 1: DECLARE c2 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t2;
 DECLARE
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c2';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c2';
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
@@ -717,7 +717,7 @@ DECLARE
 (1 row)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', -1);  <waiting ...>
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
  state 
 -------
 (0 rows)
@@ -763,7 +763,7 @@ DECLARE
  t        
 (1 row)
 -- check no endpoint info
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
  state    
 ----------
  FINISHED 
@@ -783,7 +783,7 @@ ROLLBACK
 BEGIN
 1: DECLARE c2 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t3;
 DECLARE
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c2';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c2';
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
@@ -795,7 +795,7 @@ DECLARE
 (1 row)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', -1);  <waiting ...>
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
  state 
 -------
 (0 rows)
@@ -851,7 +851,7 @@ DECLARE
  t        
 (1 row)
 -- check no endpoint info
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
  state    
 ----------
  FINISHED 
@@ -871,7 +871,7 @@ ROLLBACK
 BEGIN
 1: DECLARE c2 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t4;
 DECLARE
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c2';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c2';
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
@@ -883,7 +883,7 @@ DECLARE
 (1 row)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', -1);  <waiting ...>
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
  state 
 -------
 (0 rows)
@@ -929,7 +929,7 @@ DECLARE
  t        
 (1 row)
 -- check no endpoint info
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
  state    
 ----------
  FINISHED 
@@ -949,7 +949,7 @@ ROLLBACK
 BEGIN
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1 WHERE a = 50;
 DECLARE
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id2 | token_id | host_id | port_id | READY
 (1 row)
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', 0);
@@ -959,7 +959,7 @@ DECLARE
 (1 row)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);  <waiting ...>
 
-1U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+1U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
  state 
 -------
  READY 
@@ -981,7 +981,7 @@ DECLARE
  t        
 (1 row)
 -- check no endpoint info
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c1';
  state    
 ----------
  FINISHED 
@@ -996,7 +996,7 @@ ROLLBACK
 BEGIN
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT SUM(a) FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id2 | token_id | host_id | port_id | READY
 (1 row)
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', 0);
@@ -1006,7 +1006,7 @@ DECLARE
 (1 row)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);  <waiting ...>
 
--1U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+-1U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
  state 
 -------
  READY 
@@ -1027,7 +1027,7 @@ DECLARE
 ----------
  t        
 (1 row)
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c1';
  state    
 ----------
  FINISHED 
@@ -1042,11 +1042,11 @@ ROLLBACK
 BEGIN
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT AVG(a) FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id2 | token_id | host_id | port_id | READY
 (1 row)
 
--1U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+-1U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
  state 
 -------
  READY 
@@ -1067,7 +1067,7 @@ DECLARE
 ----------
  t        
 (1 row)
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c1';
  state    
 ----------
  FINISHED 
@@ -1082,12 +1082,12 @@ ROLLBACK
 BEGIN
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT COUNT(*) FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id2 | token_id | host_id | port_id | READY
 (1 row)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);  <waiting ...>
 
--1U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+-1U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
  state 
 -------
  READY 
@@ -1103,7 +1103,7 @@ DECLARE
 ----------
  t        
 (1 row)
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c1';
  state    
 ----------
  FINISHED 
@@ -1118,7 +1118,7 @@ ROLLBACK
 BEGIN
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1, t5 where t1.a = t5.b;
 DECLARE
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
@@ -1156,7 +1156,7 @@ DECLARE
 ----------
  t        
 (1 row)
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c1';
  state    
 ----------
  FINISHED 
@@ -1176,7 +1176,7 @@ ROLLBACK
 BEGIN
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT COUNT(*) FROM t1, t5 where t1.a = t5.b;
 DECLARE
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id2 | token_id | host_id | port_id | READY
 (1 row)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);  <waiting ...>
@@ -1192,7 +1192,7 @@ DECLARE
 ----------
  t        
 (1 row)
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c1';
  state    
 ----------
  FINISHED 
@@ -1207,14 +1207,14 @@ ROLLBACK
 BEGIN
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * from t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
 (3 rows)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);  <waiting ...>
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
  state 
 -------
 (0 rows)
@@ -1358,14 +1358,14 @@ DECLARE
 CLOSE
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * from t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
 (3 rows)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);  <waiting ...>
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
  state 
 -------
 (0 rows)
@@ -1505,7 +1505,7 @@ DECLARE
 ----------
  t        
 (1 row)
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c1';
  state    
 ----------
  FINISHED 
@@ -1525,14 +1525,14 @@ ROLLBACK
 BEGIN
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * from t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
 (3 rows)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);  <waiting ...>
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
  state 
 -------
 (0 rows)
@@ -1680,14 +1680,14 @@ DECLARE
 CLOSE
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * from t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
 (3 rows)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);  <waiting ...>
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
  state 
 -------
 (0 rows)
@@ -1827,7 +1827,7 @@ DECLARE
 ----------
  t        
 (1 row)
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c1';
  state    
 ----------
  FINISHED 
@@ -1849,14 +1849,14 @@ BEGIN
 SAVEPOINT
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * from t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
 (3 rows)
 1: ROLLBACK TO s1;
 ROLLBACK
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c1';
  state 
 -------
 (0 rows)
@@ -1888,7 +1888,7 @@ COMMIT
 BEGIN
 1: DECLARE c21a PARALLEL RETRIEVE CURSOR FOR SELECT COUNT(*) from t1;
 DECLARE
-1: @post_run 'get_tuple_cell TOKEN21a 1 1 ; create_match_sub $TOKEN21a token21a' : SELECT auth_token FROM gp_endpoints() WHERE cursorname='c21a';
+1: @post_run 'get_tuple_cell TOKEN21a 1 1 ; create_match_sub $TOKEN21a token21a' : SELECT auth_token FROM gp_get_endpoints() WHERE cursorname='c21a';
  auth_token
 ----------------------------------
  token21a
@@ -1898,7 +1898,7 @@ DECLARE
 DECLARE
 1: DECLARE c21c PARALLEL RETRIEVE CURSOR FOR SELECT * from t1;
 DECLARE
-1: SELECT auth_token FROM gp_endpoints() WHERE cursorname='c21a';
+1: SELECT auth_token FROM gp_get_endpoints() WHERE cursorname='c21a';
  auth_token                       
 ----------------------------------
  token21a 
@@ -1916,7 +1916,7 @@ Sessions not started cannot be quit
 BEGIN
 1: DECLARE c22 PARALLEL RETRIEVE CURSOR WITHOUT HOLD FOR SELECT * FROM generate_series(1,10);
 DECLARE
-1: @post_run 'parse_endpoint_info 22 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c22';
+1: @post_run 'parse_endpoint_info 22 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c22';
  endpoint_id22 | token_id | host_id | port_id | READY
 (1 row)
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c22', 0);
@@ -1925,7 +1925,7 @@ DECLARE
  f        
 (1 row)
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT22': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT22';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT22': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT22';
  state 
 -------
  READY 
@@ -1973,7 +1973,7 @@ DECLARE
  t        
 (1 row)
 -- check no endpoint info
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c22';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c22';
  state    
 ----------
  FINISHED 
@@ -1993,7 +1993,7 @@ Sessions not started cannot be quit
 BEGIN
 1: DECLARE c23 PARALLEL RETRIEVE CURSOR WITHOUT HOLD FOR SELECT relname FROM pg_class where relname='pg_class';
 DECLARE
-1: @post_run 'parse_endpoint_info 23 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c23';
+1: @post_run 'parse_endpoint_info 23 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c23';
  endpoint_id23 | token_id | host_id | port_id | READY
 (1 row)
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c23', 0);
@@ -2002,7 +2002,7 @@ DECLARE
  f        
 (1 row)
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT23': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT23';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT23': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT23';
  state 
 -------
  READY 
@@ -2041,7 +2041,7 @@ DECLARE
  t        
 (1 row)
 -- check no endpoint info
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c23';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c23';
  state    
 ----------
  FINISHED 
@@ -2063,17 +2063,17 @@ DECLARE
 DECLARE
 1: DECLARE "x1234567890123456789012345678901234567890123456789012345678901x" PARALLEL RETRIEVE CURSOR WITHOUT HOLD FOR SELECT * FROM t5;
 DECLARE
-1: @post_run 'parse_endpoint_info 24 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='x12345678901234567890123456789012345678901234567890123456789x';
+1: @post_run 'parse_endpoint_info 24 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='x12345678901234567890123456789012345678901234567890123456789x';
  endpoint_id24 | token_id | host_id | port_id | READY
  endpoint_id24 | token_id | host_id | port_id | READY
  endpoint_id24 | token_id | host_id | port_id | READY
 (3 rows)
-1: @post_run 'parse_endpoint_info 24_1 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='x12345678901234567890123456789012345678901234567890123456789012';
+1: @post_run 'parse_endpoint_info 24_1 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='x12345678901234567890123456789012345678901234567890123456789012';
  endpoint_id24_1 | token_id | host_id | port_id | READY
  endpoint_id24_1 | token_id | host_id | port_id | READY
  endpoint_id24_1 | token_id | host_id | port_id | READY
 (3 rows)
-1: @post_run 'parse_endpoint_info 24_2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='x1234567890123456789012345678901234567890123456789012345678901x';
+1: @post_run 'parse_endpoint_info 24_2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='x1234567890123456789012345678901234567890123456789012345678901x';
  endpoint_id24_2 | token_id | host_id | port_id | READY
  endpoint_id24_2 | token_id | host_id | port_id | READY
  endpoint_id24_2 | token_id | host_id | port_id | READY
@@ -2176,7 +2176,7 @@ ROLLBACK
 BEGIN
 1: DECLARE c2 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t5;
 DECLARE
-1: @post_run 'parse_endpoint_info 26 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c2';
+1: @post_run 'parse_endpoint_info 26 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c2';
  endpoint_id26 | token_id | host_id | port_id | READY
  endpoint_id26 | token_id | host_id | port_id | READY
  endpoint_id26 | token_id | host_id | port_id | READY
@@ -2210,7 +2210,7 @@ COMMIT
 BEGIN
 1: DECLARE c27 PARALLEL RETRIEVE CURSOR FOR SELECT generate_series(1,10);
 DECLARE
-1: @post_run 'parse_endpoint_info 27 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c27';
+1: @post_run 'parse_endpoint_info 27 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c27';
  endpoint_id27 | token_id | host_id | port_id | READY
 (1 row)
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c27', 0);
@@ -2219,7 +2219,7 @@ DECLARE
  f        
 (1 row)
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT27': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT27';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT27': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT27';
  state 
 -------
  READY 
@@ -2267,7 +2267,7 @@ DECLARE
  t        
 (1 row)
 -- check no endpoint info
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c27';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c27';
  state    
 ----------
  FINISHED 

--- a/src/test/isolation2/output/parallel_retrieve_cursor/fault_inject.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/fault_inject.source
@@ -23,14 +23,14 @@ INSERT 100
 BEGIN
 -- should report error on seg0
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-ERROR:  failed to allocate endpoint
+ERROR:  failed to allocate endpoint for session id xxx
 1: ROLLBACK;
 ROLLBACK
 -- test same error on another session
 3: BEGIN;
 BEGIN
 3: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
-ERROR:  failed to allocate endpoint
+ERROR:  failed to allocate endpoint for session id xxx
 3: ROLLBACK;
 ROLLBACK
 -- reset the fault injection
@@ -49,14 +49,14 @@ ROLLBACK
 BEGIN
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id1 | token_id | host_id | port_id | READY
  endpoint_id1 | token_id | host_id | port_id | READY
  endpoint_id1 | token_id | host_id | port_id | READY
 (3 rows)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);  <waiting ...>
 
-*U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1' or endpointname='DUMMYENDPOINTNAME';
+*U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1' or endpointname='DUMMYENDPOINTNAME';
  state 
 -------
 (0 rows)
@@ -199,26 +199,26 @@ DECLARE
 1: CLOSE c1;
 CLOSE
 -- check no endpoint info
-1: SELECT auth_token,state FROM gp_endpoints() WHERE cursorname='c1' or endpointname='DUMMYENDPOINTNAME';
+1: SELECT auth_token,state FROM gp_get_endpoints() WHERE cursorname='c1' or endpointname='DUMMYENDPOINTNAME';
  auth_token | state 
 ------------+-------
 (0 rows)
 -- check no token info on QE after close PARALLEL RETRIEVE CURSOR
-*U: SELECT * FROM gp_segment_endpoints() WHERE cursorname='c1' or endpointname='DUMMYENDPOINTNAME';
- auth_token | databaseid | senderpid | receiverpid | state | dbid | sessionid | userid | endpointname | cursorname 
-------------+------------+-----------+-------------+-------+------+-----------+--------+--------------+------------
+*U: SELECT * FROM gp_get_segment_endpoints() WHERE cursorname='c1' or endpointname='DUMMYENDPOINTNAME';
+ auth_token | databaseid | senderpid | receiverpid | state | gp_segment_id | sessionid | username | endpointname | cursorname 
+------------+------------+-----------+-------------+-------+---------------+-----------+----------+--------------+------------
 (0 rows)
 
- auth_token | databaseid | senderpid | receiverpid | state | dbid | sessionid | userid | endpointname | cursorname 
-------------+------------+-----------+-------------+-------+------+-----------+--------+--------------+------------
+ auth_token | databaseid | senderpid | receiverpid | state | gp_segment_id | sessionid | username | endpointname | cursorname 
+------------+------------+-----------+-------------+-------+---------------+-----------+----------+--------------+------------
 (0 rows)
 
- auth_token | databaseid | senderpid | receiverpid | state | dbid | sessionid | userid | endpointname | cursorname 
-------------+------------+-----------+-------------+-------+------+-----------+--------+--------------+------------
+ auth_token | databaseid | senderpid | receiverpid | state | gp_segment_id | sessionid | username | endpointname | cursorname 
+------------+------------+-----------+-------------+-------+---------------+-----------+----------+--------------+------------
 (0 rows)
 
- auth_token | databaseid | senderpid | receiverpid | state | dbid | sessionid | userid | endpointname | cursorname 
-------------+------------+-----------+-------------+-------+------+-----------+--------+--------------+------------
+ auth_token | databaseid | senderpid | receiverpid | state | gp_segment_id | sessionid | username | endpointname | cursorname 
+------------+------------+-----------+-------------+-------+---------------+-----------+----------+--------------+------------
 (0 rows)
 
 1: ROLLBACK;
@@ -240,14 +240,14 @@ ROLLBACK
 BEGIN
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * from t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 2 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
 (3 rows)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);  <waiting ...>
 
-0U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+0U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
  state 
 -------
  READY 
@@ -258,25 +258,25 @@ ERROR:  canceling statement due to user request
 1<:  <... completed>
 ERROR:  canceling MPP operation: "Endpoint retrieve statement aborted"
 
-1U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+1U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
  state 
 -------
 (0 rows)
 1R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
-ERROR:  the endpoint endpoint_id2 does not exist in the session
+ERROR:  the endpoint endpoint_id2 does not exist for session id xxx
 
-2U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+2U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
  state 
 -------
 (0 rows)
 2R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
-ERROR:  the endpoint endpoint_id2 does not exist in the session
+ERROR:  the endpoint endpoint_id2 does not exist for session id xxx
 
 1<:  <... completed>
 FAILED:  Execution failed
 1: ROLLBACK;
 ROLLBACK
-1: SELECT auth_token,state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT auth_token,state FROM gp_get_endpoints() WHERE cursorname='c1';
  auth_token | state 
 ------------+-------
 (0 rows)
@@ -302,14 +302,14 @@ ROLLBACK
 BEGIN
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * from t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 3 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 3 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id3 | token_id | host_id | port_id | READY
  endpoint_id3 | token_id | host_id | port_id | READY
  endpoint_id3 | token_id | host_id | port_id | READY
 (3 rows)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);  <waiting ...>
 
-1U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+1U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
  state 
 -------
  READY 
@@ -320,25 +320,25 @@ ERROR:  canceling statement due to user request
 1<:  <... completed>
 ERROR:  canceling MPP operation: "Endpoint retrieve statement aborted"
 
-0U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+0U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
  state 
 -------
 (0 rows)
 0R: @pre_run 'set_endpoint_variable @ENDPOINT3': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT3";
-ERROR:  the endpoint endpoint_id3 does not exist in the session
+ERROR:  the endpoint endpoint_id3 does not exist for session id xxx
 
-2U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+2U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
  state 
 -------
 (0 rows)
 2R: @pre_run 'set_endpoint_variable @ENDPOINT3': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT3";
-ERROR:  the endpoint endpoint_id3 does not exist in the session
+ERROR:  the endpoint endpoint_id3 does not exist for session id xxx
 
 1<:  <... completed>
 FAILED:  Execution failed
 1: ROLLBACK;
 ROLLBACK
-1: SELECT auth_token,state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT auth_token,state FROM gp_get_endpoints() WHERE cursorname='c1';
  auth_token | state 
 ------------+-------
 (0 rows)
@@ -359,14 +359,14 @@ ROLLBACK
 BEGIN
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * from t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 4 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 4 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id4 | token_id | host_id | port_id | READY
  endpoint_id4 | token_id | host_id | port_id | READY
  endpoint_id4 | token_id | host_id | port_id | READY
 (3 rows)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);  <waiting ...>
 
-1U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+1U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
  state 
 -------
  READY 
@@ -413,7 +413,7 @@ DECLARE
  98 
 (37 rows)
 
-0U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+0U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
  state 
 -------
  READY 
@@ -424,12 +424,12 @@ ERROR:  fault triggered, fault name:'fetch_tuples_from_endpoint' fault type:'err
 1<:  <... completed>
 ERROR:  canceling MPP operation: "Endpoint retrieve statement aborted"  (seg0 127.0.0.1:25432 pid=31406)
 
-2U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+2U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
  state 
 -------
 (0 rows)
 2R: @pre_run 'set_endpoint_variable @ENDPOINT4': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT4";
-ERROR:  the endpoint endpoint_id4 does not exist in the session
+ERROR:  the endpoint endpoint_id4 does not exist for session id xxx
 
 1<:  <... completed>
 FAILED:  Execution failed
@@ -477,28 +477,28 @@ ROLLBACK
 BEGIN
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * from t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 5 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 5 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id5 | token_id | host_id | port_id | READY
  endpoint_id5 | token_id | host_id | port_id | READY
  endpoint_id5 | token_id | host_id | port_id | READY
 (3 rows)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);  <waiting ...>
 
-0U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+0U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
  state 
 -------
  READY 
 (1 row)
 0R&: @pre_run 'set_endpoint_variable @ENDPOINT5': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT5";  <waiting ...>
 
-2U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+2U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
  state 
 -------
  READY 
 (1 row)
 2R&: @pre_run 'set_endpoint_variable @ENDPOINT5': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT5";  <waiting ...>
 
-1U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+1U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
  state 
 -------
  READY 
@@ -577,27 +577,27 @@ SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'suspend', '', '', '', 5, 5
 BEGIN
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * from t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 7 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 7 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id7 | token_id | host_id | port_id | READY
  endpoint_id7 | token_id | host_id | port_id | READY
  endpoint_id7 | token_id | host_id | port_id | READY
 (3 rows)
 
-0U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+0U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
  state 
 -------
  READY 
 (1 row)
 0R&: @pre_run 'set_endpoint_variable @ENDPOINT7': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT7";  <waiting ...>
 
-1U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+1U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
  state 
 -------
  READY 
 (1 row)
 1R&: @pre_run 'set_endpoint_variable @ENDPOINT7': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT7";  <waiting ...>
 
-2U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+2U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
  state 
 -------
  READY 
@@ -701,28 +701,28 @@ SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'suspend', '', '', '', 800,
 BEGIN
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * from t2;
 DECLARE
-1: @post_run 'parse_endpoint_info 6 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 6 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id6 | token_id | host_id | port_id | READY
  endpoint_id6 | token_id | host_id | port_id | READY
  endpoint_id6 | token_id | host_id | port_id | READY
 (3 rows)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);  <waiting ...>
 
-0U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+0U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
  state 
 -------
  READY 
 (1 row)
 0R&: @pre_run 'set_endpoint_variable @ENDPOINT6': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT6";  <waiting ...>
 
-2U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+2U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
  state 
 -------
  READY 
 (1 row)
 2R&: @pre_run 'set_endpoint_variable @ENDPOINT6': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT6";  <waiting ...>
 
-1U: SELECT state FROM gp_segment_endpoints() WHERE cursorname='c1';
+1U: SELECT state FROM gp_get_segment_endpoints() WHERE cursorname='c1';
  state 
 -------
  READY 

--- a/src/test/isolation2/output/parallel_retrieve_cursor/privilege.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/privilege.source
@@ -48,7 +48,7 @@ SET
 BEGIN
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id1 | token_id | host_id | port_id | READY
  endpoint_id1 | token_id | host_id | port_id | READY
  endpoint_id1 | token_id | host_id | port_id | READY
@@ -67,11 +67,11 @@ DECLARE
 1: DECLARE c12 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM generate_series(1,10);
 DECLARE
 --- u1 is able to see all endpoints created by himself.
-1: SELECT DISTINCT(cursorname), usename FROM gp_endpoints() AS e, pg_user AS u where e.userid = u.usesysid;
- cursorname | usename 
-------------+---------
- c12        | u1      
- c2         | u1      
+1: SELECT DISTINCT(cursorname), username FROM gp_get_endpoints();
+ cursorname | username 
+------------+----------
+ c12        | u1       
+ c2         | u1       
 (2 rows)
 
 --- adminuser should be able to see all the endpoints declared by u1 with state READY
@@ -82,16 +82,16 @@ SET
 --------------+--------------
  adminuser    | adminuser    
 (1 row)
-2: @post_run 'parse_endpoint_info 2 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c2';
+2: @post_run 'parse_endpoint_info 2 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c2';
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
 (3 rows)
-2: @post_run 'parse_endpoint_info 12 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c12';
+2: @post_run 'parse_endpoint_info 12 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c12';
  endpoint_id12 | token_id | host_id | port_id | READY
 (1 row)
-2: SELECT DISTINCT(cursorname), usename FROM gp_endpoints() AS e, pg_user AS u where e.userid = u.usesysid;
- cursorname | usename   
+2: SELECT DISTINCT(cursorname), username FROM gp_get_endpoints();
+ cursorname | username  
 ------------+-----------
  c1         | adminuser 
  c12        | u1        
@@ -99,8 +99,8 @@ SET
 (3 rows)
 
 --- adminuser should be able to see the cursor state change to READY
-2: SELECT auth_token, usename, state FROM gp_endpoints() endpoints, pg_user WHERE endpoints.userid = pg_user.usesysid order by usename;
- auth_token                       | usename   | state 
+2: SELECT auth_token, username, state FROM gp_get_endpoints() endpoints order by username;
+ auth_token                       | username  | state 
 ----------------------------------+-----------+-------
  token_id | adminuser | READY 
  token_id | adminuser | READY 
@@ -119,8 +119,8 @@ SET
 (1 row)
 0R: SELECT SESSION_USER, CURRENT_USER;
 ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
-0U: SELECT auth_token, usename FROM gp_segment_endpoints() AS e, pg_user AS u where e.userid = u.usesysid;
- auth_token                       | usename   
+0U: SELECT auth_token, username FROM gp_get_segment_endpoints();
+ auth_token                       | username  
 ----------------------------------+-----------
  token_id | adminuser 
  token_id | u1        
@@ -162,18 +162,18 @@ SET
 (1 row)
 1: DECLARE c3 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-2: @post_run 'parse_endpoint_info 3 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c3';
+2: @post_run 'parse_endpoint_info 3 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c3';
  endpoint_id3 | token_id | host_id | port_id | READY
  endpoint_id3 | token_id | host_id | port_id | READY
  endpoint_id3 | token_id | host_id | port_id | READY
 (3 rows)
 --- uu1 can not see u1's endpoints.
-1: SELECT DISTINCT(cursorname), usename FROM gp_endpoints() AS e, pg_user AS u where e.userid = u.usesysid;
- cursorname | usename 
-------------+---------
+1: SELECT DISTINCT(cursorname), username FROM gp_get_endpoints();
+ cursorname | username 
+------------+----------
 (0 rows)
-2: SELECT DISTINCT(cursorname), usename FROM gp_endpoints() AS e, pg_user AS u where e.userid = u.usesysid;
- cursorname | usename   
+2: SELECT DISTINCT(cursorname), username FROM gp_get_endpoints();
+ cursorname | username  
 ------------+-----------
  c1         | adminuser 
  c12        | u1        
@@ -233,13 +233,13 @@ SET
 DECLARE
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);  <waiting ...>
 
-2: @post_run 'parse_endpoint_info 40 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c0';
+2: @post_run 'parse_endpoint_info 40 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c0';
  endpoint_id40 | token_id | host_id | port_id | READY
  endpoint_id40 | token_id | host_id | port_id | READY
  endpoint_id40 | token_id | host_id | port_id | READY
 (3 rows)
 
-2: @post_run 'parse_endpoint_info 4 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+2: @post_run 'parse_endpoint_info 4 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id4 | token_id | host_id | port_id | READY
  endpoint_id4 | token_id | host_id | port_id | READY
  endpoint_id4 | token_id | host_id | port_id | READY
@@ -274,13 +274,13 @@ ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 
 
 ERROR:  the PARALLEL RETRIEVE CURSOR was created by a different user
-HINT:  Using the same user as the PARALLEL RETRIEVE CURSOR creator to retrieve.
+HINT:  Use the same user as the PARALLEL RETRIEVE CURSOR creator to retrieve.
 
 ERROR:  the PARALLEL RETRIEVE CURSOR was created by a different user
-HINT:  Using the same user as the PARALLEL RETRIEVE CURSOR creator to retrieve.
+HINT:  Use the same user as the PARALLEL RETRIEVE CURSOR creator to retrieve.
 
 ERROR:  the PARALLEL RETRIEVE CURSOR was created by a different user
-HINT:  Using the same user as the PARALLEL RETRIEVE CURSOR creator to retrieve.
+HINT:  Use the same user as the PARALLEL RETRIEVE CURSOR creator to retrieve.
 -- cancel the no privilege retrieving endpoints, otherwise it will wait until statement_timeout
 42: select pg_cancel_backend(pid) from pg_stat_activity where query like 'SELECT * FROM gp_wait_parallel_retrieve_cursor(''c1'', -1);';
  pg_cancel_backend 
@@ -331,7 +331,7 @@ BEGIN
 -- Used to let super login to retrieve session so then it can change user in session.
 1: DECLARE c0 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 50 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c0';
+1: @post_run 'parse_endpoint_info 50 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c0';
  endpoint_id50 | token_id | host_id | port_id | READY
  endpoint_id50 | token_id | host_id | port_id | READY
  endpoint_id50 | token_id | host_id | port_id | READY
@@ -341,7 +341,7 @@ SET
 --- c4 is declared and executed by u1
 1: DECLARE c4 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 5 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c4';
+1: @post_run 'parse_endpoint_info 5 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c4';
  endpoint_id5 | token_id | host_id | port_id | READY
  endpoint_id5 | token_id | host_id | port_id | READY
  endpoint_id5 | token_id | host_id | port_id | READY
@@ -350,9 +350,9 @@ DECLARE
 --- u2 is not able to see u1's endpoints on master
 1: SET SESSION AUTHORIZATION u2;
 SET
-1: SELECT * from gp_endpoints();
- dbid | auth_token | cursorname | sessionid | hostname | port | userid | state | endpointname 
-------+------------+------------+-----------+----------+------+--------+-------+--------------
+1: SELECT * from gp_get_endpoints();
+ gp_segment_id | auth_token | cursorname | sessionid | hostname | port | username | state | endpointname 
+---------------+------------+------------+-----------+----------+------+----------+-------+--------------
 (0 rows)
 
 --- execute the cursor by u1
@@ -370,24 +370,24 @@ ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 
 ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
-*U: SELECT auth_token, usename FROM gp_segment_endpoints() AS e, pg_user AS u where e.userid = u.usesysid;
- auth_token | usename 
-------------+---------
+*U: SELECT auth_token, username FROM gp_get_segment_endpoints();
+ auth_token | username 
+------------+----------
 (0 rows)
 
- auth_token                       | usename   
+ auth_token                       | username  
 ----------------------------------+-----------
  token_id | adminuser 
  token_id | u1        
 (2 rows)
 
- auth_token                       | usename   
+ auth_token                       | username  
 ----------------------------------+-----------
  token_id | adminuser 
  token_id | u1        
 (2 rows)
 
- auth_token                       | usename   
+ auth_token                       | username  
 ----------------------------------+-----------
  token_id | adminuser 
  token_id | u1        
@@ -399,13 +399,13 @@ ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 
 
 ERROR:  the PARALLEL RETRIEVE CURSOR was created by a different user
-HINT:  Using the same user as the PARALLEL RETRIEVE CURSOR creator to retrieve.
+HINT:  Use the same user as the PARALLEL RETRIEVE CURSOR creator to retrieve.
 
 ERROR:  the PARALLEL RETRIEVE CURSOR was created by a different user
-HINT:  Using the same user as the PARALLEL RETRIEVE CURSOR creator to retrieve.
+HINT:  Use the same user as the PARALLEL RETRIEVE CURSOR creator to retrieve.
 
 ERROR:  the PARALLEL RETRIEVE CURSOR was created by a different user
-HINT:  Using the same user as the PARALLEL RETRIEVE CURSOR creator to retrieve.
+HINT:  Use the same user as the PARALLEL RETRIEVE CURSOR creator to retrieve.
 -- cancel the no privilege retrieving endpoints, otherwise it will wait until statement_timeout
 42: select pg_cancel_backend(pid) from pg_stat_activity where query like 'SELECT * FROM gp_wait_parallel_retrieve_cursor(''c4'', -1);';
  pg_cancel_backend 

--- a/src/test/isolation2/output/parallel_retrieve_cursor/replicated_table.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/replicated_table.source
@@ -10,18 +10,19 @@ INSERT 100
 --------- Test1: Basic test for PARALLEL RETRIEVE CURSOR on replicated table
 
 -- Replicated table will execute on seg id: session_id % segment_number
--- Declare a cursor and check gp_endpoints(), we can find out the real
+-- Declare a cursor and check gp_get_endpoints(), we can find out the real
 -- segment id by joining gp_segment_configuration. This should equal to
 -- session_id % 3 (size of demo cluster).
 1: BEGIN;
 BEGIN
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1;
 DECLARE
-1: SELECT sc.content = current_setting('gp_session_id')::int % 3 AS diff FROM gp_endpoints() ep, gp_segment_configuration sc WHERE ep.dbid = sc.dbid;
+1: SELECT sc.content = current_setting('gp_session_id')::int % 3 AS diff FROM gp_get_endpoints() ep, gp_segment_configuration sc WHERE ep.gp_segment_id = sc.content;
  diff 
 ------
  t    
-(1 row)
+ t    
+(2 rows)
 1: ROLLBACK;
 ROLLBACK
 1q: ... <quitting>
@@ -56,7 +57,7 @@ DECLARE
 -- Just declare & CHECK PARALLEL RETRIEVE CURSORs in all segment_number (i.e. 3) sessions,
 -- so that there should have specific session: MOD(sessionid,3)=1;
 -- Get token only in specific session id and retrieve this token.
-7: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE MOD(sessionid,3)=1 LIMIT 1;
+7: @post_run 'parse_endpoint_info 2 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE MOD(sessionid,3)=1 LIMIT 1;
  endpoint_id2 | token_id | host_id | port_id | READY
 (1 row)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);  <waiting ...>
@@ -65,7 +66,7 @@ DECLARE
 4&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c4', -1);  <waiting ...>
 5&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c5', -1);  <waiting ...>
 6&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c6', -1);  <waiting ...>
-*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT2';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT2': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT2';
  state 
 -------
 (0 rows)
@@ -106,7 +107,7 @@ DECLARE
 #2retrieve> FATAL:  retrieve auth token is invalid
 
 -- cancel all 6 sessions
-7: select pg_cancel_backend(pid) from pg_stat_activity, gp_endpoints() where sess_id = sessionid AND (cursorname ='c1' or cursorname='c2' or cursorname='c3' or cursorname ='c4' or cursorname='c5' or cursorname='c6');
+7: select pg_cancel_backend(pid) from pg_stat_activity, gp_get_endpoints() where sess_id = sessionid AND (cursorname ='c1' or cursorname='c2' or cursorname='c3' or cursorname ='c4' or cursorname='c5' or cursorname='c6');
  pg_cancel_backend 
 -------------------
  t                 
@@ -186,7 +187,7 @@ DECLARE
 -- Just declare & CHECK PARALLEL RETRIEVE CURSORs in all segment_number (i.e. 3) sessions,
 -- so that there should have specific session: MOD(sessionid,3)=1;
 -- Get token only in specific session id and retrieve this token.
-7: @post_run 'parse_endpoint_info 3 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE MOD(sessionid,3)=1 LIMIT 1;
+7: @post_run 'parse_endpoint_info 3 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE MOD(sessionid,3)=1 LIMIT 1;
  endpoint_id3 | token_id | host_id | port_id | READY
 (1 row)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);  <waiting ...>
@@ -195,7 +196,7 @@ DECLARE
 4&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c4', -1);  <waiting ...>
 5&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c5', -1);  <waiting ...>
 6&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c6', -1);  <waiting ...>
-*U: @pre_run 'set_endpoint_variable @ENDPOINT3': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT3';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT3': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT3';
  state 
 -------
 (0 rows)
@@ -236,7 +237,7 @@ DECLARE
 #2retrieve> FATAL:  retrieve auth token is invalid
 
 -- cancel all 6 sessions
-7: select pg_cancel_backend(pid) from pg_stat_activity, gp_endpoints() where sess_id = sessionid AND (cursorname ='c1' or cursorname='c2' or cursorname='c3' or cursorname ='c4' or cursorname='c5' or cursorname='c6');
+7: select pg_cancel_backend(pid) from pg_stat_activity, gp_get_endpoints() where sess_id = sessionid AND (cursorname ='c1' or cursorname='c2' or cursorname='c3' or cursorname ='c4' or cursorname='c5' or cursorname='c6');
  pg_cancel_backend 
 -------------------
  t                 
@@ -316,7 +317,7 @@ DECLARE
 -- Just declare & CHECK PARALLEL RETRIEVE CURSORs in all segment_number (i.e. 3) sessions,
 -- so that there should have specific session: MOD(sessionid,3)=1;
 -- Get token only in specific session id and retrieve this token.
-7: @post_run 'parse_endpoint_info 4 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE MOD(sessionid,3)=1 LIMIT 1;
+7: @post_run 'parse_endpoint_info 4 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE MOD(sessionid,3)=1 LIMIT 1;
  endpoint_id4 | token_id | host_id | port_id | READY
 (1 row)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);  <waiting ...>
@@ -325,7 +326,7 @@ DECLARE
 4&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c4', -1);  <waiting ...>
 5&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c5', -1);  <waiting ...>
 6&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c6', -1);  <waiting ...>
-*U: @pre_run 'set_endpoint_variable @ENDPOINT4': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT4';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT4': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT4';
  state 
 -------
 (0 rows)
@@ -366,7 +367,7 @@ DECLARE
 #2retrieve> FATAL:  retrieve auth token is invalid
 
 -- cancel all 6 sessions
-7: select pg_cancel_backend(pid) from pg_stat_activity, gp_endpoints() where sess_id = sessionid AND (cursorname ='c1' or cursorname='c2' or cursorname='c3' or cursorname ='c4' or cursorname='c5' or cursorname='c6');
+7: select pg_cancel_backend(pid) from pg_stat_activity, gp_get_endpoints() where sess_id = sessionid AND (cursorname ='c1' or cursorname='c2' or cursorname='c3' or cursorname ='c4' or cursorname='c5' or cursorname='c6');
  pg_cancel_backend 
 -------------------
  t                 

--- a/src/test/isolation2/output/parallel_retrieve_cursor/retrieve_quit_check.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/retrieve_quit_check.source
@@ -17,17 +17,17 @@ DECLARE
 DECLARE
 1: DECLARE c3 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id1 | token_id | host_id | port_id | READY
  endpoint_id1 | token_id | host_id | port_id | READY
  endpoint_id1 | token_id | host_id | port_id | READY
 (3 rows)
-1: @post_run 'parse_endpoint_info 2 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c2';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c2';
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
 (3 rows)
-1: @post_run 'parse_endpoint_info 3 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c3';
+1: @post_run 'parse_endpoint_info 3 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c3';
  endpoint_id3 | token_id | host_id | port_id | READY
  endpoint_id3 | token_id | host_id | port_id | READY
  endpoint_id3 | token_id | host_id | port_id | READY
@@ -114,7 +114,7 @@ ERROR:  another session (pid: 49941) used the endpoint and completed retrieving
  24 
 (10 rows)
 
-2: SELECT cursorname, state FROM gp_endpoints();
+2: SELECT cursorname, state FROM gp_get_endpoints();
  cursorname | state    
 ------------+----------
  c1         | ATTACHED 
@@ -128,7 +128,7 @@ ERROR:  another session (pid: 49941) used the endpoint and completed retrieving
  c3         | READY    
 (9 rows)
 -- verify endpoints on seg0 for c2 has been finishied
-0U: SELECT cursorname,senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints();
+0U: SELECT cursorname,senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints();
  cursorname | ?column? | ?column? | state    
 ------------+----------+----------+----------
  c1         | t        | t        | ATTACHED 
@@ -156,7 +156,7 @@ ERROR:  another session (pid: 49941) used the endpoint and completed retrieving
 -- by this retrieve process should be cancelled.
 -- The endpoint on seg0 for c1 should firstly become to RELEASED (the retrieve process set it),
 -- and then was removed (during the endpoint QE cancelled)
-2: SELECT cursorname, state FROM gp_endpoints();
+2: SELECT cursorname, state FROM gp_get_endpoints();
  cursorname | state    
 ------------+----------
  c1         | READY    
@@ -170,7 +170,7 @@ ERROR:  another session (pid: 49941) used the endpoint and completed retrieving
 (8 rows)
 
 -- verify endpoints for c1 is gone
-0U: SELECT cursorname, senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints();
+0U: SELECT cursorname, senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints();
  cursorname | ?column? | ?column? | state    
 ------------+----------+----------+----------
  c2         | f        | t        | FINISHED 
@@ -185,7 +185,7 @@ ERROR:  canceling MPP operation: "Endpoint retrieve session is quitting. All unf
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c3', 0);
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
-2: SELECT cursorname, state FROM gp_endpoints();
+2: SELECT cursorname, state FROM gp_get_endpoints();
  cursorname | state 
 ------------+-------
 (0 rows)
@@ -193,7 +193,7 @@ ERROR:  current transaction is aborted, commands ignored until end of transactio
 1: END;
 END
 
-2: SELECT cursorname, state FROM gp_endpoints();
+2: SELECT cursorname, state FROM gp_get_endpoints();
  cursorname | state 
 ------------+-------
 (0 rows)

--- a/src/test/isolation2/output/parallel_retrieve_cursor/retrieve_quit_wait.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/retrieve_quit_wait.source
@@ -17,17 +17,17 @@ DECLARE
 DECLARE
 1: DECLARE c3 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id1 | token_id | host_id | port_id | READY
  endpoint_id1 | token_id | host_id | port_id | READY
  endpoint_id1 | token_id | host_id | port_id | READY
 (3 rows)
-1: @post_run 'parse_endpoint_info 2 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c2';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c2';
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
 (3 rows)
-1: @post_run 'parse_endpoint_info 3 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c3';
+1: @post_run 'parse_endpoint_info 3 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c3';
  endpoint_id3 | token_id | host_id | port_id | READY
  endpoint_id3 | token_id | host_id | port_id | READY
  endpoint_id3 | token_id | host_id | port_id | READY
@@ -36,7 +36,7 @@ DECLARE
 -- Wait until the c2 has been fully retrieved
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', -1);  <waiting ...>
 
-2: SELECT cursorname, state FROM gp_endpoints();
+2: SELECT cursorname, state FROM gp_get_endpoints();
  cursorname | state 
 ------------+-------
  c1         | READY 
@@ -220,7 +220,7 @@ DECLARE
  t        
 (1 row)
 
-0U: SELECT cursorname,senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints();
+0U: SELECT cursorname,senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints();
  cursorname | ?column? | ?column? | state    
 ------------+----------+----------+----------
  c1         | t        | t        | ATTACHED 
@@ -241,7 +241,7 @@ DECLARE
 -- by this retrieve process should be cancelled.
 -- The endpoint on seg0 for c1 should firstly become to RELEASED (the retrieve process set it),
 -- and then was removed (during the endpoint QE cancelled)
-2: SELECT cursorname, state FROM gp_endpoints();
+2: SELECT cursorname, state FROM gp_get_endpoints();
  cursorname | state    
 ------------+----------
  c1         | ATTACHED 
@@ -258,7 +258,7 @@ DECLARE
 1: END;
 ERROR:  canceling MPP operation: "Endpoint retrieve session is quitting. All unfinished parallel retrieve cursors on the session will be terminated."  (seg0 192.168.235.128:7002 pid=69967)
 
-2: SELECT cursorname, state FROM gp_endpoints();
+2: SELECT cursorname, state FROM gp_get_endpoints();
  cursorname | state 
 ------------+-------
 (0 rows)
@@ -273,17 +273,17 @@ DECLARE
 DECLARE
 1: DECLARE c6 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 4 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c4';
+1: @post_run 'parse_endpoint_info 4 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c4';
  endpoint_id4 | token_id | host_id | port_id | READY
  endpoint_id4 | token_id | host_id | port_id | READY
  endpoint_id4 | token_id | host_id | port_id | READY
 (3 rows)
-1: @post_run 'parse_endpoint_info 5 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c5';
+1: @post_run 'parse_endpoint_info 5 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c5';
  endpoint_id5 | token_id | host_id | port_id | READY
  endpoint_id5 | token_id | host_id | port_id | READY
  endpoint_id5 | token_id | host_id | port_id | READY
 (3 rows)
-1: @post_run 'parse_endpoint_info 6 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c6';
+1: @post_run 'parse_endpoint_info 6 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c6';
  endpoint_id6 | token_id | host_id | port_id | READY
  endpoint_id6 | token_id | host_id | port_id | READY
  endpoint_id6 | token_id | host_id | port_id | READY
@@ -455,7 +455,7 @@ DECLARE
 (25 rows)
 -- skip TOKEN3 in this session
 
-0U: SELECT cursorname,senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints();
+0U: SELECT cursorname,senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints();
  cursorname | ?column? | ?column? | state    
 ------------+----------+----------+----------
  c4         | t        | t        | ATTACHED 
@@ -469,7 +469,7 @@ DECLARE
 ERROR:  canceling MPP operation: "Endpoint retrieve session is quitting. All unfinished parallel retrieve cursors on the session will be terminated."  (seg0 192.168.235.128:7002 pid=70221)
 
 -- All endpoints should be removed since error happened.
-2: SELECT cursorname, state FROM gp_endpoints();
+2: SELECT cursorname, state FROM gp_get_endpoints();
  cursorname | state 
 ------------+-------
 (0 rows)

--- a/src/test/isolation2/output/parallel_retrieve_cursor/security.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/security.source
@@ -26,7 +26,7 @@ CREATE
 BEGIN
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id1 | token_id | host_id | port_id | READY
  endpoint_id1 | token_id | host_id | port_id | READY
  endpoint_id1 | token_id | host_id | port_id | READY
@@ -82,15 +82,15 @@ ERROR:  This is a retrieve connection, but the query is not a RETRIEVE.
 -- Test: Different illegal endpoints always lead to an error
 ---- invalid endpoints
 1R: RETRIEVE ALL FROM ENDPOINT abc;
-ERROR:  the endpoint abc does not exist in the session
+ERROR:  the endpoint abc does not exist for session id xxx
 1R: RETRIEVE ALL FROM ENDPOINT 123;
 ERROR:  syntax error at or near "123"
 LINE 1: RETRIEVE ALL FROM ENDPOINT 123;
                                    ^
 1R: RETRIEVE ALL FROM ENDPOINT tk1122;
-ERROR:  the endpoint tk1122 does not exist in the session
+ERROR:  the endpoint tk1122 does not exist for session id xxx
 1R: RETRIEVE ALL FROM ENDPOINT tktt223344556677889900112233445566;
-ERROR:  the endpoint tktt223344556677889900112233445566 does not exist in the session
+ERROR:  the endpoint tktt223344556677889900112233445566 does not exist for session id xxx
 
 -- Retrieve data.
 *R: @pre_run 'set_endpoint_variable @ENDPOINT1': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT1";

--- a/src/test/isolation2/output/parallel_retrieve_cursor/special_query.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/special_query.source
@@ -29,7 +29,7 @@ SELECT make_record(x) FROM t1;
 BEGIN
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT make_record(x) FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 1 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 1 1 2 3 4': SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id1 | token_id | host_id | port_id | READY
  endpoint_id1 | token_id | host_id | port_id | READY
  endpoint_id1 | token_id | host_id | port_id | READY
@@ -42,7 +42,7 @@ DECLARE
 (1 row)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);  <waiting ...>
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT1': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT1';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT1': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT1';
  state 
 -------
 (0 rows)
@@ -144,7 +144,7 @@ BEGIN
 (1 row)
 2: DECLARE c2 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t2 join t2 t12 on true;
 DECLARE
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
  state 
 -------
  READY 

--- a/src/test/isolation2/output/parallel_retrieve_cursor/status_check.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/status_check.source
@@ -1,4 +1,4 @@
--- @Description Tests the state for pg_endpoints AND gp_segment_endpoints(), focus in nowait mode
+-- @Description Tests the state for pg_endpoints AND gp_get_segment_endpoints(), focus in nowait mode
 -- need to fault injection to gp_wait_parallel_retrieve_cursor()
 --
 DROP TABLE IF EXISTS t1;
@@ -13,7 +13,7 @@ INSERT 100
 BEGIN
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id1 | token_id | host_id | port_id | READY
  endpoint_id1 | token_id | host_id | port_id | READY
  endpoint_id1 | token_id | host_id | port_id | READY
@@ -24,7 +24,7 @@ DECLARE
  f        
 (1 row)
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT1': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT1';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT1': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT1';
  state 
 -------
 (0 rows)
@@ -167,26 +167,26 @@ DECLARE
 1: CLOSE c1;
 CLOSE
 -- check no endpoint info
-1: SELECT auth_token,state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT auth_token,state FROM gp_get_endpoints() WHERE cursorname='c1';
  auth_token | state 
 ------------+-------
 (0 rows)
 -- check no token info on QE after close PARALLEL RETRIEVE CURSOR
-*U: SELECT * FROM gp_segment_endpoints() WHERE cursorname='c1';
- auth_token | databaseid | senderpid | receiverpid | state | dbid | sessionid | userid | endpointname | cursorname 
-------------+------------+-----------+-------------+-------+------+-----------+--------+--------------+------------
+*U: SELECT * FROM gp_get_segment_endpoints() WHERE cursorname='c1';
+ auth_token | databaseid | senderpid | receiverpid | state | gp_segment_id | sessionid | username | endpointname | cursorname 
+------------+------------+-----------+-------------+-------+---------------+-----------+----------+--------------+------------
 (0 rows)
 
- auth_token | databaseid | senderpid | receiverpid | state | dbid | sessionid | userid | endpointname | cursorname 
-------------+------------+-----------+-------------+-------+------+-----------+--------+--------------+------------
+ auth_token | databaseid | senderpid | receiverpid | state | gp_segment_id | sessionid | username | endpointname | cursorname 
+------------+------------+-----------+-------------+-------+---------------+-----------+----------+--------------+------------
 (0 rows)
 
- auth_token | databaseid | senderpid | receiverpid | state | dbid | sessionid | userid | endpointname | cursorname 
-------------+------------+-----------+-------------+-------+------+-----------+--------+--------------+------------
+ auth_token | databaseid | senderpid | receiverpid | state | gp_segment_id | sessionid | username | endpointname | cursorname 
+------------+------------+-----------+-------------+-------+---------------+-----------+----------+--------------+------------
 (0 rows)
 
- auth_token | databaseid | senderpid | receiverpid | state | dbid | sessionid | userid | endpointname | cursorname 
-------------+------------+-----------+-------------+-------+------+-----------+--------+--------------+------------
+ auth_token | databaseid | senderpid | receiverpid | state | gp_segment_id | sessionid | username | endpointname | cursorname 
+------------+------------+-----------+-------------+-------+---------------+-----------+----------+--------------+------------
 (0 rows)
 
 -- error out for closed cursor
@@ -200,7 +200,7 @@ ROLLBACK
 BEGIN
 1: DECLARE c2 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 2 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c2';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c2';
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
@@ -227,14 +227,14 @@ DECLARE
 (1 row)
 
 -- check initial state after "CHECK PARALLEL RETRIEVE CURSOR"
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
  state    
 ----------
  ATTACHED 
  READY    
  READY    
 (3 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c2';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c2';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -309,14 +309,14 @@ DECLARE
  95 
  98 
 (37 rows)
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
  state    
 ----------
  ATTACHED 
  FINISHED 
  READY    
 (3 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c2';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c2';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -399,14 +399,14 @@ DECLARE
  96  
  100 
 (25 rows)
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
  state    
 ----------
  FINISHED 
  FINISHED 
  FINISHED 
 (3 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c2';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c2';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -435,26 +435,26 @@ DECLARE
 COMMIT
 -- check the cursor auto closed when transaction closed
 -- check no endpoint info
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
  state 
 -------
 (0 rows)
 -- check no token info on QE after close PARALLEL RETRIEVE CURSOR
-*U: SELECT * FROM gp_segment_endpoints() WHERE cursorname='c2';
- auth_token | databaseid | senderpid | receiverpid | state | dbid | sessionid | userid | endpointname | cursorname 
-------------+------------+-----------+-------------+-------+------+-----------+--------+--------------+------------
+*U: SELECT * FROM gp_get_segment_endpoints() WHERE cursorname='c2';
+ auth_token | databaseid | senderpid | receiverpid | state | gp_segment_id | sessionid | username | endpointname | cursorname 
+------------+------------+-----------+-------------+-------+---------------+-----------+----------+--------------+------------
 (0 rows)
 
- auth_token | databaseid | senderpid | receiverpid | state | dbid | sessionid | userid | endpointname | cursorname 
-------------+------------+-----------+-------------+-------+------+-----------+--------+--------------+------------
+ auth_token | databaseid | senderpid | receiverpid | state | gp_segment_id | sessionid | username | endpointname | cursorname 
+------------+------------+-----------+-------------+-------+---------------+-----------+----------+--------------+------------
 (0 rows)
 
- auth_token | databaseid | senderpid | receiverpid | state | dbid | sessionid | userid | endpointname | cursorname 
-------------+------------+-----------+-------------+-------+------+-----------+--------+--------------+------------
+ auth_token | databaseid | senderpid | receiverpid | state | gp_segment_id | sessionid | username | endpointname | cursorname 
+------------+------------+-----------+-------------+-------+---------------+-----------+----------+--------------+------------
 (0 rows)
 
- auth_token | databaseid | senderpid | receiverpid | state | dbid | sessionid | userid | endpointname | cursorname 
-------------+------------+-----------+-------------+-------+------+-----------+--------+--------------+------------
+ auth_token | databaseid | senderpid | receiverpid | state | gp_segment_id | sessionid | username | endpointname | cursorname 
+------------+------------+-----------+-------------+-------+---------------+-----------+----------+--------------+------------
 (0 rows)
 
 -- error out for closed cursor
@@ -468,7 +468,7 @@ ROLLBACK
 BEGIN
 1: DECLARE c3 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 3 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c3';
+1: @post_run 'parse_endpoint_info 3 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c3';
  endpoint_id3 | token_id | host_id | port_id | READY
  endpoint_id3 | token_id | host_id | port_id | READY
  endpoint_id3 | token_id | host_id | port_id | READY
@@ -541,7 +541,7 @@ DETAIL:  An endpoint can only be attached by one retrieving session.
  98 
 (37 rows)
 -- get senderpid which is endpoint execution backend
-0U: @post_run 'get_tuple_cell PID31 1 1 ; create_sub "$PID31[ \t]*" senderpid31': SELECT senderpid, receiverpid<>-1, state FROM gp_segment_endpoints();
+0U: @post_run 'get_tuple_cell PID31 1 1 ; create_sub "$PID31[ \t]*" senderpid31': SELECT senderpid, receiverpid<>-1, state FROM gp_get_segment_endpoints();
  senderpid | ?column? | state
 -----------+----------+----------
  senderpid31| t        | ATTACHED
@@ -558,7 +558,7 @@ DETAIL:  An endpoint can only be attached by one retrieving session.
 ----------
           
 (1 row)
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c3';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c3';
  state    
 ----------
  FINISHED 
@@ -567,11 +567,11 @@ DETAIL:  An endpoint can only be attached by one retrieving session.
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c3', 0);
 ERROR:  canceling MPP operation  (seg0 192.168.235.128:7002 pid=67934)
 -- check no endpoint info left
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c3';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c3';
  state 
 -------
 (0 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c3';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c3';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -593,11 +593,11 @@ ERROR:  current transaction is aborted, commands ignored until end of transactio
 1: ROLLBACK;
 ROLLBACK
 -- check no endpoint info
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c3';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c3';
  state 
 -------
 (0 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c3';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c3';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -619,7 +619,7 @@ ROLLBACK
 BEGIN
 1: DECLARE c4 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 4 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c4';
+1: @post_run 'parse_endpoint_info 4 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c4';
  endpoint_id4 | token_id | host_id | port_id | READY
  endpoint_id4 | token_id | host_id | port_id | READY
  endpoint_id4 | token_id | host_id | port_id | READY
@@ -686,7 +686,7 @@ DECLARE
  98 
 (37 rows)
 -- get senderpid which is endpoint execution backend
-0U: @post_run 'get_tuple_cell PID41 1 1 ; create_sub "${PID41}[ \t]*" senderpid41': SELECT senderpid, receiverpid<>-1, state FROM gp_segment_endpoints();
+0U: @post_run 'get_tuple_cell PID41 1 1 ; create_sub "${PID41}[ \t]*" senderpid41': SELECT senderpid, receiverpid<>-1, state FROM gp_get_segment_endpoints();
  senderpid | ?column? | state
 -----------+----------+----------
  senderpid41| t        | ATTACHED
@@ -706,7 +706,7 @@ DECLARE
 ----------
           
 (1 row)
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c4';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c4';
 ERROR:  Error on receive from seg0 10.34.58.56:25432 pid=41925: server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
@@ -716,11 +716,11 @@ ERROR:  Error on receive from seg0 192.168.235.128:7002 pid=68097: server closed
 	before or while processing the request.
 -- check no endpoint info left
 2q: ... <quitting>
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c4';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c4';
  state 
 -------
 (0 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c4';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c4';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -742,11 +742,11 @@ ERROR:  current transaction is aborted, commands ignored until end of transactio
 1: ROLLBACK;
 ROLLBACK
 -- check no endpoint info
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c4';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c4';
  state 
 -------
 (0 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c4';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c4';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -769,7 +769,7 @@ ROLLBACK
 BEGIN
 1: DECLARE c5 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 5 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c5';
+1: @post_run 'parse_endpoint_info 5 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c5';
  endpoint_id5 | token_id | host_id | port_id | READY
  endpoint_id5 | token_id | host_id | port_id | READY
  endpoint_id5 | token_id | host_id | port_id | READY
@@ -796,7 +796,7 @@ DECLARE
 (10 rows)
 -- 1R still bind to Test4 session, so can not retrieve from current endpoint.
 1R: @pre_run 'set_endpoint_variable @ENDPOINT5': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT5";
-ERROR:  the endpoint endpoint_id5 does not exist in the session
+ERROR:  the endpoint endpoint_id5 does not exist for session id xxx
 -- Since seg1 retrieve session is bind to Test4 session. And Test4 session get killed. We need to restart it.
 1Rq: ... <quitting>
 1R: @pre_run 'set_endpoint_variable @ENDPOINT5': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT5";
@@ -841,7 +841,7 @@ ERROR:  the endpoint endpoint_id5 does not exist in the session
  98 
 (37 rows)
 -- get senderpid which is endpoint execution backend
-0U: @post_run 'get_tuple_cell PID51 1 1 ; create_sub "${PID51}[ \t]*" senderpid51': SELECT senderpid, receiverpid<>-1, state FROM gp_segment_endpoints();
+0U: @post_run 'get_tuple_cell PID51 1 1 ; create_sub "${PID51}[ \t]*" senderpid51': SELECT senderpid, receiverpid<>-1, state FROM gp_get_segment_endpoints();
  senderpid | ?column? | state
 -----------+----------+----------
  senderpid51| t        | ATTACHED
@@ -858,7 +858,7 @@ ERROR:  the endpoint endpoint_id5 does not exist in the session
 ----------
           
 (1 row)
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c5';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c5';
  state    
 ----------
  FINISHED 
@@ -867,11 +867,11 @@ ERROR:  the endpoint endpoint_id5 does not exist in the session
 1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c5', 0);
 ERROR:  terminating connection due to administrator command  (seg0 192.168.235.128:7002 pid=68210)
 -- check no endpoint info left
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c5';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c5';
  state 
 -------
 (0 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c5';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c5';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -893,11 +893,11 @@ ERROR:  current transaction is aborted, commands ignored until end of transactio
 1: ROLLBACK;
 ROLLBACK
 -- check no endpoint info
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c5';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c5';
  state 
 -------
 (0 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c5';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c5';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -930,7 +930,7 @@ ROLLBACK
 BEGIN
 1: DECLARE c6 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 6 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c6';
+1: @post_run 'parse_endpoint_info 6 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c6';
  endpoint_id6 | token_id | host_id | port_id | READY
  endpoint_id6 | token_id | host_id | port_id | READY
  endpoint_id6 | token_id | host_id | port_id | READY
@@ -1009,11 +1009,11 @@ DECLARE
 1<:  <... completed>
 ERROR:  canceling statement due to user request
 -- check no endpoint info left
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c6';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c6';
  state 
 -------
 (0 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c6';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c6';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -1035,11 +1035,11 @@ ERROR:  current transaction is aborted, commands ignored until end of transactio
 1: ROLLBACK;
 ROLLBACK
 -- check no endpoint info
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c6';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c6';
  state 
 -------
 (0 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c6';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c6';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -1072,7 +1072,7 @@ ROLLBACK
 BEGIN
 1: DECLARE c61 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 61 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c61';
+1: @post_run 'parse_endpoint_info 61 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c61';
  endpoint_id61 | token_id | host_id | port_id | READY
  endpoint_id61 | token_id | host_id | port_id | READY
  endpoint_id61 | token_id | host_id | port_id | READY
@@ -1151,11 +1151,11 @@ DECLARE
 1<:  <... completed>
 ERROR:  canceling statement due to user request
 -- check no endpoint info left
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c61';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c61';
  state 
 -------
 (0 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c61';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c61';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -1174,11 +1174,11 @@ ERROR:  canceling statement due to user request
 -- quit the session of 'CHECK PARALLEL RETRIEVE CURSOR' and keep other session connected
 1q: ... <quitting>
 -- check no endpoint info
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c61';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c61';
  state 
 -------
 (0 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c61';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c61';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -1212,7 +1212,7 @@ ERROR:  canceling statement due to user request
 BEGIN
 1: DECLARE c7 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 7 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c7';
+1: @post_run 'parse_endpoint_info 7 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c7';
  endpoint_id7 | token_id | host_id | port_id | READY
  endpoint_id7 | token_id | host_id | port_id | READY
  endpoint_id7 | token_id | host_id | port_id | READY
@@ -1279,7 +1279,7 @@ DECLARE
  95 
  98 
 (37 rows)
-2U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c7';
+2U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c7';
  ?column? | ?column? | state 
 ----------+----------+-------
  t        | f        | READY 
@@ -1302,11 +1302,11 @@ server closed the connection unexpectedly
 2q: ... <quitting>
 -1Uq: ... <quitting>
 -- check no endpoint info left
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c7';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c7';
  state 
 -------
 (0 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c7';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c7';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -1328,11 +1328,11 @@ ERROR:  cursor "c7" does not exist
 1: ROLLBACK;
 ROLLBACK
 -- check no endpoint info
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c7';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c7';
  state 
 -------
 (0 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c7';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c7';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -1354,7 +1354,7 @@ ROLLBACK
 BEGIN
 1: DECLARE c8 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'get_tuple_cell SESSION81 1 1 ; create_match_sub_with_spaces $SESSION81 session81' : SELECT sessionid,state FROM gp_session_endpoints() WHERE cursorname='c8';
+1: @post_run 'get_tuple_cell SESSION81 1 1 ; create_match_sub_with_spaces $SESSION81 session81' : SELECT sessionid,state FROM gp_get_session_endpoints() WHERE cursorname='c8';
  sessionid | state
 -----------+-------
  session81 | READY
@@ -1366,15 +1366,15 @@ DECLARE
 BEGIN
 2: DECLARE c8 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-2: @post_run 'get_tuple_cell SESSION82 1 1 ; create_match_sub_with_spaces $SESSION82 session82' : SELECT sessionid,state FROM gp_session_endpoints() WHERE cursorname='c8';
+2: @post_run 'get_tuple_cell SESSION82 1 1 ; create_match_sub_with_spaces $SESSION82 session82' : SELECT sessionid,state FROM gp_get_session_endpoints() WHERE cursorname='c8';
  sessionid | state
 -----------+-------
  session82 | READY
  session82 | READY
  session82 | READY
 (3 rows)
--- Session 2 can see all cursors with gp_endpoints().
-2: SELECT sessionid,state FROM gp_endpoints() WHERE cursorname='c8' order by sessionid;
+-- Session 2 can see all cursors with gp_get_endpoints().
+2: SELECT sessionid,state FROM gp_get_endpoints() WHERE cursorname='c8' order by sessionid;
  sessionid | state 
 -----------+-------
  session82 | READY 

--- a/src/test/isolation2/output/parallel_retrieve_cursor/status_wait.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/status_wait.source
@@ -1,4 +1,4 @@
--- @Description Tests the state for pg_endpoints AND gp_segment_endpoints(), focus in wait mode
+-- @Description Tests the state for pg_endpoints AND gp_get_segment_endpoints(), focus in wait mode
 --
 DROP TABLE IF EXISTS t1;
 DROP
@@ -12,14 +12,14 @@ INSERT 100
 BEGIN
 1: DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c1';
+1: @post_run 'parse_endpoint_info 1 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c1';
  endpoint_id1 | token_id | host_id | port_id | READY
  endpoint_id1 | token_id | host_id | port_id | READY
  endpoint_id1 | token_id | host_id | port_id | READY
 (3 rows)
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c1', -1);  <waiting ...>
 
-*U: @pre_run 'set_endpoint_variable @ENDPOINT1': SELECT state FROM gp_segment_endpoints() WHERE endpointname='@ENDPOINT1';
+*U: @pre_run 'set_endpoint_variable @ENDPOINT1': SELECT state FROM gp_get_segment_endpoints() WHERE endpointname='@ENDPOINT1';
  state 
 -------
 (0 rows)
@@ -162,26 +162,26 @@ DECLARE
 1: CLOSE c1;
 CLOSE
 -- check no endpoint info
-1: SELECT auth_token,state FROM gp_endpoints() WHERE cursorname='c1';
+1: SELECT auth_token,state FROM gp_get_endpoints() WHERE cursorname='c1';
  auth_token | state 
 ------------+-------
 (0 rows)
 -- check no token info on QE after close PARALLEL RETRIEVE CURSOR
-*U: SELECT * FROM gp_segment_endpoints() WHERE cursorname='c1';
- auth_token | databaseid | senderpid | receiverpid | state | dbid | sessionid | userid | endpointname | cursorname 
-------------+------------+-----------+-------------+-------+------+-----------+--------+--------------+------------
+*U: SELECT * FROM gp_get_segment_endpoints() WHERE cursorname='c1';
+ auth_token | databaseid | senderpid | receiverpid | state | gp_segment_id | sessionid | username | endpointname | cursorname 
+------------+------------+-----------+-------------+-------+---------------+-----------+----------+--------------+------------
 (0 rows)
 
- auth_token | databaseid | senderpid | receiverpid | state | dbid | sessionid | userid | endpointname | cursorname 
-------------+------------+-----------+-------------+-------+------+-----------+--------+--------------+------------
+ auth_token | databaseid | senderpid | receiverpid | state | gp_segment_id | sessionid | username | endpointname | cursorname 
+------------+------------+-----------+-------------+-------+---------------+-----------+----------+--------------+------------
 (0 rows)
 
- auth_token | databaseid | senderpid | receiverpid | state | dbid | sessionid | userid | endpointname | cursorname 
-------------+------------+-----------+-------------+-------+------+-----------+--------+--------------+------------
+ auth_token | databaseid | senderpid | receiverpid | state | gp_segment_id | sessionid | username | endpointname | cursorname 
+------------+------------+-----------+-------------+-------+---------------+-----------+----------+--------------+------------
 (0 rows)
 
- auth_token | databaseid | senderpid | receiverpid | state | dbid | sessionid | userid | endpointname | cursorname 
-------------+------------+-----------+-------------+-------+------+-----------+--------+--------------+------------
+ auth_token | databaseid | senderpid | receiverpid | state | gp_segment_id | sessionid | username | endpointname | cursorname 
+------------+------------+-----------+-------------+-------+---------------+-----------+----------+--------------+------------
 (0 rows)
 
 -- error out for closed cursor
@@ -195,7 +195,7 @@ ROLLBACK
 BEGIN
 1: DECLARE c2 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 2 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c2';
+1: @post_run 'parse_endpoint_info 2 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c2';
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
  endpoint_id2 | token_id | host_id | port_id | READY
@@ -218,14 +218,14 @@ DECLARE
 1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c2', -1);  <waiting ...>
 
 -- check initial state after "CHECK PARALLEL RETRIEVE CURSOR"
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
  state    
 ----------
  ATTACHED 
  READY    
  READY    
 (3 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c2';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c2';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -300,14 +300,14 @@ DECLARE
  95 
  98 
 (37 rows)
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
  state    
 ----------
  ATTACHED 
  FINISHED 
  READY    
 (3 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c2';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c2';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -390,14 +390,14 @@ DECLARE
  96  
  100 
 (25 rows)
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
  state    
 ----------
  FINISHED 
  FINISHED 
  FINISHED 
 (3 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c2';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c2';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -426,26 +426,26 @@ DECLARE
 COMMIT
 -- check the cursor auto closed when transaction closed
 -- check no endpoint info
-1: SELECT state FROM gp_endpoints() WHERE cursorname='c2';
+1: SELECT state FROM gp_get_endpoints() WHERE cursorname='c2';
  state 
 -------
 (0 rows)
 -- check no token info on QE after close PARALLEL RETRIEVE CURSOR
-*U: SELECT * FROM gp_segment_endpoints() WHERE cursorname='c2';
- auth_token | databaseid | senderpid | receiverpid | state | dbid | sessionid | userid | endpointname | cursorname 
-------------+------------+-----------+-------------+-------+------+-----------+--------+--------------+------------
+*U: SELECT * FROM gp_get_segment_endpoints() WHERE cursorname='c2';
+ auth_token | databaseid | senderpid | receiverpid | state | gp_segment_id | sessionid | username | endpointname | cursorname 
+------------+------------+-----------+-------------+-------+---------------+-----------+----------+--------------+------------
 (0 rows)
 
- auth_token | databaseid | senderpid | receiverpid | state | dbid | sessionid | userid | endpointname | cursorname 
-------------+------------+-----------+-------------+-------+------+-----------+--------+--------------+------------
+ auth_token | databaseid | senderpid | receiverpid | state | gp_segment_id | sessionid | username | endpointname | cursorname 
+------------+------------+-----------+-------------+-------+---------------+-----------+----------+--------------+------------
 (0 rows)
 
- auth_token | databaseid | senderpid | receiverpid | state | dbid | sessionid | userid | endpointname | cursorname 
-------------+------------+-----------+-------------+-------+------+-----------+--------+--------------+------------
+ auth_token | databaseid | senderpid | receiverpid | state | gp_segment_id | sessionid | username | endpointname | cursorname 
+------------+------------+-----------+-------------+-------+---------------+-----------+----------+--------------+------------
 (0 rows)
 
- auth_token | databaseid | senderpid | receiverpid | state | dbid | sessionid | userid | endpointname | cursorname 
-------------+------------+-----------+-------------+-------+------+-----------+--------+--------------+------------
+ auth_token | databaseid | senderpid | receiverpid | state | gp_segment_id | sessionid | username | endpointname | cursorname 
+------------+------------+-----------+-------------+-------+---------------+-----------+----------+--------------+------------
 (0 rows)
 
 -- error out for closed cursor
@@ -459,7 +459,7 @@ ROLLBACK
 BEGIN
 1: DECLARE c3 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 3 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c3';
+1: @post_run 'parse_endpoint_info 3 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c3';
  endpoint_id3 | token_id | host_id | port_id | READY
  endpoint_id3 | token_id | host_id | port_id | READY
  endpoint_id3 | token_id | host_id | port_id | READY
@@ -528,7 +528,7 @@ DETAIL:  An endpoint can only be attached by one retrieving session.
  98 
 (37 rows)
 -- get senderpid which is endpoint execution backend
-0U: @post_run 'get_tuple_cell PID31 1 1 ; create_sub "$PID31[ \t]*" senderpid31': SELECT senderpid, receiverpid<>-1, state FROM gp_segment_endpoints();
+0U: @post_run 'get_tuple_cell PID31 1 1 ; create_sub "$PID31[ \t]*" senderpid31': SELECT senderpid, receiverpid<>-1, state FROM gp_get_segment_endpoints();
  senderpid | ?column? | state
 -----------+----------+----------
  senderpid31| t        | ATTACHED
@@ -543,11 +543,11 @@ DETAIL:  An endpoint can only be attached by one retrieving session.
 1<:  <... completed>
 ERROR:  canceling MPP operation
 -- check no endpoint info left
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c3';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c3';
  state 
 -------
 (0 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c3';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c3';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -569,11 +569,11 @@ ERROR:  current transaction is aborted, commands ignored until end of transactio
 1: ROLLBACK;
 ROLLBACK
 -- check no endpoint info
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c3';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c3';
  state 
 -------
 (0 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c3';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c3';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -595,7 +595,7 @@ ROLLBACK
 BEGIN
 1: DECLARE c4 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 4 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c4';
+1: @post_run 'parse_endpoint_info 4 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c4';
  endpoint_id4 | token_id | host_id | port_id | READY
  endpoint_id4 | token_id | host_id | port_id | READY
  endpoint_id4 | token_id | host_id | port_id | READY
@@ -658,7 +658,7 @@ DECLARE
  98 
 (37 rows)
 -- get senderpid which is endpoint execution backend
-0U: @post_run 'get_tuple_cell PID41 1 1 ; create_sub "${PID41}[ \t]*" senderpid41': SELECT senderpid, receiverpid<>-1, state FROM gp_segment_endpoints();
+0U: @post_run 'get_tuple_cell PID41 1 1 ; create_sub "${PID41}[ \t]*" senderpid41': SELECT senderpid, receiverpid<>-1, state FROM gp_get_segment_endpoints();
  senderpid | ?column? | state
 -----------+----------+----------
  senderpid41| t        | ATTACHED
@@ -679,11 +679,11 @@ ERROR:  Error on receive from seg0 10.34.50.67:25432 pid=12603: server closed th
 	before or while processing the request.
 -- check no endpoint info left
 2q: ... <quitting>
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c4';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c4';
  state 
 -------
 (0 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c4';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c4';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -705,11 +705,11 @@ ERROR:  current transaction is aborted, commands ignored until end of transactio
 1: ROLLBACK;
 ROLLBACK
 -- check no endpoint info
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c4';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c4';
  state 
 -------
 (0 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c4';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c4';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -732,7 +732,7 @@ ROLLBACK
 BEGIN
 1: DECLARE c5 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 5 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c5';
+1: @post_run 'parse_endpoint_info 5 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c5';
  endpoint_id5 | token_id | host_id | port_id | READY
  endpoint_id5 | token_id | host_id | port_id | READY
  endpoint_id5 | token_id | host_id | port_id | READY
@@ -755,7 +755,7 @@ DECLARE
 (10 rows)
 -- 1R still bind to Test4 session, so can not retrieve from current endpoint.
 1R: @pre_run 'set_endpoint_variable @ENDPOINT5': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT5";
-ERROR:  the endpoint endpoint_id5 does not exist in the session
+ERROR:  the endpoint endpoint_id5 does not exist for session id xxx
 -- Since seg1 retrieve session is bind to Test4 session. And Test4 session get killed. We need to restart it.
 1Rq: ... <quitting>
 1R: @pre_run 'set_endpoint_variable @ENDPOINT5': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT5";
@@ -800,7 +800,7 @@ ERROR:  the endpoint endpoint_id5 does not exist in the session
  98 
 (37 rows)
 -- get senderpid which is endpoint execution backend
-0U: @post_run 'get_tuple_cell PID51 1 1 ; create_sub "${PID51}[ \t]*" senderpid51': SELECT senderpid, receiverpid<>-1, state FROM gp_segment_endpoints();
+0U: @post_run 'get_tuple_cell PID51 1 1 ; create_sub "${PID51}[ \t]*" senderpid51': SELECT senderpid, receiverpid<>-1, state FROM gp_get_segment_endpoints();
  senderpid | ?column? | state
 -----------+----------+----------
  senderpid51| t        | ATTACHED
@@ -815,11 +815,11 @@ ERROR:  the endpoint endpoint_id5 does not exist in the session
 1<:  <... completed>
 ERROR:  terminating connection due to administrator command  (seg0 10.34.50.67:25432 pid=12905)
 -- check no endpoint info left
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c5';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c5';
  state 
 -------
 (0 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c5';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c5';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -841,11 +841,11 @@ ERROR:  current transaction is aborted, commands ignored until end of transactio
 1: ROLLBACK;
 ROLLBACK
 -- check no endpoint info
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c5';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c5';
  state 
 -------
 (0 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c5';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c5';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -867,7 +867,7 @@ ROLLBACK
 BEGIN
 1: DECLARE c6 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 6 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c6';
+1: @post_run 'parse_endpoint_info 6 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c6';
  endpoint_id6 | token_id | host_id | port_id | READY
  endpoint_id6 | token_id | host_id | port_id | READY
  endpoint_id6 | token_id | host_id | port_id | READY
@@ -945,11 +945,11 @@ DECLARE
 1<:  <... completed>
 ERROR:  canceling statement due to user request
 -- check no endpoint info left
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c6';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c6';
  state 
 -------
 (0 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c6';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c6';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -971,11 +971,11 @@ ERROR:  current transaction is aborted, commands ignored until end of transactio
 1: ROLLBACK;
 ROLLBACK
 -- check no endpoint info
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c6';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c6';
  state 
 -------
 (0 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c6';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c6';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -997,7 +997,7 @@ ROLLBACK
 BEGIN
 1: DECLARE c61 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 61 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c61';
+1: @post_run 'parse_endpoint_info 61 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c61';
  endpoint_id61 | token_id | host_id | port_id | READY
  endpoint_id61 | token_id | host_id | port_id | READY
  endpoint_id61 | token_id | host_id | port_id | READY
@@ -1075,11 +1075,11 @@ DECLARE
 1<:  <... completed>
 ERROR:  canceling statement due to user request
 -- check no endpoint info left
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c61';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c61';
  state 
 -------
 (0 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c61';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c61';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -1098,11 +1098,11 @@ ERROR:  canceling statement due to user request
 -- quit the session of 'CHECK PARALLEL RETRIEVE CURSOR' and keep other session connected
 1q: ... <quitting>
 -- check no endpoint info
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c61';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c61';
  state 
 -------
 (0 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c61';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c61';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -1126,7 +1126,7 @@ ERROR:  canceling statement due to user request
 BEGIN
 1: DECLARE c7 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'parse_endpoint_info 7 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_endpoints() WHERE cursorname='c7';
+1: @post_run 'parse_endpoint_info 7 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c7';
  endpoint_id7 | token_id | host_id | port_id | READY
  endpoint_id7 | token_id | host_id | port_id | READY
  endpoint_id7 | token_id | host_id | port_id | READY
@@ -1194,7 +1194,7 @@ DECLARE
  95 
  98 
 (37 rows)
-2U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c7';
+2U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c7';
  ?column? | ?column? | state 
 ----------+----------+-------
  t        | f        | READY 
@@ -1216,11 +1216,11 @@ server closed the connection unexpectedly
 2q: ... <quitting>
 -1Uq: ... <quitting>
 -- check no endpoint info left
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c7';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c7';
  state 
 -------
 (0 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c7';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c7';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -1242,11 +1242,11 @@ ERROR:  cursor "c7" does not exist
 1: ROLLBACK;
 ROLLBACK
 -- check no endpoint info
-2: SELECT state FROM gp_endpoints() WHERE cursorname='c7';
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c7';
  state 
 -------
 (0 rows)
-*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_segment_endpoints() WHERE cursorname='c7';
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c7';
  ?column? | ?column? | state 
 ----------+----------+-------
 (0 rows)
@@ -1268,7 +1268,7 @@ ROLLBACK
 BEGIN
 1: DECLARE c8 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-1: @post_run 'get_tuple_cell SESSION81 1 1 ; create_match_sub_with_spaces $SESSION81 session81': SELECT sessionid,state FROM gp_session_endpoints() WHERE cursorname='c8';
+1: @post_run 'get_tuple_cell SESSION81 1 1 ; create_match_sub_with_spaces $SESSION81 session81': SELECT sessionid,state FROM gp_get_session_endpoints() WHERE cursorname='c8';
  sessionid | state
 -----------+-------
  session81 | READY
@@ -1280,15 +1280,15 @@ DECLARE
 BEGIN
 2: DECLARE c8 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 DECLARE
-2: @post_run 'get_tuple_cell SESSION82 1 1 ; create_match_sub_with_spaces $SESSION82 session82': SELECT sessionid,state FROM gp_session_endpoints() WHERE cursorname='c8';
+2: @post_run 'get_tuple_cell SESSION82 1 1 ; create_match_sub_with_spaces $SESSION82 session82': SELECT sessionid,state FROM gp_get_session_endpoints() WHERE cursorname='c8';
  sessionid | state
 -----------+-------
  session82 | READY
  session82 | READY
  session82 | READY
 (3 rows)
--- Session 2 can see all cursors with gp_endpoints().
-2: SELECT sessionid,state FROM gp_endpoints() WHERE cursorname='c8' order by sessionid;
+-- Session 2 can see all cursors with gp_get_endpoints().
+2: SELECT sessionid,state FROM gp_get_endpoints() WHERE cursorname='c8' order by sessionid;
  sessionid | state 
 -----------+-------
  session82 | READY 
@@ -1308,3 +1308,146 @@ CLOSE
 2: END;
 END
 
+---------- Test9: Cancel (using pg_cancel_backend(pid)) the process of 'CHECK PARALLEL RETRIEVE CURSOR'
+1: BEGIN;
+BEGIN
+1: DECLARE c9 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
+DECLARE
+1: @post_run 'parse_endpoint_info 9 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c9';
+ endpoint_id9 | token_id | host_id | port_id | READY
+ endpoint_id9 | token_id | host_id | port_id | READY
+ endpoint_id9 | token_id | host_id | port_id | READY
+(3 rows)
+
+1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c9', -1);  <waiting ...>
+-- some endpoint retrieve partial results, some endpoint finished retrieving, some endpoint not start retrieving
+0R: @pre_run 'set_endpoint_variable @ENDPOINT9': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT9";
+ERROR:  the endpoint endpoint_id9 does not exist for session id xxx
+1R: @pre_run 'set_endpoint_variable @ENDPOINT9': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT9";
+ERROR:  the endpoint endpoint_id9 does not exist for session id xxx
+-- run pg_cancel_backend(pid) to cancel the endpoint execution backend, retrieve session still can work
+2: select pg_cancel_backend(pid) from pg_stat_activity where query like 'SELECT * FROM gp_wait_parallel_retrieve_cursor(''c9'', -1);';
+ pg_cancel_backend 
+-------------------
+ t                 
+(1 row)
+-- check it can cancel the "gp_wait_parallel_retrieve_cursor"
+1<:  <... completed>
+ERROR:  canceling statement due to user request
+-- check no endpoint info left
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c9';
+ state 
+-------
+(0 rows)
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c9';
+ ?column? | ?column? | state 
+----------+----------+-------
+(0 rows)
+
+ ?column? | ?column? | state 
+----------+----------+-------
+(0 rows)
+
+ ?column? | ?column? | state 
+----------+----------+-------
+(0 rows)
+
+ ?column? | ?column? | state 
+----------+----------+-------
+(0 rows)
+-- report error for EXECUTE canceled PARALLEL RETRIEVE CURSOR
+1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c9', -1);
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+1: ROLLBACK;
+ROLLBACK
+-- check no endpoint info
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c9';
+ state 
+-------
+(0 rows)
+
+---------- Test10: terminate (using pg_terminate_backend(pid)) the process of 'CHECK PARALLEL RETRIEVE CURSOR'
+1: BEGIN;
+BEGIN
+1: DECLARE c10 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
+DECLARE
+1: @post_run 'parse_endpoint_info 10 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c10';
+ endpoint_id10 | token_id | host_id | port_id | READY
+ endpoint_id10 | token_id | host_id | port_id | READY
+ endpoint_id10 | token_id | host_id | port_id | READY
+(3 rows)
+1&: SELECT * FROM gp_wait_parallel_retrieve_cursor('c10', -1);  <waiting ...>
+-- some endpoint retrieve partial results, some endpoint finished retrieving, some endpoint not start retrieving
+0R: @pre_run 'set_endpoint_variable @ENDPOINT10': RETRIEVE 10 FROM ENDPOINT "@ENDPOINT10";
+ERROR:  the endpoint endpoint_id10 does not exist for session id xxx
+1R: @pre_run 'set_endpoint_variable @ENDPOINT10': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT10";
+ERROR:  the endpoint endpoint_id10 does not exist for session id xxx
+2U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c10';
+ ?column? | ?column? | state 
+----------+----------+-------
+ t        | f        | READY 
+(1 row)
+-- run ' pg_terminate_backend(pid)' to cancel the endpoint execution backend, retrieve session still can work
+-- here need to sleep sometime to wait for endpoint QE backend to detect QD connection lost.
+2: select pg_terminate_backend(pid) from pg_stat_activity where query like 'SELECT * FROM gp_wait_parallel_retrieve_cursor(''c10'', -1);';
+ pg_terminate_backend 
+----------------------
+ t                    
+(1 row)
+-- check it can cancel the "gp_wait_parallel_retrieve_cursor"
+1<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+-- quit all sessions on the master, because connect lost
+1q: ... <quitting>
+2q: ... <quitting>
+-1Uq: ... <quitting>
+-- check no endpoint info left
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c10';
+ state 
+-------
+(0 rows)
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c10';
+ ?column? | ?column? | state 
+----------+----------+-------
+(0 rows)
+
+ ?column? | ?column? | state 
+----------+----------+-------
+(0 rows)
+
+ ?column? | ?column? | state 
+----------+----------+-------
+(0 rows)
+
+ ?column? | ?column? | state 
+----------+----------+-------
+(0 rows)
+-- report error for EXECUTE canceled PARALLEL RETRIEVE CURSOR
+1: SELECT * FROM gp_wait_parallel_retrieve_cursor('c10', -1);
+ERROR:  cursor "c10" does not exist
+1: ROLLBACK;
+ROLLBACK
+-- check no endpoint info
+2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c10';
+ state 
+-------
+(0 rows)
+*U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c10';
+ ?column? | ?column? | state 
+----------+----------+-------
+(0 rows)
+
+ ?column? | ?column? | state 
+----------+----------+-------
+(0 rows)
+
+ ?column? | ?column? | state 
+----------+----------+-------
+(0 rows)
+
+ ?column? | ?column? | state 
+----------+----------+-------
+(0 rows)

--- a/src/test/isolation2/test_parallel_retrieve_cursor_extended_query.c
+++ b/src/test/isolation2/test_parallel_retrieve_cursor_extended_query.c
@@ -223,7 +223,7 @@ exec_check_parallel_cursor(PGconn *master_conn, int isCheckFinish)
 {
 	int			result = 0;
 	PGresult   *res1;
-	const char *check_sql = "SELECT * FROM gp_wait_parallel_retrieve_cursor('myportal', 0);";
+	const char *check_sql = "SELECT * FROM pg_catalog.gp_wait_parallel_retrieve_cursor('myportal', 0);";
 
 
 	printf("\n------ Begin checking parallel retrieve cursor status ------\n");
@@ -337,7 +337,7 @@ main(int argc, char **argv)
 	/*
 	 * get the endpoints info of this PARALLEL RETRIEVE CURSOR
 	 */
-	const char *sql1 = "select hostname,port,auth_token,endpointname from pg_catalog.gp_endpoints() where cursorname='myportal';";
+	const char *sql1 = "select hostname,port,auth_token,endpointname from pg_catalog.gp_get_endpoints() where cursorname='myportal';";
 
 	printf("\nExec SQL on the coordinator:\n\t> %s\n", sql1);
 	res1 = PQexec(master_conn, sql1);

--- a/src/test/isolation2/test_parallel_retrieve_cursor_extended_query_error.c
+++ b/src/test/isolation2/test_parallel_retrieve_cursor_extended_query_error.c
@@ -226,7 +226,7 @@ exec_check_parallel_cursor(PGconn *master_conn, int isCheckFinish)
 {
 	int			result = 0;
 	PGresult   *res1;
-	const char *check_sql = "SELECT * FROM gp_wait_parallel_retrieve_cursor('myportal', 0);";
+	const char *check_sql = "SELECT * FROM pg_catalog.gp_wait_parallel_retrieve_cursor('myportal', 0);";
 
 
 	printf("\n------ Begin checking parallel retrieve cursor status ------\n");
@@ -338,7 +338,7 @@ main(int argc, char **argv)
 	/*
 	 * get the endpoints info of this PARALLEL RETRIEVE CURSOR
 	 */
-	const char *sql1 = "select hostname,port,auth_token,endpointname from pg_catalog.gp_endpoints() where cursorname='myportal';";
+	const char *sql1 = "select hostname,port,auth_token,endpointname from pg_catalog.gp_get_endpoints() where cursorname='myportal';";
 
 	printf("\nExec SQL on Master:\n\t> %s\n", sql1);
 	res1 = PQexec(master_conn, sql1);


### PR DESCRIPTION
These changes are back ported from 6X_STABLE branch, other than refining code
and words, the names of UDFs are changed:

```
pg_catalog.gp_endpoints() -> pg_catalog.gp_get_endpoints()
pg_catalog.gp_segment_endpoints() -> pg_catalog.gp_get_segment_endpoints()
pg_catalog.gp_session_endpoints() -> pg_catalog.gp_get_session_endpoints()
```

And views are created for convenience:

```
CREATE VIEW pg_catalog.gp_endpoints AS
    SELECT * FROM pg_catalog.gp_get_endpoints();

CREATE VIEW pg_catalog.gp_segment_endpoints AS
    SELECT * FROM pg_catalog.gp_get_segment_endpoints();

CREATE VIEW pg_catalog.gp_session_endpoints AS
    SELECT * FROM pg_catalog.gp_get_session_endpoints();
```

Co-Authored-By: Jian Guo <gjian@vmware.com>
Co-Authored-By: Xuejing Zhao <zxuejing@vmware.com>