### PR TITLE
Fix flaky test fts_errors with nondeterminsitc error in FETCH

### DIFF
--- a/src/test/isolation2/expected/fts_errors.out
+++ b/src/test/isolation2/expected/fts_errors.out
@@ -137,10 +137,6 @@ END
 ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:98)
 -- session 3: in transaction and has a cursor, cann't update
 --            cdb_component_dbs, following query should fail
-3:FETCH ALL FROM c1;
- c1 | c2 
-----+----
-(0 rows)
 3:END;
 ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:98)
 -- session 4: not in transaction but has temp table, cann't update

--- a/src/test/isolation2/expected/fts_errors_1.out
+++ b/src/test/isolation2/expected/fts_errors_1.out
@@ -137,10 +137,6 @@ END
 ERROR:  gang was lost due to cluster reconfiguration (cdbgang_async.c:98)
 -- session 3: in transaction and has a cursor, cann't update
 --            cdb_component_dbs, following query should fail
-3:FETCH ALL FROM c1;
- c1 | c2 
-----+----
-(0 rows)
 3:END;
 ERROR:  Error on receive from seg1 slice1 127.0.1.1:7003 pid=31911: server closed the connection unexpectedly
 	This probably means the server terminated abnormally

--- a/src/test/isolation2/sql/fts_errors.sql
+++ b/src/test/isolation2/sql/fts_errors.sql
@@ -98,7 +98,6 @@ select gp_inject_fault('get_dns_cached_address', 'reset', 1);
 2:END;
 -- session 3: in transaction and has a cursor, cann't update
 --            cdb_component_dbs, following query should fail 
-3:FETCH ALL FROM c1;
 3:END;
 -- session 4: not in transaction but has temp table, cann't update
 --            cdb_component_dbs, following query should fail and session


### PR DESCRIPTION
This test is flaky in terms of where error will be thrown during a `FETCH` cursor transaction when some original primary segments are down. The test expects no error during `FETCH` itself but an error in the `END` statement, since the table is small (in fact, 0 row) and during `FETCH` QD should have enough data already buffered at sockets for it to read and doesn't need to reach out to QEs. However, sometimes when the interconnect is proxy, this is not true and when QD fails to read data from socket it reaches out to QEs and throw an error.

For example test diff we saw:
```
--- /tmp/build/e18b2f02/gpdb_src/src/test/isolation2/expected/fts_errors_1.out	2022-03-09 10:00:32.786358101 +0000
+++ /tmp/build/e18b2f02/gpdb_src/src/test/isolation2/results/fts_errors.out	2022-03-09 10:00:32.802359582 +0000
@@ -140,13 +153,11 @@
 -- session 3: in transaction and has a cursor, cann't update
 --            cdb_component_dbs, following query should fail
 3:FETCH ALL FROM c1;
- c1 | c2 
-----+----
-(0 rows)
-3:END;
 ERROR: server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
+3:END;
+END
```

As for the fix, since this not a bug so we should just fix the test itself. Although in theory we could insert more data to the table to force QD to talk to QEs even for UDP (e.g. 10000 rows could produce an error for `FETCH ALL` under UDP in my local test environment). But for the sake of minimal flakiness I'm just removing the `FETCH` and let it error out at the `END`.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
