### PR TITLE
motion_socket.sql: Correct regex match and ignore

### DIFF
--- a/src/test/regress/expected/motion_socket.out
+++ b/src/test/regress/expected/motion_socket.out
@@ -2,9 +2,10 @@
 -- created for motion connections both on QD and QE backends for the same
 -- gp_session_id. Additionally we check if the source address used for creating
 -- the motion sockets is equal to gp_segment_configuration.address.
--- start_matchignore
--- m/^INFO:  Checking postgres backend postgres:*/
--- end_matchignore
+-- start_matchsubs
+-- m/^INFO:  Checking postgres backend postgres:.*/
+-- s/^INFO:  Checking postgres backend postgres:.*/INFO:  Checking postgres backend postgres: XXX/
+-- end_matchsubs
 CREATE FUNCTION check_motion_sockets()
     RETURNS VOID as $$
 import psutil, socket

--- a/src/test/regress/sql/motion_socket.sql
+++ b/src/test/regress/sql/motion_socket.sql
@@ -4,9 +4,10 @@
 -- the motion sockets is equal to gp_segment_configuration.address.
 
 
--- start_matchignore
--- m/^INFO:  Checking postgres backend postgres:*/
--- end_matchignore
+-- start_matchsubs
+-- m/^INFO:  Checking postgres backend postgres:.*/
+-- s/^INFO:  Checking postgres backend postgres:.*/INFO:  Checking postgres backend postgres: XXX/
+-- end_matchsubs
 CREATE FUNCTION check_motion_sockets()
     RETURNS VOID as $$
 import psutil, socket


### PR DESCRIPTION
Use match_subs instead of match_ignore to ensure that we assert the
count of lines starting w/ "Checking postgres backend postgres"

Co-authored-by: Soumyadeep Chakraborty <soumyadeep2007@gmail.com>