### PR TITLE
Fix a flakiness in pg_rewind_fail_missing_xlog where FTS could not promote not-in-sync mirror

### DIFF
--- a/src/test/isolation2/expected/pg_rewind_fail_missing_xlog.out
+++ b/src/test/isolation2/expected/pg_rewind_fail_missing_xlog.out
@@ -56,6 +56,12 @@ INSERT 3
 1: INSERT INTO tst_missing_tbl values(2),(1),(5);
 INSERT 3
 
+-- Make sure primary/mirror pair is in sync, otherwise FTS can't promote mirror
+1: SELECT wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
 -- Mark down the primary with content 0 via fts fault injection.
 1: SELECT gp_inject_fault_infinite('fts_handle_message', 'error', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
  gp_inject_fault_infinite 

--- a/src/test/isolation2/sql/pg_rewind_fail_missing_xlog.sql
+++ b/src/test/isolation2/sql/pg_rewind_fail_missing_xlog.sql
@@ -31,6 +31,8 @@ INSERT INTO tst_missing_tbl values(2),(1),(5);
 0U: SELECT pg_switch_wal is not null FROM pg_switch_wal();
 1: INSERT INTO tst_missing_tbl values(2),(1),(5);
 
+-- Make sure primary/mirror pair is in sync, otherwise FTS can't promote mirror
+1: SELECT wait_until_all_segments_synchronized();
 -- Mark down the primary with content 0 via fts fault injection.
 1: SELECT gp_inject_fault_infinite('fts_handle_message', 'error', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
 


### PR DESCRIPTION
One of the flakiness in the test pg_rewind_fail_missing_xlog we saw is:

```
	--- expected/pg_rewind_fail_missing_xlog.out
	+++ results/pg_rewind_fail_missing_xlog.out
	@@ -73,16 +105,32 @@
	 1: SELECT role, preferred_role from gp_segment_configuration where content = 0;
	  role | preferred_role
	 ------+----------------
	- m    | p
	- p    | m
	+ m    | m
	+ p    | p
	 (2 rows)

	 -- Run two more checkpoints. Previously this causes the checkpoint.redo wal
	 -- file before the oldest replication slot LSN is recycled/removed.
	 0M: CHECKPOINT;
	-CHECKPOINT
```

This is because FTS couldn't promote the mirror after an attempted failover. The root cause of this is that the mirror was
not-in-sync before the primary is scheduled to be down. In that case the FTS will repeatedly see the primary as down (case FTS_PROBE_FAILED in processResponse()) and hence it couldn't go to a path where it can update the mirror's sync flag (should've done by updateConfiguration()). Therefore, FTS couldn't give the promote request to the mirror.

This behavior could be reproduced consistently with some hack:
```
	SET allow_system_table_mods=true;
	update gp_segment_configuration set mode = 'n' where content = 0;
	SELECT gp_inject_fault_infinite('fts_handle_message', 'error', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
	SELECT gp_request_fts_probe_scan();
```
In the master's log we would see FTS keeps complaining the following, and mirror can't be promoted for a long time.
```
2022-03-17 13:42:48.007112 UTC,,,p126242,th250229504,,,,0,con3,,seg-1,,,,,"WARNING","01000","ERROR: FTS double fault detected (content=0) primary dbid=2, mirror dbid=5",,,,,,,0,,"ftsprobe.c",1122,
```

The fix is to make sure primary/mirror is in sync before marking the primary down.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
