### PR TITLE
Fix paramcolid for param in ORCA translator

### DIFF
--- a/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
+++ b/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
@@ -109,7 +109,7 @@ CMappingColIdVarPlStmt::ParamFromDXLNodeScId(const CDXLScalarIdent *dxlop)
 		param->paramid = elem->ParamId();
 		param->paramtype = CMDIdGPDB::CastMdid(elem->MdidType())->Oid();
 		param->paramtypmod = elem->TypeModifier();
-        param->paramcollid = gpdb::TypeCollation(param->paramtype);
+		param->paramcollid = gpdb::TypeCollation(param->paramtype);
 	}
 
 	return param;

--- a/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
+++ b/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
@@ -109,6 +109,7 @@ CMappingColIdVarPlStmt::ParamFromDXLNodeScId(const CDXLScalarIdent *dxlop)
 		param->paramid = elem->ParamId();
 		param->paramtype = CMDIdGPDB::CastMdid(elem->MdidType())->Oid();
 		param->paramtypmod = elem->TypeModifier();
+        param->paramcollid = gpdb::TypeCollation(param->paramtype);
 	}
 
 	return param;

--- a/src/test/regress/expected/qp_misc.out
+++ b/src/test/regress/expected/qp_misc.out
@@ -20498,7 +20498,8 @@ WHERE  tkn_arr <> '{nullout}' ;
 ---------
 (0 rows)
 
--- Test paramcolid is correctly set
+-- Test paramcollid is correctly set
+SET optimizer_enable_hashjoin=false;
 CREATE TABLE tparam (a varchar(100) PRIMARY KEY);
 INSERT INTO tparam VALUES ('a_value');
 SELECT * FROM tparam t1 JOIN tparam t2 ON UPPER(t1.a) = t2.a;
@@ -20506,3 +20507,4 @@ SELECT * FROM tparam t1 JOIN tparam t2 ON UPPER(t1.a) = t2.a;
 ---+---
 (0 rows)
 
+RESET optimizer_enable_hashjoin;

--- a/src/test/regress/expected/qp_misc.out
+++ b/src/test/regress/expected/qp_misc.out
@@ -20498,3 +20498,11 @@ WHERE  tkn_arr <> '{nullout}' ;
 ---------
 (0 rows)
 
+-- Test paramcolid is correctly set
+CREATE TABLE tparam (a varchar(100) PRIMARY KEY);
+INSERT INTO tparam VALUES ('a_value');
+SELECT * FROM tparam t1 JOIN tparam t2 ON UPPER(t1.a) = t2.a;
+ a | a 
+---+---
+(0 rows)
+

--- a/src/test/regress/expected/qp_misc_optimizer.out
+++ b/src/test/regress/expected/qp_misc_optimizer.out
@@ -20510,3 +20510,11 @@ DETAIL:  Feature not supported: Unexpected target list entries in ProjectSet nod
 ---------
 (0 rows)
 
+-- Test paramcolid is correctly set
+CREATE TABLE tparam (a varchar(100) PRIMARY KEY);
+INSERT INTO tparam VALUES ('a_value');
+SELECT * FROM tparam t1 JOIN tparam t2 ON UPPER(t1.a) = t2.a;
+ a | a 
+---+---
+(0 rows)
+

--- a/src/test/regress/expected/qp_misc_optimizer.out
+++ b/src/test/regress/expected/qp_misc_optimizer.out
@@ -20510,7 +20510,8 @@ DETAIL:  Feature not supported: Unexpected target list entries in ProjectSet nod
 ---------
 (0 rows)
 
--- Test paramcolid is correctly set
+-- Test paramcollid is correctly set
+SET optimizer_enable_hashjoin=false;
 CREATE TABLE tparam (a varchar(100) PRIMARY KEY);
 INSERT INTO tparam VALUES ('a_value');
 SELECT * FROM tparam t1 JOIN tparam t2 ON UPPER(t1.a) = t2.a;
@@ -20518,3 +20519,4 @@ SELECT * FROM tparam t1 JOIN tparam t2 ON UPPER(t1.a) = t2.a;
 ---+---
 (0 rows)
 
+RESET optimizer_enable_hashjoin;

--- a/src/test/regress/sql/qp_misc.sql
+++ b/src/test/regress/sql/qp_misc.sql
@@ -15607,3 +15607,8 @@ WITH cte_coll AS
 SELECT *
 FROM   cte_coll
 WHERE  tkn_arr <> '{nullout}' ;
+-- Test paramcolid is correctly set
+CREATE TABLE tparam (a varchar(100) PRIMARY KEY);
+INSERT INTO tparam VALUES ('a_value');
+
+SELECT * FROM tparam t1 JOIN tparam t2 ON UPPER(t1.a) = t2.a;

--- a/src/test/regress/sql/qp_misc.sql
+++ b/src/test/regress/sql/qp_misc.sql
@@ -15607,8 +15607,10 @@ WITH cte_coll AS
 SELECT *
 FROM   cte_coll
 WHERE  tkn_arr <> '{nullout}' ;
--- Test paramcolid is correctly set
+-- Test paramcollid is correctly set
+SET optimizer_enable_hashjoin=false;
 CREATE TABLE tparam (a varchar(100) PRIMARY KEY);
 INSERT INTO tparam VALUES ('a_value');
 
 SELECT * FROM tparam t1 JOIN tparam t2 ON UPPER(t1.a) = t2.a;
+RESET optimizer_enable_hashjoin;


### PR DESCRIPTION
When there is a param, `ExprCollation` relies on paramcolid to figure out the
resultcolid. We weren't setting it while creating a param.

This commit fixes it,

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
