### PR TITLE
[6X] Remove platform specific limitation from msg type recognition logic

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -236,7 +236,7 @@ static int	InteractiveBackend(StringInfo inBuf);
 static int	interactive_getc(void);
 static int	SocketBackend(StringInfo inBuf);
 static int	ReadCommand(StringInfo inBuf);
-static void forbidden_in_wal_sender(char firstchar);
+static void forbidden_in_wal_sender(int firstchar);
 static List *pg_rewrite_query(Query *query);
 static bool check_log_statement(List *stmt_list);
 static int	errdetail_execute(List *raw_parsetree_list);
@@ -4573,7 +4573,7 @@ process_postgres_switches(int argc, char *argv[], GucContext ctx,
  * received, and is used to construct the error message.
  */
 static void
-check_forbidden_in_gpdb_handlers(char firstchar)
+check_forbidden_in_gpdb_handlers(int firstchar)
 {
 	if (am_ftshandler || am_faulthandler)
 	{
@@ -5749,7 +5749,7 @@ PostgresMain(int argc, char *argv[],
  * message was received, and is used to construct the error message.
  */
 static void
-forbidden_in_wal_sender(char firstchar)
+forbidden_in_wal_sender(int firstchar)
 {
 	if (am_walsender)
 	{


### PR DESCRIPTION
This PR introduces subtle fixes in the functions that work with firstchar
byte value received from socket. This is done for the purpose of consistency
across the codebase and avoidance of misreads of -1 (EOF) value in case gp
is compiled with default char unsigned (it can mistakenly be treated as
255 then).
An example of a platform that has the described behavior: PowerPC.

An example of the bad consequences of the firstchar being wrongly
interpreted as 255 is an invalid bytes sequence written logs:

Build gpdb on PowerPC or any platform with -funsigned-char
Run fts_error regression test
Run select count(*) from gp_toolkit.__gp_log_segment_ext where logsegment = 'seg1' and logmessage like '[CheckpointMemoryLeakTest] Possible memory leak %'; (is a query from checkpoint_memleak test present in 6X)

Backported from https://github.com/greenplum-db/gpdb/pull/13288