### PR TITLE
[6X] Fix memory leak in dtx recovery process

### DIFF
--- a/src/backend/cdb/cdbdtxrecovery.c
+++ b/src/backend/cdb/cdbdtxrecovery.c
@@ -339,6 +339,8 @@ gatherRMInDoubtTransactions(int prepared_seconds, bool raiseError)
 		}
 	}
 
+	cdbdisp_clearCdbPgResults(&cdb_pgresults);
+
 	return htab;
 }
 


### PR DESCRIPTION
This patch backports change in PR #13252.

Since commit eea513bb913dcc638bfa7076dba806ce88ea85b2, 
the Dtx Recovery Process needs to gather prepared transactions
from all segments by dispatching a query. However, we forgot to free the memory
used by the results of dispatch, which can cause memory leak.

Steps to reproduce:

1. Create a large number of transactions and leave them prepared on segments but
 not commit them so that pg_prepared_xacts on the segments is not empty.
2. Check the memory usage of the Dtx Recovery Process. It will keep increasing
since the results of querying pg_prepared_xacts is never freed.

(cherry picked from commit d7ffe63029c4135d977a37d4561904817ce6c4a3)

Co-authored-by: @dh-cloud <60729713+dh-cloud@users.noreply.github.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
