### PR TITLE
Resolve GPDB_12_MERGE_FIXMEs

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -284,12 +284,8 @@ close_ds_write(DatumStreamWrite **ds, int nvp)
 	}
 }
 
-/*
- * GPDB_12_MERGE_FIXME: Find a better name to match what this function is
- * actually doing
- */
 static void
-aocs_initscan(AOCSScanDesc scan)
+initscan_with_colinfo(AOCSScanDesc scan)
 {
 	MemoryContext	oldCtx;
 	AttrNumber		natts;
@@ -597,7 +593,7 @@ aocs_rescan(AOCSScanDesc scan)
 	close_cur_scan_seg(scan);
 	if (scan->columnScanInfo.ds)
 		close_ds_read(scan->columnScanInfo.ds, scan->columnScanInfo.relationTupleDesc->natts);
-	aocs_initscan(scan);
+	initscan_with_colinfo(scan);
 }
 
 void
@@ -737,7 +733,7 @@ aocs_getnext(AOCSScanDesc scan, ScanDirection direction, TupleTableSlot *slot)
 		scan->columnScanInfo.relationTupleDesc = slot->tts_tupleDescriptor;
 		/* Pin it! ... and of course release it upon destruction / rescan */
 		PinTupleDesc(scan->columnScanInfo.relationTupleDesc);
-		aocs_initscan(scan);
+		initscan_with_colinfo(scan);
 	}
 
 	natts = slot->tts_tupleDescriptor->natts;

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -1685,10 +1685,15 @@ aoco_estimate_rel_size(Relation rel, int32 *attr_widths,
 					(uint64)fileSegTotals->totalbytesuncompressed);
 
 	UnregisterSnapshot(snapshot);
+	
 	/*
-	 * GPDB_12_MERGE_FIXME: Do not bother scanning the visimap aux table.
-	 * Investigate if really needed
+	 * Do not bother scanning the visimap aux table.
+	 * Investigate if really needed.
+	 * 
+	 * Refer to the comments at the end of function
+	 * appendonly_estimate_rel_size().
 	 */
+
 	return;
 }
 

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -1778,9 +1778,17 @@ appendonly_estimate_rel_size(Relation rel, int32 *attr_widths,
 	UnregisterSnapshot(snapshot);
 
 	/*
-	 * GPDB_12_MERGE_FIXME: Do not bother scanning the visimap aux table.
-	 * Investigate if really needed
+	 * Do not bother scanning the visimap aux table.
+	 * Investigate if really needed.
+	 * 
+	 * For Heap table, visibility map may help to estimate
+	 * the number of page fetches can be avoided during an
+	 * index-only scan. That is not the case for AO/AOCS table
+	 * since index-only scan hasn't been used with AO/AOCS.
+	 * So leave the comment here for future reference once
+	 * we have a clear requirement to do that.
 	 */
+
 	return;
 }
 


### PR DESCRIPTION
This PR contains two following FIXMEs:
- Not scan visimap for AO/AOCS costing
  For Heap table, visibility map may help to estimate
  the number of page fetches can be avoided during an
  index-only scan. That is not the case for AO/AOCS table
  since index-only scan hasn't been used with AO/AOCS.
  So leave the comment here for future reference once
  we have a clear requirement to do that.
- Rename aocs_initscan to initscan_with_colinfo

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
