### PR TITLE
Remove overload raise function with severity_level

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -159,12 +159,9 @@ CTranslatorUtils::GetTableDescr(CMemoryPool *mp, CMDAccessor *md_accessor,
 		// the fact that catalog tables (master-only) are not analyzed often and will result in Orca producing
 		// inferior plans.
 
-		GPOS_THROW_EXCEPTION(
-			gpdxl::ExmaDXL,							 // major
-			gpdxl::ExmiQuery2DXLUnsupportedFeature,	 // minor
-			CException::
-				ExsevDebug1,  // ulSeverityLevel mapped to GPDB severity level
-			GPOS_WSZ_LIT("Queries on master-only tables"));
+		GPOS_THROW_EXCEPTION(gpdxl::ExmaDXL,						  // major
+							 gpdxl::ExmiQuery2DXLUnsupportedFeature,  // minor
+							 GPOS_WSZ_LIT("Queries on master-only tables"));
 	}
 
 	// add columns from md cache relation object to table descriptor

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -235,7 +235,7 @@ COptTasks::Execute(void *(*func)(void *), void *func_arg)
 	}
 	GPOS_CATCH_EX(ex)
 	{
-		LogExceptionMessageAndDelete(err_buf, ex.SeverityLevel());
+		LogExceptionMessageAndDelete(err_buf);
 		GPOS_RETHROW(ex);
 	}
 	GPOS_CATCH_END;
@@ -243,18 +243,11 @@ COptTasks::Execute(void *(*func)(void *), void *func_arg)
 }
 
 void
-COptTasks::LogExceptionMessageAndDelete(CHAR *err_buf, ULONG severity_level)
+COptTasks::LogExceptionMessageAndDelete(CHAR *err_buf)
 {
 	if ('\0' != err_buf[0])
 	{
-		int gpdb_severity_level;
-
-		if (severity_level == CException::ExsevDebug1)
-			gpdb_severity_level = DEBUG1;
-		else
-			gpdb_severity_level = LOG;
-
-		elog(gpdb_severity_level, "%s",
+		elog(LOG, "%s",
 			 CreateMultiByteCharStringFromWCString((WCHAR *) err_buf));
 	}
 

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXLUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXLUtils.cpp
@@ -180,7 +180,7 @@ CTranslatorExprToDXLUtils::PdxlnListFilterPartKey(CMemoryPool *mp,
 				"Unsupported part filter operator for list partitions : %ls"),
 			pexprPartKey->Pop()->SzId());
 		GPOS_THROW_EXCEPTION(gpopt::ExmaGPOPT, gpopt::ExmiUnsupportedOp,
-							 CException::ExsevDebug1, str->GetBuffer());
+							 str->GetBuffer());
 	}
 
 	GPOS_ASSERT(nullptr != pdxlnPartKey);

--- a/src/backend/gporca/libgpos/include/gpos/error/CException.h
+++ b/src/backend/gporca/libgpos/include/gpos/error/CException.h
@@ -163,9 +163,6 @@ private:
 	// line in file
 	ULONG m_line;
 
-	// severity level mapped to GPDB log severity level
-	ULONG m_severity_level;
-
 	// sql state error codes
 	static const ErrCodeElem m_errcode[ExmiSQLTest - ExmiSQLDefault + 1];
 
@@ -181,13 +178,10 @@ public:
 	enum ExSeverity
 	{
 		ExsevInvalid = 0,
-		ExsevPanic,
-		ExsevFatal,
 		ExsevError,
 		ExsevWarning,
 		ExsevNotice,
 		ExsevTrace,
-		ExsevDebug1,
 
 		ExsevSentinel
 	};
@@ -198,8 +192,6 @@ public:
 	// ctor
 	CException(ULONG major, ULONG minor);
 	CException(ULONG major, ULONG minor, const CHAR *filename, ULONG line);
-	CException(ULONG major, ULONG minor, const CHAR *filename, ULONG line,
-			   ULONG severity_level);
 
 	// accessors
 	ULONG
@@ -224,12 +216,6 @@ public:
 	Line() const
 	{
 		return m_line;
-	}
-
-	ULONG
-	SeverityLevel() const
-	{
-		return m_severity_level;
 	}
 
 	const CHAR *

--- a/src/backend/gporca/libgpos/include/gpos/error/CException.h
+++ b/src/backend/gporca/libgpos/include/gpos/error/CException.h
@@ -271,11 +271,6 @@ public:
 	static void Raise(const CHAR *filename, ULONG line, ULONG major,
 					  ULONG minor, ...) __attribute__((__noreturn__));
 
-	// wrapper around throw with severity level
-	static void Raise(const CHAR *filename, ULONG line, ULONG major,
-					  ULONG minor, ULONG severity_level, ...)
-		__attribute__((__noreturn__));
-
 	// rethrow wrapper
 	static void Reraise(CException exc, BOOL propagate = false)
 		__attribute__((__noreturn__));

--- a/src/backend/gporca/libgpos/src/error/CException.cpp
+++ b/src/backend/gporca/libgpos/src/error/CException.cpp
@@ -17,8 +17,8 @@
 
 using namespace gpos;
 
-const CHAR *CException::m_severity[] = {"INVALID", "PANIC",	 "FATAL", "ERROR",
-										"WARNING", "NOTICE", "TRACE"};
+const CHAR *CException::m_severity[] = {"INVALID", "ERROR", "WARNING", "NOTICE",
+										"TRACE"};
 
 
 // invalid exception
@@ -52,19 +52,6 @@ CException::CException(ULONG major, ULONG minor, const CHAR *filename,
 	  m_filename(const_cast<CHAR *>(filename)),
 	  m_line(line)
 {
-	m_severity_level = CException::ExsevSentinel;
-	m_sql_state = GetSQLState(major, minor);
-}
-
-// ctor
-CException::CException(ULONG major, ULONG minor, const CHAR *filename,
-					   ULONG line, ULONG severity_level)
-	: m_major(major),
-	  m_minor(minor),
-	  m_filename(const_cast<CHAR *>(filename)),
-	  m_line(line),
-	  m_severity_level(severity_level)
-{
 	m_sql_state = GetSQLState(major, minor);
 }
 
@@ -80,7 +67,6 @@ CException::CException(ULONG major, ULONG minor, const CHAR *filename,
 CException::CException(ULONG major, ULONG minor)
 	: m_major(major), m_minor(minor), m_filename(nullptr), m_line(0)
 {
-	m_severity_level = CException::ExsevSentinel;
 	m_sql_state = GetSQLState(major, minor);
 }
 

--- a/src/backend/gporca/libgpos/src/error/CException.cpp
+++ b/src/backend/gporca/libgpos/src/error/CException.cpp
@@ -123,33 +123,6 @@ CException::Raise(const CHAR *filename, ULONG line, ULONG major, ULONG minor,
 }
 
 
-void
-CException::Raise(const CHAR *filename, ULONG line, ULONG major, ULONG minor,
-				  ULONG severity_level...)
-{
-	// manufacture actual exception object
-	CException exc(major, minor, filename, line, severity_level);
-
-	// during bootstrap there's no context object otherwise, record
-	// all details in the context object
-	if (nullptr != ITask::Self())
-	{
-		CErrorContext *err_ctxt = CTask::Self()->ConvertErrCtxt();
-
-		VA_LIST va_list;
-		VA_START(va_list, severity_level);
-
-		err_ctxt->Record(exc, va_list);
-
-		VA_END(va_list);
-
-		err_ctxt->Serialize();
-	}
-
-	Raise(exc);
-}
-
-
 //---------------------------------------------------------------------------
 //	@function:
 //		CException::Reraise

--- a/src/include/gpopt/utils/COptTasks.h
+++ b/src/include/gpopt/utils/COptTasks.h
@@ -120,8 +120,7 @@ private:
 	static void Execute(void *(*func)(void *), void *func_arg);
 
 	// map GPOS log severity level to GPDB, print error and delete the given error buffer
-	static void LogExceptionMessageAndDelete(
-		CHAR *err_buf, ULONG severity_level = CException::ExsevInvalid);
+	static void LogExceptionMessageAndDelete(CHAR *err_buf);
 
 	// create optimizer configuration object
 	static COptimizerConfig *CreateOptimizerConfig(CMemoryPool *mp,


### PR DESCRIPTION
Issue is that with the overload we cannot properly raise while passing a
variadic integer argument. Instead it will interpret the arguemnt as
severity_level. This leads to bogus error messages that don't make sense.

Following SQL demonstrates the issue:
```sql
CREATE TABLE foo(a INT);
CREATE TABLE bar(b INT);
SET client_min_messages='log';
EXPLAIN SELECT * FROM foo WHERE (SELECT a FROM foo limit 1) = ALL(SELECT b FROM bar);
```

Error log with bogus attribute number:
```
LOG:  statement: EXPLAIN SELECT * FROM foo WHERE (SELECT a FROM foo limit 1) = ALL(SELECT b FROM bar);
LOG:  2022-04-08 19:12:08:288416 UTC,THD000,ERROR,"DXL-to-PlStmt Translation: Attribute number -1903101480 not found in project list",
```