### PR TITLE
Make test resgroup_seg_down_2pc stable.

### DIFF
--- a/src/test/isolation2/expected/resgroup/resgroup_seg_down_2pc.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_seg_down_2pc.out
@@ -4,6 +4,9 @@
 -- The expectation is "alter resource group" can run successfully since the mirror segment is UP.
 -- After recover the segment, there is no error or blocking.
 
+create extension if not exists gp_inject_fault;
+CREATE
+
 -- set these values purely to cut down test time, as default fts trigger is
 -- every min and 5 retries
 alter system set gp_fts_probe_interval to 10;
@@ -50,13 +53,8 @@ CREATE
 -----------------
  Success:        
 (1 row)
--- reset the injected fault on primary segment
-2:select gp_inject_fault('fts_conn_startup_packet', 'reset', dbid) from gp_segment_configuration where content=0;
- gp_inject_fault 
------------------
- Success:        
- Success:        
-(2 rows)
+-- No need to reset fts_conn_startup_packet fault inject because the segment we have set
+-- is down now, and later we will full recover it back with new init clean shared memory.
 1<:  <... completed>
 ALTER
 -- make sure "alter resource group" has taken effect.

--- a/src/test/isolation2/sql/resgroup/resgroup_seg_down_2pc.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_seg_down_2pc.sql
@@ -4,6 +4,8 @@
 -- The expectation is "alter resource group" can run successfully since the mirror segment is UP. 
 -- After recover the segment, there is no error or blocking.
 
+create extension if not exists gp_inject_fault;
+
 -- set these values purely to cut down test time, as default fts trigger is
 -- every min and 5 retries
 alter system set gp_fts_probe_interval to 10;
@@ -23,8 +25,8 @@ select pg_reload_conf();
 2:select status = 'd' from gp_segment_configuration where content = 0 and role = 'm';
 -- reset the injected fault on QD and the "alter resource group" in session1 can continue
 2:select gp_inject_fault('dtm_broadcast_commit_prepared', 'reset', dbid) from gp_segment_configuration where role='p' and content=-1;
--- reset the injected fault on primary segment
-2:select gp_inject_fault('fts_conn_startup_packet', 'reset', dbid) from gp_segment_configuration where content=0;
+-- No need to reset fts_conn_startup_packet fault inject because the segment we have set
+-- is down now, and later we will full recover it back with new init clean shared memory.
 1<:
 -- make sure "alter resource group" has taken effect.
 1:select concurrency from gp_toolkit.gp_resgroup_config where groupname = 'rgroup_seg_down';


### PR DESCRIPTION
Pipeline shows the case resgroup_seg_down_2pc flaky with the
following diffs:
     -- reset the injected fault on primary segment
     2:select gp_inject_fault('fts_conn_startup_packet', 'reset', dbid) from gp_segment_configuration where content=0;
    - gp_inject_fault
    ------------------
    - Success:
    - Success:
    -(2 rows)
    +ERROR:  connection to dbid 4 sdw1:21000 failed (gp_inject_fault.c:107)
     1<:  <... completed>
     ALTER
     -- make sure "alter resource group" has taken effect.

Actually we do not need to reset the fault inject
fts_conn_startup_packet for this case because the segment we set it
will be marked down and then recoverseg with a new clean shared
memory. Remove the statement that reset it to make this test case stable.

------

Master pipeline flaky: https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb_master/jobs/resource_group_centos7/builds/2993

**NOTE: need backport**
