### PR TITLE
Resolve GPDB_12_MERGE_FIXMEs in motion/tupser.c

### DIFF
--- a/src/backend/cdb/motion/tupser.c
+++ b/src/backend/cdb/motion/tupser.c
@@ -39,13 +39,6 @@
  */
 #define RECORD_CACHE_MAGIC_TUPLEN	-1
 
-/* A MemoryContext used within the tuple serialize code, so that freeing of
- * space is SUPAFAST.  It is initialized in the first call to InitSerTupInfo()
- * since that must be called before any tuple serialization or deserialization
- * work can be done.
- */
-static MemoryContext s_tupSerMemCtxt = NULL;
-
 static void addByteStringToChunkList(TupleChunkList tcList, char *data, int datalen, TupleChunkListCache *cache);
 
 #define addCharToChunkList(tcList, x, c)							\
@@ -80,18 +73,6 @@ InitSerTupInfo(TupleDesc tupdesc, SerTupInfo *pSerInfo)
 
 	AssertArg(tupdesc != NULL);
 	AssertArg(pSerInfo != NULL);
-
-	if (s_tupSerMemCtxt == NULL)
-	{
-		/* Create tuple-serialization memory context. */
-		s_tupSerMemCtxt =
-			AllocSetContextCreate(TopMemoryContext,
-								  "TupSerMemCtxt",
-								  ALLOCSET_DEFAULT_INITSIZE,	/* always have some
-																 * memory */
-								  ALLOCSET_DEFAULT_INITSIZE,
-								  ALLOCSET_DEFAULT_MAXSIZE);
-	}
 
 	/* Set contents to all 0, just to make things clean and easy. */
 	memset(pSerInfo, 0, sizeof(SerTupInfo));
@@ -272,7 +253,6 @@ SerializeRecordCacheIntoChunks(SerTupInfo *pSerInfo,
 							   MotionConn *conn)
 {
 	TupleChunkListItem tcItem = NULL;
-	MemoryContext oldCtxt;
 	List	   *typelist = NULL;
 	int			size = -1;
 	char	   *buf = NULL;
@@ -294,8 +274,6 @@ SerializeRecordCacheIntoChunks(SerTupInfo *pSerInfo,
 	tcItem->chunk_length = TUPLE_CHUNK_HEADER_SIZE;
 	appendChunkToTCList(tcList, tcItem);
 
-	AssertState(s_tupSerMemCtxt != NULL);
-
 	/*
 	 * To avoid inconsistency of record cache between sender and receiver in
 	 * the same motion, send the serialized record cache to receiver before
@@ -303,10 +281,8 @@ SerializeRecordCacheIntoChunks(SerTupInfo *pSerInfo,
 	 * the records to its own local cache and remapping the typmod of tuples
 	 * sent by sender.
 	 */
-	oldCtxt = MemoryContextSwitchTo(s_tupSerMemCtxt);
 	typelist = build_tuple_node_list(conn->sent_record_typmod);
 	buf = serializeNode((Node *) typelist, &size, NULL);
-	MemoryContextSwitchTo(oldCtxt);
 
 	/*
 	 * we use magic tuplen to identify that this chunk (or list of chunks)
@@ -495,17 +471,8 @@ SerializeTuple(TupleTableSlot *slot, SerTupInfo *pSerInfo, struct directTranspor
 	tcItem->chunk_length = TUPLE_CHUNK_HEADER_SIZE;
 	appendChunkToTCList(tcList, tcItem);
 
-	AssertState(s_tupSerMemCtxt != NULL);
-
 	addByteStringToChunkList(tcList, (char *) &tupbodylen, sizeof(tupbodylen), &pSerInfo->chunkCache);
 	addByteStringToChunkList(tcList, tupbody, tupbodylen, &pSerInfo->chunkCache);
-
-	/*
-	 * GPDB_12_MERGE_FIXME: This function does not use this context. This context
-	 * is only used in SerializeRecordCacheIntoChunks(). We need to find a better
-	 * place for resetting it, or eliminating the needs for this context.
-	 */
-	MemoryContextReset(s_tupSerMemCtxt);
 
 	/*
 	 * if we have more than 1 chunk we have to set the chunk types on our

--- a/src/backend/cdb/motion/tupser.c
+++ b/src/backend/cdb/motion/tupser.c
@@ -379,10 +379,11 @@ SerializeTuple(TupleTableSlot *slot, SerTupInfo *pSerInfo, struct directTranspor
 
 	/*
 	 * GPDB_12_MERGE_FIXME: This used to support serializing memtuples directly.
-	 * That got removed with MinimalTuples in the merge. Resurrect the MemtUple
-	 * support if there's a performance benefit.
+	 * That got removed with MinimalTuples in the merge.
 	 *
-	 * Details please see slack discussion:
+	 * In previous code: we using MemTuple in motion.
+	 * Comparing with MinimalTuple: it is more compact and has a little performance benefit.
+	 * Details please see gp slack discussion:
 	 * https://app.slack.com/client/T6T3AS6NL/C74P7FZFG/thread/C74P7FZFG-1582306400.252200
 	 */
 	/* Check if the slot has external attribute */

--- a/src/backend/cdb/motion/tupser.c
+++ b/src/backend/cdb/motion/tupser.c
@@ -405,6 +405,9 @@ SerializeTuple(TupleTableSlot *slot, SerTupInfo *pSerInfo, struct directTranspor
 	 * GPDB_12_MERGE_FIXME: This used to support serializing memtuples directly.
 	 * That got removed with MinimalTuples in the merge. Resurrect the MemtUple
 	 * support if there's a performance benefit.
+	 *
+	 * Details please see slack discussion:
+	 * https://app.slack.com/client/T6T3AS6NL/C74P7FZFG/thread/C74P7FZFG-1582306400.252200
 	 */
 	/* Check if the slot has external attribute */
 	for (int i = 0; i < natts; i++)


### PR DESCRIPTION
There are two fixmes in this PR:
### Removed `s_tupSerMemCtxt`
This memory context is used in `SerializeRecordCacheIntoChunks()`, and its prerequisite is
https://github.com/greenplum-db/gpdb/blob/b3acafa5cbcdc782461553da6f24b2bf3342bdbf/src/backend/cdb/motion/cdbmotion.c#L1249-L1255

So it's only for the **Transient RECORD** types (an example: https://github.com/greenplum-db/gpdb/issues/4444), and means not every query contains it and memory consumption is not big. 

After removed it, the related memory is alloced in MotionLayerMemCtxt (and parent is ExecutorState): get freed when the query is finished. So it's safe to remove `s_tupSerMemCtxt`.

### MinimalTuple vs. MemTuple in motion
Postgres introduced MinimalTuple, and GPDB introduced MemTuple. Their usage scenarios are similar. In 6x, we used MemTuple (gpdb introduced it) for the data transportation of motion. 

In the process of gp7's merge work, most of MemTuple scenarios are replaced with MinimalTuple (include motion).
But seems using MemTuple has a little performance boost, pls see the discussion:
https://app.slack.com/client/T6T3AS6NL/C74P7FZFG/thread/C74P7FZFG-1582306400.252200

We need to be cautious here, so don't change it in this PR.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
