### PR TITLE
add test cases for authentication

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -12,7 +12,7 @@ subdir = src/test
 top_builddir = ../..
 include $(top_builddir)/src/Makefile.global
 
-SUBDIRS = perl regress isolation recovery
+SUBDIRS = perl regress isolation authentication recovery
 
 SUBDIRS += fsync walrep heap_checksum isolation2 kerberos modules fdw
 

--- a/src/test/README
+++ b/src/test/README
@@ -1,0 +1,44 @@
+PostgreSQL tests
+================
+
+This directory contains a variety of test infrastructure as well as some of the
+tests in PostgreSQL. Not all tests are here -- in particular, there are more in
+individual contrib/ modules and in src/bin.
+
+Not all these tests get run by "make check". Check src/test/Makefile to see
+which tests get run automatically.
+
+authentication/
+  Tests for authentication
+
+examples/
+  Demonstration programs for libpq that double as regression tests via
+  "make check"
+
+isolation/
+  Tests for concurrent behavior at the SQL level
+
+locale/
+  Sanity checks for locale data, encodings, etc
+
+mb/
+  Tests for multibyte encoding (UTF-8) support
+
+modules/
+  Extensions used only or mainly for test purposes, generally not suitable
+  for installing in production databases
+
+perl/
+  Infrastructure for Perl-based TAP tests
+
+recovery/
+  Test suite for recovery and replication
+
+regress/
+  PostgreSQL's main regression test suite, pg_regress
+
+ssl/
+  Tests to exercise and verify SSL certificate handling
+
+thread/
+  A thread-safety-testing utility used by configure

--- a/src/test/authentication/Makefile
+++ b/src/test/authentication/Makefile
@@ -1,0 +1,23 @@
+#-------------------------------------------------------------------------
+#
+# Makefile for src/test/authentication
+#
+# Portions Copyright (c) 1996-2017, PostgreSQL Global Development Group
+# Portions Copyright (c) 1994, Regents of the University of California
+#
+# src/test/authentication/Makefile
+#
+#-------------------------------------------------------------------------
+
+subdir = src/test/authentication
+top_builddir = ../../..
+include $(top_builddir)/src/Makefile.global
+
+check:
+	$(prove_check)
+
+installcheck:
+	$(prove_installcheck)
+
+clean distclean maintainer-clean:
+	rm -rf tmp_check

--- a/src/test/authentication/README
+++ b/src/test/authentication/README
@@ -1,0 +1,16 @@
+src/test/authentication/README
+
+Regression tests for authentication
+===================================
+
+This directory contains a test suite for authentication. SSL certificate
+authentication tests are kept separate, in src/test/ssl/, because they
+are more complicated, and are not safe to run in a multi-user system.
+
+
+Running the tests
+=================
+
+    make check
+
+NOTE: This requires the --enable-tap-tests argument to configure.

--- a/src/test/authentication/t/001_password.pl
+++ b/src/test/authentication/t/001_password.pl
@@ -41,7 +41,7 @@ sub test_role
 
 SKIP:
 {
-	skip "authentication tests cannot run on Windows", 16 if ($windows_os);
+	skip "authentication tests cannot run on Windows", 9 if ($windows_os);
 
 	# Initialize master node
 	my $node = get_new_node('master');

--- a/src/test/authentication/t/001_password.pl
+++ b/src/test/authentication/t/001_password.pl
@@ -1,0 +1,76 @@
+# Set of tests for authentication and pg_hba.conf. The following password
+# methods are checked through this test:
+# - Plain
+# - MD5-encrypted
+# This test cannot run on Windows as Postgres cannot be set up with Unix
+# sockets and needs to go through SSPI.
+
+use strict;
+use warnings;
+use PostgresNode;
+use TestLib;
+use Test::More tests => 9;
+
+# Delete pg_hba.conf from the given node, add a new entry to it
+# and then execute a reload to refresh it.
+sub reset_pg_hba
+{
+	my $node = shift;
+	my $hba_method = shift;
+
+	unlink($node->data_dir . '/pg_hba.conf');
+	$node->append_conf('pg_hba.conf', "local all all $hba_method");
+	$node->reload;
+}
+
+# Test access for a single role, useful to wrap all tests into one.
+sub test_role
+{
+	my $node = shift;
+	my $role = shift;
+	my $method = shift;
+	my $expected_res = shift;
+	my $status_string = 'failed';
+
+	$status_string = 'success' if ($expected_res eq 0);
+
+	my $res = $node->psql('postgres', 'SELECT 1', extra_params => ['-U', $role]);
+	is($res, $expected_res,
+	   "authentication $status_string for method $method, role $role");
+}
+
+SKIP:
+{
+	skip "authentication tests cannot run on Windows", 16 if ($windows_os);
+
+	# Initialize master node
+	my $node = get_new_node('master');
+	$node->init;
+	$node->start;
+
+	# Create 3 roles with different password methods for each one. The same
+	# password is used for all of them.
+
+	$node->safe_psql('postgres', "SET password_hash_algorithm='md5'; CREATE ROLE md5_role LOGIN PASSWORD 'pass';");
+	$node->safe_psql('postgres', "SET password_hash_algorithm='sha-256'; CREATE ROLE sha256_role LOGIN PASSWORD 'pass';");
+	$node->safe_psql('postgres', "SET password_encryption='off'; CREATE ROLE plain_role LOGIN PASSWORD 'pass';");
+	$ENV{"PGPASSWORD"} = 'pass';
+
+	# For "trust" method, all users should be able to connect.
+	reset_pg_hba($node, 'trust');
+	test_role($node, 'md5_role', 'trust', 0);
+	test_role($node, 'sha256_role', 'trust', 0);
+	test_role($node, 'plain_role', 'trust', 0);
+
+	# For plain "password" method, all users should also be able to connect.
+	reset_pg_hba($node, 'password');
+	test_role($node, 'md5_role', 'password', 0);
+	test_role($node, 'sha256_role', 'password', 0);
+	test_role($node, 'plain_role', 'password', 0);
+
+	# For "md5" method, user "plain_role" and "md5" should be able to connect.
+	reset_pg_hba($node, 'md5');
+	test_role($node, 'md5_role', 'md5', 0);
+	test_role($node, 'sha256_role', 'md5', 2);
+	test_role($node, 'plain_role', 'md5', 0);
+}

--- a/src/test/regress/expected/password.out
+++ b/src/test/regress/expected/password.out
@@ -1,0 +1,96 @@
+--
+-- Tests for password verifiers
+--
+-- Tests for GUC password_encryption
+SET password_hash_algorithm = 'novalue'; -- error
+ERROR:  invalid value for parameter "password_hash_algorithm": "novalue"
+HINT:  Available values: MD5, SHA-256.
+SET password_encryption = on; -- ok
+SET password_hash_algorithm = 'md5'; -- ok
+SET password_encryption = off; -- ok
+-- consistency of password entries
+SET password_encryption = off;
+CREATE ROLE regress_passwd1 PASSWORD 'role_pwd1';
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+SET password_encryption = 'on';
+SET password_hash_algorithm = 'md5';
+CREATE ROLE regress_passwd2 PASSWORD 'role_pwd2';
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+SET password_encryption = 'on';
+CREATE ROLE regress_passwd3 PASSWORD 'role_pwd3';
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+SET password_encryption = 'off';
+CREATE ROLE regress_passwd5 PASSWORD NULL;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+-- check list of created entries
+-- Since the salt is random, the exact value stored will be different on every test
+-- run. Use a regular expression to mask the changing parts.
+SELECT rolname, rolpassword
+    FROM pg_authid
+    WHERE rolname LIKE 'regress_passwd%'
+    ORDER BY rolname, rolpassword;
+     rolname     |             rolpassword             
+-----------------+-------------------------------------
+ regress_passwd1 | role_pwd1
+ regress_passwd2 | md54044304ba511dd062133eb5b4b84a2a3
+ regress_passwd3 | md50e5699b6911d87f17a08b8d76a21e8b8
+ regress_passwd5 | 
+(4 rows)
+
+-- Rename a role
+ALTER ROLE regress_passwd3 RENAME TO regress_passwd3_new;
+NOTICE:  MD5 password cleared because of role rename
+-- md5 entry should have been removed
+SELECT rolname, rolpassword
+    FROM pg_authid
+    WHERE rolname LIKE 'regress_passwd3_new'
+    ORDER BY rolname, rolpassword;
+       rolname       | rolpassword 
+---------------------+-------------
+ regress_passwd3_new | 
+(1 row)
+
+ALTER ROLE regress_passwd3_new RENAME TO regress_passwd3;
+-- ENCRYPTED and UNENCRYPTED passwords
+ALTER ROLE regress_passwd1 UNENCRYPTED PASSWORD 'foo'; -- unencrypted
+ALTER ROLE regress_passwd2 UNENCRYPTED PASSWORD 'md5dfa155cadd5f4ad57860162f3fab9cdb'; -- encrypted with MD5
+SET password_encryption = 'on';
+SET password_hash_algorithm = 'md5';
+ALTER ROLE regress_passwd3 ENCRYPTED PASSWORD 'foo'; -- encrypted with MD5
+SELECT rolname, rolpassword
+    FROM pg_authid
+    WHERE rolname LIKE 'regress_passwd%'
+    ORDER BY rolname, rolpassword;
+     rolname     |             rolpassword             
+-----------------+-------------------------------------
+ regress_passwd1 | foo
+ regress_passwd2 | md5dfa155cadd5f4ad57860162f3fab9cdb
+ regress_passwd3 | md5530de4c298af94b3b9f7d20305d2a1bf
+ regress_passwd5 | 
+(4 rows)
+
+-- An empty password is not allowed, in any form
+CREATE ROLE regress_passwd_empty PASSWORD '';
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+ALTER ROLE regress_passwd_empty PASSWORD 'md585939a5ce845f1a1b620742e3c659e0a';
+ALTER ROLE regress_passwd_empty PASSWORD 'SCRAM-SHA-256$4096:hpFyHTUsSWcR7O9P$LgZFIt6Oqdo27ZFKbZ2nV+vtnYM995pDh9ca6WSi120=:qVV5NeluNfUPkwm7Vqat25RjSPLkGeoZBQs6wVv+um4=';
+SELECT rolpassword FROM pg_authid WHERE rolname='regress_passwd_empty';
+             rolpassword             
+-------------------------------------
+ md59b7ebcc0db352c57821c26b28d17e180
+(1 row)
+
+DROP ROLE regress_passwd1;
+DROP ROLE regress_passwd2;
+DROP ROLE regress_passwd3;
+DROP ROLE regress_passwd5;
+DROP ROLE regress_passwd_empty;
+-- all entries should have been removed
+SELECT rolname, rolpassword
+    FROM pg_authid
+    WHERE rolname LIKE 'regress_passwd%'
+    ORDER BY rolname, rolpassword;
+ rolname | rolpassword 
+---------+-------------
+(0 rows)
+

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -109,7 +109,7 @@ test: namespace
 # ----------
 # Another group of parallel tests
 # ----------
-test: privileges security_label collate lock replica_identity
+test: privileges security_label collate lock replica_identity password
 
 # MATERIALIZED_VIEW_FIXME : matview is not supported on greenplum. Enable the test when the feature is ready.
 test: matview

--- a/src/test/regress/serial_schedule
+++ b/src/test/regress/serial_schedule
@@ -103,6 +103,7 @@ test: collate
 test: lock
 test: replica_identity
 test: alter_generic
+test: password
 test: misc
 test: psql
 test: async

--- a/src/test/regress/sql/password.sql
+++ b/src/test/regress/sql/password.sql
@@ -1,0 +1,66 @@
+--
+-- Tests for password verifiers
+--
+
+-- Tests for GUC password_encryption
+SET password_hash_algorithm = 'novalue'; -- error
+SET password_encryption = on; -- ok
+SET password_hash_algorithm = 'md5'; -- ok
+SET password_encryption = off; -- ok
+
+-- consistency of password entries
+SET password_encryption = off;
+CREATE ROLE regress_passwd1 PASSWORD 'role_pwd1';
+SET password_encryption = 'on';
+SET password_hash_algorithm = 'md5';
+CREATE ROLE regress_passwd2 PASSWORD 'role_pwd2';
+SET password_encryption = 'on';
+CREATE ROLE regress_passwd3 PASSWORD 'role_pwd3';
+SET password_encryption = 'off';
+CREATE ROLE regress_passwd5 PASSWORD NULL;
+
+-- check list of created entries
+-- Since the salt is random, the exact value stored will be different on every test
+-- run. Use a regular expression to mask the changing parts.
+SELECT rolname, rolpassword
+    FROM pg_authid
+    WHERE rolname LIKE 'regress_passwd%'
+    ORDER BY rolname, rolpassword;
+
+-- Rename a role
+ALTER ROLE regress_passwd3 RENAME TO regress_passwd3_new;
+-- md5 entry should have been removed
+SELECT rolname, rolpassword
+    FROM pg_authid
+    WHERE rolname LIKE 'regress_passwd3_new'
+    ORDER BY rolname, rolpassword;
+ALTER ROLE regress_passwd3_new RENAME TO regress_passwd3;
+
+-- ENCRYPTED and UNENCRYPTED passwords
+ALTER ROLE regress_passwd1 UNENCRYPTED PASSWORD 'foo'; -- unencrypted
+ALTER ROLE regress_passwd2 UNENCRYPTED PASSWORD 'md5dfa155cadd5f4ad57860162f3fab9cdb'; -- encrypted with MD5
+SET password_encryption = 'on';
+SET password_hash_algorithm = 'md5';
+ALTER ROLE regress_passwd3 ENCRYPTED PASSWORD 'foo'; -- encrypted with MD5
+SELECT rolname, rolpassword
+    FROM pg_authid
+    WHERE rolname LIKE 'regress_passwd%'
+    ORDER BY rolname, rolpassword;
+
+-- An empty password is not allowed, in any form
+CREATE ROLE regress_passwd_empty PASSWORD '';
+ALTER ROLE regress_passwd_empty PASSWORD 'md585939a5ce845f1a1b620742e3c659e0a';
+ALTER ROLE regress_passwd_empty PASSWORD 'SCRAM-SHA-256$4096:hpFyHTUsSWcR7O9P$LgZFIt6Oqdo27ZFKbZ2nV+vtnYM995pDh9ca6WSi120=:qVV5NeluNfUPkwm7Vqat25RjSPLkGeoZBQs6wVv+um4=';
+SELECT rolpassword FROM pg_authid WHERE rolname='regress_passwd_empty';
+
+DROP ROLE regress_passwd1;
+DROP ROLE regress_passwd2;
+DROP ROLE regress_passwd3;
+DROP ROLE regress_passwd5;
+DROP ROLE regress_passwd_empty;
+
+-- all entries should have been removed
+SELECT rolname, rolpassword
+    FROM pg_authid
+    WHERE rolname LIKE 'regress_passwd%'
+    ORDER BY rolname, rolpassword;

--- a/src/test/ssl/Makefile
+++ b/src/test/ssl/Makefile
@@ -13,6 +13,8 @@ subdir = src/test/ssl
 top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 
+export with_openssl
+
 CERTIFICATES := server_ca server-cn-and-alt-names \
 	server-cn-only server-single-alt-name server-multiple-alt-names \
 	server-no-names server-revoked server-ss \

--- a/src/test/ssl/ServerSetup.pm
+++ b/src/test/ssl/ServerSetup.pm
@@ -26,8 +26,51 @@ use Test::More;
 
 use Exporter 'import';
 our @EXPORT = qw(
-  configure_test_server_for_ssl switch_server_cert
+  configure_test_server_for_ssl switch_server_cert test_connect_ok
 );
+
+# Define a couple of helper functions to test connecting to the server.
+
+# Attempt connection to server with given connection string.
+sub run_test_psql
+{
+	my $connstr   = $_[0];
+	my $logstring = $_[1];
+
+	local $ENV{PGOPTIONS} = '-c gp_session_role=utility';
+
+	my $cmd = [
+		'psql', '-X', '-A', '-t', '-c', "SELECT 'connected with $connstr'",
+		'-d', "$connstr" ];
+
+	my $result = run_log($cmd);
+	return $result;
+}
+
+#
+# The first argument is a base connection string to use for connection.
+# The second argument is a complementary connection string, and it's also
+# printed out as the test case name.
+sub test_connect_ok
+{
+	my $common_connstr = $_[0];
+	my $connstr = $_[1];
+	my $test_name = $_[2];
+
+	my $result =
+	  run_test_psql("$common_connstr $connstr", "(should succeed)");
+	ok($result, $test_name || $connstr);
+}
+
+sub test_connect_fails
+{
+	my $common_connstr = $_[0];
+	my $connstr = $_[1];
+	my $test_name = $_[2];
+
+	my $result = run_test_psql("$common_connstr $connstr", "(should fail)");
+	ok(!$result, $test_name || "$connstr (should fail)");
+}
 
 # Copy a set of files, taking into account wildcards
 sub copy_files
@@ -46,8 +89,7 @@ sub copy_files
 
 sub configure_test_server_for_ssl
 {
-	my $node       = $_[0];
-	my $serverhost = $_[1];
+	my ($node, $serverhost, $authmethod, $password, $password_enc) = @_;
 
 	my $pgdata = $node->data_dir;
 
@@ -56,6 +98,15 @@ sub configure_test_server_for_ssl
 	$node->psql('postgres', "CREATE USER anotheruser");
 	$node->psql('postgres', "CREATE DATABASE trustdb");
 	$node->psql('postgres', "CREATE DATABASE certdb");
+
+	# Update password of each user as needed.
+	if (defined($password))
+	{
+		$node->psql('postgres',
+"SET password_hash_algorithm='$password_enc'; ALTER USER ssltestuser PASSWORD '$password';");
+		$node->psql('postgres',
+"SET password_hash_algorithm='$password_enc'; ALTER USER anotheruser PASSWORD '$password';");
+	}
 
 	# enable logging etc.
 	open CONF, ">>$pgdata/postgresql.conf";
@@ -69,6 +120,9 @@ sub configure_test_server_for_ssl
 	print CONF "include 'sslconfig.conf'";
 
 	close CONF;
+	# ssl configuration will be placed here
+	open my $sslconf, '>', "$pgdata/sslconfig.conf";
+	close $sslconf;
 
 # Copy all server certificates and keys, and client root cert, to the data dir
 	copy_files("ssl/server-*.crt", $pgdata);
@@ -78,22 +132,11 @@ sub configure_test_server_for_ssl
 	copy_files("ssl/root_ca.crt", $pgdata);
 	copy_files("ssl/root+client.crl",    $pgdata);
 
-  # Only accept SSL connections from localhost. Our tests don't depend on this
-  # but seems best to keep it as narrow as possible for security reasons.
-  #
-  # When connecting to certdb, also check the client certificate.
-	open HBA, ">$pgdata/pg_hba.conf";
-	print HBA
-"# TYPE  DATABASE        USER            ADDRESS                 METHOD\n";
-	print HBA
-"hostssl trustdb         ssltestuser     $serverhost/32            trust\n";
-	print HBA
-"hostssl trustdb         ssltestuser     ::1/128                 trust\n";
-	print HBA
-"hostssl certdb          ssltestuser     $serverhost/32            cert\n";
-	print HBA
-"hostssl certdb          ssltestuser     ::1/128                 cert\n";
-	close HBA;
+	# Stop and restart server to load new listen_addresses.
+	$node->restart;
+
+	# Change pg_hba after restart because hostssl requires ssl=on
+	configure_hba_for_ssl($node, $serverhost, $authmethod);
 }
 
 # Change the configuration to use given server cert file, and restart
@@ -117,4 +160,27 @@ sub switch_server_cert
 
 	# Stop and restart server to reload the new config.
 	$node->restart;
+}
+
+sub configure_hba_for_ssl
+{
+	my ($node, $serverhost, $authmethod) = @_;
+	my $pgdata     = $node->data_dir;
+
+  # Only accept SSL connections from localhost. Our tests don't depend on this
+  # but seems best to keep it as narrow as possible for security reasons.
+  #
+  # When connecting to certdb, also check the client certificate.
+	open my $hba, '>', "$pgdata/pg_hba.conf";
+	print $hba
+"# TYPE  DATABASE        USER            ADDRESS                 METHOD\n";
+	print $hba
+"hostssl trustdb         ssltestuser     $serverhost/32            $authmethod\n";
+	print $hba
+"hostssl trustdb         ssltestuser     ::1/128                 $authmethod\n";
+	print $hba
+"hostssl certdb          ssltestuser     $serverhost/32            cert\n";
+	print $hba
+"hostssl certdb          ssltestuser     ::1/128                 cert\n";
+	close $hba;
 }

--- a/src/test/ssl/t/001_ssltests.pl
+++ b/src/test/ssl/t/001_ssltests.pl
@@ -84,7 +84,7 @@ $node->init;
 $ENV{PGHOST} = $node->host;
 $ENV{PGPORT} = $node->port;
 $node->start;
-configure_test_server_for_ssl($node, $SERVERHOSTADDR);
+configure_test_server_for_ssl($node, $SERVERHOSTADDR, 'trust');
 switch_server_cert($node, 'server-cn-only');
 
 ### Part 1. Run client-side tests.


### PR DESCRIPTION
in 6X_STABLE we have not yet had test cases about authentication.
we add test cases for authentication to 6X_STABLE by extracting test cases from https://github.com/greenplum-db/gpdb/pull/13286/
the pr 13286 is Backporting scram-sha-256 to 6X_STSBLE

this pr contains some test cases about scram-sha-256, md5, and password for authentication.
here we extract the test cases about none scram-sha256 so when we do ABI test, we can run these
cases in the old version of psql.