### PR TITLE
[6X] pg_upgrade check features

### DIFF
--- a/contrib/pg_upgrade/README.gpdb
+++ b/contrib/pg_upgrade/README.gpdb
@@ -88,3 +88,20 @@ intention is for this to be a quick test that all objects are handled by
 pg_upgrade; upgrade testing still requires the full run across all
 segments/mirrors. The smoketest can be invoked by "make check" in the
 contrib/pg_upgrade directory.
+
+GPDB Merge notice:
+------------------
+We added the gp_fatal_log() function to replace some of the pg_fatal() calls in
+check.c and check_gp.c to support --continue-check-on-fatal, which allows
+running through all the checks even if we get a fatal failure. We need to
+update any newly added checks to ensure they work with the flag by replacing
+pg_fatal function calls with gp_fatal_log calls.
+
+Note: we cannot skip few checks despite using the --continue-check-on-fatal
+flag. See gp_fatal_log() for details.
+
+For --skip-target-check flag while merging upstream, if we have new checks for
+new/target cluster, they should be skipped when the flag is enabled. See
+is_skip_target_check(). There might be new pre-check steps for the target
+cluster before we check_new_cluster(), such as get_sock_dir(), which must be
+guarded.

--- a/contrib/pg_upgrade/exec.c
+++ b/contrib/pg_upgrade/exec.c
@@ -10,6 +10,7 @@
 #include "postgres_fe.h"
 
 #include "pg_upgrade.h"
+#include "greenplum/pg_upgrade_greenplum.h"
 
 #include <fcntl.h>
 #include <sys/types.h>
@@ -217,8 +218,12 @@ verify_directories(void)
 
 	check_bin_dir(&old_cluster);
 	check_data_dir(old_cluster.pgdata);
-	check_bin_dir(&new_cluster);
-	check_data_dir(new_cluster.pgdata);
+
+	if(!is_skip_target_check())
+	{
+	  check_bin_dir(&new_cluster);
+	  check_data_dir(new_cluster.pgdata);
+	}
 }
 
 

--- a/contrib/pg_upgrade/function.c
+++ b/contrib/pg_upgrade/function.c
@@ -374,11 +374,12 @@ check_loadable_libraries(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation references loadable libraries that are missing from the\n"
-				 "new installation.  You can add these libraries to the new installation,\n"
-				 "or remove the functions using them from the old installation.  A list of\n"
-				 "problem libraries is in the file:\n"
-				 "    %s\n\n", output_path);
+		gp_fatal_log(
+				"| Your installation references loadable libraries that are missing from the\n"
+				"| new installation.  You can add these libraries to the new installation,\n"
+				"| or remove the functions using them from the old installation.  A list of\n"
+				"| problem libraries is in the file:\n"
+				"|     %s\n\n", output_path);
 	}
 	else
 		check_ok();

--- a/contrib/pg_upgrade/greenplum/check_gp.c
+++ b/contrib/pg_upgrade/greenplum/check_gp.c
@@ -131,7 +131,7 @@ check_online_expansion(void)
 	if (expansion)
 	{
 		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
+		gp_fatal_log(
 			   "| Your installation is in progress of online expansion,\n"
 			   "| must complete that job before the upgrade.\n\n");
 	}
@@ -216,7 +216,7 @@ check_unique_primary_constraint(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
+		gp_fatal_log(
 			   "| Your installation contains unique or primary key constraints\n"
 			   "| on tables.  These constraints need to be removed\n"
 			   "| from the tables before the upgrade.  A list of\n"
@@ -297,7 +297,7 @@ check_external_partition(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
+		gp_fatal_log(
 			   "| Your installation contains partitioned tables with external\n"
 			   "| tables as partitions.  These partitions need to be removed\n"
 			   "| from the partition hierarchy before the upgrade.  A list of\n"
@@ -405,7 +405,7 @@ check_covering_aoindex(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
+		gp_fatal_log(
 			   "| Your installation contains partitioned append-only tables\n"
 			   "| with an index defined on the partition parent which isn't\n"
 			   "| present on all partition members.  These indexes must be\n"
@@ -469,7 +469,7 @@ check_orphaned_toastrels(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
+		gp_fatal_log(
 			   "| Your installation contains orphaned toast tables which\n"
 			   "| must be dropped before upgrade.\n"
 			   "| A list of the problem databases is in the file:\n"
@@ -588,7 +588,7 @@ check_heterogeneous_partition(void)
 	if (found)
 	{
 		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
+		gp_fatal_log(
 			   "| Your installation contains heterogeneous partition tables. Either one or more\n"
 			   "| child partitions have invalid dropped column references or the columns are\n"
 			   "| misaligned compared to the root partition. Upgrade cannot output partition\n"
@@ -691,7 +691,7 @@ check_partition_indexes(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
+		gp_fatal_log(
 			   "| Your installation contains partitioned tables with\n"
 			   "| indexes defined on them.  Indexes on partition parents,\n"
 			   "| as well as children, must be dropped before upgrade.\n"
@@ -769,7 +769,7 @@ check_gphdfs_external_tables(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
+		gp_fatal_log(
 			   "| Your installation contains gphdfs external tables.  These \n"
 			   "| tables need to be dropped before upgrade.  A list of\n"
 			   "| external gphdfs tables to remove is provided in the file:\n"
@@ -846,7 +846,7 @@ check_gphdfs_user_roles(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
+		gp_fatal_log(
 			   "| Your installation contains roles that have gphdfs privileges.\n"
 			   "| These privileges need to be revoked before upgrade.  A list\n"
 			   "| of roles and their corresponding gphdfs privileges that\n"
@@ -913,11 +913,9 @@ check_for_array_of_partition_table_types(ClusterInfo *cluster)
 	if (strlen(dependee_partition_report))
 	{
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal(
-			"Array types derived from partitions of a partitioned table must not have dependants.\n"
-			"OIDs of such types found and their original partitions:\n%s",
-			dependee_partition_report
-		);
+		gp_fatal_log(
+			"| Array types derived from partitions of a partitioned table must not have dependants.\n"
+			"| OIDs of such types found and their original partitions:\n%s", dependee_partition_report);
 	}
 	pfree(dependee_partition_report);
 
@@ -989,13 +987,13 @@ check_partition_schemas(void)
 	if (found)
 	{
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal(
-			"Your installation contains partitioned tables where one or more\n"
-			"child partitions are not in the same schema as the root partition.\n"
-			"ALTER TABLE ... SET SCHEMA must be performed on the child partitions\n"
-			"to match them before upgrading. A list of problem tables is in the\n"
-			"file:\n"
-			"    %s\n\n", output_path);
+		gp_fatal_log(
+			"| Your installation contains partitioned tables where one or more\n"
+			"| child partitions are not in the same schema as the root partition.\n"
+			"| ALTER TABLE ... SET SCHEMA must be performed on the child partitions\n"
+			"| to match them before upgrading. A list of problem tables is in the\n"
+			"| file:\n"
+			"|     %s\n\n", output_path);
 	}
 	else
 		check_ok();
@@ -1049,10 +1047,11 @@ check_large_objects(void)
 	if (found)
 	{
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains large objects.  These objects are not supported\n"
-				 "by the new cluster and must be dropped.\n"
-				 "A list of databases which contains large objects is in the file:\n"
-				 "\t%s\n\n", output_path);
+		gp_fatal_log(
+				"| Your installation contains large objects.  These objects are not supported\n"
+				"| by the new cluster and must be dropped.\n"
+				"| A list of databases which contains large objects is in the file:\n"
+				"| \t%s\n\n", output_path);
 	}
 	else
 		check_ok();
@@ -1128,10 +1127,11 @@ check_invalid_indexes(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains invalid indexes.  These indexes either \n"
-			     "need to be dropped or reindexed before proceeding to upgrade.\n"
-			     "A list of invalid indexes is provided in the file:\n"
-		         "\t%s\n\n", output_path);
+		gp_fatal_log(
+				"| Your installation contains invalid indexes.  These indexes either \n"
+				"| need to be dropped or reindexed before proceeding to upgrade.\n"
+				"| A list of invalid indexes is provided in the file:\n"
+				"| \t%s\n\n", output_path);
 	}
 	else
 		check_ok();
@@ -1197,11 +1197,12 @@ check_foreign_key_constraints_on_root_partition(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains foreign key constraint on root \n"
-				 "partition tables. These constraints need to be dropped before \n"
-				 "proceeding to upgrade. A list of foreign key constraints is \n"
-				 "in the file:\n"
-				 "\t%s\n\n", output_path);
+		gp_fatal_log(
+				"| Your installation contains foreign key constraint on root \n"
+				"| partition tables. These constraints need to be dropped before \n"
+				"| proceeding to upgrade. A list of foreign key constraints is \n"
+				"| in the file:\n"
+				"| \t%s\n\n", output_path);
 	}
 	else
 		check_ok();
@@ -1269,11 +1270,12 @@ check_views_with_unsupported_lag_lead_function(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains views using lag or lead \n"
-				 "functions with the second parameter as bigint. These views \n"
-				 "need to be dropped before proceeding to upgrade. \n"
-				 "A list of views is in the file:\n"
-				 "\t%s\n\n", output_path);
+		gp_fatal_log(
+				"| Your installation contains views using lag or lead \n"
+				"| functions with the second parameter as bigint. These views \n"
+				"| need to be dropped before proceeding to upgrade. \n"
+				"| A list of views is in the file:\n"
+				"| \t%s\n\n", output_path);
 	}
 	else
 		check_ok();
@@ -1344,12 +1346,13 @@ check_views_with_fabricated_anyarray_casts()
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains views having anyarray\n"
-				 "casts. Drop the view or recreate the view without explicit \n"
-				 "array-type type casts before running the upgrade. Alternatively, drop the view \n"
-				 "before the upgrade and recreate the view after the upgrade. \n"
-				 "A list of views is in the file:\n"
-				 "\t%s\n\n", output_path);
+		gp_fatal_log(
+				"| Your installation contains views having anyarray\n"
+				"| casts. Drop the view or recreate the view without explicit \n"
+				"| array-type type casts before running the upgrade. Alternatively, drop the view \n"
+				"| before the upgrade and recreate the view after the upgrade. \n"
+				"| A list of views is in the file:\n"
+				"| \t%s\n\n", output_path);
 	}
 	else
 		check_ok();
@@ -1420,11 +1423,12 @@ check_views_with_fabricated_unknown_casts()
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains views having unknown\n"
-				 "casts. Drop the view or recreate the view without explicit \n"
-				 "unknown::cstring type casts before running the upgrade.\n"
-				 "A list of views is in the file:\n"
-				 "\t%s\n\n", output_path);
+		gp_fatal_log(
+				"| Your installation contains views having unknown\n"
+				"| casts. Drop the view or recreate the view without explicit \n"
+				"| unknown::cstring type casts before running the upgrade.\n"
+				"| A list of views is in the file:\n"
+				"| \t%s\n\n", output_path);
 	}
 	else
 		check_ok();
@@ -1504,12 +1508,13 @@ check_views_referencing_deprecated_tables()
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains views referencing catalog\n"
-				 "tables that no longer exist in the target cluster.\n"
-				 "Drop these views before running the upgrade. Please refer to\n"
-				 "the documentation for a complete list of deprecated tables.\n"
-				 "A list of such views is in the file:\n"
-				 "\t%s\n\n", output_path);
+		gp_fatal_log(
+				"| Your installation contains views referencing catalog\n"
+				"| tables that no longer exist in the target cluster.\n"
+				"| Drop these views before running the upgrade. Please refer to\n"
+				"| the documentation for a complete list of deprecated tables.\n"
+				"| A list of such views is in the file:\n"
+				"| \t%s\n\n", output_path);
 	}
 	else
 		check_ok();
@@ -1589,12 +1594,13 @@ check_views_referencing_deprecated_columns()
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains views referencing columns\n"
-				 "in catalog tables that no longer exist in the target cluster.\n"
-				 "Drop these views before running the upgrade. Please refer to\n"
-				 "the documentation for a complete list of deprecated columns.\n"
-				 "A list of such views is in the file:\n"
-				 "\t%s\n\n", output_path);
+		gp_fatal_log(
+				"| Your installation contains views referencing columns\n"
+				"| in catalog tables that no longer exist in the target cluster.\n"
+				"| Drop these views before running the upgrade. Please refer to\n"
+				"| the documentation for a complete list of deprecated columns.\n"
+				"| A list of such views is in the file:\n"
+				"| \t%s\n\n", output_path);
 	}
 	else
 		check_ok();

--- a/contrib/pg_upgrade/greenplum/option_gp.c
+++ b/contrib/pg_upgrade/greenplum/option_gp.c
@@ -14,9 +14,11 @@ typedef struct {
 	segmentMode segment_mode;
 	checksumMode checksum_mode;
 	char *old_tablespace_file_path;
+	bool continue_check_on_fatal;
 } GreenplumUserOpts;
 
 static GreenplumUserOpts greenplum_user_opts;
+static bool check_fatal_occurred;
 
 void
 initialize_greenplum_user_options(void)
@@ -26,6 +28,7 @@ initialize_greenplum_user_options(void)
 
 	old_cluster.greenplum_cluster_info = make_cluster_info();
 	new_cluster.greenplum_cluster_info = make_cluster_info();
+	greenplum_user_opts.continue_check_on_fatal = false;
 }
 
 bool
@@ -69,6 +72,20 @@ process_greenplum_option(greenplumOption option)
 			greenplum_user_opts.old_tablespace_file_path = pg_strdup(optarg);
 			break;
 
+		case GREENPLUM_CONTINUE_CHECK_ON_FATAL:
+			if (user_opts.check)
+			{
+				greenplum_user_opts.continue_check_on_fatal = true;
+				check_fatal_occurred = false;
+			}
+			else
+			{
+				pg_log(PG_FATAL,
+					"--continue-check-on-fatal: should be used with check mode (-c)\n");
+				exit(1);
+			}
+			break;
+
 		default:
 			return false;
 	}
@@ -109,4 +126,22 @@ bool
 is_show_progress_mode(void)
 {
 	return greenplum_user_opts.progress;
+}
+
+bool
+is_continue_check_on_fatal(void)
+{
+	return greenplum_user_opts.continue_check_on_fatal;
+}
+
+void
+set_check_fatal_occured(void)
+{
+	check_fatal_occurred = true;
+}
+
+bool
+get_check_fatal_occurred(void)
+{
+	return check_fatal_occurred;
 }

--- a/contrib/pg_upgrade/greenplum/pg_upgrade_greenplum.h
+++ b/contrib/pg_upgrade/greenplum/pg_upgrade_greenplum.h
@@ -48,7 +48,8 @@ typedef enum {
 	GREENPLUM_REMOVE_CHECKSUM_OPTION = 4,
 	GREENPLUM_OLD_GP_DBID = 5,
 	GREENPLUM_NEW_GP_DBID = 6,
-	GREENPLUM_OLD_TABLESPACES_FILE = 7
+	GREENPLUM_OLD_TABLESPACES_FILE = 7,
+	GREENPLUM_CONTINUE_CHECK_ON_FATAL = 8
 } greenplumOption;
 
 
@@ -59,16 +60,18 @@ typedef enum {
 	{"remove-checksum", no_argument, NULL, GREENPLUM_REMOVE_CHECKSUM_OPTION}, \
 	{"old-gp-dbid", required_argument, NULL, GREENPLUM_OLD_GP_DBID}, \
 	{"new-gp-dbid", required_argument, NULL, GREENPLUM_NEW_GP_DBID}, \
-	{"old-tablespaces-file", required_argument, NULL, GREENPLUM_OLD_TABLESPACES_FILE},
+	{"old-tablespaces-file", required_argument, NULL, GREENPLUM_OLD_TABLESPACES_FILE}, \
+	{"continue-check-on-fatal", no_argument, NULL, GREENPLUM_CONTINUE_CHECK_ON_FATAL},
 
 #define GREENPLUM_USAGE "\
-      --mode=TYPE               designate node type to upgrade, \"segment\" or \"dispatcher\" (default \"segment\")\n\
-      --progress                enable progress reporting\n\
-      --remove-checksum         remove data checksums when creating new cluster\n\
-      --add-checksum            add data checksumming to the new cluster\n\
-      --old-gp-dbid             greenplum database id of the old segment\n\
-      --new-gp-dbid             greenplum database id of the new segment\n\
-      --old-tablespaces-file    file containing the tablespaces from an old gpdb five cluster\n\
+	--mode=TYPE               designate node type to upgrade, \"segment\" or \"dispatcher\" (default \"segment\")\n\
+	--progress                enable progress reporting\n\
+	--remove-checksum         remove data checksums when creating new cluster\n\
+	--add-checksum            add data checksumming to the new cluster\n\
+	--old-gp-dbid             greenplum database id of the old segment\n\
+	--new-gp-dbid             greenplum database id of the new segment\n\
+	--old-tablespaces-file    file containing the tablespaces from an old gpdb five cluster\n\
+	--continue-check-on-fatal continue to run through all pg_upgrade checks without upgrade. Stops on major issues\n\
 "
 
 /* option_gp.c */
@@ -78,6 +81,9 @@ bool is_greenplum_dispatcher_mode(void);
 bool is_checksum_mode(checksumMode mode);
 bool is_show_progress_mode(void);
 void validate_greenplum_options(void);
+bool is_continue_check_on_fatal(void);
+void set_check_fatal_occured(void);
+bool get_check_fatal_occurred(void);
 
 /* pg_upgrade_greenplum.c */
 void freeze_all_databases(void);

--- a/contrib/pg_upgrade/greenplum/pg_upgrade_greenplum.h
+++ b/contrib/pg_upgrade/greenplum/pg_upgrade_greenplum.h
@@ -49,7 +49,8 @@ typedef enum {
 	GREENPLUM_OLD_GP_DBID = 5,
 	GREENPLUM_NEW_GP_DBID = 6,
 	GREENPLUM_OLD_TABLESPACES_FILE = 7,
-	GREENPLUM_CONTINUE_CHECK_ON_FATAL = 8
+	GREENPLUM_CONTINUE_CHECK_ON_FATAL = 8,
+	GREENPLUM_SKIP_TARGET_CHECK = 9
 } greenplumOption;
 
 
@@ -61,7 +62,8 @@ typedef enum {
 	{"old-gp-dbid", required_argument, NULL, GREENPLUM_OLD_GP_DBID}, \
 	{"new-gp-dbid", required_argument, NULL, GREENPLUM_NEW_GP_DBID}, \
 	{"old-tablespaces-file", required_argument, NULL, GREENPLUM_OLD_TABLESPACES_FILE}, \
-	{"continue-check-on-fatal", no_argument, NULL, GREENPLUM_CONTINUE_CHECK_ON_FATAL},
+	{"continue-check-on-fatal", no_argument, NULL, GREENPLUM_CONTINUE_CHECK_ON_FATAL}, \
+	{"skip-target-check", no_argument, NULL, GREENPLUM_SKIP_TARGET_CHECK},
 
 #define GREENPLUM_USAGE "\
 	--mode=TYPE               designate node type to upgrade, \"segment\" or \"dispatcher\" (default \"segment\")\n\
@@ -72,6 +74,7 @@ typedef enum {
 	--new-gp-dbid             greenplum database id of the new segment\n\
 	--old-tablespaces-file    file containing the tablespaces from an old gpdb five cluster\n\
 	--continue-check-on-fatal continue to run through all pg_upgrade checks without upgrade. Stops on major issues\n\
+	--skip-target-check       skip all checks and comparisons of new cluster\n\
 "
 
 /* option_gp.c */
@@ -84,6 +87,7 @@ void validate_greenplum_options(void);
 bool is_continue_check_on_fatal(void);
 void set_check_fatal_occured(void);
 bool get_check_fatal_occurred(void);
+bool is_skip_target_check(void);
 
 /* pg_upgrade_greenplum.c */
 void freeze_all_databases(void);

--- a/contrib/pg_upgrade/greenplum/version_gp.c
+++ b/contrib/pg_upgrade/greenplum/version_gp.c
@@ -268,7 +268,7 @@ check_hash_partition_usage(void)
 	{
 		fclose(script);
 		pg_log(PG_REPORT, "fatal\n");
-		pg_log(PG_FATAL,
+		gp_fatal_log(
 			   "| Your installation contains hash partitioned tables.\n"
 			   "| Upgrading hash partitioned tables is not supported,\n"
 			   "| so this cluster cannot currently be upgraded.  You\n"

--- a/contrib/pg_upgrade/option.c
+++ b/contrib/pg_upgrade/option.c
@@ -234,11 +234,13 @@ parseCommandLine(int argc, char *argv[])
 	/* Get values from env if not already set */
 	check_required_directory(&old_cluster.bindir, "PGBINOLD", false,
 							 "-b", "old cluster binaries reside");
-	check_required_directory(&new_cluster.bindir, "PGBINNEW", false,
+	if(!is_skip_target_check())
+		check_required_directory(&new_cluster.bindir, "PGBINNEW", false,
 							 "-B", "new cluster binaries reside");
 	check_required_directory(&old_cluster.pgdata, "PGDATAOLD", false,
 							 "-d", "old cluster data resides");
-	check_required_directory(&new_cluster.pgdata, "PGDATANEW", false,
+	if(!is_skip_target_check())
+		check_required_directory(&new_cluster.pgdata, "PGDATANEW", false,
 							 "-D", "new cluster data resides");
 	check_required_directory(&user_opts.socketdir, "PGSOCKETDIR", true,
 							 "-s", "sockets will be created");

--- a/contrib/pg_upgrade/pg_upgrade.h
+++ b/contrib/pg_upgrade/pg_upgrade.h
@@ -579,6 +579,7 @@ void		check_ok(void);
 const char *getErrorText(void);
 unsigned int str2uint(const char *str);
 void		pg_putenv(const char *var, const char *val);
+void 		gp_fatal_log(const char *fmt,...);
 
 
 /* version.c */

--- a/contrib/pg_upgrade/tablespace.c
+++ b/contrib/pg_upgrade/tablespace.c
@@ -24,12 +24,15 @@ init_tablespaces(void)
 	get_tablespace_paths();
 
 	set_tablespace_directory_suffix(&old_cluster);
-	set_tablespace_directory_suffix(&new_cluster);
+	if(!is_skip_target_check())
+	{
+		set_tablespace_directory_suffix(&new_cluster);
 
-	if (os_info.num_old_tablespaces > 0 &&
-	strcmp(old_cluster.tablespace_suffix, new_cluster.tablespace_suffix) == 0)
-		pg_fatal("Cannot upgrade to/from the same system catalog version when\n"
-				 "using tablespaces.\n");
+		if (os_info.num_old_tablespaces > 0 &&
+		strcmp(old_cluster.tablespace_suffix, new_cluster.tablespace_suffix) == 0)
+			pg_fatal("Cannot upgrade to/from the same system catalog version when\n"
+					 "using tablespaces.\n");
+	}
 }
 
 static void

--- a/contrib/pg_upgrade/util.c
+++ b/contrib/pg_upgrade/util.c
@@ -185,6 +185,38 @@ check_ok(void)
 
 
 /*
+ *  Wrapper around pg_fatal to continue check when running in check mode
+ *  with --continue-check-on-fatal
+ *
+ *	Note that there are certain checks that cannot be ignored in spite of
+ *  the flag being passed - they may be critical to the check process
+ *  itself. One such example is check_proper_datallowconn(), which ensures
+ *  that we can connect to user databases to perform the checks themselves.
+ *  Certain checks are multi-step, like the check to ensure that only the
+ *  install user is the sole user in the target database. If we get the
+ *  fatal: "could not determine the number of users", we can't really
+ *  proceed with the check. Thus, in these cases the flag will not be
+ *  respected.
+ */
+void
+gp_fatal_log(const char *fmt,...)
+{
+	va_list		args;
+	eLogType error_type = PG_FATAL;
+
+	if(is_continue_check_on_fatal())
+	{
+		set_check_fatal_occured();
+		error_type = PG_WARNING;
+	}
+
+	va_start(args, fmt);
+	pg_log_v(error_type, fmt, args);
+	va_end(args);
+}
+
+
+/*
  * quote_identifier()
  *		Properly double-quote a SQL identifier.
  *

--- a/contrib/pg_upgrade/version_old_8_3.c
+++ b/contrib/pg_upgrade/version_old_8_3.c
@@ -96,12 +96,13 @@ old_8_3_check_for_name_data_type_usage(ClusterInfo *cluster)
 	if (found)
 	{
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains the \"name\" data type in user tables.  This\n"
-		"data type changed its internal alignment between your old and new\n"
-				 "clusters so this cluster cannot currently be upgraded.  You can remove\n"
-		"the problem tables and restart the upgrade.  A list of the problem\n"
-				 "columns is in the file:\n"
-				 "    %s\n\n", output_path);
+		gp_fatal_log(
+				"| Your installation contains the \"name\" data type in user tables.  This\n"
+				"| data type changed its internal alignment between your old and new\n"
+				"| clusters so this cluster cannot currently be upgraded.  You can remove\n"
+				"| the problem tables and restart the upgrade.  A list of the problem\n"
+				"| columns is in the file:\n"
+				"|     %s\n\n", output_path);
 	}
 	else
 		check_ok();
@@ -186,12 +187,13 @@ old_8_3_check_for_tsquery_usage(ClusterInfo *cluster)
 	if (found)
 	{
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains the \"tsquery\" data type.    This data type\n"
-				 "added a new internal field between your old and new clusters so this\n"
-		"cluster cannot currently be upgraded.  You can remove the problem\n"
-				 "columns and restart the upgrade.  A list of the problem columns is in the\n"
-				 "file:\n"
-				 "    %s\n\n", output_path);
+		gp_fatal_log(
+				"| Your installation contains the \"tsquery\" data type.    This data type\n"
+				"| added a new internal field between your old and new clusters so this\n"
+				"| cluster cannot currently be upgraded.  You can remove the problem\n"
+				"| columns and restart the upgrade.  A list of the problem columns is in the\n"
+				"| file:\n"
+				"|     %s\n\n", output_path);
 	}
 	else
 		check_ok();
@@ -264,13 +266,14 @@ old_8_3_check_ltree_usage(ClusterInfo *cluster)
 	if (found)
 	{
 		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains the \"ltree\" data type.  This data type\n"
-				 "changed its internal storage format between your old and new clusters so this\n"
-				 "cluster cannot currently be upgraded.  You can manually upgrade databases\n"
-				 "that use \"contrib/ltree\" facilities and remove \"contrib/ltree\" from the old\n"
-				 "cluster and restart the upgrade.  A list of the problem functions is in the\n"
-				 "file:\n"
-				 "    %s\n\n", output_path);
+		gp_fatal_log(
+				"| Your installation contains the \"ltree\" data type.  This data type\n"
+				"| changed its internal storage format between your old and new clusters so this\n"
+				"| cluster cannot currently be upgraded.  You can manually upgrade databases\n"
+				"| that use \"contrib/ltree\" facilities and remove \"contrib/ltree\" from the old\n"
+				"| cluster and restart the upgrade.  A list of the problem functions is in the\n"
+				"| file:\n"
+				"|     %s\n\n", output_path);
 	}
 	else
 		check_ok();


### PR DESCRIPTION
Adds `--skip-target-check` and `--continue-check-on-fatal` features for check mode:


### `--continue-check-on-fatal`
The  flag lets us traverse through the pg_upgrade --check list without
exiting the first error encountered. It allows the user to get a report of 
the entire list of non-upgradable objects in their cluster at one go.

Note: We canot ignore certain checks despite the flag being supplied -
they may be critical to the check process . One such example is
heck_proper_datallowconn(), which ensures that we can connect to user
databases to perform the checks themselves.  Specific checks are
multi-step, like the check to ensure that only the install user is the
sole user in the target database. If we get fatal: "could not determine
the number of users", we can't proceed with the check. Thus, in these
cases, the flag will not respect the flag.

Example:
```
pg_upgrade \
-b /usr/local/5XSTABLE/bin/ \
-B /usr/local/6XSTABLE/bin/ \
-d /data/5XStable/demoDataDir-1 \
-D /data/6XStable/demoDataDir-1 \
-p 15432 \
-P 6000 \
--old-gp-dbid=1 \
--new-gp-dbid=1 \
-c \
--continue-check-on-fatal
```

### `--skip-target-check`
The flag allows us to skip target cluster checks performed by pg_upgrade
--check. It lets users find out incompatible objects on the source
cluster without the hassle of setting up a target cluster. For instance,
it is often non-trivial to set up GPDB specific extensions, and users
invariably run into a failure in check_loadable_libraries().

- need to be used along with check flag (-c)
- when you are using the flag we don't need to provide:
  - new-bindir (-B)
  - new-datadir (-D)
  - new-port (-P)
  - new-gp-dbid
- it can be used along with `--continue-check-on-fatal`

Example:
```
pg_upgrade \
-b /usr/local/5XSTABLE/bin/ \
-d /data/5XStable/demoDataDir-1 \
-p 15432 \
--old-gp-dbid=1 \
-c \
--continue-check-on-fatal \
--skip-target-check
```

Based on PR: https://github.com/greenplum-db/gpdb/pull/13126