### PR TITLE
Fix performance issue of syslogger_write_str()

### DIFF
--- a/src/backend/postmaster/syslogger.c
+++ b/src/backend/postmaster/syslogger.c
@@ -1249,25 +1249,6 @@ int syslogger_write_str(const char *data, int len, bool amsyslogger, bool csv)
 		syslogger_write_to_logfile(amsyslogger, data + start, cnt - start);
 	}
 
-	cnt = 0;
-    while (cnt < len && data[cnt] != '\0')
-    {
-        if (csv && data[cnt] == '"')
-		{
-			if (amsyslogger)
-				write_syslogger_file_binary("\"", 1, LOG_DESTINATION_STDERR);
-			else
-				ignore_returned_result(write(fileno(stderr), "\"", 1));
-		}
-		
-		if (amsyslogger)
-			write_syslogger_file_binary(data+cnt, 1, LOG_DESTINATION_STDERR);
-		else
-			ignore_returned_result(write(fileno(stderr), data+cnt, 1));
-
-        cnt+=1;
-    }
-
     return cnt;
 }
 

--- a/src/backend/postmaster/syslogger.c
+++ b/src/backend/postmaster/syslogger.c
@@ -137,6 +137,16 @@ ignore_returned_result(long long int result)
 	(void) result;
 }
 
+/* GPDB: wrapper function to write to log file */
+static inline void
+syslogger_write_to_logfile(bool amsyslogger, const char *data, int len)
+{
+	if (amsyslogger)
+		write_syslogger_file_binary(data, len, LOG_DESTINATION_STDERR);
+	else
+		ignore_returned_result(write(fileno(stderr), data, len));
+}
+
 static bool chunk_is_postgres_chunk(PipeProtoHeader *hdr)
 {
     return hdr->zero == 0 && hdr->pid != 0 && hdr->thid != 0 &&
@@ -1188,7 +1198,7 @@ syslogger_append_current_timestamp(bool amsyslogger)
  */
 int syslogger_write_str(const char *data, int len, bool amsyslogger, bool csv)
 {
-    int cnt = 0, start = 0;
+	int cnt = 0, start = 0;
 
     /* avoid confusing an empty string with NULL */
     if (data == NULL)
@@ -1196,35 +1206,47 @@ int syslogger_write_str(const char *data, int len, bool amsyslogger, bool csv)
         return 0;
 	}
 
+	/*
+	 * We need to process the string by two kind of modifications:
+	 *
+	 * 1. When terminate char ('\0') is found, finish the writing and ignore
+	 *    the rest.
+	 * 2. When it is CSV format and '"' is found, write an additional '"' to
+	 *    implement the escape.
+	 *
+	 * To achieve #2, use "start" to remember the start position of previous
+	 * valid substring. When it is CSV format and '"' is found, write the
+	 * substring from start to current position plus an additional '"', and
+	 * advance start to next position for next substring.
+	 */
 	while(cnt < len && data[cnt] != '\0'){
 		if(csv && data[cnt] == '"')
 		{
-			/* Write previous substring */
-			if(start <= cnt){
-				if (amsyslogger)
-					write_syslogger_file_binary(data + start, cnt - start + 1, LOG_DESTINATION_STDERR);
-				else
-					ignore_returned_result(write(fileno(stderr), data + start, cnt - start + 1));
+			/* Write the substring from "start" to current position */
+			if(start <= cnt)
+			{
+				syslogger_write_to_logfile(amsyslogger, data + start, cnt - start + 1);
 			}
 
-			/* Write an additional "\"" */ 
-			if (amsyslogger)
-				write_syslogger_file_binary("\"", 1, LOG_DESTINATION_STDERR);
-			else
-				ignore_returned_result(write(fileno(stderr), "\"", 1));
+			/* Write an additional "\"" */
+			syslogger_write_to_logfile(amsyslogger, "\"", 1);
 
-			/* Set new start of next substring */
+			/* Set new start of next substring to next position */
 			start = cnt + 1;
 		}
 		cnt++;
-	} 
+	}
 
-	/* Write latest substring if any */
-	if(start < cnt){
-		if (amsyslogger)
-			write_syslogger_file_binary(data + start, cnt - start + 1, LOG_DESTINATION_STDERR);
-		else
-			ignore_returned_result(write(fileno(stderr), data + start, cnt - start + 1));
+	/*
+	 * Write latest substring if any
+	 *
+	 * Note that current pos (cnt) must have been overed the latest position
+	 * of the string for now, so use (cnt - start) instead of (cnt - start + 1)
+	 * as len to exclude current pos.
+	 */
+	if(start < cnt)
+	{
+		syslogger_write_to_logfile(amsyslogger, data + start, cnt - start);
 	}
 
 	cnt = 0;


### PR DESCRIPTION
### Issue

In a real case CPU usage of logger process was extraordinarily high (more than 98%) and blocked other processes, 
causing seg down finally. Besides some improper settings, it's also due to a performance issue of logger code: In
`syslogger_write_str()`, `fwrite()`(or `write()`) was called per char instead of per string so it might be called for tens
of millions times when the log string is very big.

### Solution

We need to process the string by two kind of modifications (it might be the reason why existing code calls `fwrite()` 
per char instead of per string):

1. When terminate char ('\0') is found, finish the writing and ignore the rest.
2. When it is CSV format and '"' is found, write an additional '"' to implement the escape.

I was thinking about two solutions:

1. Use an extra buffer with double size (for the worst case), perform the modifications in buffer, and write the whole
 buffer. It can guarantee only one calling of `fwrite()`. However, the cost is extra memory requirement, and a lot of
memcopy in spite of how many '"' there are.
3. Go through the string, whenever hitting '"', write previous substring plus an extra '"', and continue. For the best case
(no '"' in the string), `fwrite()` is called only once. For the worst case (the entire string consist of '"'), the processing 
might fall back to "calling `fwrite()` per char", but no extra memory/memcopy is needed.

I adapted #2 since I suppose that log string containing a lot of '"' is not a common case.

### Test

I checked the log string in CSV manually. No additional test case is need because all operations writing log cover the scenario.

 
