### PR TITLE
docs - add content for new 6x gp_array_agg module

### DIFF
--- a/gpdb-doc/dita/ref_guide/modules/gp_array_agg.xml
+++ b/gpdb-doc/dita/ref_guide/modules/gp_array_agg.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE dita PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd">
+<dita>
+  <topic id="topic_gpaa">
+    <title>gp_array_agg</title>
+    <body>
+      <p>The <codeph>gp_array_agg</codeph> module introduces a parallel
+        <codeph>array_agg()</codeph> aggregate function that you can use in
+        Greenplum Database.</p>
+      <p>The <codeph>gp_array_agg</codeph> module is a Greenplum Database extension.</p>
+    </body>
+    <topic id="topic_reg">
+      <title>Installing and Registering the Module</title>
+      <body>
+        <p>The <codeph>gp_array_agg</codeph> module is installed when you install
+          Greenplum Database. Before you can use the aggregate function defined in the
+          module, you must register the <codeph>gp_array_agg</codeph> extension in each
+          database where you want to use the function:</p>
+        <codeblock>CREATE EXTENSION gp_array_agg;</codeblock>
+        <p>Refer to <xref href="../../install_guide/install_modules.html"
+            format="html" scope="external">Installing Additional Supplied Modules</xref>
+          for more information.</p>
+      </body>
+    </topic>
+    <topic id="topic_use">
+      <title>Using the Module</title>
+      <body>
+        <p>The <codeph>gp_array_agg()</codeph> function has the following
+          signature:</p>
+        <codeblock>gp_array_agg( anyelement )</codeblock>
+        <p>You can use the function to create an array from input values, including nulls.
+          For example:</p>
+        <codeblock>SELECT gp_array_agg(a) FROM t1;
+   gp_array_agg   
+------------------
+ {2,1,3,NULL,1,2}
+(1 row)</codeblock>
+        <p><codeph>gp_array_agg()</codeph> assigns each input value to an array element,
+          and then returns the array. The function returns null rather than an empty array
+          when there are no input rows.</p>
+        <p><codeph>gp_array_agg()</codeph> produces results that depend on the ordering of
+          the input rows. The ordering is unspecified by default; you can control the
+          ordering by specifying an <codeph>ORDER BY</codeph> clause within the aggregate.
+          For example:</p>
+        <codeblock>CREATE TABLE table1(a int4, b int4);
+INSERT INTO table1 VALUES (4,5), (2,1), (1,3), (3,null), (3,7);
+SELECT gp_array_agg(a ORDER BY b NULLS FIRST) FROM table1;
+  gp_array_agg  
+--------------
+ {3,2,1,4,7}
+(1 row)</codeblock>
+      </body>
+    </topic>
+    <topic id="topic_info">
+      <title>Additional Module Documentation</title>
+      <body>
+        <p>Refer to <xref href="https://www.postgresql.org/docs/9.4/functions-aggregate.html" format="html"
+          scope="external">Aggregate Functions</xref> in the PostgreSQL documentation for
+          more information about aggregates.</p>
+      </body>
+    </topic>
+  </topic>
+</dita>

--- a/gpdb-doc/dita/ref_guide/modules/intro.xml
+++ b/gpdb-doc/dita/ref_guide/modules/intro.xml
@@ -30,6 +30,9 @@
        <li><codeph><xref href="fuzzystrmatch.xml"
              format="dita">fuzzystrmatch</xref></codeph> - Determines similarities and differences
          between strings.</li>
+       <li><codeph><xref href="gp_array_agg.xml" scope="peer"
+             format="dita">gp_array_agg</xref></codeph> - Implements a parallel
+         <codeph>array_agg()</codeph> aggregate function for Greenplum Database.</li>
        <li><codeph><xref href="gp_legacy_string_agg.xml" scope="peer"
              format="dita">gp_legacy_string_agg</xref></codeph> - Implements a
          legacy, single-argument <codeph>string_agg()</codeph> aggregate function that was

--- a/gpdb-doc/dita/ref_guide/modules/modules.ditamap
+++ b/gpdb-doc/dita/ref_guide/modules/modules.ditamap
@@ -9,6 +9,7 @@
     <topicref href="dblink.xml"/>
     <topicref href="diskquota.xml"/>
     <topicref href="fuzzystrmatch.xml"/>
+    <topicref href="gp_array_agg.xml"/>
     <topicref href="gp_legacy_string_agg.xml"/>
     <topicref href="gp_sparse_vector.xml"/>
     <topicref href="hstore.xml"/>

--- a/gpdb-doc/markdown/install_guide/install_modules.html.md
+++ b/gpdb-doc/markdown/install_guide/install_modules.html.md
@@ -32,6 +32,8 @@ You can register the following modules in this manner:
 
               <li class="li"><a class="xref" href="../ref_guide/modules/fuzzystrmatch.html">fuzzystrmatch</a></li>
 
+              <li class="li"><a class="xref" href="../ref_guide/modules/gp_array_agg.html">gp_array_agg</a></li>
+
               <li class="li"><a class="xref" href="../ref_guide/modules/gp_sparse_vector.html">gp_sparse_vector</a></li>
 
             </ul>


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/13168, which introduces a new gp_array_agg aggregate function in a module of the same name.  in this PR:
- doc the new gp_array_agg module that includes the new aggregate function.
- some misc nav updates.

(there will be a separate PR for master, as the new aggregate function is built-in there, not provided in a module.)

doc review site link (behind vpn):  https://docs-lisa-gp_array_agg.sc2-04-pcf1-apps.oc.vmware.com/7-0/ref_guide/modules/gp_array_agg.html
