### PR TITLE
Fix flaky unit test in buildMirrorSegments

### DIFF
--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
@@ -47,11 +47,11 @@ class BuildMirrorsTestCase(GpTestCase):
             }
         ]
 
-        gplog.get_unittest_logger()
         self.mock_gp_era = Mock(return_value='dummy_era')
         self.apply_patches([
             patch('gppylib.operations.buildMirrorSegments.GpArray.getSegmentsByHostName'),
             patch('gppylib.operations.buildMirrorSegments.gplog.get_logger_dir', return_value='/tmp/logdir'),
+            patch('gppylib.operations.buildMirrorSegments.gplog.logging_is_verbose', return_value=False),
             patch('gppylib.operations.buildMirrorSegments.read_era', self.mock_gp_era),
             patch('gppylib.recoveryinfo.RecoveryResult.print_bb_rewind_and_start_errors'),
             patch('gppylib.recoveryinfo.RecoveryResult.print_setup_recovery_errors'),
@@ -525,6 +525,7 @@ class BuildMirrorsTestCase(GpTestCase):
         recovery_info = OrderedDict()  # We use ordered dict to deterministically assert the side effects of _run_recovery
         recovery_info['host1'] = [self.recovery_info1]
         recovery_info['host2'] = [self.recovery_info2, self.recovery_info3]
+
         self.default_build_mirrors_obj._run_recovery(self.default_action_name, recovery_info, self.gpEnv)
 
         self.assertEqual([call(ANY, progressCmds=ANY, suppressErrorCheck=True), call(ANY, suppressErrorCheck=False)],


### PR DESCRIPTION
While testing the recover_mirrors/add_mirrors function, we assert that
we make the right call to the gpsegrecovery wrapper. This unit test
failed on the 6X pipeline because for some reason gplog's verbose
setting got enabled. Because of this, the call to gpsegreovery.py
included a '-v' flag. This commit explicitly mocks the function
`logging_is_verbose` and sets the return value to False.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
