### PR TITLE
Remove overload raise function with severity_level

### DIFF
--- a/src/backend/gporca/libgpos/include/gpos/error/CException.h
+++ b/src/backend/gporca/libgpos/include/gpos/error/CException.h
@@ -271,11 +271,6 @@ public:
 	static void Raise(const CHAR *filename, ULONG line, ULONG major,
 					  ULONG minor, ...) __attribute__((__noreturn__));
 
-	// wrapper around throw with severity level
-	static void Raise(const CHAR *filename, ULONG line, ULONG major,
-					  ULONG minor, ULONG severity_level, ...)
-		__attribute__((__noreturn__));
-
 	// rethrow wrapper
 	static void Reraise(CException exc, BOOL propagate = false)
 		__attribute__((__noreturn__));

--- a/src/backend/gporca/libgpos/src/error/CException.cpp
+++ b/src/backend/gporca/libgpos/src/error/CException.cpp
@@ -123,33 +123,6 @@ CException::Raise(const CHAR *filename, ULONG line, ULONG major, ULONG minor,
 }
 
 
-void
-CException::Raise(const CHAR *filename, ULONG line, ULONG major, ULONG minor,
-				  ULONG severity_level...)
-{
-	// manufacture actual exception object
-	CException exc(major, minor, filename, line, severity_level);
-
-	// during bootstrap there's no context object otherwise, record
-	// all details in the context object
-	if (nullptr != ITask::Self())
-	{
-		CErrorContext *err_ctxt = CTask::Self()->ConvertErrCtxt();
-
-		VA_LIST va_list;
-		VA_START(va_list, severity_level);
-
-		err_ctxt->Record(exc, va_list);
-
-		VA_END(va_list);
-
-		err_ctxt->Serialize();
-	}
-
-	Raise(exc);
-}
-
-
 //---------------------------------------------------------------------------
 //	@function:
 //		CException::Reraise


### PR DESCRIPTION
Issue is that with the overload we cannot properly raise while passing a
variadic integer argument. Instead it will interpret the arguemnt as
severity_level. This leads to bogus error messages that don't make sense
like:

"Attribute number 23761064 not found in project list"
