### PR TITLE
use COORDINATOR_ONLY instead of MASTER_ONLY for gpdb master

### DIFF
--- a/gpcontrib/gp_exttable_fdw/extaccess.c
+++ b/gpcontrib/gp_exttable_fdw/extaccess.c
@@ -548,7 +548,7 @@ external_insert_init(Relation rel)
 	 */
 	extInsertDesc = (ExternalInsertDesc) palloc0(sizeof(ExternalInsertDescData));
 	extInsertDesc->ext_rel = rel;
-	if (strcmp(on_clause, "MASTER_ONLY") == 0)
+	if (strcmp(on_clause, "COORDINATOR_ONLY") == 0)
 		extInsertDesc->ext_noop = false;
 	else
 		extInsertDesc->ext_noop = (Gp_role == GP_ROLE_DISPATCH);


### PR DESCRIPTION
`on master` clause has been replaced by `on coordinator` on gpdb master.
so we have to check COORDINATOR_ONLY instead of MASTER_ONLY in external table options.

This PR is used to fix the failed cases due to #13307 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
