### PR TITLE
Fix test case notin.

### DIFF
--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -1297,6 +1297,8 @@ fetch_outer_exprs(Node *testexpr)
 		else
 			return NIL;
 	}
+	else if (IsA(testexpr, OpExpr))
+		return list_make1(linitial(((OpExpr *)testexpr)->args));
 	else
 		return NIL;
 }

--- a/src/backend/optimizer/prep/prepjointree.c
+++ b/src/backend/optimizer/prep/prepjointree.c
@@ -658,7 +658,7 @@ pull_up_sublinks_qual_recurse(PlannerInfo *root, Node *node,
 			else if (sublink->subLinkType == ANY_SUBLINK || sublink->subLinkType == ALL_SUBLINK)
 			{
 				sublink->subLinkType = (sublink->subLinkType == ANY_SUBLINK) ? ALL_SUBLINK : ANY_SUBLINK;
-				sublink->testexpr = (Node *) canonicalize_qual(negate_clause(sublink->testexpr), false);
+				sublink->testexpr = (Node *) canonicalize_qual((Expr *) negate_clause(sublink->testexpr), false);
 				return pull_up_sublinks_qual_recurse(root, (Node *) sublink,
 														jtlink1, available_rels1,
 														jtlink2, available_rels2);


### PR DESCRIPTION
Commit fe44b1f7a use negate_clause instead of make_notclause,
this might lead to (NOT =) become <>, semantically they should
be the same. But in later convert_IN_to_antijoin, it does not
consider sublink expr is OpExpr thus fails a test case notin.

This commit fixes the failure case by considering OpExpr in
convert_IN_to_antijoin.

------


No test cases needed. This just fixes a test case faliure.