### PR TITLE
(6x backport) Fix banning window agg in recursive queries.

### DIFF
--- a/src/backend/parser/parse_cte.c
+++ b/src/backend/parser/parse_cte.c
@@ -1057,30 +1057,57 @@ checkSelfRefInRangeSubSelect(SelectStmt *stmt, CteState *cstate)
 }
 
 /*
- * Check if the recursive term of a recursive cte contains a window function.
- * This is currently not supported and is checked for in the parsing stage
+ * GPDB:
+ * Check if the recursive term of a recursive cte contains a window function
+ * or ordered set aggregate function (special aggs). This is currently not
+ * supported and is checked for in the parsing stage. Refer to dicussion:
+ * https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/GIYw6t-uX7s
  */
+typedef struct CTEWindowAggSearchContext
+{
+	bool       found; /* flag to show if we have found */
+	FuncCall  *func;  /* if found is true, this field is the Agg */
+} CTEWindowAggSearchContext;
+
+static bool
+cte_window_agg_walker(Node *node, CTEWindowAggSearchContext *context)
+{
+	if (node == NULL)
+		return false;
+
+	if (IsA(node, FuncCall))
+	{
+		FuncCall *fc = (FuncCall *) node;
+		if (fc->over != NULL)
+		{
+			context->found = true;
+			context->func  = fc;
+
+			return true;
+		}
+	}
+
+	return raw_expression_tree_walker(node, cte_window_agg_walker, context);
+}
+
 static void
 checkWindowFuncInRecursiveTerm(SelectStmt *stmt, CteState *cstate)
 {
-	ListCell *lc;
-	foreach(lc, stmt->targetList)
+	CTEWindowAggSearchContext context;
+
+	context.found = false;
+	context.func  = NULL;
+
+	(void) raw_expression_tree_walker((Node *) stmt->targetList,
+									  cte_window_agg_walker,
+									  (void *) &context);
+
+	if (context.found)
 	{
-		if (IsA((Node *) lfirst(lc), ResTarget))
-		{
-			ResTarget *rt = (ResTarget *) lfirst(lc);
-			if (IsA(rt->val, FuncCall))
-			{
-				FuncCall *fc = (FuncCall *) rt->val;
-				if (fc->over != NULL)
-				{
-					ereport(ERROR,
-							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							 errmsg("Window Functions in a recursive query is not implemented"),
-							 parser_errposition(cstate->pstate,
-												exprLocation((Node *) fc))));
-				}
-			}
-		}
+		ereport(ERROR,
+				(errcode(ERRCODE_GP_FEATURE_NOT_YET),
+				 errmsg("window functions in the target list of a recursive query is not supported in Greenplum"),
+				 parser_errposition(cstate->pstate,
+									exprLocation((Node *) context.func))));
 	}
 }

--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -1046,7 +1046,7 @@ WITH RECURSIVE x(n) AS (
 	UNION ALL
 	SELECT level+1, row_number() over() FROM x, bar)
   SELECT * FROM x LIMIT 10;
-ERROR:  Window Functions in a recursive query is not implemented
+ERROR:  window functions in the target list of a recursive query is not supported in Greenplum
 LINE 4:  SELECT level+1, row_number() over() FROM x, bar)
                          ^
 CREATE TEMPORARY TABLE y (a INTEGER) DISTRIBUTED RANDOMLY;

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -1,8 +1,6 @@
 drop table if exists with_test1 cascade;
 NOTICE:  table "with_test1" does not exist, skipping
 create table with_test1 (i int, t text, value int) distributed by (i);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into with_test1 select i%10, 'text' || i%20, i%30 from generate_series(0, 99) i;
 drop table if exists with_test2 cascade;
 NOTICE:  table "with_test2" does not exist, skipping
@@ -2180,3 +2178,39 @@ WITH RECURSIVE r1 AS (
 )
 SELECT * FROM r1 LIMIT 1;
 ERROR:  joining nested RECURSIVE clauses is not supported
+-- GPDB
+-- Greenplum does not support window functions in recursive part's target list
+-- See issue https://github.com/greenplum-db/gpdb/issues/13299 for details.
+-- Previously the following SQL will PANIC or Assert Fail if compiled with assert.
+create table t_window_ordered_set_agg_rte(a bigint, b bigint, c bigint);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t_window_ordered_set_agg_rte select i,i,i from generate_series(1, 10)i;
+-- should error out during parse-analyze
+with recursive rcte(x,y) as
+(
+  select a, b from t_window_ordered_set_agg_rte
+  union all
+  select (first_value(c) over (partition by b))::int, a+x
+  from rcte,
+       t_window_ordered_set_agg_rte as t
+  where t.b = x
+)
+select * from rcte limit 10;
+ERROR:  window functions in the target list of a recursive query is not supported in Greenplum
+LINE 5:   select (first_value(c) over (partition by b))::int, a+x
+                  ^
+-- should error out during parse-analyze
+with recursive rcte(x,y) as
+(
+  select a, b from t_window_ordered_set_agg_rte
+  union all
+  select first_value(c) over (partition by b), a+x
+  from rcte,
+       t_window_ordered_set_agg_rte as t
+  where t.b = x
+)
+select * from rcte limit 10;
+ERROR:  window functions in the target list of a recursive query is not supported in Greenplum
+LINE 5:   select first_value(c) over (partition by b), a+x
+                 ^

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2179,3 +2179,39 @@ WITH RECURSIVE r1 AS (
 )
 SELECT * FROM r1 LIMIT 1;
 ERROR:  joining nested RECURSIVE clauses is not supported
+-- GPDB
+-- Greenplum does not support window functions in recursive part's target list
+-- See issue https://github.com/greenplum-db/gpdb/issues/13299 for details.
+-- Previously the following SQL will PANIC or Assert Fail if compiled with assert.
+create table t_window_ordered_set_agg_rte(a bigint, b bigint, c bigint);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t_window_ordered_set_agg_rte select i,i,i from generate_series(1, 10)i;
+-- should error out during parse-analyze
+with recursive rcte(x,y) as
+(
+  select a, b from t_window_ordered_set_agg_rte
+  union all
+  select (first_value(c) over (partition by b))::int, a+x
+  from rcte,
+       t_window_ordered_set_agg_rte as t
+  where t.b = x
+)
+select * from rcte limit 10;
+ERROR:  window functions in the target list of a recursive query is not supported in Greenplum
+LINE 5:   select (first_value(c) over (partition by b))::int, a+x
+                  ^
+-- should error out during parse-analyze
+with recursive rcte(x,y) as
+(
+  select a, b from t_window_ordered_set_agg_rte
+  union all
+  select first_value(c) over (partition by b), a+x
+  from rcte,
+       t_window_ordered_set_agg_rte as t
+  where t.b = x
+)
+select * from rcte limit 10;
+ERROR:  window functions in the target list of a recursive query is not supported in Greenplum
+LINE 5:   select first_value(c) over (partition by b), a+x
+                 ^

--- a/src/test/regress/sql/with_clause.sql
+++ b/src/test/regress/sql/with_clause.sql
@@ -358,3 +358,35 @@ WITH RECURSIVE r1 AS (
 	)
 )
 SELECT * FROM r1 LIMIT 1;
+
+-- GPDB
+-- Greenplum does not support window functions in recursive part's target list
+-- See issue https://github.com/greenplum-db/gpdb/issues/13299 for details.
+-- Previously the following SQL will PANIC or Assert Fail if compiled with assert.
+create table t_window_ordered_set_agg_rte(a bigint, b bigint, c bigint);
+
+insert into t_window_ordered_set_agg_rte select i,i,i from generate_series(1, 10)i;
+
+-- should error out during parse-analyze
+with recursive rcte(x,y) as
+(
+  select a, b from t_window_ordered_set_agg_rte
+  union all
+  select (first_value(c) over (partition by b))::int, a+x
+  from rcte,
+       t_window_ordered_set_agg_rte as t
+  where t.b = x
+)
+select * from rcte limit 10;
+
+-- should error out during parse-analyze
+with recursive rcte(x,y) as
+(
+  select a, b from t_window_ordered_set_agg_rte
+  union all
+  select first_value(c) over (partition by b), a+x
+  from rcte,
+       t_window_ordered_set_agg_rte as t
+  where t.b = x
+)
+select * from rcte limit 10;


### PR DESCRIPTION
Greenplum does not support window agg in the target list of recursive
part of recursive CTE. Current implementation of recursive queries is
based on Postgres' Worktable Scan and RecursiveUnion, this forces
the two nodes must be in the same slice, means no motion node is
allowed between them. The locus of worktable scan is determined by the
non-recurisve part of path thus it is hard to avoid motion over
worktable scan when there are window aggs. This should be the reason
why Greenplum does not support this feature.

However, previous code only checks the direct raw expression in parse
tree's targetlist, this is not enough, since it might be a compound
expression that involving window aggs, like a type cast expression. We
should use raw_expression_tree_walker to search window functions.

This commit fixes Issue: https://github.com/greenplum-db/gpdb/issues/13299,
more details can be found there.

For more discussion on this feature and furture plan, please refer to
https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/GIYw6t-uX7s.

(cherry picked from commit 7fb89f8618283365e6e6197c86af3e83e0530718)
