### PR TITLE
Removed gp_era details from gprecoverseg cli output

### DIFF
--- a/gpMgmt/bin/gppylib/gp_era.py
+++ b/gpMgmt/bin/gppylib/gp_era.py
@@ -9,6 +9,8 @@
 
 import sys, os, stat, re
 import hashlib
+from gppylib import gplog
+import logging
 
 ERA_RE = re.compile(r"era\s*=\s*(\w+)")
 
@@ -145,7 +147,7 @@ def read_era(datadir, logger):
     if os.path.exists(erafile.filepath):
         erafile.read_gp_era()
 
-    if logger: logger.info('era is %s' % erafile.era)
+    if logger: gplog.log_to_file_only('era is %s' % erafile.era, logging.DEBUG)
     return erafile.era
 
 

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -275,6 +275,7 @@ Feature: gprecoverseg tests
         And gprecoverseg should not print "ers is *" to stdout
         And verify that the "gprecoverseg" logfile contains the string "era is"
         And the segments are synchronized
+        And the cluster is rebalanced
 
 
 ########################### @concourse_cluster tests ###########################

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -266,6 +266,16 @@ Feature: gprecoverseg tests
         And the segments are synchronized
         And the cluster is rebalanced
 
+    Scenario: gprecoverseg should output master era details to log file only and not to stdout
+        Given the database is running
+        And user immediately stops all primary processes
+        And user can start transactions
+        When the user runs "gprecoverseg -a -v"
+        Then gprecoverseg should return a return code of 0
+        And gprecoverseg should not print "ers is *" to stdout
+        And verify that the "gprecoverseg" logfile contains the string "era is"
+        And the segments are synchronized
+
 
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1902,6 +1902,27 @@ def impl(context, filename, output):
     print(contents)
     check_stdout_msg(context, output)
 
+
+def get_logfile(gpAdminLogDir, utility):
+    cmd = "ls -t %s | grep \"%s\" | head -1" % (gpAdminLogDir, utility)
+    rc, output, error = run_cmd(cmd)
+
+    if rc:
+        raise Exception(error)
+    return output.strip()
+
+
+@then('verify that the "{utility}" logfile contains the string "{output}"')
+def impl(context, utility, output):
+    gpAdminLogsDir = _get_gpAdminLogs_directory()
+    filename = get_logfile(gpAdminLogsDir, utility)
+    filepath = os.path.join(gpAdminLogsDir, filename)
+    with open(filepath) as fr:
+        for line in fr:
+            if output in line.strip():
+                return True
+    raise Exception("Expected string %s but not found" % output)
+
 @then('verify that the last line of the file "{filename}" in the coordinator data directory {contain} the string "{output}"{escape}')
 def impl(context, filename, contain, output, escape):
     if contain == 'should contain':


### PR DESCRIPTION
gprecoverseg prints master era details on stdout, removed era information from stdout and included it as debug message in gprecoverseg log file.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
