### PR TITLE
(pre-port) Do not match non vars in inner plan's target for LASJ_NOTIN.

### DIFF
--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -2114,6 +2114,7 @@ set_join_references(PlannerInfo *root, Join *join, int rtoffset)
 		case JOIN_LEFT:
 		case JOIN_SEMI:
 		case JOIN_ANTI:
+		case JOIN_LASJ_NOTIN:
 			inner_itlist->has_non_vars = false;
 			break;
 		case JOIN_RIGHT:
@@ -2980,8 +2981,6 @@ fix_join_expr_mutator(Node *node, fix_join_expr_context *context)
 	}
 	if (context->inner_itlist && context->inner_itlist->has_non_vars &&
 	        context->use_inner_tlist_for_matching_nonvars)
-
-	if (context->inner_itlist && context->inner_itlist->has_non_vars)
 	{
 		newvar = search_indexed_tlist_for_non_var((Expr *) node,
 												  context->inner_itlist,

--- a/src/test/regress/expected/update_gp.out
+++ b/src/test/regress/expected/update_gp.out
@@ -800,6 +800,46 @@ SELECT tableoid::regclass, * FROM update_gp_rangep WHERE b = 1;
  update_gp_rangep_10_to_20 | 11 | 1 |      4
 (3 rows)
 
+-- Test for update with LASJ_NOTIN
+-- See Issue: https://github.com/greenplum-db/gpdb/issues/13265
+-- Actually master branch does not have the above issue even master
+-- does have the same problematic code (other parts of code are
+-- refactored). Also cherry-pick the case to master and keep it
+-- since more test cases do no harm.
+create table t1_13265(a int, b int, c int, d int) distributed by (a);
+create table t2_13265(a int, b int, c int, d int) distributed by (a);
+insert into t1_13265 values (1, null, 1, 1);
+insert into t2_13265 values (2, null, 2, 2);
+explain (verbose, costs off)
+update t1_13265 set b = 2 where
+(c, d) not in (select c, d from t2_13265 where a = 2);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Update on public.t1_13265
+   ->  Nested Loop Left Anti Semi (Not-In) Join
+         Output: t1_13265.a, 2, t1_13265.c, t1_13265.d, t1_13265.ctid, t1_13265.gp_segment_id, t2_13265.ctid
+         Join Filter: ((t1_13265.c = t2_13265.c) AND (t1_13265.d = t2_13265.d))
+         ->  Seq Scan on public.t1_13265
+               Output: t1_13265.a, t1_13265.c, t1_13265.d, t1_13265.ctid, t1_13265.gp_segment_id
+         ->  Materialize
+               Output: t2_13265.ctid, t2_13265.c, t2_13265.d
+               ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                     Output: t2_13265.ctid, t2_13265.c, t2_13265.d
+                     ->  Seq Scan on public.t2_13265
+                           Output: t2_13265.ctid, t2_13265.c, t2_13265.d
+                           Filter: (t2_13265.a = 2)
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(15 rows)
+
+update t1_13265 set b = 2 where
+(c, d) not in (select c, d from t2_13265 where a = 2);
+select * from t1_13265;
+ a | b | c | d 
+---+---+---+---
+ 1 | 2 | 1 | 1
+(1 row)
+
 -- start_ignore
 drop table r;
 drop table s;
@@ -808,4 +848,6 @@ drop table update_ao_table;
 drop table update_aoco_table;
 drop table nosplitupdate;
 drop table tsplit_entry;
+drop table t1_13265;
+drop table t2_13265;
 -- end_ignore

--- a/src/test/regress/expected/update_gp_optimizer.out
+++ b/src/test/regress/expected/update_gp_optimizer.out
@@ -800,6 +800,46 @@ SELECT tableoid::regclass, * FROM update_gp_rangep WHERE b = 1;
  update_gp_rangep_10_to_20 | 11 | 1 |      4
 (3 rows)
 
+-- Test for update with LASJ_NOTIN
+-- See Issue: https://github.com/greenplum-db/gpdb/issues/13265
+-- Actually master branch does not have the above issue even master
+-- does have the same problematic code (other parts of code are
+-- refactored). Also cherry-pick the case to master and keep it
+-- since more test cases do no harm.
+create table t1_13265(a int, b int, c int, d int) distributed by (a);
+create table t2_13265(a int, b int, c int, d int) distributed by (a);
+insert into t1_13265 values (1, null, 1, 1);
+insert into t2_13265 values (2, null, 2, 2);
+explain (verbose, costs off)
+update t1_13265 set b = 2 where
+(c, d) not in (select c, d from t2_13265 where a = 2);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Update on public.t1_13265
+   ->  Nested Loop Left Anti Semi (Not-In) Join
+         Output: t1_13265.a, 2, t1_13265.c, t1_13265.d, t1_13265.ctid, t1_13265.gp_segment_id, t2_13265.ctid
+         Join Filter: ((t1_13265.c = t2_13265.c) AND (t1_13265.d = t2_13265.d))
+         ->  Seq Scan on public.t1_13265
+               Output: t1_13265.a, t1_13265.c, t1_13265.d, t1_13265.ctid, t1_13265.gp_segment_id
+         ->  Materialize
+               Output: t2_13265.ctid, t2_13265.c, t2_13265.d
+               ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                     Output: t2_13265.ctid, t2_13265.c, t2_13265.d
+                     ->  Seq Scan on public.t2_13265
+                           Output: t2_13265.ctid, t2_13265.c, t2_13265.d
+                           Filter: (t2_13265.a = 2)
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=on
+(15 rows)
+
+update t1_13265 set b = 2 where
+(c, d) not in (select c, d from t2_13265 where a = 2);
+select * from t1_13265;
+ a | b | c | d 
+---+---+---+---
+ 1 | 2 | 1 | 1
+(1 row)
+
 -- start_ignore
 drop table r;
 drop table s;
@@ -808,4 +848,6 @@ drop table update_ao_table;
 drop table update_aoco_table;
 drop table nosplitupdate;
 drop table tsplit_entry;
+drop table t1_13265;
+drop table t2_13265;
 -- end_ignore


### PR DESCRIPTION
This commit is cherry-picked from 6X to fix issue
https://github.com/greenplum-db/gpdb/issues/13265.
Master branch's code also has the same issue, but
due to other parts of code refactor (like removing
disuse_physical_tlist), it is hard to find a bad
case for master branch. But I still keep the test
in this commit since more tests do no harm.

(cherry picked from commit f9597375fef8f37d07b283e99b6a0b8f3a6b2796)