### PR TITLE
add original storage options to AO table with index when expanding

### DIFF
--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -1734,8 +1734,8 @@ build_ao_rel_storage_opts(List *opts, Relation rel)
 
 	if (!reloptions_has_opt(opts, "compresstype"))
 	{
-		compresstype = (compresstype && compresstype[0]) ? compresstype : "none";
-		opts = lappend(opts, makeDefElem("compresstype", (Node *) makeString(pstrdup(compresstype)), -1));
+		compresstype = (compresstype && compresstype[0]) ? pstrdup(compresstype) : "none";
+		opts = lappend(opts, makeDefElem("compresstype", (Node *) makeString(compresstype), -1));
 	}
 
 	return opts;

--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -1686,3 +1686,57 @@ List* transformColumnEncoding(Relation rel, List *colDefs, List *stenc, List *wi
 
 	return result;
 }
+
+/*
+ * GPDB: Convenience function to judge a relation option whether already in opts
+ */
+bool
+reloptions_has_opt(List *opts, const char *name)
+{
+	ListCell *lc;
+	foreach(lc, opts)
+	{
+		DefElem *de = lfirst(lc);
+		if (pg_strcasecmp(de->defname, name) == 0)
+			return true;
+	}
+	return false;
+}
+
+/*
+ * GPDB: Convenience function to build storage reloptions for a given relation, just for AO table.
+ */
+List*
+build_ao_rel_storage_opts(List *opts, Relation rel)
+{
+	bool		checksum = true;
+	int32		blocksize = -1;
+	int16		compresslevel = 0;
+	char	   *compresstype = NULL;
+	NameData	compresstype_nd;
+
+	GetAppendOnlyEntryAttributes(RelationGetRelid(rel),
+								 &blocksize,
+								 NULL,
+								 &compresslevel,
+								 &checksum,
+								 &compresstype_nd);
+	compresstype = NameStr(compresstype_nd);
+
+	if (!reloptions_has_opt(opts, "blocksize"))
+		opts = lappend(opts, makeDefElem("blocksize", (Node *) makeInteger(blocksize), -1));
+
+	if (!reloptions_has_opt(opts, "compresslevel"))
+		opts = lappend(opts, makeDefElem("compresslevel", (Node *) makeInteger(compresslevel), -1));
+
+	if (!reloptions_has_opt(opts, "checksum"))
+		opts = lappend(opts, makeDefElem("checksum", (Node *) makeInteger(checksum), -1));
+
+	if (!reloptions_has_opt(opts, "compresstype"))
+	{
+		compresstype = (compresstype && compresstype[0]) ? compresstype : "none";
+		opts = lappend(opts, makeDefElem("compresstype", (Node *) makeString(compresstype), -1));
+	}
+
+	return opts;
+}

--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -1706,7 +1706,7 @@ reloptions_has_opt(List *opts, const char *name)
 /*
  * GPDB: Convenience function to build storage reloptions for a given relation, just for AO table.
  */
-List*
+List *
 build_ao_rel_storage_opts(List *opts, Relation rel)
 {
 	bool		checksum = true;

--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -1735,7 +1735,7 @@ build_ao_rel_storage_opts(List *opts, Relation rel)
 	if (!reloptions_has_opt(opts, "compresstype"))
 	{
 		compresstype = (compresstype && compresstype[0]) ? compresstype : "none";
-		opts = lappend(opts, makeDefElem("compresstype", (Node *) makeString(compresstype), -1));
+		opts = lappend(opts, makeDefElem("compresstype", (Node *) makeString(pstrdup(compresstype)), -1));
 	}
 
 	return opts;

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -15913,7 +15913,7 @@ build_ao_rel_storage_opts(List *opts, Relation rel)
 
 	if (!reloptions_has_opt(opts, "compresstype"))
 	{
-		compresstype = compresstype[0] ? compresstype : "none";
+		compresstype = (compresstype && compresstype[0]) ? compresstype : "none";
 		opts = lappend(opts, makeDefElem("compresstype", (Node *) makeString(compresstype), -1));
 	}
 

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -15996,7 +15996,6 @@ prebuild_temp_table(Relation rel, RangeVar *tmpname, DistributedBy *distro,
 				 */
 				cs->options = build_ao_rel_storage_opts(cs->options, rel);
 			}
-
 		}
 
 

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -15866,60 +15866,6 @@ get_rel_opts(Relation rel)
 	return newOptions;
 }
 
-/*
- * GPDB: Convenience function to judge a relation option whether already in opts
- */
-static bool
-reloptions_has_opt(List *opts, const char *name)
-{
-	ListCell *lc;
-	foreach(lc, opts)
-	{
-		DefElem *de = lfirst(lc);
-		if (strcmp(de->defname, name) == 0)
-			return true;
-	}
-	return false;
-}
-
-/*
- * GPDB: Convenience function to build storage reloptions for a given relation, just for AO table.
- */
-static List*
-build_ao_rel_storage_opts(List *opts, Relation rel)
-{
-	bool		checksum = true;
-	int32		blocksize = -1;
-	int16		compresslevel = 0;
-	char	   *compresstype = NULL;
-	NameData	compresstype_nd;
-
-	GetAppendOnlyEntryAttributes(RelationGetRelid(rel),
-								 &blocksize,
-								 NULL,
-								 &compresslevel,
-								 &checksum,
-								 &compresstype_nd);
-	compresstype = NameStr(compresstype_nd);
-
-	if (!reloptions_has_opt(opts, "blocksize"))
-		opts = lappend(opts, makeDefElem("blocksize", (Node *) makeInteger(blocksize), -1));
-
-	if (!reloptions_has_opt(opts, "compresslevel"))
-		opts = lappend(opts, makeDefElem("compresslevel", (Node *) makeInteger(compresslevel), -1));
-
-	if (!reloptions_has_opt(opts, "checksum"))
-		opts = lappend(opts, makeDefElem("checksum", (Node *) makeInteger(checksum), -1));
-
-	if (!reloptions_has_opt(opts, "compresstype"))
-	{
-		compresstype = (compresstype && compresstype[0]) ? compresstype : "none";
-		opts = lappend(opts, makeDefElem("compresstype", (Node *) makeString(compresstype), -1));
-	}
-
-	return opts;
-}
-
 static RangeVar *
 make_temp_table_name(Relation rel, BackendId id)
 {

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -15998,7 +15998,6 @@ prebuild_temp_table(Relation rel, RangeVar *tmpname, DistributedBy *distro,
 			}
 		}
 
-
 		for (attno = 0; attno < tupdesc->natts; attno++)
 		{
 			ColumnDef *cd = makeNode(ColumnDef);

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -15886,7 +15886,7 @@ reloptions_has_opt(List *opts, const char *name)
  * GPDB: Convenience function to build storage reloptions for a given relation, just for AO table.
  */
 static List*
-build_rel_opts(List *opts, Relation rel)
+build_ao_rel_storage_opts(List *opts, Relation rel)
 {
 	bool		checksum = true;
 	int32		blocksize = -1;
@@ -15903,18 +15903,18 @@ build_rel_opts(List *opts, Relation rel)
 	compresstype = NameStr(compresstype_nd);
 
 	if (!reloptions_has_opt(opts, "blocksize"))
-		opts = lappend(opts, makeDefElem("blocksize", (Node *)makeInteger(blocksize), -1));
+		opts = lappend(opts, makeDefElem("blocksize", (Node *) makeInteger(blocksize), -1));
 
 	if (!reloptions_has_opt(opts, "compresslevel"))
-		opts = lappend(opts, makeDefElem("compresslevel", (Node *)makeInteger(compresslevel), -1));
+		opts = lappend(opts, makeDefElem("compresslevel", (Node *) makeInteger(compresslevel), -1));
 
 	if (!reloptions_has_opt(opts, "checksum"))
-		opts = lappend(opts, makeDefElem("checksum", (Node *)makeInteger(checksum), -1));
+		opts = lappend(opts, makeDefElem("checksum", (Node *) makeInteger(checksum), -1));
 
 	if (!reloptions_has_opt(opts, "compresstype"))
 	{
-		compresstype = compresstype && compresstype[0] ? compresstype : "none";
-		opts = lappend(opts, makeDefElem("compresstype", (Node *)makeString(compresstype), -1));
+		compresstype = compresstype[0] ? compresstype : "none";
+		opts = lappend(opts, makeDefElem("compresstype", (Node *) makeString(compresstype), -1));
 	}
 
 	return opts;
@@ -16048,7 +16048,7 @@ prebuild_temp_table(Relation rel, RangeVar *tmpname, DistributedBy *distro,
 				 * gp_default_storage_options is modified, the newly created table will be
 				 * inconsistent with the original table.
 				 */
-				cs->options = build_rel_opts(cs->options, rel);
+				cs->options = build_ao_rel_storage_opts(cs->options, rel);
 			}
 
 		}

--- a/src/include/access/reloptions.h
+++ b/src/include/access/reloptions.h
@@ -327,6 +327,9 @@ extern void validate_and_refill_options(StdRdOptions *result, relopt_value *opti
 extern void validate_and_adjust_options(StdRdOptions *result, relopt_value *options,
 										int num_options, relopt_kind kind, bool validate);
 
+bool reloptions_has_opt(List *opts, const char *name);
+List* build_ao_rel_storage_opts(List *opts, Relation rel);
+
 /* attribute enconding specific functions */
 extern List *transformColumnEncoding(Relation rel, List *colDefs,
 										List *stenc, List *withOptions,

--- a/src/include/access/reloptions.h
+++ b/src/include/access/reloptions.h
@@ -328,7 +328,7 @@ extern void validate_and_adjust_options(StdRdOptions *result, relopt_value *opti
 										int num_options, relopt_kind kind, bool validate);
 
 extern bool reloptions_has_opt(List *opts, const char *name);
-extern List* build_ao_rel_storage_opts(List *opts, Relation rel);
+extern List *build_ao_rel_storage_opts(List *opts, Relation rel);
 
 /* attribute enconding specific functions */
 extern List *transformColumnEncoding(Relation rel, List *colDefs,

--- a/src/include/access/reloptions.h
+++ b/src/include/access/reloptions.h
@@ -327,8 +327,8 @@ extern void validate_and_refill_options(StdRdOptions *result, relopt_value *opti
 extern void validate_and_adjust_options(StdRdOptions *result, relopt_value *options,
 										int num_options, relopt_kind kind, bool validate);
 
-bool reloptions_has_opt(List *opts, const char *name);
-List* build_ao_rel_storage_opts(List *opts, Relation rel);
+extern bool reloptions_has_opt(List *opts, const char *name);
+extern List* build_ao_rel_storage_opts(List *opts, Relation rel);
 
 /* attribute enconding specific functions */
 extern List *transformColumnEncoding(Relation rel, List *colDefs,

--- a/src/test/regress/expected/expand_table_ao.out
+++ b/src/test/regress/expected/expand_table_ao.out
@@ -713,7 +713,7 @@ Select gp_segment_id, count(*) from part_t1 group by gp_segment_id;
 (3 rows)
 
 drop table part_t1;
--- Test expanding a AO table with index, and current gp_default_storage_options is different
+-- Test expanding an AO table with index, and current gp_default_storage_options is different
 -- from the table created.
 select gp_debug_set_create_table_default_numsegments(2);
  gp_debug_set_create_table_default_numsegments 
@@ -753,6 +753,45 @@ select blocksize,compresslevel,checksum,compresstype,columnstore from pg_appendo
 -- set back
 set gp_default_storage_options = '';
 drop table t_9527;
+-- Test change the distribution policy of an AO table with index, and current gp_default_storage_options is different
+-- from the table created.
+select gp_debug_set_create_table_default_numsegments(2);
+ gp_debug_set_create_table_default_numsegments 
+-----------------------------------------------
+ 2
+(1 row)
+
+set gp_default_storage_options = '';
+-- Create a AO table with default row-oriented storage and build index for it
+create table t_9528 (a int, b text) WITH (appendoptimized=true) distributed by (a);
+create index idx_9528 on t_9528(b);
+SET gp_default_storage_options = 'blocksize=65536, compresstype=zlib, compresslevel=5, checksum=true';
+set default_table_access_method = ao_column;
+-- Should successful and the table is still row-oriented
+alter table t_9528 set distributed by (b);
+show gp_default_storage_options;
+                   gp_default_storage_options                    
+-----------------------------------------------------------------
+ blocksize=65536,compresstype=zlib,compresslevel=5,checksum=true
+(1 row)
+
+select localoid::regclass::name, policytype, numsegments, distkey, distclass
+    from gp_distribution_policy where localoid = 't_9528'::regclass::oid;
+ localoid | policytype | numsegments | distkey | distclass 
+----------+------------+-------------+---------+-----------
+ t_9528   | p          |           2 | 2       | 10072
+(1 row)
+
+-- storage paramter should be same with before
+select blocksize,compresslevel,checksum,compresstype,columnstore from pg_appendonly where relid='t_9528'::regclass::oid;
+ blocksize | compresslevel | checksum | compresstype | columnstore 
+-----------+---------------+----------+--------------+-------------
+     32768 |             0 | t        | none         | f
+(1 row)
+
+-- set back
+set gp_default_storage_options = '';
+drop table t_9528;
 -- start_ignore
 -- We need to do a cluster expansion which will check if there are partial
 -- tables, we need to drop the partial tables to keep the cluster expansion

--- a/src/test/regress/expected/expand_table_ao.out
+++ b/src/test/regress/expected/expand_table_ao.out
@@ -713,6 +713,46 @@ Select gp_segment_id, count(*) from part_t1 group by gp_segment_id;
 (3 rows)
 
 drop table part_t1;
+-- Test expanding a AO table with index, and current gp_default_storage_options is different
+-- from the table created.
+select gp_debug_set_create_table_default_numsegments(2);
+ gp_debug_set_create_table_default_numsegments 
+-----------------------------------------------
+ 2
+(1 row)
+
+set gp_default_storage_options = ''; 
+-- Create a AO table with default row-oriented storage and build index for it
+create table t_9527 (a int, b text) WITH (appendoptimized=true) distributed by (a);
+create index idx_9527 on t_9527(b);
+-- Set default storage method to column-oriented, and change the default value of blocksize, compresstype, etc.
+SET gp_default_storage_options = 'blocksize=65536, compresstype=zlib, compresslevel=5, checksum=true';
+set default_table_access_method = ao_column;
+-- Should successful and the table is still row-oriented
+alter table t_9527 expand table;
+show gp_default_storage_options;
+                   gp_default_storage_options                    
+-----------------------------------------------------------------
+ blocksize=65536,compresstype=zlib,compresslevel=5,checksum=true
+(1 row)
+
+select localoid::regclass::name, policytype, numsegments, distkey, distclass
+    from gp_distribution_policy where localoid = 't_9527'::regclass::oid;
+ localoid | policytype | numsegments | distkey | distclass 
+----------+------------+-------------+---------+-----------
+ t_9527   | p          |           3 | 1       | 10054
+(1 row)
+
+-- storage paramter should be same with before
+select blocksize,compresslevel,checksum,compresstype,columnstore from pg_appendonly where relid='t_9527'::regclass::oid;
+ blocksize | compresslevel | checksum | compresstype | columnstore 
+-----------+---------------+----------+--------------+-------------
+     32768 |             0 | t        | none         | f
+(1 row)
+
+-- set back
+set gp_default_storage_options = ''; 
+drop table t_9527;
 -- start_ignore
 -- We need to do a cluster expansion which will check if there are partial
 -- tables, we need to drop the partial tables to keep the cluster expansion

--- a/src/test/regress/expected/expand_table_ao.out
+++ b/src/test/regress/expected/expand_table_ao.out
@@ -721,7 +721,7 @@ select gp_debug_set_create_table_default_numsegments(2);
  2
 (1 row)
 
-set gp_default_storage_options = ''; 
+set gp_default_storage_options = '';
 -- Create a AO table with default row-oriented storage and build index for it
 create table t_9527 (a int, b text) WITH (appendoptimized=true) distributed by (a);
 create index idx_9527 on t_9527(b);
@@ -751,7 +751,7 @@ select blocksize,compresslevel,checksum,compresstype,columnstore from pg_appendo
 (1 row)
 
 -- set back
-set gp_default_storage_options = ''; 
+set gp_default_storage_options = '';
 drop table t_9527;
 -- start_ignore
 -- We need to do a cluster expansion which will check if there are partial

--- a/src/test/regress/sql/expand_table_ao.sql
+++ b/src/test/regress/sql/expand_table_ao.sql
@@ -336,7 +336,7 @@ Select gp_segment_id, count(*) from part_t1 group by gp_segment_id;
 drop table part_t1;
 
 
--- Test expanding a AO table with index, and current gp_default_storage_options is different
+-- Test expanding an AO table with index, and current gp_default_storage_options is different
 -- from the table created.
 select gp_debug_set_create_table_default_numsegments(2);
 set gp_default_storage_options = '';
@@ -361,6 +361,31 @@ select blocksize,compresslevel,checksum,compresstype,columnstore from pg_appendo
 -- set back
 set gp_default_storage_options = '';
 drop table t_9527;
+
+-- Test change the distribution policy of an AO table with index, and current gp_default_storage_options is different
+-- from the table created.
+select gp_debug_set_create_table_default_numsegments(2);
+set gp_default_storage_options = '';
+
+-- Create a AO table with default row-oriented storage and build index for it
+create table t_9528 (a int, b text) WITH (appendoptimized=true) distributed by (a);
+create index idx_9528 on t_9528(b);
+
+SET gp_default_storage_options = 'blocksize=65536, compresstype=zlib, compresslevel=5, checksum=true';
+set default_table_access_method = ao_column;
+
+-- Should successful and the table is still row-oriented
+alter table t_9528 set distributed by (b);
+
+show gp_default_storage_options;
+select localoid::regclass::name, policytype, numsegments, distkey, distclass
+    from gp_distribution_policy where localoid = 't_9528'::regclass::oid;
+-- storage paramter should be same with before
+select blocksize,compresslevel,checksum,compresstype,columnstore from pg_appendonly where relid='t_9528'::regclass::oid;
+
+-- set back
+set gp_default_storage_options = '';
+drop table t_9528;
 
 
 -- start_ignore

--- a/src/test/regress/sql/expand_table_ao.sql
+++ b/src/test/regress/sql/expand_table_ao.sql
@@ -339,7 +339,7 @@ drop table part_t1;
 -- Test expanding a AO table with index, and current gp_default_storage_options is different
 -- from the table created.
 select gp_debug_set_create_table_default_numsegments(2);
-set gp_default_storage_options = ''; 
+set gp_default_storage_options = '';
 
 -- Create a AO table with default row-oriented storage and build index for it
 create table t_9527 (a int, b text) WITH (appendoptimized=true) distributed by (a);
@@ -359,7 +359,7 @@ select localoid::regclass::name, policytype, numsegments, distkey, distclass
 select blocksize,compresslevel,checksum,compresstype,columnstore from pg_appendonly where relid='t_9527'::regclass::oid;
 
 -- set back
-set gp_default_storage_options = ''; 
+set gp_default_storage_options = '';
 drop table t_9527;
 
 

--- a/src/test/regress/sql/expand_table_ao.sql
+++ b/src/test/regress/sql/expand_table_ao.sql
@@ -335,6 +335,34 @@ Select gp_segment_id, count(*) from part_t1 group by gp_segment_id;
 
 drop table part_t1;
 
+
+-- Test expanding a AO table with index, and current gp_default_storage_options is different
+-- from the table created.
+select gp_debug_set_create_table_default_numsegments(2);
+set gp_default_storage_options = ''; 
+
+-- Create a AO table with default row-oriented storage and build index for it
+create table t_9527 (a int, b text) WITH (appendoptimized=true) distributed by (a);
+create index idx_9527 on t_9527(b);
+
+-- Set default storage method to column-oriented, and change the default value of blocksize, compresstype, etc.
+SET gp_default_storage_options = 'blocksize=65536, compresstype=zlib, compresslevel=5, checksum=true';
+set default_table_access_method = ao_column;
+
+-- Should successful and the table is still row-oriented
+alter table t_9527 expand table;
+
+show gp_default_storage_options;
+select localoid::regclass::name, policytype, numsegments, distkey, distclass
+    from gp_distribution_policy where localoid = 't_9527'::regclass::oid;
+-- storage paramter should be same with before
+select blocksize,compresslevel,checksum,compresstype,columnstore from pg_appendonly where relid='t_9527'::regclass::oid;
+
+-- set back
+set gp_default_storage_options = ''; 
+drop table t_9527;
+
+
 -- start_ignore
 -- We need to do a cluster expansion which will check if there are partial
 -- tables, we need to drop the partial tables to keep the cluster expansion


### PR DESCRIPTION
When a table is an AO table and has an index, `ALTER TABLE EXPAND TABLE` will not be done directly 
using CTAS, but create table + insert data. However, when creating a table, the original storage option 
of the AO table is ignored, and the default parameters of the current environment are used, which will 
lead to inconsistency between the table before and after expansion.

The pr fixes issue #13245, reconstructs the storage option of the original table, and passes it down.