### PR TITLE
[6X] Enable execution of recovery_end_command GUC

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7531,8 +7531,6 @@ StartupXLOG(void)
 	 * problem by making the new active segment have a new timeline ID.
 	 *
 	 * In a normal crash recovery, we can just extend the timeline we were in.
-	 *
-	 * GPDB: Greenplum doesn't support archive recovery.
 	 */
 	PrevTimeLineID = ThisTimeLineID;
 	if (ArchiveRecoveryRequested)

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7711,12 +7711,10 @@ StartupXLOG(void)
 		/*
 		 * And finally, execute the recovery_end_command, if any.
 		 */
-#if 0
 		if (recoveryEndCommand)
 			ExecuteRecoveryCommand(recoveryEndCommand,
 								   "recovery_end_command",
 								   true);
-#endif
 	}
 
 	/*

--- a/src/test/gpdb_pitr/test_gpdb_pitr_cleanup.sh
+++ b/src/test/gpdb_pitr/test_gpdb_pitr_cleanup.sh
@@ -37,3 +37,4 @@ done
 # Start back up the gpdemo cluster.
 echo "Starting back up the gpdemo cluster..."
 gpstart -a
+dropdb gpdb_pitr_database


### PR DESCRIPTION
The recovery_end_command GUC was able to be set the but the execution
of it was disabled because GPDB did not support archive recovery at
the time. Now that archive recovery is being actively worked on, this
feature should be enabled back.
