### PR TITLE
docs - clarify gp_toolkit.gp_stats_missing smirecs description

### DIFF
--- a/gpdb-doc/dita/ref_guide/gp_toolkit.xml
+++ b/gpdb-doc/dita/ref_guide/gp_toolkit.xml
@@ -156,7 +156,8 @@
               </row>
               <row class="- topic/row ">
                 <entry colname="col1" class="- topic/entry ">smirecs </entry>
-                <entry colname="col2" class="- topic/entry ">Number of rows in the table.</entry>
+                <entry colname="col2" class="- topic/entry ">The total number of columns in
+                  the table that have statistics recorded.</entry>
               </row>
             </tbody>
           </tgroup>


### PR DESCRIPTION
resolves https://github.com/greenplum-db/gpdb/issues/10777.

will be backported to 6X_STABLE.
