### PR TITLE
[6X][WIP]Enable direct dispatch in deep-slice queries

### DIFF
--- a/src/backend/cdb/cdbtargeteddispatch.c
+++ b/src/backend/cdb/cdbtargeteddispatch.c
@@ -712,28 +712,6 @@ AssignContentIdsToPlanData(Query *query, Plan *plan, PlannerInfo *root)
 		FinalizeDirectDispatchDataForSlice((Node *) plan, &data, true);
 	}
 
-	/*
-	 * now check to see if we are multi-slice.  If so then we will disable the
-	 * direct dispatch (because it's not working right now -- see MPP-7630)
-	 */
-	if (list_length(data.allSlices) > 2)
-	{
-		/*
-		 * NOTE!!!  When this is fixed, make a test for subquery initPlan and
-		 * qual case (hitting code in AssignContentIdsToPlanData_SubqueryScan)
-		 */
-		ListCell   *cell;
-
-		foreach(cell, data.allSlices)
-		{
-			Plan	   *plan = (Plan *) lfirst(cell);
-
-			plan->directDispatch.isDirectDispatch = false;
-			list_free(plan->directDispatch.contentIds);
-			plan->directDispatch.contentIds = NIL;
-		}
-	}
-
 	MemoryContextSwitchTo(old_context);
 	MemoryContextDelete(new_context);
 }

--- a/src/test/regress/expected/equivclass.out
+++ b/src/test/regress/expected/equivclass.out
@@ -314,7 +314,7 @@ explain (costs off)
                                              ->  Seq Scan on ec1 ec1_3
                                  ->  Seq Scan on ec1 ec1_1
                            ->  Materialize
-                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                 ->  Broadcast Motion 1:3  (slice1; segments: 1)
                                        ->  Index Scan using ec1_pkey on ec1
                                              Index Cond: (ff = 42::bigint)
          ->  Sort
@@ -363,7 +363,7 @@ explain (costs off)
                                              ->  Seq Scan on ec1 ec1_3
                                  ->  Seq Scan on ec1 ec1_1
                            ->  Materialize
-                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                 ->  Broadcast Motion 1:3  (slice1; segments: 1)
                                        ->  Index Scan using ec1_pkey on ec1
                                              Index Cond: (ff = 42::bigint)
          ->  Sort

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -3905,7 +3905,7 @@ select * from
                                              Output: i4.f1
                            ->  Materialize
                                  Output: t1.f1
-                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                 ->  Broadcast Motion 1:3  (slice1; segments: 1)
                                        Output: t1.f1
                                        ->  Seq Scan on public.text_tbl t1
                                              Output: t1.f1

--- a/src/test/regress/expected/updatable_views.out
+++ b/src/test/regress/expected/updatable_views.out
@@ -2142,7 +2142,7 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                                                                               QUERY PLAN                                                                              
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Update on public.t1 t1_4
-   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+   ->  Redistribute Motion 1:3  (slice1; segments: 1)
          Output: ((t1.a + 1)), t1.b, t1.c, t1.a, t1.ctid, t1.gp_segment_id, (DMLAction)
          Hash Key: ((t1.a + 1))
          ->  Split
@@ -2164,7 +2164,7 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                                        ->  Seq Scan on public.t111
                                              Output: t111.ctid, t111.tableoid, t111.a
                                              Filter: ((t111.a > 5) AND (t111.a = 8))
-   ->  Redistribute Motion 3:3  (slice2; segments: 3)
+   ->  Redistribute Motion 1:3  (slice2; segments: 1)
          Output: ((t1_1.a + 1)), t1_1.b, t1_1.c, t1_1.d, t1_1.a, t1_1.ctid, t1_1.gp_segment_id, (DMLAction)
          Hash Key: ((t1_1.a + 1))
          ->  Split
@@ -2186,7 +2186,7 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                                        ->  Seq Scan on public.t111 t111_1
                                              Output: t111_1.ctid, t111_1.tableoid, t111_1.a
                                              Filter: ((t111_1.a > 5) AND (t111_1.a = 8))
-   ->  Redistribute Motion 3:3  (slice3; segments: 3)
+   ->  Redistribute Motion 1:3  (slice3; segments: 1)
          Output: ((t1_2.a + 1)), t1_2.b, t1_2.c, t1_2.e, t1_2.a, t1_2.ctid, t1_2.gp_segment_id, (DMLAction)
          Hash Key: ((t1_2.a + 1))
          ->  Split
@@ -2208,7 +2208,7 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                                        ->  Seq Scan on public.t111 t111_2
                                              Output: t111_2.ctid, t111_2.tableoid, t111_2.a
                                              Filter: ((t111_2.a > 5) AND (t111_2.a = 8))
-   ->  Redistribute Motion 3:3  (slice4; segments: 3)
+   ->  Redistribute Motion 1:3  (slice4; segments: 1)
          Output: ((t1_3.a + 1)), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.a, t1_3.ctid, t1_3.gp_segment_id, (DMLAction)
          Hash Key: ((t1_3.a + 1))
          ->  Split


### PR DESCRIPTION
About ten years ago, direct dispatch in deep-slice queries
has been disabled due to the following case that found DTM
issue with targeted dispatch and deepslice queries.

```
set test_print_direct_dispatch_info = on;
create table t1(x int);
insert into t1 select x from generate_series(1,300000)x;
analyze t1;
select * from t1 a, t1 b where a.x=b.x and a.x=23;
select count(*) from t1 a, t1 b where a.x=b.x union all select count(*) from t1 a, t1 b where a.x=b.x and a.x=23;
select count(*) from t1 a, t1 b where a.x=b.x and b.x=12 union all select count(*) from t1 a, t1 b where a.x=b.x and a.x =23;
```
Re-enable it since the DTM issue can't reproduce.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
