### PR TITLE
Restore visibility of some GUCs to be viewable from pg_settings

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2633,7 +2633,7 @@ static struct config_int ConfigureNamesInt[] =
 		{"checkpoint_timeout", PGC_SIGHUP, WAL_CHECKPOINTS,
 			gettext_noop("Sets the maximum time between automatic WAL checkpoints."),
 			NULL,
-			GUC_UNIT_S | GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_DISALLOW_USER_SET
+			GUC_UNIT_S | GUC_NOT_IN_SAMPLE | GUC_DISALLOW_USER_SET
 		},
 		&CheckPointTimeout,
 		300, 30, 86400,
@@ -3555,7 +3555,7 @@ static struct config_string ConfigureNamesString[] =
 		{"archive_command", PGC_SIGHUP, WAL_ARCHIVING,
 			gettext_noop("Sets the shell command that will be called to archive a WAL file."),
 			NULL,
-			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL
+			GUC_NOT_IN_SAMPLE
 		},
 		&XLogArchiveCommand,
 		"",
@@ -4069,7 +4069,7 @@ static struct config_string ConfigureNamesString[] =
 		{"data_directory", PGC_POSTMASTER, FILE_LOCATIONS,
 			gettext_noop("Sets the server's data directory."),
 			NULL,
-			GUC_SUPERUSER_ONLY | GUC_DISALLOW_IN_AUTO_FILE | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_SUPERUSER_ONLY | GUC_DISALLOW_IN_AUTO_FILE | GUC_NOT_IN_SAMPLE
 		},
 		&data_directory,
 		NULL,


### PR DESCRIPTION
The checkpoint_timeout, archive_command, and data_directory GUC
settings were hidden back in the early GPDB 4.0.X days to prevent
users from messing with them. It should be fine to realign the
visibility of these GUCs with how they are in Postgres
(checkpoint_timeout and archive_command visible to all users and
data_directory visible to superusers or users with
pg_read_all_settings permission). They won't be documented in
Greenplum GUC documentation so they'll still be somewhat hidden to
individual users but not for us developers and the tools we build that
may require checking their GUC values. This is mainly needed now to
allow external tools such as pgbackrest to work properly.

Edit: Updated opening comment to reflect the new commit message.