### PR TITLE
Fix planner bug: correctly handling NULL when pulling-up NOT-IN.

### DIFF
--- a/src/test/regress/expected/notin.out
+++ b/src/test/regress/expected/notin.out
@@ -1436,9 +1436,48 @@ select * from t1_12930 where (a, b) not in (select a, b from t2_12930) and b is 
 ---+---
 (0 rows)
 
+-- test for issue https://github.com/greenplum-db/gpdb/issues/13212
+create table t1_13212(a int not null, b int not null);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t2_13212(a int not null, b int not null);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+explain (costs off)  select 1 from t1_13212 where (NULL, b) not in (select a, b from t2_13212);
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop Left Anti Semi (Not-In) Join
+         Join Filter: ((t1_13212.b = t2_13212.b) AND NULL::boolean)
+         ->  Seq Scan on t1_13212
+         ->  Materialize
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     ->  Seq Scan on t2_13212
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select 1 from t1_13212 where (NULL, b) not in (select a, b from t2_13212);
+ ?column? 
+----------
+(0 rows)
+
+insert into t1_13212 values (1, 1);
+insert into t2_13212 values (1, 1);
+select 1 from t1_13212 where (NULL, b) not in (select a, b from t2_13212);
+ ?column? 
+----------
+(0 rows)
+
+update t2_13212 set b = 2;
+select 1 from t1_13212 where (NULL, b) not in (select a, b from t2_13212);
+ ?column? 
+----------
+        1
+(1 row)
+
 reset search_path;
 drop schema notin cascade;
-NOTICE:  drop cascades to 18 other objects
+NOTICE:  drop cascades to 20 other objects
 DETAIL:  drop cascades to table notin.t1
 drop cascades to table notin.t2
 drop cascades to table notin.t3
@@ -1457,3 +1496,5 @@ drop cascades to table notin.table_source4
 drop cascades to table notin.table_config
 drop cascades to table notin.t1_12930
 drop cascades to table notin.t2_12930
+drop cascades to table notin.t1_13212
+drop cascades to table notin.t2_13212

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -1480,9 +1480,48 @@ select * from t1_12930 where (a, b) not in (select a, b from t2_12930) and b is 
 ---+---
 (0 rows)
 
+-- test for issue https://github.com/greenplum-db/gpdb/issues/13212
+create table t1_13212(a int not null, b int not null);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t2_13212(a int not null, b int not null);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+explain (costs off)  select 1 from t1_13212 where (NULL, b) not in (select a, b from t2_13212);
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop Left Anti Semi (Not-In) Join
+         Join Filter: ((t1_13212.b = t2_13212.b) AND NULL::boolean)
+         ->  Seq Scan on t1_13212
+         ->  Materialize
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     ->  Seq Scan on t2_13212
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select 1 from t1_13212 where (NULL, b) not in (select a, b from t2_13212);
+ ?column? 
+----------
+(0 rows)
+
+insert into t1_13212 values (1, 1);
+insert into t2_13212 values (1, 1);
+select 1 from t1_13212 where (NULL, b) not in (select a, b from t2_13212);
+ ?column? 
+----------
+(0 rows)
+
+update t2_13212 set b = 2;
+select 1 from t1_13212 where (NULL, b) not in (select a, b from t2_13212);
+ ?column? 
+----------
+        1
+(1 row)
+
 reset search_path;
 drop schema notin cascade;
-NOTICE:  drop cascades to 18 other objects
+NOTICE:  drop cascades to 20 other objects
 DETAIL:  drop cascades to table notin.t1
 drop cascades to table notin.t2
 drop cascades to table notin.t3
@@ -1501,3 +1540,5 @@ drop cascades to table notin.table_source4
 drop cascades to table notin.table_config
 drop cascades to table notin.t1_12930
 drop cascades to table notin.t2_12930
+drop cascades to table notin.t1_13212
+drop cascades to table notin.t2_13212

--- a/src/test/regress/sql/notin.sql
+++ b/src/test/regress/sql/notin.sql
@@ -475,5 +475,16 @@ select * from t1_12930 where (a, b) not in (select a, b from t2_12930);
 explain select * from t1_12930 where (a, b) not in (select a, b from t2_12930) and b is not null;
 select * from t1_12930 where (a, b) not in (select a, b from t2_12930) and b is not null;
 
+-- test for issue https://github.com/greenplum-db/gpdb/issues/13212
+create table t1_13212(a int not null, b int not null);
+create table t2_13212(a int not null, b int not null);
+explain (costs off)  select 1 from t1_13212 where (NULL, b) not in (select a, b from t2_13212);
+select 1 from t1_13212 where (NULL, b) not in (select a, b from t2_13212);
+insert into t1_13212 values (1, 1);
+insert into t2_13212 values (1, 1);
+select 1 from t1_13212 where (NULL, b) not in (select a, b from t2_13212);
+update t2_13212 set b = 2;
+select 1 from t1_13212 where (NULL, b) not in (select a, b from t2_13212);
+
 reset search_path;
 drop schema notin cascade;


### PR DESCRIPTION
Greenplum will pull up not-in sublink to a specific join LASJ,
this kind of join's joinqual might contain a NULL const here,
for such case we do not need to split it. A case that can
reach here is:

  create table t1(a int not null, b int not null);
  create table t2(a int not null, b int not null);
  explain  select 1 from t1 where (NULL, b) not in (select a, b from t2);

The above SQL in Greenplum will be turned in a join whose qual contains
a bool expr (NULL = t2.a) and (t1.b = t2.b), this piece of expr will be
evaluated to (t1.b = t2.b) and NULL by the following code path:
  subquery_planner
    -> preprocess_qual_conditions(root, (Node *) parse->jointree)
    -> preprocess_expression
    -> eval_const_expressions
    -> eval_const_expressions_mutator

So in splitJoinQualExpr, we should expect a null const in LASJ's
qual's bool expr's arg.

Fix Issue: https://github.com/greenplum-db/gpdb/issues/13212