### PR TITLE
Allow ORCA to reuse cached PL/pgSQL fallback plans

### DIFF
--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -1178,7 +1178,7 @@ SPI_cursor_open_internal(const char *name, SPIPlanPtr plan,
 	if (plan->saved)
 	{
 		/* Replan if needed, and increment plan refcount for portal */
-		cplan = RevalidateCachedPlanWithParams(plansource, false, paramLI, NULL);
+		cplan = RevalidateCachedPlanWithParams(plansource, false, optimizer ? NULL : paramLI, NULL);
 		stmt_list = cplan->stmt_list;
 	}
 	else
@@ -1791,7 +1791,7 @@ _SPI_execute_plan(SPIPlanPtr plan, ParamListInfo paramLI,
 			if (plan->saved)
 			{
 				/* Replan if needed, and increment plan refcount locally */
-				cplan = RevalidateCachedPlanWithParams(plansource, true, paramLI, NULL);
+				cplan = RevalidateCachedPlanWithParams(plansource, true, optimizer ? NULL : paramLI, NULL);
 				stmt_list = cplan->stmt_list;
 			}
 			else


### PR DESCRIPTION
Commit 2ddd30e exposed divergent behavior between ORCA and PLANNER
through gp_toolkit functions that used to be hidden behind fallback
plans. It is questionable which is "correct".

Consider following query (based on gp_toolkit regress test):
  ```
  EXPLAIN SELECT * FROM gp_toolkit.__gp_localid, gp_toolkit.__gp_param_local_setting('gp_role');
                         QUERY PLAN
  -------------------------------------------------------------
   Nested Loop
     Join Filter: true
     ->  Function Scan on __gp_param_local_setting
     ->  Materialize
           ->  Gather Motion 3:1
                 ->  External Scan on __gp_localid
   Optimizer status: PQO version 3.122.0
  ```

ORCA runs the Function Scan on corrdinator while PLANNER runs it on
segments. But without execlocation defined in pg_proc catalog (like in
GPDB 6X) I think it's actually impossible to 100% correctly generalize
and infer the intended behavior. Unfortunately this yields different
results depending on where the function is run.

This commit partially reverts aforementioned commit and allows ORCA to
continue to hide behind a cached PL/pgSQL fallback plan. It does this by
disabling revalidate cached PL/pgSQL plans for ORCA. It may be worth
noting that ORCA does correctly revalidate cached prepare plans.


--- 

This is a potential lower risk alternative approach to https://github.com/greenplum-db/gporca/pull/637

ICW passed ORCA: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/allow-orca-to-reuse-cached-fallback-plans/jobs/icw_gporca_centos6/builds/8