### PR TITLE
[6X] gpstate -e : Display ongoing recovery progress

### DIFF
--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -3,6 +3,7 @@ import os
 import pipes
 import signal
 import time
+import re
 
 from gppylib.recoveryinfo import RecoveryResult
 from gppylib.mainUtils import *
@@ -54,6 +55,15 @@ gDatabaseFiles = [
     "postmaster.opts",
     "postmaster.pid",
 ]
+
+
+def get_recovery_progress_file(gplog):
+    # recovery progress file on the coordinator, used by gpstate to read and show progress
+    return "{}/recovery_progress.file".format(gplog.get_logger_dir())
+
+
+def get_recovery_progress_pattern():
+    return r"\d+\/\d+ (kB|mB) \(\d+\%\)"
 
 #
 # note: it's a little quirky that caller must set up failed/failover so that failover is in gparray but
@@ -358,11 +368,12 @@ class GpMirrorListToBuild:
                 usedDataDirectories[path] = dbid
 
     def _join_and_show_segment_progress(self, cmds, inplace=False, outfile=sys.stdout, interval=1):
-        written = False
 
         def print_progress():
             if written and inplace:
                 outfile.write("\x1B[%dA" % len(cmds))
+
+            complete_progress_output = []
 
             output = []
             for cmd in cmds:
@@ -387,15 +398,30 @@ class GpMirrorListToBuild:
                     output.append("\x1B[K")
                 output.append("\n")
 
+                if re.search(pattern, results):
+                    recovery_type = 'full' if os.path.basename(cmd.filePath).split('.')[0] == 'pg_basebackup' else 'incremental'
+                    complete_progress_output.extend("%s:%d:%s\n" % (recovery_type, cmd.dbid, results))
+
+            combined_progress_file.write("".join(complete_progress_output))
+            combined_progress_file.flush()
+
             outfile.write("".join(output))
             outfile.flush()
 
-        while not self.__pool.join(interval):
-            print_progress()
-            written = True
+        written = False
+        combined_progress_filepath = get_recovery_progress_file(gplog)
+        pattern = re.compile(get_recovery_progress_pattern())
+        try:
+            with open(combined_progress_filepath, 'w') as combined_progress_file:
+                while not self.__pool.join(interval):
+                    print_progress()
+                    written = True
+                # Make sure every line is updated with the final status.
+                print_progress()
+        finally:
+            if os.path.exists(combined_progress_filepath):
+                os.remove(combined_progress_filepath)
 
-        # Make sure every line is updated with the final status.
-        print_progress()
 
     def _get_progress_cmd(self, progressFile, targetSegmentDbId, targetHostname):
         """

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
@@ -2,11 +2,15 @@
 #
 # Copyright (c) Greenplum Inc 2008. All Rights Reserved.
 #
+import os
 from collections import OrderedDict
 import logging
 import StringIO
+import shutil
+import tempfile
 
-from mock import ANY, call, patch, Mock
+
+from mock import ANY, call, patch, Mock, mock_open
 from gppylib import gplog, recoveryinfo
 from gppylib.commands import base, gp
 from gppylib.commands.base import CommandResult, LocalExecutionContext
@@ -951,21 +955,34 @@ class SegmentProgressTestCase(GpTestCase):
             parallelDegree=0,
             logger=Mock(spec=logging.Logger)
         )
+        self.tmp_log_dir = tempfile.mkdtemp()
+        self.apply_patches([
+            patch('recoveryinfo.gplog.get_logger_dir', return_value=self.tmp_log_dir),
+            patch('gppylib.operations.buildMirrorSegments.os.remove')
+        ])
+        self.mock_os_remove = self.get_mock_from_apply_patch("remove")
+        self.combined_progress_file = "{}/recovery_progress.file".format(self.tmp_log_dir)
+
+    def tearDown(self):
+        super(SegmentProgressTestCase, self).tearDown()
+        shutil.rmtree(self.tmp_log_dir)
+
+    def create_command(self, remoteHost, dbid, filepath, stdout=None, stderr=None):
+            cmd = Mock(spec=GpMirrorListToBuild.ProgressCommand)
+            cmd.remoteHost = remoteHost
+            cmd.dbid = dbid
+            cmd.filePath = filepath
+            cmd.get_results.return_value.stdout = stdout
+            cmd.get_results.return_value.stderr = stderr
+            return cmd
 
     def test_command_output_is_displayed_once_after_worker_pool_completes(self):
-        cmd = Mock(spec=base.Command)
-        cmd.remoteHost = 'localhost'
-        cmd.dbid = 2
-        cmd.get_results.return_value.stdout = "string 1\n"
-
-        cmd2 = Mock(spec=base.Command)
-        cmd2.remoteHost = 'host2'
-        cmd2.dbid = 4
-        cmd2.get_results.return_value.stdout = "string 2\n"
+        cmd1 = self.create_command('localhost', 2, './pg_basebackup.23432', "string 1\n")
+        cmd2 = self.create_command('host2', 4, './pg_basebackup.234324', "string 2\n")
 
         outfile = StringIO.StringIO()
         self.pool.join.return_value = True
-        self.buildMirrorSegs._join_and_show_segment_progress([cmd, cmd2], outfile=outfile)
+        self.buildMirrorSegs._join_and_show_segment_progress([cmd1, cmd2], outfile=outfile)
 
         results = outfile.getvalue()
         self.assertEqual(results, (
@@ -974,9 +991,7 @@ class SegmentProgressTestCase(GpTestCase):
         ))
 
     def test_command_output_is_displayed_once_for_every_blocked_join(self):
-        cmd = Mock(spec=base.Command)
-        cmd.remoteHost = 'localhost'
-        cmd.dbid = 2
+        cmd = self.create_command('localhost', 2, './pg_basebackup.23432', "string 1\n")
 
         cmd.get_results.side_effect = [Mock(stdout="string 1"), Mock(stdout="string 2")]
 
@@ -991,19 +1006,16 @@ class SegmentProgressTestCase(GpTestCase):
         ))
 
     def test_inplace_display_uses_ansi_escapes_to_overwrite_previous_output(self):
-        cmd = Mock(spec=base.Command)
-        cmd.remoteHost = 'localhost'
-        cmd.dbid = 2
-        cmd.get_results.side_effect = [Mock(stdout="string 1"), Mock(stdout="string 2")]
+        cmd1 = self.create_command('localhost', 2, './pg_basebackup.234324', "string 1\n")
+        cmd2 = self.create_command('host2', 4, './pg_basebackup.234324', "string 2\n")
 
-        cmd2 = Mock(spec=base.Command)
-        cmd2.remoteHost = 'host2'
-        cmd2.dbid = 4
+        cmd1.get_results.side_effect = [Mock(stdout="string 1"), Mock(stdout="string 2")]
+
         cmd2.get_results.side_effect = [Mock(stdout="string 3"), Mock(stdout="string 4")]
 
         outfile = StringIO.StringIO()
         self.pool.join.side_effect = [False, True]
-        self.buildMirrorSegs._join_and_show_segment_progress([cmd, cmd2], inplace=True, outfile=outfile)
+        self.buildMirrorSegs._join_and_show_segment_progress([cmd1, cmd2], inplace=True, outfile=outfile)
 
         results = outfile.getvalue()
         self.assertEqual(results, (
@@ -1015,21 +1027,15 @@ class SegmentProgressTestCase(GpTestCase):
         ))
 
     def test_errors_during_command_execution_are_displayed(self):
-        cmd = Mock(spec=base.Command)
-        cmd.remoteHost = 'localhost'
-        cmd.dbid = 2
-        cmd.get_results.return_value.stderr = "some error\n"
-        cmd.run.side_effect = base.ExecutionError("Some exception", cmd)
+        cmd1 = self.create_command('localhost', 2, './pg_basebackup.234324', stderr="some error\n")
+        cmd2 = self.create_command('host2', 4, './pg_basebackup.234324', stderr='')
 
-        cmd2 = Mock(spec=base.Command)
-        cmd2.remoteHost = 'host2'
-        cmd2.dbid = 4
-        cmd2.get_results.return_value.stderr = ''
+        cmd1.run.side_effect = base.ExecutionError("Some exception", cmd1)
         cmd2.run.side_effect = base.ExecutionError("Some exception", cmd2)
 
         outfile = StringIO.StringIO()
         self.pool.join.return_value = True
-        self.buildMirrorSegs._join_and_show_segment_progress([cmd, cmd2], outfile=outfile)
+        self.buildMirrorSegs._join_and_show_segment_progress([cmd1, cmd2], outfile=outfile)
 
         results = outfile.getvalue()
         self.assertEqual(results, (
@@ -1037,6 +1043,92 @@ class SegmentProgressTestCase(GpTestCase):
             'host2 (dbid 4): \n'
         ))
 
+    def test_successful_command_execution_should_delete_the_recovery_progress_file(self):
+        cmd1 = self.create_command('host1', 1, './pg_basebackup.23432', "1164848/1371715 kB (84%)\n")
+        cmd2 = self.create_command('host2', 2, './pg_rewind.23432', "1164858/1371715 kB (90%)\n")
+
+
+        outfile = StringIO.StringIO()
+        self.pool.join.return_value = True
+        self.buildMirrorSegs._join_and_show_segment_progress([cmd1, cmd2], outfile=outfile)
+        self.mock_os_remove.assert_called_once_with(self.combined_progress_file)
+
+    def test_error_during_command_execution_should_delete_the_recovery_progress_file(self):
+        cmd1 = self.create_command('host1', 1, './pg_basebackup.23432', stderr="some error\n")
+        cmd2 = self.create_command('host2', 2, './pg_rewind.23432', stderr='')
+
+        cmd1.run.side_effect = Exception("Some exception1")
+        cmd2.run.side_effect = Exception("Some exception2")
+
+
+        outfile = StringIO.StringIO()
+        self.pool.join.return_value = True
+        with self.assertRaisesRegexp(Exception, "Some exception1"):
+            self.buildMirrorSegs._join_and_show_segment_progress([cmd1, cmd2], outfile=outfile)
+        self.mock_os_remove.assert_called_once_with(self.combined_progress_file)
+
+    def test_join_and_show_segment_progress_writes_progress_file(self):
+
+        cmd1 = self.create_command('host1', 1, './pg_basebackup.23432', "1164848/1371715 kB (84%)\n")
+        cmd2 = self.create_command('host2', 2, './pg_rewind.23432', "1164858/1371715 kB (90%)\n")
+
+        outfile = StringIO.StringIO()
+        self.pool.join.return_value = True
+
+        self.buildMirrorSegs._join_and_show_segment_progress([cmd1, cmd2], outfile=outfile)
+
+        self.mock_os_remove.assert_called_once_with(self.combined_progress_file)
+
+        with open(self.combined_progress_file, 'r') as f:
+            results = f.readlines()
+        self.assertEqual(results, [
+            'full:1:1164848/1371715 kB (84%)\n',
+            'incremental:2:1164858/1371715 kB (90%)\n'
+        ])
+
+    def test_join_and_show_segment_progress_overwrites(self):
+        cmd1 = self.create_command('host1', 1, './pg_basebackup.23432', "1164848/1371715 kB (84%)\n")
+        cmd2 = self.create_command('host2', 2, './pg_rewind.23432', "1164858/1371715 kB (90%)\n")
+
+        outfile = StringIO.StringIO()
+        self.pool.join.return_value = True
+
+        self.buildMirrorSegs._join_and_show_segment_progress([cmd1, cmd2], outfile=outfile)
+
+        self.mock_os_remove.assert_called_once_with(self.combined_progress_file)
+
+        with open(self.combined_progress_file, 'r') as f:
+            results = f.readlines()
+        self.assertEqual(results, [
+            'full:1:1164848/1371715 kB (84%)\n',
+            'incremental:2:1164858/1371715 kB (90%)\n'
+        ])
+
+        cmd1 = self.create_command('host11', 11, './pg_rewind.23432', "9964858/9971715 kB (1%)\n")
+        cmd2 = self.create_command('host22', 22, './pg_basebackup.23432', "9964848/9971715 kB (45%)\n")
+        self.buildMirrorSegs._join_and_show_segment_progress([cmd1, cmd2], outfile=outfile)
+
+        with open(self.combined_progress_file, 'r') as f:
+            results = f.readlines()
+            self.assertEqual(results, [
+                'incremental:11:9964858/9971715 kB (1%)\n',
+                'full:22:9964848/9971715 kB (45%)\n'
+            ])
+
+    def test_verify_recovery_progress_file_when_command_results_are_not_in_expected_format(self):
+            cmd1 = self.create_command('host1', 1, './pg_basebackup.23432', "string 1\n")
+            cmd2 = self.create_command('host2', 2, './pg_basebackup.23432', "string 2\n")
+
+
+            outfile = StringIO.StringIO()
+            self.pool.join.return_value = True
+            self.buildMirrorSegs._join_and_show_segment_progress([cmd1, cmd2], outfile=outfile)
+
+            self.mock_os_remove.assert_called_once_with(self.combined_progress_file)
+
+            with open(self.combined_progress_file, 'r') as f:
+                results = f.readlines()
+            self.assertEqual(results, [])
 
 if __name__ == '__main__':
     run_tests()

--- a/gpMgmt/bin/gppylib/programs/clsSystemState.py
+++ b/gpMgmt/bin/gppylib/programs/clsSystemState.py
@@ -7,7 +7,8 @@
 from gppylib.mainUtils import *
 
 from optparse import OptionGroup
-import sys
+import sys, os
+import re
 import collections
 from contextlib import closing
 
@@ -19,6 +20,7 @@ from gppylib.db import dbconn
 from gppylib.gpparseopts import OptParser, OptChecker
 from gppylib.operations.startSegments import *
 from gppylib.operations.buildMirrorSegments import *
+from gppylib.operations.buildMirrorSegments import get_recovery_progress_file, get_recovery_progress_pattern
 from gppylib.system import configurationInterface as configInterface
 from gppylib.system.environment import GpMasterEnvironment
 from gppylib.utils import TableLogger
@@ -70,6 +72,11 @@ VALUE__REPL_SENT_LEFT = FieldDefinition("Bytes remaining to send to mirror", "se
 VALUE__REPL_FLUSH_LEFT = FieldDefinition("Bytes received but remain to flush", "flush_left", "int")
 VALUE__REPL_REPLAY_LEFT = FieldDefinition("Bytes received but remain to replay", "replay_left", "int")
 VALUE__REPL_SYNC_REMAINING_BYTES = FieldDefinition("WAL sync remaining bytes", "wal_sync_bytes", "int")
+
+VALUE_RECOVERY_COMPLETED_BYTES = FieldDefinition("Completed bytes (kB)", "recovery_completed_bytes", "int")
+VALUE_RECOVERY_TOTAL_BYTES = FieldDefinition("Total bytes (kB)", "recovery_total_bytes", "int")
+VALUE_RECOVERY_PERCENTAGE = FieldDefinition("Percentage completed", "recovery_percentage", "int")
+VALUE_RECOVERY_TYPE = FieldDefinition("Recovery type", "recovery_type", "int")
 
 CATEGORY__STATUS = "Status"
 VALUE__MASTER_REPORTS_STATUS = FieldDefinition("Configuration reports status as", "status_in_config", "text", "Config status")
@@ -156,7 +163,9 @@ class GpStateData:
                     VALUE__HAS_DATABASE_STATUS_WARNING,
                     VALUE__VERSION_STRING, VALUE__POSTMASTER_PID_FILE_EXISTS, VALUE__LOCK_FILES_EXIST,
                     VALUE__ACTIVE_PID_INT, VALUE__POSTMASTER_PID_VALUE_INT,
-                    VALUE__POSTMASTER_PID_FILE, VALUE__POSTMASTER_PID_VALUE, VALUE__LOCK_FILES
+                    VALUE__POSTMASTER_PID_FILE, VALUE__POSTMASTER_PID_VALUE, VALUE__LOCK_FILES,
+                    VALUE_RECOVERY_COMPLETED_BYTES, VALUE_RECOVERY_TOTAL_BYTES, VALUE_RECOVERY_PERCENTAGE,
+                    VALUE_RECOVERY_TYPE
                     ]:
             self.__allValues[k] = True
 
@@ -674,6 +683,15 @@ class GpSystemStateProgram:
 
         self.__addClusterDownWarning(gpArray, data)
 
+        recovery_progress_file = get_recovery_progress_file(gplog)
+        recovery_progress_segs = self._parse_recovery_progress_data(data, recovery_progress_file, gpArray)
+        if recovery_progress_segs:
+            logger.info("----------------------------------------------------")
+            logger.info("Segments in recovery")
+            logSegments(recovery_progress_segs, False, [VALUE_RECOVERY_TYPE, VALUE_RECOVERY_COMPLETED_BYTES, VALUE_RECOVERY_TOTAL_BYTES,
+                                                          VALUE_RECOVERY_PERCENTAGE])
+            exitCode = 1
+
         # final output -- no errors, then log this message
         if exitCode == 0:
             logger.info("----------------------------------------------------")
@@ -937,6 +955,45 @@ class GpSystemStateProgram:
             logger.warn("*****************************************************" )
 
         return 1 if hasWarnings else 0
+
+    @staticmethod
+    def _parse_recovery_progress_data(data, recovery_progress_file, gpArray):
+        """
+        helper function for adding recovery segments progress to GpstateData
+        :param gpArray: gpArray instance
+        :param recovery_progress_file: progress file written by gprecoverseg on the coordinator
+        returns recovery_progress_segs
+        """
+        if not os.path.exists(recovery_progress_file):
+            return []
+
+        recovery_progress_by_dbid = {}
+        with open(recovery_progress_file, 'r') as fp:
+            for line in fp:
+                recovery_type, dbid, progress = line.strip().split(':',2)
+                pattern = re.compile(get_recovery_progress_pattern())
+                if re.search(pattern, progress):
+                    bytes, units, precentage_str = progress.strip().split(' ',2)
+                    completed_bytes, total_bytes = bytes.split('/')
+                    percentage = re.search(r'(\d+\%)', precentage_str).group()
+                    recovery_progress_by_dbid[int(dbid)] = [recovery_type, completed_bytes, total_bytes, percentage]
+
+        # Now the catalog update happens before we run recovery,
+        # so now when we query gpArray here, it will have new address/port for the recovering segments
+        recovery_progress_segs = []
+        for seg in gpArray.getSegDbList():
+            dbid = seg.getSegmentDbId()
+            if dbid in recovery_progress_by_dbid.keys():
+                data.switchSegment(seg)
+                recovery_progress_segs.append(seg)
+                recovery_type, completed_bytes, total_bytes, percentage = recovery_progress_by_dbid[dbid]
+                data.addValue(VALUE_RECOVERY_TYPE, recovery_type)
+                data.addValue(VALUE_RECOVERY_COMPLETED_BYTES, completed_bytes)
+                data.addValue(VALUE_RECOVERY_TOTAL_BYTES, total_bytes)
+                data.addValue(VALUE_RECOVERY_PERCENTAGE, percentage)
+
+        return recovery_progress_segs
+
 
     @staticmethod
     def _get_unsync_segs_add_wal_remaining_bytes(data, gpArray):

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpstate.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpstate.py
@@ -2,6 +2,7 @@ import unittest
 import mock
 
 from pygresql import pgdb
+import tempfile
 
 from gppylib import gparray
 from .gp_unittest import GpTestCase
@@ -40,6 +41,90 @@ def create_mirror(**kwargs):
     """Like create_segment() but with the role overridden to ROLE_MIRROR."""
     kwargs['role'] = gparray.ROLE_MIRROR
     return create_segment(**kwargs)
+
+class RecoveryProgressTestCase(unittest.TestCase):
+    """
+        A test case for GpSystemStateProgram.parseRecoveryProgressData().
+    """
+
+    def setUp(self):
+
+        self.primary1 = create_primary(dbid=1)
+        self.primary2 = create_primary(dbid=2)
+        self.primary3 = create_primary(dbid=3)
+
+        self.data = GpStateData()
+        self.data.beginSegment(self.primary1)
+        self.data.beginSegment(self.primary2)
+        self.data.beginSegment(self.primary3)
+
+        self.gpArrayMock = mock.MagicMock(spec=gparray.GpArray)
+        self.gpArrayMock.getSegDbList.return_value = [self.primary1, self.primary2, self.primary3]
+
+    def check_recovery_fields(self, segment, type, completed, total, percentage):
+        self.assertEqual(type, self.data.getStrValue(segment, VALUE_RECOVERY_TYPE))
+        self.assertEqual(completed, self.data.getStrValue(segment, VALUE_RECOVERY_COMPLETED_BYTES))
+        self.assertEqual(total, self.data.getStrValue(segment, VALUE_RECOVERY_TOTAL_BYTES))
+        self.assertEqual(percentage, self.data.getStrValue(segment, VALUE_RECOVERY_PERCENTAGE))
+
+    def test_parse_recovery_progress_data_returns_empty_when_file_does_not_exist(self):
+        self.assertEqual([], GpSystemStateProgram._parse_recovery_progress_data(self.data, '/file/does/not/exist', self.gpArrayMock))
+
+        self.check_recovery_fields(self.primary1, '', '', '', '')
+        self.check_recovery_fields(self.primary2, '', '', '', '')
+        self.check_recovery_fields(self.primary3, '', '', '', '')
+
+    def test_parse_recovery_progress_data_adds_recovery_progress_data_during_recovery(self):
+        with tempfile.NamedTemporaryFile() as f:
+            f.write("full:1: 1164848/1371715 kB (84%), 0/1 tablespace (...t1/demoDataDir0/base/16384/40962)".encode("utf-8"))
+            f.flush()
+            self.assertEqual([self.primary1], GpSystemStateProgram._parse_recovery_progress_data(self.data, f.name, self.gpArrayMock))
+
+            self.check_recovery_fields(self.primary1, 'full', '1164848', '1371715', '84%')
+            self.check_recovery_fields(self.primary2, '', '', '', '')
+            self.check_recovery_fields(self.primary3, '', '', '', '')
+
+    def test_parse_recovery_progress_data_adds_recovery_progress_data_during_multiple_recoveries(self):
+        with tempfile.NamedTemporaryFile() as f:
+            f.write("full:1: 1164848/1371715 kB (0%), 0/1 tablespace (...t1/demoDataDir0/base/16384/40962)\n".encode("utf-8"))
+            f.write("incremental:2: 1171384/1371875 kB (85%)anything can appear here".encode('utf-8'))
+            f.flush()
+            self.assertEqual([self.primary1, self.primary2], GpSystemStateProgram._parse_recovery_progress_data(self.data, f.name, self.gpArrayMock))
+
+            self.check_recovery_fields(self.primary1,'full', '1164848', '1371715', '0%')
+            self.check_recovery_fields(self.primary2, 'incremental', '1171384', '1371875', '85%')
+            self.check_recovery_fields(self.primary3, '', '', '', '')
+
+    def test_parse_recovery_progress_data_doesnt_adds_recovery_progress_data_only_for_completed_recoveries(self):
+        with tempfile.NamedTemporaryFile() as f:
+            f.write("full:1: 1164848/1371715 kB (84%), 0/1 tablespace (...t1/demoDataDir0/base/16384/40962)\n".encode("utf-8"))
+            f.write("full:2: 1164848/1371715 kB (100%), 0/1 tablespace (...t1/demoDataDir0/base/16384/40962)\n".encode("utf-8"))
+            f.write("full:3: 1164848/1371715 kB (100#), 0/1 tablespace (...t1/demoDataDir0/base/16384/40962)\n".encode("utf-8"))
+            f.write("full:3: 1164848/1371715 kB 84%, 0/1 tablespace (...t1/demoDataDir0/base/16384/40962)\n".encode("utf-8"))
+            f.write("full:3: 1164848/1371715 kB (100), 0/1 tablespace (...t1/demoDataDir0/base/16384/40962)\n".encode("utf-8"))
+            f.write("full:3: /1371715 kB (100%, 0/1 tablespace (...t1/demoDataDir0/base/16384/40962)\n".encode("utf-8"))
+            f.write("full:3: 1/1371715 KB (100%), 0/1 tablespace (...t1/demoDataDir0/base/16384/40962)\n".encode("utf-8"))
+            f.write("full:3: 1/1371715 kB 100%), 0/1 tablespace (...t1/demoDataDir0/base/16384/40962)\n".encode("utf-8"))
+            f.write("full:3: 1/1371715 kB (100%, 0/1 tablespace (...t1/demoDataDir0/base/16384/40962)\n".encode("utf-8"))
+            f.write("full:3: 1/1371715 MB (100%), 0/1 tablespace (...t1/demoDataDir0/base/16384/40962)\n".encode("utf-8"))
+            f.write("full:3: 1/1371715 B (100%), 0/1 tablespace (...t1/demoDataDir0/base/16384/40962)\n".encode("utf-8"))
+            f.write("full:3: 1164848/1371715 kB (84%%), 0/1 tablespace (...t1/demoDataDir0/base/16384/40962)\n".encode("utf-8"))
+            f.write("full:3: 1164848/1371715 kB (84%a), 0/1 tablespace (...t1/demoDataDir0/base/16384/40962)\n".encode("utf-8"))
+            f.write("full:3: 1164848/1371715 kB (a84%), 0/1 tablespace (...t1/demoDataDir0/base/16384/40962)\n".encode("utf-8"))
+            f.write("full:3: 1164848/1371715 kB ((84%), 0/1 tablespace (...t1/demoDataDir0/base/16384/40962)\n".encode("utf-8"))
+            f.write("incremental:2: pg_rewind: done.\n".encode('utf-8'))
+            f.write("incremental:3: pg_rewind: Error \n".encode('utf-8'))
+            f.write("incremental:3: 1171384/1371875 kB (a8ab5%)\n".encode('utf-8'))
+            f.write("incremental:3: 1171384/1371875 kB ((85%)\n".encode('utf-8'))
+            f.write("incremental:3: 1171384/1371875 kB (85%%1))\n".encode('utf-8'))
+            f.write("incremental:3: 1171384/1371875 kB (foo%))\n".encode('utf-8'))
+            f.flush()
+            self.assertEqual([self.primary1, self.primary2], GpSystemStateProgram._parse_recovery_progress_data(self.data, f.name, self.gpArrayMock))
+
+            self.check_recovery_fields(self.primary1,'full', '1164848', '1371715', '84%')
+            self.check_recovery_fields(self.primary2,'full', '1164848', '1371715', '100%')
+            self.check_recovery_fields(self.primary3, '', '', '', '')
+
 
 class ReplicationInfoTestCase(unittest.TestCase):
     """

--- a/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
@@ -151,7 +151,6 @@ Feature: Tests for gpmovemirrors
         And all the segments are running
         And the segments are synchronized
         And all files in gpAdminLogs directory are deleted on all hosts in the cluster
-        And all files in gpAdminLogs directory are deleted on all hosts in the cluster
         And a gpmovemirrors directory under '/tmp' with mode '0700' is created
         And a gpmovemirrors input file is created
         And edit the input file to move mirror with content 0 to a new directory with mode 0700
@@ -179,6 +178,55 @@ Feature: Tests for gpmovemirrors
         And all the segments are running
         And the segments are synchronized
         And user can start transactions
+
+
+  @demo_cluster
+  Scenario: gpmovemirrors -i creates recovery_progress.file if some mirrors are moved
+    Given the database is running
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user can start transactions
+    And sql "DROP TABLE if exists test_movemirrors; CREATE TABLE test_movemirrors AS SELECT generate_series(1,100000000) AS i" is executed in "postgres" db
+    And a gpmovemirrors directory under '/tmp' with mode '0700' is created
+    And a gpmovemirrors input file is created
+    And edit the input file to recover mirror with content 0 to a new directory on remote host with mode 0700
+    And edit the input file to recover mirror with content 1 to a new directory on remote host with mode 0700
+    When the user asynchronously runs gpmovemirrors with input file and additional args " " and the process is saved
+    And the user waits until mirror on content 0,1 is down
+    And the user suspend the walsender on the primary on content 0
+    Then the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
+    And verify that lines from recovery_progress.file are present in segment progress files in gpAdminLogs
+    And the user reset the walsender on the primary on content 0
+    And the user waits until saved async process is completed
+    And recovery_progress.file should not exist in gpAdminLogs
+    And the user waits until mirror on content 0,1 is up
+    And check if mirrors on content 0,1 are moved to new location on input file
+    And user can start transactions
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+
+  @demo_cluster
+  Scenario: gpmovemirrors -i creates recovery_progress.file if all mirrors are moved
+    Given the database is running
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user can start transactions
+    And sql "DROP TABLE if exists test_movemirrors; CREATE TABLE test_movemirrors AS SELECT generate_series(1,100000000) AS i" is executed in "postgres" db
+    And a gpmovemirrors directory under '/tmp' with mode '0700' is created
+    And a gpmovemirrors input file is created
+    And edit the input file to recover mirror with content 0 to a new directory on remote host with mode 0700
+    And edit the input file to recover mirror with content 1 to a new directory on remote host with mode 0700
+    And edit the input file to recover mirror with content 2 to a new directory on remote host with mode 0700
+    When the user asynchronously runs gpmovemirrors with input file and additional args " " and the process is saved
+    And the user waits until mirror on content 0,1,2 is down
+    And the user suspend the walsender on the primary on content 0
+    Then the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
+    And verify that lines from recovery_progress.file are present in segment progress files in gpAdminLogs
+    And the user reset the walsender on the primary on content 0
+    And the user waits until saved async process is completed
+    And recovery_progress.file should not exist in gpAdminLogs
+    And the user waits until mirror on content 0,1,2 is up
+    And check if mirrors on content 0,1,2 are moved to new location on input file
+    And user can start transactions
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+
 
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster
@@ -286,8 +334,8 @@ Feature: Tests for gpmovemirrors
         And all files in gpAdminLogs directory are deleted on all hosts in the cluster
         And the information of contents 0,1,2 is saved
 
-        And sql "DROP TABLE if exists test_start_failure; CREATE TABLE test_start_failure AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
-        And the "test_start_failure" table row count in "postgres" is saved
+        And sql "DROP TABLE if exists test_movemirrors; CREATE TABLE test_movemirrors AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
+        And the "test_movemirrors" table row count in "postgres" is saved
 
         And a gpmovemirrors directory under '/tmp' with mode '0700' is created
         And a gpmovemirrors input file is created
@@ -309,7 +357,7 @@ Feature: Tests for gpmovemirrors
 
         And the mode of all the created data directories is changed to 0700
         And the cluster is recovered in full and rebalanced
-        And the row count from table "test_start_failure" in "postgres" is verified against the saved data
+        And the row count from table "test_movemirrors" in "postgres" is verified against the saved data
 
     @concourse_cluster
     Scenario: gpmovemirrors mirrors come up even if one basebackup fails
@@ -320,8 +368,8 @@ Feature: Tests for gpmovemirrors
         And all files in gpAdminLogs directory are deleted on all hosts in the cluster
         And the information of contents 0,1,2 is saved
 
-        And sql "DROP TABLE if exists test_start_failure; CREATE TABLE test_start_failure AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
-        And the "test_start_failure" table row count in "postgres" is saved
+        And sql "DROP TABLE if exists test_movemirrors; CREATE TABLE test_movemirrors AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
+        And the "test_movemirrors" table row count in "postgres" is saved
 
         And a gpmovemirrors directory under '/tmp' with mode '0700' is created
         And a gpmovemirrors input file is created
@@ -343,7 +391,7 @@ Feature: Tests for gpmovemirrors
 
         And the mode of all the created data directories is changed to 0700
         And the cluster is recovered in full and rebalanced
-        And the row count from table "test_start_failure" in "postgres" is verified against the saved data
+        And the row count from table "test_movemirrors" in "postgres" is verified against the saved data
 
     @concourse_cluster
     Scenario: gpmovemirrors mirrors works even if all the mirrors to moved fail during basebackup
@@ -354,8 +402,8 @@ Feature: Tests for gpmovemirrors
         And all files in gpAdminLogs directory are deleted on all hosts in the cluster
         And the information of contents 0,1,2,3,4,5 is saved
 
-        And sql "DROP TABLE if exists test_start_failure; CREATE TABLE test_start_failure AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
-        And the "test_start_failure" table row count in "postgres" is saved
+        And sql "DROP TABLE if exists test_movemirrors; CREATE TABLE test_movemirrors AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
+        And the "test_movemirrors" table row count in "postgres" is saved
 
         And a gpmovemirrors directory under '/tmp' with mode '0700' is created
         And a gpmovemirrors input file is created
@@ -376,7 +424,7 @@ Feature: Tests for gpmovemirrors
 
         And the mode of all the created data directories is changed to 0700
         And the cluster is recovered in full and rebalanced
-        And the row count from table "test_start_failure" in "postgres" is verified against the saved data
+        And the row count from table "test_movemirrors" in "postgres" is verified against the saved data
 
     @concourse_cluster
     Scenario: gpmovemirrors mirrors works even if all mirrors are moved and all fail during basebackup
@@ -387,8 +435,8 @@ Feature: Tests for gpmovemirrors
         And all files in gpAdminLogs directory are deleted on all hosts in the cluster
         And the information of contents 0,1,2,3,4,5 is saved
 
-        And sql "DROP TABLE if exists test_start_failure; CREATE TABLE test_start_failure AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
-        And the "test_start_failure" table row count in "postgres" is saved
+        And sql "DROP TABLE if exists test_movemirrors; CREATE TABLE test_movemirrors AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
+        And the "test_movemirrors" table row count in "postgres" is saved
 
         And a gpmovemirrors directory under '/tmp' with mode '0700' is created
         And a gpmovemirrors input file is created
@@ -411,4 +459,4 @@ Feature: Tests for gpmovemirrors
 
         And the mode of all the created data directories is changed to 0700
         And the cluster is recovered in full and rebalanced
-        And the row count from table "test_start_failure" in "postgres" is verified against the saved data
+        And the row count from table "test_movemirrors" in "postgres" is verified against the saved data

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -117,8 +117,8 @@ Feature: gprecoverseg tests
       And all files in gpAdminLogs directory are deleted
       And user immediately stops all primary processes
       And user can start transactions
-      And sql "DROP TABLE if exists test_mixed_recovery; CREATE TABLE test_mixed_recovery AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
-      And the "test_mixed_recovery" table row count in "postgres" is saved
+      And sql "DROP TABLE if exists test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
+      And the "test_recoverseg" table row count in "postgres" is saved
       And a gprecoverseg directory under '/tmp' with mode '0700' is created
       And a gprecoverseg input file is created
       And edit the input file to recover mirror with content 0 to a new directory with mode 0700
@@ -135,15 +135,15 @@ Feature: gprecoverseg tests
       And gpAdminLogs directory has no "pg_rewind*" files
       And gpAdminLogs directory has "gpsegsetuprecovery*" files on all segment hosts
       And gpAdminLogs directory has "gpsegrecovery*" files on all segment hosts
+      And the old data directories are cleaned up for content 0
 
       And all the segments are running
       And the segments are synchronized
       And the user runs "gprecoverseg -ar"
       And gprecoverseg should return a return code of 0
-      And the row count from table "test_mixed_recovery" in "postgres" is verified against the saved data
+      And the row count from table "test_recoverseg" in "postgres" is verified against the saved data
 
-
-  Scenario: gprecoverseg incremental recovery displays pg_rewind progress to the user
+    Scenario: gprecoverseg incremental recovery displays pg_rewind progress to the user
         Given the database is running
         And all the segments are running
         And the segments are synchronized
@@ -266,6 +266,9 @@ Feature: gprecoverseg tests
         And the segments are synchronized
         And the cluster is rebalanced
 
+
+########################### @concourse_cluster tests ###########################
+# The @concourse_cluster tag denotes the scenario that requires a remote cluster
     @demo_cluster
     @concourse_cluster
     Scenario Outline: <scenario> recovery skips unreachable segments
@@ -282,8 +285,8 @@ Feature: gprecoverseg tests
 
       And the host for the primary on content 1 is made unreachable
 
-      And the user runs psql with "-c 'CREATE TABLE IF NOT EXISTS foo (i int)'" against database "postgres"
-      And the user runs psql with "-c 'INSERT INTO foo SELECT generate_series(1, 10000)'" against database "postgres"
+      And the user runs psql with "-c 'CREATE TABLE IF NOT EXISTS test_recoverseg (i int)'" against database "postgres"
+      And the user runs psql with "-c 'INSERT INTO test_recoverseg SELECT generate_series(1, 10000)'" against database "postgres"
 
       When the user runs "gprecoverseg <args>"
       Then gprecoverseg should print "Not recovering segment \d because invalid_host is unreachable" to stdout
@@ -298,16 +301,13 @@ Feature: gprecoverseg tests
       And content 0 is balanced
       And content 1 is unbalanced
 
-      And the user runs psql with "-c 'DROP TABLE foo'" against database "postgres"
+      And the user runs psql with "-c 'DROP TABLE test_recoverseg'" against database "postgres"
       And the cluster is returned to a good state
 
       Examples:
         | scenario    | args |
         | incremental | -a   |
         | full        | -aF  |
-
-########################### @concourse_cluster tests ###########################
-# The @concourse_cluster tag denotes the scenario that requires a remote cluster
 
   @concourse_cluster
   Scenario: incremental recovery works with tablespaces on a multi-host environment
@@ -389,6 +389,139 @@ Feature: gprecoverseg tests
 
   @demo_cluster
   @concourse_cluster
+  Scenario: gprecoverseg creates recovery_progress.file in gpAdminLogs
+    Given the database is running
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user immediately stops all primary processes for content 0,1,2
+    And the user waits until mirror on content 0,1,2 is down
+    And user can start transactions
+    And sql "DROP TABLE IF EXISTS test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,100000000) AS a;" is executed in "postgres" db
+    When the user asynchronously runs "gprecoverseg -a" and the process is saved
+    Then the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
+    And the user waits until saved async process is completed
+    And recovery_progress.file should not exist in gpAdminLogs
+    And the user waits until mirror on content 0,1,2 is up
+    And user can start transactions
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And a sample recovery_progress.file is created from saved lines
+    When the user runs "gpstate -e"
+    Then gpstate should print "Segments in recovery" to stdout
+#    And gpstate output contains "incremental,incremental,incremental" entries for mirrors of content 0,1,2
+#    And gpstate output looks like
+#      | Segment | Port   | Recovery type  | Completed bytes \(kB\) | Total bytes \(kB\) | Percentage completed |
+#      | \S+     | [0-9]+ | incremental    | [0-9]+                 | [0-9]+             | [0-9]+\%             |
+#      | \S+     | [0-9]+ | incremental    | [0-9]+                 | [0-9]+             | [0-9]+\%             |
+#      | \S+     | [0-9]+ | incremental    | [0-9]+                 | [0-9]+             | [0-9]+\%             |
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+
+    And user immediately stops all primary processes for content 0,1,2
+    And user can start transactions
+    When the user asynchronously runs "gprecoverseg -aF" and the process is saved
+    And the user suspend the walsender on the primary on content 0
+    Then the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
+    And verify that lines from recovery_progress.file are present in segment progress files in gpAdminLogs
+
+    And the user reset the walsender on the primary on content 0
+    And the user waits until saved async process is completed
+    And recovery_progress.file should not exist in gpAdminLogs
+    And the user waits until mirror on content 0,1,2 is up
+    And user can start transactions
+
+    And a sample recovery_progress.file is created from saved lines
+    When the user runs "gpstate -e"
+    Then gpstate should print "Segments in recovery" to stdout
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+
+  @demo_cluster
+  @concourse_cluster
+  Scenario: gprecoverseg creates recovery_progress.file in gpAdminLogs for full recovery of mirrors
+    Given the database is running
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user immediately stops all mirror processes for content 0,1,2
+    And the user waits until mirror on content 0,1,2 is down
+    And user can start transactions
+    And sql "DROP TABLE IF EXISTS test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,100000000) AS a;" is executed in "postgres" db
+    When the user asynchronously runs "gprecoverseg -aF" and the process is saved
+    And the user suspend the walsender on the primary on content 0
+    Then the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
+    And verify that lines from recovery_progress.file are present in segment progress files in gpAdminLogs
+    And the user reset the walsender on the primary on content 0
+    And the user waits until saved async process is completed
+    And recovery_progress.file should not exist in gpAdminLogs
+    And the user waits until mirror on content 0,1,2 is up
+    And user can start transactions
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+
+  @demo_cluster
+  @concourse_cluster
+  Scenario: gprecoverseg creates recovery_progress.file in custom logdir for full recovery of mirrors
+    Given the database is running
+    And all files in "/tmp/custom_logdir" directory are deleted on all hosts in the cluster
+    And user immediately stops all mirror processes for content 0,1,2
+    And the user waits until mirror on content 0,1,2 is down
+    And user can start transactions
+    When the user asynchronously runs "gprecoverseg -aF -l /tmp/custom_logdir" and the process is saved
+    And the user suspend the walsender on the primary on content 0
+    Then the user waits until recovery_progress.file is created in /tmp/custom_logdir and verifies its format
+    And verify that lines from recovery_progress.file are present in segment progress files in /tmp/custom_logdir
+    And the user reset the walsender on the primary on content 0
+    And the user waits until saved async process is completed
+    And recovery_progress.file should not exist in /tmp/custom_logdir
+    And the user waits until mirror on content 0,1,2 is up
+    And user can start transactions
+    And all files in "/tmp/custom_logdir" directory are deleted on all hosts in the cluster
+
+
+  @demo_cluster
+  @concourse_cluster
+  Scenario: gprecoverseg -i creates recovery_progress.file in gpAdminLogs for mixed recovery of mirrors
+    Given the database is running
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user immediately stops all primary processes for content 0,1,2
+    And the user waits until mirror on content 0,1,2 is down
+    And user can start transactions
+    And sql "DROP TABLE IF EXISTS test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,100000000) AS a;" is executed in "postgres" db
+    And a gprecoverseg directory under '/tmp' with mode '0700' is created
+    And a gprecoverseg input file is created
+    And edit the input file to recover mirror with content 0 to a new directory on remote host with mode 0700
+    And edit the input file to recover mirror with content 1 full inplace
+    And edit the input file to recover mirror with content 2 incremental
+    When the user asynchronously runs gprecoverseg with input file and additional args "-a" and the process is saved
+    And the user suspend the walsender on the primary on content 0
+    Then the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
+    And verify that lines from recovery_progress.file are present in segment progress files in gpAdminLogs
+    And the user reset the walsender on the primary on content 0
+    And the user waits until saved async process is completed
+    And recovery_progress.file should not exist in gpAdminLogs
+    And the user waits until mirror on content 0,1,2 is up
+    And the old data directories are cleaned up for content 0
+    And user can start transactions
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+
+  @demo_cluster
+  @concourse_cluster
+  Scenario:  SIGINT on gprecoverseg should delete the progress file
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user immediately stops all primary processes for content 0,1,2
+    And user can start transactions
+    And sql "DROP TABLE IF EXISTS test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,100000000) AS a;" is executed in "postgres" db
+    And the user suspend the walsender on the primary on content 0
+    When the user asynchronously runs "gprecoverseg -aF" and the process is saved
+    Then the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
+    When the user asynchronously sets up to end gprecoverseg process with SIGINT
+    And the user waits until saved async process is completed
+    Then recovery_progress.file should not exist in gpAdminLogs
+    Then the user reset the walsender on the primary on content 0
+    And the gprecoverseg lock directory is removed
+    And the user waits until mirror on content 0,1,2 is up
+    And verify that lines from recovery_progress.file are present in segment progress files in gpAdminLogs
+    And the cluster is rebalanced
+
+  @demo_cluster
+  @concourse_cluster
   Scenario: gprecoverseg mixed recovery segments come up even if one basebackup takes longer
     Given the database is running
     And all the segments are running
@@ -397,18 +530,19 @@ Feature: gprecoverseg tests
     And user immediately stops all primary processes for content 0,1,2
     And user can start transactions
     And the user suspend the walsender on the primary on content 0
-    And sql "DROP TABLE if exists test_slow_basebackup; CREATE TABLE test_slow_basebackup AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
-    And the "test_slow_basebackup" table row count in "postgres" is saved
+    And sql "DROP TABLE if exists test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,100000000) AS i" is executed in "postgres" db
+    And the "test_recoverseg" table row count in "postgres" is saved
     And a gprecoverseg directory under '/tmp' with mode '0700' is created
     And a gprecoverseg input file is created
     And edit the input file to recover mirror with content 0 full inplace
     And edit the input file to recover mirror with content 1 full inplace
     And edit the input file to recover mirror with content 2 incremental
     When the user asynchronously runs gprecoverseg with input file and additional args "-a" and the process is saved
-    Then the user waits until mirror on content 1 is up
-    And the user waits until mirror on content 2 is up
+    Then the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
+    And the user waits until mirror on content 1,2 is up
     And verify that mirror on content 0 is down
     And user can start transactions
+    And verify that lines from recovery_progress.file are present in segment progress files in gpAdminLogs
     And the user reset the walsender on the primary on content 0
     And the user waits until saved async process is completed
     And gpAdminLogs directory has no "pg_basebackup*" files on all segment hosts
@@ -416,7 +550,7 @@ Feature: gprecoverseg tests
     And gpAdminLogs directory has "gpsegsetuprecovery*" files on all segment hosts
     And gpAdminLogs directory has "gpsegrecovery*" files on all segment hosts
     And the cluster is recovered in full and rebalanced
-    And the row count from table "test_slow_basebackup" in "postgres" is verified against the saved data
+    And the row count from table "test_recoverseg" in "postgres" is verified against the saved data
 
   @demo_cluster
   @concourse_cluster
@@ -427,8 +561,8 @@ Feature: gprecoverseg tests
     And all files in gpAdminLogs directory are deleted on all hosts in the cluster
     And user immediately stops all primary processes for content 0,1,2
     And user can start transactions
-    And sql "DROP TABLE if exists test_rewind_failure; CREATE TABLE test_rewind_failure AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
-    And the "test_rewind_failure" table row count in "postgres" is saved
+    And sql "DROP TABLE if exists test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
+    And the "test_recoverseg" table row count in "postgres" is saved
     And all files in pg_xlog directory are deleted from data directory of preferred primary of content 0
     When the user runs "gprecoverseg -a"
     Then gprecoverseg should return a return code of 1
@@ -442,7 +576,7 @@ Feature: gprecoverseg tests
     And gpAdminLogs directory has "gpsegrecovery*" files on all segment hosts
 
     And the cluster is recovered in full and rebalanced
-    And the row count from table "test_rewind_failure" in "postgres" is verified against the saved data
+    And the row count from table "test_recoverseg" in "postgres" is verified against the saved data
 
   @demo_cluster
   @concourse_cluster
@@ -455,8 +589,8 @@ Feature: gprecoverseg tests
     And user immediately stops all primary processes for content 0,1,2
     And user can start transactions
 
-    And sql "DROP TABLE if exists test_rewind_failure; CREATE TABLE test_rewind_failure AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
-    And the "test_rewind_failure" table row count in "postgres" is saved
+    And sql "DROP TABLE if exists test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
+    And the "test_recoverseg" table row count in "postgres" is saved
     And all files in pg_xlog directory are deleted from data directory of preferred primary of content 0
 
     And a gprecoverseg directory under '/tmp' with mode '0700' is created
@@ -480,7 +614,7 @@ Feature: gprecoverseg tests
 
     And the mode of all the created data directories is changed to 0700
     And the cluster is recovered in full and rebalanced
-    And the row count from table "test_rewind_failure" in "postgres" is verified against the saved data
+    And the row count from table "test_recoverseg" in "postgres" is verified against the saved data
 
   @demo_cluster
   @concourse_cluster
@@ -493,8 +627,8 @@ Feature: gprecoverseg tests
     And user immediately stops all primary processes for content 0,1,2
     And user can start transactions
 
-    And sql "DROP TABLE if exists test_start_failure; CREATE TABLE test_start_failure AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
-    And the "test_start_failure" table row count in "postgres" is saved
+    And sql "DROP TABLE if exists test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
+    And the "test_recoverseg" table row count in "postgres" is saved
 
     And a gprecoverseg directory under '/tmp' with mode '0700' is created
     And a gprecoverseg input file is created
@@ -518,6 +652,7 @@ Feature: gprecoverseg tests
     And gpAdminLogs directory has "gpsegsetuprecovery*" files on all segment hosts
     And gpAdminLogs directory has "gpsegrecovery*" files on all segment hosts
     And verify there are no recovery backout files
+    And the old data directories are cleaned up for content 0
 
     And the mode of all the created data directories is changed to 0700
     Then the user runs "gprecoverseg -a"
@@ -525,7 +660,7 @@ Feature: gprecoverseg tests
     And user can start transactions
     And the segments are synchronized
     And the cluster is rebalanced
-    And the row count from table "test_start_failure" in "postgres" is verified against the saved data
+    And the row count from table "test_recoverseg" in "postgres" is verified against the saved data
 
   @demo_cluster
   @concourse_cluster
@@ -538,8 +673,8 @@ Feature: gprecoverseg tests
     And user immediately stops all primary processes for content 0,1,2
     And user can start transactions
 
-    And sql "DROP TABLE if exists test_start_failure; CREATE TABLE test_start_failure AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
-    And the "test_start_failure" table row count in "postgres" is saved
+    And sql "DROP TABLE if exists test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
+    And the "test_recoverseg" table row count in "postgres" is saved
 
     And a gprecoverseg directory under '/tmp' with mode '0700' is created
     And a gprecoverseg input file is created
@@ -562,13 +697,14 @@ Feature: gprecoverseg tests
     And gpAdminLogs directory has "gpsegsetuprecovery*" files on all segment hosts
     And gpAdminLogs directory has "gpsegrecovery*" files on all segment hosts
     And verify there are no recovery backout files
+    And the old data directories are cleaned up for content 0,1,2
     And the mode of all the created data directories is changed to 0700
     Then the user runs "gprecoverseg -a"
     And gprecoverseg should return a return code of 0
     And user can start transactions
     And the segments are synchronized
     And the cluster is rebalanced
-    And the row count from table "test_start_failure" in "postgres" is verified against the saved data
+    And the row count from table "test_recoverseg" in "postgres" is verified against the saved data
 
     @concourse_cluster
     Scenario: gprecoverseg behave test requires a cluster with at least 2 hosts
@@ -712,7 +848,7 @@ Feature: gprecoverseg tests
           And user can start transactions
          Then the saved "primary" segment is marked down in config
 
-         When all files in gpAdminLogs directory are deleted
+         When all files in gpAdminLogs directory are deleted on all hosts in the cluster
           And the user asynchronously sets up to end gprecoverseg process when "Recovery type" is printed in the logs
           And the user runs "gprecoverseg -a"
          Then gprecoverseg should return a return code of -15
@@ -817,9 +953,12 @@ Feature: gprecoverseg tests
     And user can start transactions
     And the primary on content 1 is stopped
     And user can start transactions
-    And an FTS probe is triggered
+    And the primary on content 2 is stopped
+    And user can start transactions
     And the status of the primary on content 0 should be "d"
     And the status of the primary on content 1 should be "d"
+    And the status of the primary on content 2 should be "d"
+    And user can start transactions
 
     And a gprecoverseg directory under '/tmp' with mode '0700' is created
     And a gprecoverseg input file is created
@@ -837,6 +976,7 @@ Feature: gprecoverseg tests
     And verify that mirror on content 2 is up
     And check if mirrors on content 0,1 are in their original configuration
     And check if mirrors on content 2 are moved to new location on input file
+    And the old data directories are cleaned up for content 2
     And the gp_configuration_history table should contain a backout entry for the primary segment for contents 0,1
 
     And the mode of all the created data directories is changed to 0700

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
@@ -1,6 +1,28 @@
+from behave import given, when, then
+import os
 import re
 
-from behave import given, when, then
+from gppylib.db import dbconn
+from gppylib.gparray import GpArray, ROLE_MIRROR
+from test.behave_utils.utils import check_stdout_msg, check_string_not_present_stdout
+
+@then('a sample recovery_progress.file is created from saved lines')
+def impl(context):
+    with open('{}/gpAdminLogs/recovery_progress.file'.format(os.path.expanduser("~")), 'w+') as fp:
+        fp.writelines(context.recovery_lines)
+
+@given('a sample recovery_progress.file is created with ongoing recoveries in gpAdminLogs')
+def impl(context):
+    with open('{}/gpAdminLogs/recovery_progress.file'.format(os.path.expanduser("~")), 'w+') as fp:
+        fp.write("full:5: 1164848/1371715 kB (84%), 0/1 tablespace (...t1/demoDataDir0/base/16384/40962)\n")
+        fp.write("incremental:6: 1/1371875 kB (1%)")
+
+@given('a sample recovery_progress.file is created with completed recoveries in gpAdminLogs')
+def impl(context):
+    with open('{}/gpAdminLogs/recovery_progress.file'.format(os.path.expanduser("~")), 'w+') as fp:
+        fp.write("incremental:5: pg_rewind: Done!\n")
+        fp.write("full:6: 1164848/1371715 kB (84%), 0/1 tablespace (...t1/demoDataDir0/base/16384/40962)\n")
+        fp.write("full:7: pg_basebackup: completed")
 
 @then('gpstate output looks like')
 def impl(context):
@@ -10,6 +32,31 @@ def impl(context):
 
     check_rows_exist(context)
 
+@then('gpstate output contains "{recovery_types}" entries for mirrors of content {contents}')
+def impl(context, recovery_types, contents):
+    recovery_types = recovery_types.split(',')
+    contents = [int(c) for c in contents.split(',')]
+    contents = set(contents)
+
+    all_segments = GpArray.initFromCatalog(dbconn.DbURL()).getDbList()
+    segments_to_display = []
+    segments_to_not_display = []
+    for seg in all_segments:
+        if seg.getSegmentContentId() in contents and seg.getSegmentRole() == ROLE_MIRROR:
+            segments_to_display.append(seg)
+        else:
+            segments_to_not_display.append(seg)
+
+    for index, seg_to_display in enumerate(segments_to_display):
+        hostname = seg_to_display.getSegmentHostName()
+        port = seg_to_display.getSegmentPort()
+        expected_msg = "{}[ \t]+{}[ \t]+{}[ \t]+[0-9]+[ \t]+[0-9]+[ \t]+[0-9]+\%".format(hostname, port,
+                                                                                         recovery_types[index])
+        check_stdout_msg(context, expected_msg)
+
+    #TODO assert that only segments_to_display are printed to the console
+    # for seg_to_not_display in segments_to_not_display:
+    #     check_string_not_present_stdout(context, str(seg_to_not_display.getSegmentPort()))
 
 @then('gpstate output has rows')
 def impl(context):

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -29,6 +29,7 @@ from gppylib.commands.gp import SegmentStart, GpStandbyStart, MasterStop
 from gppylib.commands import gp
 from gppylib.commands.unix import findCmdInPath, Scp
 from gppylib.operations.startSegments import MIRROR_MODE_MIRRORLESS
+from gppylib.operations.buildMirrorSegments import get_recovery_progress_pattern
 from gppylib.operations.unix import ListRemoteFilesByPattern, CheckRemoteFile
 from test.behave_utils.gpfdist_utils.gpfdist_mgmt import Gpfdist
 from test.behave_utils.utils import *
@@ -380,6 +381,7 @@ def impl(context, content_ids):
 
 
 @given('the user {action} the walsender on the {segment} on content {content}')
+@when('the user {action} the walsender on the {segment} on content {content}')
 @then('the user {action} the walsender on the {segment} on content {content}')
 def impl(context, action, segment, content):
     if segment == 'mirror':
@@ -424,6 +426,62 @@ def impl(context, content):
     dburl = dbconn.DbURL(hostname=host, port=port, dbname='template1')
     wait_for_desired_query_result(dburl, query, desired_result, utility=True)
 
+@then('the user waits until recovery_progress.file is created in {logdir} and verifies its format')
+def impl(context, logdir):
+    attempt = 0
+    num_retries = 60000
+    log_dir = _get_gpAdminLogs_directory() if logdir == 'gpAdminLogs' else logdir
+    recovery_progress_file = '{}/recovery_progress.file'.format(log_dir)
+    while attempt < num_retries:
+        attempt += 1
+        if os.path.exists(recovery_progress_file):
+            with open(recovery_progress_file, 'r') as fp:
+                context.recovery_lines = fp.readlines()
+            for line in context.recovery_lines:
+                recovery_type, dbid, progress = line.strip().split(':', 2)
+                progress_pattern = re.compile(get_recovery_progress_pattern())
+                # TODO: assert progress line in the actual hosts bb/rewind progress file
+                if re.search(progress_pattern, progress) and dbid.isdigit() and recovery_type in ['full', 'incremental']:
+                    return
+                else:
+                    raise Exception('File present but incorrect format line "{}"'.format(line))
+        time.sleep(0.01)
+        if attempt == num_retries:
+            raise Exception('Timed out after {} retries'.format(num_retries))
+
+
+@then('verify that lines from recovery_progress.file are present in segment progress files in {logdir}')
+def impl(context, logdir):
+    all_progress_lines_by_dbid = {}
+    for line in context.recovery_lines:
+        recovery_type, dbid, line_from_combined_progress_file = line.strip().split(':', 2)
+        all_progress_lines_by_dbid[int(dbid)] = [recovery_type, line_from_combined_progress_file]
+
+    all_segments = GpArray.initFromCatalog(dbconn.DbURL()).getDbList()
+
+    log_dir = _get_gpAdminLogs_directory() if logdir == 'gpAdminLogs' else logdir
+    for seg in all_segments:
+        seg_dbid = seg.getSegmentDbId()
+        if seg_dbid in all_progress_lines_by_dbid:
+            recovery_type, line_from_combined_progress_file = all_progress_lines_by_dbid[seg_dbid]
+            process_name = 'pg_basebackup' if recovery_type == 'full' else 'pg_rewind'
+            seg_progress_file = '{}/{}.*.dbid{}.out'.format(log_dir, process_name, seg_dbid)
+            check_cmd_str = 'grep "{}" {}'.format(line_from_combined_progress_file, seg_progress_file)
+            check_cmd = Command(name='check line in segment progress file',
+                          cmdStr=check_cmd_str,
+                          ctxt=REMOTE,
+                          remoteHost=seg.getSegmentHostName())
+            check_cmd.run()
+            if check_cmd.get_return_code() != 0:
+                raise Exception('Expected line {} in segment progress file {} on host {} but not found.'
+                                .format(line_from_combined_progress_file, seg_progress_file, seg.getSegmentHostName()))
+
+
+@then('recovery_progress.file should not exist in {logdir}')
+def impl(context, logdir):
+    log_dir = _get_gpAdminLogs_directory() if logdir == 'gpAdminLogs' else logdir
+    if os.path.exists('{}/recovery_progress.file'.format(log_dir)):
+        raise Exception('recovery_progress.file is still present under {}'.format(log_dir))
 
 def backup_bashrc():
     home_dir = os.environ.get('HOME')
@@ -545,6 +603,19 @@ def impl(context, process_name, log_msg):
               "fi; done" % (log_msg, process_name, process_name)
     run_async_command(context, command)
 
+@then('the user asynchronously sets up to end {kill_process_name} process when {log_msg} is printed in the {logfile_name} logs')
+def impl(context, kill_process_name, log_msg, logfile_name):
+    command = "while sleep 0.1; " \
+              "do if egrep --quiet %s  ~/gpAdminLogs/%s*log ; " \
+              "then ps ux | grep bin/%s |awk '{print $2}' | xargs kill -2 ;break 2; " \
+              "fi; done" % (log_msg, logfile_name, kill_process_name)
+    run_async_command(context, command)
+
+
+@when('the user asynchronously sets up to end {process_name} process with SIGINT')
+def impl(context, process_name):
+    command = "ps ux | grep bin/%s | awk '{print $2}' | xargs kill -2" % (process_name)
+    run_async_command(context, command)
 
 @when('the user asynchronously sets up to end gpcreateseg process when it starts')
 def impl(context):
@@ -2525,7 +2596,19 @@ def impl(context, hosts):
                               remoteHost=host, ctxt=REMOTE)
         rm_cmd.run(validateAfter=True)
 
+@given('all files in "{dir}" directory are deleted on all hosts in the cluster')
+@then('all files in "{dir}" directory are deleted on all hosts in the cluster')
+def impl(context, dir):
+    host_list = GpArray.initFromCatalog(dbconn.DbURL()).getHostList()
+    for host in host_list:
+        rm_cmd = Command(name="remove files in {}".format(dir),
+                         cmdStr="rm -rf {}/*".format(dir),
+                         remoteHost=host, ctxt=REMOTE)
+        rm_cmd.run(validateAfter=True)
+
 @given('all files in gpAdminLogs directory are deleted on all hosts in the cluster')
+@when('all files in gpAdminLogs directory are deleted on all hosts in the cluster')
+@then('all files in gpAdminLogs directory are deleted on all hosts in the cluster')
 def impl(context):
     host_list = GpArray.initFromCatalog(dbconn.DbURL()).getHostList()
     log_dir = _get_gpAdminLogs_directory()

--- a/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
@@ -349,6 +349,7 @@ def impl(context, mirror_config):
 def impl(context, utility):
     context.mirror_context.input_file = "{}_config.txt".format(utility)
     context.data_dirs_created = defaultdict(list)
+    context.old_data_dirs = defaultdict(list)
     context.mirror_new_location = defaultdict(str)
     open(context.mirror_context.input_file_path(), 'w').close()
 
@@ -369,6 +370,7 @@ def impl(context, content_ids, mode):
                 valid_config = '{}|{}|{}'.format(mirror.getSegmentHostName(),
                                                  mirror.getSegmentPort(),
                                                  mirror.getSegmentDataDirectory())
+                context.old_data_dirs[content] = [mirror.getSegmentHostName(), mirror.getSegmentDataDirectory()]
 
                 valid_config_new = '{}|{}|{}'.format(mirror.getSegmentHostName(),
                                                      mirror.getSegmentPort(),
@@ -434,6 +436,7 @@ def impl(context, content, mode):
             valid_config = '{}|{}|{}'.format(mirror.getSegmentHostName(),
                                              mirror.getSegmentPort(),
                                              mirror.getSegmentDataDirectory())
+            context.old_data_dirs[content] = [mirror.getSegmentHostName(), mirror.getSegmentDataDirectory()]
 
             make_temp_dir_on_remote(context, mirror.getSegmentHostName(), '/tmp', mode)
             new_datadir = context.temp_base_dir_remote
@@ -445,6 +448,16 @@ def impl(context, content, mode):
             context.data_dirs_created[seg.mirrorDB.getSegmentHostName()].append(new_datadir)
             context.mirror_new_location[content] = valid_config_new
             break
+
+
+@then('the old data directories are cleaned up for content {content_ids}')
+def impl(context, content_ids):
+    for content in [int(c) for c in content_ids.split(',')]:
+        old_host, old_datadir = context.old_data_dirs[content]
+        rm_cmd = Command(name="Remove old datadirs on remote host", cmdStr='rm -rf {}'.format(old_datadir),
+                      remoteHost=old_host, ctxt=REMOTE)
+        rm_cmd.run(validateAfter=True)
+
 
 @given("the mode of all the created data directories is changed to 0700")
 @when("the mode of all the created data directories is changed to 0700")
@@ -653,10 +666,9 @@ def impl(context, utility, extra_args=''):
     run_gpcommand(context, cmd)
 
 
-@when('the user asynchronously runs gprecoverseg with input file and additional args "{extra_args}" and the process is saved')
-def impl(context, extra_args=''):
-    cmd = "gprecoverseg -i %s %s" % (
-        context.mirror_context.input_file_path(), extra_args)
+@when('the user asynchronously runs {utility} with input file and additional args "{extra_args}" and the process is saved')
+def impl(context, utility, extra_args=''):
+    cmd = "%s -i %s %s" % (utility, context.mirror_context.input_file_path(), extra_args)
     run_gpcommand_async(context, cmd)
 
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
@@ -533,11 +533,14 @@ def impl(context, filename, content):
 
 
 
-@when('the user waits until mirror on content {content} is {expected_status}')
-@then('the user waits until mirror on content {content} is {expected_status}')
-def impl(context, content, expected_status):
-    query = "SELECT gp_request_fts_probe_scan(); SELECT status FROM gp_segment_configuration where role = 'm' and content = {};".format(content)
-    wait_for_desired_query_result(dbconn.DbURL(), query, 'u' if expected_status == 'up' else 'd')
+@given('the user waits until mirror on content {content_ids} is {expected_status}')
+@when('the user waits until mirror on content {content_ids} is {expected_status}')
+@then('the user waits until mirror on content {content_ids} is {expected_status}')
+def impl(context, content_ids, expected_status):
+    contents = content_ids.split(',')
+    for content in contents:
+        query = "SELECT gp_request_fts_probe_scan(); SELECT status FROM gp_segment_configuration where role = 'm' and content = {};".format(content)
+        wait_for_desired_query_result(dbconn.DbURL(), query, 'u' if expected_status == 'up' else 'd')
 
 
 @then('the contents {contents} should have their original data directory in the system configuration')

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -125,8 +125,7 @@ def run_gpcommand(context, command, cmd_prefix=''):
 def run_gpcommand_async(context, command):
     cmd = Command(name='run %s' % command, cmdStr='$GPHOME/bin/%s' % (command))
     asyncproc = cmd.runNoWait()
-    if 'asyncproc' not in context:
-        context.asyncproc = asyncproc
+    context.asyncproc = asyncproc
 
 
 def check_stdout_msg(context, msg, escapeStr = False):


### PR DESCRIPTION
Added new section under gpstate -e, which displays progress of mirrorss
in recovery

-Edited buildMirrorSegments to create new file (recovery_progress.file)
and updates the current recovery progress, deletes the file after
recoveries are completed.
-Added new section under gpstate -e to display progress of mirrors in
recovery
-Added _parse_recovery_progress_data(), which will look for the
recovery_progress.file and populate the required fields -Added behave
and unit tests for above scenario

Sample output:
-----------------------------------------------------
Segments in recovery
Segment                     Port   Recovery type   Completed bytes (kB)   Total bytes (kB)   Percentage completed
hmaddileti-a01.vmware.com   7002   full            1164848                1371715            84%
hmaddileti-a01.vmware.com   7003   incremental     1171384                1371875            85%
hmaddileti-a01.vmware.com   7004   full            116488                 1371715            60%

Co-authored-by: Divyesh Vanjare <vanjared@vmware.com>
Co-authored-by: Nikhil Kak <nkak@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
