### PR TITLE
Clean the deprecated lockmode logic of AcquireExecutorLocks in plancache

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1140,6 +1140,7 @@ transformOnConflictClause(ParseState *pstate,
 	if (onConflictClause->action == ONCONFLICT_UPDATE)
 	{
 		Relation	targetrel = pstate->p_target_relation;
+		RangeTblEntry    *rte = pstate->p_target_rangetblentry;
 
 		/*
 		 * All INSERT expressions have been parsed, get ready for potentially
@@ -1153,9 +1154,14 @@ transformOnConflictClause(ParseState *pstate,
 		 * relation, and no permission checks are required on it.  (We'll
 		 * check the actual target relation, instead.)
 		 */
+		/*
+		 * GPDB spec. The lockmode of actual target relation might be upgraded.
+		 * The pseudo one should follow it to avoid involving another lockmode
+		 * which is not the appropriate.
+		 */
 		exclRte = addRangeTableEntryForRelation(pstate,
 												targetrel,
-												RowExclusiveLock,
+												rte->rellockmode, /* GPDB */
 												makeAlias("excluded", NIL),
 												false, false);
 		exclRte->relkind = RELKIND_COMPOSITE_TYPE;

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -271,6 +271,7 @@ setTargetTable(ParseState *pstate, RangeVar *relation,
 	RangeTblEntry *rte;
 	int			rtindex;
 	ParseCallbackState pcbstate;
+	bool lockUpgraded = false;
 
 	/*
 	 * ENRs hide tables of the same name, so we need to check for them first.
@@ -314,14 +315,14 @@ setTargetTable(ParseState *pstate, RangeVar *relation,
 	}
 	else
 	{
-		pstate->p_target_relation = parserOpenTable(pstate, relation, RowExclusiveLock, NULL);
+		pstate->p_target_relation = parserOpenTable(pstate, relation, RowExclusiveLock, &lockUpgraded);
 	}
 
 	/*
 	 * Now build an RTE.
 	 */
 	rte = addRangeTableEntryForRelation(pstate, pstate->p_target_relation,
-										RowExclusiveLock,
+										lockUpgraded ? ExclusiveLock : RowExclusiveLock, /* CDB */
 										relation->alias, inh, false);
 	pstate->p_target_rangetblentry = rte;
 

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -1371,9 +1371,9 @@ addRangeTableEntry(ParseState *pstate,
  * given an already-open relation instead of a RangeVar reference.
  *
  * lockmode is the lock type required for query execution; it must be one
- * of AccessShareLock, RowShareLock, or RowExclusiveLock depending on the
- * RTE's role within the query.  The caller must hold that lock mode
- * or a stronger one.
+ * of AccessShareLock, RowShareLock, RowExclusiveLock, or ExclusiveLock
+ * depending on the RTE's role within the query.  The caller must hold that
+ * lock mode or a stronger one.
  *
  * Note: properly, lockmode should be declared LOCKMODE not int, but that
  * would require importing storage/lock.h into parse_relation.h.  Since
@@ -1394,7 +1394,8 @@ addRangeTableEntryForRelation(ParseState *pstate,
 
 	Assert(lockmode == AccessShareLock ||
 		   lockmode == RowShareLock ||
-		   lockmode == RowExclusiveLock);
+		   lockmode == RowExclusiveLock ||
+		   lockmode == ExclusiveLock); /* GPDB: we might upgrade lock level */
 	Assert(CheckRelationLockedByMe(rel, lockmode, true));
 
 	rte->rtekind = RTE_RELATION;

--- a/src/backend/utils/cache/plancache.c
+++ b/src/backend/utils/cache/plancache.c
@@ -1724,48 +1724,6 @@ AcquireExecutorLocks(List *stmt_list, bool acquire)
 			 * fail if it's been dropped entirely --- we'll just transiently
 			 * acquire a non-conflicting lock.
 			 */
-/* GPDB_12_MERGE_FIXME: Where does this GPDB-specific logic belong now? */
-#if 0
-			if (list_member_int(plannedstmt->resultRelations, rt_index))
-			{
-				/*
-				 * RowExclusiveLock is acquired in PostgreSQL here.  Greenplum
-				 * acquires ExclusiveLock to avoid distributed deadlock due to
-				 * concurrent UPDATE/DELETE on the same table.  This is in
-				 * parity with CdbTryOpenRelation(). If it is heap table and
-				 * the GDD is enabled, we could acquire RowExclusiveLock here.
-				 */
-				if ((plannedstmt->commandType == CMD_UPDATE ||
-					 plannedstmt->commandType == CMD_DELETE ||
-					 IsOnConflictUpdate(plannedstmt)) &&
-					CondUpgradeRelLock(rte->relid))
-					lockmode = ExclusiveLock;
-				else
-					lockmode = RowExclusiveLock;
-			}
-			else
-			{
-				/*
-				 * Greenplum specific behavior:
-				 * The implementation of select statement with locking clause
-				 * (for update | no key update | share | key share) in postgres
-				 * is to hold RowShareLock on tables during parsing stage, and
-				 * generate a LockRows plan node for executor to lock the tuples.
-				 * It is not easy to lock tuples in Greenplum database, since
-				 * tuples may be fetched through motion nodes.
-				 *
-				 * But when Global Deadlock Detector is enabled, and the select
-				 * statement with locking clause contains only one table, we are
-				 * sure that there are no motions. For such simple cases, we could
-				 * make the behavior just the same as Postgres.
-				 */
-				rc = get_plan_rowmark(plannedstmt->rowMarks, rt_index);
-				if (rc != NULL)
-					lockmode = rc->canOptSelectLockingClause ? RowShareLock : ExclusiveLock;
-				else
-					lockmode = AccessShareLock;
-			}
-#endif
 			if (acquire)
 				LockRelationOid(rte->relid, rte->rellockmode);
 			else
@@ -1811,7 +1769,6 @@ static void
 ScanQueryForLocks(Query *parsetree, bool acquire)
 {
 	ListCell   *lc;
-	int			rt_index;
 
 	/* Shouldn't get called on utility commands */
 	Assert(parsetree->commandType != CMD_UTILITY);
@@ -1819,63 +1776,17 @@ ScanQueryForLocks(Query *parsetree, bool acquire)
 	/*
 	 * First, process RTEs of the current query level.
 	 */
-	rt_index = 0;
 	foreach(lc, parsetree->rtable)
 	{
 		RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
-		LOCKMODE	lockmode;
 
-		rt_index++;
 		switch (rte->rtekind)
 		{
 			case RTE_RELATION:
-				/* Acquire or release the appropriate type of lock */
-				if (rt_index == parsetree->resultRelation)
-				{
-					/*
-					 * RowExclusiveLock is acquired in PostgreSQL here.  Greenplum
-					 * acquires ExclusiveLock to avoid distributed deadlock due to
-					 * concurrent UPDATE/DELETE on the same table.  This is in
-					 * parity with CdbTryOpenRelation(). If it is heap table and
-					 * the GDD is enabled, we could acquire RowExclusiveLock here.
-					 */
-					if ((parsetree->commandType == CMD_UPDATE ||
-						 parsetree->commandType == CMD_DELETE ||
-						 (parsetree->onConflict &&
-						  parsetree->onConflict->action == ONCONFLICT_UPDATE)) &&
-						CondUpgradeRelLock(rte->relid))
-						lockmode = ExclusiveLock;
-					else
-						lockmode = RowExclusiveLock;
-				}
-				else
-				{
-					/*
-					 * Greenplum specific behavior:
-					 * The implementation of select statement with locking clause
-					 * (for update | no key update | share | key share) in postgres
-					 * is to hold RowShareLock on tables during parsing stage, and
-					 * generate a LockRows plan node for executor to lock the tuples.
-					 * It is not easy to lock tuples in Greenplum database, since
-					 * tuples may be fetched through motion nodes.
-					 *
-					 * But when Global Deadlock Detector is enabled, and the select
-					 * statement with locking clause contains only one table, we are
-					 * sure that there are no motions. For such simple cases, we could
-					 * make the behavior just the same as Postgres.
-					 */
-					RowMarkClause *rc;
-
-					rc = get_parse_rowmark(parsetree, rt_index);
-					if (rc != NULL)
-						lockmode = parsetree->canOptSelectLockingClause ? RowShareLock : ExclusiveLock;
-					else
-						lockmode = AccessShareLock;
-				}
 				if (acquire)
-					LockRelationOid(rte->relid, lockmode);
+					LockRelationOid(rte->relid, rte->rellockmode);
 				else
-					UnlockRelationOid(rte->relid, lockmode);
+					UnlockRelationOid(rte->relid, rte->rellockmode);
 				break;
 
 			case RTE_SUBQUERY:

--- a/src/test/isolation2/expected/lockmodes.out
+++ b/src/test/isolation2/expected/lockmodes.out
@@ -452,11 +452,10 @@ BEGIN
 1: execute upsert_tlockmods;
 EXECUTE 1
 2: select * from show_locks_lockmodes;
- locktype | mode            | granted | relation          
-----------+-----------------+---------+-------------------
- relation | AccessShareLock | t       | t_lockmods_upsert 
- relation | ExclusiveLock   | t       | t_lockmods_upsert 
-(2 rows)
+ locktype | mode          | granted | relation          
+----------+---------------+---------+-------------------
+ relation | ExclusiveLock | t       | t_lockmods_upsert 
+(1 row)
 1: abort;
 ABORT
 
@@ -1024,8 +1023,6 @@ ABORT
 --   * DML on one specific leaf
 -- For detailed behavior and notes, please refer below
 -- cases's comments.
--- GPDB_12_MERGE_FIXME: DML lockmodes on partition table
--- is a bit in disorder, we shoule correct them.
 -- Details: https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/wAPKpJzhbpM
 -- start_ignore
 1:DROP TABLE IF EXISTS t_lockmods_part_tbl_upd_del;
@@ -1044,12 +1041,12 @@ BEGIN
 DELETE 10
 -- on QD, there's a lock on the root and the target partition
 1: select * from show_locks_lockmodes;
- locktype | mode             | granted | relation                            
-----------+------------------+---------+-------------------------------------
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_upd_del_1_prt_2 
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_upd_del_1_prt_1 
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_upd_del         
- relation | ExclusiveLock    | t       | t_lockmods_part_tbl_upd_del         
+ locktype | mode            | granted | relation                            
+----------+-----------------+---------+-------------------------------------
+ relation | AccessShareLock | t       | t_lockmods_part_tbl_upd_del         
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del         
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del_1_prt_1 
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del_1_prt_2 
 (4 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -1083,12 +1080,12 @@ BEGIN
 UPDATE 1
 -- on QD, there's a lock on the root and the target partition
 1: select * from show_locks_lockmodes;
- locktype | mode             | granted | relation                            
-----------+------------------+---------+-------------------------------------
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_upd_del_1_prt_2 
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_upd_del_1_prt_1 
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_upd_del         
- relation | ExclusiveLock    | t       | t_lockmods_part_tbl_upd_del         
+ locktype | mode            | granted | relation                            
+----------+-----------------+---------+-------------------------------------
+ relation | AccessShareLock | t       | t_lockmods_part_tbl_upd_del         
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del         
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del_1_prt_1 
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del_1_prt_2 
 (4 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -1570,9 +1567,8 @@ EXECUTE 1
 2: select * from show_locks_lockmodes;
  locktype | mode             | granted | relation          
 ----------+------------------+---------+-------------------
- relation | AccessShareLock  | t       | t_lockmods_upsert 
  relation | RowExclusiveLock | t       | t_lockmods_upsert 
-(2 rows)
+(1 row)
 1: abort;
 ABORT
 

--- a/src/test/isolation2/expected/lockmodes_optimizer.out
+++ b/src/test/isolation2/expected/lockmodes_optimizer.out
@@ -452,11 +452,10 @@ BEGIN
 1: execute upsert_tlockmods;
 EXECUTE 1
 2: select * from show_locks_lockmodes;
- locktype | mode            | granted | relation          
-----------+-----------------+---------+-------------------
- relation | AccessShareLock | t       | t_lockmods_upsert 
- relation | ExclusiveLock   | t       | t_lockmods_upsert 
-(2 rows)
+ locktype | mode          | granted | relation          
+----------+---------------+---------+-------------------
+ relation | ExclusiveLock | t       | t_lockmods_upsert 
+(1 row)
 1: abort;
 ABORT
 
@@ -1024,8 +1023,6 @@ ABORT
 --   * DML on one specific leaf
 -- For detailed behavior and notes, please refer below
 -- cases's comments.
--- GPDB_12_MERGE_FIXME: DML lockmodes on partition table
--- is a bit in disorder, we shoule correct them.
 -- Details: https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/wAPKpJzhbpM
 -- start_ignore
 1:DROP TABLE IF EXISTS t_lockmods_part_tbl_upd_del;
@@ -1044,12 +1041,12 @@ BEGIN
 DELETE 10
 -- on QD, there's a lock on the root and the target partition
 1: select * from show_locks_lockmodes;
- locktype | mode             | granted | relation                            
-----------+------------------+---------+-------------------------------------
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_upd_del_1_prt_2 
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_upd_del_1_prt_1 
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_upd_del         
- relation | ExclusiveLock    | t       | t_lockmods_part_tbl_upd_del         
+ locktype | mode            | granted | relation                            
+----------+-----------------+---------+-------------------------------------
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del_1_prt_1 
+ relation | AccessShareLock | t       | t_lockmods_part_tbl_upd_del         
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del         
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del_1_prt_2 
 (4 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -1083,12 +1080,12 @@ BEGIN
 UPDATE 1
 -- on QD, there's a lock on the root and the target partition
 1: select * from show_locks_lockmodes;
- locktype | mode             | granted | relation                            
-----------+------------------+---------+-------------------------------------
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_upd_del_1_prt_2 
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_upd_del_1_prt_1 
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_upd_del         
- relation | ExclusiveLock    | t       | t_lockmods_part_tbl_upd_del         
+ locktype | mode            | granted | relation                            
+----------+-----------------+---------+-------------------------------------
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del_1_prt_1 
+ relation | AccessShareLock | t       | t_lockmods_part_tbl_upd_del         
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del         
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del_1_prt_2 
 (4 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -1570,9 +1567,8 @@ EXECUTE 1
 2: select * from show_locks_lockmodes;
  locktype | mode             | granted | relation          
 ----------+------------------+---------+-------------------
- relation | AccessShareLock  | t       | t_lockmods_upsert 
  relation | RowExclusiveLock | t       | t_lockmods_upsert 
-(2 rows)
+(1 row)
 1: abort;
 ABORT
 

--- a/src/test/isolation2/output/uao/parallel_delete.source
+++ b/src/test/isolation2/output/uao/parallel_delete.source
@@ -21,9 +21,9 @@ DELETE 1
  ao       | ExclusiveLock | relation | master 
 (1 row)
 2: SELECT * FROM locktest_segments WHERE coalesce = 'ao';
- coalesce | mode             | locktype | node      
-----------+------------------+----------+-----------
- ao       | RowExclusiveLock | relation | 1 segment 
+ coalesce | mode          | locktype | node      
+----------+---------------+----------+-----------
+ ao       | ExclusiveLock | relation | 1 segment 
 (1 row)
 -- The case here should delete a tuple at the same seg with(2).
 -- Under jump hash, (2) and (3) are on the same seg(seg0).

--- a/src/test/isolation2/output/uao/parallel_update.source
+++ b/src/test/isolation2/output/uao/parallel_update.source
@@ -21,9 +21,9 @@ UPDATE 1
  ao       | ExclusiveLock | relation | master 
 (1 row)
 2: SELECT * FROM locktest_segments WHERE coalesce = 'ao';
- coalesce | mode             | locktype | node      
-----------+------------------+----------+-----------
- ao       | RowExclusiveLock | relation | 1 segment 
+ coalesce | mode          | locktype | node      
+----------+---------------+----------+-----------
+ ao       | ExclusiveLock | relation | 1 segment 
 (1 row)
 -- The case here should update a tuple at the same seg with(2).
 -- Under jump hash, (2) and (3) are on the same seg(seg0).

--- a/src/test/isolation2/sql/lockmodes.sql
+++ b/src/test/isolation2/sql/lockmodes.sql
@@ -318,8 +318,6 @@ create table t_lockmods_ao1 (c int) with (appendonly=true) distributed randomly;
 --   * DML on one specific leaf
 -- For detailed behavior and notes, please refer below
 -- cases's comments.
--- GPDB_12_MERGE_FIXME: DML lockmodes on partition table
--- is a bit in disorder, we shoule correct them.
 -- Details: https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/wAPKpJzhbpM
 -- start_ignore
 1:DROP TABLE IF EXISTS t_lockmods_part_tbl_upd_del;

--- a/src/test/regress/expected/ao_locks.out
+++ b/src/test/regress/expected/ao_locks.out
@@ -82,7 +82,7 @@ SELECT * FROM locktest_segments where coalesce = 'ao_locks_table' or
  coalesce like 'aovisimap%' or coalesce like 'aoseg%';
     coalesce     |       mode       | locktype |   node    
 -----------------+------------------+----------+-----------
- ao_locks_table  | RowExclusiveLock | relation | 1 segment
+ ao_locks_table  | ExclusiveLock    | relation | 1 segment
  aovisimap table | RowExclusiveLock | relation | 1 segment
  aovisimap index | RowExclusiveLock | relation | 1 segment
 (3 rows)
@@ -101,7 +101,7 @@ SELECT * FROM locktest_segments where coalesce = 'ao_locks_table' or
  coalesce like 'aovisimap%' or coalesce like 'aoseg%';
     coalesce     |       mode       | locktype |   node    
 -----------------+------------------+----------+-----------
- ao_locks_table  | RowExclusiveLock | relation | 1 segment
+ ao_locks_table  | ExclusiveLock    | relation | 1 segment
  aovisimap table | RowExclusiveLock | relation | 1 segment
  aovisimap index | RowExclusiveLock | relation | 1 segment
 (3 rows)

--- a/src/test/regress/expected/partition_locking.out
+++ b/src/test/regress/expected/partition_locking.out
@@ -439,21 +439,21 @@ begin;
 delete from partlockt where i = 4;
 -- Known_opt_diff: MPP-20936
 select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
-        coalesce         |       mode       | locktype |  node  
--------------------------+------------------+----------+--------
- partlockt               | AccessShareLock  | relation | master
- partlockt               | ExclusiveLock    | relation | master
- partlockt_1_prt_4       | RowExclusiveLock | relation | master
- partlockt_1_prt_4_i_idx | RowExclusiveLock | relation | master
+        coalesce         |      mode       | locktype |  node  
+-------------------------+-----------------+----------+--------
+ partlockt               | AccessShareLock | relation | master
+ partlockt               | ExclusiveLock   | relation | master
+ partlockt_1_prt_4       | ExclusiveLock   | relation | master
+ partlockt_1_prt_4_i_idx | ExclusiveLock   | relation | master
 (4 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
-        coalesce         |       mode       | locktype |   node    
--------------------------+------------------+----------+-----------
- partlockt               | AccessShareLock  | relation | 1 segment
- partlockt               | RowExclusiveLock | relation | 1 segment
- partlockt_1_prt_4       | RowExclusiveLock | relation | 1 segment
- partlockt_1_prt_4_i_idx | RowExclusiveLock | relation | 1 segment
+        coalesce         |      mode       | locktype |   node    
+-------------------------+-----------------+----------+-----------
+ partlockt               | AccessShareLock | relation | 1 segment
+ partlockt               | ExclusiveLock   | relation | 1 segment
+ partlockt_1_prt_4       | ExclusiveLock   | relation | 1 segment
+ partlockt_1_prt_4_i_idx | ExclusiveLock   | relation | 1 segment
 (4 rows)
 
 commit;

--- a/src/test/regress/expected/partition_locking_optimizer.out
+++ b/src/test/regress/expected/partition_locking_optimizer.out
@@ -445,24 +445,24 @@ delete from partlockt where i = 4;
 -- GPDB_12_MERGE_FIXME Revisit this post merge and see if we have a chance to unlock the pruned partitions
 -- end_ignore
 select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
-        coalesce         |       mode       | locktype |  node  
--------------------------+------------------+----------+--------
- partlockt               | AccessShareLock  | relation | master
- partlockt               | ExclusiveLock    | relation | master
- partlockt_1_prt_4       | RowExclusiveLock | relation | master
- partlockt_1_prt_4_i_idx | RowExclusiveLock | relation | master
+        coalesce         |      mode       | locktype |  node  
+-------------------------+-----------------+----------+--------
+ partlockt               | AccessShareLock | relation | master
+ partlockt               | ExclusiveLock   | relation | master
+ partlockt_1_prt_4       | ExclusiveLock   | relation | master
+ partlockt_1_prt_4_i_idx | ExclusiveLock   | relation | master
 (4 rows)
 
 -- start_ignore
 -- GPDB_12_MERGE_FIXME Revisit this post merge and see if we have a chance to unlock the root table
 -- end_ignore
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
-        coalesce         |       mode       | locktype |   node    
--------------------------+------------------+----------+-----------
- partlockt               | AccessShareLock  | relation | 1 segment
- partlockt               | RowExclusiveLock | relation | 1 segment
- partlockt_1_prt_4       | RowExclusiveLock | relation | 1 segment
- partlockt_1_prt_4_i_idx | RowExclusiveLock | relation | 1 segment
+        coalesce         |      mode       | locktype |   node    
+-------------------------+-----------------+----------+-----------
+ partlockt               | AccessShareLock | relation | 1 segment
+ partlockt               | ExclusiveLock   | relation | 1 segment
+ partlockt_1_prt_4       | ExclusiveLock   | relation | 1 segment
+ partlockt_1_prt_4_i_idx | ExclusiveLock   | relation | 1 segment
 (4 rows)
 
 commit;


### PR DESCRIPTION
Since GPDB_12_MERGE, the appropriate lockmode of the relations in a
query has been decided and recorded into RTE.rellockmode field when
transforming parsetree to querytree. the cached plan can just reuse
those info.
    
No testcase is added, as this commit only clean commented-out code
and isolation2/lockmodes.sql has already covered the lockmode test