### PR TITLE
Fix memory leak in dtx recovery process

### DIFF
--- a/src/backend/cdb/cdbdtxrecovery.c
+++ b/src/backend/cdb/cdbdtxrecovery.c
@@ -350,6 +350,8 @@ gatherRMInDoubtTransactions(int prepared_seconds, bool raiseError)
 		}
 	}
 
+	cdbdisp_clearCdbPgResults(&cdb_pgresults);
+
 	return htab;
 }
 


### PR DESCRIPTION
Need to call cdbdisp_clearCdbPgResults() to free up cdb_pgresults
returned by CdbDispatchCommand(), but PR #10393 forgot.

Speed up reproduction:

```
psql# create extension if not exists gp_inject_fault;
psql# select gp_inject_fault_infinite('finish_prepared_start_of_function', 'suspend', dbid)
  from gp_segment_configuration where content != -1 and role = 'p';

shell# gpconfig -c gp_dtx_recovery_interval -v 5
shell# for ((i=0;i<50;i++)); do psql -c "create table test_$(date +%H%M%S)(id int)" & sleep 2; done
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
