### PR TITLE
Dispatch temporary tablespace id to all Gangs.

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -26,6 +26,7 @@
 #include "cdb/cdbmutate.h"
 #include "cdb/cdbsrlz.h"
 #include "cdb/tupleremap.h"
+#include "catalog/namespace.h" /* for GetTempNamespaceState() */
 #include "nodes/execnodes.h"
 #include "pgstat.h"
 #include "tcop/tcopprot.h"
@@ -866,6 +867,7 @@ buildGpQueryString(DispatchCommandQueryParms *pQueryParms,
 	Oid			currentUserId = GetUserId();
 	int32		numsegments = getgpsegmentCount();
 	StringInfoData resgroupInfo;
+	Oid			tempNamespaceId, tempToastNamespaceId;
 
 	int			tmp,
 				len;
@@ -917,7 +919,10 @@ buildGpQueryString(DispatchCommandQueryParms *pQueryParms,
 		sddesc_len +
 		sizeof(numsegments) +
 		sizeof(resgroupInfo.len) +
-		resgroupInfo.len;
+		resgroupInfo.len +
+		sizeof(tempNamespaceId) +
+		sizeof(tempToastNamespaceId) +
+		0;
 
 	shared_query = palloc(total_query_len);
 
@@ -1012,11 +1017,20 @@ buildGpQueryString(DispatchCommandQueryParms *pQueryParms,
 		pos += resgroupInfo.len;
 	}
 
-	len = pos - shared_query - 1;
+	/* in-process variable for temporary namespace */
+	GetTempNamespaceState(&tempNamespaceId, &tempToastNamespaceId);
+	tempNamespaceId = htonl(tempNamespaceId);
+	tempToastNamespaceId = htonl(tempToastNamespaceId);
+
+	memcpy(pos, &tempNamespaceId, sizeof(tempNamespaceId));
+	pos += sizeof(tempNamespaceId);
+	memcpy(pos, &tempToastNamespaceId, sizeof(tempToastNamespaceId));
+	pos += sizeof(tempToastNamespaceId);
 
 	/*
 	 * fill in length placeholder
 	 */
+	len = pos - shared_query - 1;
 	tmp = htonl(len);
 	memcpy(shared_query + 1, &tmp, sizeof(len));
 

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -43,6 +43,7 @@
 #include "access/xact.h"
 #include "catalog/oid_dispatch.h"
 #include "catalog/pg_type.h"
+#include "catalog/namespace.h"
 #include "commands/async.h"
 #include "commands/prepare.h"
 #include "commands/extension.h"
@@ -5403,6 +5404,15 @@ PostgresMain(int argc, char *argv[],
 					resgroupInfoLen = pq_getmsgint(&input_message, 4);
 					if (resgroupInfoLen > 0)
 						resgroupInfoBuf = pq_getmsgbytes(&input_message, resgroupInfoLen);
+
+					/* in-process variable for temporary namespace */
+					{
+						Oid			tempNamespaceId, tempToastNamespaceId;
+
+						tempNamespaceId = pq_getmsgint(&input_message, sizeof(tempNamespaceId));
+						tempToastNamespaceId = pq_getmsgint(&input_message, sizeof(tempToastNamespaceId));
+						SetTempNamespaceStateAfterBoot(tempNamespaceId, tempToastNamespaceId);
+					}
 
 					pq_getmsgend(&input_message);
 

--- a/src/include/catalog/namespace.h
+++ b/src/include/catalog/namespace.h
@@ -149,6 +149,8 @@ extern void GetTempNamespaceState(Oid *tempNamespaceId,
 								  Oid *tempToastNamespaceId);
 extern void SetTempNamespaceState(Oid tempNamespaceId,
 								  Oid tempToastNamespaceId);
+extern void SetTempNamespaceStateAfterBoot(Oid tempNamespaceId,
+								  Oid tempToastNamespaceId); /* GPDB only */
 extern void ResetTempTableNamespace(void);
 
 extern OverrideSearchPath *GetOverrideSearchPath(MemoryContext context);

--- a/src/test/regress/expected/bfv_temp.out
+++ b/src/test/regress/expected/bfv_temp.out
@@ -64,3 +64,38 @@ reset role;
 drop table temp_nspnames;
 drop function public.sec_definer_create_test();
 drop role sec_definer_role;
+-- Check if myTempNamespace is correct in N-Gang query.
+create table tn_a(id int) distributed by (id);
+create temp table tn_a_tmp(a int) distributed replicated;
+insert into tn_a values (1), (2);
+insert into tn_a_tmp values(1);
+create or replace function fun(sql text, a oid) returns bigint AS 'return plpy.execute(sql).nrows() + a' language plpython3u stable;
+create table tn_a_new as with c as (select fun('select * from tn_a_tmp', s.id) from tn_a s) select 1 from c;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named '?column?' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+drop table tn_a;
+drop table tn_a_tmp;
+drop table tn_a_new;
+-- Check if old gang can accept new temp schema, after temp schema changed on coordinator
+\c
+create table tn_b_a(id int) distributed by (id);
+create table tn_b_b(id int, a_id int) distributed by (id);
+insert into tn_b_a values (1), (2);
+insert into tn_b_b values (3, 1), (4, 2);
+select a.id, b.id from tn_b_a a, tn_b_b b where a.id = b.a_id order by 1, 2;
+ id | id 
+----+----
+  1 |  3
+  2 |  4
+(2 rows)
+
+create temp table tn_b_temp(a int) distributed replicated;
+insert into tn_b_temp values(1);
+create table tn_b_new as with c as (select fun('select * from tn_b_temp', s.id) from tn_b_b s) select 1 from c;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named '?column?' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+drop table tn_b_a;
+drop table tn_b_b;
+drop table tn_b_temp;
+drop table tn_b_new;
+drop function fun(sql text, a oid);

--- a/src/test/regress/expected/guc.out
+++ b/src/test/regress/expected/guc.out
@@ -823,13 +823,6 @@ END;
 $$ LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = n1, pg_temp;
--- Destroy the QD-QE libpq connections.
-select cleanupAllGangs();
- cleanupallgangs 
------------------
- t
-(1 row)
-
 select n1.drop_table('public','t1');
 NOTICE:  table "t1" does not exist, skipping
  drop_table 

--- a/src/test/regress/sql/guc.sql
+++ b/src/test/regress/sql/guc.sql
@@ -317,9 +317,6 @@ $$ LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = n1, pg_temp;
 
--- Destroy the QD-QE libpq connections.
-select cleanupAllGangs();
-
 select n1.drop_table('public','t1');
 
 -- After funtion drop table, public schema is still in search_path


### PR DESCRIPTION
Dispatch temporary tablespace id to all Gangs.

If a query has multiple Gangs, the secondary Gang cannot get correct temporary tablespace ID.

Consider this SQL:

```
    create table tn_a(id int) distributed by (id); insert into tn_a values (1), (2);
    create temp table tn_a_tmp(a int) distributed replicated; insert into tn_a_tmp values(1);

    create or replace function fun(sql text, a oid) returns bigint AS '
        return plpy.execute(sql).nrows() + a
    ' language plpython3u stable;

    create table tn_a_new as with c as (
        select fun('select * from tn_a_tmp', s.id) from tn_a s
    ) select 1 from c;
```

The key to reproducing this bug is forcing the secondary Gang to scan on temp
table which normally won't happen. to reach that, the test case uses SPI to
scan on replicated table.

In this scenario. the first `create temp table` will create a
temporary schema then dispatch to primary QE. both QD and QE have a
correct myTempNamespaceID. when executing the 2-Gang query. the
secondary Gang will boot dynamically with myTempNamespaceID = InvalidOid.

In the end, the secondary Gang scaning on temporary table. will throw a
'table not exist' error without checking temporary schema.

The basic idea to solve this problem comes from parallel worker on PG.
The life cycle of the parallel worker is basically the same as our Gang.

This patch did these changes:

When booting Gang: copy coordinator's temp tablespace ID.
When creating temp schema: dispatch new tablespace id to primary Gang,
                           plug out other Gangs.
Other logic such as cleaning temp tablespace is not changed.
