### PR TITLE
[WIP]Reset idle_gang_timeout_occurred to zero after disable GANG_TIMEOUT

### DIFF
--- a/src/backend/tcop/idle_resource_cleaner.c
+++ b/src/backend/tcop/idle_resource_cleaner.c
@@ -49,6 +49,15 @@ void
 CancelIdleResourceCleanupTimers()
 {
 	disable_timeout(GANG_TIMEOUT, false);
+
+	/*
+	 * If backend received SIGALRM between DisableClientWaitTimeoutInterrupt()
+	 * and CancelIdleResourceCleanupTimers(), idle_gang_timeout_occurred will
+	 * be set to 1 by IdleGangTimeoutHandler(). Then it will affect next round
+	 * of idle gang timeout process. So reset idle_gang_timeout_occurred to
+	 * zero after disable GANG_TIMEOUT.
+	 */
+	idle_gang_timeout_occurred = 0;
 }
 
 void


### PR DESCRIPTION
If backend process received `SIGALRM` between `StartIdleResourceCleanupTimer()` and
`EnableClientWaitTimeoutInterrupt()`, `idle_gang_timeout_occurred` will be set to 1 by 
`IdleGangTimeoutHandler()`. For the same reason, if backend process received 
`SIGALRM` between `DisableClientWaitTimeoutInterrupt()` and 
`CancelIdleResourceCleanupTimers()`, `idle_gang_timeout_occurred` will be set to 1 by
`IdleGangTimeoutHandler()`. Then it will affect next round of idle gang timeout process.
`EnableClientWaitTimeoutInterrupt()->IdleGangTimeoutHandler()->DisconnectAndDestroyUnusedQEs()`
probably conflicts by `handle_sig_alarm()->IdleGangTimeoutHandler()`. So reset 
`idle_gang_timeout_occurred` to zero after disable `GANG_TIMEOUT` to avoid this situation.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
