### PR TITLE
Fix testexpr translation of outer expr

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -879,6 +879,58 @@ CTranslatorDXLToScalar::TranslateDXLScalarSubplanToScalar(
 
 //---------------------------------------------------------------------------
 //      @function:
+//              CTranslatorDXLToScalar::TranslateDXLTestExprScalarIdentToExpr
+//
+//      @doc:
+//              Translate subplan test expression parameter
+//
+//---------------------------------------------------------------------------
+void
+CTranslatorDXLToScalar::TranslateDXLTestExprScalarIdentToExpr(
+	CDXLNode *child_node, Param *param, CDXLScalarIdent **ident, Expr **expr)
+{
+	if (EdxlopScalarIdent == child_node->GetOperator()->GetDXLOperator())
+	{
+		// Ident
+		*ident = CDXLScalarIdent::Cast(child_node->GetOperator());
+		*expr = (Expr *) param;
+	}
+	else if (EdxlopScalarCast == child_node->GetOperator()->GetDXLOperator() &&
+			 child_node->Arity() > 0 &&
+			 EdxlopScalarIdent ==
+				 (*child_node)[0]->GetOperator()->GetDXLOperator())
+	{
+		// Casted Ident
+		*ident = CDXLScalarIdent::Cast((*child_node)[0]->GetOperator());
+		CDXLScalarCast *scalar_cast =
+			CDXLScalarCast::Cast(child_node->GetOperator());
+		*expr =
+			TranslateDXLScalarCastWithChildExpr(scalar_cast, (Expr *) param);
+	}
+	else if (EdxlopScalarCoerceViaIO ==
+				 child_node->GetOperator()->GetDXLOperator() &&
+			 child_node->Arity() > 0 &&
+			 EdxlopScalarIdent ==
+				 (*child_node)[0]->GetOperator()->GetDXLOperator())
+	{
+		// CoerceViaIO over Ident
+		*ident = CDXLScalarIdent::Cast((*child_node)[0]->GetOperator());
+		CDXLScalarCoerceViaIO *coerce =
+			CDXLScalarCoerceViaIO::Cast(child_node->GetOperator());
+		*expr =
+			TranslateDXLScalarCoerceViaIOWithChildExpr(coerce, (Expr *) param);
+	}
+	else
+	{
+		// ORCA currently only supports PARAMs of the form id or cast(id)
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion,
+				   GPOS_WSZ_LIT("Unsupported subplan test expression"));
+	}
+}
+
+
+//---------------------------------------------------------------------------
+//      @function:
 //              CTranslatorDXLToScalar::TranslateDXLSubplanTestExprToScalar
 //
 //      @doc:
@@ -932,10 +984,13 @@ CTranslatorDXLToScalar::TranslateDXLSubplanTestExprToScalar(
 		Param *param1 = MakeNode(Param);
 		param1->paramkind = PARAM_EXEC;
 
-		// Ident
-		CDXLScalarIdent *outer_ident =
-			CDXLScalarIdent::Cast(outer_child_node->GetOperator());
-		Expr *outer_expr = (Expr *) param1;
+		CDXLScalarIdent *outer_ident = nullptr;
+		Expr *outer_expr = nullptr;
+
+		TranslateDXLTestExprScalarIdentToExpr(outer_child_node, param1,
+											  &outer_ident, &outer_expr);
+		GPOS_ASSERT(nullptr != outer_ident);
+		GPOS_ASSERT(nullptr != outer_expr);
 
 		// finalize outer expression
 		param1->paramtype = CMDIdGPDB::CastMdid(outer_ident->MdidType())->Oid();
@@ -962,47 +1017,10 @@ CTranslatorDXLToScalar::TranslateDXLSubplanTestExprToScalar(
 
 	CDXLScalarIdent *inner_ident = nullptr;
 	Expr *inner_expr = nullptr;
-	if (EdxlopScalarIdent == inner_child_node->GetOperator()->GetDXLOperator())
-	{
-		// Ident
-		inner_ident = CDXLScalarIdent::Cast(inner_child_node->GetOperator());
-		inner_expr = (Expr *) param;
-	}
-	else if (EdxlopScalarCast ==
-				 inner_child_node->GetOperator()->GetDXLOperator() &&
-			 inner_child_node->Arity() > 0 &&
-			 EdxlopScalarIdent ==
-				 (*inner_child_node)[0]->GetOperator()->GetDXLOperator())
-	{
-		// Casted Ident
-		inner_ident =
-			CDXLScalarIdent::Cast((*inner_child_node)[0]->GetOperator());
-		CDXLScalarCast *scalar_cast =
-			CDXLScalarCast::Cast(inner_child_node->GetOperator());
-		inner_expr =
-			TranslateDXLScalarCastWithChildExpr(scalar_cast, (Expr *) param);
-	}
-	else if (EdxlopScalarCoerceViaIO ==
-				 inner_child_node->GetOperator()->GetDXLOperator() &&
-			 inner_child_node->Arity() > 0 &&
-			 EdxlopScalarIdent ==
-				 (*inner_child_node)[0]->GetOperator()->GetDXLOperator())
-	{
-		// CoerceViaIO over Ident
-		inner_ident =
-			CDXLScalarIdent::Cast((*inner_child_node)[0]->GetOperator());
-		CDXLScalarCoerceViaIO *coerce =
-			CDXLScalarCoerceViaIO::Cast(inner_child_node->GetOperator());
-		inner_expr =
-			TranslateDXLScalarCoerceViaIOWithChildExpr(coerce, (Expr *) param);
-	}
-	else
-	{
-		// ORCA currently only supports PARAMs on the inner side of the form id or cast(id)
-		// The outer side may be any non-param thing.
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion,
-				   GPOS_WSZ_LIT("Unsupported subplan test expression"));
-	}
+
+	TranslateDXLTestExprScalarIdentToExpr(inner_child_node, param, &inner_ident,
+										  &inner_expr);
+
 	GPOS_ASSERT(nullptr != inner_ident);
 	GPOS_ASSERT(nullptr != inner_expr);
 

--- a/src/include/gpopt/translate/CTranslatorDXLToScalar.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToScalar.h
@@ -159,6 +159,12 @@ private:
 								const CDXLColRefArray *outer_refs,
 								CMappingColIdVar *colid_var);
 
+	// translate subplan test expression parameters
+	void TranslateDXLTestExprScalarIdentToExpr(CDXLNode *child_node,
+											   Param *param,
+											   CDXLScalarIdent **ident,
+											   Expr **expr);
+
 	CHAR *GetSubplanAlias(ULONG plan_id);
 
 	static Param *TranslateParamFromMapping(

--- a/src/test/regress/expected/correlated_subquery.out
+++ b/src/test/regress/expected/correlated_subquery.out
@@ -1,8 +1,6 @@
 SET optimizer_enforce_subplans = 1;
 SET optimizer_trace_fallback=on;
-SET client_min_messages=log;
 SELECT a = ALL (SELECT generate_series(1, 2)), a FROM (values (1),(2)) v(a);
-LOG:  statement: SELECT a = ALL (SELECT generate_series(1, 2)), a FROM (values (1),(2)) v(a);
  ?column? | a 
 ----------+---
  f        | 1
@@ -10,7 +8,6 @@ LOG:  statement: SELECT a = ALL (SELECT generate_series(1, 2)), a FROM (values (
 (2 rows)
 
 SELECT a = ALL (SELECT generate_series(2, 2)), a FROM (values (1),(2)) v(a);
-LOG:  statement: SELECT a = ALL (SELECT generate_series(2, 2)), a FROM (values (1),(2)) v(a);
  ?column? | a 
 ----------+---
  f        | 1
@@ -18,7 +15,6 @@ LOG:  statement: SELECT a = ALL (SELECT generate_series(2, 2)), a FROM (values (
 (2 rows)
 
 SELECT 1 = ALL (SELECT generate_series(1, 2)) FROM (values (1),(2)) v(a);
-LOG:  statement: SELECT 1 = ALL (SELECT generate_series(1, 2)) FROM (values (1),(2)) v(a);
  ?column? 
 ----------
  f
@@ -26,7 +22,6 @@ LOG:  statement: SELECT 1 = ALL (SELECT generate_series(1, 2)) FROM (values (1),
 (2 rows)
 
 SELECT 2 = ALL (SELECT generate_series(2, 2)) FROM (values (1),(2)) v(a);
-LOG:  statement: SELECT 2 = ALL (SELECT generate_series(2, 2)) FROM (values (1),(2)) v(a);
  ?column? 
 ----------
  t
@@ -34,7 +29,6 @@ LOG:  statement: SELECT 2 = ALL (SELECT generate_series(2, 2)) FROM (values (1),
 (2 rows)
 
 SELECT 2 = ALL (SELECT generate_series(2, 3)) FROM (values (1),(2)) v(a);
-LOG:  statement: SELECT 2 = ALL (SELECT generate_series(2, 3)) FROM (values (1),(2)) v(a);
  ?column? 
 ----------
  f
@@ -42,7 +36,6 @@ LOG:  statement: SELECT 2 = ALL (SELECT generate_series(2, 3)) FROM (values (1),
 (2 rows)
 
 SELECT 2+1 = ALL (SELECT generate_series(2, 3)) FROM (values (1),(2)) v(a);
-LOG:  statement: SELECT 2+1 = ALL (SELECT generate_series(2, 3)) FROM (values (1),(2)) v(a);
  ?column? 
 ----------
  f
@@ -50,7 +43,6 @@ LOG:  statement: SELECT 2+1 = ALL (SELECT generate_series(2, 3)) FROM (values (1
 (2 rows)
 
 SELECT 2+1 = ALL (SELECT generate_series(3, 3)) FROM (values (1),(2)) v(a);
-LOG:  statement: SELECT 2+1 = ALL (SELECT generate_series(3, 3)) FROM (values (1),(2)) v(a);
  ?column? 
 ----------
  t
@@ -58,7 +50,6 @@ LOG:  statement: SELECT 2+1 = ALL (SELECT generate_series(3, 3)) FROM (values (1
 (2 rows)
 
 SELECT (SELECT a) = ALL (SELECT generate_series(1, 2)), a FROM (values (1),(2)) v(a);
-LOG:  statement: SELECT (SELECT a) = ALL (SELECT generate_series(1, 2)), a FROM (values (1),(2)) v(a);
  ?column? | a 
 ----------+---
  f        | 1
@@ -66,7 +57,6 @@ LOG:  statement: SELECT (SELECT a) = ALL (SELECT generate_series(1, 2)), a FROM 
 (2 rows)
 
 SELECT (SELECT a) = ALL (SELECT generate_series(2, 2)), a FROM (values (1),(2)) v(a);
-LOG:  statement: SELECT (SELECT a) = ALL (SELECT generate_series(2, 2)), a FROM (values (1),(2)) v(a);
  ?column? | a 
 ----------+---
  f        | 1
@@ -74,7 +64,6 @@ LOG:  statement: SELECT (SELECT a) = ALL (SELECT generate_series(2, 2)), a FROM 
 (2 rows)
 
 SELECT (SELECT a+1) = ALL (SELECT generate_series(2, 2)), a FROM (values (1),(2)) v(a);
-LOG:  statement: SELECT (SELECT a+1) = ALL (SELECT generate_series(2, 2)), a FROM (values (1),(2)) v(a);
  ?column? | a 
 ----------+---
  t        | 1
@@ -82,7 +71,6 @@ LOG:  statement: SELECT (SELECT a+1) = ALL (SELECT generate_series(2, 2)), a FRO
 (2 rows)
 
 SELECT (SELECT 1) = ALL (SELECT generate_series(1, 1)) FROM (values (1),(2)) v(a);
-LOG:  statement: SELECT (SELECT 1) = ALL (SELECT generate_series(1, 1)) FROM (values (1),(2)) v(a);
  ?column? 
 ----------
  t
@@ -90,7 +78,6 @@ LOG:  statement: SELECT (SELECT 1) = ALL (SELECT generate_series(1, 1)) FROM (va
 (2 rows)
 
 SELECT (SELECT 1) = ALL (SELECT generate_series(1, 2)) FROM  (values (1),(2)) v(a);
-LOG:  statement: SELECT (SELECT 1) = ALL (SELECT generate_series(1, 2)) FROM  (values (1),(2)) v(a);
  ?column? 
 ----------
  f
@@ -98,7 +85,6 @@ LOG:  statement: SELECT (SELECT 1) = ALL (SELECT generate_series(1, 2)) FROM  (v
 (2 rows)
 
 SELECT (SELECT 3) = ALL (SELECT generate_series(3, 3)) FROM  (values (1),(2)) v(a);
-LOG:  statement: SELECT (SELECT 3) = ALL (SELECT generate_series(3, 3)) FROM  (values (1),(2)) v(a);
  ?column? 
 ----------
  t
@@ -106,23 +92,40 @@ LOG:  statement: SELECT (SELECT 3) = ALL (SELECT generate_series(3, 3)) FROM  (v
 (2 rows)
 
 SELECT (SELECT 1) = ALL (SELECT generate_series(1, 1));
-LOG:  statement: SELECT (SELECT 1) = ALL (SELECT generate_series(1, 1));
  ?column? 
 ----------
  t
 (1 row)
 
 SELECT (SELECT 1) = ALL (SELECT generate_series(1, 2));
-LOG:  statement: SELECT (SELECT 1) = ALL (SELECT generate_series(1, 2));
  ?column? 
 ----------
  f
 (1 row)
 
 SELECT (SELECT 3) = ALL (SELECT generate_series(3, 3));
-LOG:  statement: SELECT (SELECT 3) = ALL (SELECT generate_series(3, 3));
  ?column? 
 ----------
  t
 (1 row)
 
+CREATE TABLE correlated_subquery_test(
+   a varchar(100),
+   b int
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT (SELECT a FROM correlated_subquery_test LIMIT 1)=ALL(SELECT a FROM correlated_subquery_test);
+ ?column? 
+----------
+ t
+(1 row)
+
+CREATE CAST (integer AS text) WITH INOUT AS IMPLICIT;
+SELECT (SELECT b FROM correlated_subquery_test LIMIT 1)=ALL(SELECT a FROM correlated_subquery_test);
+ ?column? 
+----------
+ t
+(1 row)
+
+DROP CAST (integer AS text);

--- a/src/test/regress/sql/correlated_subquery.sql
+++ b/src/test/regress/sql/correlated_subquery.sql
@@ -1,6 +1,5 @@
 SET optimizer_enforce_subplans = 1;
 SET optimizer_trace_fallback=on;
-SET client_min_messages=log;
 
 SELECT a = ALL (SELECT generate_series(1, 2)), a FROM (values (1),(2)) v(a);
 SELECT a = ALL (SELECT generate_series(2, 2)), a FROM (values (1),(2)) v(a);
@@ -19,3 +18,12 @@ SELECT (SELECT 3) = ALL (SELECT generate_series(3, 3)) FROM  (values (1),(2)) v(
 SELECT (SELECT 1) = ALL (SELECT generate_series(1, 1));
 SELECT (SELECT 1) = ALL (SELECT generate_series(1, 2));
 SELECT (SELECT 3) = ALL (SELECT generate_series(3, 3));
+
+CREATE TABLE correlated_subquery_test(
+   a varchar(100),
+   b int
+);
+SELECT (SELECT a FROM correlated_subquery_test LIMIT 1)=ALL(SELECT a FROM correlated_subquery_test);
+CREATE CAST (integer AS text) WITH INOUT AS IMPLICIT;
+SELECT (SELECT b FROM correlated_subquery_test LIMIT 1)=ALL(SELECT a FROM correlated_subquery_test);
+DROP CAST (integer AS text);


### PR DESCRIPTION
Commit 6f175df1 added support for subplan test expression containing
scalar ident on left side. But in order to properly support that
scenario we needed to account for cast and coerceio as well.