### PR TITLE
Fix flaky qp_misc test case (#13261)

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CScalarSortGroupClause.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CScalarSortGroupClause.cpp
@@ -54,7 +54,13 @@ CScalarSortGroupClause::CScalarSortGroupClause(CMemoryPool *mp,
 BOOL
 CScalarSortGroupClause::Matches(COperator *other) const
 {
+	if (Eopid() != other->Eopid())
+	{
+		return false;
+	}
+
 	CScalarSortGroupClause *op = CScalarSortGroupClause::PopConvert(other);
+
 	return Index() == op->Index() && EqOp() == op->EqOp() &&
 		   SortOp() == op->SortOp() && NullsFirst() == op->NullsFirst() &&
 		   IsHashable() == op->IsHashable();

--- a/src/test/regress/expected/qp_misc_optimizer.out
+++ b/src/test/regress/expected/qp_misc_optimizer.out
@@ -99,6 +99,7 @@ CREATE TABLE tjoin2 (
     c1 integer,
     c2 character(2)
 ) DISTRIBUTED BY (rnum);
+ANALYZE tjoin2;
 --
 -- Name: tjoin3; Type: TABLE; Schema: public; Owner: gpadmin; Tablespace:
 --
@@ -11863,6 +11864,8 @@ select tjoin1.c1,tjoin2.c2 from tjoin1 left outer join tjoin2 on tjoin1.c1=tjoin
 group by
 f1,f2
 ) Q ) P;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  No plan has been computed for required properties
           test_name_part           | pass_ind 
 -----------------------------------+----------
  JoinCoreOnConditionSetFunction_p1 |        1
@@ -12861,6 +12864,8 @@ select sum( distinct c1 ), count( distinct c2 ) from tset1
 group by
 f1,f2
 ) Q ) P;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
      test_name_part     | pass_ind 
 ------------------------+----------
  MultipleSumDistinct_p1 |        1
@@ -14791,6 +14796,8 @@ select rnum, c1, c2 from tjoin1 where (c1,'BB') in (select c1, c2 from tjoin2 wh
 group by
 f1,f2,f3
 ) Q ) P;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Non-Scalar Subquery
  test_name_part | pass_ind 
 ----------------+----------
  RowSubquery_p1 |        1
@@ -14809,6 +14816,8 @@ select * from tset1 where (c1,c2) in (select c1,c2 from tset2)
 group by
 f1,f2,f3
 ) Q ) P;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Non-Scalar Subquery
      test_name_part     | pass_ind 
 ------------------------+----------
  RowValueConstructor_p1 |        1

--- a/src/test/regress/sql/qp_misc.sql
+++ b/src/test/regress/sql/qp_misc.sql
@@ -8,6 +8,7 @@ SET standard_conforming_strings = off;
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET escape_string_warning = off;
+SET optimizer_trace_fallback = on;
 
 SET default_with_oids = false;
 
@@ -9609,6 +9610,8 @@ group by
 f1,f2,f3
 ) Q ) P;
 -- JoinCoreSimpleAndJoinedTable_p1
+SET optimizer_trace_fallback = off;
+-- FIXME: ORCA CHistogram.cpp:793: Failed assertion: result_histogram->IsValid()
 select 'JoinCoreSimpleAndJoinedTable_p1' test_name_part, case when c = 1 then 1 else 0 end pass_ind from (
 select count(distinct c) c from (
 select f1,f2,f3,f4, count(*) c  from (
@@ -9619,6 +9622,7 @@ select tjoin2.rnum, tjoin1.c1, tjoin1.c2, tjoin2.c2 as c2j2 from tjoin1 left out
 group by
 f1,f2,f3,f4
 ) Q ) P;
+SET optimizer_trace_fallback = on;
 -- JoinCoreTwoSidedJoinRestrictionFilter_p1
 select 'JoinCoreTwoSidedJoinRestrictionFilter_p1' test_name_part, case when c = 1 then 1 else 0 end pass_ind from (
 select count(distinct c) c from (


### PR DESCRIPTION
ICW caught cases where qp_misc SIGSEGV'd.  Issue is that
CScalarSortGroupClause::Matches() incorrectly assumed that it is only
used to check for matches against other CScalarSortGroupClause objects.
When that was not the case, dynamic_cast returns nullptr and leads to
SIGSEGV.

Also set optimizer trace fallback in qp_misc test so that we can catch
unexpected fallbacks when assert are enabled.

Co-authored-by: Orhan Kislal <okislal@vmware.com>
(cherry picked from commit cd84fb806f24cecc584040a6420545600b67ef9d)

cherry picked from PR https://github.com/greenplum-db/gpdb/pull/13261