### PR TITLE
remove redundant codes of invoking paramFetch before preprocess_initplans

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -603,31 +603,6 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 			 */
 			if (list_length(queryDesc->plannedstmt->paramExecTypes) > 0)
 			{
-				ParamListInfoData *pli = queryDesc->params;
-
-				/*
-				 * First, use paramFetch to fetch any "lazy" parameters, so that
-				 * they are dispatched along with the queries. The QE nodes cannot
-				 * call the callback function on their own.
-				 */
-				if (pli && pli->paramFetch)
-				{
-					int			iparam;
-
-					for (iparam = 0; iparam < queryDesc->params->numParams; iparam++)
-					{
-						ParamExternData *prm = &pli->params[iparam];
-						ParamExternData prmdata;
-
-						/*
-						 * GPDB_12_MERGE_FIXME: What should speculative value
-						 * should paramFetch be called with?
-						 */
-						if (!OidIsValid(prm->ptype))
-							(*pli->paramFetch) (pli, iparam + 1, false, &prmdata);
-					}
-				}
-
 				preprocess_initplans(queryDesc);
 			}
 

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -602,9 +602,7 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 			 * First, pre-execute any initPlan subplans.
 			 */
 			if (list_length(queryDesc->plannedstmt->paramExecTypes) > 0)
-			{
 				preprocess_initplans(queryDesc);
-			}
 
 			if (toplevelOidCache != NIL)
 			{


### PR DESCRIPTION
ParamListInfo structures are used to pass parameters into the executor
for parameterized plans.  We support two basic approaches to supplying
parameter values, the "static" way and the "dynamic" way.

In the dynamic approach, all access to parameter values is done through
hook functions found in the ParamListInfo struct. The params will be
lazily evaluated in Executor. And more specifically, dynamic approach is
designed for plpgsql, there has a complete mechanism internally to call 
the `plpgsql_param_fetch` method to obtain dynamic parameters from 
the entrance of `plpgsql_call_handler()`.

In conclusion, we don't need to explicitly call the `paramFetch` method 
to get dynamic parameters before `preprocess_initplans`, but get them 
during the actual execution.

No more tests need, already have regression tests will go through the 
deleted code branch, such as `plpgsql_cache`, `plpgsql`, `case_gp`, etc. 
So no need to add more tests for this PR.
