### PR TITLE
Fix subquery all subquery context

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/AllSubqueryWithSubqueryInScalar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AllSubqueryWithSubqueryInScalar.mdp
@@ -3,6 +3,25 @@
      CREATE TABLE foo(a INT);
      CREATE TABLE bar(b INT);
      EXPLAIN SELECT * FROM foo WHERE (SELECT a FROM foo limit 1) = ALL(SELECT b FROM bar);
+
+     Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1356704383.34 rows=1 width=4)
+       ->  Result  (cost=0.00..1356704383.34 rows=1 width=4)
+             Filter: (SubPlan 2)
+             ->  Seq Scan on foo  (cost=0.00..1356704383.32 rows=334 width=5)
+             SubPlan 2
+               ->  Result  (cost=0.00..1324044.59 rows=1000 width=9)
+                     ->  Materialize  (cost=0.00..1324044.58 rows=1000 width=8)
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1324044.57 rows=1000 width=8)
+                                 ->  Seq Scan on bar  (cost=0.00..1324044.43 rows=334 width=8)
+                                       SubPlan 1
+                                         ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                                               ->  Broadcast Motion 1:3  (slice3)  (cost=0.00..431.00 rows=1 width=4)
+                                                     ->  Limit  (cost=0.00..431.00 rows=1 width=4)
+                                                           ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                                                 ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=4)
+     Optimizer: Pivotal Optimizer (GPORCA)
+    (16 rows)
+
 -->
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">

--- a/src/backend/gporca/data/dxl/minidump/AllSubqueryWithSubqueryInScalar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AllSubqueryWithSubqueryInScalar.mdp
@@ -339,181 +339,221 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="12">
-      <dxl:Result>
+    <dxl:Plan Id="0" SpaceSize="118">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="8620.424108" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="2155.218383" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
             <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
-        <dxl:Filter>
-          <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AllSubPlan">
-            <dxl:TestExpr>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
-                <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:Comparison>
-            </dxl:TestExpr>
-            <dxl:ParamList/>
-            <dxl:Result>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.035598" Rows="1000.000000" Width="8"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="8" Alias="b">
-                  <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter>
-                <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="ScalarSubPlan">
-                  <dxl:TestExpr/>
-                  <dxl:ParamList/>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000079" Rows="1.000000" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="32" Alias="ColRef_0032">
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                    <dxl:Materialize Eager="true">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000079" Rows="1.000000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="16" Alias="a">
-                          <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:Limit>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000075" Rows="1.000000" Width="4"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="16" Alias="a">
-                            <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="16" Alias="a">
-                              <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:SortingColumnList/>
-                          <dxl:TableScan>
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="16" Alias="a">
-                                <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:TableDescriptor Mdid="0.377090.1.0" TableName="foo">
-                              <dxl:Columns>
-                                <dxl:Column ColId="16" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="17" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                <dxl:Column ColId="18" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="19" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="20" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="21" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="22" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="23" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                              </dxl:Columns>
-                            </dxl:TableDescriptor>
-                          </dxl:TableScan>
-                        </dxl:GatherMotion>
-                        <dxl:LimitCount>
-                          <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                          </dxl:Cast>
-                        </dxl:LimitCount>
-                        <dxl:LimitOffset>
-                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                        </dxl:LimitOffset>
-                      </dxl:Limit>
-                    </dxl:Materialize>
-                  </dxl:Result>
-                </dxl:SubPlan>
-              </dxl:Filter>
-              <dxl:OneTimeFilter/>
-              <dxl:Materialize Eager="true">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000075" Rows="1.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="8" Alias="b">
-                    <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="8" Alias="b">
-                      <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:SortingColumnList/>
-                  <dxl:TableScan>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="8" Alias="b">
-                        <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="0.377093.1.0" TableName="bar">
-                      <dxl:Columns>
-                        <dxl:Column ColId="8" Attno="1" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                        <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
-                </dxl:GatherMotion>
-              </dxl:Materialize>
-            </dxl:Result>
-          </dxl:SubPlan>
-        </dxl:Filter>
-        <dxl:OneTimeFilter/>
-        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000024" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="2155.218369" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:SortingColumnList/>
+          <dxl:Filter>
+            <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AllSubPlan">
+              <dxl:TestExpr>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+              </dxl:TestExpr>
+              <dxl:ParamList/>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.172338" Rows="3000.000000" Width="9"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="8" Alias="b">
+                    <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="16" Alias="a">
+                    <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+                <dxl:Result>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="1293.172338" Rows="3000.000000" Width="9"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="24" Alias="ColRef_0024">
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="8" Alias="b">
+                      <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="16" Alias="a">
+                      <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Materialize Eager="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="1293.163338" Rows="3000.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="8" Alias="b">
+                        <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="16" Alias="a">
+                        <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="1293.155338" Rows="3000.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="8" Alias="b">
+                          <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="16" Alias="a">
+                          <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList/>
+                      <dxl:Result>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="1293.012138" Rows="1000.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="8" Alias="b">
+                            <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="16" Alias="a">
+                            <dxl:SubPlan TypeMdid="0.23.1.0" SubPlanType="ScalarSubPlan">
+                              <dxl:TestExpr/>
+                              <dxl:ParamList/>
+                              <dxl:Materialize Eager="false">
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000294" Rows="3.000000" Width="4"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="16" Alias="a">
+                                    <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000290" Rows="3.000000" Width="4"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="16" Alias="a">
+                                      <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:SortingColumnList/>
+                                  <dxl:Limit>
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.000075" Rows="1.000000" Width="4"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="16" Alias="a">
+                                        <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
+                                      </dxl:Properties>
+                                      <dxl:ProjList>
+                                        <dxl:ProjElem ColId="16" Alias="a">
+                                          <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                      </dxl:ProjList>
+                                      <dxl:Filter/>
+                                      <dxl:SortingColumnList/>
+                                      <dxl:TableScan>
+                                        <dxl:Properties>
+                                          <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
+                                        </dxl:Properties>
+                                        <dxl:ProjList>
+                                          <dxl:ProjElem ColId="16" Alias="a">
+                                            <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+                                          </dxl:ProjElem>
+                                        </dxl:ProjList>
+                                        <dxl:Filter/>
+                                        <dxl:TableDescriptor Mdid="0.377090.1.0" TableName="foo">
+                                          <dxl:Columns>
+                                            <dxl:Column ColId="16" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                            <dxl:Column ColId="17" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                            <dxl:Column ColId="18" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                            <dxl:Column ColId="19" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                            <dxl:Column ColId="20" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                            <dxl:Column ColId="21" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                            <dxl:Column ColId="22" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                            <dxl:Column ColId="23" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                          </dxl:Columns>
+                                        </dxl:TableDescriptor>
+                                      </dxl:TableScan>
+                                    </dxl:GatherMotion>
+                                    <dxl:LimitCount>
+                                      <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
+                                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                                      </dxl:Cast>
+                                    </dxl:LimitCount>
+                                    <dxl:LimitOffset>
+                                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                                    </dxl:LimitOffset>
+                                  </dxl:Limit>
+                                </dxl:BroadcastMotion>
+                              </dxl:Materialize>
+                            </dxl:SubPlan>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:OneTimeFilter/>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="1293.012138" Rows="1000.000000" Width="8"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="8" Alias="b">
+                              <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="0.377093.1.0" TableName="bar">
+                            <dxl:Columns>
+                              <dxl:Column ColId="8" Attno="1" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                              <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:Result>
+                    </dxl:BroadcastMotion>
+                  </dxl:Materialize>
+                </dxl:Result>
+              </dxl:Result>
+            </dxl:SubPlan>
+          </dxl:Filter>
+          <dxl:OneTimeFilter/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="2155.207402" Rows="1000.000000" Width="5"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -534,8 +574,8 @@
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>
-        </dxl:GatherMotion>
-      </dxl:Result>
+        </dxl:Result>
+      </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -3,6 +3,7 @@
 -- ----------------------------------------------------------------------
 create schema qp_correlated_query;
 set search_path to qp_correlated_query;
+set optimizer_trace_fallback TO on;
 -- ----------------------------------------------------------------------
 -- Test: csq_heap_in.sql (Correlated Subquery: CSQ using IN clause (Heap))
 -- ----------------------------------------------------------------------
@@ -3799,3 +3800,4 @@ DROP TABLE IF EXISTS supplier;
 -- ----------------------------------------------------------------------
 set client_min_messages='warning';
 drop schema qp_correlated_query cascade;
+reset optimizer_trace_fallback;

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -919,6 +919,58 @@ select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C where C.j =
  1 | -1 | 62
 (10 rows)
 
+-- -- -- --
+-- Test ALL clause with subqueries
+-- -- -- --
+create table qp_csq_all_t1(a int) distributed by (a);
+create table qp_csq_all_t2(b int) distributed by (b);
+truncate qp_csq_all_t1, qp_csq_all_t2;
+insert into qp_csq_all_t1 values (null);
+select * from qp_csq_all_t1 where (select a from qp_csq_all_t1 limit 1) = all(select b from qp_csq_all_t2);
+ a 
+---
+  
+(1 row)
+
+truncate qp_csq_all_t1, qp_csq_all_t2;
+insert into qp_csq_all_t2 values (null);
+select * from qp_csq_all_t1 where (select a from qp_csq_all_t1 limit 1) = all(select b from qp_csq_all_t2);
+ a 
+---
+(0 rows)
+
+truncate qp_csq_all_t1, qp_csq_all_t2;
+insert into qp_csq_all_t1 values (1);
+select * from qp_csq_all_t1 where (select a from qp_csq_all_t1 limit 1) = all(select b from qp_csq_all_t2);
+ a 
+---
+ 1
+(1 row)
+
+truncate qp_csq_all_t1, qp_csq_all_t2;
+insert into qp_csq_all_t2 values (1);
+select * from qp_csq_all_t1 where (select a from qp_csq_all_t1 limit 1) = all(select b from qp_csq_all_t2);
+ a 
+---
+(0 rows)
+
+truncate qp_csq_all_t1, qp_csq_all_t2;
+insert into qp_csq_all_t1 values (1);
+insert into qp_csq_all_t2 values (1);
+select * from qp_csq_all_t1 where (select a from qp_csq_all_t1 limit 1) = all(select b from qp_csq_all_t2);
+ a 
+---
+ 1
+(1 row)
+
+truncate qp_csq_all_t1, qp_csq_all_t2;
+insert into qp_csq_all_t1 values (1);
+insert into qp_csq_all_t2 values (2);
+select * from qp_csq_all_t1 where (select a from qp_csq_all_t1 limit 1) = all(select b from qp_csq_all_t2);
+ a 
+---
+(0 rows)
+
 -- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ using EXISTS clause (Heap)
 -- ----------------------------------------------------------------------

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -924,7 +924,6 @@ select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C where C.j =
 -- -- -- --
 create table qp_csq_all_t1(a int) distributed by (a);
 create table qp_csq_all_t2(b int) distributed by (b);
-truncate qp_csq_all_t1, qp_csq_all_t2;
 insert into qp_csq_all_t1 values (null);
 select * from qp_csq_all_t1 where (select a from qp_csq_all_t1 limit 1) = all(select b from qp_csq_all_t2);
  a 

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -965,7 +965,6 @@ select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C where C.j =
 -- -- -- --
 create table qp_csq_all_t1(a int) distributed by (a);
 create table qp_csq_all_t2(b int) distributed by (b);
-truncate qp_csq_all_t1, qp_csq_all_t2;
 insert into qp_csq_all_t1 values (null);
 select * from qp_csq_all_t1 where (select a from qp_csq_all_t1 limit 1) = all(select b from qp_csq_all_t2);
  a 

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -960,6 +960,58 @@ select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C where C.j =
  1 | -1 | 62
 (10 rows)
 
+-- -- -- --
+-- Test ALL clause with subqueries
+-- -- -- --
+create table qp_csq_all_t1(a int) distributed by (a);
+create table qp_csq_all_t2(b int) distributed by (b);
+truncate qp_csq_all_t1, qp_csq_all_t2;
+insert into qp_csq_all_t1 values (null);
+select * from qp_csq_all_t1 where (select a from qp_csq_all_t1 limit 1) = all(select b from qp_csq_all_t2);
+ a 
+---
+  
+(1 row)
+
+truncate qp_csq_all_t1, qp_csq_all_t2;
+insert into qp_csq_all_t2 values (null);
+select * from qp_csq_all_t1 where (select a from qp_csq_all_t1 limit 1) = all(select b from qp_csq_all_t2);
+ a 
+---
+(0 rows)
+
+truncate qp_csq_all_t1, qp_csq_all_t2;
+insert into qp_csq_all_t1 values (1);
+select * from qp_csq_all_t1 where (select a from qp_csq_all_t1 limit 1) = all(select b from qp_csq_all_t2);
+ a 
+---
+ 1
+(1 row)
+
+truncate qp_csq_all_t1, qp_csq_all_t2;
+insert into qp_csq_all_t2 values (1);
+select * from qp_csq_all_t1 where (select a from qp_csq_all_t1 limit 1) = all(select b from qp_csq_all_t2);
+ a 
+---
+(0 rows)
+
+truncate qp_csq_all_t1, qp_csq_all_t2;
+insert into qp_csq_all_t1 values (1);
+insert into qp_csq_all_t2 values (1);
+select * from qp_csq_all_t1 where (select a from qp_csq_all_t1 limit 1) = all(select b from qp_csq_all_t2);
+ a 
+---
+ 1
+(1 row)
+
+truncate qp_csq_all_t1, qp_csq_all_t2;
+insert into qp_csq_all_t1 values (1);
+insert into qp_csq_all_t2 values (2);
+select * from qp_csq_all_t1 where (select a from qp_csq_all_t1 limit 1) = all(select b from qp_csq_all_t2);
+ a 
+---
+(0 rows)
+
 -- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ using EXISTS clause (Heap)
 -- ----------------------------------------------------------------------

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -3,6 +3,7 @@
 -- ----------------------------------------------------------------------
 create schema qp_correlated_query;
 set search_path to qp_correlated_query;
+set optimizer_trace_fallback TO on;
 -- ----------------------------------------------------------------------
 -- Test: csq_heap_in.sql (Correlated Subquery: CSQ using IN clause (Heap))
 -- ----------------------------------------------------------------------
@@ -1752,6 +1753,8 @@ SELECT a, (SELECT (SELECT d FROM qp_csq_t3 WHERE a=c)) FROM qp_csq_t1 GROUP BY a
 -- Basic queries in SELECT list
 -- -- -- --
 select A.i, (select C.j from C group by C.j having max(C.j) = any (select min(B.j) from B)) as C_j from A,B,C where A.i = 99 order by A.i, C_j limit 10;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  DXL-to-PlStmt Translation: Assert not supported
  i  | c_j 
 ----+-----
  99 |   1
@@ -1777,14 +1780,20 @@ select (select avg(x) from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a = any (select 
 
 -- Planner should fail due to skip-level correlation not supported. Query should not cause segfault like in issue #12054.
 select A.j, (select array_agg(a_B) from (select B.j, (select array_agg(a_C) from (select C.j from C where C.i = A.i) a_C) from B where B.i = A.i order by A.j) a_B) from A;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Whole-row variable
 ERROR:  correlated subquery with skip-level correlations is not supported
 -- Planner should fail due to skip-level correlation not supported. Query should not return wrong results like in issue #12054.
 select A.j, (select array_agg(a_B) from (select B.j, (select sum(a_C.j) from (select C.j from C where C.i = A.i) a_C) from B where B.i = A.i order by A.j) a_B) from A;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Whole-row variable
 ERROR:  correlated subquery with skip-level correlations is not supported
 -- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ with multiple columns (Heap)
 -- ----------------------------------------------------------------------
 select A.i, B.i from A, B where (A.i,A.j) = (select min(B.i),min(B.j) from B where B.i = A.i) order by A.i, B.i;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Non-Scalar Subquery
  i | i  
 ---+----
  1 | -1
@@ -1802,6 +1811,8 @@ select A.i, B.i from A, B where (A.i,A.j) = (select min(B.i),min(B.j) from B whe
 (12 rows)
 
 select A.i, B.i from A, B where (A.i,A.j) = all(select B.i,B.j from B where B.i = A.i) order by A.i, B.i;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Non-Scalar Subquery
  i  | i  
 ----+----
  19 | -1
@@ -1848,6 +1859,8 @@ select A.i, B.i from A, B where not exists (select B.i,B.j from B where B.i = A.
 (18 rows)
 
 select A.i, B.i from A, B where (A.i,A.j) in (select B.i,B.j from B where B.i = A.i) order by A.i, B.i;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Non-Scalar Subquery
  i | i  
 ---+----
  1 | -1
@@ -1865,6 +1878,8 @@ select A.i, B.i from A, B where (A.i,A.j) in (select B.i,B.j from B where B.i = 
 (12 rows)
 
 select A.i, B.i,C.i from A, B, C where (A.i,B.i) = any (select A.i, B.i from A,B where A.i = C.i and B.i = C.i) order by A.i, B.i, C.i;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Non-Scalar Subquery
  i | i | i 
 ---+---+---
  1 | 1 | 1
@@ -2119,6 +2134,8 @@ select A.i, B.i,C.i from A, B, C where not exists (select A.i, B.i from A,B wher
 (240 rows)
 
 select A.i, B.i,C.i from A, B, C where (A.i,B.i) in (select A.i, B.i from A,B where A.i = C.i and B.i = C.i) order by A.i, B.i, C.i;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Non-Scalar Subquery
  i | i | i 
 ---+---+---
  1 | 1 | 1
@@ -2128,6 +2145,8 @@ select A.i, B.i,C.i from A, B, C where (A.i,B.i) in (select A.i, B.i from A,B wh
 (4 rows)
 
 select * from A,B,C where (A.i,B.i) = any (select A.i, B.i from A,B where A.i < C.i and B.i = C.i and C.i not in (select A.i from A where A.j = 1 and A.j = B.j)) order by 1,2,3,4,5,6;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Non-Scalar Subquery
  i  | j | i  | j | i  | j  
 ----+---+----+---+----+----
   1 | 1 |  2 | 7 |  2 |  7
@@ -2141,6 +2160,8 @@ select * from A,B,C where (A.i,B.i) = any (select A.i, B.i from A,B where A.i < 
 (8 rows)
 
 select A.i as A_i, B.i as B_i,C.i as C_i from A, B, C where (A.i,B.i) = (select min(A.i), min(B.i) from A,B where A.i = C.i and B.i = C.i) order by A_i, B_i, C_i;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Non-Scalar Subquery
  a_i | b_i | c_i 
 -----+-----+-----
    1 |   1 |   1
@@ -2269,6 +2290,8 @@ SELECT id, first_name FROM employee WHERE id IN
 SELECT id, first_name, salary from employee
     where (id, salary) IN
         (SELECT id, MIN(salary) FROM employee GROUP BY id) order by id;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Non-Scalar Subquery
  id | first_name | salary  
 ----+------------+---------
  01 | Jason      | 1234.56
@@ -3650,6 +3673,8 @@ EXPLAIN SELECT a FROM qp_tab1 f1 LEFT JOIN qp_tab2 on a=c WHERE NOT EXISTS(SELEC
 GPDB_12_MERGE_FIXME: Fallsback due to unsupported exec location.
 -- end_ignore
 EXPLAIN SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS (SELECT * FROM qp_tab3 WHERE qp_tab2.c = qp_tab3.e));
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  DXL-to-PlStmt Translation: Assert not supported
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=1.02..10001.04 rows=1 width=4)
@@ -3672,6 +3697,8 @@ EXPLAIN SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE
 (17 rows)
 
 SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS (SELECT * FROM qp_tab3 WHERE qp_tab2.c = qp_tab3.e));
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  DXL-to-PlStmt Translation: Assert not supported
  a 
 ---
 (0 rows)
@@ -3911,3 +3938,4 @@ DROP TABLE IF EXISTS supplier;
 -- ----------------------------------------------------------------------
 set client_min_messages='warning';
 drop schema qp_correlated_query cascade;
+reset optimizer_trace_fallback;

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -3,6 +3,7 @@
 -- ----------------------------------------------------------------------
 create schema qp_correlated_query;
 set search_path to qp_correlated_query;
+set optimizer_trace_fallback TO on;
 
 -- ----------------------------------------------------------------------
 -- Test: csq_heap_in.sql (Correlated Subquery: CSQ using IN clause (Heap))
@@ -752,3 +753,4 @@ DROP TABLE IF EXISTS supplier;
 -- ----------------------------------------------------------------------
 set client_min_messages='warning';
 drop schema qp_correlated_query cascade;
+reset optimizer_trace_fallback;

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -198,7 +198,6 @@ select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C where C.j =
 create table qp_csq_all_t1(a int) distributed by (a);
 create table qp_csq_all_t2(b int) distributed by (b);
 
-truncate qp_csq_all_t1, qp_csq_all_t2;
 insert into qp_csq_all_t1 values (null);
 select * from qp_csq_all_t1 where (select a from qp_csq_all_t1 limit 1) = all(select b from qp_csq_all_t2);
 

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -192,6 +192,38 @@ select A.i, B.i, C.j from A, B, C where A.j < all ( select C.j from C where not 
 explain select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
 select A.i, B.i, C.j from A, B, C where A.j = all (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
 
+-- -- -- --
+-- Test ALL clause with subqueries
+-- -- -- --
+create table qp_csq_all_t1(a int) distributed by (a);
+create table qp_csq_all_t2(b int) distributed by (b);
+
+truncate qp_csq_all_t1, qp_csq_all_t2;
+insert into qp_csq_all_t1 values (null);
+select * from qp_csq_all_t1 where (select a from qp_csq_all_t1 limit 1) = all(select b from qp_csq_all_t2);
+
+truncate qp_csq_all_t1, qp_csq_all_t2;
+insert into qp_csq_all_t2 values (null);
+select * from qp_csq_all_t1 where (select a from qp_csq_all_t1 limit 1) = all(select b from qp_csq_all_t2);
+
+truncate qp_csq_all_t1, qp_csq_all_t2;
+insert into qp_csq_all_t1 values (1);
+select * from qp_csq_all_t1 where (select a from qp_csq_all_t1 limit 1) = all(select b from qp_csq_all_t2);
+
+truncate qp_csq_all_t1, qp_csq_all_t2;
+insert into qp_csq_all_t2 values (1);
+select * from qp_csq_all_t1 where (select a from qp_csq_all_t1 limit 1) = all(select b from qp_csq_all_t2);
+
+truncate qp_csq_all_t1, qp_csq_all_t2;
+insert into qp_csq_all_t1 values (1);
+insert into qp_csq_all_t2 values (1);
+select * from qp_csq_all_t1 where (select a from qp_csq_all_t1 limit 1) = all(select b from qp_csq_all_t2);
+
+truncate qp_csq_all_t1, qp_csq_all_t2;
+insert into qp_csq_all_t1 values (1);
+insert into qp_csq_all_t2 values (2);
+select * from qp_csq_all_t1 where (select a from qp_csq_all_t1 limit 1) = all(select b from qp_csq_all_t2);
+
 
 -- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ using EXISTS clause (Heap)


### PR DESCRIPTION
If SubqueryAll operator has a Subquery scalar child then we should treat
the subquery context as EsqctxtValue, even if the SubqueryAll comes from
the predicate. Let's use the following example:

```
SELECT * FROM foo WHERE (SELECT a FROM foo limit 1) = ALL(SELECT b FROM bar);

+--CScalarSubqueryAll(=)["b" (8)]
   |--CLogicalGet "bar" ("bar"),
   +--CScalarSubquery["a" (16)]
      +--CLogicalLimit <empty> global
         |--CLogicalGet "foo" ("foo"),
         |--CScalarConst (0)
         +--CScalarCast
            +--CScalarConst (1)
```

Setting subquery context EsqctxtValue signals to transform the scalar
subquery into a left outer apply as opposed to an inner apply in
function FGenerateCorrelatedApplyForScalarSubquery(). A left outer apply
is necessary to preserve non-matching rows in the output (inner apply
would have filtered them out) which are required to correctly determine
the ALL_SUBLINK result.
