### PR TITLE
[6X] gpstate -e: Changes to avoid fatal message on primary segments

### DIFF
--- a/gpMgmt/sbin/gpgetstatususingtransition.py
+++ b/gpMgmt/sbin/gpgetstatususingtransition.py
@@ -36,7 +36,7 @@ POSTMASTER_MIRROR_VERSION_DETAIL_MSG = "- VERSION:"
 
 def _get_segment_status(segment):
     cmd = base.Command('pg_isready for segment',
-                       "pg_isready -q -h %s -p %d -d %s" % (segment.hostname, segment.port, gp.PGDATABASE_FOR_COMMON_USE))
+                       "PGOPTIONS=\"-c gp_session_role=utility\" pg_isready -q -h %s -p %d -d %s" % (segment.hostname, segment.port, gp.PGDATABASE_FOR_COMMON_USE))
     cmd.run()
 
     rc = cmd.get_return_code()

--- a/gpMgmt/test/behave/mgmt_utils/gpstate.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstate.feature
@@ -553,6 +553,14 @@ Feature: gpstate tests
         Then command should print "pg_isready -q -h .* -p .* -d postgres" to stdout
         And command should print "All segments are running normally" to stdout
 
+    Scenario: gpstate -e -v logs no fatal message in pg_log files on primary segments
+        Given a standard local demo cluster is running
+        And the user records the current timestamp in log_timestamp table
+        And the user runs command "gpstate -e -v"
+        Then command should print "PGOPTIONS=\"-c gp_session_role=utility\" pg_isready -q -h .* -p .* -d postgres" to stdout
+        And the pg_log files on primary segments should not contain "connections to primary segments are not allowed"
+        And the user drops log_timestamp table
+
 
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -717,6 +717,41 @@ def impl(context, command, out_msg, num):
     if count != int(num):
         raise Exception("Expected %s to occur %s times. Found %d. stdout: %s" % (out_msg, num, count, msg_list))
 
+@given('the user records the current timestamp in log_timestamp table')
+@when('the user records the current timestamp in log_timestamp table')
+@then('the user records the current timestamp in log_timestamp table')
+def impl(context):
+    sql = "CREATE TABLE log_timestamp AS SELECT CURRENT_TIMESTAMP;"
+    rc, output, error = run_cmd("psql -d template1 -c \'%s\'" %sql)
+    if rc:
+        raise Exception(error)
+
+
+@then('the user drops log_timestamp table')
+def impl(context):
+    rc, output, error = run_cmd("psql -d template1 -c \"DROP TABLE log_timestamp;\"")
+    if rc:
+        raise Exception(error)
+
+@then('the pg_log files on primary segments should not contain "{msg}"')
+def impl(context, msg):
+
+    gparray = GpArray.initFromCatalog(dbconn.DbURL())
+    segments = gparray.getDbList()
+    conn = dbconn.connect(dbconn.DbURL(dbname='template1'), unsetSearchPath=False)
+
+    for seg in segments:
+        if seg.isSegmentPrimary():
+            segname = "seg"+str(seg.content)
+            sql = "select * from gp_toolkit.__gp_log_segment_ext where logsegment='%s' and logtime > (select * from log_timestamp) and logmessage like '%s'" %(segname, msg)
+            try:
+                cursor = dbconn.query(conn, sql)
+                if cursor.fetchone():
+                    raise Exception("Fatal message exists in pg_log file on primary segment %s" %segname)
+            finally:
+                pass
+    conn.close()
+
 
 def lines_matching_both(in_str, str_1, str_2):
     lines = [x.strip() for x in in_str.split('\n')]

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -745,7 +745,7 @@ def impl(context, msg):
             segname = "seg"+str(seg.content)
             sql = "select * from gp_toolkit.__gp_log_segment_ext where logsegment='%s' and logtime > (select * from log_timestamp) and logmessage like '%s'" %(segname, msg)
             try:
-                cursor = dbconn.query(conn, sql)
+                cursor = dbconn.execSQL(conn, sql)
                 if cursor.fetchone():
                     raise Exception("Fatal message exists in pg_log file on primary segment %s" %segname)
             finally:


### PR DESCRIPTION
pg_isready was generating fatal message on primary segments to use utiltily mode for direct connections to primary segments. Included PGOPTIONS="-c gp_role=utility" with pg_isready command to avoid the fatal message.

Added behave test case for above scenario.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
