### PR TITLE
Try to lookup commands by $PATH before iterating over hardcoded paths.

### DIFF
--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -37,6 +37,11 @@ GP_UNIQUE_COMMAND=gpstart
 findCmdInPath() {
 		cmdtofind=$1
 
+		CMD=`which $cmdtofind`
+		if [ $? -eq 0 ]; then
+				echo $CMD
+				return
+		fi
 		for pathel in ${CMDPATH[@]}
 				do
 				CMD=$pathel/$cmdtofind


### PR DESCRIPTION
To my surprise, gp_bash_functions.sh finds available commands by
iterating over hardcoded paths. This patch helps teach the script
find commands by using the `which` command.

I encountered this problem on my macOS laptop, the `ip` command
is installed by Homebrew and the path of it isn’t hardcoded in the script.
