### PR TITLE
Initialize lastSequence only for the target scanning segments before index scan.

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -1647,7 +1647,7 @@ aoco_relation_size(Relation rel, ForkNumber forkNumber)
 		return totalbytes;
 
 	snapshot = RegisterSnapshot(GetLatestSnapshot());
-	allseg = GetAllAOCSFileSegInfo(rel, snapshot, &totalseg);
+	allseg = GetAllAOCSFileSegInfo(rel, snapshot, &totalseg, NULL);
 	for (int seg = 0; seg < totalseg; seg++)
 	{
 		for (int attr = 0; attr < RelationGetNumberOfAttributes(rel); attr++)
@@ -1688,7 +1688,6 @@ aoco_relation_needs_toast_table(Relation rel)
 	 */
 	return false;
 }
-
 
 /* ------------------------------------------------------------------------
  * Planner related callbacks for the heap AM

--- a/src/backend/access/aocs/aocssegfiles.c
+++ b/src/backend/access/aocs/aocssegfiles.c
@@ -267,7 +267,8 @@ GetAOCSFileSegInfo(Relation prel,
 AOCSFileSegInfo **
 GetAllAOCSFileSegInfo(Relation prel,
 					  Snapshot appendOnlyMetaDataSnapshot,
-					  int32 *totalseg)
+					  int32 *totalseg,
+					  Oid *segrelidptr)
 {
 	Relation	pg_aocsseg_rel;
 	AOCSFileSegInfo **results;
@@ -283,6 +284,9 @@ GetAllAOCSFileSegInfo(Relation prel,
 	if (segrelid == InvalidOid)
 		elog(ERROR, "could not find pg_aoseg aux table for AOCO table \"%s\"",
 			 RelationGetRelationName(prel));
+
+	if (segrelidptr != NULL)
+		*segrelidptr = segrelid;
 
 	pg_aocsseg_rel = relation_open(segrelid, AccessShareLock);
 
@@ -449,7 +453,7 @@ GetAOCSSSegFilesTotals(Relation parentrel, Snapshot appendOnlyMetaDataSnapshot)
 	totals = (FileSegTotals *) palloc0(sizeof(FileSegTotals));
 	memset(totals, 0, sizeof(FileSegTotals));
 
-	allseg = GetAllAOCSFileSegInfo(parentrel, appendOnlyMetaDataSnapshot, &totalseg);
+	allseg = GetAllAOCSFileSegInfo(parentrel, appendOnlyMetaDataSnapshot, &totalseg, NULL);
 	for (s = 0; s < totalseg; s++)
 	{
 		int32		nEntry;

--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -348,7 +348,8 @@ GetFileSegInfo(Relation parentrel, Snapshot appendOnlyMetaDataSnapshot, int segn
 FileSegInfo **
 GetAllFileSegInfo(Relation parentrel,
 				  Snapshot appendOnlyMetaDataSnapshot,
-				  int *totalsegs)
+				  int *totalsegs,
+				  Oid *segrelidptr)
 {
 	Relation	pg_aoseg_rel;
 	FileSegInfo **result;
@@ -361,6 +362,9 @@ GetAllFileSegInfo(Relation parentrel,
 			 RelationGetRelationName(parentrel));
 
 	Assert(RelationIsAoRows(parentrel));
+
+	if (segrelidptr != NULL)
+		*segrelidptr = segrelid;
 
 	pg_aoseg_rel = table_open(segrelid, AccessShareLock);
 

--- a/src/backend/access/appendonly/appendonly_visimap_udf.c
+++ b/src/backend/access/appendonly/appendonly_visimap_udf.c
@@ -218,13 +218,14 @@ gp_aovisimap_hidden_info(PG_FUNCTION_ARGS)
 		{
 			context->appendonlySegfileInfo = GetAllFileSegInfo(context->parentRelation,
 															   snapshot,
-															   &context->segfile_info_total);
+															   &context->segfile_info_total,
+															   NULL);
 		}
 		else
 		{
 			Assert(RelationIsAoCols(context->parentRelation));
 			context->aocsSegfileInfo = GetAllAOCSFileSegInfo(context->parentRelation,
-															 snapshot, &context->segfile_info_total);
+															 snapshot, &context->segfile_info_total, NULL);
 		}
 		context->i = 0;
 

--- a/src/backend/access/heap/heapam_handler.c
+++ b/src/backend/access/heap/heapam_handler.c
@@ -2080,7 +2080,6 @@ heapam_relation_needs_toast_table(Relation rel)
 	return (tuple_length > TOAST_TUPLE_THRESHOLD);
 }
 
-
 /* ------------------------------------------------------------------------
  * Planner related callbacks for the heap AM
  * ------------------------------------------------------------------------

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -5982,7 +5982,7 @@ ATAocsWriteNewColumns(AlteredTableInfo *tab)
 	/* Try to recycle any old segfiles first. */
 	AppendOptimizedRecycleDeadSegments(rel);
 
-	segInfos = GetAllAOCSFileSegInfo(rel, snapshot, &nseg);
+	segInfos = GetAllAOCSFileSegInfo(rel, snapshot, &nseg, NULL);
 	basepath = relpathbackend(rel->rd_node, rel->rd_backend, MAIN_FORKNUM);
 	if (nseg > 0)
 	{

--- a/src/backend/commands/vacuum_ao.c
+++ b/src/backend/commands/vacuum_ao.c
@@ -484,14 +484,16 @@ vacuum_appendonly_indexes(Relation aoRelation, int options,
 	{
 		segmentFileInfo = GetAllFileSegInfo(aoRelation,
 											appendOnlyMetaDataSnapshot,
-											&totalSegfiles);
+											&totalSegfiles,
+											NULL);
 	}
 	else
 	{
 		Assert(RelationIsAoCols(aoRelation));
 		segmentFileInfo = (FileSegInfo **) GetAllAOCSFileSegInfo(aoRelation,
 																appendOnlyMetaDataSnapshot,
-																&totalSegfiles);
+																&totalSegfiles,
+																NULL);
 	}
 
 	GetAppendOnlyEntryAuxOids(aoRelation->rd_id,

--- a/src/include/access/aocssegfiles.h
+++ b/src/include/access/aocssegfiles.h
@@ -138,7 +138,8 @@ extern AOCSFileSegInfo *GetAOCSFileSegInfo(Relation prel,
 
 extern AOCSFileSegInfo **GetAllAOCSFileSegInfo(Relation prel,
 					  Snapshot appendOnlyMetaDataSnapshot,
-					  int *totalseg);
+					  int *totalseg,
+					  Oid *segrelidptr);
 extern void FreeAllAOCSSegFileInfo(AOCSFileSegInfo **allAOCSSegInfo, int totalSegFiles);
 
 extern FileSegTotals *GetAOCSSSegFilesTotals(Relation parentrel,

--- a/src/include/access/aosegfiles.h
+++ b/src/include/access/aosegfiles.h
@@ -32,6 +32,7 @@
 
 #define InvalidFileSegNumber			-1
 #define InvalidUncompressedEof			-1
+#define InvalidAORowNum					-1
 
 #define AO_FILESEGINFO_ARRAY_SIZE		8
 
@@ -133,7 +134,7 @@ extern void ValidateAppendonlySegmentDataBeforeStorage(int segno);
   */
 extern FileSegInfo *GetFileSegInfo(Relation parentrel, Snapshot appendOnlyMetaDataSnapshot, int segno, bool locked);
 
-extern FileSegInfo **GetAllFileSegInfo(Relation parentrel, Snapshot appendOnlyMetaDataSnapshot, int *totalsegs);
+extern FileSegInfo **GetAllFileSegInfo(Relation parentrel, Snapshot appendOnlyMetaDataSnapshot, int *totalsegs, Oid *segrelidptr);
 
 extern void UpdateFileSegInfo(Relation parentrel,
 				  int segno,

--- a/src/include/access/tableam.h
+++ b/src/include/access/tableam.h
@@ -602,7 +602,6 @@ typedef struct TableAmRoutine
 	 */
 	bool		(*relation_needs_toast_table) (Relation rel);
 
-
 	/* ------------------------------------------------------------------------
 	 * Planner related functions.
 	 * ------------------------------------------------------------------------
@@ -1669,7 +1668,6 @@ table_relation_needs_toast_table(Relation rel)
 {
 	return rel->rd_tableam->relation_needs_toast_table(rel);
 }
-
 
 /* ----------------------------------------------------------------------------
  * Planner related functionality

--- a/src/include/cdb/cdbaocsam.h
+++ b/src/include/cdb/cdbaocsam.h
@@ -206,13 +206,15 @@ typedef struct AOCSFetchDescData
 	struct AOCSFileSegInfo **segmentFileInfo;
 
 	/*
-	 * The largest row number of this aoseg. Maximum row number is required in
-	 * function "aocs_fetch". If we have no updates and deletes, the
-	 * total_tupcount is equal to the maximum row number. But after some updates
-	 * and deletes, the maximum row number always much bigger than
-	 * total_tupcount. The appendonly_insert function will get fast sequence and
-	 * use it as the row number. So the last sequence will be the correct
-	 * maximum row number.
+	 * Array containing the maximum row number in each aoseg (to be consulted
+	 * during fetch). This is a sparse array as not all segments are involved
+	 * in a scan. Sparse entries are marked with InvalidAORowNum.
+	 *
+	 * Note:
+	 * If we have no updates and deletes, the total_tupcount is equal to the
+	 * maximum row number. But after some updates and deletes, the maximum row
+	 * number is always much bigger than total_tupcount, so this carries the
+	 * last sequence from gp_fastsequence.
 	 */
 	int64			lastSequence[AOTupleId_MultiplierSegmentFileNum];
 

--- a/src/include/cdb/cdbappendonlyam.h
+++ b/src/include/cdb/cdbappendonlyam.h
@@ -307,13 +307,15 @@ typedef struct AppendOnlyFetchDescData
 	int				segmentFileNameMaxLen;
 
 	/*
-	 * The largest row number of this aoseg. Maximum row number is required in
-	 * function "aocs_fetch". If we have no updates and deletes, the
-	 * total_tupcount is equal to the maximum row number. But after some updates
-	 * and deletes, the maximum row number always much bigger than
-	 * total_tupcount. The appendonly_insert function will get fast sequence and
-	 * use it as the row number. So the last sequence will be the correct
-	 * maximum row number.
+	 * Array containing the maximum row number in each aoseg (to be consulted
+	 * during fetch). This is a sparse array as not all segments are involved
+	 * in a scan. Sparse entries are marked with InvalidAORowNum.
+	 *
+	 * Note:
+	 * If we have no updates and deletes, the total_tupcount is equal to the
+	 * maximum row number. But after some updates and deletes, the maximum row
+	 * number is always much bigger than total_tupcount, so this carries the
+	 * last sequence from gp_fastsequence.
 	 */
 	int64			lastSequence[AOTupleId_MultiplierSegmentFileNum];
 

--- a/src/test/isolation2/input/uao/limit_indexscan_inits.source
+++ b/src/test/isolation2/input/uao/limit_indexscan_inits.source
@@ -1,0 +1,76 @@
+-- This is intended to test lastSequence initialization during indexscan should be limited
+-- to the scope of the target scanning AO/CO segfiles, rather than the max 128 segfiles.
+-- The theory is comparing the count of indexscan (or pg_stat_all_tables.idx_scan) between
+-- pre and post query on bitmapheapscan(could trigger indexscan) plan.
+-- We are using gp_ao_or_aocs_seg() helper UDF to obtain the number of AO/CO segfiles (segnos),
+-- then plus 1 to count in segfile0 due to the implementation constraint.
+-- For BTREE index, we verify the equation: post_nscans - pre_nscans == segnos + 1;
+-- for BRIN index, we verify the equation: post_nscans - pre_nscans == (segnos + 1) * 2.
+-- BRIN index doubles the number of nscans of BTREE because lastSequence was initialized twice
+-- during BRIN indexed bitmapheapscan (in index_getbitmap and ao/co fetch_init), which is probably
+-- optimizable, too.
+
+create or replace function test_iscan_inits_same_as_aosegs(tablename text, icol text, itype text) returns bool as $$
+declare
+    segnos smallint; /* in func */
+    pre_nscans smallint; /* in func */
+    post_nscans smallint; /* in func */
+    result bool; /* in func */
+begin
+    select count(segno) into segnos from gp_ao_or_aocs_seg(tablename); /* in func */
+
+    select pg_stat_get_xact_numscans('gp_fastsequence_objid_objmod_index'::regclass) into pre_nscans; /* get idx_scan before query */
+    execute 'select * from ' || quote_ident(tablename) || ' where ' || quote_ident(icol) || ' = 2'; /* vaule 2 is distributed to the segment with content 0 */
+    select pg_stat_get_xact_numscans('gp_fastsequence_objid_objmod_index'::regclass) into post_nscans; /* get idx_scan after query */
+
+    if quote_ident(itype) = 'btree' then /* for BTREE index */
+        select post_nscans - pre_nscans = segnos + 1 into result; /* calculate the diff and compare to segnos plus 1 to count in segfile0, expect equal */
+        raise notice '[BTREE] expect: post_nscans - pre_nscans == segnos + 1'; /* in func */
+    elsif quote_ident(itype) = 'brin' then /* for BRIN index */
+        select post_nscans - pre_nscans = (segnos + 1) * 2 into result; /* BRIN doubles nscans(of BTREE) due to implementation constraint */
+        raise notice '[BRIN] expect: post_nscans - pre_nscans == (segnos + 1) * 2'; /* in func */
+    else /* in func */
+        raise exception 'unexpected type of index %', itype::text; /* in func */
+    end if; /* in func */
+
+    raise notice 'pre_nscans = %, post_nscans = %, segnos = %', pre_nscans, post_nscans, segnos; /* verbose */
+
+    return result; /* in func */
+end; /* in func */
+$$ language plpgsql;
+
+set default_table_access_method=@amname@;
+
+create table @amname@_limit_iscan_inits_tbl (a int, b int, c int, d int);
+create index on @amname@_limit_iscan_inits_tbl(a);
+create index on @amname@_limit_iscan_inits_tbl using brin (b);
+
+-- Start three concurrent writing sessions to generate three segment files.
+1: begin;
+1: insert into @amname@_limit_iscan_inits_tbl select a, a, a, a from generate_series(1, 10)a;
+
+2: begin;
+2: insert into @amname@_limit_iscan_inits_tbl select a, a, a, a from generate_series(11, 20)a;
+
+3: begin;
+3: insert into @amname@_limit_iscan_inits_tbl select a, a, a, a from generate_series(21, 30)a;
+
+1: end;
+2: end;
+3: end;
+
+-- diable seqscan
+0U: set enable_seqscan = off;
+-- make sure it goes to bitmapheapscan
+-- start_ignore
+0U: explain (costs off) select * from @amname@_limit_iscan_inits_tbl where a = 2;
+0U: explain (costs off) select * from @amname@_limit_iscan_inits_tbl where b = 2;
+-- end_ignore
+-- expect to return true
+0U: select test_iscan_inits_same_as_aosegs('@amname@_limit_iscan_inits_tbl', 'a', 'btree');
+0U: select test_iscan_inits_same_as_aosegs('@amname@_limit_iscan_inits_tbl', 'b', 'brin');
+0Uq:
+
+drop table @amname@_limit_iscan_inits_tbl;
+drop function test_iscan_inits_same_as_aosegs;
+reset default_table_access_method;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -152,6 +152,7 @@ test: uao/vacuum_while_insert_row
 test: uao/vacuum_while_vacuum_row
 test: uao/vacuum_cleanup_row
 test: uao/bitmapindex_rescan_row
+test: uao/limit_indexscan_inits_row
 test: reorganize_after_ao_vacuum_skip_drop truncate_after_ao_vacuum_skip_drop mark_all_aoseg_await_drop
 # below test(s) inject faults so each of them need to be in a separate group
 test: segwalrep/master_wal_switch
@@ -203,6 +204,7 @@ test: uao/vacuum_while_insert_column
 test: uao/vacuum_while_vacuum_column
 test: uao/vacuum_cleanup_column
 test: uao/bitmapindex_rescan_column
+test: uao/limit_indexscan_inits_column
 
 # this case contains fault injection, must be put in a separate test group
 test: terminate_in_gang_creation

--- a/src/test/isolation2/output/uao/limit_indexscan_inits.source
+++ b/src/test/isolation2/output/uao/limit_indexscan_inits.source
@@ -1,0 +1,95 @@
+-- This is intended to test lastSequence initialization during indexscan should be limited
+-- to the scope of the target scanning AO/CO segfiles, rather than the max 128 segfiles.
+-- The theory is comparing the count of indexscan (or pg_stat_all_tables.idx_scan) between
+-- pre and post query on bitmapheapscan(could trigger indexscan) plan.
+-- We are using gp_ao_or_aocs_seg() helper UDF to obtain the number of AO/CO segfiles (segnos),
+-- then plus 1 to count in segfile0 due to the implementation constraint.
+-- For BTREE index, we verify the equation: post_nscans - pre_nscans == segnos + 1;
+-- for BRIN index, we verify the equation: post_nscans - pre_nscans == (segnos + 1) * 2.
+-- BRIN index doubles the number of nscans of BTREE because lastSequence was initialized twice
+-- during BRIN indexed bitmapheapscan (in index_getbitmap and ao/co fetch_init), which is probably
+-- optimizable, too.
+
+create or replace function test_iscan_inits_same_as_aosegs(tablename text, icol text, itype text) returns bool as $$ declare segnos smallint; /* in func */ pre_nscans smallint; /* in func */ post_nscans smallint; /* in func */ result bool; /* in func */ begin select count(segno) into segnos from gp_ao_or_aocs_seg(tablename); /* in func */ 
+select pg_stat_get_xact_numscans('gp_fastsequence_objid_objmod_index'::regclass) into pre_nscans; /* get idx_scan before query */ execute 'select * from ' || quote_ident(tablename) || ' where ' || quote_ident(icol) || ' = 2'; /* vaule 2 is distributed to the segment with content 0 */ select pg_stat_get_xact_numscans('gp_fastsequence_objid_objmod_index'::regclass) into post_nscans; /* get idx_scan after query */ 
+if quote_ident(itype) = 'btree' then /* for BTREE index */ select post_nscans - pre_nscans = segnos + 1 into result; /* calculate the diff and compare to segnos plus 1 to count in segfile0, expect equal */ raise notice '[BTREE] expect: post_nscans - pre_nscans == segnos + 1'; /* in func */ elsif quote_ident(itype) = 'brin' then /* for BRIN index */ select post_nscans - pre_nscans = (segnos + 1) * 2 into result; /* BRIN doubles nscans(of BTREE) due to implementation constraint */ raise notice '[BRIN] expect: post_nscans - pre_nscans == (segnos + 1) * 2'; /* in func */ else /* in func */ raise exception 'unexpected type of index %', itype::text; /* in func */ end if; /* in func */ 
+raise notice 'pre_nscans = %, post_nscans = %, segnos = %', pre_nscans, post_nscans, segnos; /* verbose */ 
+return result; /* in func */ end; /* in func */ $$ language plpgsql;
+CREATE
+
+set default_table_access_method=@amname@;
+SET
+
+create table @amname@_limit_iscan_inits_tbl (a int, b int, c int, d int);
+CREATE
+create index on @amname@_limit_iscan_inits_tbl(a);
+CREATE
+create index on @amname@_limit_iscan_inits_tbl using brin (b);
+CREATE
+
+-- Start three concurrent writing sessions to generate three segment files.
+1: begin;
+BEGIN
+1: insert into @amname@_limit_iscan_inits_tbl select a, a, a, a from generate_series(1, 10)a;
+INSERT 10
+
+2: begin;
+BEGIN
+2: insert into @amname@_limit_iscan_inits_tbl select a, a, a, a from generate_series(11, 20)a;
+INSERT 10
+
+3: begin;
+BEGIN
+3: insert into @amname@_limit_iscan_inits_tbl select a, a, a, a from generate_series(21, 30)a;
+INSERT 10
+
+1: end;
+END
+2: end;
+END
+3: end;
+END
+
+-- diable seqscan
+0U: set enable_seqscan = off;
+SET
+-- make sure it goes to bitmapheapscan
+-- start_ignore
+0U: explain (costs off) select * from @amname@_limit_iscan_inits_tbl where a = 2;
+ QUERY PLAN                                                       
+------------------------------------------------------------------
+ Bitmap Heap Scan on @amname@_limit_iscan_inits_tbl              
+   Recheck Cond: (a = 2)                                         
+   ->  Bitmap Index Scan on @amname@_limit_iscan_inits_tbl_a_idx 
+         Index Cond: (a = 2)                                     
+ Optimizer: Postgres query optimizer                             
+(5 rows)
+0U: explain (costs off) select * from @amname@_limit_iscan_inits_tbl where b = 2;
+ QUERY PLAN                                                       
+------------------------------------------------------------------
+ Bitmap Heap Scan on @amname@_limit_iscan_inits_tbl              
+   Recheck Cond: (b = 2)                                         
+   ->  Bitmap Index Scan on @amname@_limit_iscan_inits_tbl_a_idx 
+         Index Cond: (b = 2)                                     
+ Optimizer: Postgres query optimizer                             
+(5 rows)
+-- end_ignore
+-- expect to return true
+0U: select test_iscan_inits_same_as_aosegs('@amname@_limit_iscan_inits_tbl', 'a', 'btree');
+ test_iscan_inits_same_as_aosegs 
+---------------------------------
+ t                               
+(1 row)
+0U: select test_iscan_inits_same_as_aosegs('@amname@_limit_iscan_inits_tbl', 'b', 'brin');
+ test_iscan_inits_same_as_aosegs 
+---------------------------------
+ t                               
+(1 row)
+0Uq: ... <quitting>
+
+drop table @amname@_limit_iscan_inits_tbl;
+DROP
+drop function test_iscan_inits_same_as_aosegs;
+DROP
+reset default_table_access_method;
+RESET


### PR DESCRIPTION
Previously, initialization of segment file lastSequence during
Append-Optimized table index scan is by calling ReadLastSequence()
for all 128 segments, which introduced many unnecessary gp_fastsequence
scans in most cases, slowing down the query speed.

This change narrows down to initialize lastSequence only for AO
target scanning segments, excluding non-existing ones to reduce
unnecessary gp_fastsequence scans.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
