### PR TITLE
remove DynamicTableScanInfo struct and correlative codes

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1776,12 +1776,6 @@ InitPlan(QueryDesc *queryDesc, int eflags)
 	}
 
 	/*
-	 * set the number of partition selectors for every dynamic scan id
-	 */
-	// GPDB_12_MERGE_FIXME
-	//estate->dynamicTableScanInfo->numSelectorsPerScanId = plannedstmt->numSelectorsPerScanId;
-
-	/*
 	 * Next, build the ExecRowMark array from the PlanRowMark(s), if any.
 	 */
 	if (plannedstmt->rowMarks)

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -513,57 +513,6 @@ typedef struct ResultRelInfo
 	struct CopyMultiInsertBuffer *ri_CopyMultiInsertBuffer;
 } ResultRelInfo;
 
-/*
- * DynamicTableScanInfo
- *   Encapsulate the information that is needed to maintain the pid indexes
- * for all dynamic table scans in a plan.
- */
-/* GPDB_12_MERGE_FIXME: dead code now? */
-typedef struct DynamicTableScanInfo
-{
-	/*
-	 * The total number of unique dynamic table scans in the plan.
-	 */
-	int			numScans;
-
-	/*
-	 * List containing the number of partition selectors for every scan id.
-	 * Element #i in the list corresponds to scan id i
-	 */
-	List	   *numSelectorsPerScanId;
-
-	/*
-	 * An array of pid indexes, one for each unique dynamic table scans.
-	 * Each of these pid indexes maintains unique pids that are involved
-	 * in the scan.
-	 */
-	HTAB	  **pidIndexes;
-
-	/*
-	 * An array of Oids, for the current partition being scanned in each
-	 *  dynamic scan. (XXX: Currently only used to pass the oid from
-	 * DynamicBitmapHeapScan to DynamicBitmapIndexScans.
-	 */
-	Oid		   *curRelOids;
-
-	/*
-	 * Partitioning metadata for all relevant partition tables.
-	 */
-	List	   *partsMetadata;
-} DynamicTableScanInfo;
-
-/*
- * Number of pids used when initializing the pid-index hash table for each dynamic
- * table scan.
- */
-#define INITIAL_NUM_PIDS 1000
-
-/*
- * The initial estimate size for dynamic table scan pid-index array, and the
- * default incremental number when the array is out of space.
- */
-#define NUM_PID_INDEXES_ADDED 10
-
 /* ----------------
  *	  EState information
  *


### PR DESCRIPTION
Since PostgreSQL 10 has it's own partition table and partition pruning implementation, 
we'll never need `DynamicTableScanInfo` to record inner leaf tables' OID during HashJoin.

We can improve that from the below case:

```
create table foo (a int, b int, c int) partition by range(a) (start(0) end (10) every(1));
create table bar (d int, e int, f int) partition by range(d)  (start(5) end (15) every(1));

explain select * from foo, bar where foo.a = bar.d and bar.d > 5;
```

In 6X, we can use Dynamic Seq Scan to prune some leaf tables:

```
postgres=# explain select * from foo, bar where foo.a = bar.d and bar.d > 5;
                                                  QUERY PLAN                                                   
---------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=24)
   ->  Hash Join  (cost=0.00..862.00 rows=1 width=24)
         Hash Cond: (foo.a = bar.d)
         ->  Sequence  (cost=0.00..431.00 rows=1 width=12)
               ->  Partition Selector for foo (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
                     Partitions selected: 5 (out of 10)
               ->  Dynamic Seq Scan on foo (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=12)
                     Filter: (a > 5)
         ->  Hash  (cost=431.00..431.00 rows=1 width=12)
               ->  Sequence  (cost=0.00..431.00 rows=1 width=12)
                     ->  Partition Selector for bar (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
                           Partitions selected: 10 (out of 10)
                     ->  Dynamic Seq Scan on bar (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=12)
                           Filter: (d > 5)
 Optimizer: Pivotal Optimizer (GPORCA)
(15 rows)
```

And in the master branch, ORCA and PostgreSQL's optimizer do the same thing:

```
postgres=# explain select * from foo, bar where foo.a = bar.d and bar.d > 5;
                                      QUERY PLAN                                       
---------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=40)
   ->  Hash Join  (cost=0.00..862.00 rows=1 width=40)
         Hash Cond: (foo.a = bar_1_prt_1.d)
         ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=28)
               Filter: (a > 5)
         ->  Hash  (cost=431.00..431.00 rows=1 width=12)
               ->  Append  (cost=0.00..431.00 rows=1 width=12)
                     ->  Seq Scan on bar_1_prt_1  (cost=0.00..431.00 rows=1 width=12)
                           Filter: (d > 5)
                     ->  Seq Scan on bar_1_prt_2  (cost=0.00..431.00 rows=1 width=12)
                           Filter: (d > 5)
                     ->  Seq Scan on bar_1_prt_3  (cost=0.00..431.00 rows=1 width=12)
                           Filter: (d > 5)
                     ->  Seq Scan on bar_1_prt_4  (cost=0.00..431.00 rows=1 width=12)
                           Filter: (d > 5)
                     ->  Seq Scan on bar_1_prt_5  (cost=0.00..431.00 rows=1 width=12)
                           Filter: (d > 5)
                     ->  Seq Scan on bar_1_prt_6  (cost=0.00..431.00 rows=1 width=12)
                           Filter: (d > 5)
                     ->  Seq Scan on bar_1_prt_7  (cost=0.00..431.00 rows=1 width=12)
                           Filter: (d > 5)
                     ->  Seq Scan on bar_1_prt_8  (cost=0.00..431.00 rows=1 width=12)
                           Filter: (d > 5)
                     ->  Seq Scan on bar_1_prt_9  (cost=0.00..431.00 rows=1 width=12)
                           Filter: (d > 5)
                     ->  Seq Scan on bar_1_prt_10  (cost=0.00..431.00 rows=1 width=12)
                           Filter: (d > 5)
 Optimizer: Pivotal Optimizer (GPORCA)
(28 rows)

postgres=# set optimizer = off;
SET

postgres=# explain select * from foo, bar where foo.a = bar.d and bar.d > 5;
                                           QUERY PLAN                                            
-------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=173.44..50726.75 rows=2172544 width=112)
   ->  Hash Join  (cost=173.44..21759.49 rows=724181 width=112)
         Hash Cond: (bar_1_prt_1.d = foo.a)
         ->  Append  (cost=0.00..4018.61 rows=86556 width=12)
               Partition Selectors: $0
               ->  Seq Scan on bar_1_prt_1  (cost=0.00..358.58 rows=8656 width=12)
                     Filter: (d > 5)
               ->  Seq Scan on bar_1_prt_2  (cost=0.00..358.58 rows=8656 width=12)
                     Filter: (d > 5)
               ->  Seq Scan on bar_1_prt_3  (cost=0.00..358.58 rows=8656 width=12)
                     Filter: (d > 5)
               ->  Seq Scan on bar_1_prt_4  (cost=0.00..358.58 rows=8656 width=12)
                     Filter: (d > 5)
               ->  Seq Scan on bar_1_prt_5  (cost=0.00..358.58 rows=8656 width=12)
                     Filter: (d > 5)
               ->  Seq Scan on bar_1_prt_6  (cost=0.00..358.58 rows=8656 width=12)
                     Filter: (d > 5)
               ->  Seq Scan on bar_1_prt_7  (cost=0.00..358.58 rows=8656 width=12)
                     Filter: (d > 5)
               ->  Seq Scan on bar_1_prt_8  (cost=0.00..358.58 rows=8656 width=12)
                     Filter: (d > 5)
               ->  Seq Scan on bar_1_prt_9  (cost=0.00..358.58 rows=8656 width=12)
                     Filter: (d > 5)
               ->  Seq Scan on bar_1_prt_10  (cost=0.00..358.58 rows=8656 width=12)
                     Filter: (d > 5)
         ->  Hash  (cost=138.58..138.58 rows=2789 width=100)
               ->  Partition Selector (selector id: $0)  (cost=0.00..138.58 rows=2789 width=100)
                     ->  Seq Scan on foo  (cost=0.00..138.58 rows=2789 width=100)
                           Filter: (a > 5)
 Optimizer: Postgres query optimizer
```

So we can remove `DynamicTableScanInfo` struct and correlative codes.
