### PR TITLE
Fix paramcollid for param in ORCA translator (#13302)

### DIFF
--- a/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
+++ b/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
@@ -109,6 +109,7 @@ CMappingColIdVarPlStmt::ParamFromDXLNodeScId(const CDXLScalarIdent *dxlop)
 		param->paramid = elem->ParamId();
 		param->paramtype = CMDIdGPDB::CastMdid(elem->MdidType())->Oid();
 		param->paramtypmod = elem->TypeModifier();
+		param->paramcollid = gpdb::TypeCollation(param->paramtype);
 	}
 
 	return param;

--- a/src/test/regress/expected/qp_misc.out
+++ b/src/test/regress/expected/qp_misc.out
@@ -20497,3 +20497,13 @@ WHERE  tkn_arr <> '{nullout}' ;
 ---------
 (0 rows)
 
+-- Test paramcollid is correctly set
+SET optimizer_enable_hashjoin=false;
+CREATE TABLE tparam (a varchar(100) PRIMARY KEY);
+INSERT INTO tparam VALUES ('a_value');
+SELECT * FROM tparam t1 JOIN tparam t2 ON UPPER(t1.a) = t2.a;
+ a | a 
+---+---
+(0 rows)
+
+RESET optimizer_enable_hashjoin;

--- a/src/test/regress/expected/qp_misc_optimizer.out
+++ b/src/test/regress/expected/qp_misc_optimizer.out
@@ -20506,3 +20506,13 @@ WHERE  tkn_arr <> '{nullout}' ;
 ---------
 (0 rows)
 
+-- Test paramcollid is correctly set
+SET optimizer_enable_hashjoin=false;
+CREATE TABLE tparam (a varchar(100) PRIMARY KEY);
+INSERT INTO tparam VALUES ('a_value');
+SELECT * FROM tparam t1 JOIN tparam t2 ON UPPER(t1.a) = t2.a;
+ a | a 
+---+---
+(0 rows)
+
+RESET optimizer_enable_hashjoin;

--- a/src/test/regress/sql/qp_misc.sql
+++ b/src/test/regress/sql/qp_misc.sql
@@ -15607,3 +15607,10 @@ WITH cte_coll AS
 SELECT *
 FROM   cte_coll
 WHERE  tkn_arr <> '{nullout}' ;
+-- Test paramcollid is correctly set
+SET optimizer_enable_hashjoin=false;
+CREATE TABLE tparam (a varchar(100) PRIMARY KEY);
+INSERT INTO tparam VALUES ('a_value');
+
+SELECT * FROM tparam t1 JOIN tparam t2 ON UPPER(t1.a) = t2.a;
+RESET optimizer_enable_hashjoin;


### PR DESCRIPTION
When there is a param, `ExprCollation` relies on paramcollid to figure out the
resultcollid. We weren't setting it while creating a param.

This commit fixes it.

Co-authored-by: Sambitesh Dash <sdash@pivotal.io>
Co-authored-by: Bhuvnesh Chaudhary <bchaudhary@vmware.com>

(cherry picked from commit d03632b6c0a389944ca50ddc788b1d5fbc2a4308)