### PR TITLE
Revert C++11 nullptr usage

### DIFF
--- a/src/backend/gpopt/gpopt.mk
+++ b/src/backend/gpopt/gpopt.mk
@@ -1,3 +1,4 @@
+override CPPFLAGS := -std=c++98 $(CPPFLAGS)
 override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpos/include $(CPPFLAGS)
 override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpopt/include $(CPPFLAGS)
 override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libnaucrates/include $(CPPFLAGS)


### PR DESCRIPTION
Commit ac6ce1a5c4 accidentally introduced nullptr usage during backport
to 6X branch. In 6X compiler is C++98 and nullptr is C++11. Fix that and
add explicit -std=c++98 in gpopt.mk to catch better next time.
