### PR TITLE
Remove gpdb_12_merge_fixme in functioncmds.c

### DIFF
--- a/src/backend/commands/functioncmds.c
+++ b/src/backend/commands/functioncmds.c
@@ -1790,8 +1790,6 @@ AlterFunction(ParseState *pstate, AlterFunctionStmt *stmt)
 		procForm->proparallel = interpret_func_parallel(parallel_item);
 	if (describe_item)
 	{
-		// GPDB_12_MERGE_FIXME: This cannot happen, because grammar doesn't allow it.
-		// But we probably should support it.
 		elog(ERROR, "cannot change DESCRIBE function");
 	}
 	if (data_access_item)


### PR DESCRIPTION
In GPDB, we don’t support ‘describe’ grammar in create function and
alter function, there is no ‘describe’ in upstream codes either,
so delete it here.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
