### PR TITLE
remove MERGE FIXME in function ExecAddMatchingSubPlans

### DIFF
--- a/src/backend/executor/execPartition.c
+++ b/src/backend/executor/execPartition.c
@@ -2011,10 +2011,6 @@ ExecAddMatchingSubPlans(PartitionPruneState *prunestate, Bitmapset *result)
 {
 	Bitmapset *thisresult;
 
-	/* GPDB_12_MERGE_FIXME: Currently, this just calls
-	 * ExecFindMatchingSubPlans() and adds the new result to
-	 * the passed-in Bitmapset. That's a bit inefficient.
-	 */
 	thisresult = ExecFindMatchingSubPlans(prunestate, NULL, -1, NIL);
 
 	result = bms_add_members(result, thisresult);


### PR DESCRIPTION
In the master branch, Partition Selector is implemented by `ExecAddMatchingSubPlans()`, 
which computes a subset of eligible partitions, this will be used by the outer table filtering
of the hash join. 

And reuse pg's function `ExecFindMatchingSubPlans`, find all subpartitions that match 
the pruning steps. Also returns a heap-allocated bitmap that stores the subpartition where 
the tuple is located. Therefore, if we want to collect all subsets of partitions, we have to 
keep calling `ExecAddMatchingSubPlans` in Seq Scan to add existing subpartitions to the 
final result, and because `ExecFindMatchingSubPlans` returns heap memory objects, we 
have to active free, which does bring some performance overhead.

But on the one hand we don't have a way to get all the partition subsets (volcano model) 
at once, and we can't modify the ExecAddMatchingSubPlans function.

So I think the current method is the only implementation, so remove the fixme.