### PR TITLE
fix inaccurate int type total_memory_coordinator of PlannedStmt

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -263,7 +263,7 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 			 */
 			if (IsResGroupEnabled())
 			{
-				int32 	total_memory_coordinator = queryDesc->plannedstmt->total_memory_coordinator;
+				int 	total_memory_coordinator = queryDesc->plannedstmt->total_memory_coordinator;
 				int    	nsegments_coordinator = queryDesc->plannedstmt->nsegments_coordinator;
 
 				/*
@@ -275,7 +275,7 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 					should_skip_operator_memory_assign = false;
 
 					/* Get total system memory on the QE in MB */
-					int32 	total_memory_segment = ResGroupOps_GetTotalMemory();
+					int 	total_memory_segment = ResGroupOps_GetTotalMemory();
 					int 	nsegments_segment = ResGroupGetSegmentNum();
 					uint64	coordinator_query_mem = queryDesc->plannedstmt->query_mem;
 

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -388,7 +388,7 @@ _outPlannedStmt(StringInfo str, const PlannedStmt *node)
 
 	WRITE_UINT64_FIELD(query_mem);
 
-	WRITE_UINT_FIELD(total_memory_coordinator);
+	WRITE_INT_FIELD(total_memory_coordinator);
 	WRITE_INT_FIELD(nsegments_coordinator);
 
 	WRITE_NODE_FIELD(intoClause);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2459,7 +2459,7 @@ _readPlannedStmt(void)
 
 	READ_UINT64_FIELD(query_mem);
 
-	READ_UINT_FIELD(total_memory_coordinator);
+	READ_INT_FIELD(total_memory_coordinator);
 	READ_INT_FIELD(nsegments_coordinator);
 
 	READ_NODE_FIELD(intoClause);

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -144,7 +144,7 @@ typedef struct PlannedStmt
 	/* What is the memory reserved for this query's execution? */
 	uint64		query_mem;
 
-	int32		total_memory_coordinator;	/* GPDB: The total usable virtual memory on coordinator node in MB */
+	int			total_memory_coordinator;	/* GPDB: The total usable virtual memory on coordinator node in MB */
 	int			nsegments_coordinator;		/* GPDB: The number of primary segments on coordinator node  */
 
 	/*


### PR DESCRIPTION
This PR is a patch to #13160, which fixed inaccurate int type `total_memory_coordinator` of `PlannedStmt`.

The return type of the function `ResGroupOps_GetTotalMemory` is `int`, we need to be consistent with it, 
and fix the incorrect type writing and reading in functions such as `_outPlannedStmt` and `_readPlannedStmt`.

No more tests need, since #13160 already has.
