### PR TITLE
Remove gpdb_12_merge_fixme in buffile.c.

### DIFF
--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -238,11 +238,10 @@ extendBufFile(BufFile *file)
 	 * Register the file as a "work file", so that the Greenplum workfile
 	 * limits apply to it.
 	 *
-	 * GPDB_12_MERGE_FIXME: In previous Greenplum versions, we had disabled
-	 * the Postgres 1 GB segmentation of BufFiles. It was resurrected with
-	 * The v12 merge. Now each 1 GB segment file counts as one work file.
-	 * That makes the limit on the number of work files work differently.
-	 * Is that OK? Documentation changes needed, at least.
+	 * Note: The GUC gp_workfile_limit_files_per_query is used to control the
+	 * maximum number of spill files for a given query, to prevent runaway
+	 * queries from destroying the entire system. Counting each segment file is
+	 * reasonable for this scenario.
 	 */
 	FileSetIsWorkfile(pfile);
 	RegisterFileWithSet(pfile, file->work_set);

--- a/src/test/regress/expected/workfile_limits.out
+++ b/src/test/regress/expected/workfile_limits.out
@@ -36,6 +36,30 @@ union
 select count(g) from generate_series(1, 500000) g
 order by 1;
 ERROR:  number of workfiles per query limit exceeded
+-- Test work file limit number after merge PG 1GB segment
+-- Ensure the queries below need to spill to disk.
+set statement_mem='1 MB';
+-- Also test limit on number of files (gp_workfile_limit_files_per_query)
+-- The query below will generate 6 temp files:
+-- 1 gpadmin gpadmin 1.0G Mar 25 23:13 pgsql_tmpLogicalTape16802.3
+-- 1 gpadmin gpadmin 1.0G Mar 25 23:13 pgsql_tmpLogicalTape16802.4
+-- 1 gpadmin gpadmin 247M Mar 25 23:13 pgsql_tmpLogicalTape16802.5
+-- 1 gpadmin gpadmin 1.0G Mar 25 23:08 pgsql_tmpslice0_tuplestore16802.0
+-- 1 gpadmin gpadmin 1.0G Mar 25 23:09 pgsql_tmpslice0_tuplestore16802.1
+-- 1 gpadmin gpadmin 623M Mar 25 23:09 pgsql_tmpslice0_tuplestore16802.2
+-- On GP6, the query will generate 2 temp files:
+-- 1 gpadmin gpadmin 1.5G Mar 24 22:50 pgsql_tmp_slice-1_tuplestore_1_3251.16
+-- 1 gpadmin gpadmin 2.2G Mar 24 22:54 pgsql_tmp_Sort_2_3251.17
+-- On master, each 1 GB segment file count as work file, and the work_set->perquery->num_files count as 6.
+set gp_workfile_limit_files_per_query='6';
+select count(distinct g) from generate_series(1, 200000000) g;
+   count   
+-----------
+ 200000000
+(1 row)
+
+reset gp_workfile_limit_files_per_query;
+reset statement_mem;
 -- We cannot test the per-segment limit, because changing it requires
 -- a postmaster restart. It's enforced in the same way as the per-query
 -- limit, though, and it's simpler, so if the per-query limit works,

--- a/src/test/regress/sql/workfile_limits.sql
+++ b/src/test/regress/sql/workfile_limits.sql
@@ -31,6 +31,27 @@ union
 select count(g) from generate_series(1, 500000) g
 order by 1;
 
+-- Test work file limit number after merge PG 1GB segment
+
+-- Ensure the queries below need to spill to disk.
+set statement_mem='1 MB';
+-- Also test limit on number of files (gp_workfile_limit_files_per_query)
+-- The query below will generate 6 temp files:
+-- 1 gpadmin gpadmin 1.0G Mar 25 23:13 pgsql_tmpLogicalTape16802.3
+-- 1 gpadmin gpadmin 1.0G Mar 25 23:13 pgsql_tmpLogicalTape16802.4
+-- 1 gpadmin gpadmin 247M Mar 25 23:13 pgsql_tmpLogicalTape16802.5
+-- 1 gpadmin gpadmin 1.0G Mar 25 23:08 pgsql_tmpslice0_tuplestore16802.0
+-- 1 gpadmin gpadmin 1.0G Mar 25 23:09 pgsql_tmpslice0_tuplestore16802.1
+-- 1 gpadmin gpadmin 623M Mar 25 23:09 pgsql_tmpslice0_tuplestore16802.2
+-- On GP6, the query will generate 2 temp files:
+-- 1 gpadmin gpadmin 1.5G Mar 24 22:50 pgsql_tmp_slice-1_tuplestore_1_3251.16
+-- 1 gpadmin gpadmin 2.2G Mar 24 22:54 pgsql_tmp_Sort_2_3251.17
+-- On master, each 1 GB segment file count as work file, and the work_set->perquery->num_files count as 6.
+set gp_workfile_limit_files_per_query='6';
+select count(distinct g) from generate_series(1, 200000000) g;
+
+reset gp_workfile_limit_files_per_query;
+reset statement_mem;
 
 -- We cannot test the per-segment limit, because changing it requires
 -- a postmaster restart. It's enforced in the same way as the per-query


### PR DESCRIPTION
PostgreSQL breaks temporary files into 1 GB segments. Greenplum didn't do that until
v12 merge https://github.com/greenplum-db/gpdb/commit/19cd1cf4b68faff2e29bc2fa884c480e4644cdb4 breaks BufFiles into segments and counts each segment file as one work file.

The GUC `gp_workfile_limit_files_per_query` is used to control the maximum number of spill files for a given query, to prevent runaway queries from destroying the entire system. Counting each segment file is reasonable for this scenario and 100,000 seems reasonable default.

We for sure need to count all physical files and not logical files, this parameter/GUC is just for defensive mechanism and ideally not required to be tuned/configured by users most of the time (practically can just be #define in code, though fine as we have exposed it already as GUC.

Controlling the actual disk size used for spill files via other GUC is something users should tune more often, like `gp_workfile_limit_per_query`

This PR removes the FIXME of worrying about the count method and adds a test.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
