### PR TITLE
Resolve GPDB_12_MERGE_FIXME: taken almost verbadim from appendonly_va…

### DIFF
--- a/src/backend/commands/vacuum_ao.c
+++ b/src/backend/commands/vacuum_ao.c
@@ -748,8 +748,6 @@ vacuum_appendonly_fill_stats(Relation aorel, Snapshot snapshot, int elevel,
 }
 
 /*
- * GPDB_12_MERGE_FIXME: taken almost verbadim from appendonly_vacuum.c, verify
- *
  *	scan_index() -- scan one index relation to update pg_class statistics.
  *
  * We use this when we have no deletions to do.
@@ -761,7 +759,6 @@ scan_index(Relation indrel, double num_tuples,
 	IndexBulkDeleteResult *stats;
 	IndexVacuumInfo ivinfo;
 	PGRUsage	ru0;
-	BlockNumber relallvisible;
 
 	pg_rusage_init(&ru0);
 
@@ -777,11 +774,6 @@ scan_index(Relation indrel, double num_tuples,
 	if (!stats)
 		return;
 
-	if (RelationIsAppendOptimized(indrel))
-		relallvisible = 0;
-	else
-		visibilitymap_count(indrel, &relallvisible, NULL);
-
 	/*
 	 * Now update statistics in pg_class, but only if the index says the count
 	 * is accurate.
@@ -789,7 +781,7 @@ scan_index(Relation indrel, double num_tuples,
 	if (!stats->estimated_count)
 		vac_update_relstats(indrel,
 							stats->num_pages, stats->num_index_tuples,
-							relallvisible,
+							0, /* relallvisible, don't bother for indexes */
 							false,
 							InvalidTransactionId,
 							InvalidMultiXactId,


### PR DESCRIPTION
…cuum.c, verify

Correct the code to ignore relallvisible for updating index
statistic during vacuum. 'relallvisible' is a pg_class attribute
that denotes the number of visbile pages in table's visibility map.
It is a statistical indicator for tables, not for indexes.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community

No test was added for this change due to no existing behavior changes.
