### PR TITLE
Refactor IC motion socket setup

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -1021,7 +1021,6 @@ ensureInterconnectAddress(void)
 	if (GpIdentity.segindex >= 0)
 	{
 		Assert(Gp_role == GP_ROLE_EXECUTE);
-		Assert(MyProcPort != NULL);
 		Assert(MyProcPort->laddr.addr.ss_family == AF_INET
 				|| MyProcPort->laddr.addr.ss_family == AF_INET6);
 		/*
@@ -1055,8 +1054,7 @@ ensureInterconnectAddress(void)
 		 */
 		interconnect_address = qdHostname;
 	}
-	else
-		Assert(false);
+	Assert(interconnect_address && strlen(interconnect_address) > 0);
 }
 /*
  * performs all necessary setup required for Greenplum Database mode.

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -663,13 +663,7 @@ getCdbProcessesForQD(int isPrimary)
 
 	/*
 	 * Set QD listener address to the ADDRESS of the master, so the motions that connect to
-	 * the master knows what the interconnect address of the peer is. `adjustMasterRouting()`
-	 * is not necessary, and it could be wrong if the QD/QE on the master binds a single IP
-	 * address for interconnection instead of the wildcard address. Binding the wildcard address
-	 * for interconnection has some flaws:
-	 * 1. All the QD/QE in the same node share the same port space(for a same AF_INET/AF_INET6),
-	 *    which contributes to run out of port.
-	 * 2. When the segments have their own ADDRESS, the connection address could be confusing.
+	 * the master knows what the interconnect address of the peer is.
 	 */
 	proc->listenerAddr = pstrdup(qdinfo->config->hostip);
 

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -155,28 +155,18 @@ setupTCPListeningSocket(int backlog, int *listenerSocketFd, uint16 *listenerPort
 	memset(&hints, 0, sizeof(struct addrinfo));
 	hints.ai_family = AF_UNSPEC;	/* Allow IPv4 or IPv6 */
 	hints.ai_socktype = SOCK_STREAM;	/* Two-way, out of band connection */
-	hints.ai_flags = AI_PASSIVE;	/* For wildcard IP address */
 	hints.ai_protocol = 0;		/* Any protocol - TCP implied for network use due to SOCK_STREAM */
 
 	/*
-	 * We set interconnect_address on the primary to the local address of the connection from QD
-	 * to the primary, which is the primary's ADDRESS from gp_segment_configuration,
-	 * used for interconnection.
-	 * However it's wrong on the master. Because the connection from the client to the master may
-	 * have different IP addresses as its destination, which is very likely not the master's
-	 * ADDRESS in gp_segment_configuration.
+	 * Restrict what IP address we will listen on to just the one that was
+	 * used to create this QE session.
 	 */
-	if (interconnect_address)
-	{
-		/*
-		 * Restrict what IP address we will listen on to just the one that was
-		 * used to create this QE session.
-		 */
-		hints.ai_flags |= AI_NUMERICHOST;
-		ereport(DEBUG1, (errmsg("binding to %s only", interconnect_address)));
-		if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
-			ereport(DEBUG4, (errmsg("binding listener %s", interconnect_address)));
-	}
+	Assert(interconnect_address && strlen(interconnect_address) > 0);
+	hints.ai_flags |= AI_NUMERICHOST;
+	if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
+		ereport(DEBUG1,
+				(errmsg("getaddrinfo called with interconnect_address %s",
+						interconnect_address)));
 
 	s = getaddrinfo(interconnect_address, service, &hints, &addrs);
 	if (s != 0)

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -1187,7 +1187,6 @@ setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort, int *txFami
 	memset(&hints, 0, sizeof(struct addrinfo));
 	hints.ai_family = AF_UNSPEC;	/* Allow IPv4 or IPv6 */
 	hints.ai_socktype = SOCK_DGRAM; /* Datagram socket */
-	hints.ai_flags = AI_PASSIVE;	/* For wildcard IP address */
 	hints.ai_protocol = 0;		/* Any protocol - UDP implied for network use due to SOCK_DGRAM */
 
 #ifdef USE_ASSERT_CHECKING
@@ -1197,24 +1196,16 @@ setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort, int *txFami
 
 	fun = "getaddrinfo";
 	/*
-	 * We set interconnect_address on the primary to the local address of the connection from QD
-	 * to the primary, which is the primary's ADDRESS from gp_segment_configuration,
-	 * used for interconnection.
-	 * However it's wrong on the master. Because the connection from the client to the master may
-	 * have different IP addresses as its destination, which is very likely not the master's
-	 * ADDRESS in gp_segment_configuration.
+	 * Restrict what IP address we will listen on to just the one that was
+	 * used to create this QE session.
 	 */
-	if (interconnect_address)
-	{
-		/*
-		 * Restrict what IP address we will listen on to just the one that was
-		 * used to create this QE session.
-		 */
-		hints.ai_flags |= AI_NUMERICHOST;
-		ereport(DEBUG1, (errmsg("binding to %s only", interconnect_address)));
-		if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
-			ereport(DEBUG4, (errmsg("binding address %s", interconnect_address)));
-	}
+	Assert(interconnect_address && strlen(interconnect_address) > 0);
+	hints.ai_flags |= AI_NUMERICHOST;
+	if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
+		ereport(DEBUG1,
+				(errmsg("getaddrinfo called with interconnect_address %s",
+								interconnect_address)));
+
 	s = getaddrinfo(interconnect_address, service, &hints, &addrs);
 	if (s != 0)
 		elog(ERROR, "getaddrinfo says %s", gai_strerror(s));

--- a/src/test/regress/expected/motion_socket.out
+++ b/src/test/regress/expected/motion_socket.out
@@ -1,0 +1,71 @@
+-- The following test checks if the correct number and type of sockets are
+-- created for motion connections both on QD and QE backends for the same
+-- gp_session_id. Additionally we check if the source address used for creating
+-- the motion sockets is equal to gp_segment_configuration.address.
+-- start_matchignore
+-- m/^INFO:  Checking postgres backend postgres:*/
+-- end_matchignore
+CREATE FUNCTION check_motion_sockets()
+    RETURNS VOID as $$
+import psutil, socket
+
+# Create a temporary table to create a gang
+plpy.execute("CREATE TEMP TABLE motion_socket_force_create_gang(i int);")
+
+# We expect different number of sockets to be created for different
+# interconnect types
+# UDP: See calls to setupUDPListeningSocket in InitMotionUDPIFC
+# TCP/PROXY: See call to setupTCPListeningSocket in InitMotionTCP
+res = plpy.execute("SELECT current_setting('gp_interconnect_type');", 1)
+ic_type = res[0]['current_setting']
+if ic_type in ['tcp', 'proxy']:
+    expected_socket_count_per_segment = 1
+    expected_socket_kind = socket.SocketKind.SOCK_STREAM
+elif ic_type=='udpifc':
+    expected_socket_count_per_segment = 2
+    expected_socket_kind = socket.SocketKind.SOCK_DGRAM
+else:
+    plpy.error('Unrecognized gp_interconnect_type {}.'.format(ic_type))
+
+# Since this test is run on a single physical host we assume that all segments
+# have the same gp_segment_configuration.address
+res = plpy.execute("SELECT address FROM gp_segment_configuration;", 1)
+hostip = socket.gethostbyname(res[0]['address'])
+
+res = plpy.execute("SELECT current_setting('gp_session_id');", 1)
+qd_backend_conn_id = res[0]['current_setting']
+
+for process in psutil.process_iter():
+    # We iterate through all backends related to connection id
+    # of current session
+    # Exclude zombies to avoid psutil.ZombieProcess exceptions
+    # on calling process.cmdline()
+    if process.name() == 'postgres' and process.status() != psutil.STATUS_ZOMBIE:
+        if ' con' + qd_backend_conn_id + ' ' in process.cmdline()[0]:
+            motion_socket_count = 0
+            plpy.info('Checking postgres backend {}'.format(process.cmdline()[0]))
+            for conn in process.connections():
+                if conn.type == expected_socket_kind and conn.raddr == () \
+                and conn.laddr.ip == hostip:
+                    motion_socket_count += 1
+
+            if motion_socket_count != expected_socket_count_per_segment:
+                plpy.error('Expected {} motion sockets but found {}. '\
+                'For backend process {}. connections= {}'\
+                .format(expected_socket_count_per_segment, process,\
+                motion_socket_count, process.connections()))
+
+
+$$ LANGUAGE plpython3u EXECUTE ON MASTER;
+SELECT check_motion_sockets();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Checking postgres backend postgres:  7000, vanjared regression 127.0.0.1(59545) con1812 cmd2 SELECT
+INFO:  Checking postgres backend postgres:  7002, vanjared regression 127.0.0.1(59550) con1812 seg0 idle in transaction
+INFO:  Checking postgres backend postgres:  7003, vanjared regression 127.0.0.1(59551) con1812 seg1 idle in transaction
+INFO:  Checking postgres backend postgres:  7004, vanjared regression 127.0.0.1(59552) con1812 seg2 idle in transaction
+ check_motion_sockets 
+----------------------
+ 
+(1 row)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -293,4 +293,7 @@ test: run_utility_gpexpand_phase1
 # check correct error message when create extension error on segment
 test: create_extension_fail
 
+# test if motion sockets are created with the gp_segment_configuration.address
+test: motion_socket
+
 # end of tests

--- a/src/test/regress/sql/motion_socket.sql
+++ b/src/test/regress/sql/motion_socket.sql
@@ -1,0 +1,62 @@
+-- The following test checks if the correct number and type of sockets are
+-- created for motion connections both on QD and QE backends for the same
+-- gp_session_id. Additionally we check if the source address used for creating
+-- the motion sockets is equal to gp_segment_configuration.address.
+
+
+-- start_matchignore
+-- m/^INFO:  Checking postgres backend postgres:*/
+-- end_matchignore
+CREATE FUNCTION check_motion_sockets()
+    RETURNS VOID as $$
+import psutil, socket
+
+# Create a temporary table to create a gang
+plpy.execute("CREATE TEMP TABLE motion_socket_force_create_gang(i int);")
+
+# We expect different number of sockets to be created for different
+# interconnect types
+# UDP: See calls to setupUDPListeningSocket in InitMotionUDPIFC
+# TCP/PROXY: See call to setupTCPListeningSocket in InitMotionTCP
+res = plpy.execute("SELECT current_setting('gp_interconnect_type');", 1)
+ic_type = res[0]['current_setting']
+if ic_type in ['tcp', 'proxy']:
+    expected_socket_count_per_segment = 1
+    expected_socket_kind = socket.SocketKind.SOCK_STREAM
+elif ic_type=='udpifc':
+    expected_socket_count_per_segment = 2
+    expected_socket_kind = socket.SocketKind.SOCK_DGRAM
+else:
+    plpy.error('Unrecognized gp_interconnect_type {}.'.format(ic_type))
+
+# Since this test is run on a single physical host we assume that all segments
+# have the same gp_segment_configuration.address
+res = plpy.execute("SELECT address FROM gp_segment_configuration;", 1)
+hostip = socket.gethostbyname(res[0]['address'])
+
+res = plpy.execute("SELECT current_setting('gp_session_id');", 1)
+qd_backend_conn_id = res[0]['current_setting']
+
+for process in psutil.process_iter():
+    # We iterate through all backends related to connection id
+    # of current session
+    # Exclude zombies to avoid psutil.ZombieProcess exceptions
+    # on calling process.cmdline()
+    if process.name() == 'postgres' and process.status() != psutil.STATUS_ZOMBIE:
+        if ' con' + qd_backend_conn_id + ' ' in process.cmdline()[0]:
+            motion_socket_count = 0
+            plpy.info('Checking postgres backend {}'.format(process.cmdline()[0]))
+            for conn in process.connections():
+                if conn.type == expected_socket_kind and conn.raddr == () \
+                and conn.laddr.ip == hostip:
+                    motion_socket_count += 1
+
+            if motion_socket_count != expected_socket_count_per_segment:
+                plpy.error('Expected {} motion sockets but found {}. '\
+                'For backend process {}. connections= {}'\
+                .format(expected_socket_count_per_segment, process,\
+                motion_socket_count, process.connections()))
+
+
+$$ LANGUAGE plpython3u EXECUTE ON MASTER;
+SELECT check_motion_sockets();


### PR DESCRIPTION
- Assert that interconnect_address is always set, in order to get rid of
  conditional code
- Remove AI_PASSIVE flag from socket setup functions (it was being
  ignored anyway as we always pass a unicast address to getaddrinfo)
- Comment cleanup
- Added regress test for checking motion socket 

Co-authored-by: Soumyadeep Chakraborty <soumyadeep2007@gmail.com>

Pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-refactor_ic_addr
This is a follow-up for https://github.com/greenplum-db/gpdb/pull/9696. Once we merge this, we are considering backporting the changes in #9696 along with the changes in this PR.