### PR TITLE
Fix plpgsql testcase for ORCA

### DIFF
--- a/src/test/regress/expected/plpgsql.out
+++ b/src/test/regress/expected/plpgsql.out
@@ -2338,7 +2338,7 @@ begin
 		when data_exception then  -- category match
 			raise notice 'caught data_exception';
 			x := -1;
-		when NUMERIC_VALUE_OUT_OF_RANGE OR CARDINALITY_VIOLATION then
+		when NUMERIC_VALUE_OUT_OF_RANGE OR CARDINALITY_VIOLATION or TOO_MANY_ROWS then
 			raise notice 'caught numeric_value_out_of_range or cardinality_violation';
 			x := -2;
 	end;

--- a/src/test/regress/expected/plpgsql_optimizer.out
+++ b/src/test/regress/expected/plpgsql_optimizer.out
@@ -2358,7 +2358,7 @@ begin
 		when data_exception then  -- category match
 			raise notice 'caught data_exception';
 			x := -1;
-		when NUMERIC_VALUE_OUT_OF_RANGE OR CARDINALITY_VIOLATION then
+		when NUMERIC_VALUE_OUT_OF_RANGE OR CARDINALITY_VIOLATION or TOO_MANY_ROWS then
 			raise notice 'caught numeric_value_out_of_range or cardinality_violation';
 			x := -2;
 	end;

--- a/src/test/regress/sql/plpgsql.sql
+++ b/src/test/regress/sql/plpgsql.sql
@@ -1733,7 +1733,7 @@ begin
 		when data_exception then  -- category match
 			raise notice 'caught data_exception';
 			x := -1;
-		when NUMERIC_VALUE_OUT_OF_RANGE OR CARDINALITY_VIOLATION then
+		when NUMERIC_VALUE_OUT_OF_RANGE OR CARDINALITY_VIOLATION or TOO_MANY_ROWS then
 			raise notice 'caught numeric_value_out_of_range or cardinality_violation';
 			x := -2;
 	end;


### PR DESCRIPTION
Commit 2ddd30e336 exposed an ORCA issue with following diff in test
output:

      select trap_matching_test(1);
    - NOTICE:  caught numeric_value_out_of_range or cardinality_violation
    -  trap_matching_test
    - --------------------
    -                  -2
    - (1 row)
    -
    + ERROR:  One or more assertions failed
    + DETAIL:  Expected no more than one row to be returned by expression
    + CONTEXT:  SQL statement "select unique1 from tenk1 where unique2 = (select unique2 from tenk1 b where ten =  $1 )"
    + PL/pgSQL function "trap_matching_test" line 8 at SQL statement

Previously ORCA would fall back because it doesn't support SIRV
functions. It used to be that before commit 2ddd30e336 we would reuse
the cached plan. Now, we may build a new plan because of existence of
boundParams. This gives ORCA a chance to plan individual statements
inside the PL/pgSQL function.

Issue is that ORCA raises PL/pgSQL error code P0003 too many rows [1]
instead of error code 21000 cardinality violation [1].

NB: This actually keeps parity with GPDB 6 which has similar
"workaround".

[1] https://www.postgresql.org/docs/14/errcodes-appendix.html
