### PR TITLE
Wiped out fake "Failed to kill processes for segment" message on gpst…

### DIFF
--- a/gpMgmt/bin/gppylib/commands/pg.py
+++ b/gpMgmt/bin/gppylib/commands/pg.py
@@ -66,15 +66,15 @@ class ReadPostmasterTempFile(Command):
             raise ExecutionError("Command did not complete successfully rc: %d" % self.results.rc, self)   
     
     def getResults(self):
-        if self.results.stderr.find("No such file or directory") != -1:
+        if self.results.rc != 0:
             return (False,-1,None)
         if self.results.stdout is None:
-            return (False,-2,None)
+            return (False,-1,None)
         
         lines = self.results.stdout.split()
         
         if len(lines) < 2:
-            return (False,-3,None)
+            return (False,-1,None)
         
         PID=int(self.results.stdout.split()[0])
         datadir = self.results.stdout.split()[1]


### PR DESCRIPTION
Wiped out fake "Failed to kill processes for segment" message on gpstop command

# Bug

`gpstop` command shows a fake `ERROR` message when the language of a Linux system is not English (such as Chinese).
But actually no errors occurred during the execution of the command.
Test case:

```bash
[fairyfar@bogon gpdb]$ echo $LANG
zh_CN.UTF-8
[fairyfar@bogon gpdb]$ gpstop -a
20220311:15:38:39:014634 gpstop:bogon:fairyfar-[INFO]:-Starting gpstop with args: -a
20220311:15:38:39:014634 gpstop:bogon:fairyfar-[INFO]:-Gathering information and validating the environment...
20220311:15:38:39:014634 gpstop:bogon:fairyfar-[INFO]:-Obtaining Greenplum Coordinator catalog information
20220311:15:38:39:014634 gpstop:bogon:fairyfar-[INFO]:-Obtaining Segment details from coordinator...
20220311:15:38:39:014634 gpstop:bogon:fairyfar-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.14958.gd673b309ce build dev'
20220311:15:38:39:014634 gpstop:bogon:fairyfar-[INFO]:-Commencing Coordinator instance shutdown with mode='smart'
20220311:15:38:39:014634 gpstop:bogon:fairyfar-[INFO]:-Coordinator segment instance directory=/home/fairyfar/gpdb/db/coordinator/gpseg-1
20220311:15:38:39:014634 gpstop:bogon:fairyfar-[INFO]:-Stopping coordinator segment and waiting for user connections to finish ...
server shutting down
20220311:15:38:40:014634 gpstop:bogon:fairyfar-[INFO]:-Attempting forceful termination of any leftover coordinator process
20220311:15:38:40:014634 gpstop:bogon:fairyfar-[INFO]:-Terminating processes for segment /home/fairyfar/gpdb/db/coordinator/gpseg-1
20220311:15:38:40:014634 gpstop:bogon:fairyfar-[ERROR]:-Failed to kill processes for segment /home/fairyfar/gpdb/db/coordinator/gpseg-1: ([Errno 3] No such process)
20220311:15:38:40:014634 gpstop:bogon:fairyfar-[INFO]:-No standby coordinator host configured
20220311:15:38:40:014634 gpstop:bogon:fairyfar-[INFO]:-Targeting dbid [2, 3] for shutdown
20220311:15:38:40:014634 gpstop:bogon:fairyfar-[INFO]:-Commencing parallel segment instance shutdown, please wait...
20220311:15:38:40:014634 gpstop:bogon:fairyfar-[INFO]:-0.00% of jobs completed
20220311:15:38:41:014634 gpstop:bogon:fairyfar-[INFO]:-100.00% of jobs completed
20220311:15:38:41:014634 gpstop:bogon:fairyfar-[INFO]:-----------------------------------------------------
20220311:15:38:41:014634 gpstop:bogon:fairyfar-[INFO]:-   Segments stopped successfully      = 2
20220311:15:38:41:014634 gpstop:bogon:fairyfar-[INFO]:-   Segments with errors during stop   = 0
20220311:15:38:41:014634 gpstop:bogon:fairyfar-[INFO]:-----------------------------------------------------
20220311:15:38:41:014634 gpstop:bogon:fairyfar-[INFO]:-Successfully shutdown 2 of 2 segment instances
20220311:15:38:41:014634 gpstop:bogon:fairyfar-[INFO]:-Database successfully shutdown with no errors reported
```

# Analysis

The problem code snippet in `gpMgmt/bin/gppylib/commands/pg.py` is as follows:
```python
class ReadPostmasterTempFile(Command):
    def __init__(self,name,port,ctxt=LOCAL,remoteHost=None):
        self.port=port
        self.cmdStr="cat /tmp/.s.PGSQL.%s.lock" % port
        Command.__init__(self,name,self.cmdStr,ctxt,remoteHost)        
……
    def getResults(self):
        if self.results.stderr.find("No such file or directory") != -1:
            return (False,-1,None)
        if self.results.stdout is None:
            return (False,-2,None)
        
        lines = self.results.stdout.split()
        
        if len(lines) < 2:
            return (False,-3,None)
……
```

The output of a command may be localized in different languages of Linux system.
In the above code, it is inaccurate to use the output string (`self.results.stderr`) of the command to judge the result.

For example, the following command:
```bash
cat /tmp/.s.PGSQL.xxx.lock
```

If the file does not exist, it will echo the string "No such file or directory" in the English environment, but will echo "没有那个文件或目录" in the Chinese environment.
Therefore, it is best to use the `return code` of the command to judge the execution result.

In addition, the `pid` returned by this function should not contain `-2` and `-3`, because a negative value means kill `process group` when calling `kill` command after soon.