### PR TITLE
docs - new optimizer_enable_orderedagg guc

### DIFF
--- a/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-limitations.xml
+++ b/gpdb-doc/dita/admin_guide/query/topics/query-piv-opt-limitations.xml
@@ -32,7 +32,17 @@
                 partition.</li>
             </ul></li>
           <li>SortMergeJoin (SMJ).</li>
-          <li>Ordered aggregations.</li>
+          <li>Ordered aggregates are not supported by default. You can enable GPORCA
+            support for ordered aggregates with the <codeph><xref
+              href="../../../ref_guide/config_params/guc-list.xml#optimizer_enable_orderedagg"
+              ></xref> server configuration parameter.</li>
+          <li>Grouping sets with ordered aggregates.</li>
+          <li>Multi-argument <codeph>DISTINCT</codeph> qualified aggregates, for example
+              <codeph>SELECT corr(DISTINCT a, b) FROM tbl1;</codeph>, are not supported
+              by default. You can enable GPORCA support for multi-argument distinct
+              aggregates with the <codeph><xref
+              href="../../../ref_guide/config_params/guc-list.xml#optimizer_enable_orderedagg"
+              ></xref> server configuration parameter.</li>
           <li>These analytics extensions:<ul id="ul_iwr_3yl_vp">
               <li>CUBE</li>
               <li>Multiple grouping sets</li>

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -464,6 +464,8 @@
               <xref href="#optimizer_enable_multiple_distinct_aggs" type="section"
                 >optimizer_enable_multiple_distinct_aggs</xref>
             </li>
+            <li><xref href="#optimizer_enable_orderedagg" type="section"
+                >optimizer_enable_orderedagg</xref></li>
             <li>
               <xref href="#optimizer_force_comprehensive_join_implementation" type="section"
                 >optimizer_force_comprehensive_join_implementation</xref>
@@ -7673,6 +7675,41 @@
         planner.</p>
       <p>The parameter can be set for a database system, an individual database, or a session or
         query.</p>
+      <p>For information about GPORCA, see <xref
+          href="../../admin_guide/query/topics/query-piv-optimizer.xml">About GPORCA</xref><ph
+          otherprops="op-print"> in the <cite>Greenplum Database Administrator Guide</cite></ph>. </p>
+      <table id="table_zct_qn1_bpb">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">Boolean</entry>
+              <entry colname="col2">off</entry>
+              <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="optimizer_enable_orderedagg">
+    <title>optimizer_enable_orderedagg</title>
+    <body>
+      <p>When GPORCA is enabled (the default), this parameter determines whether or not
+        GPORCA generates a query plan for ordered aggregates. This parameter is disabled by
+        default; GPORCA does not generate a plan for a query that includes an ordered
+        aggregate, and the query falls back to the Postgres Planner.</p>
+      <p>You can set this parameter for a database system, an individual database,
+        or a session or query.</p>
       <p>For information about GPORCA, see <xref
           href="../../admin_guide/query/topics/query-piv-optimizer.xml">About GPORCA</xref><ph
           otherprops="op-print"> in the <cite>Greenplum Database Administrator Guide</cite></ph>. </p>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -355,6 +355,8 @@
                 >optimizer_enable_master_only_queries</xref></p>
             <p><xref href="guc-list.xml#optimizer_enable_multiple_distinct_aggs" type="section"
               >optimizer_enable_multiple_distinct_aggs</xref></p>
+            <p><xref href="guc-list.xml#optimizer_enable_orderedagg" type="section"
+                >optimizer_enable_orderedagg</xref></p>
             <p><xref href="guc-list.xml#optimizer_force_agg_skew_avoidance" type="section"
                 >optimizer_force_agg_skew_avoidance</xref></p>
             <p><xref href="guc-list.xml#optimizer_force_comprehensive_join_implementation" type="section"

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -240,6 +240,7 @@
             <topicref href="guc-list.xml#optimizer_enable_indexonlyscan"/>
             <topicref href="guc-list.xml#optimizer_enable_master_only_queries"/>
             <topicref href="guc-list.xml#optimizer_enable_multiple_distinct_aggs"/>
+            <topicref href="guc-list.xml#optimizer_enable_orderedagg"/>
             <topicref href="guc-list.xml#optimizer_force_agg_skew_avoidance"/>
             <topicref href="guc-list.xml#optimizer_force_comprehensive_join_implementation"/>
             <topicref href="guc-list.xml#optimizer_force_multistage_agg"/>


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/12992 - gporca supports ordered aggregates and multi-argument distinct aggregates.  in this PR:
- docs for new server configuration parameter optimizer_enable_orderedagg
- updates to the "gporca does not support" topic

(there will be a separate docs PR for master.)
