### PR TITLE
Release idle reader gangs in transaction or transaction block

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -5219,14 +5219,14 @@ PostgresMain(int argc, char *argv[],
 				strncat(activity, "idle", remain);
 				set_ps_display(activity, false);
 				pgstat_report_activity(STATE_IDLE, NULL);
+			}
 
-				/* Start the idle-gang timer */
-				if (Gp_role == GP_ROLE_DISPATCH && IdleSessionGangTimeout > 0 && cdbcomponent_qesExist())
-				{
-					idle_gang_timeout_enabled = true;
-					enable_timeout_after(IDLE_GANG_TIMEOUT,
-										 IdleSessionGangTimeout);
-				}
+			/* Start the idle-gang timer */
+			if (Gp_role == GP_ROLE_DISPATCH && IdleSessionGangTimeout > 0 && cdbcomponent_qesExist())
+			{
+				idle_gang_timeout_enabled = true;
+				enable_timeout_after(IDLE_GANG_TIMEOUT,
+									 IdleSessionGangTimeout);
 			}
 
 			ReadyForQuery(whereToSendOutput);

--- a/src/test/isolation2/input/idle_gang_cleaner.source
+++ b/src/test/isolation2/input/idle_gang_cleaner.source
@@ -46,6 +46,18 @@ select count(*) from idle_gang_cleaner_t a
 
 0U: select gp_inject_fault('proc_kill', 'reset', 2, target_session_id) from target_session_id_t;
 
+-- Release idle Reader gangs in transaction or transaction block
+select cleanupAllGangs();
+0U: select gp_inject_fault('proc_kill', 'suspend', 2, target_session_id) from target_session_id_t;
+
+begin;
+select count(*) from idle_gang_cleaner_t a
+                         join idle_gang_cleaner_t b using (c2)
+;
+0U: select gp_inject_fault('proc_kill', 'wait_until_triggered', '','','', 1, 1, 1, 2 ,target_session_id) from target_session_id_t;
+0U: select gp_inject_fault('proc_kill', 'reset', 2, target_session_id) from target_session_id_t;
+end;
+
 select idle_gang_pressure_test();
 
 drop table target_session_id_t;

--- a/src/test/isolation2/output/idle_gang_cleaner.source
+++ b/src/test/isolation2/output/idle_gang_cleaner.source
@@ -65,6 +65,38 @@ select count(*) from idle_gang_cleaner_t a join idle_gang_cleaner_t b using (c2)
  Success:        
 (1 row)
 
+-- Release idle Reader gangs in transaction or transaction block
+select cleanupAllGangs();
+ cleanupallgangs 
+-----------------
+ t               
+(1 row)
+0U: select gp_inject_fault('proc_kill', 'suspend', 2, target_session_id) from target_session_id_t;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+begin;
+BEGIN
+select count(*) from idle_gang_cleaner_t a join idle_gang_cleaner_t b using (c2) ;
+ count 
+-------
+ 0     
+(1 row)
+0U: select gp_inject_fault('proc_kill', 'wait_until_triggered', '','','', 1, 1, 1, 2 ,target_session_id) from target_session_id_t;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+0U: select gp_inject_fault('proc_kill', 'reset', 2, target_session_id) from target_session_id_t;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+end;
+END
+
 select idle_gang_pressure_test();
  idle_gang_pressure_test 
 -------------------------


### PR DESCRIPTION
After commit cdc0104566d34374701bd2a889f15093655e43e5, `IDLE_GANG_TIMEOUT` won't enable in transaction or transaction block. It will cause `IDLE_GANG_TIMEOUT` to behave inconsistently as before. This commit fixed this issue and add a testcase for idle gang cleanup in transaction or transaction block.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
