### PR TITLE
motion_socket.sql: additional test coverage

### DIFF
--- a/src/test/regress/expected/motion_socket.out
+++ b/src/test/regress/expected/motion_socket.out
@@ -9,8 +9,13 @@ CREATE FUNCTION check_motion_sockets()
     RETURNS VOID as $$
 import psutil, socket
 
-# Create a temporary table to create a gang
+# Create a temporary table to create a writer gang
 plpy.execute("CREATE TEMP TABLE motion_socket_force_create_gang(i int);")
+
+# Since we have slightly different logic in constructing the source address of
+# motion sockets for singleton readers on the QD, create a singleton reader on
+# the QD as well.
+plpy.execute("SELECT * FROM motion_socket_force_create_gang, pg_database;")
 
 # We expect different number of sockets to be created for different
 # interconnect types
@@ -64,6 +69,7 @@ INFO:  Checking postgres backend postgres:  7000, vanjared regression 127.0.0.1(
 INFO:  Checking postgres backend postgres:  7002, vanjared regression 127.0.0.1(59550) con1812 seg0 idle in transaction
 INFO:  Checking postgres backend postgres:  7003, vanjared regression 127.0.0.1(59551) con1812 seg1 idle in transaction
 INFO:  Checking postgres backend postgres:  7004, vanjared regression 127.0.0.1(59552) con1812 seg2 idle in transaction
+INFO:  Checking postgres backend postgres:  7000, vanjared regression 127.0.0.1(59553) con1812 seg-1 idle
  check_motion_sockets 
 ----------------------
  

--- a/src/test/regress/sql/motion_socket.sql
+++ b/src/test/regress/sql/motion_socket.sql
@@ -11,8 +11,13 @@ CREATE FUNCTION check_motion_sockets()
     RETURNS VOID as $$
 import psutil, socket
 
-# Create a temporary table to create a gang
+# Create a temporary table to create a writer gang
 plpy.execute("CREATE TEMP TABLE motion_socket_force_create_gang(i int);")
+
+# Since we have slightly different logic in constructing the source address of
+# motion sockets for singleton readers on the QD, create a singleton reader on
+# the QD as well.
+plpy.execute("SELECT * FROM motion_socket_force_create_gang, pg_database;")
 
 # We expect different number of sockets to be created for different
 # interconnect types


### PR DESCRIPTION
Since we have slightly different logic in constructing the source
address of motion sockets for singleton readers on the QD, create a
singleton reader on the QD as well.

Co-authored-by: Soumyadeep Chakraborty <soumyadeep2007@gmail.com>