### PR TITLE
[6X] Support writable s3 external table on master

### DIFF
--- a/gpcontrib/gpcloud/regress/input/3_01_create_wet.source
+++ b/gpcontrib/gpcloud/regress/input/3_01_create_wet.source
@@ -1,4 +1,9 @@
 CREATE WRITABLE EXTERNAL TABLE s3regress_create_wet (date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-us-west-2.amazonaws.com/@write_prefix@/create/ config=@config_file@') FORMAT 'csv';
 
+CREATE WRITABLE EXTERNAL TABLE s3regress_create_wet_on_master (date text) LOCATION('s3://s3-us-west-2.amazonaws.com/@write_prefix@/create/ config=@config_file@') ON MASTER FORMAT 'csv';
+
+-- should no motion for on master external table
+EXPLAIN (verbose, costs off) INSERT INTO s3regress_create_wet_on_master VALUES ('aaa');
+
 DROP EXTERNAL TABLE s3regress_create_wet;

--- a/gpcontrib/gpcloud/regress/input/3_01_create_wet.source
+++ b/gpcontrib/gpcloud/regress/input/3_01_create_wet.source
@@ -7,3 +7,4 @@ CREATE WRITABLE EXTERNAL TABLE s3regress_create_wet_on_master (date text) LOCATI
 EXPLAIN (verbose, costs off) INSERT INTO s3regress_create_wet_on_master VALUES ('aaa');
 
 DROP EXTERNAL TABLE s3regress_create_wet;
+DROP EXTERNAL TABLE s3regress_create_wet_on_master;

--- a/gpcontrib/gpcloud/regress/output/3_01_create_wet.source
+++ b/gpcontrib/gpcloud/regress/output/3_01_create_wet.source
@@ -1,3 +1,14 @@
 CREATE WRITABLE EXTERNAL TABLE s3regress_create_wet (date text, time text, open float, high float,
         low float, volume int) LOCATION('s3://s3-us-west-2.amazonaws.com/@write_prefix@/create/ config=@config_file@') FORMAT 'csv';
+CREATE WRITABLE EXTERNAL TABLE s3regress_create_wet_on_master (date text) LOCATION('s3://s3-us-west-2.amazonaws.com/@write_prefix@/create/ config=@config_file@') ON MASTER FORMAT 'csv';
+-- should no motion for on master external table
+EXPLAIN (verbose, costs off) INSERT INTO s3regress_create_wet_on_master VALUES ('aaa');
+                   QUERY PLAN                    
+-------------------------------------------------
+ Insert on public.s3regress_create_wet_on_master
+   ->  Result
+         Output: 'aaa'::text
+ Optimizer: Postgres query optimizer
+(4 rows)
+
 DROP EXTERNAL TABLE s3regress_create_wet;

--- a/gpcontrib/gpcloud/regress/output/3_01_create_wet.source
+++ b/gpcontrib/gpcloud/regress/output/3_01_create_wet.source
@@ -12,3 +12,4 @@ EXPLAIN (verbose, costs off) INSERT INTO s3regress_create_wet_on_master VALUES (
 (4 rows)
 
 DROP EXTERNAL TABLE s3regress_create_wet;
+DROP EXTERNAL TABLE s3regress_create_wet_on_master;

--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -580,18 +580,22 @@ external_insert_init(Relation rel)
 	List	   *copyFmtOpts;
 	char	   *custom_formatter_name = NULL;
 	List	   *custom_formatter_params = NIL;
+	char       *on_clause;
 
 	/*
 	 * Get the pg_exttable information for this table
 	 */
 	extentry = GetExtTableEntry(RelationGetRelid(rel));
-
+	on_clause = (char *) strVal(linitial(extentry->execlocations));
 	/*
 	 * allocate and initialize the insert descriptor
 	 */
 	extInsertDesc = (ExternalInsertDesc) palloc0(sizeof(ExternalInsertDescData));
 	extInsertDesc->ext_rel = rel;
-	extInsertDesc->ext_noop = (Gp_role == GP_ROLE_DISPATCH);
+	if (strcmp(on_clause, "MASTER_ONLY") == 0)
+		extInsertDesc->ext_noop = false;
+	else
+		extInsertDesc->ext_noop = (Gp_role == GP_ROLE_DISPATCH);
 	extInsertDesc->ext_formatter_data = NULL;
 
 	if (extentry->command)


### PR DESCRIPTION
The writable s3 external table on master is supported in the [document](https://gpdb.docs.pivotal.io/6-20/ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.html)
But it will be dispatched to QE:
```
gpadmin=# explain insert into all_ext_tab01_wr values(1,1);
                                       QUERY PLAN
----------------------------------------------------------------------------------------
 Insert on all_ext_tab01_wr  (cost=0.00..0.01 rows=1 width=0)
   ->  Redistribute Motion 1:3  (slice1; segments: 1)  (cost=0.00..0.01 rows=1 width=0)
         ->  Result  (cost=0.00..0.01 rows=1 width=0)
 Optimizer: Postgres query optimizer
(4 rows)
```
So, the insert will fail if s3 config file in only on master.

This PR fix the bug by:
    1. set distribute policy as POLICYTYPE_ENTRY for writable external
    talbe too.
    2. do insert if the external table with on master clause.

The plan will be:
```
gpadmin=# explain insert into all_ext_tab01_wr values(1,1);
                          QUERY PLAN
--------------------------------------------------------------
 Insert on all_ext_tab01_wr  (cost=0.00..0.01 rows=1 width=0)
   ->  Result  (cost=0.00..0.01 rows=1 width=0)
 Optimizer: Postgres query optimizer
(3 rows)
```

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
