### PR TITLE
Fix Printing Expression Properties

### DIFF
--- a/src/backend/gporca/libgpopt/src/base/CDrvdPropScalar.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDrvdPropScalar.cpp
@@ -407,12 +407,12 @@ CDrvdPropScalar::DeriveHasScalarArrayCmp(CExpressionHandle &exprhdl)
 IOstream &
 CDrvdPropScalar::OsPrint(IOstream &os) const
 {
-	os << "Defined Columns: [" << GetDefinedColumns() << "], "
-	   << "Used Columns: [" << GetUsedColumns() << "], "
+	os << "Defined Columns: [" << *GetDefinedColumns() << "], "
+	   << "Used Columns: [" << *GetUsedColumns() << "], "
 	   << "Set Returning Function Columns: ["
-	   << GetSetReturningFunctionColumns() << "], "
+	   << *GetSetReturningFunctionColumns() << "], "
 	   << "Has Subqs: [" << HasSubquery() << "], "
-	   << "Function Properties: [" << GetFunctionProperties() << "], "
+	   << "Function Properties: [" << *GetFunctionProperties() << "], "
 	   << "Has Non-scalar Funcs: [" << HasNonScalarFunction() << "], ";
 
 	if (0 < m_ulDistinctAggs)

--- a/src/backend/gporca/libgpopt/src/operators/CExpression.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpression.cpp
@@ -1009,12 +1009,12 @@ CExpression::PrintProperties(IOstream &os, CPrintPrefix &pfx) const
 {
 	GPOS_CHECK_ABORT;
 
-	if (nullptr != m_pdprel)
+	if (nullptr != m_pdprel && m_pdprel->IsComplete())
 	{
 		os << pfx << "DrvdRelProps:{" << *m_pdprel << "}" << std::endl;
 	}
 
-	if (nullptr != m_pdpscalar)
+	if (nullptr != m_pdpscalar && m_pdpscalar->IsComplete())
 	{
 		os << pfx << "DrvdScalarProps:{" << *m_pdpscalar << "}" << std::endl;
 	}


### PR DESCRIPTION
During cafe3a6ce refactoring we introduced on demand property
derivation, but accidentaly broke the printing of expression properties.
This commit does the following
1) Print Expression Properties (DrvdPropScalar / DrvdPropRelational)
   only when they have been derived completely.
2) Print the actual values of instead of addresses.

```sql
set client_min_messages = log;
set optimizer_print_expression_properties=on;
set optimizer_print_plan=on;
explain select 1;
```

Before this commit:
```
LOG:  statement: explain select 1;
LOG:  2022-03-12 18:29:33:987979 PST,THD000,ERROR,"CDrvdPropScalar.cpp:151: Failed assertion: IsComplete()
Stack trace:
1    0x000000010c0ee480 gpos::CException::Raise + 432
2    0x000000010c38782d gpopt::CDrvdPropScalar::GetDefinedColumns + 125
3    0x000000010c387dc9 gpopt::CDrvdPropScalar::OsPrint + 57
4    0x000000010c37de14 gpopt::operator + 36
5    0x000000010c41f2d1 gpopt::CExpression::PrintProperties + 209
6    0x000000010c41fa68 gpopt::CExpression::OsPrintExpression + 760
7    0x000000010c41f768 gpopt::CExpression::OsPrint + 72
8    0x000000010c372741 gpopt::operator + 33
9    0x000000010c530887 gpopt::COptimizer::PrintPlan + 199
10   0x000000010c530ef8 gpopt::COptimizer::PrintQueryOrPlan + 1288
11   0x000000010c532317 gpopt::COptimizer::PexprOptimize + 263
12   0x000000010c53185c gpopt::COptimizer::PdxlnOptimize + 2252
13   0x000000010c76b553 COptTasks::OptimizeTask + 2403
14   0x000000010c10caf0 gpos::CTask::Execute + 208
15   0x000000010c11035a gpos::CWorker::Execute + 282
16   0x000000010c10b2e2 gpos::CAutoTaskProxy::Execute + 482
17   0x000000010c113152 gpos_exec + 1362
```

After the fix:
```
Physical plan:
+--CPhysicalComputeScalar   rows:1   width:1  rebinds:1   cost:0.000005   origin: [Grp:4, GrpExpr:1]
   DrvdRelProps:{Output Cols: ["" (0), "?column?" (1)], Outer Refs: [], Not Null Cols: [], Corr. Apply Cols: [],  Keys: (["" (0)]), Max Card: 1, Join Depth: 0, Constraint Property: [Equivalence Classes: { ("?column?" (1)) } Constraint:{"?column?" (1), ranges: [1, 1] }], FDs: [("" (0)) --> ("?column?" (1))], Function Properties: [Immutable], Part Info: [Part Consumers: , Part Keys: ], Has Partial Indexes}
   DrvdPlanProps:{Drvd Plan Props (ORD: <empty>, DIST: UNIVERSAL , REWIND: REWINDABLE NO-MOTION), Part-Index Map: [], Part Filter Map: , CTE Map: []}
   ReqdPlanProps:{req CTEs: [], req order: [<empty> match: satisfy ], req dist: [SINGLETON (master) match: satisfy], req rewind: [], req rewind: [NONE NO-MOTION match: satisfy], req partition propagation: [Filters: [] match: satisfy ]}
   |--CPhysicalConstTableGet Columns: ["" (0)] Values: [(1)]   rows:1   width:1  rebinds:1   cost:0.000001   origin: [Grp:0, GrpExpr:1]
   |  DrvdRelProps:{Output Cols: ["" (0)], Outer Refs: [], Not Null Cols: [], Corr. Apply Cols: [],  Keys: (["" (0)]), Max Card: 1, Join Depth: 0, Constraint Property: [], FDs: [], Function Properties: [Immutable], Part Info: [Part Consumers: , Part Keys: ], Has Partial Indexes}
   |  DrvdPlanProps:{Drvd Plan Props (ORD: <empty>, DIST: UNIVERSAL , REWIND: MARK-RESTORE NO-MOTION), Part-Index Map: [], Part Filter Map: , CTE Map: []}
   |  ReqdPlanProps:{req CTEs: [], req order: [], req dist: [], req rewind: [], req partition propagation: [Filters: [] match: satisfy ]}
   +--CScalarProjectList   origin: [Grp:3, GrpExpr:0]
      DrvdScalarProps:{Defined Columns: ["?column?" (1)], Used Columns: [], Set Returning Function Columns: [], Has Subqs: [0], Function Properties: [Immutable], Has Non-scalar Funcs: [0], }
      +--CScalarProjectElement "?column?" (1)   origin: [Grp:2, GrpExpr:0]
         DrvdScalarProps:{Defined Columns: ["?column?" (1)], Used Columns: [], Set Returning Function Columns: [], Has Subqs: [0], Function Properties: [Immutable], Has Non-scalar Funcs: [0], }
         +--CScalarConst (1)   origin: [Grp:1, GrpExpr:0]
            DrvdScalarProps:{Defined Columns: [], Used Columns: [], Set Returning Function Columns: [], Has Subqs: [0], Function Properties: [Immutable], Has Non-scalar Funcs: [0], }
",
                   QUERY PLAN
------------------------------------------------
 Result  (cost=0.00..0.00 rows=1 width=4)
   ->  Result  (cost=0.00..0.00 rows=1 width=1)
 Optimizer: Pivotal Optimizer (GPORCA)
(3 rows)
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
