### PR TITLE
[6X] add original storage options to AO table with index when expanding

### DIFF
--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -30,6 +30,7 @@
 #include "utils/guc.h"
 #include "utils/memutils.h"
 #include "miscadmin.h"
+#include "nodes/makefuncs.h"
 
 /*
  * Confusingly, RELOPT_KIND_HEAP is also used for AO/CO tables. To reduce
@@ -1298,4 +1299,51 @@ get_option_set(relopt_value *options, int num_options, const char *opt_name)
 			return &options[i];
 	}
 	return NULL;
+}
+
+/*
+ * GPDB: Convenience function to judge a relation option whether already in opts
+ */
+bool
+reloptions_has_opt(List *opts, const char *name)
+{
+	ListCell *lc;
+	foreach(lc, opts)
+	{
+		DefElem *de = lfirst(lc);
+		if (pg_strcasecmp(de->defname, name) == 0)
+			return true;
+	}
+	return false;
+}
+
+/*
+ * GPDB: Convenience function to build storage reloptions for a given relation, just for AO table .
+ */
+List*
+build_ao_rel_storage_opts(List *opts, Relation rel)
+{
+	if (!reloptions_has_opt(opts, "blocksize"))
+		opts = lappend(opts, makeDefElem("blocksize", (Node *) makeInteger(rel->rd_appendonly->blocksize)));
+
+	if (!reloptions_has_opt(opts, "compresslevel"))
+		opts = lappend(opts, makeDefElem("compresslevel", (Node *) makeInteger(rel->rd_appendonly->compresslevel)));
+
+	if (!reloptions_has_opt(opts, "checksum"))
+		opts = lappend(opts, makeDefElem("checksum", (Node *) makeInteger(rel->rd_appendonly->checksum)));
+
+	if (!reloptions_has_opt(opts, "compresstype"))
+	{
+		char *compresstype = rel->rd_appendonly->compresstype.data;
+		compresstype = (compresstype && compresstype[0]) ? compresstype : "none";
+		opts = lappend(opts, makeDefElem("compresstype", (Node *) makeString(compresstype)));
+	}
+
+	if (!reloptions_has_opt(opts, "orientation"))
+	{
+		char *orientation = rel->rd_appendonly->columnstore ? "column" : "row";
+		opts = lappend(opts, makeDefElem("orientation", (Node *) makeString(orientation)));
+	}
+
+	return opts;
 }

--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -1335,7 +1335,7 @@ build_ao_rel_storage_opts(List *opts, Relation rel)
 	if (!reloptions_has_opt(opts, "compresstype"))
 	{
 		char *compresstype = rel->rd_appendonly->compresstype.data;
-		compresstype = (compresstype && compresstype[0]) ? compresstype : "none";
+		compresstype = (compresstype && compresstype[0]) ? pnstrdup(compresstype, strlen(compresstype)) : "none";
 		opts = lappend(opts, makeDefElem("compresstype", (Node *) makeString(compresstype)));
 	}
 

--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -1320,7 +1320,7 @@ reloptions_has_opt(List *opts, const char *name)
 /*
  * GPDB: Convenience function to build storage reloptions for a given relation, just for AO table .
  */
-List*
+List *
 build_ao_rel_storage_opts(List *opts, Relation rel)
 {
 	if (!reloptions_has_opt(opts, "blocksize"))

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14716,6 +14716,55 @@ get_rel_opts(Relation rel)
 	return newOptions;
 }
 
+/*
+ * GPDB: Convenience function to judge a relation option whether already in opts
+ */
+static bool
+reloptions_has_opt(List *opts, const char *name)
+{
+	ListCell *lc;
+	foreach(lc, opts)
+	{
+		DefElem *de = lfirst(lc);
+		if (strcmp(de->defname, name) == 0)
+			return true;
+	}
+	return false;
+}
+
+/*
+ * GPDB: Convenience function to build storage reloptions for a given relation, just for AO table .
+ */
+static List*
+build_ao_rel_storage_opts(List *opts, Relation rel)
+{
+	if (!reloptions_has_opt(opts, "blocksize"))
+		opts = lappend(opts, makeDefElem("blocksize", (Node *) makeInteger(rel->rd_appendonly->blocksize)));
+
+	if (!reloptions_has_opt(opts, "compresslevel"))
+		opts = lappend(opts, makeDefElem("compresslevel", (Node *) makeInteger(rel->rd_appendonly->compresslevel)));
+
+	if (!reloptions_has_opt(opts, "checksum"))
+		opts = lappend(opts, makeDefElem("checksum", (Node *) makeInteger(rel->rd_appendonly->checksum)));
+
+	if (!reloptions_has_opt(opts, "compresstype"))
+	{
+		char *compresstype = rel->rd_appendonly->compresstype.data;
+		compresstype = (compresstype && compresstype[0]) ? compresstype : "none";
+
+		opts = lappend(opts, makeDefElem("compresstype", (Node *) makeString(compresstype)));
+	}
+
+	if (!reloptions_has_opt(opts, "orientation"))
+	{
+		char *orientation = rel->rd_appendonly->columnstore ? "column" : "row";
+		opts = lappend(opts, makeDefElem("orientation", (Node *) makeString(orientation)));
+	}
+
+	return opts;
+}
+
+
 static RangeVar *
 make_temp_table_name(Relation rel, BackendId id)
 {
@@ -14843,7 +14892,24 @@ prebuild_temp_table(Relation rel, RangeVar *tmpname, DistributedBy *distro, List
 			}
 		}
 		else
+		{
 			cs->options = opts;
+
+			if (RelationIsAoRows(rel))
+			{
+				/*
+				 * In order to avoid being affected by the GUC of gp_default_storage_options,
+				 * we should re-build storage options from original table.
+				 *
+				 * The reason is that when we use the default parameters to create a table,
+				 * the configuration will not be written to pg_class.reloptions, and then if
+				 * gp_default_storage_options is modified, the newly created table will be
+				 * inconsistent with the original table.
+				 */
+				cs->options = build_ao_rel_storage_opts(cs->options, rel);
+			}
+		}
+
 
 		for (attno = 0; attno < tupdesc->natts; attno++)
 		{

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14861,7 +14861,6 @@ prebuild_temp_table(Relation rel, RangeVar *tmpname, DistributedBy *distro, List
 			}
 		}
 
-
 		for (attno = 0; attno < tupdesc->natts; attno++)
 		{
 			ColumnDef *cd = makeNode(ColumnDef);

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14716,55 +14716,6 @@ get_rel_opts(Relation rel)
 	return newOptions;
 }
 
-/*
- * GPDB: Convenience function to judge a relation option whether already in opts
- */
-static bool
-reloptions_has_opt(List *opts, const char *name)
-{
-	ListCell *lc;
-	foreach(lc, opts)
-	{
-		DefElem *de = lfirst(lc);
-		if (strcmp(de->defname, name) == 0)
-			return true;
-	}
-	return false;
-}
-
-/*
- * GPDB: Convenience function to build storage reloptions for a given relation, just for AO table .
- */
-static List*
-build_ao_rel_storage_opts(List *opts, Relation rel)
-{
-	if (!reloptions_has_opt(opts, "blocksize"))
-		opts = lappend(opts, makeDefElem("blocksize", (Node *) makeInteger(rel->rd_appendonly->blocksize)));
-
-	if (!reloptions_has_opt(opts, "compresslevel"))
-		opts = lappend(opts, makeDefElem("compresslevel", (Node *) makeInteger(rel->rd_appendonly->compresslevel)));
-
-	if (!reloptions_has_opt(opts, "checksum"))
-		opts = lappend(opts, makeDefElem("checksum", (Node *) makeInteger(rel->rd_appendonly->checksum)));
-
-	if (!reloptions_has_opt(opts, "compresstype"))
-	{
-		char *compresstype = rel->rd_appendonly->compresstype.data;
-		compresstype = (compresstype && compresstype[0]) ? compresstype : "none";
-
-		opts = lappend(opts, makeDefElem("compresstype", (Node *) makeString(compresstype)));
-	}
-
-	if (!reloptions_has_opt(opts, "orientation"))
-	{
-		char *orientation = rel->rd_appendonly->columnstore ? "column" : "row";
-		opts = lappend(opts, makeDefElem("orientation", (Node *) makeString(orientation)));
-	}
-
-	return opts;
-}
-
-
 static RangeVar *
 make_temp_table_name(Relation rel, BackendId id)
 {

--- a/src/include/access/reloptions.h
+++ b/src/include/access/reloptions.h
@@ -316,5 +316,7 @@ extern void validate_and_refill_options(StdRdOptions *result, relopt_value *opti
 							int numoptions, relopt_kind kind, bool validate);
 extern void validate_and_adjust_options(StdRdOptions *result, relopt_value *options,
 										int num_options, relopt_kind kind, bool validate);
+extern bool reloptions_has_opt(List *opts, const char *name);
+extern List *build_ao_rel_storage_opts(List *opts, Relation rel);
 
 #endif   /* RELOPTIONS_H */

--- a/src/test/regress/expected/expand_table_ao.out
+++ b/src/test/regress/expected/expand_table_ao.out
@@ -834,6 +834,78 @@ Select gp_segment_id, count(*) from part_t1 group by gp_segment_id;
 (3 rows)
 
 drop table part_t1;
+-- Test expanding an AO table with index, and current gp_default_storage_options is different
+-- from the table created.
+select gp_debug_set_create_table_default_numsegments(2);
+ gp_debug_set_create_table_default_numsegments 
+-----------------------------------------------
+ 2
+(1 row)
+
+set gp_default_storage_options = '';
+-- Create an AO table with default row-oriented storage and build index for it
+create table t_9527 (a int, b text) WITH (appendoptimized=true) distributed by (a);
+create index idx_9527 on t_9527(b);
+-- Set default storage method to column-oriented, and change the default value of blocksize, compresstype, etc.
+SET gp_default_storage_options = 'blocksize=65536, compresstype=zstd, compresslevel=12, checksum=true, appendoptimized=true, orientation=column';
+-- Should successful and the table is still row-oriented
+alter table t_9527 expand table;
+select localoid::regclass::name, policytype, numsegments, distkey, distclass
+    from gp_distribution_policy where localoid = 't_9527'::regclass::oid;
+ localoid | policytype | numsegments | distkey | distclass 
+----------+------------+-------------+---------+-----------
+ t_9527   | p          |           3 | 1       | 10027
+(1 row)
+
+select relname, relstorage from pg_class where relname = 't_9527';
+ relname | relstorage 
+---------+------------
+ t_9527  | a
+(1 row)
+
+-- storage paramter should be same with before
+select blocksize,compresslevel,checksum,compresstype,columnstore from pg_appendonly where relid='t_9527'::regclass::oid;
+ blocksize | compresslevel | checksum | compresstype | columnstore 
+-----------+---------------+----------+--------------+-------------
+     32768 |             0 | t        | none         | f
+(1 row)
+
+-- set back
+set gp_default_storage_options = '';
+drop table t_9527;
+-- Test change the distribution policy of an AO table with index, and current gp_default_storage_options is different
+-- from the table created.
+set gp_default_storage_options = ''; 
+-- Create an AO table with default row-oriented storage and build index for it
+create table t_9528 (a int, b text) WITH (appendoptimized=true) distributed by (a);
+create index idx_9528 on t_9528(b);
+-- Set default storage method to column-oriented, and change the default value of blocksize, compresstype, etc.
+SET gp_default_storage_options = 'blocksize=65536, compresstype=zstd, compresslevel=12, checksum=true, appendoptimized=true, orientation=column';
+-- Should successful and the table is still row-oriented
+alter table t_9528 set distributed by (b);
+select localoid::regclass::name, policytype, numsegments, distkey, distclass
+    from gp_distribution_policy where localoid = 't_9528'::regclass::oid;
+ localoid | policytype | numsegments | distkey | distclass 
+----------+------------+-------------+---------+-----------
+ t_9528   | p          |           2 | 2       | 10043
+(1 row)
+
+select relname, relstorage from pg_class where relname = 't_9528';
+ relname | relstorage 
+---------+------------
+ t_9528  | a
+(1 row)
+
+-- storage paramter should be same with before
+select blocksize,compresslevel,checksum,compresstype,columnstore from pg_appendonly where relid='t_9528'::regclass::oid;
+ blocksize | compresslevel | checksum | compresstype | columnstore 
+-----------+---------------+----------+--------------+-------------
+     32768 |             0 | t        | none         | f
+(1 row)
+
+-- set back
+set gp_default_storage_options = ''; 
+drop table t_9528;
 -- start_ignore
 -- We need to do a cluster expansion which will check if there are partial
 -- tables, we need to drop the partial tables to keep the cluster expansion

--- a/src/test/regress/sql/expand_table_ao.sql
+++ b/src/test/regress/sql/expand_table_ao.sql
@@ -337,6 +337,56 @@ Select gp_segment_id, count(*) from part_t1 group by gp_segment_id;
 
 drop table part_t1;
 
+
+-- Test expanding an AO table with index, and current gp_default_storage_options is different
+-- from the table created.
+select gp_debug_set_create_table_default_numsegments(2);
+set gp_default_storage_options = '';
+
+-- Create an AO table with default row-oriented storage and build index for it
+create table t_9527 (a int, b text) WITH (appendoptimized=true) distributed by (a);
+create index idx_9527 on t_9527(b);
+
+-- Set default storage method to column-oriented, and change the default value of blocksize, compresstype, etc.
+SET gp_default_storage_options = 'blocksize=65536, compresstype=zstd, compresslevel=12, checksum=true, appendoptimized=true, orientation=column';
+
+-- Should successful and the table is still row-oriented
+alter table t_9527 expand table;
+select localoid::regclass::name, policytype, numsegments, distkey, distclass
+    from gp_distribution_policy where localoid = 't_9527'::regclass::oid;
+select relname, relstorage from pg_class where relname = 't_9527';
+-- storage paramter should be same with before
+select blocksize,compresslevel,checksum,compresstype,columnstore from pg_appendonly where relid='t_9527'::regclass::oid;
+
+-- set back
+set gp_default_storage_options = '';
+drop table t_9527;
+
+
+-- Test change the distribution policy of an AO table with index, and current gp_default_storage_options is different
+-- from the table created.
+set gp_default_storage_options = ''; 
+
+-- Create an AO table with default row-oriented storage and build index for it
+create table t_9528 (a int, b text) WITH (appendoptimized=true) distributed by (a);
+create index idx_9528 on t_9528(b);
+
+-- Set default storage method to column-oriented, and change the default value of blocksize, compresstype, etc.
+SET gp_default_storage_options = 'blocksize=65536, compresstype=zstd, compresslevel=12, checksum=true, appendoptimized=true, orientation=column';
+
+-- Should successful and the table is still row-oriented
+alter table t_9528 set distributed by (b);
+select localoid::regclass::name, policytype, numsegments, distkey, distclass
+    from gp_distribution_policy where localoid = 't_9528'::regclass::oid;
+select relname, relstorage from pg_class where relname = 't_9528';
+-- storage paramter should be same with before
+select blocksize,compresslevel,checksum,compresstype,columnstore from pg_appendonly where relid='t_9528'::regclass::oid;
+
+-- set back
+set gp_default_storage_options = ''; 
+drop table t_9528;
+
+
 -- start_ignore
 -- We need to do a cluster expansion which will check if there are partial
 -- tables, we need to drop the partial tables to keep the cluster expansion


### PR DESCRIPTION
When a table is an AO table and has an index, ALTER TABLE EXPAND TABLE will not be done directly
using CTAS, but create table + insert data. However, when creating a table, the original storage option
of the AO table is ignored, and the default parameters of the current environment are used, which will
lead to inconsistency between the table before and after expansion.

The pr fixes issue https://github.com/greenplum-db/gpdb/issues/13245, reconstructs the storage option of the original table, and passes it down.

This is the backport of #13246.