### PR TITLE
Allow setting direct dispatch info if predicate on  gp_segment_id for…

### DIFF
--- a/src/backend/cdb/cdbtargeteddispatch.c
+++ b/src/backend/cdb/cdbtargeteddispatch.c
@@ -19,6 +19,7 @@
 #include "parser/parsetree.h"	/* for rt_fetch() */
 #include "nodes/makefuncs.h"	/* for makeVar() */
 #include "utils/relcache.h"		/* RelationGetPartitioningKey() */
+#include "utils/lsyscache.h"    /* get_atttypetypmodcoll() */
 #include "optimizer/predtest.h"
 
 #include "catalog/gp_policy.h"
@@ -191,13 +192,77 @@ GetContentIdsFromPlanForSingleRelation(List *rtable, Plan *plan, int rangeTableI
 		/* fall through, policy will be NULL so we won't direct dispatch */
 	}
 
-	if (rte->forceDistRandom ||
-		policy == NULL ||
-		!GpPolicyIsHashPartitioned(policy))
+
+	if (rte->forceDistRandom ||	policy == NULL)
 	{
-		result.dd.isDirectDispatch = false;
+		/*  we won't direct dispatch  */
+		if (rte->rtekind == RTE_RELATION)
+			relation_close(relation, NoLock);
+		result.haveProcessedAnyCalculations = true;
+		return result;
 	}
-	else
+
+	/*
+	 * We first test if the predict contains a qual like
+	 * gp_segment_id = some_const. This is very suitable
+	 * for a direct dispatch. If this leads to direct dispatch
+	 * then we just return because it does not need to
+	 * eval distkey.
+	 */
+	if (GpPolicyIsPartitioned(policy))
+	{
+		Var                *seg_id_var;
+		Oid                 vartypeid;
+		int32               type_mod;
+		Oid                 type_coll;
+		PossibleValueSet    pvs_segids;
+		Node              **seg_ids;
+		int                 len;
+		int                 i;
+		List               *contentIds = NULL;
+
+		get_atttypetypmodcoll(rte->relid, GpSegmentIdAttributeNumber,
+							  &vartypeid, &type_mod, &type_coll);
+		seg_id_var = makeVar(rangeTableIndex,
+							 GpSegmentIdAttributeNumber,
+							 vartypeid, type_mod, type_coll, 0);
+		pvs_segids = DeterminePossibleValueSet((Node *) qualification,
+											   (Node *) seg_id_var);
+		if (!pvs_segids.isAnyValuePossible)
+		{
+			seg_ids = GetPossibleValuesAsArray(&pvs_segids, &len);
+			if (len > 0 && len < policy->numsegments)
+			{
+				result.dd.isDirectDispatch = true;
+				for (i = 0; i < len; i++)
+				{
+					Node *val = seg_ids[i];
+					if (IsA(val, Const))
+					{
+						int32 segid = DatumGetInt32(((Const *) val)->constvalue);
+						contentIds = list_append_unique_int(contentIds, segid);
+					}
+					else
+					{
+						result.dd.isDirectDispatch = false;
+						break;
+					}
+				}
+			}
+		}
+
+		DeletePossibleValueSetData(&pvs_segids);
+		if (result.dd.isDirectDispatch)
+		{
+			result.dd.contentIds = contentIds;
+			result.haveProcessedAnyCalculations = true;
+			if (rte->rtekind == RTE_RELATION)
+				relation_close(relation, NoLock);
+			return result;
+		}
+	}
+
+	if (GpPolicyIsHashPartitioned(policy))
 	{
 		long		totalCombinations = 1;
 

--- a/src/test/regress/expected/direct_dispatch.out
+++ b/src/test/regress/expected/direct_dispatch.out
@@ -664,14 +664,14 @@ INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL cont
 explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=0;
                 QUERY PLAN                
 ------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
+ Gather Motion 1:1  (slice1; segments: 1)
    ->  Seq Scan on t_test_dd_via_segid
          Filter: (gp_segment_id = 0)
  Optimizer: Postgres query optimizer
 (4 rows)
 
 select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=0;
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to SINGLE content
  gp_segment_id | id 
 ---------------+----
              0 |  2
@@ -682,14 +682,14 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1;
                 QUERY PLAN                
 ------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
+ Gather Motion 1:1  (slice1; segments: 1)
    ->  Seq Scan on t_test_dd_via_segid
          Filter: (gp_segment_id = 1)
  Optimizer: Postgres query optimizer
 (4 rows)
 
 select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1;
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to SINGLE content
  gp_segment_id | id 
 ---------------+----
              1 |  1
@@ -698,14 +698,14 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=2;
                 QUERY PLAN                
 ------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
+ Gather Motion 1:1  (slice1; segments: 1)
    ->  Seq Scan on t_test_dd_via_segid
          Filter: (gp_segment_id = 2)
  Optimizer: Postgres query optimizer
 (4 rows)
 
 select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=2;
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to SINGLE content
  gp_segment_id | id 
 ---------------+----
              2 |  5
@@ -715,14 +715,14 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1 or gp_segment_id=2;
                           QUERY PLAN                          
 --------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
+ Gather Motion 2:1  (slice1; segments: 2)
    ->  Seq Scan on t_test_dd_via_segid
          Filter: ((gp_segment_id = 1) OR (gp_segment_id = 2))
  Optimizer: Postgres query optimizer
 (4 rows)
 
 select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1 or gp_segment_id=2;
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to PARTIAL contents: 1 2
  gp_segment_id | id 
 ---------------+----
              1 |  1

--- a/src/test/regress/expected/direct_dispatch.out
+++ b/src/test/regress/expected/direct_dispatch.out
@@ -796,6 +796,64 @@ INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
              2 |     2
 (3 rows)
 
+-- test direct dispatch via gp_segment_id qual on distributed randomly table
+alter table t_test_dd_via_segid set distributed randomly;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=0;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on t_test_dd_via_segid
+         Filter: (gp_segment_id = 0)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on t_test_dd_via_segid
+         Filter: (gp_segment_id = 1)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=2;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on t_test_dd_via_segid
+         Filter: (gp_segment_id = 2)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1 or gp_segment_id=2;
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)
+   ->  Seq Scan on t_test_dd_via_segid
+         Filter: ((gp_segment_id = 1) OR (gp_segment_id = 2))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1 or gp_segment_id=2;
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)
+   ->  Seq Scan on t_test_dd_via_segid
+         Filter: ((gp_segment_id = 1) OR (gp_segment_id = 2))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1 or gp_segment_id=2 or gp_segment_id=3;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on t_test_dd_via_segid
+         Filter: ((gp_segment_id = 1) OR (gp_segment_id = 2) OR (gp_segment_id = 3))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
 -- cleanup
 set test_print_direct_dispatch_info=off;
 begin;

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -818,6 +818,70 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
              2 |     2
 (3 rows)
 
+-- test direct dispatch via gp_segment_id qual on distributed randomly table
+alter table t_test_dd_via_segid set distributed randomly;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=0;
+                 QUERY PLAN                  
+---------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Result
+         ->  Seq Scan on t_test_dd_via_segid
+               Filter: (gp_segment_id = 0)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1;
+                 QUERY PLAN                  
+---------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Result
+         ->  Seq Scan on t_test_dd_via_segid
+               Filter: (gp_segment_id = 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=2;
+                 QUERY PLAN                  
+---------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Result
+         ->  Seq Scan on t_test_dd_via_segid
+               Filter: (gp_segment_id = 2)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1 or gp_segment_id=2;
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Result
+         ->  Seq Scan on t_test_dd_via_segid
+               Filter: ((gp_segment_id = 1) OR (gp_segment_id = 2))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1 or gp_segment_id=2;
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Result
+         ->  Seq Scan on t_test_dd_via_segid
+               Filter: ((gp_segment_id = 1) OR (gp_segment_id = 2))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1 or gp_segment_id=2 or gp_segment_id=3;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Result
+         ->  Seq Scan on t_test_dd_via_segid
+               Filter: ((gp_segment_id = 1) OR (gp_segment_id = 2) OR (gp_segment_id = 3))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
 -- cleanup
 set test_print_direct_dispatch_info=off;
 begin;

--- a/src/test/regress/sql/direct_dispatch.sql
+++ b/src/test/regress/sql/direct_dispatch.sql
@@ -314,6 +314,21 @@ select t1.gp_segment_id, t2.gp_segment_id, * from t_test_dd_via_segid t1, t_test
 explain (costs off) select gp_segment_id, count(*) from t_test_dd_via_segid group by gp_segment_id;
 select gp_segment_id, count(*) from t_test_dd_via_segid group by gp_segment_id;
 
+-- test direct dispatch via gp_segment_id qual on distributed randomly table
+alter table t_test_dd_via_segid set distributed randomly;
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=0;
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1;
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=2;
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1 or gp_segment_id=2;
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1 or gp_segment_id=2;
+
+explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_segment_id=1 or gp_segment_id=2 or gp_segment_id=3;
+
 -- cleanup
 set test_print_direct_dispatch_info=off;
 


### PR DESCRIPTION
Backport **https://github.com/greenplum-db/gpdb/pull/10690** from master branch. 

… planner.

This commit implements the same feature for planner as the PR
https://github.com/greenplum-db/gpdb/pull/10679.

This commit does not implement the group-by feature in PR 10679.
The following commit message is almost the same as PR 10679.

This approach special cases gp_segment_id enough to include the column
as a distributed column constraint. It also updates direct dispatch info
to be aware of gp_segment_id which represents the raw value of the
segment where the data resides. This is different than other columns
which hash the datum value to decide where the data resides.

After this change the following DDL shows Gather Motion from 2 segments
on a 3 segment demo cluster.

```
CREATE TABLE t(a int, b int) DISTRIBUTED BY (a);
EXPLAIN SELECT gp_segment_id, * FROM t WHERE gp_segment_id=1 or gp_segment_id=2;
                                    QUERY PLAN
-----------------------------------------------------------------------------------
 Gather Motion 2:1  (slice1; segments: 2)
   ->  Seq Scan on t
         Filter: ((gp_segment_id = 1) OR (gp_segment_id = 2))
 Optimizer: Postgres query optimizer
(4 rows)
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
