### PR TITLE
6X: dispatch temporary namespace ID to all Gangs.

### DIFF
--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -3943,6 +3943,7 @@ ResetTempNamespace(void)
 	cancel_before_shmem_exit(RemoveTempRelationsCallback, 0);
 
 	myTempNamespace = InvalidOid;
+	myTempToastNamespace = InvalidOid;
 	myTempNamespaceSubID = InvalidSubTransactionId;
 	baseSearchPathValid = false;	/* need to rebuild list */
 
@@ -4303,6 +4304,45 @@ bool
 TempNamespaceOidIsValid(void)
 {
 	return OidIsValid(myTempNamespace);
+}
+
+
+/*
+ * GetTempNamespaceState - fetch status of session's temporary namespace
+ *
+ * This is used for conveying state to a parallel worker, and is not meant
+ * for general-purpose access.
+ *
+ * GPDB: also used when dispatch MPP query
+ */
+void
+GetTempNamespaceState(Oid *tempNamespaceId, Oid *tempToastNamespaceId)
+{
+	/* Return namespace OIDs, or 0 if session has not created temp namespace */
+	*tempNamespaceId = myTempNamespace;
+	*tempToastNamespaceId = myTempToastNamespace;
+}
+
+/*
+ * GPDB: used to set session level temporary namespace after reader gang launched.
+ */
+void
+SetTempNamespaceStateAfterBoot(Oid tempNamespaceId, Oid tempToastNamespaceId)
+{
+	Assert(Gp_role == GP_ROLE_EXECUTE);
+
+	/* writer gang will do InitTempTableNamespace(), ignore the dispatch on writer gang */
+	if (Gp_is_writer)
+		return;
+
+	/* skip rebuild search path if search path is correct and valid */
+	if (tempNamespaceId == myTempNamespace && myTempToastNamespace == tempToastNamespaceId)
+		return;
+
+	myTempNamespace = tempNamespaceId;
+	myTempToastNamespace = tempToastNamespaceId;
+
+	baseSearchPathValid = false;	/* need to rebuild list */
 }
 
 /*

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -43,6 +43,7 @@
 #include "access/xact.h"
 #include "catalog/oid_dispatch.h"
 #include "catalog/pg_type.h"
+#include "catalog/namespace.h"
 #include "commands/async.h"
 #include "commands/prepare.h"
 #include "commands/extension.h"
@@ -5410,6 +5411,15 @@ PostgresMain(int argc, char *argv[],
 					resgroupInfoLen = pq_getmsgint(&input_message, 4);
 					if (resgroupInfoLen > 0)
 						resgroupInfoBuf = pq_getmsgbytes(&input_message, resgroupInfoLen);
+
+					/* process local variables for temporary namespace */
+					{
+						Oid			tempNamespaceId, tempToastNamespaceId;
+
+						tempNamespaceId = pq_getmsgint(&input_message, sizeof(tempNamespaceId));
+						tempToastNamespaceId = pq_getmsgint(&input_message, sizeof(tempToastNamespaceId));
+						SetTempNamespaceStateAfterBoot(tempNamespaceId, tempToastNamespaceId);
+					}
 
 					pq_getmsgend(&input_message);
 

--- a/src/include/catalog/namespace.h
+++ b/src/include/catalog/namespace.h
@@ -117,6 +117,10 @@ extern void DropTempTableNamespaceForResetSession(Oid namespaceOid);
 extern void SetTempNamespace(Oid namespaceOid, Oid toastNamespaceOid);
 extern Oid  ResetTempNamespace(void);
 extern bool TempNamespaceOidIsValid(void);  /* GPDB only:  used by cdbgang.c */
+extern void GetTempNamespaceState(Oid *tempNamespaceId,
+								  Oid *tempToastNamespaceId);
+extern void SetTempNamespaceStateAfterBoot(Oid tempNamespaceId,
+								  Oid tempToastNamespaceId); /* GPDB only */
 extern void InitTempTableNamespace(void);
 
 extern Oid	LookupCreationNamespace(const char *nspname);

--- a/src/test/regress/expected/bfv_temp.out
+++ b/src/test/regress/expected/bfv_temp.out
@@ -64,3 +64,65 @@ reset role;
 drop table temp_nspnames;
 drop function public.sec_definer_create_test();
 drop role sec_definer_role;
+-- Check if myTempNamespace is correct in N-Gang query.
+create table tn_a(id int) distributed by (id);
+create temp table tn_a_tmp(a int) distributed replicated;
+insert into tn_a values (1), (2);
+insert into tn_a_tmp values(1);
+create or replace function fun(sql text, a oid) returns bigint AS 'return plpy.execute(sql).nrows() + a' language plpythonu stable;
+create table tn_a_new as with c as (select fun('select * from tn_a_tmp', s.id) from tn_a s) select 1 from c;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named '?column?' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+drop table tn_a;
+drop table tn_a_tmp;
+drop table tn_a_new;
+-- Check if old gang can accept new temp schema, after temp schema changed on coordinator
+\c
+create table tn_b_a(id int) distributed by (id);
+create table tn_b_b(id int, a_id int) distributed by (id);
+insert into tn_b_a values (1), (2);
+insert into tn_b_b values (3, 1), (4, 2);
+select a.id, b.id from tn_b_a a, tn_b_b b where a.id = b.a_id order by 1, 2;
+ id | id 
+----+----
+  1 |  3
+  2 |  4
+(2 rows)
+
+create temp table tn_b_temp(a int) distributed replicated;
+insert into tn_b_temp values(1);
+create table tn_b_new as with c as (select fun('select * from tn_b_temp', s.id) from tn_b_b s) select 1 from c;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named '?column?' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+drop table tn_b_a;
+drop table tn_b_b;
+drop table tn_b_temp;
+drop table tn_b_new;
+drop function fun(sql text, a oid);
+-- Chek if error out inside UDF, myTempNamespace will roll back
+\c
+create or replace function errored_udf() returns int[] as 'BEGIN RAISE EXCEPTION ''AAA''; END' language plpgsql;
+create table n as select from generate_series(1, 10);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named '' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select count(*) from n n1, n n2; -- boot reader gang
+ count 
+-------
+   100
+(1 row)
+
+create temp table nn as select errored_udf() from n;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'errored_udf' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ERROR:  AAA  (seg2 slice1 127.0.0.1:6004 pid=350024)
+create temp table nnn as select * from generate_series(1, 10); -- check if reader do the rollback. should OK
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'generate_series' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select count(*) from nnn n1, nnn n2; -- check if reader can read temp table. should OK
+ count 
+-------
+   100
+(1 row)
+
+drop table n;
+drop function errored_udf();


### PR DESCRIPTION
If a query has multiple Gangs, the secondary Gang cannot get the correct temporary namespace ID.

Consider this SQL:

```
    create table tn_a(id int) distributed by (id); insert into tn_a values (1), (2);
    create temp table tn_a_tmp(a int) distributed replicated; insert into tn_a_tmp values(1);

    create or replace function fun(sql text, a oid) returns bigint AS '
        return plpy.execute(sql).nrows() + a
    ' language plpython3u stable;

    create table tn_a_new as with c as (
        select fun('select * from tn_a_tmp', s.id) from tn_a s
    ) select 1 from c;
```

The key is to the reader gang to access temp table via text-sql execute, this can only happen when
UDF executing text SQL and the temp table is replicated.

In this scenario happened. the first `create temp table` will create a
temporary schema then dispatch oid to primary QE. both QD and QE have a
correct `myTempNamespaceID`. when executing the 2-Gang query. the
secondary Gang will boot dynamic with myTempNamespaceID = InvalidOid.

In the end, the secondary Gang scanning on temporary table. will throw a
'table not exist' error without checking temporary schema.

The method to solve this problem is the same as `numsegments` in GPDB.
We re-dispatch the temporary namespace OID in each query. By adding 8 bytes
to be sent in the MPP query message.

Backport from 7X https://github.com/greenplum-db/gpdb/commit/a8c88bcc904aaca9fb0d93d7b5144a8f46e3cf54
