### PR TITLE
fix incorrect RTE's rellockmode in the process of translating DXL to PlannedStmt

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1742,29 +1742,6 @@ InitPlan(QueryDesc *queryDesc, int eflags)
 		ResultRelInfo *resultRelInfos;
 		ResultRelInfo *resultRelInfo;
 
-		/*
-		 * MPP-2879: The QEs don't pass their MPPEXEC statements through
-		 * the parse (where locks would ordinarily get acquired). So we
-		 * need to take some care to pick them up here (otherwise we get
-		 * some very strange interactions with QE-local operations (vacuum?
-		 * utility-mode ?)).
-		 *
-		 * NOTE: There is a comment in lmgr.c which reads forbids use of
-		 * heap_open/relation_open with "NoLock" followed by use of
-		 * RelationOidLock/RelationLock with a stronger lock-mode:
-		 * RelationOidLock/RelationLock expect a relation to already be
-		 * locked.
-		 *
-		 * But we also need to serialize CMD_UPDATE && CMD_DELETE to preserve
-		 * order on mirrors.
-		 *
-		 * So we're going to ignore the "NoLock" issue above.
-		 */
-
-		/* CDB: we must promote locks for UPDATE and DELETE operations for ao table. */
-		LOCKMODE    lockmode;
-		lockmode = (Gp_role != GP_ROLE_EXECUTE || Gp_is_writer) ? RowExclusiveLock : NoLock;
-
 		resultRelInfos = (ResultRelInfo *)
 			palloc(numResultRelations * sizeof(ResultRelInfo));
 		resultRelInfo = resultRelInfos;
@@ -1861,10 +1838,6 @@ InitPlan(QueryDesc *queryDesc, int eflags)
 			switch (rc->markType)
 			{
 				/*
-				 * GPDB_12_MERGE_FIXME: We lost the GPDB change that this comment
-				 * talks about in the merge. I'm not sure where it should go now.
-				 * In ExecGetRangeTableRelation maybe?
-				 *
 				 * Greenplum specific behavior:
 				 * The implementation of select statement with locking clause
 				 * (for update | no key update | share | key share) in postgres

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -882,14 +882,9 @@ ExecGetRangeTableRelation(EState *estate, Index rti)
 			 * seems sufficient to check this only when rellockmode is higher
 			 * than the minimum.
 			 */
-			/* GPDB_12_MERGE_FIXME: if GDD is not enabled, we acquire a stronger
-			 * lock earlier. What would be a good way to formulate this check?
-			 * For now, just pass orstronger=true.
-			 */
 			rel = table_open(rte->relid, NoLock);
 			Assert(rte->rellockmode == AccessShareLock ||
-				   CheckRelationLockedByMe(rel, rte->rellockmode,
-										   true /* orstronger */));
+				   CheckRelationLockedByMe(rel, rte->rellockmode, false));
 		}
 		else
 		{

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -3906,8 +3906,6 @@ CTranslatorDXLToPlStmt::TranslateDXLDml(
 	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(
 		table_descr, index, &base_table_context);
 	GPOS_ASSERT(nullptr != rte);
-	// GPDB_12_MERGE_FIXME: Make this an parameter in TranslateDXLTblDescrToRangeTblEntry
-	rte->rellockmode = RowExclusiveLock;
 	rte->requiredPerms |= acl_mode;
 	m_dxl_to_plstmt_context->AddRTE(rte, true);
 
@@ -4328,8 +4326,7 @@ CTranslatorDXLToPlStmt::TranslateDXLTblDescrToRangeTblEntry(
 	rte->relid = oid;
 	rte->checkAsUser = table_descr->GetExecuteAsUserId();
 	rte->requiredPerms |= ACL_NO_RIGHTS;
-	// GPDB_12_MERGE_FIXME: Make this an parameter
-	rte->rellockmode = AccessShareLock;
+	rte->rellockmode = table_descr->LockMode();
 
 	// save oid and range index in translation context
 	base_table_context->SetOID(oid);

--- a/src/test/isolation2/output/uao/parallel_delete_optimizer.source
+++ b/src/test/isolation2/output/uao/parallel_delete_optimizer.source
@@ -21,11 +21,10 @@ DELETE 1
  ao       | ExclusiveLock | relation | master 
 (1 row)
 2: SELECT * FROM locktest_segments WHERE coalesce = 'ao';
- coalesce | mode             | locktype | node       
-----------+------------------+----------+------------
- ao       | AccessShareLock  | relation | n segments 
- ao       | RowExclusiveLock | relation | n segments 
-(2 rows)
+ coalesce | mode          | locktype | node       
+----------+---------------+----------+------------
+ ao       | ExclusiveLock | relation | n segments 
+(1 row)
 -- The case here should delete a tuple at the same seg with(2).
 -- Under jump hash, (2) and (3) are on the same seg(seg0).
 1&: DELETE FROM ao WHERE a = 3;  <waiting ...>

--- a/src/test/isolation2/output/uao/parallel_update_optimizer.source
+++ b/src/test/isolation2/output/uao/parallel_update_optimizer.source
@@ -21,11 +21,10 @@ UPDATE 1
  ao       | ExclusiveLock | relation | master 
 (1 row)
 2: SELECT * FROM locktest_segments WHERE coalesce = 'ao';
- coalesce | mode             | locktype | node       
-----------+------------------+----------+------------
- ao       | AccessShareLock  | relation | n segments 
- ao       | RowExclusiveLock | relation | n segments 
-(2 rows)
+ coalesce | mode          | locktype | node       
+----------+---------------+----------+------------
+ ao       | ExclusiveLock | relation | n segments 
+(1 row)
 -- The case here should update a tuple at the same seg with(2).
 -- Under jump hash, (2) and (3) are on the same seg(seg0).
 1&: UPDATE ao SET b = 42 WHERE a = 3;  <waiting ...>

--- a/src/test/regress/expected/ao_locks_optimizer.out
+++ b/src/test/regress/expected/ao_locks_optimizer.out
@@ -82,11 +82,10 @@ SELECT * FROM locktest_segments where coalesce = 'ao_locks_table' or
  coalesce like 'aovisimap%' or coalesce like 'aoseg%';
     coalesce     |       mode       | locktype |    node    
 -----------------+------------------+----------+------------
- ao_locks_table  | AccessShareLock  | relation | n segments
- ao_locks_table  | RowExclusiveLock | relation | n segments
+ ao_locks_table  | ExclusiveLock    | relation | n segments
  aovisimap table | RowExclusiveLock | relation | 1 segment
  aovisimap index | RowExclusiveLock | relation | 1 segment
-(4 rows)
+(3 rows)
 
 COMMIT;
 BEGIN;
@@ -102,10 +101,9 @@ SELECT * FROM locktest_segments where coalesce = 'ao_locks_table' or
  coalesce like 'aovisimap%' or coalesce like 'aoseg%';
     coalesce     |       mode       | locktype |    node    
 -----------------+------------------+----------+------------
- ao_locks_table  | AccessShareLock  | relation | n segments
+ ao_locks_table  | ExclusiveLock    | relation | n segments
  aovisimap table | RowExclusiveLock | relation | 1 segment
  aovisimap index | RowExclusiveLock | relation | 1 segment
- ao_locks_table  | RowExclusiveLock | relation | n segments
-(4 rows)
+(3 rows)
 
 COMMIT;


### PR DESCRIPTION
By default, Greenplum Database acquires the more restrictive `EXCLUSIVE` lock 
(rather than `ROW EXCLUSIVE` in PostgreSQL) for `UPDATE`, `DELETE`, and 
`SELECT...FOR UPDATE` operations on heap tables. When the Global Deadlock 
Detector is enabled the lock mode for `UPDATE` and `DELETE` operations on 
heap tables is `ROW EXCLUSIVE`.

During the parse stage, the appropriate lock will be granted and store the lock
mode in `RangeTableEntry.rellockmode`. And there has lock upgrade in gpdb,
which has been perfected by #13274.

But the ORCA did not process the `rellockmode` in `RangeTableEntry` correctly
during translating DXL to PlannedStmt, this PR makes it correct.

After that, `rte->rellockmode` will be exactly equal to what lock we granted in the
parse stage, so we don't need to check stronger lock in `CheckRelationLockedByMe`,
so we change the param `orstronger` to false.
