### PR TITLE
Fallback to planner for functions returning composite types

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -3623,7 +3623,7 @@ CTranslatorQueryToDXL::TranslateTVFToDXL(const RangeTblEntry *rte,
 		if (gpdb::IsCompositeType(funcTypeOid))
 		{
 			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
-					   GPOS_WSZ_LIT("Whole-row variable"));
+					   GPOS_WSZ_LIT("Row-type variable"));
 		}
 
 		CDXLNode *const_tbl_get_dxlnode = DXLDummyConstTableGet();

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -3619,6 +3619,12 @@ CTranslatorQueryToDXL::TranslateTVFToDXL(const RangeTblEntry *rte,
 	// if this is a folded function expression, generate a project over a CTG
 	if (!IsA(funcexpr, FuncExpr))
 	{
+		if (gpdb::IsCompositeType(funcexpr->funcid))
+		{
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
+					   GPOS_WSZ_LIT("Whole-row variable"));
+		}
+
 		CDXLNode *const_tbl_get_dxlnode = DXLDummyConstTableGet();
 
 		CDXLNode *project_list_dxlnode = GPOS_NEW(m_mp)

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -3619,7 +3619,8 @@ CTranslatorQueryToDXL::TranslateTVFToDXL(const RangeTblEntry *rte,
 	// if this is a folded function expression, generate a project over a CTG
 	if (!IsA(funcexpr, FuncExpr))
 	{
-		if (gpdb::IsCompositeType(funcexpr->funcid))
+		Oid funcTypeOid = gpdb::ExprType(rtfunc->funcexpr);
+		if (gpdb::IsCompositeType(funcTypeOid))
 		{
 			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
 					   GPOS_WSZ_LIT("Whole-row variable"));

--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -186,7 +186,7 @@ CTranslatorScalarToDXL::TranslateVarToDXL(
 	if (var->varattno == 0)
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
-				   GPOS_WSZ_LIT("Whole-row variable"));
+				   GPOS_WSZ_LIT("Row-type variable"));
 	}
 
 	// column name

--- a/src/test/regress/expected/qp_orca_fallback.out
+++ b/src/test/regress/expected/qp_orca_fallback.out
@@ -247,3 +247,12 @@ explain select count(*) from foo group by a;
  Optimizer: Postgres query optimizer
 (5 rows)
 
+-- Orca should fallback for functions returning composite types
+create type compType as (a int, b int);
+create function myfunc5() returns compType IMMUTABLE as $$ select 2,3 $$ language sql;
+select a from myfunc5();
+ a 
+---
+ 2
+(1 row)
+

--- a/src/test/regress/expected/qp_orca_fallback_optimizer.out
+++ b/src/test/regress/expected/qp_orca_fallback_optimizer.out
@@ -295,3 +295,14 @@ DETAIL:  No plan has been computed for required properties
  Optimizer: Postgres query optimizer
 (5 rows)
 
+-- Orca should fallback for functions returning composite types
+create type compType as (a int, b int);
+create function myfunc5() returns compType IMMUTABLE as $$ select 2,3 $$ language sql;
+select a from myfunc5();
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Whole-row variable
+ a 
+---
+ 2
+(1 row)
+

--- a/src/test/regress/expected/qp_orca_fallback_optimizer.out
+++ b/src/test/regress/expected/qp_orca_fallback_optimizer.out
@@ -300,7 +300,7 @@ create type compType as (a int, b int);
 create function myfunc5() returns compType IMMUTABLE as $$ select 2,3 $$ language sql;
 select a from myfunc5();
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Whole-row variable
+DETAIL:  Feature not supported: Row-type variable
  a 
 ---
  2

--- a/src/test/regress/sql/qp_orca_fallback.sql
+++ b/src/test/regress/sql/qp_orca_fallback.sql
@@ -101,3 +101,8 @@ explain select count(*) from foo group by a;
 set optimizer_enable_hashagg = off;
 set optimizer_enable_groupagg = off;
 explain select count(*) from foo group by a;
+
+-- Orca should fallback for functions returning composite types
+create type compType as (a int, b int);
+create function myfunc5() returns compType IMMUTABLE as $$ select 2,3 $$ language sql;
+select a from myfunc5();


### PR DESCRIPTION
Orca doesn't support composite types (also called "whole-row
variables"). While we have a fallback when we project
composite type, we missed the case for functions returning
composite types, which led to wrong results.

This fallback was already added to the master branch during the
PG12 merge. We are also looking at adding support for composite 
types to Orca, but let's fix the wrong results here first.