### PR TITLE
remove merge fixme in execUtils.c:ExecGetRangeTableRelation

### DIFF
--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -882,10 +882,6 @@ ExecGetRangeTableRelation(EState *estate, Index rti)
 			 * seems sufficient to check this only when rellockmode is higher
 			 * than the minimum.
 			 */
-			/* GPDB_12_MERGE_FIXME: if GDD is not enabled, we acquire a stronger
-			 * lock earlier. What would be a good way to formulate this check?
-			 * For now, just pass orstronger=true.
-			 */
 			rel = table_open(rte->relid, NoLock);
 			Assert(rte->rellockmode == AccessShareLock ||
 				   CheckRelationLockedByMe(rel, rte->rellockmode,


### PR DESCRIPTION
In the execution stage, we need to open a relation to get the `Relation` result to 
support what we need to do, such as table scan. And if we call the function of 
`table_open`, we should pass the appropriate LOCKMOD to it.

But if we have reached the haul of the execution phase, we should already have 
the appropriate lock. For select, maybe have an AccessShare lock on the relation;
For update, maybe have a RowExclusiveLock on it if we enabled global deadlock
detect, otherwise we'll have ExclusiveLock on the relation. So we need to check
the current process holding the above lock exactly in the execution stage.

In the current implementation, we just need to look in the local cache of 
`LockMethodLocalHash`, which is also what the function `CheckRelationLockedByMe` 
does. It seems that there is no more elegant way to do this.

So remove the FIXME comments.
