### PR TITLE
Cherrypick TAP test for "Detect client disconnection while running query and interrupt execution"

### DIFF
--- a/src/test/recovery/t/201_close_connection.pl
+++ b/src/test/recovery/t/201_close_connection.pl
@@ -1,0 +1,103 @@
+# Check if backend stopped after client disconnection
+# FIXME: this test should really be among the src/test/modules tests. 
+# However because currently modules are not recursed into for installcheck,
+# we put this test here for now in order to have it running in pipeline. 
+# We should move it to modules/connection like 6X once we could run modules tests
+# in pipeline (either let installcheck recurse into modules, or run modules separately).
+use strict;
+use warnings;
+use PostgresNode;
+use TestLib;
+use Test::More;
+use File::Copy;
+
+if ($ENV{with_openssl} eq 'yes')
+{
+    plan tests => 3;
+}
+else
+{
+    plan tests => 2;
+}
+
+my $long_query = q{
+    SELECT pg_sleep(60);
+};
+my $set_guc_on = q{
+    SET client_connection_check_interval = 1000;
+};
+my $set_guc_off = q{
+    SET client_connection_check_interval = 0;
+};
+my ($pid, $timed_out);
+
+my $node = get_new_node('node');
+$node->init;
+$node->start;
+
+#########################################################
+# TEST 1: GUC client_connection_check_interval: enabled #
+#########################################################
+
+# Set GUC options, get backend pid and run a long time query
+# Leverage the timeout argument to psql to cause client 
+# termination without causing immediate backend termination
+$node->psql('postgres', "$set_guc_on SELECT pg_backend_pid(); $long_query",
+            stdout => \$pid, timeout => 1, timed_out => \$timed_out);
+
+# Give time to the backend to detect client disconnected
+sleep 4;
+# Check if backend is still alive
+my $is_alive = $node->safe_psql('postgres', "SELECT count(*) FROM pg_stat_activity where pid = $pid;");
+is($is_alive, '0', 'Test: client_connection_check_interval enable');
+$node->stop;
+
+##########################################################
+# TEST 2: GUC client_connection_check_interval: disabled #
+##########################################################
+
+$node->start;
+$node->psql('postgres', "$set_guc_off SELECT pg_backend_pid(); $long_query",
+            stdout => \$pid, timeout => 1, timed_out => \$timed_out);
+# Give time to the client to disconnect
+sleep 4;
+# Check if backend is still alive
+$is_alive = $node->safe_psql('postgres', "SELECT count(*) FROM pg_stat_activity where pid = $pid;");
+is($is_alive, '1', 'Test: client_connection_check_interval disable');
+$node->stop;
+
+##########################################################
+# TEST 3: Using client_connection_check_interval when    #
+#         client connected using SSL                     #
+##########################################################
+
+if ($ENV{with_openssl} eq 'yes')
+{
+    # The client's private key must not be world-readable, so take a copy
+    # of the key stored in the code tree and update its permissions.
+    copy("../../ssl/ssl/client.key", "../../ssl/ssl/client_tmp.key");
+    chmod 0600, "../../ssl/ssl/client_tmp.key";
+    copy("../../ssl/ssl/client-revoked.key", "../../ssl/ssl/client-revoked_tmp.key");
+    chmod 0600, "../../ssl/ssl/client-revoked_tmp.key";
+    $ENV{PGHOST} = $node->host;
+    $ENV{PGPORT} = $node->port;
+
+    open my $sslconf, '>', $node->data_dir . "/sslconfig.conf";
+    print $sslconf "ssl=on\n";
+    print $sslconf "ssl_cert_file='server-cn-only.crt'\n";
+    print $sslconf "ssl_key_file='server-password.key'\n";
+    print $sslconf "ssl_passphrase_command='echo secret1'\n";
+    close $sslconf;
+
+    $node->start;
+    $node->psql('postgres', "$set_guc_on SELECT pg_backend_pid(); $long_query",
+                stdout => \$pid, timeout => 1, timed_out => \$timed_out,
+                sslmode => 'require');
+
+    # Give time to the backend to detect client disconnected
+    sleep 4;
+    # Check if backend is still alive
+    my $is_alive = $node->safe_psql('postgres', "SELECT count(*) FROM pg_stat_activity where pid = $pid;");
+    is($is_alive, '0', 'Test: client_connection_check_interval enabled, SSL');
+    $node->stop;
+}


### PR DESCRIPTION
Commit 733cbbd adjusted and backported an upstream fix that when client is disconnected the backend could be left as a zombie.

Both the upstream and our backport commits are without a test. The initial upstream patch, however, had a TAP test. It was removed later because it could suffer issues on slow machines in the buildfarm (details see https://www.postgresql.org/message-id/flat/77def86b27e41f0efcba411460e929ae%40postgrespro.ru)

The same fix in GPDB 6X (0bb081e) has an isolation2 test. But it was seen to be flaky in pipeline due to a race condition. Failure diff:
```
--- \/tmp\/build\/e18b2f02\/gpdb_src\/src\/test\/isolation2\/expected\/pg_terminate_backend\.out	2022-04-06 14:16:31.922530584 +0000
+++ \/tmp\/build\/e18b2f02\/gpdb_src\/src\/test\/isolation2\/results\/pg_terminate_backend\.out	2022-04-06 14:16:31.922530584 +0000
@@ -50,7 +50,7 @@
 !& psql -c "set client_connection_check_interval to 5000; commit; select pg_sleep(1359);" postgres; 2: select count(*) from pg_stat_activity where query='set client_connection_check_interval to 5000; commit; select pg_sleep(1359);';
  count 
 -------
- 1     
+ 0     
 (1 row)
 !\retcode kill `ps -ef | grep -v /bin/sh | grep psql | grep client_connection_check_interval | awk '{print $2}' | head -1`;
```

Now, because GPDB doesn't suffer the slow animals in the buildfarm, we think it's more useful than harmful for GPDB to have the initial TAP test. So cherrypicking the same with two changes:
1. Using pg_sleep for the long query instead of a heavy select (discussed in upstream too).
2. Putting this test under src/test/recovery temporarily, because currently ./modules are not recursed into by installcheck so we can't put it there if we want to run the test in pipeline. We'll address that issue separately, and once it's addressed, we can move this test back to src/test/modules.

For 6X, we'll add the same TAP test too. With that we'll remove the isolation2 test case. It is still possible that a race could occur even with TAP, but after all the TAP test has more cases covered, and for client testing TAP might be a bit more suitable too.

Upstream discussion: https://www.postgresql.org/message-id/flat/77def86b27e41f0efcba411460e929ae%40postgrespro.ru
Original patch: https://www.postgresql.org/message-id/attachment/98627/Add_client_connection_check_v2.patch

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
