### PR TITLE
Add distributed snapshot support to pg_export_snapshot

### DIFF
--- a/src/backend/cdb/cdbdistributedsnapshot.c
+++ b/src/backend/cdb/cdbdistributedsnapshot.c
@@ -23,6 +23,12 @@
 #include "utils/snapmgr.h"
 #include "storage/procarray.h"
 
+int
+GetMaxSnapshotDistributedXidCount()
+{
+	return GetMaxSnapshotXidCount();
+}
+
 /*
  * DistributedSnapshotWithLocalMapping_CommittedTest
  *		Is the given XID still-in-progress according to the
@@ -228,7 +234,7 @@ DistributedSnapshot_Reset(DistributedSnapshot *distributedSnapshot)
 	if (distributedSnapshot->inProgressXidArray == NULL)
 	{
 		distributedSnapshot->inProgressXidArray =
-			(DistributedTransactionId*) malloc(GetMaxSnapshotXidCount() * sizeof(DistributedTransactionId));
+			(DistributedTransactionId*) malloc(GetMaxSnapshotDistributedXidCount() * sizeof(DistributedTransactionId));
 		if (distributedSnapshot->inProgressXidArray == NULL)
 			ereport(ERROR,
 					(errcode(ERRCODE_OUT_OF_MEMORY),
@@ -270,14 +276,14 @@ DistributedSnapshot_Copy(DistributedSnapshot *target,
 	if (target->inProgressXidArray == NULL)
 	{
 		target->inProgressXidArray =
-			(DistributedTransactionId*) malloc(GetMaxSnapshotXidCount() * sizeof(DistributedTransactionId));
+			(DistributedTransactionId*) malloc(GetMaxSnapshotDistributedXidCount() * sizeof(DistributedTransactionId));
 		if (target->inProgressXidArray == NULL)
 			ereport(ERROR,
 					(errcode(ERRCODE_OUT_OF_MEMORY),
 					 errmsg("out of memory")));
 	}
 
-	Assert(source->count <= GetMaxSnapshotXidCount());
+	Assert(source->count <= GetMaxSnapshotDistributedXidCount());
 	memcpy(target->inProgressXidArray,
 			source->inProgressXidArray,
 			source->count * sizeof(DistributedTransactionId));

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -133,19 +133,12 @@ static void sendWaitGxidsToQD(List *waitGxids);
 
 extern void GpDropTempTables(void);
 
-/**
- * All assignments of the global DistributedTransactionContext should go through this function
- *   (so we can add logging here to see all assignments)
- *
- * @param context the new value for DistributedTransactionContext
- */
-static void
+void
 setDistributedTransactionContext(DtxContext context)
 {
-	/*
-	 * elog(INFO, "Setting DistributedTransactionContext to '%s'",
-	 * DtxContextToString(context));
-	 */
+	elog((Debug_print_full_dtm ? LOG : DEBUG5),
+		  "Setting DistributedTransactionContext to '%s'",
+		  DtxContextToString(context));
 	DistributedTransactionContext = context;
 }
 

--- a/src/backend/storage/ipc/sinval.c
+++ b/src/backend/storage/ipc/sinval.c
@@ -223,12 +223,12 @@ ProcessCatchupInterrupt(void)
 			 */
 			DtxContext  saveDistributedTransactionContext;
 			saveDistributedTransactionContext = DistributedTransactionContext;
-			DistributedTransactionContext = DTX_CONTEXT_LOCAL_ONLY;
+			setDistributedTransactionContext(DTX_CONTEXT_LOCAL_ONLY);
 
 			StartTransactionCommand();
 			CommitTransactionCommand();
 
-			DistributedTransactionContext = saveDistributedTransactionContext;
+			setDistributedTransactionContext(saveDistributedTransactionContext);
 		}
 
 		in_process_catchup_event = 0;

--- a/src/backend/utils/time/snapmgr.c
+++ b/src/backend/utils/time/snapmgr.c
@@ -635,13 +635,16 @@ SetTransactionSnapshot(Snapshot sourcesnap, VirtualTransactionId *sourcevxid,
 	 * snapshot importers compute reasonably up-to-date values for them.)
 	 */
 
-	/*
-	 * Pass in DTX_CONTEXT_LOCAL_ONLY to prevent a distributed snapshot from
-	 * getting created here, as we will be using the one we parsed in
-	 * ImportSnapshot.
+	 /*
+	 * GPDB: If the source snapshot already has a distributed snapshot, pass in
+	 * DTX_CONTEXT_LOCAL_ONLY to GetSnapshotData(). This prevents a new
+	 * distributed snapshot from being created in GetSnapshotData() and ensures
+	 * that we can use the distributed snapshot from the source snapshot below.
 	 */
-	CurrentSnapshot = GetSnapshotData(&CurrentSnapshotData, DTX_CONTEXT_LOCAL_ONLY);
-
+	if (sourcesnap->haveDistribSnapshot)
+		CurrentSnapshot = GetSnapshotData(&CurrentSnapshotData, DTX_CONTEXT_LOCAL_ONLY);
+	else
+		CurrentSnapshot = GetSnapshotData(&CurrentSnapshotData, DistributedTransactionContext);
 	/*
 	 * Now copy appropriate fields from the source snapshot.
 	 */

--- a/src/backend/utils/time/snapmgr.c
+++ b/src/backend/utils/time/snapmgr.c
@@ -68,6 +68,8 @@
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 
+#include "cdb/cdbdisp_query.h"
+#include "cdb/cdbdispatchresult.h"
 #include "cdb/cdbtm.h"
 #include "cdb/cdbvars.h"
 #include "utils/guc.h"
@@ -632,7 +634,13 @@ SetTransactionSnapshot(Snapshot sourcesnap, VirtualTransactionId *sourcevxid,
 	 * two variables in exported snapshot files, but it seems better to have
 	 * snapshot importers compute reasonably up-to-date values for them.)
 	 */
-	CurrentSnapshot = GetSnapshotData(&CurrentSnapshotData, DistributedTransactionContext);
+
+	/*
+	 * Pass in DTX_CONTEXT_LOCAL_ONLY to prevent a distributed snapshot from
+	 * getting created here, as we will be using the one we parsed in
+	 * ImportSnapshot.
+	 */
+	CurrentSnapshot = GetSnapshotData(&CurrentSnapshotData, DTX_CONTEXT_LOCAL_ONLY);
 
 	/*
 	 * Now copy appropriate fields from the source snapshot.
@@ -649,6 +657,16 @@ SetTransactionSnapshot(Snapshot sourcesnap, VirtualTransactionId *sourcevxid,
 		   sourcesnap->subxcnt * sizeof(TransactionId));
 	CurrentSnapshot->suboverflowed = sourcesnap->suboverflowed;
 	CurrentSnapshot->takenDuringRecovery = sourcesnap->takenDuringRecovery;
+
+	/*
+	 * GPDB: Copy over distributed snapshot if present.
+	 */
+	if (sourcesnap->haveDistribSnapshot)
+	{
+		CurrentSnapshot->haveDistribSnapshot = true;
+		DistributedSnapshot_Copy(&CurrentSnapshot->distribSnapshotWithLocalMapping.ds,
+								 &sourcesnap->distribSnapshotWithLocalMapping.ds);
+	}
 	/* NB: curcid should NOT be copied, it's a local matter */
 
 	/*
@@ -1265,6 +1283,7 @@ ExportSnapshot(Snapshot snapshot)
 	char		path[MAXPGPATH];
 	char		pathtmp[MAXPGPATH];
 
+	DistributedSnapshot *distributed_snapshot;
 	/*
 	 * It's tempting to call RequireTransactionBlock here, since it's not very
 	 * useful to export a snapshot that will disappear immediately afterwards.
@@ -1380,6 +1399,21 @@ ExportSnapshot(Snapshot snapshot)
 	appendStringInfo(&buf, "rec:%u\n", snapshot->takenDuringRecovery);
 
 	/*
+	 * GPDB: Serialize distributed snapshot if present.
+	 */
+	if (snapshot->haveDistribSnapshot)
+	{
+		distributed_snapshot = &snapshot->distribSnapshotWithLocalMapping.ds;
+		appendStringInfo(&buf, "dsxminall:%lu\n", distributed_snapshot->xminAllDistributedSnapshots);
+		appendStringInfo(&buf, "dsid:%d\n", distributed_snapshot->distribSnapshotId);
+		appendStringInfo(&buf, "dsxmin:%lu\n", distributed_snapshot->xmin);
+		appendStringInfo(&buf, "dsxmax:%lu\n", distributed_snapshot->xmax);
+		appendStringInfo(&buf, "dsxcnt:%d\n", distributed_snapshot->count);
+		for (i = 0; i < distributed_snapshot->count; i++)
+			appendStringInfo(&buf, "dsxip:%lu\n", distributed_snapshot->inProgressXidArray[i]);
+	}
+
+	/*
 	 * Now write the text representation into a file.  We first write to a
 	 * ".tmp" filename, and rename to final filename if no error.  This
 	 * ensures that no other backend can read an incomplete file
@@ -1491,6 +1525,31 @@ parseXidFromText(const char *prefix, char **s, const char *filename)
 	return val;
 }
 
+static DistributedTransactionId
+parseDistributedXidFromText(const char *prefix, char **s, const char *filename)
+{
+	char	   *ptr = *s;
+	int			prefixlen = strlen(prefix);
+	DistributedTransactionId val;
+
+	if (strncmp(ptr, prefix, prefixlen) != 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+				 errmsg("invalid snapshot data in file \"%s\"", filename)));
+	ptr += prefixlen;
+	if (sscanf(ptr, "%lu", &val) != 1)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+				 errmsg("invalid snapshot data in file \"%s\"", filename)));
+	ptr = strchr(ptr, '\n');
+	if (!ptr)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+				 errmsg("invalid snapshot data in file \"%s\"", filename)));
+	*s = ptr + 1;
+	return val;
+}
+
 static void
 parseVxidFromText(const char *prefix, char **s, const char *filename,
 				  VirtualTransactionId *vxid)
@@ -1529,6 +1588,7 @@ ImportSnapshot(const char *idstr)
 	struct stat stat_buf;
 	char	   *filebuf;
 	int			xcnt;
+	int			dxcnt;
 	int			i;
 	VirtualTransactionId src_vxid;
 	int			src_pid;
@@ -1536,6 +1596,7 @@ ImportSnapshot(const char *idstr)
 	int			src_isolevel;
 	bool		src_readonly;
 	SnapshotData snapshot;
+	DistributedSnapshot *distributed_snapshot;
 
 	/*
 	 * Must be at top level of a fresh transaction.  Note in particular that
@@ -1642,6 +1703,43 @@ ImportSnapshot(const char *idstr)
 	}
 
 	snapshot.takenDuringRecovery = parseIntFromText("rec:", &filebuf, path);
+
+	/*
+	 * GPDB: Extract distributed snapshot
+	 * Importing a distributed snapshot in utility mode is not allowed because
+	 * functionality to dispatch pg_export_snapshot to all segments and create
+	 * a snapshot with ds fields in each segments datadir is not implemented.
+	 * Since there is no reliable way to export a utility mode distributed snapshot,
+	 * we have no way to judge its provenance.
+	 */
+	if(*filebuf != '\0')
+	{
+		if (Gp_role == GP_ROLE_UTILITY) {
+			ereport(ERROR,
+				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+				errmsg("cannot import distributed snapshot in utility mode"),
+				errhint("export the snapshot in utility mode")));
+		}
+		distributed_snapshot = &snapshot.distribSnapshotWithLocalMapping.ds;
+		distributed_snapshot->xminAllDistributedSnapshots = parseDistributedXidFromText("dsxminall:", &filebuf, path);
+		distributed_snapshot->distribSnapshotId = parseIntFromText("dsid:", &filebuf, path);
+		distributed_snapshot->xmin = parseDistributedXidFromText("dsxmin:", &filebuf, path);
+		distributed_snapshot->xmax = parseDistributedXidFromText("dsxmax:", &filebuf, path);
+		distributed_snapshot->count = dxcnt = parseIntFromText("dsxcnt:", &filebuf, path);
+		
+		/* sanity-check dsxmin and the xid count before palloc */
+		if (distributed_snapshot->xmin < distributed_snapshot->xminAllDistributedSnapshots ||
+			(dxcnt < 0 || dxcnt > GetMaxSnapshotDistributedXidCount())
+			)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+					errmsg("invalid snapshot data in file \"%s\"", path)));
+
+		distributed_snapshot->inProgressXidArray = (DistributedTransactionId *) palloc(dxcnt * sizeof(DistributedTransactionId));
+		for (i = 0; i < dxcnt; i++)
+			distributed_snapshot->inProgressXidArray[i] = parseDistributedXidFromText("dsxip:", &filebuf, path);
+		snapshot.haveDistribSnapshot = true;
+	}
 
 	/*
 	 * Do some additional sanity checking, just to protect ourselves.  We

--- a/src/include/cdb/cdbdistributedsnapshot.h
+++ b/src/include/cdb/cdbdistributedsnapshot.h
@@ -66,6 +66,8 @@ typedef enum
 	DISTRIBUTEDSNAPSHOT_COMMITTED_IGNORE
 } DistributedSnapshotCommitted;
 
+extern int GetMaxSnapshotDistributedXidCount(void);
+
 extern DistributedSnapshotCommitted DistributedSnapshotWithLocalMapping_CommittedTest(
 	DistributedSnapshotWithLocalMapping		*dslm,
 	TransactionId 							localXid,

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -289,6 +289,8 @@ extern void dtxFormGid(char *gid, DistributedTransactionId gxid);
 extern DistributedTransactionId getDistributedTransactionId(void);
 extern bool getDistributedTransactionIdentifier(char *id);
 
+extern void setDistributedTransactionContext(DtxContext context);
+
 extern void resetTmGxact(void);
 extern void	prepareDtxTransaction(void);
 extern bool isPreparedDtxTransaction(void);

--- a/src/test/isolation2/expected/export_distributed_snapshot.out
+++ b/src/test/isolation2/expected/export_distributed_snapshot.out
@@ -1,0 +1,290 @@
+-- Export distributed snapshot tests
+
+-- start_matchsubs
+-- m/[0-9a-fA-F]+-[0-9a-fA-F]+-\d/
+-- s/[0-9a-fA-F]+-[0-9a-fA-F]+-\d/#######-########-#/
+
+-- m/^DETAIL:  The source process with PID \d+ is not running anymore./
+-- s/^DETAIL:  The source process with PID \d+ is not running anymore./DETAIL:  The source process with PID is not running anymore./
+-- end_matchsubs
+
+-- start_ignore
+DROP FUNCTION IF EXISTS corrupt_snapshot_file(text, text);
+DROP
+DROP FUNCTION IF EXISTS snapshot_file_ds_fields_exist(text);
+DROP
+DROP LANGUAGE IF EXISTS plpython3u cascade;
+DROP
+DROP TABLE IF EXISTS export_distributed_snapshot_test1;
+DROP
+-- end_ignore
+
+CREATE LANGUAGE plpython3u;
+CREATE
+
+-- Corrupt field entry for given snapshot file
+CREATE OR REPLACE FUNCTION  corrupt_snapshot_file(token text, field text) RETURNS integer as $$ import os content = bytearray() query = "select (select datadir from gp_segment_configuration where role='p' and content=-1) || '/pg_snapshots/' as path" rv = plpy.execute(query) abs_path = rv[0]['path'] snapshot_file = abs_path + token if not os.path.isfile(snapshot_file): plpy.info('skipping non-existent file %s' % (snapshot_file)) else: plpy.info('corrupting file %s for field %s' % (snapshot_file, field)) with open(snapshot_file , "rb+") as f: for line in f: l = line.decode() id = l.split(":")[0] if field == id: corrupt = l[:-2] + '*' + l[len(l)-1:] content.extend(corrupt.encode()) else: content.extend(line) f.seek(0) f.truncate f.write(content) f.close() return 0 $$ LANGUAGE plpython3u EXECUTE ON MASTER;
+CREATE
+
+-- Determine if field exists for given snapshot file
+CREATE OR REPLACE FUNCTION  snapshot_file_ds_fields_exist(token text) RETURNS boolean as $$ import os content = bytearray() query = "select (select datadir from gp_segment_configuration where role='p' and content=-1) || '/pg_snapshots/' as path" rv = plpy.execute(query) abs_path = rv[0]['path'] snapshot_file = abs_path + token if not os.path.isfile(snapshot_file): plpy.info('snapshot file %s does not exist' % (snapshot_file)) return -1 else: plpy.info('checking file %s for ds fields' % (snapshot_file)) with open(snapshot_file , "rb+") as f: for line in f: l = line.decode() if "ds" in l: return True return False $$ LANGUAGE plpython3u EXECUTE ON MASTER;
+CREATE
+
+-- INSERT test
+CREATE TABLE export_distributed_snapshot_test1 (a int);
+CREATE
+INSERT INTO export_distributed_snapshot_test1 values(1);
+INSERT 1
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+ pg_export_snapshot
+---------------------
+ 00000007-00000011-1
+(1 row)
+
+INSERT INTO export_distributed_snapshot_test1 values(2);
+INSERT 1
+SELECT * FROM  export_distributed_snapshot_test1;
+ a 
+---
+ 2 
+ 1 
+(2 rows)
+
+-- Transaction 2 should return 2 rows
+2: SELECT * FROM  export_distributed_snapshot_test1;
+ a 
+---
+ 2 
+ 1 
+(2 rows)
+2: COMMIT;
+COMMIT
+
+2: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+SET
+-- Transaction 2 should now return 1 row
+2: SELECT * FROM  export_distributed_snapshot_test1;
+ a 
+---
+ 1 
+(1 row)
+2: COMMIT;
+COMMIT
+
+1: COMMIT;
+COMMIT
+
+-- DROP test
+CREATE TABLE export_distributed_snapshot_test2 (a int);
+CREATE
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+2: BEGIN;
+BEGIN
+
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+ pg_export_snapshot
+---------------------
+ 00000007-00000012-1
+(1 row)
+1: SELECT gp_segment_id, relname from gp_dist_random('pg_class') where relname = 'export_distributed_snapshot_test2';
+ gp_segment_id | relname                           
+---------------+-----------------------------------
+ 1             | export_distributed_snapshot_test2 
+ 2             | export_distributed_snapshot_test2 
+ 0             | export_distributed_snapshot_test2 
+(3 rows)
+
+-- Drop table in transaction
+2: DROP TABLE export_distributed_snapshot_test2;
+DROP
+2: COMMIT;
+COMMIT
+
+3: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+3: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+SET
+-- The table should still be visible to transaction 3 using transaction 1's snapshot.
+3: SELECT gp_segment_id, relname from gp_dist_random('pg_class') where relname = 'export_distributed_snapshot_test2';
+ gp_segment_id | relname                           
+---------------+-----------------------------------
+ 1             | export_distributed_snapshot_test2 
+ 2             | export_distributed_snapshot_test2 
+ 0             | export_distributed_snapshot_test2 
+(3 rows)
+3: COMMIT;
+COMMIT
+-- The table should no longer be visible to transaction 3.
+3: SELECT gp_segment_id, relname from gp_dist_random('pg_class') where relname = 'export_distributed_snapshot_test2';
+ gp_segment_id | relname 
+---------------+---------
+(0 rows)
+
+1: COMMIT;
+COMMIT
+
+-- Test corrupt fields in snapshot file
+
+-- xmin
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+ pg_export_snapshot
+---------------------
+ 00000007-00000013-1
+(1 row)
+
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': select corrupt_snapshot_file('@TOKEN', 'xmin');
+ corrupt_snapshot_file 
+-----------------------
+ 0                     
+(1 row)
+
+2: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+ERROR:  could not import the requested snapshot
+DETAIL:  The source process with PID 651456 is not running anymore.
+
+1: END;
+END
+2: END;
+END
+
+-- dsxminall
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+ pg_export_snapshot
+---------------------
+ 00000007-00000014-1
+(1 row)
+
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': select corrupt_snapshot_file('@TOKEN', 'dsxminall');
+ corrupt_snapshot_file 
+-----------------------
+ 0                     
+(1 row)
+
+2: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+SET
+
+1: END;
+END
+2: END;
+END
+
+-- dsxmin
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+ pg_export_snapshot
+---------------------
+ 00000007-00000006-1
+(1 row)
+
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': select corrupt_snapshot_file('@TOKEN', 'dsxmin');
+ corrupt_snapshot_file 
+-----------------------
+ 0                     
+(1 row)
+
+2: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+ERROR:  invalid snapshot data in file "pg_snapshots/00000007-00000006-1"
+
+1: END;
+END
+2: END;
+END
+
+-- Test export snapshot in utility mode does not export distributed snapshot fields
+
+-1U: BEGIN;
+BEGIN
+-1U: BEGIN;
+BEGIN
+-1U: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+ pg_export_snapshot
+---------------------
+ 00000009-00000302-1
+(1 row)
+
+-- Should return false
+1: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': select snapshot_file_ds_fields_exist('@TOKEN');
+ snapshot_file_ds_fields_exist 
+-------------------------------
+ f                             
+(1 row)
+
+-1Uq: ... <quitting>
+1: END;
+END
+
+-- Test import snapshot in utility mode fails if distributed snapshot fields exist
+1: BEGIN;
+BEGIN
+1: BEGIN;
+BEGIN
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+ pg_export_snapshot
+---------------------
+ 00000006-00000008-1
+(1 row)
+
+-- Open utility mode connection on coordinator and set snapshot
+-1U: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+-1U: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+ERROR:  cannot import distributed snapshot in utility mode
+HINT:  export the snapshot in utility mode
+
+-1Uq: ... <quitting>
+1: END;
+END
+
+-- Test export snapshot in utility mode and import snapshot in utility mode succeeds
+-1U: @db_name postgres: BEGIN;
+BEGIN
+-1U: BEGIN;
+BEGIN
+-1U: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+ pg_export_snapshot
+---------------------
+ 00000009-0000030A-1
+(1 row)
+
+-- Should return false
+1: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': select snapshot_file_ds_fields_exist('@TOKEN');
+ snapshot_file_ds_fields_exist 
+-------------------------------
+ f                             
+(1 row)
+
+-- Open another utility mode connection and set the snapshot
+! TOKEN=$(find ${COORDINATOR_DATA_DIRECTORY}/pg_snapshots/ -name "0*" -exec basename {} \;) \ && echo ${TOKEN} \ && PGOPTIONS='-c gp_role=utility' psql postgres -Atc "BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ; SET TRANSACTION SNAPSHOT '${TOKEN}';";
+0000000A-0000000E-1
+SET
+
+
+-1Uq: ... <quitting>

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -293,3 +293,5 @@ test: check_gxid
 # test if GUC is synchronized from the QD to QEs.
 test: sync_guc
 
+# test pg_export_snapshot with distributed snapshot functionality
+test: export_distributed_snapshot

--- a/src/test/isolation2/sql/export_distributed_snapshot.sql
+++ b/src/test/isolation2/sql/export_distributed_snapshot.sql
@@ -1,0 +1,198 @@
+-- Export distributed snapshot tests
+
+-- start_matchsubs
+-- m/[0-9a-fA-F]+-[0-9a-fA-F]+-\d/
+-- s/[0-9a-fA-F]+-[0-9a-fA-F]+-\d/#######-########-#/
+
+-- m/^DETAIL:  The source process with PID \d+ is not running anymore./
+-- s/^DETAIL:  The source process with PID \d+ is not running anymore./DETAIL:  The source process with PID is not running anymore./
+-- end_matchsubs
+
+-- start_ignore
+DROP FUNCTION IF EXISTS corrupt_snapshot_file(text, text);
+DROP FUNCTION IF EXISTS snapshot_file_ds_fields_exist(text);
+DROP LANGUAGE IF EXISTS plpython3u cascade;
+DROP TABLE IF EXISTS export_distributed_snapshot_test1;
+-- end_ignore
+
+CREATE LANGUAGE plpython3u;
+
+-- Corrupt field entry for given snapshot file
+CREATE OR REPLACE FUNCTION  corrupt_snapshot_file(token text, field text) RETURNS integer as
+$$
+  import os
+  content = bytearray()
+  query = "select (select datadir from gp_segment_configuration where role='p' and content=-1) || '/pg_snapshots/' as path"
+  rv = plpy.execute(query)
+  abs_path = rv[0]['path']
+  snapshot_file = abs_path + token
+  if not os.path.isfile(snapshot_file):
+    plpy.info('skipping non-existent file %s' % (snapshot_file))
+  else:
+    plpy.info('corrupting file %s for field %s' % (snapshot_file, field))
+    with open(snapshot_file , "rb+") as f:
+      for line in f:
+        l = line.decode()
+        id = l.split(":")[0]
+        if field == id:
+          corrupt = l[:-2] + '*' + l[len(l)-1:]
+          content.extend(corrupt.encode())
+        else:
+          content.extend(line)
+      f.seek(0)
+      f.truncate
+      f.write(content)
+      f.close()
+  return 0
+$$ LANGUAGE plpython3u EXECUTE ON MASTER;
+
+-- Determine if field exists for given snapshot file
+CREATE OR REPLACE FUNCTION  snapshot_file_ds_fields_exist(token text) RETURNS boolean as
+$$
+  import os
+  content = bytearray()
+  query = "select (select datadir from gp_segment_configuration where role='p' and content=-1) || '/pg_snapshots/' as path"
+  rv = plpy.execute(query)
+  abs_path = rv[0]['path']
+  snapshot_file = abs_path + token
+  if not os.path.isfile(snapshot_file):
+    plpy.info('snapshot file %s does not exist' % (snapshot_file))
+    return -1
+  else:
+    plpy.info('checking file %s for ds fields' % (snapshot_file))
+    with open(snapshot_file , "rb+") as f:
+      for line in f:
+        l = line.decode()
+        if "ds" in l:
+          return True
+  return False
+$$ LANGUAGE plpython3u EXECUTE ON MASTER;
+
+-- INSERT test
+CREATE TABLE export_distributed_snapshot_test1 (a int);
+INSERT INTO export_distributed_snapshot_test1 values(1);
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+
+INSERT INTO export_distributed_snapshot_test1 values(2);
+SELECT * FROM  export_distributed_snapshot_test1;
+
+-- Transaction 2 should return 2 rows
+2: SELECT * FROM  export_distributed_snapshot_test1;
+2: COMMIT;
+
+2: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+-- Transaction 2 should now return 1 row
+2: SELECT * FROM  export_distributed_snapshot_test1;
+2: COMMIT;
+
+1: COMMIT;
+
+-- DROP test
+CREATE TABLE export_distributed_snapshot_test2 (a int);
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+2: BEGIN;
+
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+1: SELECT gp_segment_id, relname from gp_dist_random('pg_class') where relname = 'export_distributed_snapshot_test2';
+
+-- Drop table in transaction
+2: DROP TABLE export_distributed_snapshot_test2;
+2: COMMIT;
+
+3: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+3: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+-- The table should still be visible to transaction 3 using transaction 1's snapshot.
+3: SELECT gp_segment_id, relname from gp_dist_random('pg_class') where relname = 'export_distributed_snapshot_test2';
+3: COMMIT;
+-- The table should no longer be visible to transaction 3.
+3: SELECT gp_segment_id, relname from gp_dist_random('pg_class') where relname = 'export_distributed_snapshot_test2';
+
+1: COMMIT;
+
+-- Test corrupt fields in snapshot file
+
+-- xmin
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': select corrupt_snapshot_file('@TOKEN', 'xmin');
+
+2: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+
+1: END;
+2: END;
+
+-- dsxminall
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': select corrupt_snapshot_file('@TOKEN', 'dsxminall');
+
+2: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+
+1: END;
+2: END;
+
+-- dsxmin
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': select corrupt_snapshot_file('@TOKEN', 'dsxmin');
+
+2: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+
+1: END;
+2: END;
+
+-- Test export snapshot in utility mode does not export distributed snapshot fields
+
+-1U: BEGIN;
+-1U: BEGIN;
+-1U: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+
+-- Should return false
+1: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': select snapshot_file_ds_fields_exist('@TOKEN');
+
+-1Uq:
+1: END;
+
+-- Test import snapshot in utility mode fails if distributed snapshot fields exist
+1: BEGIN;
+1: BEGIN;
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+
+-- Open utility mode connection on coordinator and set snapshot
+-1U: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+-1U: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+
+-1Uq:
+1: END;
+
+-- Test export snapshot in utility mode and import snapshot in utility mode succeeds
+-1U: @db_name postgres: BEGIN;
+-1U: BEGIN;
+-1U: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+
+-- Should return false
+1: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': select snapshot_file_ds_fields_exist('@TOKEN');
+
+-- Open another utility mode connection and set the snapshot
+! TOKEN=$(find ${COORDINATOR_DATA_DIRECTORY}/pg_snapshots/ -name "0*" -exec basename {} \;) \
+&& echo ${TOKEN} \
+&& PGOPTIONS='-c gp_role=utility' psql postgres -Atc "BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ; SET TRANSACTION SNAPSHOT '${TOKEN}';";
+
+-1Uq:


### PR DESCRIPTION
Add distributed snapshot support to pg_export_snapshot
    
This PR adds distributed snapshot metadata when exporting and
importing snapshots.
    
Calling `select pg_export_snapshot()` from the QD will write the
following fields to the snapshot file in `pg_snapshots` in the
coordinator data directory.
    
```
dsxminall
dsid
dsxmin
dsxmax
dscnt
dsxip
 ```
    
When a snapshot is imported via SET TRANSACTION SNAPSHOT from the QD, subsequent
queries will have the distributed snapshot metadata dispatched to the QEs.
This enables cluster-wide data visibility consistency.
  
Reference: https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/C6cY8yIbcps