### PR TITLE
fix gpload cannot recoginze capital letters in staging_table

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -2117,7 +2117,7 @@ class gpload:
                          pg_namespace pgns
                          on(pg_class.relnamespace = pgns.oid)
                       """
-            conditionStr = "pgns.nspname = '%s'" % schemaName
+            conditionStr = "pgns.nspname = '%s'" % self.get_sql_name(schemaName)
         if noGpVersion or self.gpdb_version < "7.0.0":
             relkind='r'
         else:
@@ -2204,7 +2204,7 @@ class gpload:
             joinStr = """join
                     pg_namespace pgns
                     on(pg_class.relnamespace = pgns.oid)"""
-            conditionStr = "pgns.nspname = '%s'" % schemaName
+            conditionStr = "pgns.nspname = '%s'" % self.get_sql_name(schemaName)
         if noGpVersion or self.gpdb_version < "7.0.0":
             relkind='r'
         else:
@@ -2263,20 +2263,35 @@ class gpload:
 		
         return '%s:%s:%s:%s' % (target_table_name, columns_num, staging_cols_str, distribution_cols_str)
 
-		
 
-    def get_reuse_staging_table_query(self, encoding_conditions):
+    def get_sql_name(self, name):
+        '''
+        this function return the sql name without double quotes and in right lower or upper case
+        if name is double quoted, then return the content in it
+        if not, returen the name in lower case
+        '''
+        if isDelimited(name):
+            # if the name is double quoted, we keep the capital letters
+            name = quote_unident(name)
+        else:
+            # if not, table name should be lower letters
+            name = name.lower()
+        return name
+
+
+    def get_reuse_staging_table_query(self, table_name):
         '''
         This function will return the SQL to run in order to find out whether
         we have an existing staging table in the catalog which could be reused for this
         operation, according to the method and the encoding conditions.
-
         return:
             sql(string)
         '''
-        sql = """SELECT oid::regclass \
-FROM pg_class \
-WHERE relname = 'staging_gpload_reusable_%s';""" % (encoding_conditions)
+        if self.extSchemaName:
+            schema_name = self.get_sql_name(self.extSchemaName)
+            sql = "SELECT * FROM pg_catalog.pg_tables WHERE schemaname = '%s' AND tablename = '%s'" % (schema_name, table_name)
+        else:
+            sql = "SELECT oid::regclass FROM pg_class WHERE relname = '%s';" % (table_name)
 
         self.log(self.DEBUG, "query used to identify reusable temporary relations: %s" % sql)
         return sql
@@ -2455,12 +2470,7 @@ WHERE relname = 'staging_gpload_reusable_%s';""" % (encoding_conditions)
                     self.log(self.ERROR, "Character '.' is not allowed in staging_table parameter. Please use EXTERNAL->SCHEMA to set the schema of external table")
                 self.extTableName = self.staging_table
                 # we need a name without double quotes and in right upper or lower case
-                if isDelimited(self.extTableName):
-                    # if the name is double quoted, we keep the capital letters
-                    sql_table_name = quote_unident(self.extTableName)
-                else:
-                    # if not, table name should be lower letters
-                    sql_table_name = self.extTableName.lower()
+                sql_table_name = self.get_sql_name(self.extTableName)
 
                 sql = """SELECT n.nspname as Schema, c.relname as Name
                          FROM pg_catalog.pg_class c
@@ -2574,14 +2584,14 @@ WHERE relname = 'staging_gpload_reusable_%s';""" % (encoding_conditions)
             # create a string from all reuse conditions for staging tables and ancode it
             conditions_str = self.get_staging_conditions_string(target_table_name, target_columns, distcols).encode()
             encoding_conditions = hashlib.md5(conditions_str).hexdigest()
-					
-            sql = self.get_reuse_staging_table_query(encoding_conditions)
+            table_name = 'staging_gpload_reusable_%s'% (encoding_conditions)	
+            sql = self.get_reuse_staging_table_query(table_name)
             resultList = self.db.query(sql).getresult()
 
             if len(resultList) > 0:
 
                 # found a temp table to reuse. no need to create one. we're done here.
-                self.staging_table_name = (resultList[0])[0]
+                self.staging_table_name = self.get_schematable(self.extSchemaName, table_name)
                 self.log(self.INFO, "reusing staging table %s" % self.staging_table_name)
 
                 # truncate it so we don't use old data

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_base.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_base.py
@@ -471,6 +471,15 @@ class AnsFile():
     def __eq__(self, other):
         return isFileEqual(self.path, other.path, '-U3', outputPath="")
 
+
+def do_assert(f1, f2, num, ifile):
+    # this will help print the diff message in the screen if case fail
+    assert f1 == f2 , read_diff(ifile, "")
+    if num==54:
+        assert f1==AnsFile(mkpath('54tmp.log'))
+    return True
+
+
 def check_result(ifile,  optionalFlags = "-U3", outputPath = "", num=None):
     """
     PURPOSE: compare the actual and expected output files and report an
@@ -489,10 +498,7 @@ def check_result(ifile,  optionalFlags = "-U3", outputPath = "", num=None):
     f1 = AnsFile(f1)
     f2 = outFile(ifile, outputPath=outputPath)
     f2 = AnsFile(f2)
-    assert f1 == f2 #, read_diff(ifile, "")
-    if num==54:
-        assert f1==AnsFile(mkpath('54tmp.log'))
-    return True
+    do_assert(f1, f2, num, ifile)
 
 
 def ModifyOutFile(file,old_str,new_str):

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_preload.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_preload.py
@@ -33,17 +33,17 @@ def test_603_with_reuse_tables_true_and_staging():
     file = mkpath('setup.sql')
     runfile(file)
     f = open(mkpath('query603.sql'),'a')
-    f.write("\\! psql -d reuse_gptest -c \"SELECT count(*) from pg_class WHERE relname like 'staging_test';\"")
+    f.write("\\! psql -d reuse_gptest -c \"SELECT count(*) from pg_class WHERE relname = 'STAGING_test';\"")
     f.close()
     copy_data('external_file_04.txt','data_file.txt')
-    write_config_file(mode='insert',reuse_tables=True,fast_match=False,file='data_file.txt',table='texttable', staging_table='staging_test', error_limit=1002, truncate=False)
+    write_config_file(mode='insert',reuse_tables=True,fast_match=False,file='data_file.txt',table='texttable', staging_table='\'"STAGING_test"\'', error_limit=1002, truncate=False)
 
 @prepare_before_test(num=604, times=1)
 def test_604_with_reuse_tables_true_table_changed():
     "604 gpload with reuse_tables is true and specifying a staging_table, but table's schema is changed. so staging table dosen't match the destination table, load failed"
     psql_run(cmd="ALTER TABLE texttable ADD column n8 text",dbname='reuse_gptest')
     copy_data('external_file_08.txt','data_file.txt')
-    write_config_file(mode='insert',reuse_tables=True,fast_match=False,file='data_file.txt',table='texttable', staging_table='staging_test', error_limit=1002, truncate=False)
+    write_config_file(mode='insert',reuse_tables=True,fast_match=False,file='data_file.txt',table='texttable', staging_table='\'"STAGING_test"\'', error_limit=1002, truncate=False)
 
 @prepare_before_test(num=605, times=1)
 def test_605_with_reuse_tables_true_table_changed():
@@ -67,4 +67,4 @@ def test_608_gpload_ext_staging_table():
     file = mkpath('setup.sql')
     runfile(file)
     copy_data('external_file_13.csv','data_file.csv')
-    write_config_file(reuse_tables=False, format='csv', file='data_file.csv', table='csvtable', delimiter="','", log_errors=True,error_limit=10,staging_table='staging_table')
+    write_config_file(reuse_tables=False, format='csv', file='data_file.csv', table='csvtable', delimiter="','", log_errors=True,error_limit=10,staging_table='"Staging_table"')

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_schema_and_mode.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_schema_and_mode.py
@@ -25,10 +25,11 @@ def append_gpload_cmd(test_num, config_path):
 def test_401_gpload_yaml_existing_external_schema():
     """401 test gpload works with an existing external schema"""
     TestBase.drop_tables()
-    schema = "ext_schema_test"
-    TestBase.psql_run(cmd=f'CREATE SCHEMA IF NOT EXISTS {schema};',
-                      dbname='reuse_gptest')
-    TestBase.write_config_file(externalSchema=schema)
+    schema = "'\"EXT_schema_test\"'"
+    f = open(TestBase.mkpath('query401.sql'), 'a')
+    f.write("\\! psql -d reuse_gptest -c \"select count(*) from pg_catalog.pg_namespace where nspname = 'EXT_schema_test';\"")
+    f.close()
+    TestBase.write_config_file(externalSchema=schema, reuse_tables=True)
 
 
 @TestBase.prepare_before_test(num=402, times=1)

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_schema_and_mode.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_schema_and_mode.py
@@ -65,6 +65,32 @@ def test_404_gpload_yaml_percent_default_external_schema():
     TestBase.write_config_file(externalSchema='\'%\'')
 
 
+@TestBase.prepare_before_test(num=405, times=2)
+def test_405_gpload_external_schema_merge():
+    """405 test gpload works with an existing external schema "EXT_schema_test" """
+    TestBase.drop_tables()
+    schema = "'\"EXT_schema_test\"'"
+    f = open(TestBase.mkpath('query405.sql'), 'a')
+    f.write("\\! gpload -f "+TestBase.mkpath('config/config_file1')+'\n')
+    f.write("\\! psql -d reuse_gptest -c \"select count(*) from pg_tables where schemaname = 'EXT_schema_test';\"")
+    f.close()
+    TestBase.write_config_file(externalSchema=schema, reuse_tables=True, mode='merge')
+    TestBase.write_config_file(config='config/config_file1',externalSchema=schema, reuse_tables=True, mode='merge')
+
+
+@TestBase.prepare_before_test(num=406, times=2)
+def test_406_gpload_external_schema_merge():
+    """406 test gpload works with schema test and write as "Test" in config"""
+    TestBase.drop_tables()
+    schema = '"Test"'
+    f = open(TestBase.mkpath('query406.sql'), 'a')
+    f.write("\\! gpload -f "+TestBase.mkpath('config/config_file1')+'\n')
+    f.write("\\! psql -d reuse_gptest -c \"select count(*) from pg_tables where schemaname = 'test';\"")
+    f.close()
+    TestBase.write_config_file(externalSchema=schema, reuse_tables=True, mode='merge')
+    TestBase.write_config_file(config='config/config_file1',externalSchema=schema, reuse_tables=True, mode='merge')
+
+
 @TestBase.prepare_before_test(num=430, times=1)
 def test_430_gpload_yaml_table_empty_string():
     """430 test gpload reports error if table is an empty string"""

--- a/gpMgmt/bin/gpload_test/gpload2/query27.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query27.ans
@@ -7,7 +7,7 @@
 2018-01-17 21:43:21|INFO|gpload succeeded
 2018-01-17 21:43:21|INFO|gpload session started 2018-01-17 21:43:21
 2018-01-17 21:43:22|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/lhl/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.csv" -t 30
-2018-01-17 21:43:22|INFO|reusing external staging table test.staging_table
+2018-01-17 21:43:22|INFO|reusing external staging table "test".staging_table
 2018-01-17 21:43:22|INFO|running time: 0.08 seconds
 2018-01-17 21:43:22|INFO|rows Inserted          = 2
 2018-01-17 21:43:22|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query401.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query401.ans
@@ -1,9 +1,14 @@
 2021-01-05 16:58:59|INFO|gpload session started 2021-01-05 16:58:59
 2021-01-05 16:58:59|INFO|setting schema 'public' for table 'texttable'
 2021-01-05 16:58:59|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/external_file_01.txt" -t 30
-2021-01-05 16:58:59|INFO|did not find an external table to reuse. creating ext_schema_test.ext_gpload_reusable_400adfb0_4f34_11eb_bb6c_7085c2381836
+2021-01-05 16:58:59|INFO|did not find an external table to reuse. creating "EXT_schema_test".ext_gpload_reusable_400adfb0_4f34_11eb_bb6c_7085c2381836
 2021-01-05 16:58:59|INFO|running time: 0.13 seconds
 2021-01-05 16:58:59|INFO|rows Inserted          = 16
 2021-01-05 16:58:59|INFO|rows Updated           = 0
 2021-01-05 16:58:59|INFO|data formatting errors = 0
 2021-01-05 16:58:59|INFO|gpload succeeded
+ count 
+-------
+     1
+(1 row)
+

--- a/gpMgmt/bin/gpload_test/gpload2/query405.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query405.ans
@@ -1,0 +1,37 @@
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 's1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+2022-03-11 17:16:44|INFO|gpload session started 2022-03-11 17:16:44
+2022-03-11 17:16:44|INFO|setting schema 'public' for table 'texttable'
+2022-03-11 17:16:44|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/external_file_01.txt" -t 30
+2022-03-11 17:16:44|INFO|did not find a staging table to reuse. creating "EXT_schema_test".staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2022-03-11 17:16:44|INFO|did not find an external table to reuse. creating "EXT_schema_test".ext_gpload_reusable_f8871e16_a11b_11ec_8885_0050569e2380
+2022-03-11 17:16:44|INFO|running time: 0.08 seconds
+2022-03-11 17:16:44|INFO|rows Inserted          = 0
+2022-03-11 17:16:44|INFO|rows Updated           = 32
+2022-03-11 17:16:44|INFO|data formatting errors = 0
+2022-03-11 17:16:44|INFO|gpload succeeded
+2022-03-11 17:16:44|INFO|gpload session started 2022-03-11 17:16:44
+2022-03-11 17:16:44|INFO|setting schema 'public' for table 'texttable'
+2022-03-11 17:16:44|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/external_file_01.txt" -t 30
+2022-03-11 17:16:45|INFO|reusing staging table "EXT_schema_test".staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2022-03-11 17:16:45|INFO|reusing external table "EXT_schema_test".ext_gpload_reusable_f8871e16_a11b_11ec_8885_0050569e2380
+2022-03-11 17:16:45|INFO|running time: 0.08 seconds
+2022-03-11 17:16:45|INFO|rows Inserted          = 0
+2022-03-11 17:16:45|INFO|rows Updated           = 32
+2022-03-11 17:16:45|INFO|data formatting errors = 0
+2022-03-11 17:16:45|INFO|gpload succeeded
+2022-03-11 17:16:45|INFO|gpload session started 2022-03-11 17:16:45
+2022-03-11 17:16:45|INFO|setting schema 'public' for table 'texttable'
+2022-03-11 17:16:45|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/external_file_01.txt" -t 30
+2022-03-11 17:16:45|INFO|reusing staging table "EXT_schema_test".staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2022-03-11 17:16:45|INFO|reusing external table "EXT_schema_test".ext_gpload_reusable_f8871e16_a11b_11ec_8885_0050569e2380
+2022-03-11 17:16:45|INFO|running time: 0.08 seconds
+2022-03-11 17:16:45|INFO|rows Inserted          = 0
+2022-03-11 17:16:45|INFO|rows Updated           = 32
+2022-03-11 17:16:45|INFO|data formatting errors = 0
+2022-03-11 17:16:45|INFO|gpload succeeded
+ count 
+-------
+     1
+(1 row)
+

--- a/gpMgmt/bin/gpload_test/gpload2/query406.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query406.ans
@@ -1,0 +1,37 @@
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 's1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+2022-03-11 16:54:18|INFO|gpload session started 2022-03-11 16:54:18
+2022-03-11 16:54:18|INFO|setting schema 'public' for table 'texttable'
+2022-03-11 16:54:18|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/external_file_01.txt" -t 30
+2022-03-11 16:54:18|INFO|did not find a staging table to reuse. creating Test.staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2022-03-11 16:54:18|INFO|did not find an external table to reuse. creating Test.ext_gpload_reusable_d60c4828_a118_11ec_8f05_0050569e2380
+2022-03-11 16:54:18|INFO|running time: 0.08 seconds
+2022-03-11 16:54:18|INFO|rows Inserted          = 0
+2022-03-11 16:54:18|INFO|rows Updated           = 32
+2022-03-11 16:54:18|INFO|data formatting errors = 0
+2022-03-11 16:54:18|INFO|gpload succeeded
+2022-03-11 16:54:18|INFO|gpload session started 2022-03-11 16:54:18
+2022-03-11 16:54:18|INFO|setting schema 'public' for table 'texttable'
+2022-03-11 16:54:18|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/external_file_01.txt" -t 30
+2022-03-11 16:54:18|INFO|reusing staging table Test.staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2022-03-11 16:54:18|INFO|reusing external table test.ext_gpload_reusable_d60c4828_a118_11ec_8f05_0050569e2380
+2022-03-11 16:54:18|INFO|running time: 0.09 seconds
+2022-03-11 16:54:18|INFO|rows Inserted          = 0
+2022-03-11 16:54:18|INFO|rows Updated           = 32
+2022-03-11 16:54:18|INFO|data formatting errors = 0
+2022-03-11 16:54:18|INFO|gpload succeeded
+2022-03-11 16:54:18|INFO|gpload session started 2022-03-11 16:54:18
+2022-03-11 16:54:18|INFO|setting schema 'public' for table 'texttable'
+2022-03-11 16:54:18|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/workspace/gpdb/gpMgmt/bin/gpload_test/gpload2/data/external_file_01.txt" -t 30
+2022-03-11 16:54:18|INFO|reusing staging table Test.staging_gpload_reusable_afbaac0da7ced19791c9ab9c537f41d3
+2022-03-11 16:54:18|INFO|reusing external table test.ext_gpload_reusable_d60c4828_a118_11ec_8f05_0050569e2380
+2022-03-11 16:54:18|INFO|running time: 0.08 seconds
+2022-03-11 16:54:18|INFO|rows Inserted          = 0
+2022-03-11 16:54:18|INFO|rows Updated           = 32
+2022-03-11 16:54:18|INFO|data formatting errors = 0
+2022-03-11 16:54:18|INFO|gpload succeeded
+ count 
+-------
+     2
+(1 row)
+

--- a/gpMgmt/bin/gpload_test/gpload2/query433.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query433.ans
@@ -1,6 +1,6 @@
 2021-01-05 17:09:31|INFO|gpload session started 2021-01-05 17:09:31
 2021-01-05 17:09:31|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/external_file_01.txt" -t 30
-2021-01-05 17:09:31|INFO|reusing external table ext_gpload_reusable_3653d0a2_4f35_11eb_8508_7085c2381836
+2021-01-05 17:09:31|INFO|did not find an external table to reuse. creating ext_gpload_reusable_3653d0a2_4f35_11eb_8508_7085c2381836
 2021-01-05 17:09:31|INFO|running time: 0.12 seconds
 2021-01-05 17:09:31|INFO|rows Inserted          = 16
 2021-01-05 17:09:31|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query603.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query603.ans
@@ -9,7 +9,7 @@
 2021-01-17 18:25:59|INFO|gpload session started 2021-01-17 18:25:59
 2021-01-17 18:25:59|INFO|setting schema 'public' for table 'texttable'
 2021-01-17 18:25:59|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/temp/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-01-17 18:25:59|INFO|reusing external staging table staging_test
+2021-01-17 18:25:59|INFO|reusing external staging table "STAGING_test"
 2021-01-17 18:25:59|INFO|running time: 0.12 seconds
 2021-01-17 18:25:59|INFO|rows Inserted          = 16
 2021-01-17 18:25:59|INFO|rows Updated           = 0

--- a/gpMgmt/bin/gpload_test/gpload2/query604.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query604.ans
@@ -1,12 +1,12 @@
 2021-01-17 20:28:18|INFO|gpload session started 2021-01-17 20:28:18
 2021-01-17 20:28:18|INFO|setting schema 'public' for table 'texttable'
 2021-01-17 20:28:18|INFO|started gpfdist -p 8081 -P 8082 -f "/home/gpadmin/temp/gpdb/gpMgmt/bin/gpload_test/gpload2/data_file.txt" -t 30
-2021-01-17 20:28:18|INFO|reusing external staging table staging_test
+2021-01-17 20:28:18|INFO|reusing external staging table "STAGING_test"
 2021-01-17 20:28:18|ERROR|ERROR:  column "n8" does not exist
 LINE 1: ..."s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8" FROM ...
                                                              ^
 HINT:  There is a column named "n8" in table "texttable", but it cannot be referenced from this part of the query.
- encountered while running INSERT INTO public."texttable" ("s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8") SELECT "s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8" FROM staging_test
+ encountered while running INSERT INTO public."texttable" ("s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8") SELECT "s1","s2","s3","dt","n1","n2","n3","n4","n5","n6","n7","n8" FROM "STAGING_test"
 2021-01-17 20:28:18|INFO|rows Inserted          = 0
 2021-01-17 20:28:18|INFO|rows Updated           = 0
 2021-01-17 20:28:18|INFO|data formatting errors = 0

--- a/gpMgmt/bin/gpload_test/gpload2/setup.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/setup.ans
@@ -5,6 +5,8 @@ CREATE DATABASE
 You are now connected to database "reuse_gptest" as user "gpadmin".
 CREATE SCHEMA test;
 CREATE SCHEMA
+CREATE SCHEMA "EXT_schema_test";
+CREATE SCHEMA
 set client_min_messages='warning';
 SET
 DROP EXTERNAL TABLE IF EXISTS temp_gpload_staging_table;

--- a/gpMgmt/bin/gpload_test/gpload2/setup.sql
+++ b/gpMgmt/bin/gpload_test/gpload2/setup.sql
@@ -5,6 +5,7 @@ CREATE DATABASE reuse_gptest;
 \c reuse_gptest
 
 CREATE SCHEMA test;
+CREATE SCHEMA "EXT_schema_test";
 
 set client_min_messages='warning';
 DROP EXTERNAL TABLE IF EXISTS temp_gpload_staging_table;


### PR DESCRIPTION
backport pr #13192 to master branch
1. gpload should recognize capital letters table name in '" and "', gpload YAML file like:
```
GPLOAD:
PRELOAD:
- STAGING_TABLE: '"Staging_table"'
```
2. better gpload test frame. Make pytest print the diff file if the case fail


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
