### PR TITLE
Resolve GPDB_12_MERGE_FIXME in nodeHash.c and nodeHashjoin.c

### DIFF
--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -1800,9 +1800,7 @@ SpillCurrentBatch(HashJoinState *node)
 
 	for (i = 0; i < hashtable->nbuckets; i++)
 	{
-		/* GPDB_12_MERGE_FIXME: this only looks at 'unshared'. I think this is
-		 * broken for parallel hashjoins
-		 */
+		/* don't need to consider parallel hashjoins which use shared tuplestores instead of raw files */
 		tuple = hashtable->buckets.unshared[i];
 
 		while (tuple != NULL)

--- a/src/include/executor/hashjoin.h
+++ b/src/include/executor/hashjoin.h
@@ -359,8 +359,8 @@ typedef struct HashJoinTableData
 	 * These arrays are allocated for the life of the hash join, but only if
 	 * nbatch > 1.  A file is opened only when we first write a tuple into it
 	 * (otherwise its pointer remains NULL).  Note that the zero'th array
-	 * elements never get used, since we will process rather than dump out any
-	 * tuples of batch zero.
+	 * elements can still get used while nbatch > 1 in GPDB to support rescan
+	 * of hashjoin.
 	 */
 	BufFile	  **innerBatchFile; /* buffered virtual temp file per batch */
 	BufFile   **outerBatchFile; /* buffered virtual temp file per batch */

--- a/src/test/regress/expected/dpe.out
+++ b/src/test/regress/expected/dpe.out
@@ -9,6 +9,12 @@
 -- s/Buckets: \d+/Buckets: ###/
 -- m/Batches: \d+/
 -- s/Batches: \d+/Batches: ###/
+-- m/Extra Text: \(seg\d+\)/
+-- s/Extra Text: \(seg\d+\)/Extra Text: ###/
+-- m/Hash chain length \d+\.\d+ avg, \d+ max/
+-- s/Hash chain length \d+\.\d+ avg, \d+ max/Hash chain length ###/
+-- m/using \d+ of \d+ buckets/
+-- s/using \d+ of \d+ buckets/using ## of ### buckets/
 -- end_matchsubs
 drop schema if exists dpe_single cascade;
 NOTICE:  schema "dpe_single" does not exist, skipping
@@ -75,6 +81,7 @@ explain (costs off, timing off, summary off, analyze) select * from t, pt where 
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=18 loops=1)
    ->  Hash Join (actual rows=8 loops=1)
          Hash Cond: (pt_1_prt_2.ptid = t.tid)
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 2 of 524288 buckets.
          ->  Append (actual rows=8 loops=1)
                Partition Selectors: $0
                ->  Seq Scan on pt_1_prt_2 (actual rows=5 loops=1)
@@ -120,6 +127,7 @@ explain (costs off, timing off, summary off, analyze) select * from t, pt where 
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=18 loops=1)
    ->  Hash Join (actual rows=8 loops=1)
          Hash Cond: (pt_1_prt_2.ptid = (t.tid + 1))
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 2 of 524288 buckets.
          ->  Append (actual rows=8 loops=1)
                Partition Selectors: $0
                ->  Seq Scan on pt_1_prt_2 (never executed)
@@ -165,6 +173,7 @@ explain (costs off, timing off, summary off, analyze) select * from t, pt where 
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=18 loops=1)
    ->  Hash Join (actual rows=8 loops=1)
          Hash Cond: (pt_1_prt_2.ptid = t.tid)
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 2 of 524288 buckets.
          ->  Append (actual rows=8 loops=1)
                Partition Selectors: $0
                ->  Seq Scan on pt_1_prt_2 (actual rows=5 loops=1)
@@ -211,6 +220,7 @@ explain (costs off, timing off, summary off, analyze) select * from t, pt where 
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=2 loops=1)
    ->  Hash Join (actual rows=2 loops=1)
          Hash Cond: ((pt_1_prt_2.pt1 = t.t1) AND (pt_1_prt_2.ptid = t.tid))
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 2 of 524288 buckets.
          ->  Append (actual rows=8 loops=1)
                Partition Selectors: $0
                ->  Seq Scan on pt_1_prt_2 (actual rows=5 loops=1)
@@ -243,6 +253,7 @@ explain (costs off, timing off, summary off, analyze) select * from pt where pti
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=18 loops=1)
    ->  Hash Semi Join (actual rows=8 loops=1)
          Hash Cond: (pt_1_prt_2.ptid = t.tid)
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 2 of 524288 buckets.
          ->  Append (actual rows=8 loops=1)
                Partition Selectors: $0
                ->  Seq Scan on pt_1_prt_2 (actual rows=5 loops=1)
@@ -292,6 +303,7 @@ explain (costs off, timing off, summary off, analyze) select * from pt where exi
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=18 loops=1)
    ->  Hash Semi Join (actual rows=8 loops=1)
          Hash Cond: (pt_1_prt_2.ptid = t.tid)
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 2 of 524288 buckets.
          ->  Append (actual rows=8 loops=1)
                Partition Selectors: $0
                ->  Seq Scan on pt_1_prt_2 (actual rows=5 loops=1)
@@ -343,6 +355,7 @@ explain (costs off, timing off, summary off, analyze) select count(*) from t, pt
          ->  Partial Aggregate (actual rows=1 loops=1)
                ->  Hash Join (actual rows=8 loops=1)
                      Hash Cond: (pt_1_prt_2.ptid = t.tid)
+                     Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 2 of 524288 buckets.
                      ->  Append (actual rows=8 loops=1)
                            Partition Selectors: $0
                            ->  Seq Scan on pt_1_prt_2 (actual rows=5 loops=1)
@@ -380,6 +393,7 @@ explain (costs off, timing off, summary off, analyze) select *, rank() over (ord
                Sort Method:  quicksort  Memory: 152kB
                ->  Hash Join (actual rows=8 loops=1)
                      Hash Cond: (pt_1_prt_2.ptid = t.tid)
+                     Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 2 of 262144 buckets.
                      ->  Append (actual rows=8 loops=1)
                            Partition Selectors: $0
                            ->  Seq Scan on pt_1_prt_2 (actual rows=5 loops=1)
@@ -431,6 +445,7 @@ explain (costs off, timing off, summary off, analyze) select * from t, pt where 
    ->  Append (actual rows=14 loops=1)
          ->  Hash Join (actual rows=8 loops=1)
                Hash Cond: (pt_1_prt_2.ptid = t.tid)
+               Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 2 of 262144 buckets.
                ->  Append (actual rows=8 loops=1)
                      Partition Selectors: $0
                      ->  Seq Scan on pt_1_prt_2 (actual rows=5 loops=1)
@@ -446,6 +461,7 @@ explain (costs off, timing off, summary off, analyze) select * from t, pt where 
                                  ->  Seq Scan on t (actual rows=2 loops=1)
          ->  Hash Join (actual rows=7 loops=1)
                Hash Cond: (pt_1_prt_2_1.ptid = (t_1.tid + 2))
+               Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 2 of 262144 buckets.
                ->  Append (actual rows=7 loops=1)
                      Partition Selectors: $1
                      ->  Seq Scan on pt_1_prt_2 pt_1_prt_2_1 (never executed)
@@ -522,6 +538,7 @@ explain (costs off, timing off, summary off, analyze) select count(*) from
                      ->  Subquery Scan on "*SELECT* 1" (actual rows=8 loops=1)
                            ->  Hash Join (actual rows=8 loops=1)
                                  Hash Cond: (pt_1_prt_2.ptid = t.tid)
+                                 Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 2 of 262144 buckets.
                                  ->  Append (actual rows=8 loops=1)
                                        Partition Selectors: $0
                                        ->  Seq Scan on pt_1_prt_2 (actual rows=5 loops=1)
@@ -538,6 +555,7 @@ explain (costs off, timing off, summary off, analyze) select count(*) from
                      ->  Subquery Scan on "*SELECT* 2" (actual rows=7 loops=1)
                            ->  Hash Join (actual rows=7 loops=1)
                                  Hash Cond: (pt_1_prt_2_1.ptid = (t_1.tid + 2))
+                                 Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 2 of 262144 buckets.
                                  ->  Append (actual rows=7 loops=1)
                                        Partition Selectors: $1
                                        ->  Seq Scan on pt_1_prt_2 pt_1_prt_2_1 (never executed)
@@ -719,6 +737,7 @@ explain (costs off, timing off, summary off, analyze) select * from t, pt where 
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=2 loops=1)
    ->  Hash Join (actual rows=2 loops=1)
          Hash Cond: (pt_1_prt_2.pt1 = t.t1)
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 2 of 524288 buckets.
          ->  Append (actual rows=20 loops=1)
                ->  Seq Scan on pt_1_prt_2 (actual rows=5 loops=1)
                ->  Seq Scan on pt_1_prt_3 (actual rows=3 loops=1)
@@ -860,8 +879,10 @@ explain (costs off, timing off, summary off, analyze) select * from t, t1, pt wh
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=36 loops=1)
    ->  Hash Join (actual rows=16 loops=1)
          Hash Cond: (t1.t2 = t.t2)
+         Extra Text: (seg1)   Hash chain length 2.0 avg, 2 max, using 1 of 131072 buckets.
          ->  Hash Join (actual rows=8 loops=1)
                Hash Cond: (pt_1_prt_2.ptid = t1.tid)
+               Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 2 of 131072 buckets.
                ->  Append (actual rows=8 loops=1)
                      Partition Selectors: $0
                      ->  Seq Scan on pt_1_prt_2 (never executed)
@@ -937,8 +958,10 @@ explain (costs off, timing off, summary off, analyze) select * from t, t1, pt wh
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=9 loops=1)
    ->  Hash Join (actual rows=3 loops=1)
          Hash Cond: (pt_1_prt_2.ptid = t1.tid)
+         Extra Text: (seg0)   Hash chain length 4.0 avg, 10 max, using 3 of 131072 buckets.
          ->  Hash Join (actual rows=3 loops=1)
                Hash Cond: (pt_1_prt_2.ptid = t.tid)
+               Extra Text: (seg0)   Hash chain length 4.0 avg, 10 max, using 3 of 131072 buckets.
                ->  Append (actual rows=6 loops=1)
                      Partition Selectors: $0, $1
                      ->  Seq Scan on pt_1_prt_2 (never executed)
@@ -989,9 +1012,11 @@ explain (costs off, timing off, summary off, analyze) select * from t1 inner joi
    ->  Hash Join (actual rows=1 loops=1)
          Hash Cond: ((pt1.dist = t1.dist) AND (pt1.ptid = t1.tid))
          Join Filter: ((t1.tid <= pt2.ptid) AND (pt1.ptid <= t1.tid))
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 1 of 262144 buckets.
          ->  Hash Join (actual rows=3 loops=1)
                Hash Cond: ((pt1.dist = pt2.dist) AND (pt1.ptid = pt2.ptid))
                Join Filter: (pt1.ptid <= pt2.ptid)
+               Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 14 of 262144 buckets.
                ->  Append (actual rows=3 loops=1)
                      Partition Selectors: $0, $1
                      ->  Seq Scan on pt_1_prt_2 pt1 (never executed)
@@ -1034,6 +1059,7 @@ explain (costs off, timing off, summary off, analyze) select * from pt, pt1 wher
          Sort Method:  quicksort  Memory: 150kB
          ->  Hash Join (actual rows=5 loops=1)
                Hash Cond: (pt1_1_prt_2.ptid = pt_1_prt_2.ptid)
+               Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 1 of 131072 buckets.
                ->  Append (actual rows=5 loops=1)
                      Partition Selectors: $0
                      ->  Seq Scan on pt1_1_prt_2 (actual rows=5 loops=1)
@@ -1085,6 +1111,7 @@ explain (costs off, timing off, summary off, analyze) select count(*) from pt, p
          ->  Partial Aggregate (actual rows=1 loops=1)
                ->  Hash Join (actual rows=5 loops=1)
                      Hash Cond: (pt1_1_prt_2.ptid = pt_1_prt_2.ptid)
+                     Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 1 of 524288 buckets.
                      ->  Append (actual rows=5 loops=1)
                            Partition Selectors: $0
                            ->  Seq Scan on pt1_1_prt_2 (actual rows=5 loops=1)
@@ -1264,6 +1291,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
          Sort Method:  quicksort  Memory: 158kB
          ->  Hash Join (actual rows=50 loops=1)
                Hash Cond: ((fact1_1_prt_1_2_prt_ca.pid = dim1.pid) AND (fact1_1_prt_1_2_prt_ca.code = dim1.code))
+               Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 262144 buckets.
                ->  Append (actual rows=200 loops=1)
                      ->  Seq Scan on fact1_1_prt_1_2_prt_ca (actual rows=25 loops=1)
                      ->  Seq Scan on fact1_1_prt_1_2_prt_oh (actual rows=25 loops=1)
@@ -1350,6 +1378,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
          Sort Method:  quicksort  Memory: 158kB
          ->  Hash Join (actual rows=50 loops=1)
                Hash Cond: ((fact1_1_prt_1_2_prt_ca.pid = dim1.pid) AND (fact1_1_prt_1_2_prt_ca.code = dim1.code))
+               Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 262144 buckets.
                ->  Append (actual rows=50 loops=1)
                      Partition Selectors: $0
                      ->  Seq Scan on fact1_1_prt_1_2_prt_ca (never executed)
@@ -1441,6 +1470,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
          Sort Method:  quicksort  Memory: 166kB
          ->  Hash Join (actual rows=100 loops=1)
                Hash Cond: (fact1_1_prt_1_2_prt_ca.pid = dim1.pid)
+               Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 262144 buckets.
                ->  Append (actual rows=200 loops=1)
                      ->  Seq Scan on fact1_1_prt_1_2_prt_ca (actual rows=25 loops=1)
                      ->  Seq Scan on fact1_1_prt_1_2_prt_oh (actual rows=25 loops=1)
@@ -1577,6 +1607,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
          Sort Method:  quicksort  Memory: 166kB
          ->  Hash Join (actual rows=100 loops=1)
                Hash Cond: (fact1_1_prt_1_2_prt_ca.pid = dim1.pid)
+               Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 262144 buckets.
                ->  Append (actual rows=100 loops=1)
                      Partition Selectors: $0
                      ->  Seq Scan on fact1_1_prt_1_2_prt_ca (actual rows=25 loops=1)
@@ -1715,6 +1746,7 @@ select * from dim1 inner join fact1 on (dim1.dist = fact1.dist and dim1.code=fac
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=200 loops=1)
    ->  Hash Join (actual rows=200 loops=1)
          Hash Cond: ((fact1_1_prt_1_2_prt_ca.dist = dim1.dist) AND (fact1_1_prt_1_2_prt_ca.code = dim1.code))
+         Extra Text: (seg1)   Hash chain length 1.5 avg, 2 max, using 2 of 524288 buckets.
          ->  Append (actual rows=200 loops=1)
                ->  Seq Scan on fact1_1_prt_1_2_prt_ca (actual rows=25 loops=1)
                ->  Seq Scan on fact1_1_prt_1_2_prt_oh (actual rows=25 loops=1)
@@ -1947,6 +1979,7 @@ select * from dim1 inner join fact1 on (dim1.dist = fact1.dist and dim1.code=fac
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=200 loops=1)
    ->  Hash Join (actual rows=200 loops=1)
          Hash Cond: ((fact1_1_prt_1_2_prt_ca.dist = dim1.dist) AND (fact1_1_prt_1_2_prt_ca.code = dim1.code))
+         Extra Text: (seg1)   Hash chain length 1.5 avg, 2 max, using 2 of 524288 buckets.
          ->  Append (actual rows=100 loops=1)
                Partition Selectors: $0
                ->  Seq Scan on fact1_1_prt_1_2_prt_ca (never executed)
@@ -2187,6 +2220,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
          Sort Method:  quicksort  Memory: 158kB
          ->  Hash Join (actual rows=50 loops=1)
                Hash Cond: (fact1_1_prt_1_2_prt_oh.pid = dim1.pid)
+               Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 262144 buckets.
                ->  Append (actual rows=100 loops=1)
                      ->  Seq Scan on fact1_1_prt_1_2_prt_oh (actual rows=25 loops=1)
                            Filter: (code = 'OH'::text)
@@ -2269,6 +2303,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
          Sort Method:  quicksort  Memory: 158kB
          ->  Hash Join (actual rows=50 loops=1)
                Hash Cond: (fact1_1_prt_1_2_prt_oh.pid = dim1.pid)
+               Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 262144 buckets.
                ->  Append (actual rows=50 loops=1)
                      Partition Selectors: $0
                      ->  Seq Scan on fact1_1_prt_1_2_prt_oh (actual rows=25 loops=1)
@@ -2360,6 +2395,7 @@ explain (costs off, timing off, summary off, analyze) select fact1.code, count(*
                      Hash Key: fact1_1_prt_1_2_prt_ca.code
                      ->  Hash Join (actual rows=100 loops=1)
                            Hash Cond: (fact1_1_prt_1_2_prt_ca.pid = dim1.pid)
+                           Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 262144 buckets.
                            ->  Append (actual rows=200 loops=1)
                                  ->  Seq Scan on fact1_1_prt_1_2_prt_ca (actual rows=25 loops=1)
                                  ->  Seq Scan on fact1_1_prt_1_2_prt_oh (actual rows=25 loops=1)
@@ -2402,6 +2438,7 @@ explain (costs off, timing off, summary off, analyze) select fact1.code, count(*
                      Hash Key: fact1_1_prt_1_2_prt_ca.code
                      ->  Hash Join (actual rows=100 loops=1)
                            Hash Cond: (fact1_1_prt_1_2_prt_ca.pid = dim1.pid)
+                           Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 262144 buckets.
                            ->  Append (actual rows=100 loops=1)
                                  Partition Selectors: $0
                                  ->  Seq Scan on fact1_1_prt_1_2_prt_ca (actual rows=25 loops=1)
@@ -2475,6 +2512,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim inner jo
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
    ->  Hash Join (actual rows=3 loops=1)
          Hash Cond: (malp_p1.i = dim.i)
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 1 of 524288 buckets.
          ->  Append (actual rows=3 loops=1)
                ->  Seq Scan on malp_p1 (actual rows=3 loops=1)
                ->  Seq Scan on malp_p2 (never executed)
@@ -2541,8 +2579,10 @@ explain (costs off, timing off, summary off, analyze) select * from apart as a, 
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=5 loops=1)
    ->  Hash Join (actual rows=3 loops=1)
          Hash Cond: (a.id = c.id)
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 8 of 262144 buckets.
          ->  Hash Join (actual rows=3 loops=1)
                Hash Cond: (a.t = b.t)
+               Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 5 of 262144 buckets.
                ->  Append (actual rows=340 loops=1)
                      ->  Seq Scan on apart_1_prt_1 a (actual rows=70 loops=1)
                      ->  Seq Scan on apart_1_prt_2 a_1 (actual rows=68 loops=1)
@@ -2576,8 +2616,10 @@ explain (costs off, timing off, summary off, analyze) select * from apart as a, 
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=5 loops=1)
    ->  Hash Join (actual rows=3 loops=1)
          Hash Cond: (a.id = c.id)
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 8 of 262144 buckets.
          ->  Hash Join (actual rows=3 loops=1)
                Hash Cond: (a.t = b.t)
+               Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 5 of 262144 buckets.
                ->  Append (actual rows=70 loops=1)
                      Partition Selectors: $0
                      ->  Seq Scan on apart_1_prt_1 a (actual rows=70 loops=1)
@@ -2633,6 +2675,7 @@ explain (costs off, timing off, summary off, analyze) select * from (select coun
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=1 loops=1)
    ->  Hash Join (actual rows=1 loops=1)
          Hash Cond: (pat_1_prt_2.b = jpat.b)
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 1 of 131072 buckets.
          ->  Append (actual rows=1 loops=1)
                Partition Selectors: $0
                ->  Seq Scan on pat_1_prt_2 (never executed)
@@ -2702,6 +2745,7 @@ select * from pt, t where t.id = pt.id;
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=2 loops=1)
    ->  Hash Join (actual rows=1 loops=1)
          Hash Cond: (pt1.id = t.id)
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 1 of 524288 buckets.
          ->  Append (actual rows=1 loops=1)
                Partition Selectors: $0
                ->  Seq Scan on pt1 (actual rows=1 loops=1)
@@ -2724,6 +2768,7 @@ select * from pt, t where t.id = pt.id;
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=4 loops=1)
    ->  Hash Join (actual rows=2 loops=1)
          Hash Cond: (pt1.id = t.id)
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 3 of 524288 buckets.
          ->  Append (actual rows=3 loops=1)
                Partition Selectors: $0
                ->  Seq Scan on pt1 (actual rows=1 loops=1)
@@ -2747,6 +2792,7 @@ select * from pt, t where pt.id = 4 and t.id = 4 and (t.b % 2) = (pt.b % 2);
  Gather Motion 1:1  (slice1; segments: 1) (actual rows=1 loops=1)
    ->  Hash Join (actual rows=1 loops=1)
          Hash Cond: ((ptx_even.b % 2) = (t.b % 2))
+         Extra Text: Hash chain length 1.0 avg, 1 max, using 1 of 524288 buckets.
          ->  Append (actual rows=1 loops=1)
                Partition Selectors: $0
                ->  Seq Scan on ptx_even (actual rows=1 loops=1)
@@ -2771,6 +2817,7 @@ select * from pt, t where t.id = pt.id and (t.b % 2) = (pt.b % 2);
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=4 loops=1)
    ->  Hash Join (actual rows=2 loops=1)
          Hash Cond: ((pt1.id = t.id) AND ((pt1.b % 2) = (t.b % 2)))
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 3 of 524288 buckets.
          ->  Append (actual rows=2 loops=1)
                Partition Selectors: $0
                ->  Seq Scan on pt1 (actual rows=1 loops=1)
@@ -2818,6 +2865,7 @@ select * from pt, t where t.dist = pt.dist and t.tid < pt.ptid;
          Hash Cond: (pt1.dist = t.dist)
          Join Filter: (t.tid < pt1.ptid)
          Rows Removed by Join Filter: 3
+         Extra Text: (seg1)   Hash chain length 2.0 avg, 2 max, using 1 of 524288 buckets.
          ->  Append (actual rows=7 loops=1)
                Partition Selectors: $0
                ->  Seq Scan on pt1 (never executed)

--- a/src/test/regress/expected/dpe_optimizer.out
+++ b/src/test/regress/expected/dpe_optimizer.out
@@ -9,6 +9,12 @@
 -- s/Buckets: \d+/Buckets: ###/
 -- m/Batches: \d+/
 -- s/Batches: \d+/Batches: ###/
+-- m/Extra Text: \(seg\d+\)/
+-- s/Extra Text: \(seg\d+\)/Extra Text: ###/
+-- m/Hash chain length \d+\.\d+ avg, \d+ max/
+-- s/Hash chain length \d+\.\d+ avg, \d+ max/Hash chain length ###/
+-- m/using \d+ of \d+ buckets/
+-- s/using \d+ of \d+ buckets/using ## of ### buckets/
 -- end_matchsubs
 drop schema if exists dpe_single cascade;
 NOTICE:  schema "dpe_single" does not exist, skipping
@@ -257,6 +263,7 @@ explain (costs off, timing off, summary off, analyze) select * from pt where pti
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=18 loops=1)
    ->  Hash Join (actual rows=8 loops=1)
          Hash Cond: (pt_1_prt_2.ptid = t.tid)
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 2 of 262144 buckets.
          ->  Append (actual rows=8 loops=1)
                Partition Selectors: $0
                ->  Seq Scan on pt_1_prt_2 (actual rows=5 loops=1)
@@ -313,6 +320,7 @@ explain (costs off, timing off, summary off, analyze) select * from pt where exi
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=18 loops=1)
    ->  Hash Join (actual rows=8 loops=1)
          Hash Cond: (pt_1_prt_2.ptid = t.tid)
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 2 of 262144 buckets.
          ->  Append (actual rows=8 loops=1)
                Partition Selectors: $0
                ->  Seq Scan on pt_1_prt_2 (actual rows=5 loops=1)
@@ -671,6 +679,7 @@ explain (costs off, timing off, summary off, analyze) select * from t, pt where 
 ------------------------------------------------------------------------------------------------------------
  Hash Join (actual rows=1 loops=1)
    Hash Cond: (t.tid = pt_1_prt_2.ptid)
+   Extra Text: Hash chain length 1.0 avg, 1 max, using 1 of 262144 buckets.
    ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=2 loops=1)
          ->  Seq Scan on t (actual rows=2 loops=1)
    ->  Hash (actual rows=1 loops=1)
@@ -913,6 +922,7 @@ explain (costs off, timing off, summary off, analyze) select * from t, t1, pt wh
 -------------------------------------------------------------------------------------------------------------
  Hash Join (actual rows=36 loops=1)
    Hash Cond: (t1.t2 = t.t2)
+   Extra Text: Hash chain length 2.0 avg, 2 max, using 1 of 262144 buckets.
    ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=18 loops=1)
          ->  Nested Loop (actual rows=8 loops=1)
                Join Filter: true
@@ -993,6 +1003,7 @@ explain (costs off, timing off, summary off, analyze) select * from t, t1, pt wh
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=9 loops=1)
    ->  Hash Join (actual rows=9 loops=1)
          Hash Cond: (t.tid = pt_1_prt_2.ptid)
+         Extra Text: (seg1)   Hash chain length 9.0 avg, 9 max, using 1 of 262144 buckets.
          ->  Redistribute Motion 3:3  (slice2; segments: 3) (actual rows=2 loops=1)
                Hash Key: t.tid
                ->  Seq Scan on t (actual rows=5 loops=1)
@@ -1111,6 +1122,7 @@ explain (costs off, timing off, summary off, analyze) select * from pt, pt1 wher
          Sort Method:  quicksort  Memory: 150kB
          ->  Hash Join (actual rows=5 loops=1)
                Hash Cond: (pt1_1_prt_2.ptid = pt_1_prt_2.ptid)
+               Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 1 of 131072 buckets.
                ->  Append (actual rows=5 loops=1)
                      Partition Selectors: $0
                      ->  Seq Scan on pt1_1_prt_2 (actual rows=5 loops=1)
@@ -1161,6 +1173,7 @@ explain (costs off, timing off, summary off, analyze) select count(*) from pt, p
          ->  Partial Aggregate (actual rows=1 loops=1)
                ->  Hash Join (actual rows=5 loops=1)
                      Hash Cond: (pt1_1_prt_2.ptid = pt_1_prt_2.ptid)
+                     Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 1 of 524288 buckets.
                      ->  Append (actual rows=5 loops=1)
                            Partition Selectors: $0
                            ->  Seq Scan on pt1_1_prt_2 (actual rows=5 loops=1)
@@ -1219,6 +1232,7 @@ explain (costs off, timing off, summary off, analyze) select * from t, pt where 
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=5 loops=1)
    ->  Hash Join (actual rows=3 loops=1)
          Hash Cond: (t.a = pt_1_prt_1.b)
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 3 of 524288 buckets.
          ->  Redistribute Motion 3:3  (slice2; segments: 3) (actual rows=3 loops=1)
                Hash Key: t.a
                ->  Seq Scan on t (actual rows=3 loops=1)
@@ -1344,6 +1358,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
          Sort Method:  quicksort  Memory: 158kB
          ->  Hash Join (actual rows=50 loops=1)
                Hash Cond: ((fact1_1_prt_1_2_prt_ca.pid = dim1.pid) AND (fact1_1_prt_1_2_prt_ca.code = dim1.code))
+               Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 131072 buckets.
                ->  Append (actual rows=200 loops=1)
                      ->  Seq Scan on fact1_1_prt_1_2_prt_ca (actual rows=25 loops=1)
                      ->  Seq Scan on fact1_1_prt_1_2_prt_oh (actual rows=25 loops=1)
@@ -1430,6 +1445,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
          Sort Method:  quicksort  Memory: 158kB
          ->  Hash Join (actual rows=50 loops=1)
                Hash Cond: ((fact1_1_prt_1_2_prt_ca.pid = dim1.pid) AND (fact1_1_prt_1_2_prt_ca.code = dim1.code))
+               Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 131072 buckets.
                ->  Append (actual rows=50 loops=1)
                      Partition Selectors: $0
                      ->  Seq Scan on fact1_1_prt_1_2_prt_ca (never executed)
@@ -1521,6 +1537,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
          Sort Method:  quicksort  Memory: 166kB
          ->  Hash Join (actual rows=100 loops=1)
                Hash Cond: (fact1_1_prt_1_2_prt_ca.pid = dim1.pid)
+               Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 131072 buckets.
                ->  Append (actual rows=200 loops=1)
                      ->  Seq Scan on fact1_1_prt_1_2_prt_ca (actual rows=25 loops=1)
                      ->  Seq Scan on fact1_1_prt_1_2_prt_oh (actual rows=25 loops=1)
@@ -1657,6 +1674,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
          Sort Method:  quicksort  Memory: 166kB
          ->  Hash Join (actual rows=100 loops=1)
                Hash Cond: (fact1_1_prt_1_2_prt_ca.pid = dim1.pid)
+               Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 131072 buckets.
                ->  Append (actual rows=100 loops=1)
                      Partition Selectors: $0
                      ->  Seq Scan on fact1_1_prt_1_2_prt_ca (actual rows=25 loops=1)
@@ -1795,6 +1813,7 @@ select * from dim1 inner join fact1 on (dim1.dist = fact1.dist and dim1.code=fac
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=200 loops=1)
    ->  Hash Join (actual rows=200 loops=1)
          Hash Cond: ((fact1_1_prt_1_2_prt_ca.dist = dim1.dist) AND (fact1_1_prt_1_2_prt_ca.code = dim1.code))
+         Extra Text: (seg1)   Hash chain length 1.5 avg, 2 max, using 2 of 262144 buckets.
          ->  Append (actual rows=200 loops=1)
                ->  Seq Scan on fact1_1_prt_1_2_prt_ca (actual rows=25 loops=1)
                ->  Seq Scan on fact1_1_prt_1_2_prt_oh (actual rows=25 loops=1)
@@ -2027,6 +2046,7 @@ select * from dim1 inner join fact1 on (dim1.dist = fact1.dist and dim1.code=fac
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=200 loops=1)
    ->  Hash Join (actual rows=200 loops=1)
          Hash Cond: ((fact1_1_prt_1_2_prt_ca.dist = dim1.dist) AND (fact1_1_prt_1_2_prt_ca.code = dim1.code))
+         Extra Text: (seg1)   Hash chain length 1.5 avg, 2 max, using 2 of 262144 buckets.
          ->  Append (actual rows=100 loops=1)
                Partition Selectors: $0
                ->  Seq Scan on fact1_1_prt_1_2_prt_ca (never executed)
@@ -2267,6 +2287,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
          Sort Method:  quicksort  Memory: 158kB
          ->  Hash Join (actual rows=50 loops=1)
                Hash Cond: (fact1_1_prt_1_2_prt_oh.pid = dim1.pid)
+               Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 131072 buckets.
                ->  Append (actual rows=100 loops=1)
                      ->  Seq Scan on fact1_1_prt_1_2_prt_oh (actual rows=25 loops=1)
                            Filter: (code = 'OH'::text)
@@ -2349,6 +2370,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
          Sort Method:  quicksort  Memory: 158kB
          ->  Hash Join (actual rows=50 loops=1)
                Hash Cond: (fact1_1_prt_1_2_prt_oh.pid = dim1.pid)
+               Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 131072 buckets.
                ->  Append (actual rows=50 loops=1)
                      Partition Selectors: $0
                      ->  Seq Scan on fact1_1_prt_1_2_prt_oh (actual rows=25 loops=1)
@@ -2440,6 +2462,7 @@ explain (costs off, timing off, summary off, analyze) select fact1.code, count(*
                      Hash Key: fact1_1_prt_1_2_prt_ca.code
                      ->  Hash Join (actual rows=100 loops=1)
                            Hash Cond: (fact1_1_prt_1_2_prt_ca.pid = dim1.pid)
+                           Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 262144 buckets.
                            ->  Append (actual rows=200 loops=1)
                                  ->  Seq Scan on fact1_1_prt_1_2_prt_ca (actual rows=25 loops=1)
                                  ->  Seq Scan on fact1_1_prt_1_2_prt_oh (actual rows=25 loops=1)
@@ -2482,6 +2505,7 @@ explain (costs off, timing off, summary off, analyze) select fact1.code, count(*
                      Hash Key: fact1_1_prt_1_2_prt_ca.code
                      ->  Hash Join (actual rows=100 loops=1)
                            Hash Cond: (fact1_1_prt_1_2_prt_ca.pid = dim1.pid)
+                           Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 262144 buckets.
                            ->  Append (actual rows=100 loops=1)
                                  Partition Selectors: $0
                                  ->  Seq Scan on fact1_1_prt_1_2_prt_ca (actual rows=25 loops=1)
@@ -2555,6 +2579,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim inner jo
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
    ->  Hash Join (actual rows=3 loops=1)
          Hash Cond: (malp_p1.i = dim.i)
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 1 of 524288 buckets.
          ->  Append (actual rows=3 loops=1)
                ->  Seq Scan on malp_p1 (actual rows=3 loops=1)
                ->  Seq Scan on malp_p2 (never executed)
@@ -2621,8 +2646,10 @@ explain (costs off, timing off, summary off, analyze) select * from apart as a, 
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=5 loops=1)
    ->  Hash Join (actual rows=3 loops=1)
          Hash Cond: (apart_1_prt_1.id = c.id)
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 8 of 262144 buckets.
          ->  Hash Join (actual rows=3 loops=1)
                Hash Cond: (apart_1_prt_1.t = b.t)
+               Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 5 of 262144 buckets.
                ->  Append (actual rows=70 loops=1)
                      Partition Selectors: $0
                      ->  Seq Scan on apart_1_prt_1 (actual rows=70 loops=1)
@@ -2658,8 +2685,10 @@ explain (costs off, timing off, summary off, analyze) select * from apart as a, 
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=5 loops=1)
    ->  Hash Join (actual rows=3 loops=1)
          Hash Cond: (apart_1_prt_1.id = c.id)
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 8 of 262144 buckets.
          ->  Hash Join (actual rows=3 loops=1)
                Hash Cond: (apart_1_prt_1.t = b.t)
+               Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 5 of 262144 buckets.
                ->  Append (actual rows=70 loops=1)
                      Partition Selectors: $0
                      ->  Seq Scan on apart_1_prt_1 (actual rows=70 loops=1)
@@ -2714,6 +2743,7 @@ explain (costs off, timing off, summary off, analyze) select * from (select coun
 -------------------------------------------------------------------------------
  Hash Join (actual rows=1 loops=1)
    Hash Cond: (jpat.b = pat_1_prt_2.b)
+   Extra Text: Hash chain length 1.0 avg, 1 max, using 10 of 131072 buckets.
    ->  WindowAgg (actual rows=1 loops=1)
          Order By: jpat.a
          ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=1 loops=1)
@@ -2780,6 +2810,7 @@ select * from pt, t where t.id = pt.id;
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=2 loops=1)
    ->  Hash Join (actual rows=1 loops=1)
          Hash Cond: (pt1.id = t.id)
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 1 of 524288 buckets.
          ->  Append (actual rows=1 loops=1)
                Partition Selectors: $0
                ->  Seq Scan on pt1 (actual rows=1 loops=1)
@@ -2802,6 +2833,7 @@ select * from pt, t where t.id = pt.id;
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=4 loops=1)
    ->  Hash Join (actual rows=2 loops=1)
          Hash Cond: (pt1.id = t.id)
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 3 of 524288 buckets.
          ->  Append (actual rows=3 loops=1)
                Partition Selectors: $0
                ->  Seq Scan on pt1 (actual rows=1 loops=1)
@@ -2825,6 +2857,7 @@ select * from pt, t where pt.id = 4 and t.id = 4 and (t.b % 2) = (pt.b % 2);
  Gather Motion 1:1  (slice1; segments: 1) (actual rows=1 loops=1)
    ->  Hash Join (actual rows=1 loops=1)
          Hash Cond: ((ptx_even.b % 2) = (t.b % 2))
+         Extra Text: Hash chain length 1.0 avg, 1 max, using 1 of 524288 buckets.
          ->  Append (actual rows=1 loops=1)
                Partition Selectors: $0
                ->  Seq Scan on ptx_even (actual rows=1 loops=1)
@@ -2849,6 +2882,7 @@ select * from pt, t where t.id = pt.id and (t.b % 2) = (pt.b % 2);
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=4 loops=1)
    ->  Hash Join (actual rows=2 loops=1)
          Hash Cond: ((pt1.id = t.id) AND ((pt1.b % 2) = (t.b % 2)))
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 3 of 524288 buckets.
          ->  Append (actual rows=2 loops=1)
                Partition Selectors: $0
                ->  Seq Scan on pt1 (actual rows=1 loops=1)
@@ -2896,6 +2930,7 @@ select * from pt, t where t.dist = pt.dist and t.tid < pt.ptid;
          Hash Cond: (pt1.dist = t.dist)
          Join Filter: (t.tid < pt1.ptid)
          Rows Removed by Join Filter: 3
+         Extra Text: (seg1)   Hash chain length 2.0 avg, 2 max, using 1 of 524288 buckets.
          ->  Append (actual rows=7 loops=1)
                Partition Selectors: $0
                ->  Seq Scan on pt1 (never executed)
@@ -2952,6 +2987,7 @@ select * from pt, t where t.dist = pt.dist and t.tid = pt.ptid order by t.tid, t
          Sort Method:  quicksort  Memory: 150kB
          ->  Hash Join  (cost=0.00..862.05 rows=33 width=24) (actual rows=2 loops=1)
                Hash Cond: ((pt1.dist = t.dist) AND (pt1.ptid = t.tid))
+               Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 36 of 262144 buckets.
                ->  Append  (cost=0.00..431.00 rows=33 width=12) (actual rows=36 loops=1)
                      Partition Selectors: $0
                      ->  Seq Scan on pt1  (cost=0.00..431.00 rows=33 width=12) (actual rows=1 loops=1)

--- a/src/test/regress/expected/partition_prune.out
+++ b/src/test/regress/expected/partition_prune.out
@@ -13,6 +13,12 @@
 -- s/Buckets: \d+/Buckets: ###/
 -- m/Batches: \d+/
 -- s/Batches: \d+/Batches: ###/
+-- m/Extra Text: \(seg\d+\)/
+-- s/Extra Text: \(seg\d+\)/Extra Text: ###/
+-- m/Hash chain length \d+\.\d+ avg, \d+ max/
+-- s/Hash chain length \d+\.\d+ avg, \d+ max/Hash chain length ###/
+-- m/using \d+ of \d+ buckets/
+-- s/using \d+ of \d+ buckets/using ## of ### buckets/
 -- m/((0[1-9]|1[0-2])-(0[1-9]|1[0-9]|2[0-9])|(0[13-9]|1[0-2])-30|(0[13578]|1[02])-31)-(?!0000)[0-9]{4}/
 -- s/((0[1-9]|1[0-2])-(0[1-9]|1[0-9]|2[0-9])|(0[13-9]|1[0-2])-30|(0[13578]|1[02])-31)-(?!0000)[0-9]{4}/xx-xx-xxxx/
 -- m/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/

--- a/src/test/regress/expected/partition_prune_optimizer.out
+++ b/src/test/regress/expected/partition_prune_optimizer.out
@@ -13,6 +13,12 @@
 -- s/Buckets: \d+/Buckets: ###/
 -- m/Batches: \d+/
 -- s/Batches: \d+/Batches: ###/
+-- m/Extra Text: \(seg\d+\)/
+-- s/Extra Text: \(seg\d+\)/Extra Text: ###/
+-- m/Hash chain length \d+\.\d+ avg, \d+ max/
+-- s/Hash chain length \d+\.\d+ avg, \d+ max/Hash chain length ###/
+-- m/using \d+ of \d+ buckets/
+-- s/using \d+ of \d+ buckets/using ## of ### buckets/
 -- m/((0[1-9]|1[0-2])-(0[1-9]|1[0-9]|2[0-9])|(0[13-9]|1[0-2])-30|(0[13578]|1[02])-31)-(?!0000)[0-9]{4}/
 -- s/((0[1-9]|1[0-2])-(0[1-9]|1[0-9]|2[0-9])|(0[13-9]|1[0-2])-30|(0[13578]|1[02])-31)-(?!0000)[0-9]{4}/xx-xx-xxxx/
 -- m/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/
@@ -2990,6 +2996,7 @@ select * from tbl1 join tprt on tbl1.col1 = tprt.col1;
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=2 loops=1)
    ->  Hash Join (actual rows=1 loops=1)
          Hash Cond: (tbl1.col1 = tprt_1.col1)
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 3 of 524288 buckets.
          ->  Seq Scan on tbl1 (actual rows=1 loops=1)
          ->  Hash (actual rows=3 loops=1)
                Buckets: 524288  Batches: 1  Memory Usage: 4097kB
@@ -3054,6 +3061,7 @@ select * from tbl1 inner join tprt on tbl1.col1 = tprt.col1;
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
    ->  Hash Join (actual rows=2 loops=1)
          Hash Cond: (tbl1.col1 = tprt_1.col1)
+         Extra Text: (seg2)   Hash chain length 1.0 avg, 1 max, using 3 of 524288 buckets.
          ->  Seq Scan on tbl1 (actual rows=3 loops=1)
          ->  Hash (actual rows=3 loops=1)
                Buckets: 524288  Batches: 1  Memory Usage: 4097kB

--- a/src/test/regress/sql/dpe.sql
+++ b/src/test/regress/sql/dpe.sql
@@ -10,6 +10,12 @@
 -- s/Buckets: \d+/Buckets: ###/
 -- m/Batches: \d+/
 -- s/Batches: \d+/Batches: ###/
+-- m/Extra Text: \(seg\d+\)/
+-- s/Extra Text: \(seg\d+\)/Extra Text: ###/
+-- m/Hash chain length \d+\.\d+ avg, \d+ max/
+-- s/Hash chain length \d+\.\d+ avg, \d+ max/Hash chain length ###/
+-- m/using \d+ of \d+ buckets/
+-- s/using \d+ of \d+ buckets/using ## of ### buckets/
 -- end_matchsubs
 
 drop schema if exists dpe_single cascade;

--- a/src/test/regress/sql/partition_prune.sql
+++ b/src/test/regress/sql/partition_prune.sql
@@ -14,6 +14,12 @@
 -- s/Buckets: \d+/Buckets: ###/
 -- m/Batches: \d+/
 -- s/Batches: \d+/Batches: ###/
+-- m/Extra Text: \(seg\d+\)/
+-- s/Extra Text: \(seg\d+\)/Extra Text: ###/
+-- m/Hash chain length \d+\.\d+ avg, \d+ max/
+-- s/Hash chain length \d+\.\d+ avg, \d+ max/Hash chain length ###/
+-- m/using \d+ of \d+ buckets/
+-- s/using \d+ of \d+ buckets/using ## of ### buckets/
 -- m/((0[1-9]|1[0-2])-(0[1-9]|1[0-9]|2[0-9])|(0[13-9]|1[0-2])-30|(0[13578]|1[02])-31)-(?!0000)[0-9]{4}/
 -- s/((0[1-9]|1[0-2])-(0[1-9]|1[0-9]|2[0-9])|(0[13-9]|1[0-2])-30|(0[13578]|1[02])-31)-(?!0000)[0-9]{4}/xx-xx-xxxx/
 -- m/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/


### PR DESCRIPTION
1.remove GPDB_12_MERGE_FIXME in nodeHash.c: In GPDB, we don't skip batch 0
is because batch 0 can still be used to support rescan of hashjoin.
2.remove GPDB_12_MERGE_FIXME in nodeHash.c:function BufFileGetSize has been
removed,use BufFileSize to get the size of buffile.support the collection of
hash chain statistics.
3.remove GPDB_12_MERGE_FIXME in nodeHashjoin.c: don't need to consider
parallel hashjoins which use shared tuplestores instead of raw files.
parallel hashjoins will never call the function SpillCurrentBatch,so we can
only check unshared here.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
