### PR TITLE
Add ORCA GUC optimizer_enable_nljoin to disable NLJ

### DIFF
--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -344,6 +344,13 @@ CConfigParamMapping::PackConfigParamInBitset(
 		}
 	}
 
+	if (!optimizer_enable_nljoin)
+	{
+		CBitSet *nl_join_bitset = CXform::PbsNLJoinXforms(mp);
+		traceflag_bitset->Union(nl_join_bitset);
+		nl_join_bitset->Release();
+	}
+
 	if (!optimizer_enable_indexjoin)
 	{
 		CBitSet *index_join_bitset = CXform::PbsIndexJoinXforms(mp);

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXform.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXform.h
@@ -309,6 +309,9 @@ public:
 	// equality function over xform ids
 	static BOOL FEqualIds(const CHAR *szIdOne, const CHAR *szIdTwo);
 
+	// returns a set containing all xforms related to nl join
+	// caller takes ownership of the returned set
+	static CBitSet *PbsNLJoinXforms(CMemoryPool *mp);
 
 	// returns a set containing all xforms related to index join
 	// caller takes ownership of the returned set

--- a/src/backend/gporca/libgpopt/src/xforms/CXform.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXform.cpp
@@ -128,6 +128,33 @@ CXform::FEqualIds(const CHAR *szIdOne, const CHAR *szIdTwo)
 
 //---------------------------------------------------------------------------
 //	@function:
+//		CXform::PbsNLJoinXforms
+//
+//	@doc:
+//		Returns a set containing all xforms related to nestloop join.
+//		Caller takes ownership of the returned set
+//
+//---------------------------------------------------------------------------
+CBitSet *
+CXform::PbsNLJoinXforms(CMemoryPool *mp)
+{
+	CBitSet *pbs = GPOS_NEW(mp) CBitSet(mp, EopttraceSentinel);
+	(void) pbs->ExchangeSet(
+		GPOPT_DISABLE_XFORM_TF(CXform::ExfInnerJoin2NLJoin));
+	(void) pbs->ExchangeSet(
+		GPOPT_DISABLE_XFORM_TF(CXform::ExfLeftOuterJoin2NLJoin));
+	(void) pbs->ExchangeSet(
+		GPOPT_DISABLE_XFORM_TF(CXform::ExfLeftSemiJoin2NLJoin));
+	(void) pbs->ExchangeSet(
+		GPOPT_DISABLE_XFORM_TF(CXform::ExfLeftAntiSemiJoin2NLJoin));
+	(void) pbs->ExchangeSet(
+		GPOPT_DISABLE_XFORM_TF(CXform::ExfLeftAntiSemiJoinNotIn2NLJoinNotIn));
+
+	return pbs;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
 //		CXform::PbsIndexJoinXforms
 //
 //	@doc:

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2004,130 +2004,130 @@ struct config_bool ConfigureNamesBool_gp[] =
 		NULL, NULL, NULL
 	},
 	{
-		{"optimizer_enable_nljoin", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_nljoin", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable nested loops join plans in the optimizer."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_nljoin,
 		true,
 		NULL, NULL, NULL
 	},
 	{
-		{"optimizer_enable_indexjoin", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_indexjoin", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable index nested loops join plans in the optimizer."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_indexjoin,
 		true,
 		NULL, NULL, NULL
 	},
 	{
-		{"optimizer_enable_motions_masteronly_queries", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_motions_masteronly_queries", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable plans with Motion operators in the optimizer for queries with no distributed tables."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_motions_masteronly_queries,
 		false,
 		NULL, NULL, NULL
 	},
 	{
-		{"optimizer_enable_motions", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_motions", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable plans with Motion operators in the optimizer."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_motions,
 		true,
 		NULL, NULL, NULL
 	},
 	{
-		{"optimizer_enable_motion_broadcast", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_motion_broadcast", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable plans with Motion Broadcast operators in the optimizer."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_motion_broadcast,
 		true,
 		NULL, NULL, NULL
 	},
 	{
-		{"optimizer_enable_motion_gather", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_motion_gather", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable plans with Motion Gather operators in the optimizer."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_motion_gather,
 		true,
 		NULL, NULL, NULL
 	},
 	{
-		{"optimizer_enable_motion_redistribute", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_motion_redistribute", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable plans with Motion Redistribute operators in the optimizer."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_motion_redistribute,
 		true,
 		NULL, NULL, NULL
 	},
 	{
-		{"optimizer_enable_sort", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_sort", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable plans with Sort operators in the optimizer."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_sort,
 		true,
 		NULL, NULL, NULL
 	},
 	{
-		{"optimizer_enable_materialize", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_materialize", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable plans with Materialize operators in the optimizer."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_materialize,
 		true,
 		NULL, NULL, NULL
 	},
 	{
-		{"optimizer_enable_partition_propagation", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_partition_propagation", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable plans with Partition Propagation operators in the optimizer."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_partition_propagation,
 		true,
 		NULL, NULL, NULL
 	},
 	{
-		{"optimizer_enable_partition_selection", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_partition_selection", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable plans with Partition Selection operators in the optimizer."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_partition_selection,
 		true,
 		NULL, NULL, NULL
 	},
 	{
-		{"optimizer_enable_outerjoin_rewrite", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_outerjoin_rewrite", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable outer join to inner join rewrite in the optimizer."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_outerjoin_rewrite,
 		true,
 		NULL, NULL, NULL
 	},
 	{
-		{"optimizer_enable_direct_dispatch", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_direct_dispatch", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable direct dispatch in the optimizer."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_direct_dispatch,
 		true,
@@ -2146,7 +2146,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"optimizer_enable_space_pruning", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Enable space pruning in the optimizer."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_space_pruning,
 		true,
@@ -2154,10 +2154,10 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"optimizer_enable_master_only_queries", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_master_only_queries", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Process master only queries via the optimizer."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_master_only_queries,
 		false,
@@ -2165,10 +2165,10 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"optimizer_enable_hashjoin", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_hashjoin", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enables the optimizer's use of hash join plans."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_hashjoin,
 		true,
@@ -2176,10 +2176,10 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"optimizer_enable_dynamictablescan", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_dynamictablescan", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enables the optimizer's use of plans with dynamic table scan."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_dynamictablescan,
 		true,
@@ -2187,10 +2187,10 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"optimizer_enable_indexscan", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_indexscan", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enables the optimizer's use of plans with index scan."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_indexscan,
 		true,
@@ -2198,10 +2198,10 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"optimizer_enable_indexonlyscan", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_indexonlyscan", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enables the optimizer's use of plans with index only scan."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_indexonlyscan,
 		true,
@@ -2209,10 +2209,10 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"optimizer_enable_tablescan", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_tablescan", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enables the optimizer's use of plans with table scan."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_tablescan,
 		true,
@@ -2220,10 +2220,10 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"optimizer_enable_hashagg", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_hashagg", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enables Pivotal Optimizer (GPORCA) to use hash aggregates."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_hashagg,
 		true,
@@ -2231,10 +2231,10 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"optimizer_enable_groupagg", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_groupagg", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enables Pivotal Optimizer (GPORCA) to use group aggregates."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_groupagg,
 		true,
@@ -2245,7 +2245,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"optimizer_force_agg_skew_avoidance", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Always pick a plan for aggregate distinct that minimizes skew."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_force_agg_skew_avoidance,
 		true,
@@ -2256,7 +2256,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"optimizer_penalize_skew", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Penalize operators with skewed hash redistribute below it."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_penalize_skew,
 		true,
@@ -2267,7 +2267,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"optimizer_multilevel_partitioning", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Enable optimization of queries on multilevel partitioned tables."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_multilevel_partitioning,
 		true,
@@ -2289,7 +2289,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"optimizer_force_multistage_agg", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Force optimizer to always pick multistage aggregates when such a plan alternative is generated."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_force_multistage_agg,
 		false,
@@ -2297,10 +2297,10 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"optimizer_enable_multiple_distinct_aggs", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_multiple_distinct_aggs", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable plans with multiple distinct aggregates in the optimizer."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_multiple_distinct_aggs,
 		false,
@@ -2311,7 +2311,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"optimizer_force_expanded_distinct_aggs", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Always pick plans that expand multiple distinct aggregates into join of single distinct aggregate in the optimizer."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_force_expanded_distinct_aggs,
 		true,
@@ -2322,7 +2322,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"optimizer_prune_computed_columns", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Prune unused computed columns when pre-processing query"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_prune_computed_columns,
 		true,
@@ -2333,7 +2333,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"optimizer_push_requirements_from_consumer_to_producer", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Optimize CTE producer plan on requirements enforced on top of CTE consumer in the optimizer."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_push_requirements_from_consumer_to_producer,
 		true,
@@ -2341,60 +2341,60 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"optimizer_enable_hashjoin_redistribute_broadcast_children", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_hashjoin_redistribute_broadcast_children", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable hash join plans with, Redistribute outer child and Broadcast inner child, in the optimizer."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_hashjoin_redistribute_broadcast_children,
 		false,
 		NULL, NULL, NULL
 	},
 	{
-		{"optimizer_enable_broadcast_nestloop_outer_child", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_broadcast_nestloop_outer_child", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable nested loops join plans with replicated outer child in the optimizer."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_broadcast_nestloop_outer_child,
 		true,
 		NULL, NULL, NULL
 	},
 	{
-		{"optimizer_expand_fulljoin", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_expand_fulljoin", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enables the optimizer's support of expanding full outer joins using union all."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_expand_fulljoin,
 		false,
 		NULL, NULL, NULL
 	},
 	{
-		{"optimizer_enable_mergejoin", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_mergejoin", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enables the optimizer's support of merge joins."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_mergejoin,
 		true,
 		NULL, NULL, NULL
 	},
 	{
-		{"optimizer_enable_streaming_material", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_streaming_material", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable plans with a streaming material node in the optimizer."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_streaming_material,
 		true,
 		NULL, NULL, NULL
 	},
 	{
-		{"optimizer_enable_gather_on_segment_for_dml", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_gather_on_segment_for_dml", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable DML optimization by enforcing a non-master gather in the optimizer."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_gather_on_segment_for_dml,
 		true,
@@ -2404,17 +2404,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"optimizer_enforce_subplans", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Enforce correlated execution in the optimizer"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enforce_subplans,
 		false,
 		NULL, NULL, NULL
 	},
 	{
-		{"optimizer_enable_assert_maxonerow", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_assert_maxonerow", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable Assert MaxOneRow plans to check number of rows at runtime."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_assert_maxonerow,
 		true,
@@ -2446,7 +2446,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"optimizer_cte_inlining", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Enable CTE inlining"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_cte_inlining,
 		false,
@@ -2467,7 +2467,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"optimizer_analyze_midlevel_partition", PGC_USERSET, STATS_ANALYZE,
 			gettext_noop("Enable statistics collection on intermediate partitions during ANALYZE"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_analyze_midlevel_partition,
 		false,
@@ -2475,10 +2475,10 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"optimizer_enable_constant_expression_evaluation", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_constant_expression_evaluation", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable constant expression evaluation in the optimizer"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_constant_expression_evaluation,
 		true,
@@ -2489,7 +2489,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"optimizer_use_external_constant_expression_evaluation_for_ints", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Use external constant expression evaluation in the optimizer for all integer types"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_use_external_constant_expression_evaluation_for_ints,
 		false,
@@ -2497,10 +2497,10 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"optimizer_enable_bitmapscan", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_bitmapscan", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable bitmap plans in the optimizer"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_bitmapscan,
 		true,
@@ -2508,10 +2508,10 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"optimizer_enable_outerjoin_to_unionall_rewrite", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_outerjoin_to_unionall_rewrite", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable rewriting Left Outer Join to UnionAll"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_outerjoin_to_unionall_rewrite,
 		false,
@@ -2522,7 +2522,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"optimizer_apply_left_outer_to_union_all_disregarding_stats", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Always apply Left Outer Join to Inner Join UnionAll Left Anti Semi Join without looking at stats."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_apply_left_outer_to_union_all_disregarding_stats,
 		false,
@@ -2530,10 +2530,10 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"optimizer_enable_ctas", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_ctas", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable CTAS plans in the optimizer"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_ctas,
 		true,
@@ -2544,7 +2544,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"optimizer_remove_order_below_dml", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Remove OrderBy below a DML operation"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_remove_order_below_dml,
 		false,
@@ -2552,10 +2552,10 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"optimizer_enable_partial_index", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_partial_index", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable heterogeneous index plans."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_partial_index,
 		true,
@@ -2563,10 +2563,10 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"optimizer_enable_dml", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_dml", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable DML plans in Pivotal Optimizer (GPORCA)."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_dml,
 		true,
@@ -2574,10 +2574,10 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"optimizer_enable_dml_constraints", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_dml_constraints", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Support DML with CHECK constraints and NOT NULL constraints."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_dml_constraints,
 		true,
@@ -2794,7 +2794,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"optimizer_enable_eageragg", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Enable Eager Agg transform for pushing aggregate below an innerjoin."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_eageragg,
 		false,
@@ -2805,7 +2805,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"optimizer_prune_unused_columns", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Prune unused table columns during query optimization."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_prune_unused_columns,
 		true,
@@ -2816,7 +2816,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"optimizer_enable_range_predicate_dpe", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Enable range predicates for dynamic partition elimination."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_range_predicate_dpe,
 		false,
@@ -2845,23 +2845,23 @@ struct config_bool ConfigureNamesBool_gp[] =
 
 	{
 		{"optimizer_enable_redistribute_nestloop_loj_inner_child", PGC_USERSET, DEVELOPER_OPTIONS,
-		 gettext_noop("Enable nested loops left join plans with redistributed inner child in the optimizer."),
-		 NULL,
-		 GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		 },
-		 &optimizer_enable_redistribute_nestloop_loj_inner_child,
-		 true,
-		 NULL, NULL, NULL
+			gettext_noop("Enable nested loops left join plans with redistributed inner child in the optimizer."),
+			NULL,
+			GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_enable_redistribute_nestloop_loj_inner_child,
+		true,
+		NULL, NULL, NULL
 	},
 	{
 		{"optimizer_force_comprehensive_join_implementation", PGC_USERSET, QUERY_TUNING_METHOD,
-		 gettext_noop("Explore a nested loop join even if a hash join is possible"),
-		 NULL,
-		 GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		 },
-		 &optimizer_force_comprehensive_join_implementation,
-		 false,
-		 NULL, NULL, NULL
+			gettext_noop("Explore a nested loop join even if a hash join is possible"),
+			NULL,
+			GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_force_comprehensive_join_implementation,
+		false,
+		NULL, NULL, NULL
 	},
 
 	/* End-of-list marker */

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -294,6 +294,7 @@ bool		optimizer_xforms[OPTIMIZER_XFORMS_COUNT] = {[0 ... OPTIMIZER_XFORMS_COUNT 
 char	   *optimizer_search_strategy_path = NULL;
 
 /* GUCs to tell Optimizer to enable a physical operator */
+bool		optimizer_enable_nljoin;
 bool		optimizer_enable_indexjoin;
 bool		optimizer_enable_motions_masteronly_queries;
 bool		optimizer_enable_motions;
@@ -1999,6 +2000,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_dpe_stats,
+		true,
+		NULL, NULL, NULL
+	},
+	{
+		{"optimizer_enable_nljoin", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Enable nested loops join plans in the optimizer."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_enable_nljoin,
 		true,
 		NULL, NULL, NULL
 	},

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -469,6 +469,7 @@ extern bool optimizer_xforms[OPTIMIZER_XFORMS_COUNT];
 extern char *optimizer_search_strategy_path;
 
 /* GUCs to tell Optimizer to enable a physical operator */
+extern bool optimizer_enable_nljoin;
 extern bool optimizer_enable_indexjoin;
 extern bool optimizer_enable_motions_masteronly_queries;
 extern bool optimizer_enable_motions;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -378,6 +378,7 @@
 		"optimizer_enable_hashagg",
 		"optimizer_enable_hashjoin",
 		"optimizer_enable_hashjoin_redistribute_broadcast_children",
+		"optimizer_enable_nljoin",
 		"optimizer_enable_indexjoin",
 		"optimizer_enable_indexscan",
 		"optimizer_enable_indexonlyscan",

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -3349,6 +3349,36 @@ EXPLAIN SELECT a, b FROM gp_float1 JOIN gp_float2 ON a = c AND b = float8 '3.0' 
  Optimizer: Postgres query optimizer
 (10 rows)
 
+-- Testing optimizer_enable_nljoin
+SET optimizer_enable_hashjoin=off;
+SET optimizer_enable_nljoin=off;
+EXPLAIN SELECT * FROM t1 JOIN t2 ON t1.a=t2.a;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=679.75..227587.25 rows=7413210 width=16)
+   ->  Hash Join  (cost=679.75..128744.45 rows=2471070 width=16)
+         Hash Cond: (t1.a = t2.a)
+         ->  Seq Scan on t1  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
+               ->  Seq Scan on t2  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+SET optimizer_enable_nljoin=on;
+EXPLAIN SELECT * FROM t1 JOIN t2 ON t1.a=t2.a;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=679.75..227587.25 rows=7413210 width=16)
+   ->  Hash Join  (cost=679.75..128744.45 rows=2471070 width=16)
+         Hash Cond: (t1.a = t2.a)
+         ->  Seq Scan on t1  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
+               ->  Seq Scan on t2  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+RESET optimizer_enable_hashjoin;
+RESET optimizer_enable_nljoin;
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -3345,6 +3345,35 @@ EXPLAIN SELECT a, b FROM gp_float1 JOIN gp_float2 ON a = c AND b = float8 '3.0' 
  Optimizer: Postgres query optimizer
 (10 rows)
 
+-- Testing optimizer_enable_nljoin
+SET optimizer_enable_hashjoin=off;
+SET optimizer_enable_nljoin=off;
+EXPLAIN SELECT * FROM t1 JOIN t2 ON t1.a=t2.a;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=679.75..227587.25 rows=7413210 width=16)
+   ->  Hash Join  (cost=679.75..128744.45 rows=2471070 width=16)
+         Hash Cond: (t1.a = t2.a)
+         ->  Seq Scan on t1  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
+               ->  Seq Scan on t2  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+SET optimizer_enable_nljoin=on;
+EXPLAIN SELECT * FROM t1 JOIN t2 ON t1.a=t2.a;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.35 rows=1 width=16)
+   ->  Nested Loop  (cost=0.00..1324032.35 rows=1 width=16)
+         Join Filter: (t1.a = t2.a)
+         ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=8)
+         ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
+RESET optimizer_enable_hashjoin;
+RESET optimizer_enable_nljoin;
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';

--- a/src/test/regress/sql/bfv_joins.sql
+++ b/src/test/regress/sql/bfv_joins.sql
@@ -347,6 +347,17 @@ EXPLAIN SELECT a, b FROM gp_float1 JOIN gp_float2 ON a = c AND b = float8 '3.0';
 -- redistribute based on the compatible constant.
 EXPLAIN SELECT a, b FROM gp_float1 JOIN gp_float2 ON a = c AND b = float8 '3.0' AND b = float4 '3.0';
 
+-- Testing optimizer_enable_nljoin
+SET optimizer_enable_hashjoin=off;
+SET optimizer_enable_nljoin=off;
+EXPLAIN SELECT * FROM t1 JOIN t2 ON t1.a=t2.a;
+
+SET optimizer_enable_nljoin=on;
+EXPLAIN SELECT * FROM t1 JOIN t2 ON t1.a=t2.a;
+
+RESET optimizer_enable_hashjoin;
+RESET optimizer_enable_nljoin;
+
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';


### PR DESCRIPTION
Use optimizer_enable_nljoin to disable all xforms that produce nestloop
join alternatives.

Co-authored-by: Orhan Kislal <okislal@vmware.com>
