### PR TITLE
Resolve GPDB_12_MERGE_FIXME: Implement relation_vacuum AM for AO/CO tables.

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -1039,13 +1039,12 @@ aoco_vacuum_rel(Relation onerel, VacuumParams *params,
                       BufferAccessStrategy bstrategy)
 {
 	/*
-	 * GPDB_12_MERGE_FIXME: This is a dummy function in order to proceed with
-	 * the implementation of the aocsam_handler.
-	 *
-	 * It's not invoked ever, we do the AO different phases vacuuming in
-	 * vacuum_rel() directly for now.
+	 * Implemented but not invoked, we do the AO_COLUMN different phases vacuuming by
+	 * calling ao_vacuum_rel() in vacuum_rel() directly for now.
 	 */
-	elog(ERROR, "not implemented yet");
+	ao_vacuum_rel(onerel, params, bstrategy);
+
+	return;
 }
 
 static void

--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -497,7 +497,7 @@ AppendOnlySegmentFileFullCompaction(Relation aorel,
  * available. If it's not, no segments are dropped.
  */
 void
-AppendOnlyRecycleDeadSegments(Relation aorel)
+AppendOptimizedRecycleDeadSegments(Relation aorel)
 {
 	Relation	pg_aoseg_rel;
 	TupleDesc	pg_aoseg_dsc;
@@ -629,7 +629,7 @@ AppendOnlyRecycleDeadSegments(Relation aorel)
  * the segment file is skipped.
  */
 void
-AppendOnlyTruncateToEOF(Relation aorel)
+AppendOptimizedTruncateToEOF(Relation aorel)
 {
 	const char *relname;
 	Relation	pg_aoseg_rel;

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -847,15 +847,11 @@ appendonly_vacuum_rel(Relation onerel, VacuumParams *params,
 					  BufferAccessStrategy bstrategy)
 {
 	/*
-	 * GPDB_12_MERGE_FIXME: This is a dummy function in order to proceed with
-	 * the implementation of the appendonlyam_handler.
-	 *
-	 * It's not invoked ever, we do the AO different phases vacuuming in
-	 * vacuum_rel() directly for now.
-	 *
-	 * A snipped implementation exists in appendonly_vacuum.c which would need
-	 * to get revived here.
+	 * Implemented but not invoked, we do the AO_ROW different phases vacuuming by
+	 * calling ao_vacuum_rel() in vacuum_rel() directly for now.
 	 */
+	ao_vacuum_rel(onerel, params, bstrategy);
+	
 	return;
 }
 

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -5955,7 +5955,7 @@ ATAocsWriteNewColumns(AlteredTableInfo *tab)
 	Assert(RelationIsAoCols(rel));
 
 	/* Try to recycle any old segfiles first. */
-	AppendOnlyRecycleDeadSegments(rel);
+	AppendOptimizedRecycleDeadSegments(rel);
 
 	segInfos = GetAllAOCSFileSegInfo(rel, snapshot, &nseg);
 	basepath = relpathbackend(rel->rd_node, rel->rd_backend, MAIN_FORKNUM);

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -2323,26 +2323,9 @@ vacuum_rel(Oid relid, RangeVar *relation, VacuumParams *params,
 			LockRelation(onerel, ShareLock);
 	}
 
-	/*
-	 * Do the actual work --- either FULL or "lazy" vacuum
-	 */
-	if (ao_vacuum_phase == VACOPT_AO_PRE_CLEANUP_PHASE)
-	{
-		ao_vacuum_rel_pre_cleanup(onerel, params->options, params, vac_strategy);
-	}
-	else if (ao_vacuum_phase == VACOPT_AO_COMPACT_PHASE)
-	{
-		ao_vacuum_rel_compact(onerel, params->options, params, vac_strategy);
-	}
-	else if (ao_vacuum_phase == VACOPT_AO_POST_CLEANUP_PHASE)
-	{
-		ao_vacuum_rel_post_cleanup(onerel, params->options, params, vac_strategy);
-	}
-	else if (is_appendoptimized)
-	{
-		/* Do nothing here, we will launch the stages later */
-		Assert(ao_vacuum_phase == 0);
-	}
+	if (is_appendoptimized)
+		/* entrance of vacuuming Append-Optimized table */
+		ao_vacuum_rel(onerel, params, vac_strategy);
 	else if ((params->options & VACOPT_FULL))
 	{
 		int			cluster_options = 0;

--- a/src/backend/commands/vacuum_ao.c
+++ b/src/backend/commands/vacuum_ao.c
@@ -199,13 +199,13 @@ ao_vacuum_rel_pre_cleanup(Relation onerel, int options, VacuumParams *params,
 					get_namespace_name(RelationGetNamespace(onerel)),
 					relname)));
 
-	AppendOnlyRecycleDeadSegments(onerel);
+	AppendOptimizedRecycleDeadSegments(onerel);
 
 	/*
 	 * Also truncate all live segments to the EOF values stored in pg_aoseg.
 	 * This releases space left behind by aborted inserts.
 	 */
-	AppendOnlyTruncateToEOF(onerel);
+	AppendOptimizedTruncateToEOF(onerel);
 }
 
 
@@ -242,7 +242,7 @@ ao_vacuum_rel_post_cleanup(Relation onerel, int options, VacuumParams *params,
 	 */
 	Assert(RelationIsAoRows(onerel) || RelationIsAoCols(onerel));
 
-	AppendOnlyRecycleDeadSegments(onerel);
+	AppendOptimizedRecycleDeadSegments(onerel);
 
 	vacuum_appendonly_indexes(onerel, options, bstrategy);
 
@@ -362,6 +362,33 @@ ao_vacuum_rel_compact(Relation onerel, int options, VacuumParams *params,
 	}
 
 	UnregisterSnapshot(appendOnlyMetaDataSnapshot);
+}
+
+/*
+ * ao_vacuum_rel()
+ *
+ * Common interface for vacuuming Append-Optimized table.
+ */
+void
+ao_vacuum_rel(Relation rel, VacuumParams *params, BufferAccessStrategy bstrategy)
+{
+	Assert(RelationIsAppendOptimized(rel));
+	Assert(params != NULL);
+
+	int ao_vacuum_phase = (params->options & VACUUM_AO_PHASE_MASK);
+
+	/*
+	 * Do the actual work --- either FULL or "lazy" vacuum
+	 */
+	if (ao_vacuum_phase == VACOPT_AO_PRE_CLEANUP_PHASE)
+		ao_vacuum_rel_pre_cleanup(rel, params->options, params, bstrategy);
+	else if (ao_vacuum_phase == VACOPT_AO_COMPACT_PHASE)
+		ao_vacuum_rel_compact(rel, params->options, params, bstrategy);
+	else if (ao_vacuum_phase == VACOPT_AO_POST_CLEANUP_PHASE)
+		ao_vacuum_rel_post_cleanup(rel, params->options, params, bstrategy);
+	else
+		/* Do nothing here, we will launch the stages later */
+		Assert(ao_vacuum_phase == 0);
 }
 
 

--- a/src/include/access/appendonly_compaction.h
+++ b/src/include/access/appendonly_compaction.h
@@ -21,7 +21,7 @@
 
 #define APPENDONLY_COMPACTION_SEGNO_INVALID (-1)
 
-extern void AppendOnlyRecycleDeadSegments(Relation aorel);
+extern void AppendOptimizedRecycleDeadSegments(Relation aorel);
 extern void AppendOnlyCompact(Relation aorel,
 							  int compaction_segno,
 							  int *insert_segno,
@@ -34,6 +34,6 @@ extern bool AppendOnlyCompaction_ShouldCompact(
 								   bool isFull,
 								   Snapshot appendOnlyMetaDataSnapshot);
 extern void AppendOnlyThrowAwayTuple(Relation rel, TupleTableSlot *slot);
-extern void AppendOnlyTruncateToEOF(Relation aorel);
+extern void AppendOptimizedTruncateToEOF(Relation aorel);
 
 #endif

--- a/src/include/commands/vacuum.h
+++ b/src/include/commands/vacuum.h
@@ -329,6 +329,8 @@ extern void ao_vacuum_rel_compact(Relation onerel, int options, VacuumParams *pa
 extern void ao_vacuum_rel_post_cleanup(Relation onerel, int options, VacuumParams *params,
 									   BufferAccessStrategy bstrategy);
 
+extern void ao_vacuum_rel(Relation rel, VacuumParams *params, BufferAccessStrategy bstrategy);
+
 extern bool std_typanalyze(VacAttrStats *stats);
 
 /* in utils/misc/sampling.c --- duplicate of declarations in utils/sampling.h */


### PR DESCRIPTION
This is intended to provide a simple implementation for relation_vacuum
access method for Append-Optimized tables to address FIXMEs in
appendonly_vacuum_rel() and aoco_vacuum_rel().
    
It should be noted that although we implement both AMs, they still will not
be invoked in current code. Instead, we will keep doing AO/CO different
phases vacuuming by calling a wrapper function ao_vacuum_rel()(enclosing
ao_vacuum_rel_*()) in vacuum_rel() directly.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
