### PR TITLE
[6X Only] fix cache look up failed for relation 25 in pg_catalog.gp_dump_query_oids()

### DIFF
--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -455,7 +455,7 @@ coerce_type(ParseState *pstate, Node *node,
 			 * type we're casting to
 			 */
 			args = list_make3(fe,
-							  makeConst(OIDOID, -1, InvalidOid, sizeof(Oid),
+							  makeConst(VOIDOID, -1, InvalidOid, sizeof(Oid),
 										ObjectIdGetDatum(intypioparam),
 										false, true),
 							  makeConst(INT4OID, -1, InvalidOid, sizeof(int32),

--- a/src/test/regress/expected/gp_dump_query_oids.out
+++ b/src/test/regress/expected/gp_dump_query_oids.out
@@ -141,6 +141,16 @@ SELECT array['pg_class'::regclass::oid::text] <@  (string_to_array((SELECT info-
  t
 (1 row)
 
+CREATE TABLE unknown_to_text_dump (pid varchar(1), dummy varchar(1)) DISTRIBUTED BY (pid);
+CREATE VIEW unknown_view AS SELECT 'D' as dummy;
+WARNING:  column "dummy" has type "unknown"
+DETAIL:  Proceeding with relation creation anyway.
+SELECT count(*) from (SELECT pg_catalog.gp_dump_query_oids('select * from unknown_to_text_dump join unknown_view on unknown_to_text_dump.dummy = unknown_view.dummy')) x;
+ count 
+-------
+     1
+(1 row)
+
 DROP TABLE foo;
 DROP TABLE cctable;
 DROP TABLE ctable;
@@ -148,3 +158,5 @@ DROP TABLE ptable;
 DROP TABLE minirepro_partition_test;
 DROP FUNCTION dumptestfunc(text);
 DROP FUNCTION dumptestfunc2(text);
+DROP TABLE unknown_to_text_dump;
+DROP VIEW unknown_view;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -12386,8 +12386,8 @@ SELECT DISTINCT L1.c, L1.lid
 FROM t55 L1 CROSS JOIN META
 WHERE L1.lid = META.LOAD_ID;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
-                                                        QUERY PLAN                                                        
---------------------------------------------------------------------------------------------------------------------------
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..0.00 rows=0 width=0)
    Output: c, lid
    ->  Result  (cost=0.00..431.10 rows=1 width=8)
@@ -12402,7 +12402,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entr
                            Sort Key: t55.c, t55.lid
                            ->  Hash Join  (cost=0.00..431.08 rows=1 width=8)
                                  Output: c, lid
-                                 Hash Cond: (t55.lid = pg_catalog.int4in(unknownout("outer".load_id), 23::oid, (-1)))
+                                 Hash Cond: (t55.lid = pg_catalog.int4in(unknownout("outer".load_id), ''::void, (-1)))
                                  ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.02 rows=334 width=8)
                                        Output: c, lid
                                        Hash Key: lid
@@ -12413,7 +12413,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entr
                                        ->  Result  (cost=0.00..0.00 rows=1 width=8)
                                              Output: load_id
                                              ->  Result  (cost=0.00..0.00 rows=1 width=8)
-                                                   Output: load_id, pg_catalog.int4in(unknownout(load_id), 23::oid, (-1))
+                                                   Output: load_id, pg_catalog.int4in(unknownout(load_id), ''::void, (-1))
                                                    ->  Result  (cost=0.00..0.00 rows=1 width=8)
                                                          Output: load_id
                                                          ->  Result  (cost=0.00..0.00 rows=1 width=8)

--- a/src/test/regress/sql/gp_dump_query_oids.sql
+++ b/src/test/regress/sql/gp_dump_query_oids.sql
@@ -74,6 +74,11 @@ SELECT array['ptable'::regclass::oid::text,
              'ctable'::regclass::oid::text,
              'cctable'::regclass::oid::text] <@  (string_to_array((SELECT info->>'relids' FROM minirepro_partition_test WHERE id = 2),','));
 SELECT array['pg_class'::regclass::oid::text] <@  (string_to_array((SELECT info->>'relids' FROM minirepro_partition_test WHERE id = 3),','));
+
+CREATE TABLE unknown_to_text_dump (pid varchar(1), dummy varchar(1)) DISTRIBUTED BY (pid);
+CREATE VIEW unknown_view AS SELECT 'D' as dummy;
+SELECT count(*) from (SELECT pg_catalog.gp_dump_query_oids('select * from unknown_to_text_dump join unknown_view on unknown_to_text_dump.dummy = unknown_view.dummy')) x;
+
 DROP TABLE foo;
 DROP TABLE cctable;
 DROP TABLE ctable;
@@ -81,3 +86,5 @@ DROP TABLE ptable;
 DROP TABLE minirepro_partition_test;
 DROP FUNCTION dumptestfunc(text);
 DROP FUNCTION dumptestfunc2(text);
+DROP TABLE unknown_to_text_dump;
+DROP VIEW unknown_view;


### PR DESCRIPTION
This PR is trying to fix issue #13195.

### RCA

The RCA is that PostgreSQL does not support type conversion between `unknown` and `text`, 
but Greenplum hacks this behavior so that the below SQL can be executed on 6X:

```
CREATE TABLE t (pid varchar(1), dummy varchar(1)) DISTRIBUTED BY (pid);
CREATE VIEW s AS SELECT 'D' as dummy;

select * from t join s on t.dummy = s.dummy;	// not allowed in PostgreSQL 9
```

In the process of hack, the principle is multi-level function nesting, first convert `unknown` into 
`cstring` through `unknownout` function, and then use `textin` function to convert `cstring` into 
`text`. Then in the nested process, the constructed function parameters are:

```
args = list_make3(fe,
        makeConst(OIDOID, -1, InvalidOid, sizeof(Oid),
	        ObjectIdGetDatum(intypioparam),
	        false, true),
        makeConst(INT4OID, -1, InvalidOid, sizeof(int32),
	        Int32GetDatum(-1),
	        false, true));
```

The problem lies in `OIDOID`. Greenplum itself uses it as a placeholder, or a default parameter, 
because in the actual type conversion execution process, the executor does not care what type 
of Const you are. Will only take constvalue. 

However, in the implementation of  `pg_catalog.gp_dump_query_oids()`, the entire query tree 
will be traversed, the RelationID will  be saved and returned. In the `fix_expr_common()` function. 
There is this logic:

```
static void
fix_expr_common(PlannerInfo *root, Node *node)
{
    else if (IsA(node, Const))
    {
          Const	   *con = (Const *) node;
          
          /* Check for regclass reference */
          if (ISREGCLASSCONST(con))
              root->glob->relationOids = lappend_oid(
                    root->glob->relationOids, 
                    DatumGetObjectId(con->constvalue));
    }
```

And `OIDOID` is a legal `REGCLASSCONST`. Therefore, `ObjectIdGetDatum(intypioparam)` 
will be thrown into `RelationOids`, and an error will be reported when it is finally judged whether 
it has sub class.

### Work Around Fix

I have to say, The way to fix above problem in this PR is not canonical, and is a little weird, but I 
do not have a better idea.

When performing the actual `unknown -> text` type conversion, such as performing HASH JOIN, 
the executor does not care what type of the second parameter of the conversion function is, and 
the OID type is added only to satisfy the number and type of function parameters, so this change 
does not affect Planner. But ORCA prints some information, and that's the only place affected.



