### PR TITLE
Remove duplicate code of file allocation in pgstat_read_statsfile().

### DIFF
--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -3341,14 +3341,6 @@ pgstat_read_statsfile(Oid onlydb, bool permanent)
 	if ((fpin = AllocateFile(statfile, PG_BINARY_R)) == NULL)
 		return dbhash;
 
-		/*
-	 * Try to open the status file. If it doesn't exist, the backends simply
-	 * return zero for anything and the collector simply starts from scratch
-	 * with empty counters.
-	 */
-	if ((fpin = AllocateFile(statfile, PG_BINARY_R)) == NULL)
-		return dbhash;
-
 	/*
 	 * Verify it's of the expected format.
 	 */


### PR DESCRIPTION
The duplicate calling of AllocateFile() in pgstat_read_statsfile() is obviously wrong.
That will cause file allocation leak and easily hit the limit to result error out with
"too many private files demanded".

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
