### PR TITLE
[MERGE_FIXME] Move macro RelationIsAppendOptimized into table AM routine method.

### DIFF
--- a/contrib/indexscan/indexscan.c
+++ b/contrib/indexscan/indexscan.c
@@ -182,7 +182,7 @@ readindex(PG_FUNCTION_ARGS)
 		info->ireloid = irelid;
 
 		hrel = relation_open(irel->rd_index->indrelid, AccessShareLock);
-		if (hrel->rd_rel != NULL && RelationIsAppendOptimized(hrel))
+		if (hrel->rd_rel != NULL && table_relation_append_only_optimized(hrel))
 		{
 			relation_close(hrel, AccessShareLock);
 			hrel = NULL;

--- a/contrib/pageinspect/rawpage.c
+++ b/contrib/pageinspect/rawpage.c
@@ -19,6 +19,7 @@
 
 #include "access/htup_details.h"
 #include "access/relation.h"
+#include "access/tableam.h"
 #include "catalog/namespace.h"
 #include "catalog/pg_type.h"
 #include "funcapi.h"
@@ -136,7 +137,7 @@ get_raw_page_internal(text *relname, ForkNumber forknum, BlockNumber blkno)
 						RelationGetRelationName(rel))));
 
 	/* Check that this relation has the right kind of storage */
-	if (RelationIsAppendOptimized(rel))
+	if (table_relation_append_only_optimized(rel))
 		ereport(ERROR,
 				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
 				 errmsg("cannot get raw page from append-optimized relation \"%s\"",

--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -1375,7 +1375,7 @@ get_ao_distribution(PG_FUNCTION_ARGS)
 		/*
 		 * verify this is an AO relation
 		 */
-		if (!RelationIsAppendOptimized(parentrel))
+		if (!table_relation_append_only_optimized(parentrel))
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("'%s' is not an append-only relation",
@@ -1526,7 +1526,7 @@ get_ao_compression_ratio(PG_FUNCTION_ARGS)
 	/* open the parent (main) relation */
 	parentrel = table_open(relid, AccessShareLock);
 
-	if (!RelationIsAppendOptimized(parentrel))
+	if (!table_relation_append_only_optimized(parentrel))
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("'%s' is not an append-only relation",

--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -129,7 +129,7 @@ AppendOnlyCompaction_ShouldCompact(Relation aoRelation,
     Oid         visimaprelid;
     Oid         visimapidxid;
 
-	Assert(RelationIsAppendOptimized(aoRelation));
+	Assert(table_relation_append_only_optimized(aoRelation));
     GetAppendOnlyEntryAuxOids(aoRelation->rd_id, appendOnlyMetaDataSnapshot,
                               NULL, NULL, NULL,
                               &visimaprelid, &visimapidxid);
@@ -508,7 +508,7 @@ AppendOnlyRecycleDeadSegments(Relation aorel)
 	TransactionId cutoff_xid = InvalidTransactionId;
 	Oid			segrelid;
 
-	Assert(RelationIsAppendOptimized(aorel));
+	Assert(table_relation_append_only_optimized(aorel));
 
 	/*
 	 * The algorithm below for choosing a target segment is not concurrent-safe.
@@ -639,7 +639,7 @@ AppendOnlyTruncateToEOF(Relation aorel)
 	Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
 	Oid			segrelid;
 
-	Assert(RelationIsAppendOptimized(aorel));
+	Assert(table_relation_append_only_optimized(aorel));
 
 	relname = RelationGetRelationName(aorel);
 

--- a/src/backend/access/appendonly/appendonly_visimap_udf.c
+++ b/src/backend/access/appendonly/appendonly_visimap_udf.c
@@ -82,7 +82,7 @@ gp_aovisimap(PG_FUNCTION_ARGS)
 		context = (Context *) palloc0(sizeof(Context));
 
 		context->aorel = table_open(aoRelOid, AccessShareLock);
-		if (!RelationIsAppendOptimized(context->aorel))
+		if (!table_relation_append_only_optimized(context->aorel))
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("function not supported on relation")));
@@ -197,7 +197,7 @@ gp_aovisimap_hidden_info(PG_FUNCTION_ARGS)
 		context = (Context *) palloc0(sizeof(Context));
 
 		context->parentRelation = table_open(aoRelOid, AccessShareLock);
-		if (!RelationIsAppendOptimized(context->parentRelation))
+		if (!table_relation_append_only_optimized(context->parentRelation))
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("function not supported on relation")));
@@ -376,7 +376,7 @@ gp_aovisimap_entry(PG_FUNCTION_ARGS)
 		context = (Context *) palloc0(sizeof(Context));
 
 		context->parentRelation = table_open(aoRelOid, AccessShareLock);
-		if (!RelationIsAppendOptimized(context->parentRelation))
+		if (!table_relation_append_only_optimized(context->parentRelation))
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("function not supported on relation")));

--- a/src/backend/access/brin/brin.c
+++ b/src/backend/access/brin/brin.c
@@ -428,7 +428,7 @@ bringetbitmap(IndexScanDesc scan, Node **bmNodeP)
 	 * If the data table is append only table, we need to calculate the range
 	 * of tid in each aoseg.
 	 */
-	if (RelationIsAppendOptimized(heapRel))
+	if (table_relation_append_only_optimized(heapRel))
 	{
 		Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
 		Oid			segrelid;
@@ -494,7 +494,7 @@ bringetbitmap(IndexScanDesc scan, Node **bmNodeP)
 		 * If the largest row number of the current aoseg is scanned, switch to
 		 * the next aoseg.
 		 */
-		if (RelationIsAppendOptimized(heapRel))
+		if (table_relation_append_only_optimized(heapRel))
 		{
 			seg_start_blk = segnoGetCurrentAosegStart(segno);
 
@@ -751,7 +751,7 @@ brinbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 	BlockNumber pagesPerRange;
 	bool		isAo;
 
-	isAo = RelationIsAppendOptimized(heap);
+	isAo = table_relation_append_only_optimized(heap);
 	/*
 	 * We expect to be called exactly once for any index relation.
 	 */
@@ -769,7 +769,7 @@ brinbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 	LockBuffer(meta, BUFFER_LOCK_EXCLUSIVE);
 
 	brin_metapage_init(BufferGetPage(meta), BrinGetPagesPerRange(index),
-					   BRIN_CURRENT_VERSION, RelationIsAppendOptimized(heap));
+					   BRIN_CURRENT_VERSION, table_relation_append_only_optimized(heap));
 	MarkBufferDirty(meta);
 
 	if (RelationNeedsWAL(index))
@@ -1424,7 +1424,7 @@ brinsummarize(Relation index, Relation heapRel, BlockNumber pageRange,
 	 * If the data table is append only table, we need to calculate the range
 	 * of tid in each aoseg.
 	 */
-	if (RelationIsAppendOptimized(heapRel))
+	if (table_relation_append_only_optimized(heapRel))
 	{
 		Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
 		Oid			segrelid;
@@ -1491,7 +1491,7 @@ brinsummarize(Relation index, Relation heapRel, BlockNumber pageRange,
 		 * If the data table is append only table, we need to calculate the range
 		 * of tid in each aoseg.
 		 */
-		if (RelationIsAppendOptimized(heapRel))
+		if (table_relation_append_only_optimized(heapRel))
 		{
 			seg_start_blk = segnoGetCurrentAosegStart(segno);
 

--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -1240,7 +1240,7 @@ default_column_encoding_clause(Relation rel)
 	char	   *compresstype = NULL;
 	NameData	compresstype_nd;
 
-	appendonly = rel && RelationIsAppendOptimized(rel);
+	appendonly = rel && table_relation_append_only_optimized(rel);
 	if (appendonly)
 	{
 		GetAppendOnlyEntryAttributes(RelationGetRelid(rel),

--- a/src/backend/access/table/table.c
+++ b/src/backend/access/table/table.c
@@ -23,6 +23,7 @@
 
 #include "access/relation.h"
 #include "access/table.h"
+#include "access/tableam.h"
 #include "storage/lmgr.h"
 
 #include "catalog/namespace.h"
@@ -200,7 +201,7 @@ CdbTryOpenTable(Oid relid, LOCKMODE reqmode, bool *lockUpgraded)
 	 * okay.
 	 */
 	if (lockmode == RowExclusiveLock &&
-		Gp_role == GP_ROLE_DISPATCH && RelationIsAppendOptimized(rel))
+		Gp_role == GP_ROLE_DISPATCH && rel->rd_tableam->relation_append_only_optimized(rel))
 	{
 		elog(ERROR, "table \"%s\" concurrently updated", 
 			 RelationGetRelationName(rel));

--- a/src/backend/catalog/aoblkdir.c
+++ b/src/backend/catalog/aoblkdir.c
@@ -17,6 +17,7 @@
 #include "postgres.h"
 
 #include "access/table.h"
+#include "access/tableam.h"
 #include "catalog/pg_am.h"
 #include "catalog/pg_opclass.h"
 #include "catalog/aoblkdir.h"
@@ -44,7 +45,7 @@ AlterTableCreateAoBlkdirTable(Oid relOid)
 	 * Check if this is an appendoptimized table, without acquiring any lock.
 	 */
 	rel = table_open(relOid, NoLock);
-	isAO = RelationIsAppendOptimized(rel);
+	isAO = table_relation_append_only_optimized(rel);
 	table_close(rel, NoLock);
 	if (!isAO)
 		return;

--- a/src/backend/catalog/aocatalog.c
+++ b/src/backend/catalog/aocatalog.c
@@ -60,7 +60,7 @@ CreateAOAuxiliaryTable(
 	Oid			namespaceid;
 
 	Assert(RelationIsValid(rel));
-	Assert(RelationIsAppendOptimized(rel));
+	Assert(table_relation_append_only_optimized(rel));
 	Assert(auxiliaryNamePrefix);
 	Assert(tupledesc);
 	if (relkind != RELKIND_AOSEGMENTS)

--- a/src/backend/catalog/aovisimap.c
+++ b/src/backend/catalog/aovisimap.c
@@ -16,6 +16,7 @@
 #include "postgres.h"
 
 #include "access/table.h"
+#include "access/tableam.h"
 #include "catalog/aovisimap.h"
 #include "catalog/aocatalog.h"
 #include "catalog/pg_opclass.h"
@@ -45,7 +46,7 @@ AlterTableCreateAoVisimapTable(Oid relOid)
 	 */
 	rel = table_open(relOid, AccessExclusiveLock);
 
-	if (!RelationIsAppendOptimized(rel))
+	if (!table_relation_append_only_optimized(rel))
 	{
 		table_close(rel, NoLock);
 		return;

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -502,7 +502,7 @@ heap_create(const char *relname,
 		 * AO tables don't use the buffer manager, better to not keep the
 		 * smgr open for it.
 		 */
-		if (RelationIsAppendOptimized(rel))
+		if (table_relation_append_only_optimized(rel))
 			RelationCloseSmgr(rel);
 	}
 
@@ -1577,7 +1577,7 @@ heap_create_with_catalog(const char *relname,
 	 * OID first on QD and use the name as key to retrieve the pre-assigned
 	 * OID from QE.
 	 */
-	if (IsUnderPostmaster && ((relkind == RELKIND_RELATION  && !RelationIsAppendOptimized(new_rel_desc)) ||
+	if (IsUnderPostmaster && ((relkind == RELKIND_RELATION  && !table_relation_append_only_optimized(new_rel_desc)) ||
 							  relkind == RELKIND_VIEW ||
 							  relkind == RELKIND_MATVIEW ||
 							  relkind == RELKIND_FOREIGN_TABLE ||
@@ -1664,7 +1664,7 @@ heap_create_with_catalog(const char *relname,
 	/*
 	 * If this is an append-only relation, add an entry in pg_appendonly.
 	 */
-	if (RelationIsAppendOptimized(new_rel_desc))
+	if (table_relation_append_only_optimized(new_rel_desc))
 	{
 		StdRdOptions *stdRdOptions = (StdRdOptions *)default_reloptions(reloptions,
 																	 !valid_opts,
@@ -2310,7 +2310,7 @@ heap_drop_with_catalog(Oid relid)
 	 */
 	rel = relation_open(relid, AccessExclusiveLock);
 
-	is_appendonly_rel = RelationIsAppendOptimized(rel);
+	is_appendonly_rel = table_relation_append_only_optimized(rel);
 
 	/*
 	 * There can no longer be anyone *else* touching the relation, but we

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -2675,7 +2675,7 @@ index_update_stats(Relation rel,
 		 * GPDB: In theory, it is possible to support index only scans with AO
 		 * tables, but disable them for now by setting relallvisible to 0.
 		 */
-		if (rd_rel->relkind != RELKIND_INDEX && !RelationIsAppendOptimized(rel))
+		if (rd_rel->relkind != RELKIND_INDEX && !table_relation_append_only_optimized(rel))
 			visibilitymap_count(rel, &relallvisible, NULL);
 		else					/* don't bother for indexes */
 			relallvisible = 0;
@@ -3667,7 +3667,7 @@ reindex_relation(Oid relid, int flags, int options)
 			 get_namespace_name(RelationGetNamespace(rel)),
 			 RelationGetRelationName(rel));
 
-	relIsAO = RelationIsAppendOptimized(rel);
+	relIsAO = table_relation_append_only_optimized(rel);
 
 	toast_relid = rel->rd_rel->reltoastrelid;
 

--- a/src/backend/catalog/storage.c
+++ b/src/backend/catalog/storage.c
@@ -20,7 +20,7 @@
 #include "postgres.h"
 
 #include "miscadmin.h"
-
+#include "access/tableam.h"
 #include "access/visibilitymap.h"
 #include "access/xact.h"
 #include "access/xlog.h"
@@ -159,7 +159,7 @@ RelationDropStorage(Relation rel)
 	pending->atCommit = true;	/* delete if commit */
 	pending->nestLevel = GetCurrentTransactionNestLevel();
 	pending->relnode.smgr_which =
-		RelationIsAppendOptimized(rel) ? SMGR_AO : SMGR_MD;
+		table_relation_append_only_optimized(rel) ? SMGR_AO : SMGR_MD;
 	pending->next = pendingDeletes;
 	pendingDeletes = pending;
 

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -915,7 +915,7 @@ do_analyze_rel(Relation onerel, VacuumParams *params,
 	{
 		BlockNumber relallvisible;
 
-		if (RelationIsAppendOptimized(onerel))
+		if (table_relation_append_only_optimized(onerel))
 			relallvisible = 0;
 		else
 			visibilitymap_count(onerel, &relallvisible, NULL);
@@ -1412,7 +1412,7 @@ acquire_sample_rows(Relation onerel, int elevel,
 	 * GPDB_12_MERGE_FIXME: BlockNumber is uint32 and Number of tuples is uint64.
 	 * That means that after row number UINT_MAX we will never analyze the table.
 	 */
-	if (RelationIsAppendOptimized(onerel))
+	if (table_relation_append_only_optimized(onerel))
 	{
 		BlockNumber pages;
 		double		tuples;

--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -639,12 +639,8 @@ rebuild_relation(Relation OldHeap, Oid indexOid, bool verbose)
 	bool		swap_toast_by_content;
 	TransactionId frozenXid;
 	MultiXactId cutoffMulti;
-	/*
-	 * GPDB_12_MERGE_FIXME: We use specific bool in abstract code. This should
-	 * be somehow hidden by table am api or necessity of this switch should be
-	 * revisited.
-	 */
-	bool		is_ao = RelationIsAppendOptimized(OldHeap);
+
+	bool		is_ao = table_relation_append_only_optimized(OldHeap);
 
 	/* Mark the correct index as clustered */
 	if (OidIsValid(indexOid))
@@ -808,7 +804,7 @@ make_new_heap(Oid OIDOldHeap, Oid NewTableSpace, char relpersistence,
 		ReleaseSysCache(tuple);
 	}
 
-	if (RelationIsAppendOptimized(OldHeap))
+	if (table_relation_append_only_optimized(OldHeap))
 		NewRelationCreateAOAuxTables(OIDNewHeap, createAoBlockDirectory);
 
 	CacheInvalidateRelcacheByRelid(OIDNewHeap);

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -708,7 +708,7 @@ DefineIndex(Oid relationId,
 	 * we can use the same lock as heap tables.
 	 */
 	rel = table_open(relationId, NoLock);
-	if (RelationIsAppendOptimized(rel))
+	if (table_relation_append_only_optimized(rel))
 	{
 		Oid blkdirrelid = InvalidOid;
 		GetAppendOnlyEntryAuxOids(relationId, NULL, NULL, &blkdirrelid, NULL, NULL, NULL);
@@ -946,7 +946,7 @@ DefineIndex(Oid relationId,
 				 errmsg("access method \"%s\" does not support exclusion constraints",
 						accessMethodName)));
 
-    if  (stmt->unique && RelationIsAppendOptimized(rel))
+    if  (stmt->unique && table_relation_append_only_optimized(rel))
         ereport(ERROR,
                 (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
                  errmsg("append-only tables do not support unique indexes")));

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -734,7 +734,7 @@ CreateTrigger(CreateTrigStmt *stmt, const char *queryString,
 	}
 
 	/* Check GPDB limitations */
-	if (RelationIsAppendOptimized(rel) &&
+	if (table_relation_append_only_optimized(rel) &&
 		TRIGGER_FOR_ROW(tgtype) &&
 		!stmt->isconstraint)
 	{
@@ -3412,7 +3412,7 @@ GetTupleForTrigger(EState *estate,
 	Relation	relation = relinfo->ri_RelationDesc;
 
 	/* these should be rejected when you try to create such triggers, but let's check */
-	if (RelationIsAppendOptimized(relation))
+	if (table_relation_append_only_optimized(relation))
 		elog(ERROR, "UPDATE and DELETE triggers are not supported on append-only tables");
 
 	Assert(RelationIsHeap(relation));

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1436,7 +1436,7 @@ vac_update_relstats(Relation relation,
 		{
 			Assert(Gp_role == GP_ROLE_UTILITY);
 			Assert(!IsSystemRelation(relation));
-			Assert(RelationIsAppendOptimized(relation));
+			Assert(table_relation_append_only_optimized(relation));
 			num_tuples = 0;
 		}
 
@@ -2173,7 +2173,7 @@ vacuum_rel(Oid relid, RangeVar *relation, VacuumParams *params,
 	else
 		toast_relid = InvalidOid;
 
-	if (RelationIsAppendOptimized(onerel))
+	if (table_relation_append_only_optimized(onerel))
 	{
 		GetAppendOnlyEntryAuxOids(RelationGetRelid(onerel), NULL,
 								  &aoseg_relid,
@@ -2263,7 +2263,7 @@ vacuum_rel(Oid relid, RangeVar *relation, VacuumParams *params,
 		return false;
 	}
 
-	is_appendoptimized = RelationIsAppendOptimized(onerel);
+	is_appendoptimized = table_relation_append_only_optimized(onerel);
 	is_toast = (onerel->rd_rel->relkind == RELKIND_TOASTVALUE);
 
 	if (ao_vacuum_phase && !(is_appendoptimized || is_toast))

--- a/src/backend/commands/vacuum_ao.c
+++ b/src/backend/commands/vacuum_ao.c
@@ -375,7 +375,7 @@ vacuum_appendonly_index_should_vacuum(Relation aoRelation,
 	int64		hidden_tupcount;
 	FileSegTotals *totals;
 
-	Assert(RelationIsAppendOptimized(aoRelation));
+	Assert(table_relation_append_only_optimized(aoRelation));
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
@@ -437,7 +437,7 @@ vacuum_appendonly_indexes(Relation aoRelation, int options,
 	Oid			visimaprelid;
 	Oid			visimapidxid;
 
-	Assert(RelationIsAppendOptimized(aoRelation));
+	Assert(table_relation_append_only_optimized(aoRelation));
 
 	memset(&vacuumIndexState, 0, sizeof(vacuumIndexState));
 

--- a/src/backend/executor/nodeBitmapHeapscan.c
+++ b/src/backend/executor/nodeBitmapHeapscan.c
@@ -860,7 +860,7 @@ ExecInitBitmapHeapScan(BitmapHeapScan *node, EState *estate, int eflags)
 	}
 
 	/* Prefetching hasn't been implemented for AO tables */
-	if (RelationIsAppendOptimized(currentRelation))
+	if (table_relation_append_only_optimized(currentRelation))
 		scanstate->prefetch_maximum = 0;
 
 	scanstate->ss.ss_currentRelation = currentRelation;

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -1094,7 +1094,7 @@ ldelete:;
 	 * triggers on an UPDATE that moves tuples from one partition to another.
 	 * Should we follow that example with cross-segment UPDATEs too?
 	 */
-	if (!RelationIsAppendOptimized(resultRelationDesc) && !splitUpdate)
+	if (!table_relation_append_only_optimized(resultRelationDesc) && !splitUpdate)
 	{
 		ExecARDeleteTriggers(estate, resultRelInfo, tupleid, oldtuple,
 							 ar_delete_trig_tcs);
@@ -1503,7 +1503,7 @@ lreplace:;
 				 * AO case, as visimap update within same command happens at end
 				 * of command.
 				 */
-				if (!RelationIsAppendOptimized(resultRelationDesc) &&
+				if (!table_relation_append_only_optimized(resultRelationDesc) &&
 					tmfd.cmax != estate->es_output_cid)
 					ereport(ERROR,
 							(errcode(ERRCODE_TRIGGERED_DATA_CHANGE_VIOLATION),
@@ -1615,7 +1615,7 @@ lreplace:;
 
 	/* AFTER ROW UPDATE Triggers */
 	/* GPDB: AO and AOCO tables don't support triggers */
-	if (!RelationIsAppendOptimized(resultRelationDesc))
+	if (!table_relation_append_only_optimized(resultRelationDesc))
 		ExecARUpdateTriggers(estate, resultRelInfo, tupleid, oldtuple, slot,
 						 recheckIndexes,
 						 mtstate->operation == CMD_INSERT ?

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -22,6 +22,7 @@
 #include "access/relation.h"
 #include "access/sysattr.h"
 #include "access/table.h"
+#include "access/tableam.h"
 #include "catalog/heap.h"
 #include "catalog/namespace.h"
 #include "catalog/pg_proc_callback.h"
@@ -1293,7 +1294,7 @@ addRangeTableEntry(ParseState *pstate,
 
 		if (rel->rd_rel->relkind != RELKIND_RELATION ||
 			GpPolicyIsReplicated(rel->rd_cdbpolicy) ||
-			RelationIsAppendOptimized(rel))
+			table_relation_append_only_optimized(rel))
 			pstate->p_canOptSelectLockingClause = false;
 
 		if (rel->rd_rel->relkind == RELKIND_MATVIEW)

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -1342,7 +1342,7 @@ transformTableLikeClause(CreateStmtContext *cxt, TableLikeClause *table_like_cla
 		 */
 		oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 
-		if (RelationIsAppendOptimized(relation))
+		if (table_relation_append_only_optimized(relation))
 		{
 			int32 blocksize;
 			int32 safefswritersize;

--- a/src/backend/storage/lmgr/lmgr.c
+++ b/src/backend/storage/lmgr/lmgr.c
@@ -1353,7 +1353,7 @@ CondUpgradeRelLock(Oid relid)
 
 	if (!rel)
 		return false;
-	else if (RelationIsAppendOptimized(rel))
+	else if (table_relation_append_only_optimized(rel))
 		upgrade = true;
 	else
 		upgrade = false;

--- a/src/backend/storage/smgr/smgr.c
+++ b/src/backend/storage/smgr/smgr.c
@@ -20,6 +20,7 @@
 #include "postgres.h"
 
 #include "access/aomd.h"
+#include "access/tableam.h"
 #include "access/xact.h"
 #include "access/xlogutils.h"
 #include "catalog/catalog.h"
@@ -236,6 +237,19 @@ smgropen(RelFileNode rnode, BackendId backend, SMgrImpl which)
 	}
 
 	return reln;
+}
+
+/*
+ *	smgropenrel() -- Return an SMgrRelation object, creating it if need be.
+ *
+ *		This overrides smgopen() with no explicit SMgrImpl given, but infered from
+ *		the relation.
+ */
+SMgrRelation
+smgropenrel(Relation rel)
+{
+	SMgrImpl which = table_relation_append_only_optimized(rel)?SMGR_AO:SMGR_MD;
+	return smgropen(rel->rd_node, rel->rd_backend, which);
 }
 
 /*

--- a/src/backend/utils/adt/dbsize.c
+++ b/src/backend/utils/adt/dbsize.c
@@ -407,7 +407,7 @@ calculate_relation_size(Relation rel, ForkNumber forknum)
 	unsigned int segcount = 0;
 
 	/* Call into the tableam api for AO/AOCO relations */
-	if (RelationIsAppendOptimized(rel))
+	if (table_relation_append_only_optimized(rel))
 		return table_relation_size(rel, forknum);
 
 	relationpath = relpathbackend(rel->rd_node, rel->rd_backend, forknum);
@@ -582,7 +582,7 @@ calculate_table_size(Relation rel)
 	if (OidIsValid(rel->rd_rel->reltoastrelid))
 		size += calculate_toast_table_size(rel->rd_rel->reltoastrelid);
 
-	if (RelationIsAppendOptimized(rel))
+	if (table_relation_append_only_optimized(rel))
 	{
 		Oid	auxRelIds[3];
 		GetAppendOnlyEntryAuxOids(rel->rd_id, NULL, &auxRelIds[0],

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -1822,7 +1822,7 @@ RelationInitTableAccessMethod(Relation relation)
 		 * Greenplum: append-optimized relations should not have a valid
 		 * relfrozenxid.
 		 */
-		Assert (!RelationIsAppendOptimized(relation) ||
+		Assert (!table_relation_append_only_optimized(relation) ||
 				!TransactionIdIsValid(relation->rd_rel->relfrozenxid));
 	}
 

--- a/src/include/access/tableam.h
+++ b/src/include/access/tableam.h
@@ -602,6 +602,12 @@ typedef struct TableAmRoutine
 	 */
 	bool		(*relation_needs_toast_table) (Relation rel);
 
+	/*
+	 * If append only storage with row orientation or column orientation, return true;
+	 * otherwise, return false.
+	 */
+	bool		(*relation_append_only_optimized) (Relation rel);
+
 
 	/* ------------------------------------------------------------------------
 	 * Planner related functions.
@@ -1668,6 +1674,16 @@ static inline bool
 table_relation_needs_toast_table(Relation rel)
 {
 	return rel->rd_tableam->relation_needs_toast_table(rel);
+}
+
+/*
+ * If append only storage with row orientation or column orientation, return true;
+ * otherwise, return false.
+ */
+static inline bool
+table_relation_append_only_optimized(Relation rel)
+{
+	return rel->rd_amhandler == AO_ROW_TABLE_AM_HANDLER_OID || rel->rd_amhandler == AO_COLUMN_TABLE_AM_HANDLER_OID;
 }
 
 

--- a/src/include/storage/smgr.h
+++ b/src/include/storage/smgr.h
@@ -20,6 +20,7 @@
 #include "storage/block.h"
 #include "storage/relfilenode.h"
 #include "storage/dbdirnode.h"
+#include "utils/relcache.h"
 
 typedef enum SMgrImplementation
 {
@@ -91,6 +92,7 @@ typedef SMgrRelationData *SMgrRelation;
 extern void smgrinit(void);
 extern SMgrRelation smgropen(RelFileNode rnode, BackendId backend,
 							 SMgrImpl smgr_which);
+extern SMgrRelation smgropenrel(Relation rel);
 extern bool smgrexists(SMgrRelation reln, ForkNumber forknum);
 extern void smgrsetowner(SMgrRelation *owner, SMgrRelation reln);
 extern void smgrclearowner(SMgrRelation *owner, SMgrRelation reln);

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -432,17 +432,6 @@ typedef struct ViewOptions
 #define RelationIsAoCols(relation) \
 	((relation)->rd_amhandler == AO_COLUMN_TABLE_AM_HANDLER_OID)
 
-/*
- * CAUTION: this macro is a violation of the absraction that table AM and
- * index AM interfaces provide.  Use of this macro is discouraged.  If
- * table/index AM API falls short for your use case, consider enhancing the
- * interface.
- *
- * RelationIsAppendOptimized
- * 		True iff relation has append only storage (can be row or column orientation)
- */
-#define RelationIsAppendOptimized(relation) \
-	(RelationIsAoRows(relation) || RelationIsAoCols(relation))
 
 /*
  * RelationIsBitmapIndex
@@ -535,9 +524,7 @@ typedef struct ViewOptions
 	do { \
 		if ((relation)->rd_smgr == NULL) \
 			smgrsetowner(&((relation)->rd_smgr), \
-						 smgropen((relation)->rd_node, \
-								  (relation)->rd_backend, \
-								  RelationIsAppendOptimized(relation)?SMGR_AO:SMGR_MD)); \
+						 smgropenrel(relation)); \
 	} while (0)
 
 /*


### PR DESCRIPTION
The macro `RelationIsAppendOptimized` is a violation of the absraction that table AM and index AM interfaces provide.  Use of this macro is discouraged.  To resolve a GPDB_12_MERGE_FIXME in `cluster.c`, this PR refactored the code base, moved the macro `RelationIsAppendOptimized` into table AM routine as a table routine method.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
