### PR TITLE
Resolve GPDB_12_MERGE_FIXME in psql/command.c

### DIFF
--- a/src/bin/psql/command.c
+++ b/src/bin/psql/command.c
@@ -810,12 +810,6 @@ exec_command_d(PsqlScanState scan_state, bool active_branch, const char *cmd)
 			case 'i':
 			case 's':
 			case 'E':  /* PostgreSQL use dx for extension, change to dE for foreign table */
-			/* case 'S':  // GPDB:  We used to show just system tables for this */
-
-				/* GPDB_12_MERGE_FIXME: 'P' clashes with new upstream 'P' option */
-#if 0
-			case 'P':  /* GPDB: Parent-only tables, no children */
-#endif
 				success = listTables(&cmd[1], pattern, show_verbose, show_system);
 				break;
 			case 'r':


### PR DESCRIPTION
In 6X_STABLE, `\dP` means "list parent-only tables", no children, but in PG_12_STABLE, `\dP[tin+]` means "list [only table/index] partitioned relations", they conflict.

This needs to be consistent with PG's behavior.
