### PR TITLE
Resolve GPDB_12_MERGE_FIXME in motion/ic_udpifc.c

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -452,11 +452,11 @@ cdbdisp_checkForCancel(CdbDispatcherState *ds)
  * periodically, to process results from the other QEs.
  */
 int
-cdbdisp_getWaitSocketFd(CdbDispatcherState *ds)
+cdbdisp_getWaitSocketFd(CdbDispatcherState *ds, int **fds)
 {
 	if (pDispatchFuncs == NULL || pDispatchFuncs->getWaitSocketFd == NULL)
 		return -1;
-	return (pDispatchFuncs->getWaitSocketFd) (ds);
+	return (pDispatchFuncs->getWaitSocketFd) (ds, fds);
 }
 
 dispatcher_handle_t *

--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -441,23 +441,23 @@ cdbdisp_checkForCancel(CdbDispatcherState *ds)
  * Return all file descriptors to wait for events from the QEs after
  * dispatching a query.
  *
- * fds is a fd array (as an output param):
- * it will be palloced in pDispatchFuncs->getWaitSocketFd(), and contains
- * all wait fds. (caller need to pfree it)
+ * nsocks is the returned socket fds number (as an output param):
  *
- * return value is the length of fds
+ * Return value is the array of socket fds.
+ * It will be palloced in pDispatchFuncs->getWaitSocketFd(), and contains
+ * all waiting socket fds. (Note: caller need to pfree it)
  *
  * This is intended for use with cdbdisp_checkForCancel(). First call
- * cdbdisp_getWaitSocketFd(), and wait on that sockets to become readable
+ * cdbdisp_getWaitSocketFds(), and wait on that sockets to become readable
  * e.g. with select() or poll(). When it becomes readable, call
  * cdbdisp_checkForCancel() to process the incoming data, and repeat.
  */
-int
-cdbdisp_getWaitSocketFd(CdbDispatcherState *ds, int **fds)
+int *
+cdbdisp_getWaitSocketFds(CdbDispatcherState *ds, int *nsocks)
 {
-	if (pDispatchFuncs == NULL || pDispatchFuncs->getWaitSocketFd == NULL)
-		return -1;
-	return (pDispatchFuncs->getWaitSocketFd) (ds, fds);
+	if (pDispatchFuncs == NULL || pDispatchFuncs->getWaitSocketFds == NULL)
+		return NULL;
+	return (pDispatchFuncs->getWaitSocketFds) (ds, nsocks);
 }
 
 dispatcher_handle_t *

--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -438,18 +438,19 @@ cdbdisp_checkForCancel(CdbDispatcherState *ds)
 }
 
 /*
- * Return a file descriptor to wait for events from the QEs after dispatching
- * a query.
+ * Return all file descriptors to wait for events from the QEs after
+ * dispatching a query.
+ *
+ * fds is a fd array (as an output param):
+ * it will be palloced in pDispatchFuncs->getWaitSocketFd(), and contains
+ * all wait fds. (caller need to pfree it)
+ *
+ * return value is the length of fds
  *
  * This is intended for use with cdbdisp_checkForCancel(). First call
- * cdbdisp_getWaitSocketFd(), and wait on that socket to become readable
+ * cdbdisp_getWaitSocketFd(), and wait on that sockets to become readable
  * e.g. with select() or poll(). When it becomes readable, call
  * cdbdisp_checkForCancel() to process the incoming data, and repeat.
- *
- * XXX: This returns only one fd, but we might be waiting for results from
- * multiple QEs. In that case, this returns arbitrarily one of them. You
- * should still have a timeout, and call cdbdisp_checkForCancel()
- * periodically, to process results from the other QEs.
  */
 int
 cdbdisp_getWaitSocketFd(CdbDispatcherState *ds, int **fds)

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -168,6 +168,11 @@ cdbdisp_checkForCancel_async(struct CdbDispatcherState *ds)
 
 /*
  * Return all FDs to wait for, after dispatching.
+ *
+ * fds is a fd array (as an output param): it will be palloced in
+ * the function, and contains all wait fds. (caller need to pfree it)
+ *
+ * return value is the length of fds
  */
 static int
 cdbdisp_getWaitSocketFd_async(struct CdbDispatcherState *ds, int **fds)
@@ -180,7 +185,7 @@ cdbdisp_getWaitSocketFd_async(struct CdbDispatcherState *ds, int **fds)
 	if (proc_exit_inprogress)
 		return 0;
 
-	int fds_len = 0;
+	int			fds_len = 0;
 	*fds = (int *)palloc(pParms->dispatchCount * sizeof(int));
 
 	/*

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -2578,12 +2578,16 @@ RecvTupleChunkFromAnyTCP(ChunkTransportState *transportStates,
 		 */
 		if (Gp_role == GP_ROLE_DISPATCH)
 		{
-			waitFd = cdbdisp_getWaitSocketFd(transportStates->estate->dispatcherState);
-			if (waitFd != PGINVALID_SOCKET)
+			int *waitFds = NULL;
+			int fds_len = cdbdisp_getWaitSocketFd(transportStates->estate->dispatcherState, &waitFds);
+			if (fds_len > 0)
 			{
+				// XXX: select all later
+				waitFd = waitFds[0];
 				MPP_FD_SET(waitFd, &rset);
 				if (waitFd > nfds)
 					nfds = waitFd;
+				pfree(waitFds);
 			}
 		}
 

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -2592,7 +2592,8 @@ RecvTupleChunkFromAnyTCP(ChunkTransportState *transportStates,
 
 		}
 
-		// XXX: should use WaitEventSetWait() instead of select()
+		// GPDB_12_MERGE_FIXME: should use WaitEventSetWait() instead of select()
+		// follow the routine in ic_udpifc.c
 		n = select(nfds + 1, (fd_set *) &rset, NULL, NULL, &timeout);
 		if (n < 0)
 		{

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -3723,8 +3723,13 @@ receiveChunksUDPIFC(ChunkTransportState *pTransportStates, ChunkTransportStateEn
 {
 	int			retries = 0;
 	bool		directed = false;
-	MotionConn *rxconn = NULL;
-	TupleChunkListItem tcItem = NULL;
+	int 		nFds = 0;
+	int 		*waitFds = NULL;
+	int 		nevent = 0;
+	MotionConn 	*rxconn = NULL;
+	WaitEvent	*rEvents = NULL;
+	WaitEventSet		*waitset = NULL;
+	TupleChunkListItem	tcItem = NULL;
 
 #ifdef AMS_VERBOSE_LOGGING
 	elog(DEBUG5, "receivechunksUDP: motnodeid %d", motNodeID);
@@ -3745,6 +3750,28 @@ receiveChunksUDPIFC(ChunkTransportState *pTransportStates, ChunkTransportStateEn
 		/* non-directed receive */
 		setMainThreadWaiting(&rx_control_info.mainWaitingState, motNodeID, ANY_ROUTE,
 							 pTransportStates->sliceTable->ic_instance_id);
+	}
+
+	nFds = 0;
+	nevent = 2; /* nevent = waited fds number + 2 (latch and postmaster) */
+	if (Gp_role == GP_ROLE_DISPATCH)
+	{
+		/* get all wait sock fds */
+		waitFds = cdbdisp_getWaitSocketFds(pTransportStates->estate->dispatcherState, &nFds);
+		if (waitFds != NULL)
+			nevent += nFds;
+
+	}
+
+	/* init WaitEventSet */
+	waitset = CreateWaitEventSet(CurrentMemoryContext, nevent);
+	rEvents = palloc(nevent * sizeof(WaitEvent)); /* returned events */
+	AddWaitEventToSet(waitset, WL_LATCH_SET, PGINVALID_SOCKET, &ic_control_info.latch, NULL);
+	AddWaitEventToSet(waitset, WL_POSTMASTER_DEATH, PGINVALID_SOCKET, NULL, NULL);
+
+	for (int i = 0; i < nFds; i++)
+	{
+		AddWaitEventToSet(waitset, WL_SOCKET_READABLE, waitFds[i], NULL, NULL);
 	}
 
 	/* we didn't have any data, so we've got to read it from the network. */
@@ -3776,6 +3803,12 @@ receiveChunksUDPIFC(ChunkTransportState *pTransportStates, ChunkTransportStateEn
 			if (!directed)
 				*srcRoute = rxconn->route;
 
+			FreeWaitEventSet(waitset);
+			if (rEvents != NULL)
+				pfree(rEvents);
+			if (waitFds != NULL)
+				pfree(waitFds);
+
 			return tcItem;
 		}
 
@@ -3802,35 +3835,9 @@ receiveChunksUDPIFC(ChunkTransportState *pTransportStates, ChunkTransportStateEn
 		 * error through the main QD-QE libpq connection. For that, ask
 		 * the dispatcher for a file descriptor to wait on for that.
 		 */
-
-		/*
-		 * init WaitEventSet:
-		 *  - nFds and waitFds: wait sock fd array, event may happens on them
-		 *	- nevent = waited fd number + 2 (latch and postmaster)
-		 */
-		int nFds = 0;
-		int *waitFds = NULL;
-		int nevent = 2;
-
-		if (Gp_role == GP_ROLE_DISPATCH)
-		{
-			/* get all wait sock fds */
-			nFds = cdbdisp_getWaitSocketFd(pTransportStates->estate->dispatcherState, &waitFds);
-			nevent += nFds;
-		}
-
-		WaitEventSet *waitset = CreateWaitEventSet(CurrentMemoryContext, nevent);
-		AddWaitEventToSet(waitset, WL_LATCH_SET, PGINVALID_SOCKET, &ic_control_info.latch, NULL);
-		AddWaitEventToSet(waitset, WL_POSTMASTER_DEATH, PGINVALID_SOCKET, NULL, NULL);
-
-		for (int i = 0; i < nFds; i++)
-		{
-			AddWaitEventToSet(waitset, WL_SOCKET_READABLE, waitFds[i], NULL, NULL);
-		}
-
-		/* get one event is ok, becase it will check all events later */
-		WaitEvent revent;
-		int rc = WaitEventSetWait(waitset, MAIN_THREAD_COND_TIMEOUT_MS, &revent, 1, WAIT_EVENT_INTERCONNECT);
+		int rc = WaitEventSetWait(waitset, MAIN_THREAD_COND_TIMEOUT_MS, rEvents, nevent, WAIT_EVENT_INTERCONNECT);
+		if (rc == 0)
+			elog(DEBUG2, "receiveChunksUDPIFC(): WaitEventSetWait timeout after %d ms", MAIN_THREAD_COND_TIMEOUT_MS);
 
 		/* check the potential errors in rx thread. */
 		checkRxThreadError();
@@ -3838,17 +3845,18 @@ receiveChunksUDPIFC(ChunkTransportState *pTransportStates, ChunkTransportStateEn
 		/* do not check interrupts when holding the lock */
 		ML_CHECK_FOR_INTERRUPTS(pTransportStates->teardownActive);
 
-		FreeWaitEventSet(waitset);
-		if (waitFds != NULL)
-			pfree(waitFds);
-
 		/*
 		 * check to see if the dispatcher should cancel
-		 * note: rc == 0 means timeout, so no event happened
 		 */
-		if (rc != 0 && Gp_role == GP_ROLE_DISPATCH)
+		if (Gp_role == GP_ROLE_DISPATCH)
 		{
-			checkForCancelFromQD(pTransportStates);
+			for (int i = 0; i < rc; i++)
+				if (rEvents[i].events & WL_SOCKET_READABLE)
+				{
+					/* event happened on wait fds, need to check cancel */
+					checkForCancelFromQD(pTransportStates);
+					break;
+				}
 		}
 
 		/*
@@ -3869,6 +3877,12 @@ receiveChunksUDPIFC(ChunkTransportState *pTransportStates, ChunkTransportStateEn
 		pthread_mutex_lock(&ic_control_info.lock);
 
 	}							/* for (;;) */
+
+	FreeWaitEventSet(waitset);
+	if (rEvents != NULL)
+		pfree(rEvents);
+	if (waitFds != NULL)
+		pfree(waitFds);
 
 	/* We either got data, or get cancelled. We never make it out to here. */
 	return NULL;				/* make GCC behave */

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -3836,7 +3836,7 @@ receiveChunksUDPIFC(ChunkTransportState *pTransportStates, ChunkTransportStateEn
 		 * the dispatcher for a file descriptor to wait on for that.
 		 */
 		int rc = WaitEventSetWait(waitset, MAIN_THREAD_COND_TIMEOUT_MS, rEvents, nevent, WAIT_EVENT_INTERCONNECT);
-		if (rc == 0)
+		if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG && rc == 0)
 			elog(DEBUG2, "receiveChunksUDPIFC(): WaitEventSetWait timeout after %d ms", MAIN_THREAD_COND_TIMEOUT_MS);
 
 		/* check the potential errors in rx thread. */

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1147,6 +1147,8 @@ exec_mpp_query(const char *query_string,
 	ExecSlice  *slice = NULL;
 	ParamListInfo paramLI = NULL;
 
+	SIMPLE_FAULT_INJECTOR("exec_mpp_query_start");
+
 	Assert(Gp_role == GP_ROLE_EXECUTE);
 	/*
 	 * If we didn't get passed a query string, dummy something up for ps display and pg_stat_activity

--- a/src/include/cdb/cdbdisp.h
+++ b/src/include/cdb/cdbdisp.h
@@ -56,7 +56,7 @@ typedef struct CdbDispatcherState
 typedef struct DispatcherInternalFuncs
 {
 	bool (*checkForCancel)(struct CdbDispatcherState *ds);
-	int (*getWaitSocketFd)(struct CdbDispatcherState *ds);
+	int (*getWaitSocketFd)(struct CdbDispatcherState *ds, int **fds);
 	void* (*makeDispatchParams)(int maxSlices, int largestGangSize, char *queryText, int queryTextLen);
 	bool (*checkAckMessage)(struct CdbDispatcherState *ds, const char* message, int timeout_sec);
 	void (*checkResults)(struct CdbDispatcherState *ds, DispatchWaitMode waitMode);
@@ -203,7 +203,7 @@ cdbdisp_makeDispatchParams(CdbDispatcherState *ds,
 						   int queryTextLen);
 
 bool cdbdisp_checkForCancel(CdbDispatcherState * ds);
-int cdbdisp_getWaitSocketFd(CdbDispatcherState *ds);
+int cdbdisp_getWaitSocketFd(CdbDispatcherState *ds, int **fds);
 
 void cdbdisp_cleanupDispatcherHandle(const struct ResourceOwnerData * owner);
 

--- a/src/include/cdb/cdbdisp.h
+++ b/src/include/cdb/cdbdisp.h
@@ -56,7 +56,7 @@ typedef struct CdbDispatcherState
 typedef struct DispatcherInternalFuncs
 {
 	bool (*checkForCancel)(struct CdbDispatcherState *ds);
-	int (*getWaitSocketFd)(struct CdbDispatcherState *ds, int **fds);
+	int* (*getWaitSocketFds)(struct CdbDispatcherState *ds, int *nsocks);
 	void* (*makeDispatchParams)(int maxSlices, int largestGangSize, char *queryText, int queryTextLen);
 	bool (*checkAckMessage)(struct CdbDispatcherState *ds, const char* message, int timeout_sec);
 	void (*checkResults)(struct CdbDispatcherState *ds, DispatchWaitMode waitMode);
@@ -203,7 +203,7 @@ cdbdisp_makeDispatchParams(CdbDispatcherState *ds,
 						   int queryTextLen);
 
 bool cdbdisp_checkForCancel(CdbDispatcherState * ds);
-int cdbdisp_getWaitSocketFd(CdbDispatcherState *ds, int **fds);
+int *cdbdisp_getWaitSocketFds(CdbDispatcherState *ds, int *nsocks);
 
 void cdbdisp_cleanupDispatcherHandle(const struct ResourceOwnerData * owner);
 

--- a/src/test/regress/expected/ic_1.out
+++ b/src/test/regress/expected/ic_1.out
@@ -618,7 +618,7 @@ set statement_timeout to 150; -- 150ms < MAIN_THREAD_COND_TIMEOUT_MS(250ms)
 --  * udpifc, "ERROR:  fault triggered"
 --  * tcp,    "ERROR:  canceling statement due to statement timeout"
 begin; select count(*) from qe_errors_ic; rollback;
-ERROR:  fault triggered, fault name:'exec_mpp_query_start' fault type:'error'  (seg1 slice1 127.0.0.1:6001 pid=69822)
+ERROR:  canceling statement due to statement timeout
 reset statement_timeout;
 select gp_inject_fault('exec_mpp_query_start', 'reset', 2);
  gp_inject_fault 


### PR DESCRIPTION
In `receiveChunksUDPIFC()`, a loop is waiting for: ( latch / one QE fd / timeout ) happens.

But waiting only one QE fd has a drawback, the fixme message said it clearly:
```
		 * GPDB_12_MERGE_FIXME:
		 * XXX: We currently only get a single FD to wait on. That catches
		 * the common case that *all* the QEs report the same error more or
		 * less at the same time. WaitLatchOrSocket doesn't allow waiting for
		 * more than one socket at a time. PostgreSQL 9.6 introduces a more
		 * flexible "wait event" API for the latches, so once we merge with
		 * that, we could improve this.
```
This PR enhances it: now, can sense the QE events more quickly. 
Because PR changed `DispatcherInternalFuncs` interface, so also need to modify ic_tcp.c to follow this change.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
