### PR TITLE
Force ORCA fallback for queries with boundParams

### DIFF
--- a/src/backend/optimizer/plan/orca.c
+++ b/src/backend/optimizer/plan/orca.c
@@ -102,6 +102,12 @@ optimize_query(Query *parse, ParamListInfo boundParams)
 		return NULL;
 
 	/*
+	 * ORCA doesn't currently support PARAM nodes and likewise boundParams.
+	 */
+	if (boundParams)
+		return NULL;
+
+	/*
 	 * Initialize a dummy PlannerGlobal struct. ORCA doesn't use it, but the
 	 * pre- and post-processing steps do.
 	 */

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -320,9 +320,9 @@ INFO:  Dispatch command to ALL contents
 prepare test_update (int) as update direct_test set value = 'boo' where key = $1;
 -- Known_opt_diff: MPP-21346
 execute test_update(2);
-INFO:  Dispatch command to ALL contents
-INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents
+INFO:  Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to SINGLE content
 select * from direct_test;
 INFO:  Dispatch command to ALL contents
  key | value 

--- a/src/test/regress/expected/qp_olap_group_optimizer.out
+++ b/src/test/regress/expected/qp_olap_group_optimizer.out
@@ -6031,12 +6031,18 @@ PREPARE p AS SELECT COUNT(DISTINCT cn) as cn_r, f, g FROM (SELECT cn, vn + $1 AS
 EXECUTE p(2);
  cn_r | f  | g 
 ------+----+---
+    1 | 12 | 2
     1 | 22 | 2
     2 | 32 | 2
-    1 | 12 | 2
     3 | 42 | 2
     2 | 52 | 2
-(5 rows)
+    1 | 12 |  
+    1 | 22 |  
+    2 | 32 |  
+    3 | 42 |  
+    2 | 52 |  
+    4 |    |  
+(11 rows)
 
 -- ###### Queries involving CUBE with HAVING CLAUSE ###### --
 WITH src AS (SELECT 1 AS a, 1 AS b)


### PR DESCRIPTION
After commit 2ddd30e336c following SQL gives unexpected results on ORCA:
 
 ```sql
 SELECT paramsegment,paramname
 FROM gp_toolkit.gp_param_settings()
 WHERE paramname='gp_role';
 ```

This is because ORCA doesn't support executing the function on the
segment. Previously ORCA fell back to PLANNER because the query tree
contained a PARAM node that is unsupported in ORCA. Commit 2ddd30e336c
instead passes boundParam to RevalidateCachedPlan(), leading to a query
tree that doesn't contain a PARAM node. Therefore ORCA didn't fallback.

In 6X, commit aa148d2a3cb added functions execution defintions [MASTER |
ALL SEGMENTS]. LookupFuncProps() uses those definitions to fallback if
function isn't PROEXECLOCATION_ANY.

However, commit aa148d2a3cb includes a catalog change that cannot be
backported to 5X. Instead this commit brings back the behavior of ORCA
fallback to PLANNER when PARAM node existed by doing the same when
boundParams exists.


--

Testing: passed ICW https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev?group=G%3AICW