### PR TITLE
docs - rework gp_sparse_vector upgrade topic a bit

### DIFF
--- a/gpdb-doc/dita/ref_guide/modules/gp_sparse_vector.xml
+++ b/gpdb-doc/dita/ref_guide/modules/gp_sparse_vector.xml
@@ -36,9 +36,10 @@
           <codeph>search_path</codeph>, or alternatively you can choose to prepend
           <codeph>sparse_vector.</codeph> to all non-<codeph>CAST</codeph>
           <codeph>gp_sparse_vector</codeph> function or object name references.</note>
-        <p>Update the <codeph>gp_sparse_vector</codeph> module to version
-            1.0.1 in each database in which you are using the module:
-            <codeblock>ALTER EXTENSION gp_sparse_vector UPDATE TO '1.0.1';</codeblock></p>
+        <p>Update the <codeph>gp_sparse_vector</codeph> module
+            in each database in which you are using the module:
+            <codeblock>DROP EXTENSION gp_sparse_vector;
+CREATE EXTENSION gp_sparse_vector;</codeblock></p>
       </body>
     </topic>
     <topic id="topic_about">

--- a/gpdb-doc/dita/ref_guide/modules/gp_sparse_vector.xml
+++ b/gpdb-doc/dita/ref_guide/modules/gp_sparse_vector.xml
@@ -22,41 +22,23 @@
       </body>
     </topic>
     <topic id="topic_upgrade">
-      <title>Upgrading the Module from Version 1.0.0 to 1.0.1</title>
+      <title>Upgrading the Module</title>
       <body>
-        <p>Starting in Greenplum Database 6.16, <codeph>gp_sparse_vector</codeph>
-          (version 1.0.1) functions and objects are installed in the schema named
-          <codeph>sparse_vector</codeph>. If you used <codeph>gp_sparse_vector</codeph>
-          version 1.0.0 in your previous Greenplum Database installation and are
-          considering upgrading to version 1.0.1, you have two options:</p>
-          <ol>
-            <li>Upgrade the module:
-              <note>Upgrading to <codeph>gp_sparse_vector</codeph> 1.0.1 requires 
-                that you update any scripts that reference the module's objects.
-                You must also adjust how you reference these objects in a client
-                session.</note>
-              <ol>
-                <li>Update the <codeph>gp_sparse_vector</codeph> module to version
-                  1.0.1 in each database in which you are using the module:
-                  <codeblock>ALTER EXTENSION gp_sparse_vector UPDATE TO '1.0.1';</codeblock></li>
-                <li>Locate any scripts in which you reference
-                  <codeph>gp_sparse_vector</codeph> objects. You must either add the
-                  <codeph>sparse_vector</codeph> schema to a <codeph>search_path</codeph>,
-                  or alternatively you can choose to prepend <codeph>sparse_vector.</codeph>
-                  to all non-<codeph>CAST</codeph> <codeph>gp_sparse_vector</codeph> function
-                  or object name references.</li>
-              </ol>
-              <p>When you reference <codeph>gp_sparse_vector</codeph> functions or objects
-                in a client session, you must also update the <codeph>search_path</codeph> or
-                prepend <codeph>sparse_vector.</codeph> to all non-<codeph>CAST</codeph>
-                function or object name references.</p>
-            </li>
-            <li>Do not upgrade the module.<p>No changes are required on your part if
-              you choose not to upgrade the <codeph>gp_sparse_vector</codeph> module.
-              Your existing scripts, workloads, and how you reference
-              <codeph>gp_sparse_vector</codeph> objects in a client session remain
-              the same.</p></li>
-          </ol>
+        <p>You must upgrade the <codeph>gp_sparse_vector</codeph> module to obtain
+          bug fixes.</p>
+        <note>Starting in Greenplum Database 6.16, <codeph>gp_sparse_vector</codeph>
+          functions and objects are installed in the schema named
+          <codeph>sparse_vector</codeph>. Upgrading the module requires 
+          that you update any scripts that reference the module's objects.
+          You must also adjust how you reference these objects in a client
+          session. <b>If you have not done this already, you will need to</b>
+          either add the <codeph>sparse_vector</codeph> schema to a
+          <codeph>search_path</codeph>, or alternatively you can choose to prepend
+          <codeph>sparse_vector.</codeph> to all non-<codeph>CAST</codeph>
+          <codeph>gp_sparse_vector</codeph> function or object name references.</note>
+        <p>Update the <codeph>gp_sparse_vector</codeph> module to version
+            1.0.1 in each database in which you are using the module:
+            <codeblock>ALTER EXTENSION gp_sparse_vector UPDATE TO '1.0.1';</codeblock></p>
       </body>
     </topic>
     <topic id="topic_about">


### PR DESCRIPTION
https://github.com/greenplum-db/gpdb/pull/13156 is a gp_sparse_vector bug fix.  to get the fix, the user must upgrade the gp_sparse_vector module in any databases where they are currently using it.  there is an existing upgrade topic because a previous fix moved the functions/objects to a new schema.

question:  please verify the upgrade commmand.  the version of the extension did not change with this fix, will the ALTER EXTENSION ... UPDATE actually update the same version of an extension?  or does this need a drop/create extension (but doesn't that remove dependent objects)?
