### PR TITLE
6X: Use a unicast IP address for motion sockets

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -1021,7 +1021,6 @@ ensureInterconnectAddress(void)
 	if (GpIdentity.segindex >= 0)
 	{
 		Assert(Gp_role == GP_ROLE_EXECUTE);
-		Assert(MyProcPort != NULL);
 		Assert(MyProcPort->laddr.addr.ss_family == AF_INET
 				|| MyProcPort->laddr.addr.ss_family == AF_INET6);
 		/*
@@ -1055,8 +1054,7 @@ ensureInterconnectAddress(void)
 		 */
 		interconnect_address = qdHostname;
 	}
-	else
-		Assert(false);
+	Assert(interconnect_address && strlen(interconnect_address) > 0);
 }
 /*
  * performs all necessary setup required for Greenplum Database mode.

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -48,11 +48,13 @@
 #include "libpq-fe.h"
 #include "libpq-int.h"
 #include "libpq/ip.h"
+#include "miscadmin.h"		/* MyProcPort */
 #include "cdb/cdbconn.h"
 #include "cdb/cdbfts.h"
 #include "storage/ipc.h"
 #include "storage/proc.h"
 #include "postmaster/fts.h"
+#include "postmaster/postmaster.h"
 #include "catalog/namespace.h"
 #include "utils/gpexpand.h"
 #include "access/xact.h"
@@ -1010,6 +1012,52 @@ cdbcomponent_getComponentInfo(int contentId)
 	return cdbInfo;
 }
 
+static void
+ensureInterconnectAddress(void)
+{
+	if (interconnect_address)
+		return;
+
+	if (GpIdentity.segindex >= 0)
+	{
+		Assert(Gp_role == GP_ROLE_EXECUTE);
+		Assert(MyProcPort != NULL);
+		Assert(MyProcPort->laddr.addr.ss_family == AF_INET
+				|| MyProcPort->laddr.addr.ss_family == AF_INET6);
+		/*
+		 * We assume that the QD, using the address in gp_segment_configuration
+		 * as its destination IP address, connects to the segment/QE.
+		 * So, the local address in the PORT can be used for interconnect.
+		 */
+		char local_addr[NI_MAXHOST];
+		getnameinfo((const struct sockaddr *)&MyProcPort->laddr.addr,
+					MyProcPort->laddr.salen,
+					local_addr, sizeof(local_addr),
+					NULL, 0, NI_NUMERICHOST);
+		interconnect_address = MemoryContextStrdup(TopMemoryContext, local_addr);
+	}
+	else if (Gp_role == GP_ROLE_DISPATCH)
+	{
+		/*
+		 * Here, we can only retrieve the ADDRESS in gp_segment_configuration
+		 * from `cdbcomponent*`. We couldn't get it in a way as the QEs.
+		 */
+		CdbComponentDatabaseInfo *qdInfo;
+		qdInfo = cdbcomponent_getComponentInfo(MASTER_CONTENT_ID);
+		interconnect_address = MemoryContextStrdup(TopMemoryContext, qdInfo->config->hostip);
+	}
+	else if (qdHostname && qdHostname[0] != '\0')
+	{
+		Assert(Gp_role == GP_ROLE_EXECUTE);
+		/*
+		 * QE on the master can't get its interconnect address like that on the primary.
+		 * The QD connects to its postmaster via the unix domain socket.
+		 */
+		interconnect_address = qdHostname;
+	}
+	else
+		Assert(false);
+}
 /*
  * performs all necessary setup required for Greenplum Database mode.
  *
@@ -1023,6 +1071,7 @@ cdb_setup(void)
 	/* If gp_role is UTILITY, skip this call. */
 	if (Gp_role != GP_ROLE_UTILITY)
 	{
+		ensureInterconnectAddress();
 		/* Initialize the Motion Layer IPC subsystem. */
 		InitMotionLayerIPC();
 	}

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -668,13 +668,7 @@ getCdbProcessesForQD(int isPrimary)
 
 	/*
 	 * Set QD listener address to the ADDRESS of the master, so the motions that connect to
-	 * the master knows what the interconnect address of the peer is. `adjustMasterRouting()`
-	 * is not necessary, and it could be wrong if the QD/QE on the master binds a single IP
-	 * address for interconnection instead of the wildcard address. Binding the wildcard address
-	 * for interconnection has some flaws:
-	 * 1. All the QD/QE in the same node share the same port space(for a same AF_INET/AF_INET6),
-	 *    which contributes to run out of port.
-	 * 2. When the segments have their own ADDRESS, the connection address could be confusing.
+	 * the master knows what the interconnect address of the peer is.
 	 */
 	proc->listenerAddr = pstrdup(qdinfo->config->hostip);
 

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -667,10 +667,16 @@ getCdbProcessesForQD(int isPrimary)
 	proc = makeNode(CdbProcess);
 
 	/*
-	 * Set QD listener address to NULL. This will be filled during starting up
-	 * outgoing interconnect connection.
+	 * Set QD listener address to the ADDRESS of the master, so the motions that connect to
+	 * the master knows what the interconnect address of the peer is. `adjustMasterRouting()`
+	 * is not necessary, and it could be wrong if the QD/QE on the master binds a single IP
+	 * address for interconnection instead of the wildcard address. Binding the wildcard address
+	 * for interconnection has some flaws:
+	 * 1. All the QD/QE in the same node share the same port space(for a same AF_INET/AF_INET6),
+	 *    which contributes to run out of port.
+	 * 2. When the segments have their own ADDRESS, the connection address could be confusing.
 	 */
-	proc->listenerAddr = NULL;
+	proc->listenerAddr = pstrdup(qdinfo->config->hostip);
 
 	if (Gp_interconnect_type == INTERCONNECT_TYPE_UDPIFC)
 		proc->listenerPort = (Gp_listener_port >> 16) & 0x0ffff;

--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -872,3 +872,37 @@ interconnect_abort_callback(ResourceReleasePhase phase,
 		}
 	}
 }
+
+/*
+ * format_sockaddr
+ *			Format a sockaddr to a human readable string
+ *
+ * This function must be kept threadsafe, elog/ereport/palloc etc are not
+ * allowed within this function.
+ */
+char *
+format_sockaddr(struct sockaddr_storage *sa, char *buf, size_t len)
+{
+	int			ret;
+	char		remote_host[NI_MAXHOST];
+	char		remote_port[NI_MAXSERV];
+
+	ret = pg_getnameinfo_all(sa, sizeof(struct sockaddr_storage),
+							 remote_host, sizeof(remote_host),
+							 remote_port, sizeof(remote_port),
+							 NI_NUMERICHOST | NI_NUMERICSERV);
+
+	if (ret != 0)
+		snprintf(buf, len, "?host?:?port?");
+	else
+	{
+#ifdef HAVE_IPV6
+		if (sa->ss_family == AF_INET6)
+			snprintf(buf, len, "[%s]:%s", remote_host, remote_port);
+		else
+#endif
+			snprintf(buf, len, "%s:%s", remote_host, remote_port);
+	}
+
+	return buf;
+}

--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -713,33 +713,6 @@ removeChunkTransportState(ChunkTransportState *transportStates,
 }
 
 /*
- * Set the listener address associated with the slice to
- * the master address that is established through libpq
- * connection. This guarantees that the outgoing connections
- * will connect to an address that is reachable in the event
- * when the master can not be reached by segments through
- * the network interface recorded in the catalog.
- */
-void
-adjustMasterRouting(Slice *recvSlice)
-{
-	ListCell   *lc = NULL;
-
-	Assert(MyProcPort);
-
-	foreach(lc, recvSlice->primaryProcesses)
-	{
-		CdbProcess *cdbProc = (CdbProcess *) lfirst(lc);
-
-		if (cdbProc)
-		{
-			if (cdbProc->listenerAddr == NULL)
-				cdbProc->listenerAddr = pstrdup(MyProcPort->remote_host);
-		}
-	}
-}
-
-/*
  * checkForCancelFromQD
  * 		Check for cancel from QD.
  *

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -20,6 +20,7 @@
 #include "miscadmin.h"
 #include "libpq/libpq-be.h"
 #include "libpq/ip.h"
+#include "postmaster/postmaster.h"
 #include "utils/builtins.h"
 
 #include "cdb/cdbselect.h"
@@ -126,8 +127,6 @@ setupTCPListeningSocket(int backlog, int *listenerSocketFd, uint16 *listenerPort
 			   *rp;
 	int			s;
 	char		service[32];
-	char		myname[128];
-	char	   *localname = NULL;
 
 	/*
 	 * we let the system pick the TCP port here so we don't have to manage
@@ -141,31 +140,26 @@ setupTCPListeningSocket(int backlog, int *listenerSocketFd, uint16 *listenerPort
 	hints.ai_protocol = 0;		/* Any protocol */
 
 	/*
-	 * We use INADDR_ANY if we don't have a valid address for ourselves (e.g.
-	 * QD local connections tend to be AF_UNIX, or on 127.0.0.1 -- so bind
-	 * everything)
+	 * We set interconnect_address on the primary to the local address of the connection from QD
+	 * to the primary, which is the primary's ADDRESS from gp_segment_configuration,
+	 * used for interconnection.
+	 * However it's wrong on the master. Because the connection from the client to the master may
+	 * have different IP addresses as its destination, which is very likely not the master's
+	 * ADDRESS in gp_segment_configuration.
 	 */
-	if (Gp_role == GP_ROLE_DISPATCH || MyProcPort == NULL ||
-		(MyProcPort->laddr.addr.ss_family != AF_INET &&
-		 MyProcPort->laddr.addr.ss_family != AF_INET6))
-		localname = NULL;		/* We will listen on all network adapters */
-	else
+	if (interconnect_address)
 	{
 		/*
 		 * Restrict what IP address we will listen on to just the one that was
 		 * used to create this QE session.
 		 */
-		getnameinfo((const struct sockaddr *) &(MyProcPort->laddr.addr), MyProcPort->laddr.salen,
-					myname, sizeof(myname),
-					NULL, 0, NI_NUMERICHOST);
 		hints.ai_flags |= AI_NUMERICHOST;
-		localname = myname;
-		elog(DEBUG1, "binding to %s only", localname);
+		ereport(DEBUG1, (errmsg("binding to %s only", interconnect_address)));
 		if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
-			ereport(DEBUG4, (errmsg("binding listener %s", localname)));
+			ereport(DEBUG4, (errmsg("binding listener %s", interconnect_address)));
 	}
 
-	s = getaddrinfo(localname, service, &hints, &addrs);
+	s = getaddrinfo(interconnect_address, service, &hints, &addrs);
 	if (s != 0)
 		elog(ERROR, "getaddrinfo says %s", gai_strerror(s));
 
@@ -499,8 +493,6 @@ startOutgoingConnections(ChunkTransportState *transportStates,
 	*pOutgoingCount = 0;
 
 	recvSlice = (Slice *) list_nth(transportStates->sliceTable->slices, sendSlice->parentIndex);
-
-	adjustMasterRouting(recvSlice);
 
 	if (gp_interconnect_aggressive_retry)
 	{

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -68,8 +68,6 @@ static ChunkTransportStateEntry *startOutgoingConnections(ChunkTransportState *t
 						 int *pOutgoingCount);
 
 static void format_fd_set(StringInfo buf, int nfds, mpp_fd_set *fds, char *pfx, char *sfx);
-static char *format_sockaddr(struct sockaddr *sa, char *buf, int bufsize);
-
 static void setupOutgoingConnection(ChunkTransportState *transportStates,
 						ChunkTransportStateEntry *pEntry, MotionConn *conn);
 static void updateOutgoingConnection(ChunkTransportState *transportStates,
@@ -598,10 +596,10 @@ setupOutgoingConnection(ChunkTransportState *transportStates, ChunkTransportStat
 #ifdef ENABLE_IC_PROXY
 	if (Gp_interconnect_type == INTERCONNECT_TYPE_PROXY)
 	{
-		/* 
+		/*
 		 * Using libuv pipe to register backend to proxy.
 		 * ic_proxy_backend_connect only appends the connect request into
-		 * connection queue and waits for the libuv_run_loop to handle the queue. 
+		 * connection queue and waits for the libuv_run_loop to handle the queue.
 		 */
 		ic_proxy_backend_connect(transportStates->proxyContext,
 								 pEntry, conn, true);
@@ -807,7 +805,7 @@ sendRegisterMessage(ChunkTransportState *transportStates, ChunkTransportStateEnt
 					 errdetail("getsockname sockfd=%d remote=%s: %m",
 							   conn->sockfd, conn->remoteHostAndPort)));
 		}
-		format_sockaddr((struct sockaddr *) &localAddr, conn->localHostAndPort,
+		format_sockaddr(&localAddr, conn->localHostAndPort,
 						sizeof(conn->localHostAndPort));
 
 		if (gp_log_interconnect >= GPVARS_VERBOSITY_VERBOSE)
@@ -1202,7 +1200,7 @@ acceptIncomingConnection(void)
 	conn->remoteContentId = -2;
 
 	/* Save remote and local host:port strings for error messages. */
-	format_sockaddr((struct sockaddr *) &remoteAddr, conn->remoteHostAndPort,
+	format_sockaddr(&remoteAddr, conn->remoteHostAndPort,
 					sizeof(conn->remoteHostAndPort));
 	addrsize = sizeof(localAddr);
 	if (getsockname(newsockfd, (struct sockaddr *) &localAddr, &addrsize))
@@ -1213,7 +1211,7 @@ acceptIncomingConnection(void)
 				 errdetail("getsockname sockfd=%d remote=%s: %m",
 						   newsockfd, conn->remoteHostAndPort)));
 	}
-	format_sockaddr((struct sockaddr *) &localAddr, conn->localHostAndPort,
+	format_sockaddr(&localAddr, conn->localHostAndPort,
 					sizeof(conn->localHostAndPort));
 
 	/* make socket non-blocking */
@@ -1334,11 +1332,11 @@ SetupTCPInterconnect(EState *estate)
 				{
 					incoming_count++;
 
-					/* 
+					/*
 					 * Using libuv pipe to register backend to proxy.
 					 * ic_proxy_backend_connect only appends the connect request
 					 * into connection queue and waits for the libuv_run_loop to
-					 * handle the queue. 
+					 * handle the queue.
 					 */
 					ic_proxy_backend_connect(interconnect_context->proxyContext,
 											 pEntry, conn, false /* isSender */);
@@ -2212,80 +2210,6 @@ format_fd_set(StringInfo buf, int nfds, mpp_fd_set *fds, char *pfx, char *sfx)
 	appendStringInfoString(buf, sfx);
 }
 
-static char *
-format_sockaddr(struct sockaddr *sa, char *buf, int bufsize)
-{
-	/* Save remote host:port string for error messages. */
-	if (sa->sa_family == AF_INET)
-	{
-		struct sockaddr_in *sin = (struct sockaddr_in *) sa;
-		uint32		saddr = ntohl(sin->sin_addr.s_addr);
-
-		snprintf(buf, bufsize, "%d.%d.%d.%d:%d",
-				 (saddr >> 24) & 0xff,
-				 (saddr >> 16) & 0xff,
-				 (saddr >> 8) & 0xff,
-				 saddr & 0xff,
-				 ntohs(sin->sin_port));
-	}
-#ifdef HAVE_IPV6
-	else if (sa->sa_family == AF_INET6)
-	{
-		char		remote_port[32] = {'\0'};
-
-		if (bufsize > 10)
-		{
-			buf[0] = '[';
-
-			/*
-			 * inet_ntop isn't portable. //inet_ntop(AF_INET6,
-			 * &sin6->sin6_addr, buf, bufsize - 8);
-			 *
-			 * postgres has a standard routine for converting addresses to
-			 * printable format, which works for IPv6, IPv4, and Unix domain
-			 * sockets.  I've changed this routine to use that, but I think
-			 * the entire format_sockaddr routine could be replaced with it.
-			 */
-			int			ret = pg_getnameinfo_all((const struct sockaddr_storage *) sa, sizeof(struct sockaddr_storage),
-												 buf + 1, bufsize - 10,
-												 remote_port, sizeof(remote_port),
-												 NI_NUMERICHOST | NI_NUMERICSERV);
-
-			if (ret != 0)
-			{
-				elog(LOG, "getnameinfo returned %d: %s, and says %s port %s", ret, gai_strerror(ret), buf, remote_port);
-
-				/*
-				 * Fall back to using our internal inet_ntop routine, which
-				 * really is for inet datatype This is because of a bug in
-				 * solaris, where getnameinfo sometimes fails Once we find out
-				 * why, we can remove this
-				 */
-				snprintf(remote_port, sizeof(remote_port), "%d", ((struct sockaddr_in6 *) sa)->sin6_port);
-
-				/*
-				 * This is nasty: our internal inet_net_ntop takes
-				 * PGSQL_AF_INET6, not AF_INET6, which is very odd... They are
-				 * NOT the same value (even though PGSQL_AF_INET == AF_INET
-				 */
-#define PGSQL_AF_INET6	(AF_INET + 1)
-				inet_net_ntop(PGSQL_AF_INET6, sa, sizeof(struct sockaddr_in6), buf + 1, bufsize - 10);
-				elog(LOG, "Our alternative method says %s]:%s", buf, remote_port);
-
-			}
-			buf += strlen(buf);
-			strcat(buf, "]");
-			buf++;
-		}
-		snprintf(buf, 8, ":%s", remote_port);
-	}
-#endif
-	else
-		snprintf(buf, bufsize, "?host?:?port?");
-
-	return buf;
-}								/* format_sockaddr */
-
 static void
 flushInterconnectListenerBacklog(void)
 {
@@ -2326,7 +2250,7 @@ flushInterconnectListenerBacklog(void)
 				if (gp_log_interconnect >= GPVARS_VERBOSITY_VERBOSE)
 				{
 					/* Get remote and local host:port strings for message. */
-					format_sockaddr((struct sockaddr *) &remoteAddr, remoteHostAndPort,
+					format_sockaddr(&remoteAddr, remoteHostAndPort,
 									sizeof(remoteHostAndPort));
 					addrsize = sizeof(localAddr);
 					if (getsockname(newfd, (struct sockaddr *) &localAddr, &addrsize))
@@ -2339,7 +2263,7 @@ flushInterconnectListenerBacklog(void)
 					}
 					else
 					{
-						format_sockaddr((struct sockaddr *) &localAddr, localHostAndPort,
+						format_sockaddr(&localAddr, localHostAndPort,
 										sizeof(localHostAndPort));
 						ereport(DEBUG2, (errmsg("Interconnect clearing incoming connection "
 												"from remote=%s to local=%s.  sockfd=%d.",
@@ -2622,7 +2546,7 @@ RecvTupleChunkFromAnyTCP(ChunkTransportState *transportStates,
 
 		struct timeval timeout = tval;
 		int	nfds = pEntry->highReadSock;
-		
+
 		/* make sure we check for these. */
 		ML_CHECK_FOR_INTERRUPTS(transportStates->teardownActive);
 
@@ -2651,7 +2575,7 @@ RecvTupleChunkFromAnyTCP(ChunkTransportState *transportStates,
 		if (skipSelect)
 			break;
 
-		/* 
+		/*
 		 * Also monitor the events on dispatch fds, eg, errors or sequence
 		 * request from QEs.
 		 */

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -136,28 +136,18 @@ setupTCPListeningSocket(int backlog, int *listenerSocketFd, uint16 *listenerPort
 	memset(&hints, 0, sizeof(struct addrinfo));
 	hints.ai_family = AF_UNSPEC;	/* Allow IPv4 or IPv6 */
 	hints.ai_socktype = SOCK_STREAM;	/* TCP socket */
-	hints.ai_flags = AI_PASSIVE;	/* For wildcard IP address */
 	hints.ai_protocol = 0;		/* Any protocol */
 
 	/*
-	 * We set interconnect_address on the primary to the local address of the connection from QD
-	 * to the primary, which is the primary's ADDRESS from gp_segment_configuration,
-	 * used for interconnection.
-	 * However it's wrong on the master. Because the connection from the client to the master may
-	 * have different IP addresses as its destination, which is very likely not the master's
-	 * ADDRESS in gp_segment_configuration.
+	 * Restrict what IP address we will listen on to just the one that was
+	 * used to create this QE session.
 	 */
-	if (interconnect_address)
-	{
-		/*
-		 * Restrict what IP address we will listen on to just the one that was
-		 * used to create this QE session.
-		 */
-		hints.ai_flags |= AI_NUMERICHOST;
-		ereport(DEBUG1, (errmsg("binding to %s only", interconnect_address)));
-		if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
-			ereport(DEBUG4, (errmsg("binding listener %s", interconnect_address)));
-	}
+	Assert(interconnect_address && strlen(interconnect_address) > 0);
+	hints.ai_flags |= AI_NUMERICHOST;
+	if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
+		ereport(DEBUG1,
+				(errmsg("getaddrinfo called with interconnect_address %s",
+						interconnect_address)));
 
 	s = getaddrinfo(interconnect_address, service, &hints, &addrs);
 	if (s != 0)

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -671,7 +671,6 @@ static ChunkTransportStateEntry *startOutgoingUDPConnections(ChunkTransportState
 							int *pOutgoingCount);
 static void setupOutgoingUDPConnection(ChunkTransportState *transportStates,
 						   ChunkTransportStateEntry *pEntry, MotionConn *conn);
-static char *formatSockAddr(struct sockaddr *sa, char *buf, int bufsize);
 
 /* Connection hash table functions. */
 static bool initConnHashTable(ConnHashTable *ht, MemoryContext ctx);
@@ -2804,7 +2803,7 @@ setupOutgoingUDPConnection(ChunkTransportState *transportStates, ChunkTransportS
 	getSockAddr(&conn->peer, &conn->peer_len, cdbProc->listenerAddr, cdbProc->listenerPort);
 
 	/* Save the destination IP address */
-	formatSockAddr((struct sockaddr *) &conn->peer, conn->remoteHostAndPort,
+	format_sockaddr(&conn->peer, conn->remoteHostAndPort,
 				   sizeof(conn->remoteHostAndPort));
 
 	Assert(conn->peer.ss_family == AF_INET || conn->peer.ss_family == AF_INET6);
@@ -5756,96 +5755,6 @@ doSendStopMessageUDPIFC(ChunkTransportState *transportStates, int16 motNodeID)
 }
 
 /*
- * formatSockAddr
- * 		Format sockaddr.
- *
- * NOTE: Because this function can be called in a thread (rxThreadFunc),
- * it must not use services such as elog, ereport, palloc/pfree and StringInfo.
- * elog is NOT thread-safe.  Developers should instead use something like:
- *
- *	if (DEBUG3 >= log_min_messages)
- *		write_log("my brilliant log statement here.");
- */
-char *
-formatSockAddr(struct sockaddr *sa, char *buf, int bufsize)
-{
-	/* Save remote host:port string for error messages. */
-	if (sa->sa_family == AF_INET)
-	{
-		struct sockaddr_in *sin = (struct sockaddr_in *) sa;
-		uint32		saddr = ntohl(sin->sin_addr.s_addr);
-
-		snprintf(buf, bufsize, "%d.%d.%d.%d:%d",
-				 (saddr >> 24) & 0xff,
-				 (saddr >> 16) & 0xff,
-				 (saddr >> 8) & 0xff,
-				 saddr & 0xff,
-				 ntohs(sin->sin_port));
-	}
-#ifdef HAVE_IPV6
-	else if (sa->sa_family == AF_INET6)
-	{
-		char		remote_port[32];
-
-		remote_port[0] = '\0';
-		buf[0] = '\0';
-
-		if (bufsize > 10)
-		{
-			buf[0] = '[';
-			buf[1] = '\0';		/* in case getnameinfo fails */
-
-			/*
-			 * inet_ntop isn't portable. //inet_ntop(AF_INET6,
-			 * &sin6->sin6_addr, buf, bufsize - 8);
-			 *
-			 * postgres has a standard routine for converting addresses to
-			 * printable format, which works for IPv6, IPv4, and Unix domain
-			 * sockets.  I've changed this routine to use that, but I think
-			 * the entire formatSockAddr routine could be replaced with it.
-			 */
-			int			ret = pg_getnameinfo_all((const struct sockaddr_storage *) sa, sizeof(struct sockaddr_in6),
-												 buf + 1, bufsize - 10,
-												 remote_port, sizeof(remote_port),
-												 NI_NUMERICHOST | NI_NUMERICSERV);
-
-			if (ret != 0)
-			{
-				write_log("getnameinfo returned %d: %s, and says %s port %s",
-						  ret, gai_strerror(ret), buf, remote_port);
-
-				/*
-				 * Fall back to using our internal inet_ntop routine, which
-				 * really is for inet datatype This is because of a bug in
-				 * solaris, where getnameinfo sometimes fails Once we find out
-				 * why, we can remove this
-				 */
-				snprintf(remote_port, sizeof(remote_port), "%d", ((struct sockaddr_in6 *) sa)->sin6_port);
-
-				/*
-				 * This is nasty: our internal inet_net_ntop takes
-				 * PGSQL_AF_INET6, not AF_INET6, which is very odd... They are
-				 * NOT the same value (even though PGSQL_AF_INET == AF_INET
-				 */
-#define PGSQL_AF_INET6	(AF_INET + 1)
-				inet_net_ntop(PGSQL_AF_INET6, sa, sizeof(struct sockaddr_in6), buf + 1, bufsize - 10);
-				write_log("Our alternative method says %s]:%s", buf, remote_port);
-
-			}
-			buf += strlen(buf);
-			strcat(buf, "]");
-			buf++;
-		}
-		snprintf(buf, 8, ":%s", remote_port);
-	}
-#endif
-	else
-		snprintf(buf, bufsize, "?host?:?port?");
-
-	return buf;
-}								/* formatSockAddr */
-
-/*
  * dispatcherAYT
  * 		Check the connection from the dispatcher to verify that it is still there.
  *
@@ -6618,7 +6527,7 @@ handleMismatch(icpkthdr *pkt, struct sockaddr_storage *peer, int peer_len)
 				write_log("ACKING PACKET WITH FLAGS: pkt->seq %d 0x%x [pkt->icId %d last-teardown %d interconnect_id %d]",
 						  pkt->seq, dummyconn.conn_info.flags, pkt->icId, rx_control_info.lastTornIcId, ic_control_info.ic_instance_id);
 
-			formatSockAddr((struct sockaddr *) &dummyconn.peer, buf, sizeof(buf));
+			format_sockaddr(&dummyconn.peer, buf, sizeof(buf));
 
 			if (DEBUG1 >= log_min_messages)
 				write_log("ACKING PACKET TO %s", buf);

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -1193,7 +1193,6 @@ setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort, int *txFami
 	memset(&hints, 0, sizeof(struct addrinfo));
 	hints.ai_family = AF_UNSPEC;	/* Allow IPv4 or IPv6 */
 	hints.ai_socktype = SOCK_DGRAM; /* Datagram socket */
-	hints.ai_flags = AI_PASSIVE;	/* For wildcard IP address */
 	hints.ai_protocol = 0;		/* Any protocol */
 
 #ifdef USE_ASSERT_CHECKING
@@ -1203,24 +1202,16 @@ setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort, int *txFami
 
 	fun = "getaddrinfo";
 	/*
-	 * We set interconnect_address on the primary to the local address of the connection from QD
-	 * to the primary, which is the primary's ADDRESS from gp_segment_configuration,
-	 * used for interconnection.
-	 * However it's wrong on the master. Because the connection from the client to the master may
-	 * have different IP addresses as its destination, which is very likely not the master's
-	 * ADDRESS in gp_segment_configuration.
+	 * Restrict what IP address we will listen on to just the one that was
+	 * used to create this QE session.
 	 */
-	if (interconnect_address)
-	{
-		/*
-		 * Restrict what IP address we will listen on to just the one that was
-		 * used to create this QE session.
-		 */
-		hints.ai_flags |= AI_NUMERICHOST;
-		ereport(DEBUG1, (errmsg("binding to %s only", interconnect_address)));
-		if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
-			ereport(DEBUG4, (errmsg("binding address %s", interconnect_address)));
-	}
+	Assert(interconnect_address && strlen(interconnect_address) > 0);
+	hints.ai_flags |= AI_NUMERICHOST;
+	if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
+		ereport(DEBUG1,
+				(errmsg("getaddrinfo called with interconnect_address %s",
+								interconnect_address)));
+
 	s = getaddrinfo(interconnect_address, service, &hints, &addrs);
 	if (s != 0)
 		elog(ERROR, "getaddrinfo says %s", gai_strerror(s));

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -36,6 +36,7 @@
 #include "libpq/ip.h"
 #include "port/atomics.h"
 #include "port/pg_crc32c.h"
+#include "postmaster/postmaster.h"
 #include "storage/latch.h"
 #include "storage/pmsignal.h"
 #include "utils/builtins.h"
@@ -1201,7 +1202,26 @@ setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort, int *txFami
 #endif
 
 	fun = "getaddrinfo";
-	s = getaddrinfo(NULL, service, &hints, &addrs);
+	/*
+	 * We set interconnect_address on the primary to the local address of the connection from QD
+	 * to the primary, which is the primary's ADDRESS from gp_segment_configuration,
+	 * used for interconnection.
+	 * However it's wrong on the master. Because the connection from the client to the master may
+	 * have different IP addresses as its destination, which is very likely not the master's
+	 * ADDRESS in gp_segment_configuration.
+	 */
+	if (interconnect_address)
+	{
+		/*
+		 * Restrict what IP address we will listen on to just the one that was
+		 * used to create this QE session.
+		 */
+		hints.ai_flags |= AI_NUMERICHOST;
+		ereport(DEBUG1, (errmsg("binding to %s only", interconnect_address)));
+		if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
+			ereport(DEBUG4, (errmsg("binding address %s", interconnect_address)));
+	}
+	s = getaddrinfo(interconnect_address, service, &hints, &addrs);
 	if (s != 0)
 		elog(ERROR, "getaddrinfo says %s", gai_strerror(s));
 
@@ -2642,12 +2662,6 @@ startOutgoingUDPConnections(ChunkTransportState *transportStates,
 	*pOutgoingCount = 0;
 
 	recvSlice = (Slice *) list_nth(transportStates->sliceTable->slices, sendSlice->parentIndex);
-
-	/*
-	 * Potentially introduce a Bug (MPP-17186). The workaround is to turn off
-	 * log_hostname guc.
-	 */
-	adjustMasterRouting(recvSlice);
 
 	if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
 		elog(DEBUG1, "Interconnect seg%d slice%d setting up sending motion node",
@@ -6907,7 +6921,7 @@ SendDummyPacket(void)
 	hint.ai_flags = AI_NUMERICHOST;
 #endif
 
-	ret = pg_getaddrinfo_all(NULL, port_str, &hint, &addrs);
+	ret = pg_getaddrinfo_all(interconnect_address, port_str, &hint, &addrs);
 	if (ret || !addrs)
 	{
 		elog(LOG, "send dummy packet failed, pg_getaddrinfo_all(): %m");

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -220,6 +220,12 @@ char	   *Unix_socket_directories;
 char	   *ListenAddresses;
 
 /*
+ * The interconnect address. We assume the interconnect is the address
+ * in gp_segment_configuration. And it's never changed at runtime.
+ */
+char	   *interconnect_address = NULL;
+
+/*
  * ReservedBackends is the number of backends reserved for superuser use.
  * This number is taken out of the pool size given by MaxBackends so
  * number of backend slots available to non-superusers is

--- a/src/include/cdb/ml_ipc.h
+++ b/src/include/cdb/ml_ipc.h
@@ -320,7 +320,6 @@ extern void TeardownUDPIFCInterconnect(ChunkTransportState *transportStates,
 								 bool hasErrors);
 
 extern uint32 getActiveMotionConns(void);
-extern void adjustMasterRouting(Slice *recvSlice);
 
 extern char *format_sockaddr(struct sockaddr_storage *sa, char *buf, size_t len);
 

--- a/src/include/cdb/ml_ipc.h
+++ b/src/include/cdb/ml_ipc.h
@@ -322,4 +322,6 @@ extern void TeardownUDPIFCInterconnect(ChunkTransportState *transportStates,
 extern uint32 getActiveMotionConns(void);
 extern void adjustMasterRouting(Slice *recvSlice);
 
+extern char *format_sockaddr(struct sockaddr_storage *sa, char *buf, size_t len);
+
 #endif   /* ML_IPC_H */

--- a/src/include/postmaster/postmaster.h
+++ b/src/include/postmaster/postmaster.h
@@ -21,6 +21,7 @@ extern int	Unix_socket_permissions;
 extern char *Unix_socket_group;
 extern char *Unix_socket_directories;
 extern char *ListenAddresses;
+extern char *interconnect_address;
 extern bool ClientAuthInProgress;
 extern int	PreAuthDelay;
 extern int	AuthenticationTimeout;

--- a/src/test/regress/expected/motion_socket.out
+++ b/src/test/regress/expected/motion_socket.out
@@ -1,0 +1,77 @@
+-- The following test checks if the correct number and type of sockets are
+-- created for motion connections both on QD and QE backends for the same
+-- gp_session_id. Additionally we check if the source address used for creating
+-- the motion sockets is equal to gp_segment_configuration.address.
+-- start_matchignore
+-- m/^INFO:  Checking postgres backend postgres:*/
+-- end_matchignore
+CREATE FUNCTION check_motion_sockets()
+    RETURNS VOID as $$
+import psutil, socket
+
+# Create a temporary table to create a gang
+plpy.execute("CREATE TEMP TABLE motion_socket_force_create_gang(i int);")
+
+# We expect different number of sockets to be created for different
+# interconnect types
+# UDP: See calls to setupUDPListeningSocket in InitMotionUDPIFC
+# TCP/PROXY: See call to setupTCPListeningSocket in InitMotionTCP
+res = plpy.execute("SELECT current_setting('gp_interconnect_type');", 1)
+ic_type = res[0]['current_setting']
+if ic_type in ['tcp', 'proxy']:
+    expected_socket_count_per_segment = 1
+    expected_socket_kind = socket.SOCK_STREAM
+elif ic_type=='udpifc':
+    expected_socket_count_per_segment = 2
+    expected_socket_kind = socket.SOCK_DGRAM
+else:
+    plpy.error('Unrecognized gp_interconnect_type {}.'.format(ic_type))
+
+# Since this test is run on a single physical host we assume that all segments
+# have the same gp_segment_configuration.address
+res = plpy.execute("SELECT address FROM gp_segment_configuration;", 1)
+hostip = socket.gethostbyname(res[0]['address'])
+
+res = plpy.execute("SELECT current_setting('gp_session_id');", 1)
+qd_backend_conn_id = res[0]['current_setting']
+
+for process in psutil.process_iter():
+    # We iterate through all backends related to connection id
+    # of current session
+    # Exclude zombies to avoid psutil.ZombieProcess exceptions
+    # on calling process.cmdline()
+    if process.name() == 'postgres' and process.status() != psutil.STATUS_ZOMBIE:
+        if ' con' + qd_backend_conn_id + ' ' in process.cmdline()[0]:
+            motion_socket_count = 0
+            plpy.info('Checking postgres backend {}'.format(process.cmdline()[0]))
+            for conn in process.connections():
+                if conn.type == expected_socket_kind and conn.raddr == () \
+                and conn.laddr[0] == hostip:   # Compare source ip of conn
+                    motion_socket_count += 1
+
+            if motion_socket_count != expected_socket_count_per_segment:
+                plpy.error('Expected {} motion sockets but found {}. '\
+                'For backend process {}. connections= {}'\
+                .format(expected_socket_count_per_segment, process,\
+                motion_socket_count, process.connections()))
+
+
+$$ LANGUAGE plpythonu EXECUTE ON MASTER;
+SELECT check_motion_sockets();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CONTEXT:  SQL statement "CREATE TEMP TABLE motion_socket_force_create_gang(i int);"
+PL/Python function "check_motion_sockets"
+INFO:  Checking postgres backend postgres:  6000, vanjared regression 127.0.0.1(60826) con67 cmd2 SELECT
+CONTEXT:  PL/Python function "check_motion_sockets"
+INFO:  Checking postgres backend postgres:  6002, vanjared regression 127.0.0.1(60827) con67 seg0 idle in transaction
+CONTEXT:  PL/Python function "check_motion_sockets"
+INFO:  Checking postgres backend postgres:  6003, vanjared regression 127.0.0.1(60828) con67 seg1 idle in transaction
+CONTEXT:  PL/Python function "check_motion_sockets"
+INFO:  Checking postgres backend postgres:  6004, vanjared regression 127.0.0.1(60829) con67 seg2 idle in transaction
+CONTEXT:  PL/Python function "check_motion_sockets"
+ check_motion_sockets 
+----------------------
+ 
+(1 row)
+

--- a/src/test/regress/expected/motion_socket.out
+++ b/src/test/regress/expected/motion_socket.out
@@ -2,9 +2,10 @@
 -- created for motion connections both on QD and QE backends for the same
 -- gp_session_id. Additionally we check if the source address used for creating
 -- the motion sockets is equal to gp_segment_configuration.address.
--- start_matchignore
--- m/^INFO:  Checking postgres backend postgres:*/
--- end_matchignore
+-- start_matchsubs
+-- m/^INFO:  Checking postgres backend postgres:.*/
+-- s/^INFO:  Checking postgres backend postgres:.*/INFO:  Checking postgres backend postgres: XXX/
+-- end_matchsubs
 CREATE FUNCTION check_motion_sockets()
     RETURNS VOID as $$
 import psutil, socket

--- a/src/test/regress/expected/motion_socket.out
+++ b/src/test/regress/expected/motion_socket.out
@@ -9,8 +9,13 @@ CREATE FUNCTION check_motion_sockets()
     RETURNS VOID as $$
 import psutil, socket
 
-# Create a temporary table to create a gang
+# Create a temporary table to create a writer gang
 plpy.execute("CREATE TEMP TABLE motion_socket_force_create_gang(i int);")
+
+# Since we have slightly different logic in constructing the source address of
+# motion sockets for singleton readers on the QD, create a singleton reader on
+# the QD as well.
+plpy.execute("SELECT * FROM motion_socket_force_create_gang, pg_database;")
 
 # We expect different number of sockets to be created for different
 # interconnect types
@@ -69,6 +74,8 @@ CONTEXT:  PL/Python function "check_motion_sockets"
 INFO:  Checking postgres backend postgres:  6003, vanjared regression 127.0.0.1(60828) con67 seg1 idle in transaction
 CONTEXT:  PL/Python function "check_motion_sockets"
 INFO:  Checking postgres backend postgres:  6004, vanjared regression 127.0.0.1(60829) con67 seg2 idle in transaction
+CONTEXT:  PL/Python function "check_motion_sockets"
+INFO:  Checking postgres backend postgres:  6000, vanjared regression 127.0.0.1(60830) con67 seg-1 idle
 CONTEXT:  PL/Python function "check_motion_sockets"
  check_motion_sockets 
 ----------------------

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -293,4 +293,7 @@ test: run_utility_gpexpand_phase1
 # check correct error message when create extension error on segment
 test: create_extension_fail
 
+# test if motion sockets are created with the gp_segment_configuration.address
+test: motion_socket
+
 # end of tests

--- a/src/test/regress/sql/motion_socket.sql
+++ b/src/test/regress/sql/motion_socket.sql
@@ -1,0 +1,62 @@
+-- The following test checks if the correct number and type of sockets are
+-- created for motion connections both on QD and QE backends for the same
+-- gp_session_id. Additionally we check if the source address used for creating
+-- the motion sockets is equal to gp_segment_configuration.address.
+
+
+-- start_matchignore
+-- m/^INFO:  Checking postgres backend postgres:*/
+-- end_matchignore
+CREATE FUNCTION check_motion_sockets()
+    RETURNS VOID as $$
+import psutil, socket
+
+# Create a temporary table to create a gang
+plpy.execute("CREATE TEMP TABLE motion_socket_force_create_gang(i int);")
+
+# We expect different number of sockets to be created for different
+# interconnect types
+# UDP: See calls to setupUDPListeningSocket in InitMotionUDPIFC
+# TCP/PROXY: See call to setupTCPListeningSocket in InitMotionTCP
+res = plpy.execute("SELECT current_setting('gp_interconnect_type');", 1)
+ic_type = res[0]['current_setting']
+if ic_type in ['tcp', 'proxy']:
+    expected_socket_count_per_segment = 1
+    expected_socket_kind = socket.SOCK_STREAM
+elif ic_type=='udpifc':
+    expected_socket_count_per_segment = 2
+    expected_socket_kind = socket.SOCK_DGRAM
+else:
+    plpy.error('Unrecognized gp_interconnect_type {}.'.format(ic_type))
+
+# Since this test is run on a single physical host we assume that all segments
+# have the same gp_segment_configuration.address
+res = plpy.execute("SELECT address FROM gp_segment_configuration;", 1)
+hostip = socket.gethostbyname(res[0]['address'])
+
+res = plpy.execute("SELECT current_setting('gp_session_id');", 1)
+qd_backend_conn_id = res[0]['current_setting']
+
+for process in psutil.process_iter():
+    # We iterate through all backends related to connection id
+    # of current session
+    # Exclude zombies to avoid psutil.ZombieProcess exceptions
+    # on calling process.cmdline()
+    if process.name() == 'postgres' and process.status() != psutil.STATUS_ZOMBIE:
+        if ' con' + qd_backend_conn_id + ' ' in process.cmdline()[0]:
+            motion_socket_count = 0
+            plpy.info('Checking postgres backend {}'.format(process.cmdline()[0]))
+            for conn in process.connections():
+                if conn.type == expected_socket_kind and conn.raddr == () \
+                and conn.laddr[0] == hostip:   # Compare source ip of conn
+                    motion_socket_count += 1
+
+            if motion_socket_count != expected_socket_count_per_segment:
+                plpy.error('Expected {} motion sockets but found {}. '\
+                'For backend process {}. connections= {}'\
+                .format(expected_socket_count_per_segment, process,\
+                motion_socket_count, process.connections()))
+
+
+$$ LANGUAGE plpythonu EXECUTE ON MASTER;
+SELECT check_motion_sockets();

--- a/src/test/regress/sql/motion_socket.sql
+++ b/src/test/regress/sql/motion_socket.sql
@@ -11,8 +11,13 @@ CREATE FUNCTION check_motion_sockets()
     RETURNS VOID as $$
 import psutil, socket
 
-# Create a temporary table to create a gang
+# Create a temporary table to create a writer gang
 plpy.execute("CREATE TEMP TABLE motion_socket_force_create_gang(i int);")
+
+# Since we have slightly different logic in constructing the source address of
+# motion sockets for singleton readers on the QD, create a singleton reader on
+# the QD as well.
+plpy.execute("SELECT * FROM motion_socket_force_create_gang, pg_database;")
 
 # We expect different number of sockets to be created for different
 # interconnect types

--- a/src/test/regress/sql/motion_socket.sql
+++ b/src/test/regress/sql/motion_socket.sql
@@ -4,9 +4,10 @@
 -- the motion sockets is equal to gp_segment_configuration.address.
 
 
--- start_matchignore
--- m/^INFO:  Checking postgres backend postgres:*/
--- end_matchignore
+-- start_matchsubs
+-- m/^INFO:  Checking postgres backend postgres:.*/
+-- s/^INFO:  Checking postgres backend postgres:.*/INFO:  Checking postgres backend postgres: XXX/
+-- end_matchsubs
 CREATE FUNCTION check_motion_sockets()
     RETURNS VOID as $$
 import psutil, socket


### PR DESCRIPTION
This backports #9696 and follow-up refactor #13326, and follow-up test fixes #13351 and #13352 in order to reduce the number of ports consumed by interconnect sockets. We also had to backport commit 349bf7cc1a.

Co-authored-by: Soumyadeep Chakraborty <soumyadeep2007@gmail.com>

Pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/6x_ic_use_address