### PR TITLE
Increase the timeout of isolation2 GlobalShellExecutor

### DIFF
--- a/src/test/isolation2/sql_isolation_testcase.py
+++ b/src/test/isolation2/sql_isolation_testcase.py
@@ -132,7 +132,7 @@ class GlobalShellExecutor(object):
         output = ""
         while self.sh_proc.poll() is None:
             # If not returns in 10 seconds, consider it as an fatal error.
-            r, w, e = select.select([self.master_fd], [], [self.master_fd], 10)
+            r, w, e = select.select([self.master_fd], [], [self.master_fd], 30)
             if e:
                 # Terminate the shell when we get any output from stderr
                 o = os.read(self.master_fd, 10240)


### PR DESCRIPTION
Probably because of the heavy CI load, we observed several timeouts,
increase the timeout value to work around it.