### PR TITLE
6X: report error if writable s3 external table is ON MASTER only

### DIFF
--- a/gpcontrib/gpcloud/regress/input/3_01_create_wet.source
+++ b/gpcontrib/gpcloud/regress/input/3_01_create_wet.source
@@ -1,4 +1,7 @@
 CREATE WRITABLE EXTERNAL TABLE s3regress_create_wet (date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-us-west-2.amazonaws.com/@write_prefix@/create/ config=@config_file@') FORMAT 'csv';
 
+CREATE WRITABLE EXTERNAL TABLE s3regress_create_wet_on_master (date text, time text, open float, high float,
+        low float, volume int) LOCATION('s3://s3-us-west-2.amazonaws.com/@write_prefix@/create/ config=@config_file@') ON MASTER FORMAT 'csv';
+
 DROP EXTERNAL TABLE s3regress_create_wet;

--- a/gpcontrib/gpcloud/regress/output/3_01_create_wet.source
+++ b/gpcontrib/gpcloud/regress/output/3_01_create_wet.source
@@ -1,3 +1,6 @@
 CREATE WRITABLE EXTERNAL TABLE s3regress_create_wet (date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-us-west-2.amazonaws.com/@write_prefix@/create/ config=@config_file@') FORMAT 'csv';
+CREATE WRITABLE EXTERNAL TABLE s3regress_create_wet_on_master (date text, time text, open float, high float,
+        low float, volume int) LOCATION('s3://s3-us-west-2.amazonaws.com/@write_prefix@/create/ config=@config_file@') ON MASTER FORMAT 'csv';
+ERROR:  External s3 table with ON MASTER clause cannot be writable.
 DROP EXTERNAL TABLE s3regress_create_wet;


### PR DESCRIPTION
The "ON MASTER" for the writable s3 external table is ignored. When trying to write to the table one of the segments will report an error.

So, we should report error if writable s3 external table is ON MASTER only.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
