### PR TITLE
Fix banning window agg in recursive queries.

### DIFF
--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -1047,7 +1047,7 @@ WITH RECURSIVE x(n) AS (
 	UNION ALL
 	SELECT level+1, row_number() over() FROM x, bar)
   SELECT * FROM x LIMIT 10;
-ERROR:  window functions in a recursive query is not implemented
+ERROR:  window functions in the target list of a recursive query is not supported in Greenplum
 LINE 4:  SELECT level+1, row_number() over() FROM x, bar)
                          ^
 CREATE TEMPORARY TABLE y (a INTEGER) DISTRIBUTED RANDOMLY;

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -1,8 +1,6 @@
 drop table if exists with_test1 cascade;
 NOTICE:  table "with_test1" does not exist, skipping
 create table with_test1 (i int, t text, value int) distributed by (i);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into with_test1 select i%10, 'text' || i%20, i%30 from generate_series(0, 99) i;
 analyze with_test1;
 drop table if exists with_test2 cascade;
@@ -2199,6 +2197,42 @@ WITH RECURSIVE r1 AS (
 )
 SELECT * FROM r1 LIMIT 1;
 ERROR:  joining nested RECURSIVE clauses is not supported
+-- GPDB
+-- Greenplum does not support window functions in recursive part's target list
+-- See issue https://github.com/greenplum-db/gpdb/issues/13299 for details.
+-- Previously the following SQL will PANIC or Assert Fail if compiled with assert.
+create table t_window_ordered_set_agg_rte(a bigint, b bigint, c bigint);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t_window_ordered_set_agg_rte select i,i,i from generate_series(1, 10)i;
+-- should error out during parse-analyze
+with recursive rcte(x,y) as
+(
+  select a, b from t_window_ordered_set_agg_rte
+  union all
+  select (first_value(c) over (partition by b))::int, a+x
+  from rcte,
+       t_window_ordered_set_agg_rte as t
+  where t.b = x
+)
+select * from rcte limit 10;
+ERROR:  window functions in the target list of a recursive query is not supported in Greenplum
+LINE 5:   select (first_value(c) over (partition by b))::int, a+x
+                  ^
+-- should error out during parse-analyze
+with recursive rcte(x,y) as
+(
+  select a, b from t_window_ordered_set_agg_rte
+  union all
+  select first_value(c) over (partition by b), a+x
+  from rcte,
+       t_window_ordered_set_agg_rte as t
+  where t.b = x
+)
+select * from rcte limit 10;
+ERROR:  window functions in the target list of a recursive query is not supported in Greenplum
+LINE 5:   select first_value(c) over (partition by b), a+x
+                 ^
 -- This used to deadlock, before the IPC between ShareInputScans across
 -- slices was rewritten.
 set gp_cte_sharing=on;

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2200,6 +2200,42 @@ WITH RECURSIVE r1 AS (
 )
 SELECT * FROM r1 LIMIT 1;
 ERROR:  joining nested RECURSIVE clauses is not supported
+-- GPDB
+-- Greenplum does not support window functions in recursive part's target list
+-- See issue https://github.com/greenplum-db/gpdb/issues/13299 for details.
+-- Previously the following SQL will PANIC or Assert Fail if compiled with assert.
+create table t_window_ordered_set_agg_rte(a bigint, b bigint, c bigint);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t_window_ordered_set_agg_rte select i,i,i from generate_series(1, 10)i;
+-- should error out during parse-analyze
+with recursive rcte(x,y) as
+(
+  select a, b from t_window_ordered_set_agg_rte
+  union all
+  select (first_value(c) over (partition by b))::int, a+x
+  from rcte,
+       t_window_ordered_set_agg_rte as t
+  where t.b = x
+)
+select * from rcte limit 10;
+ERROR:  window functions in the target list of a recursive query is not supported in Greenplum
+LINE 5:   select (first_value(c) over (partition by b))::int, a+x
+                  ^
+-- should error out during parse-analyze
+with recursive rcte(x,y) as
+(
+  select a, b from t_window_ordered_set_agg_rte
+  union all
+  select first_value(c) over (partition by b), a+x
+  from rcte,
+       t_window_ordered_set_agg_rte as t
+  where t.b = x
+)
+select * from rcte limit 10;
+ERROR:  window functions in the target list of a recursive query is not supported in Greenplum
+LINE 5:   select first_value(c) over (partition by b), a+x
+                 ^
 -- This used to deadlock, before the IPC between ShareInputScans across
 -- slices was rewritten.
 set gp_cte_sharing=on;


### PR DESCRIPTION
Greenplum does not support window agg in the target list of recursive
part of recursive CTE. Current implementation of recursive queries is
based on Postgres' Worktable Scan and RecursiveUnion, this forces
the two nodes must be in the same slice, means no motion node is
allowed between them. The locus of worktable scan is determined by the
non-recurisve part of path thus it is hard to avoid motion over
worktable scan when there are window aggs. This should be the reason
why Greenplum does not support this feature.

However, previous code only checks the direct raw expression in parse
tree's targetlist, this is not enough, since it might be a compound
expression that involving window aggs, like a type cast expression. We
should use raw_expression_tree_walker to search window functions.

This commit fixes Issue: https://github.com/greenplum-db/gpdb/issues/13299,
more details can be found there.

For more discussion on this feature and furture plan, please refer to
https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/GIYw6t-uX7s.