### PR TITLE
Error out in DECLARE if gp_parallel_retrieve_cursor is not installed

### DIFF
--- a/src/backend/commands/portalcmds.c
+++ b/src/backend/commands/portalcmds.c
@@ -26,11 +26,11 @@
 #include <limits.h>
 
 #include "access/xact.h"
+#include "commands/extension.h"
 #include "commands/portalcmds.h"
 #include "executor/executor.h"
 #include "executor/tstoreReceiver.h"
 #include "miscadmin.h"
-#include "parser/parse_func.h"
 #include "tcop/pquery.h"
 #include "utils/memutils.h"
 #include "utils/snapmgr.h"
@@ -104,21 +104,7 @@ PerformCursorOpen(PlannedStmt *stmt, ParamListInfo params,
 
 	if (cstmt->options & CURSOR_OPT_PARALLEL_RETRIEVE)
 	{
-		List *funcname = NIL;
-		funcname = lappend(funcname, makeString("gp_get_endpoints"));
-
-		if (!OidIsValid(LookupFuncName(funcname, 0, NULL, true)))
-		{
-			/*
-			 * We don't have gp_get_endpoints(), so we can't use parallel
-			 * retrieve.
-			 */
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("the gp_parallel_retrieve_cursor extension is not installed"),
-					 errdetail("gp_get_endpoints() is not available")));
-		}
-
+		get_extension_oid("gp_parallel_retrieve_cursor", false);
 	}
 
 	/*

--- a/src/test/isolation2/.gitignore
+++ b/src/test/isolation2/.gitignore
@@ -11,6 +11,8 @@ sql/fts_manual_probe.sql
 expected/fts_manual_probe.out
 sql/workfile_mgr_test.sql
 expected/workfile_mgr_test.out
+expected/idle_gang_cleaner.out
+sql/idle_gang_cleaner.sql
 
 -- ignore generated pg_basebackup tests
 /sql/pg_basebackup*.sql

--- a/src/test/isolation2/expected/parallel_retrieve_cursor/set.out
+++ b/src/test/isolation2/expected/parallel_retrieve_cursor/set.out
@@ -6,5 +6,12 @@
 (exited with code 0)
 !\retcode gpstop -u;
 (exited with code 0)
+BEGIN;
+BEGIN
+DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT 1;
+ERROR:  the gp_parallel_retrieve_cursor extension is not installed
+DETAIL:  gp_get_endpoints() is not available
+END;
+END
 CREATE EXTENSION IF NOT EXISTS gp_parallel_retrieve_cursor;
 CREATE

--- a/src/test/isolation2/expected/parallel_retrieve_cursor/set.out
+++ b/src/test/isolation2/expected/parallel_retrieve_cursor/set.out
@@ -9,8 +9,7 @@
 BEGIN;
 BEGIN
 DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT 1;
-ERROR:  the gp_parallel_retrieve_cursor extension is not installed
-DETAIL:  gp_get_endpoints() is not available
+ERROR:  extension "gp_parallel_retrieve_cursor" does not exist
 END;
 END
 CREATE EXTENSION IF NOT EXISTS gp_parallel_retrieve_cursor;

--- a/src/test/isolation2/sql/parallel_retrieve_cursor/set.sql
+++ b/src/test/isolation2/sql/parallel_retrieve_cursor/set.sql
@@ -4,4 +4,7 @@
 
 !\retcode gpconfig -c statement_timeout -v 60000;
 !\retcode gpstop -u;
+BEGIN;
+DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT 1;
+END;
 CREATE EXTENSION IF NOT EXISTS gp_parallel_retrieve_cursor;


### PR DESCRIPTION
The PARALLEL RETRIEVE CURSOR feature depends on the extension
gp_parallel_retrieve_cursor on Greenplum 6.X, error out in the DECLARE
statement to save resources and tell the users if the extension is not
installed.

DECLARE is the beginning of everything, it's good enough to do this on
it only.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Pass `make installcheck`