### PR TITLE
drop s3 external table in test cases

### DIFF
--- a/gpcontrib/gpcloud/regress/input/3_01_create_wet.source
+++ b/gpcontrib/gpcloud/regress/input/3_01_create_wet.source
@@ -7,3 +7,4 @@ CREATE WRITABLE EXTERNAL TABLE s3regress_create_wet_on_master (date text) LOCATI
 EXPLAIN (verbose, costs off) INSERT INTO s3regress_create_wet_on_master VALUES ('aaa');
 
 DROP EXTERNAL TABLE s3regress_create_wet;
+DROP EXTERNAL TABLE s3regress_create_wet_on_master;

--- a/gpcontrib/gpcloud/regress/output/3_01_create_wet.source
+++ b/gpcontrib/gpcloud/regress/output/3_01_create_wet.source
@@ -12,3 +12,4 @@ EXPLAIN (verbose, costs off) INSERT INTO s3regress_create_wet_on_master VALUES (
 (4 rows)
 
 DROP EXTERNAL TABLE s3regress_create_wet;
+DROP EXTERNAL TABLE s3regress_create_wet_on_master;


### PR DESCRIPTION
drop the s3 external table in test cases to make sure the final `DROP PROTOCOL IF EXISTS s3` operation success

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
