### PR TITLE
(6x)Do not match non vars in inner plan's target for LASJ_NOTIN.

### DIFF
--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -1747,6 +1747,7 @@ set_join_references(PlannerInfo *root, Join *join, int rtoffset)
 		case JOIN_LEFT:
 		case JOIN_SEMI:
 		case JOIN_ANTI:
+		case JOIN_LASJ_NOTIN:
 			inner_itlist->has_non_vars = false;
 			break;
 		case JOIN_RIGHT:
@@ -2401,8 +2402,6 @@ fix_join_expr_mutator(Node *node, fix_join_expr_context *context)
 	}
 	if (context->inner_itlist && context->inner_itlist->has_non_vars &&
 	        context->use_inner_tlist_for_matching_nonvars)
-
-	if (context->inner_itlist && context->inner_itlist->has_non_vars)
 	{
 		newvar = search_indexed_tlist_for_non_var(node,
 												  context->inner_itlist,

--- a/src/test/regress/expected/update_gp.out
+++ b/src/test/regress/expected/update_gp.out
@@ -564,6 +564,44 @@ SELECT * from update_gp_foo;
      12 | 1 |      1 | 12
 (1 row)
 
+-- Test for update with LASJ_NOTIN
+-- See Issue: https://github.com/greenplum-db/gpdb/issues/13265
+create table t1_13265(a int, b int, c int, d int) distributed by (a);
+create table t2_13265(a int, b int, c int, d int) distributed by (a);
+insert into t1_13265 values (1, null, 1, 1);
+insert into t2_13265 values (2, null, 2, 2);
+explain (verbose, costs off)
+update t1_13265 set b = 2 where
+(c, d) not in (select c, d from t2_13265 where a = 2);
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Update on public.t1_13265
+   ->  Explicit Redistribute Motion 3:3  (slice2; segments: 3)
+         Output: t1_13265.a, 2, t1_13265.c, t1_13265.d, t1_13265.ctid, t1_13265.gp_segment_id, t2_13265.ctid
+         ->  Nested Loop Left Anti Semi (Not-In) Join
+               Output: t1_13265.a, 2, t1_13265.c, t1_13265.d, t1_13265.ctid, t1_13265.gp_segment_id, t2_13265.ctid
+               Join Filter: ((t1_13265.c = t2_13265.c) AND (t1_13265.d = t2_13265.d))
+               ->  Seq Scan on public.t1_13265
+                     Output: t1_13265.a, t1_13265.c, t1_13265.d, t1_13265.ctid, t1_13265.gp_segment_id
+               ->  Materialize
+                     Output: t2_13265.ctid, t2_13265.c, t2_13265.d, (2)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                           Output: t2_13265.ctid, t2_13265.c, t2_13265.d, (2)
+                           ->  Seq Scan on public.t2_13265
+                                 Output: t2_13265.ctid, t2_13265.c, t2_13265.d, 2
+                                 Filter: (t2_13265.a = 2)
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(17 rows)
+
+update t1_13265 set b = 2 where
+(c, d) not in (select c, d from t2_13265 where a = 2);
+select * from t1_13265;
+ a | b | c | d 
+---+---+---+---
+ 1 | 2 | 1 | 1
+(1 row)
+
 -- start_ignore
 drop table r;
 drop table s;
@@ -572,4 +610,6 @@ drop table ao_table;
 drop table aoco_table;
 drop table nosplitupdate;
 drop table tsplit_entry;
+drop table t1_13265;
+drop table t2_13265;
 -- end_ignore

--- a/src/test/regress/expected/update_gp_optimizer.out
+++ b/src/test/regress/expected/update_gp_optimizer.out
@@ -567,6 +567,44 @@ SELECT * from update_gp_foo;
      12 | 1 |      1 | 12
 (1 row)
 
+-- Test for update with LASJ_NOTIN
+-- See Issue: https://github.com/greenplum-db/gpdb/issues/13265
+create table t1_13265(a int, b int, c int, d int) distributed by (a);
+create table t2_13265(a int, b int, c int, d int) distributed by (a);
+insert into t1_13265 values (1, null, 1, 1);
+insert into t2_13265 values (2, null, 2, 2);
+explain (verbose, costs off)
+update t1_13265 set b = 2 where
+(c, d) not in (select c, d from t2_13265 where a = 2);
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Update on public.t1_13265
+   ->  Explicit Redistribute Motion 3:3  (slice2; segments: 3)
+         Output: t1_13265.a, 2, t1_13265.c, t1_13265.d, t1_13265.ctid, t1_13265.gp_segment_id, t2_13265.ctid
+         ->  Nested Loop Left Anti Semi (Not-In) Join
+               Output: t1_13265.a, 2, t1_13265.c, t1_13265.d, t1_13265.ctid, t1_13265.gp_segment_id, t2_13265.ctid
+               Join Filter: ((t1_13265.c = t2_13265.c) AND (t1_13265.d = t2_13265.d))
+               ->  Seq Scan on public.t1_13265
+                     Output: t1_13265.a, t1_13265.c, t1_13265.d, t1_13265.ctid, t1_13265.gp_segment_id
+               ->  Materialize
+                     Output: t2_13265.ctid, t2_13265.c, t2_13265.d, (2)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                           Output: t2_13265.ctid, t2_13265.c, t2_13265.d, (2)
+                           ->  Seq Scan on public.t2_13265
+                                 Output: t2_13265.ctid, t2_13265.c, t2_13265.d, 2
+                                 Filter: (t2_13265.a = 2)
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=on
+(17 rows)
+
+update t1_13265 set b = 2 where
+(c, d) not in (select c, d from t2_13265 where a = 2);
+select * from t1_13265;
+ a | b | c | d 
+---+---+---+---
+ 1 | 2 | 1 | 1
+(1 row)
+
 -- start_ignore
 drop table r;
 drop table s;
@@ -575,4 +613,6 @@ drop table ao_table;
 drop table aoco_table;
 drop table nosplitupdate;
 drop table tsplit_entry;
+drop table t1_13265;
+drop table t2_13265;
 -- end_ignore

--- a/src/test/regress/sql/update_gp.sql
+++ b/src/test/regress/sql/update_gp.sql
@@ -282,6 +282,23 @@ FROM   update_gp_foo1;
 
 SELECT * from update_gp_foo;
 
+-- Test for update with LASJ_NOTIN
+-- See Issue: https://github.com/greenplum-db/gpdb/issues/13265
+create table t1_13265(a int, b int, c int, d int) distributed by (a);
+create table t2_13265(a int, b int, c int, d int) distributed by (a);
+
+insert into t1_13265 values (1, null, 1, 1);
+insert into t2_13265 values (2, null, 2, 2);
+
+explain (verbose, costs off)
+update t1_13265 set b = 2 where
+(c, d) not in (select c, d from t2_13265 where a = 2);
+
+update t1_13265 set b = 2 where
+(c, d) not in (select c, d from t2_13265 where a = 2);
+
+select * from t1_13265;
+
 -- start_ignore
 drop table r;
 drop table s;
@@ -290,4 +307,6 @@ drop table ao_table;
 drop table aoco_table;
 drop table nosplitupdate;
 drop table tsplit_entry;
+drop table t1_13265;
+drop table t2_13265;
 -- end_ignore


### PR DESCRIPTION
Greenplum planner will pull up NOT-IN sublink to a join type called
left-anti-semi-join (LASJ_NOTIN), the executor logic of it is similar
to anti-join or semi-join. So during set_join_references's
fix_join_expr, for LASJ_NOTIN,  we should use the same logic as
anti-join. This commit fixes Issue:
https://github.com/greenplum-db/gpdb/issues/13265.

A case that leads to wrong behavior without this commit is shown
below:

    create table t1(a int, b int, c int, d int);
    create table t2(a int, b int, c int, d int);

    insert into t1 values (1, null, 1, 1);
    insert into t2 values (2, null, 2, 2);

    explain (verbose, costs off)
    update t1 set b = 2 where
    (c, d) not in (select c, d from t2 where a = 2);

     Update on public.t1
       ->  Explicit Redistribute Motion 3:3  (slice2; segments: 3)
             Output: t1.a, (2), t1.c, t1.d, t1.ctid, t1.gp_segment_id, t2.ctid
             ->  Nested Loop Left Anti Semi (Not-In) Join
                   Output: t1.a, (2), t1.c, t1.d, t1.ctid, t1.gp_segment_id, t2.ctid
                   Join Filter: ((t1.c = t2.c) AND (t1.d = t2.d))
                   ->  Seq Scan on public.t1
                         Output: t1.a, t1.c, t1.d, t1.ctid, t1.gp_segment_id
                   ->  Materialize
                         Output: t2.ctid, t2.c, t2.d, (2)
                         ->  Broadcast Motion 3:3  (slice1; segments: 3)
                               Output: t2.ctid, t2.c, t2.d, (2)
                               ->  Seq Scan on public.t2
                                     Output: t2.ctid, t2.c, t2.d, 2
                                     Filter: (t2.a = 2)
     Optimizer: Postgres query optimizer

1. Look at the above plan, the bottom table scan of t2 contains a target
entry, the const 2. The table t2 is distributed by column a, and there
is a filter (a = 2) on the scan, so the planner will consider the flow's
locus' hash expression is 2, and add it in the target list (we might
look into this and fix it later).

2. Planner now tries to set_plan_referecences, and during the
execution of fix_join_expr, it forgets to use the same logic as
anti-join, so the planner tries to match the const 2 in the target list of
the update statement using the inner plan, and in the case the new
value to set is just the same as the where condition of t2, thus the
const 2 in the target list of nestloop join will be considered as
InnerVar.

3. Now comes to the executor of Nestloop. It will use null inner to
make the projection, and recall the const 2 is marked from Inner, so
it is NULL.

4. ExecUpdate will take the new value to set as NULL and update fails
modify the column.

This commit fixes the issue by not matching non vars in the inner plan for LASJ-NOTIN.