### PR TITLE
Improve gp_hyperloglog codes and add tests for it.

### DIFF
--- a/src/include/utils/hyperloglog/gp_hyperloglog.h
+++ b/src/include/utils/hyperloglog/gp_hyperloglog.h
@@ -407,14 +407,6 @@ static const double PE[NUM_OF_PRECOMPUTED_EXPONENTS] = { 1.,
 
 #define POW2(a) (1 << (a))
 
-/* Provides encoding and decoding to convert the estimator bytes into a human
- * readable form. Currently only base 64 encoding is provided. */
-
-int gp_hll_b64_encode(const char *src, unsigned len, char *dst);
-int gp_hll_b64_decode(const char *src, unsigned len, char *dst);
-int gp_b64_enc_len(const char *src, unsigned srclen);
-int gp_b64_dec_len(const char *src, unsigned srclen);
-
 uint64_t GpMurmurHash64A (const void * key, int len, unsigned int seed);
 
 #endif // #ifndef _GP_HYPERLOGLOG_H_

--- a/src/test/regress/expected/gp_hyperloglog.out
+++ b/src/test/regress/expected/gp_hyperloglog.out
@@ -1,0 +1,99 @@
+-- This file contains test cases from gp_hyperloglog.
+-- 1. Test estimating the cardinality of an given stream.
+SELECT gp_hyperloglog_get_estimate(gp_hyperloglog_accum(i))
+  FROM generate_series(1, 10000)i;
+ gp_hyperloglog_get_estimate 
+-----------------------------
+           9998.401034851891
+(1 row)
+
+-- 2. Test merging two hloglog counter.
+-- a) A ∩ B = {}, A ∪ B = {1, 2, ..., 20}
+SELECT gp_hyperloglog_get_estimate(
+    gp_hyperloglog_merge(gp_hyperloglog_accum(x), gp_hyperloglog_accum(y)))
+  FROM generate_series(1, 10)x, generate_series(11, 20)y;
+ gp_hyperloglog_get_estimate 
+-----------------------------
+           20.01316254251873
+(1 row)
+
+-- b) A ∩ B = {5, 6, 7, 8, 9, 10}, A ∪ B = {1, 2, ..., 20}
+SELECT gp_hyperloglog_get_estimate(
+    gp_hyperloglog_merge(gp_hyperloglog_accum(x), gp_hyperloglog_accum(y)))
+  FROM generate_series(1, 10)x, generate_series(5, 20)y;
+ gp_hyperloglog_get_estimate 
+-----------------------------
+           20.01316254251873
+(1 row)
+
+-- c) A ∩ B = A, A ∪ B = {1, 2, ..., 20}
+SELECT gp_hyperloglog_get_estimate(
+    gp_hyperloglog_merge(gp_hyperloglog_accum(x), gp_hyperloglog_accum(y)))
+  FROM generate_series(1, 10)x, generate_series(1, 20)y;
+ gp_hyperloglog_get_estimate 
+-----------------------------
+           20.01316254251873
+(1 row)
+
+-- 3. Test the gp_hyperloglog_add_item_agg_default() UDF.
+-- a) The newly added item is out of the range of the original set.
+SELECT gp_hyperloglog_get_estimate(
+    gp_hyperloglog_add_item_agg_default(gp_hyperloglog_accum(i), 101))
+  FROM generate_series(1, 100)i;
+ gp_hyperloglog_get_estimate 
+-----------------------------
+          101.31306376074124
+(1 row)
+
+-- b) The newly added item is within the range of the original set.
+SELECT gp_hyperloglog_get_estimate(
+    gp_hyperloglog_add_item_agg_default(gp_hyperloglog_accum(i), 50))
+  FROM generate_series(1, 100)i;
+ gp_hyperloglog_get_estimate 
+-----------------------------
+          100.30560977271011
+(1 row)
+
+-- c) When the first argument of gp_hyperloglog_add_item_agg_default() is null,
+-- it will create a new hloglog counter for us. The following test will create
+-- 5 hloglog counters.
+SELECT gp_hyperloglog_get_estimate(
+    gp_hyperloglog_add_item_agg_default(null, 50))
+  FROM generate_series(1, 5)i;
+ gp_hyperloglog_get_estimate 
+-----------------------------
+          0.9999694836635816
+          0.9999694836635816
+          0.9999694836635816
+          0.9999694836635816
+          0.9999694836635816
+(5 rows)
+
+-- d) When the second argument of gp_hyperloglog_add_item_agg_default() is null,
+-- hloglog counter will skip that value.
+SELECT gp_hyperloglog_get_estimate(
+    gp_hyperloglog_add_item_agg_default(gp_hyperloglog_accum(i), null::int))
+  FROM generate_series(1, 100)i;
+ gp_hyperloglog_get_estimate 
+-----------------------------
+          100.30560977271011
+(1 row)
+
+-- 3. Test printing out hloglog counter in base64.
+SELECT gp_hyperloglog_accum(i) FROM generate_series(1, 100)i;
+                                                                                                                                                                                                                                                                                                                                                             gp_hyperloglog_accum                                                                                                                                                                                                                                                                                                                                                             
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ 8gYCAP////8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAegAPAWQGDyANDwH/DwH/DwECAdsPIA0PAQgDDyANDwEUAg8gDQ8BNe8P5ygPAXofLVUPARgEDyANDwH4H7t/9w8BFhjjBcQFDy4IDwH/DwEET48F/0+mWQ9rNG8ENA8Bxh/PWQ8BDx+qRQ/jev8PARpvuf8PAVUvMBJ/K3wv4mEfATNfm3T3H8xGLyRmD3hlBw/xZw8B/w8BLk9QKf8/03QPAUFfZGEGAc/NEw+hFj+mYR88H/+P+8g6IC9Uag8BEQ+fjQ8BFg/HtQ8B/98PAVJvz8cPAT0/ZH8fuYgHDyANDwH//yliL2g0L65/DwEdD8BSrydDH3mbD62b/w8Bas+fAR88Rx+VyA/ayA8B/w8B/w8Bif+vSTp/VEMPAf8fc0vPWIh/kg0PARltin8P9JQPATx/jicfLeIPASeP9P8PAR0E/w8gDQ8BQx+1/w8Bti9OHS8IHi84/w8BzP8f74MPlYMPAXFvSSCP6NbftPE/Nf8PAaX/P7N/L1lCL61gD3IFAhcPjjsP22BcBr9vJgAvU38PAf8PAbcv/gc/FxIDf8gA/z9OaQ8BsR8+FB9kdq/fIA8B/w8BB2MDHx/qHC8Ydg8BVUJ8fytbAAAAAA==
+(1 row)
+
+-- 4. Test convert a base64 string to hloglog counter.
+-- a) Test convert a valid hloglog counter.
+SELECT gp_hyperloglog_get_estimate('8gYCAP////8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAegAPAWQGDyANDwH/DwH/DwECAdsPIA0PAQgDDyANDwEUAg8gDQ8BNe8P5ygPAXofLVUPARgEDyANDwH4H7t/9w8BFhjjBcQFDy4IDwH/DwEET48F/0+mWQ9rNG8ENA8Bxh/PWQ8BDx+qRQ/jev8PARpvuf8PAVUvMBJ/K3wv4mEfATNfm3T3H8xGLyRmD3hlBw/xZw8B/w8BLk9QKf8/03QPAUFfZGEGAc/NEw+hFj+mYR88H/+P+8g6IC9Uag8BEQ+fjQ8BFg/HtQ8B/98PAVJvz8cPAT0/ZH8fuYgHDyANDwH//yliL2g0L65/DwEdD8BSrydDH3mbD62b/w8Bas+fAR88Rx+VyA/ayA8B/w8B/w8Bif+vSTp/VEMPAf8fc0vPWIh/kg0PARltin8P9JQPATx/jicfLeIPASeP9P8PAR0E/w8gDQ8BQx+1/w8Bti9OHS8IHi84/w8BzP8f74MPlYMPAXFvSSCP6NbftPE/Nf8PAaX/P7N/L1lCL61gD3IFAhcPjjsP22BcBr9vJgAvU38PAf8PAbcv/gc/FxIDf8gA/z9OaQ8BsR8+FB9kdq/fIA8B/w8BB2MDHx/qHC8Ydg8BVUJ8fytbAAAAAA==');
+ gp_hyperloglog_get_estimate 
+-----------------------------
+          100.30560977271011
+(1 row)
+
+-- b) Test convert an invalid hloglog counter.
+SELECT gp_hyperloglog_get_estimate('blah');
+ERROR:  ERROR: The stored counter is version 161 while the library is version 2. Please change library version or use upgrade function to upgrade the counter (gp_hyperloglog.c:970)

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -101,7 +101,7 @@ test: cursor
 # so it needs to be in a group by itself
 test: query_finish_pending
 
-test: gpdiffcheck gptokencheck gp_hashagg sequence_gp tidscan_gp co_nestloop_idxscan dml_in_udf gpdtm_plpgsql gp_array_agg
+test: gpdiffcheck gptokencheck gp_hashagg sequence_gp tidscan_gp co_nestloop_idxscan dml_in_udf gpdtm_plpgsql gp_array_agg gp_hyperloglog
 
 # The test must be run by itself as it injects a fault on QE to fail
 # at the 2nd phase of 2PC.

--- a/src/test/regress/sql/gp_hyperloglog.sql
+++ b/src/test/regress/sql/gp_hyperloglog.sql
@@ -1,0 +1,55 @@
+-- This file contains test cases from gp_hyperloglog.
+
+-- 1. Test estimating the cardinality of an given stream.
+SELECT gp_hyperloglog_get_estimate(gp_hyperloglog_accum(i))
+  FROM generate_series(1, 10000)i;
+
+-- 2. Test merging two hloglog counter.
+-- a) A ∩ B = {}, A ∪ B = {1, 2, ..., 20}
+SELECT gp_hyperloglog_get_estimate(
+    gp_hyperloglog_merge(gp_hyperloglog_accum(x), gp_hyperloglog_accum(y)))
+  FROM generate_series(1, 10)x, generate_series(11, 20)y;
+
+-- b) A ∩ B = {5, 6, 7, 8, 9, 10}, A ∪ B = {1, 2, ..., 20}
+SELECT gp_hyperloglog_get_estimate(
+    gp_hyperloglog_merge(gp_hyperloglog_accum(x), gp_hyperloglog_accum(y)))
+  FROM generate_series(1, 10)x, generate_series(5, 20)y;
+
+-- c) A ∩ B = A, A ∪ B = {1, 2, ..., 20}
+SELECT gp_hyperloglog_get_estimate(
+    gp_hyperloglog_merge(gp_hyperloglog_accum(x), gp_hyperloglog_accum(y)))
+  FROM generate_series(1, 10)x, generate_series(1, 20)y;
+
+-- 3. Test the gp_hyperloglog_add_item_agg_default() UDF.
+-- a) The newly added item is out of the range of the original set.
+SELECT gp_hyperloglog_get_estimate(
+    gp_hyperloglog_add_item_agg_default(gp_hyperloglog_accum(i), 101))
+  FROM generate_series(1, 100)i;
+
+-- b) The newly added item is within the range of the original set.
+SELECT gp_hyperloglog_get_estimate(
+    gp_hyperloglog_add_item_agg_default(gp_hyperloglog_accum(i), 50))
+  FROM generate_series(1, 100)i;
+
+-- c) When the first argument of gp_hyperloglog_add_item_agg_default() is null,
+-- it will create a new hloglog counter for us. The following test will create
+-- 5 hloglog counters.
+SELECT gp_hyperloglog_get_estimate(
+    gp_hyperloglog_add_item_agg_default(null, 50))
+  FROM generate_series(1, 5)i;
+
+-- d) When the second argument of gp_hyperloglog_add_item_agg_default() is null,
+-- hloglog counter will skip that value.
+SELECT gp_hyperloglog_get_estimate(
+    gp_hyperloglog_add_item_agg_default(gp_hyperloglog_accum(i), null::int))
+  FROM generate_series(1, 100)i;
+
+-- 3. Test printing out hloglog counter in base64.
+SELECT gp_hyperloglog_accum(i) FROM generate_series(1, 100)i;
+
+-- 4. Test convert a base64 string to hloglog counter.
+-- a) Test convert a valid hloglog counter.
+SELECT gp_hyperloglog_get_estimate('8gYCAP////8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAegAPAWQGDyANDwH/DwH/DwECAdsPIA0PAQgDDyANDwEUAg8gDQ8BNe8P5ygPAXofLVUPARgEDyANDwH4H7t/9w8BFhjjBcQFDy4IDwH/DwEET48F/0+mWQ9rNG8ENA8Bxh/PWQ8BDx+qRQ/jev8PARpvuf8PAVUvMBJ/K3wv4mEfATNfm3T3H8xGLyRmD3hlBw/xZw8B/w8BLk9QKf8/03QPAUFfZGEGAc/NEw+hFj+mYR88H/+P+8g6IC9Uag8BEQ+fjQ8BFg/HtQ8B/98PAVJvz8cPAT0/ZH8fuYgHDyANDwH//yliL2g0L65/DwEdD8BSrydDH3mbD62b/w8Bas+fAR88Rx+VyA/ayA8B/w8B/w8Bif+vSTp/VEMPAf8fc0vPWIh/kg0PARltin8P9JQPATx/jicfLeIPASeP9P8PAR0E/w8gDQ8BQx+1/w8Bti9OHS8IHi84/w8BzP8f74MPlYMPAXFvSSCP6NbftPE/Nf8PAaX/P7N/L1lCL61gD3IFAhcPjjsP22BcBr9vJgAvU38PAf8PAbcv/gc/FxIDf8gA/z9OaQ8BsR8+FB9kdq/fIA8B/w8BB2MDHx/qHC8Ydg8BVUJ8fytbAAAAAA==');
+
+-- b) Test convert an invalid hloglog counter.
+SELECT gp_hyperloglog_get_estimate('blah');


### PR DESCRIPTION
This patch helps remove redundant base64 encoding and decoding functions
in gp_hyperloglog.c and add test cases for gp_hyperloglog.

1. Postgres upstream provides the implementation of base64 encoding and
   decoding utilities. The difference between Postgres's base64 and the
   original base64 is that the original encoding function obeys the
   76-character per-line rule (it inserts a `\n` to the encoded string
   every 76-character). I think it doesn't matter whether to start a new
   line every 76-characters and it's good to remove redundant codes.

2. Test cases for gp_hyperloglog are added in this patch (I don't know
   why there isn't any test for it).

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Pass `make installcheck`
