### PR TITLE
Update mirror port in postgresql.conf 

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -176,13 +176,8 @@ class PgCtlBackendOptions(CmdArgs):
 
     """
 
-    def __init__(self, port):
-        """
-        @param port: backend port
-        """
-        CmdArgs.__init__(self, [
-            "-p", str(port),
-        ])
+    def __init__(self):
+        CmdArgs.__init__(self, [])
 
     #
     # coordinator/segment-specific options
@@ -305,7 +300,7 @@ class CoordinatorStart(Command):
         self.wrapper_args=wrapper_args
 
         # build backend options
-        b = PgCtlBackendOptions(port)
+        b = PgCtlBackendOptions()
         if utilityMode:
             b.set_utility()
         else:
@@ -363,7 +358,7 @@ class SegmentStart(Command):
         datadir = gpdb.getSegmentDataDirectory()
 
         # build backend options
-        b = PgCtlBackendOptions(port)
+        b = PgCtlBackendOptions()
         if utilityMode:
             b.set_utility()
         else:

--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -477,7 +477,7 @@ class GpMirrorListToBuild:
     def _run_recovery(self, action_name, recovery_info_by_host, gpEnv):
         completed_recovery_results = self._do_recovery(recovery_info_by_host, gpEnv)
         recovery_results = RecoveryResult(action_name, completed_recovery_results, self.__logger)
-        recovery_results.print_bb_rewind_and_start_errors()
+        recovery_results.print_bb_rewind_update_and_start_errors()
 
         self._remove_progress_files(recovery_info_by_host, recovery_results)
         return recovery_results

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
@@ -56,7 +56,7 @@ class BuildMirrorsTestCase(GpTestCase):
             patch('gppylib.operations.buildMirrorSegments.gplog.get_logger_dir', return_value='/tmp/logdir'),
             patch('gppylib.operations.buildMirrorSegments.gplog.logging_is_verbose', return_value=False),
             patch('gppylib.operations.buildMirrorSegments.read_era', self.mock_gp_era),
-            patch('gppylib.recoveryinfo.RecoveryResult.print_bb_rewind_and_start_errors'),
+            patch('gppylib.recoveryinfo.RecoveryResult.print_bb_rewind_update_and_start_errors'),
             patch('gppylib.recoveryinfo.RecoveryResult.print_setup_recovery_errors'),
             patch('gppylib.operations.buildMirrorSegments.dbconn')
         ])
@@ -152,7 +152,7 @@ class BuildMirrorsTestCase(GpTestCase):
 
     def _assert_setup_recovery(self):
         self.assertEqual(1, RecoveryResult.print_setup_recovery_errors.call_count)
-        self.assertEqual(0, RecoveryResult.print_bb_rewind_and_start_errors.call_count)
+        self.assertEqual(0, RecoveryResult.print_bb_rewind_update_and_start_errors.call_count)
         self.assertEqual([], self.mock_logger.info.call_args_list)
         self.assertEqual([], self.mock_logger.error.call_args_list)
 
@@ -161,7 +161,7 @@ class BuildMirrorsTestCase(GpTestCase):
         self.assertEqual(expected_info_msgs, self.mock_logger.info.call_args_list)
         self.assertEqual([], self.mock_logger.error.call_args_list)
         self.assertEqual(0, RecoveryResult.print_setup_recovery_errors.call_count)
-        self.assertEqual(1, RecoveryResult.print_bb_rewind_and_start_errors.call_count)
+        self.assertEqual(1, RecoveryResult.print_bb_rewind_update_and_start_errors.call_count)
 
     def _run_buildMirrors(self, mirrors_to_build, action):
         self.mock_logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegrecovery.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegrecovery.py
@@ -17,12 +17,14 @@ class IncrementalRecoveryTestCase(GpTestCase):
         self.maxDiff = None
         self.mock_logger = Mock()
         self.apply_patches([
+            patch('gpsegrecovery.ModifyConfSetting', return_value=Mock()),
             patch('gpsegrecovery.start_segment', return_value=Mock()),
             patch('gppylib.commands.pg.PgRewind.__init__', return_value=None),
             patch('gppylib.commands.pg.PgRewind.run')
         ])
         self.mock_pgrewind_run = self.get_mock_from_apply_patch('run')
         self.mock_pgrewind_init = self.get_mock_from_apply_patch('__init__')
+        self.mock_pgrewind_modifyconfsetting = self.get_mock_from_apply_patch('ModifyConfSetting')
 
         p = Segment.initFromString("1|0|p|p|s|u|sdw1|sdw1|40000|/data/primary0")
         m = Segment.initFromString("2|0|m|m|s|u|sdw2|sdw2|50000|/data/mirror0")
@@ -54,9 +56,11 @@ class IncrementalRecoveryTestCase(GpTestCase):
                                   'sdw1', 40000, '/tmp/test_progress_file')
         self.assertEqual(expected_init_args, self.mock_pgrewind_init.call_args)
         self.assertEqual(1, self.mock_pgrewind_run.call_count)
+        self.assertEqual(1, self.mock_pgrewind_modifyconfsetting.call_count)
         self.assertEqual(call(validateAfter=True), self.mock_pgrewind_run.call_args)
         logger_call_args = [call('Running pg_rewind with progress output temporarily in /tmp/test_progress_file'),
-                            call('Successfully ran pg_rewind for dbid: 2')]
+                            call('Successfully ran pg_rewind for dbid: 2'),
+                            call("Updating /data/mirror0/postgresql.conf")]
         self.assertEqual(logger_call_args, self.mock_logger.info.call_args_list)
         gpsegrecovery.start_segment.assert_called_once_with(self.seg_recovery_info, self.mock_logger, self.era)
 
@@ -92,11 +96,27 @@ class IncrementalRecoveryTestCase(GpTestCase):
         self.assertEqual(1, self.mock_pgrewind_init.call_count)
         self.assertEqual(1, self.mock_pgrewind_run.call_count)
         logger_call_args = [call('Running pg_rewind with progress output temporarily in /tmp/test_progress_file'),
-                            call('Successfully ran pg_rewind for dbid: 2')]
+                            call('Successfully ran pg_rewind for dbid: 2'),
+                            call("Updating /data/mirror0/postgresql.conf")]
         self.assertEqual(logger_call_args, self.mock_logger.info.call_args_list)
         gpsegrecovery.start_segment.assert_called_once_with(self.seg_recovery_info, self.mock_logger, self.era)
         self._assert_cmd_failed('{"error_type": "start", "error_msg": "pg_ctl start failed", "dbid": 2, ' \
                                 '"datadir": "/data/mirror0", "port": 50000, "progress_file": "/tmp/test_progress_file"}')
+
+    def test_incremental_modify_conf_setting_exception(self):
+        self.mock_pgrewind_modifyconfsetting.side_effect = [Exception('modify conf port failed'), Mock()]
+        self.incremental_recovery_cmd.run()
+
+        self.assertEqual(1, self.mock_pgrewind_init.call_count)
+        self.assertEqual(1, self.mock_pgrewind_run.call_count)
+        self.mock_pgrewind_modifyconfsetting.assert_called_once_with('Updating %s/postgresql.conf' % self.seg_recovery_info.target_datadir,
+                                                                     "{}/{}".format(self.seg_recovery_info.target_datadir, 'postgresql.conf'),
+                                                                     'port', self.seg_recovery_info.target_port, optType='number')
+        self.assertEqual(1, self.mock_pgrewind_modifyconfsetting.call_count)
+        self.assertEqual(0, gpsegrecovery.start_segment.call_count)
+        self._assert_cmd_failed('{"error_type": "update", "error_msg": "modify conf port failed", "dbid": 2, ' \
+                                '"datadir": "/data/mirror0", "port": 50000, "progress_file": "/tmp/test_progress_file"}')
+
 
 
 class FullRecoveryTestCase(GpTestCase):
@@ -106,12 +126,14 @@ class FullRecoveryTestCase(GpTestCase):
         self.maxDiff = None
         self.mock_logger = Mock(spec=['log', 'info', 'debug', 'error', 'warn', 'exception'])
         self.apply_patches([
+            patch('gpsegrecovery.ModifyConfSetting', return_value=Mock()),
             patch('gpsegrecovery.start_segment', return_value=Mock()),
             patch('gpsegrecovery.PgBaseBackup.__init__', return_value=None),
             patch('gpsegrecovery.PgBaseBackup.run')
         ])
         self.mock_pgbasebackup_run = self.get_mock_from_apply_patch('run')
         self.mock_pgbasebackup_init = self.get_mock_from_apply_patch('__init__')
+        self.mock_pgbasebackup_modifyconfsetting = self.get_mock_from_apply_patch('ModifyConfSetting')
 
         p = Segment.initFromString("1|0|p|p|s|u|sdw1|sdw1|40000|/data/primary0")
         m = Segment.initFromString("2|0|m|m|s|u|sdw2|sdw2|50000|/data/mirror0")
@@ -133,9 +155,11 @@ class FullRecoveryTestCase(GpTestCase):
         self.assertEqual(1, self.mock_pgbasebackup_init.call_count)
         self.assertEqual(expected_init_args, self.mock_pgbasebackup_init.call_args)
         self.assertEqual(1, self.mock_pgbasebackup_run.call_count)
+        self.assertEqual(1, self.mock_pgbasebackup_modifyconfsetting.call_count)
         self.assertEqual(call(validateAfter=True), self.mock_pgbasebackup_run.call_args)
         expected_logger_info_args = [call('Running pg_basebackup with progress output temporarily in /tmp/test_progress_file'),
-                                     call("Successfully ran pg_basebackup for dbid: 2")]
+                                     call("Successfully ran pg_basebackup for dbid: 2"),
+                                     call("Updating /data/mirror0/postgresql.conf")]
         self.assertEqual(expected_logger_info_args, self.mock_logger.info.call_args_list)
         gpsegrecovery.start_segment.assert_called_once_with(self.seg_recovery_info, self.mock_logger, self.era)
 
@@ -259,6 +283,19 @@ class FullRecoveryTestCase(GpTestCase):
         self._assert_cmd_failed('{"error_type": "start", "error_msg": "pg_ctl start failed", "dbid": 2, ' \
                                 '"datadir": "/data/mirror0", "port": 50000, "progress_file": "/tmp/test_progress_file"}')
 
+    def test_basebackup_modify_conf_setting_exception(self):
+        self.mock_pgbasebackup_modifyconfsetting.side_effect = [Exception('modify conf port failed'), Mock()]
+        self.full_recovery_cmd.run()
+
+        self.assertEqual(1, self.mock_pgbasebackup_init.call_count)
+        self.assertEqual(1, self.mock_pgbasebackup_run.call_count)
+        self.mock_pgbasebackup_modifyconfsetting.assert_called_once_with('Updating %s/postgresql.conf' % self.seg_recovery_info.target_datadir,
+                                                                          "{}/{}".format(self.seg_recovery_info.target_datadir, 'postgresql.conf'),
+                                                                          'port', self.seg_recovery_info.target_port, optType='number')
+        self.assertEqual(1, self.mock_pgbasebackup_modifyconfsetting.call_count)
+        self.assertEqual(0, gpsegrecovery.start_segment.call_count)
+        self._assert_cmd_failed('{"error_type": "update", "error_msg": "modify conf port failed", "dbid": 2, ' \
+                                '"datadir": "/data/mirror0", "port": 50000, "progress_file": "/tmp/test_progress_file"}')
 
 class SegRecoveryTestCase(GpTestCase):
     def setUp(self):

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_recoveryinfo.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_recoveryinfo.py
@@ -393,6 +393,52 @@ class RecoveryResultTestCase(GpTestCase):
                 "recovery_successful": False,
                 "dbids_that_failed_bb_rewind": [2]
             },
+            {
+                "name": "run_recovery_all_dbids_fail_only_update_errors",
+                "host1_error": '[{"error_type": "update", "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}, ' \
+                               '{"error_type": "update", "error_msg":"some error for dbid 3", "dbid": 3, "datadir": "/datadir3", "port": 7003, "progress_file": "/tmp/progress3"}]',
+                "host2_error": '[{"error_type": "update", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]',
+                "expected_info_msgs": [call(Contains('-----')),
+                                       call(Contains('Did not start the following segments due to failure while updating the port.')),
+                                       call(self._msg('host1', 7001, datadir='/datadir2')),
+                                       call(self._msg('host1', 7003, datadir='/datadir3')),
+                                       call(self._msg('host2', 7005, datadir='/datadir4'))],
+                "expected_error_msgs": [],
+                "setup_successful": True,
+                "full_recovery_successful": True,
+                "recovery_successful": False,
+                "dbids_that_failed_bb_rewind": []
+            },
+            {
+                "name": "run_recovery_some_dbids_fail_only_update_errors",
+                "host1_error": '[{"error_type": "update", "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}]',
+                "host2_error": '[{"error_type": "update", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]',
+                "expected_info_msgs": [call(Contains('-----')),
+                                       call(Contains('Did not start the following segments due to failure while updating the port.')),
+                                       call(self._msg('host1', 7001, datadir='/datadir2')),
+                                       call(self._msg('host2', 7005, datadir='/datadir4'))],
+                "expected_error_msgs": [],
+                "setup_successful": True,
+                "full_recovery_successful": True,
+                "recovery_successful": False,
+                "dbids_that_failed_bb_rewind": []
+            },
+            {
+                "name": "run_recovery_some_dbids_fail_recovery_and_update_errors",
+                "host1_error": '[{"error_type": "full",  "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}, ' \
+                               '{"error_type": "default",  "error_msg":"some error for dbid 3", "dbid": 3, "datadir": "/datadir3", "port": 7003, "progress_file": "/tmp/progress3"}]',
+                "host2_error": '[{"error_type": "update", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]',
+                "expected_info_msgs": [call(Contains('-----')),
+                                       call(Contains(
+                                           'Did not start the following segments due to failure while updating the port.')),
+                                       call(self._msg('host1', 7001, datadir='/datadir2')),
+                                       call(self._msg('host2', 7005, datadir='/datadir4'))],
+                "expected_error_msgs": [],
+                "setup_successful": True,
+                "full_recovery_successful": False,
+                "recovery_successful": False,
+                "dbids_that_failed_bb_rewind": []
+            },
         ]
         self.run_tests(tests, run_recovery=True)
 
@@ -420,7 +466,7 @@ class RecoveryResultTestCase(GpTestCase):
                 self.assertEqual(r.recovery_successful(), test["recovery_successful"])
 
                 if run_recovery:
-                    r.print_bb_rewind_and_start_errors()
+                    r.print_bb_rewind_update_and_start_errors()
                 else:
                     r.print_setup_recovery_errors()
 

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -353,9 +353,9 @@ SED_PG_CONF () {
 				fi
 			else
 				if [ $KEEP_PREV -eq 0 ];then
-					$SED -i'.bak1' -e "s/${SEARCH_TXT}/${SUB_TXT} #${SEARCH_TXT}/" $FILENAME
+					$SED -i'.bak1' -e "s/^[ ]*${SEARCH_TXT}[ ]*=/${SUB_TXT} #${SEARCH_TXT}/" $FILENAME
 				else
-					$SED -i'.bak1' -e "s/${SEARCH_TXT}.*/${SUB_TXT}/" $FILENAME
+					$SED -i'.bak1' -e "s/^[ ]*${SEARCH_TXT}[ ]*=.*/${SUB_TXT}/" $FILENAME
 				fi
 				RETVAL=$?
 				if [ $RETVAL -ne 0 ]; then
@@ -364,7 +364,7 @@ SED_PG_CONF () {
 					LOG_MSG "[INFO]:-Replaced line in $FILENAME"
 					$RM -f ${FILENAME}.bak1
 				fi
-				$SED -i'.bak2' -e "s/^#${SEARCH_TXT}/${SEARCH_TXT}/" $FILENAME
+				$SED -i'.bak2' -e "s/^[ ]*#${SEARCH_TXT}[ ]*=/${SEARCH_TXT}/" $FILENAME
 				RETVAL=$?
 				if [ $RETVAL -ne 0 ]; then
 					ERROR_EXIT "[FATAL]:-Failed to replace #$SEARCH_TXT in $FILENAME"
@@ -395,9 +395,9 @@ SED_PG_CONF () {
 			fi
 		else
 			if [ $KEEP_PREV -eq 0 ];then
-				SED_COMMAND="s/${SEARCH_TXT}/${SUB_TXT} #${SEARCH_TXT}/"
+				SED_COMMAND="s/^[ ]*${SEARCH_TXT}[ ]*=/${SUB_TXT} #${SEARCH_TXT}/"
 			else
-				SED_COMMAND="s/${SEARCH_TXT}.*/${SUB_TXT}/"
+				SED_COMMAND="s/^[ ]*${SEARCH_TXT}[ ]*=.*/${SUB_TXT}/"
 			fi
 			$TRUSTED_SHELL $SED_HOST sed -i'.bak1' -f /dev/stdin "$FILENAME" <<< "$SED_COMMAND" > /dev/null 2>&1
 			if [ $RETVAL -ne 0 ]; then
@@ -407,7 +407,7 @@ SED_PG_CONF () {
 				$TRUSTED_SHELL $SED_HOST "$RM -f ${FILENAME}.bak1" > /dev/null 2>&1
 			fi
 
-			SED_COMMAND="s/^#${SEARCH_TXT}/${SEARCH_TXT}/"
+			SED_COMMAND="s/^[ ]*#${SEARCH_TXT}[ ]*=/${SEARCH_TXT}/"
 			$TRUSTED_SHELL $SED_HOST sed -i'.bak2' -f /dev/stdin "$FILENAME" <<< "$SED_COMMAND" > /dev/null 2>&1
 			if [ $RETVAL -ne 0 ]; then
 				ERROR_EXIT "[FATAL]:-Failed to substitute #${SEARCH_TXT} in $FILENAME on $SED_HOST"

--- a/gpMgmt/bin/lib/gpcreateseg.sh
+++ b/gpMgmt/bin/lib/gpcreateseg.sh
@@ -244,6 +244,8 @@ CREATE_QES_MIRROR () {
     START_QE "-w"
     RETVAL=$?
     PARA_EXIT $RETVAL "pg_basebackup of segment data directory from ${PRIMARY_HOSTADDRESS} to ${GP_HOSTADDRESS}"
+    SED_PG_CONF ${GP_DIR}/$PG_CONF "port" port=$GP_PORT 0 $GP_HOSTADDRESS
+    PARA_EXIT $RETVAL "Update port number to $GP_PORT"
     LOG_MSG "[INFO][$INST_COUNT]:-End Function $FUNCNAME"
 }
 

--- a/gpMgmt/sbin/gpsegrecovery.py
+++ b/gpMgmt/sbin/gpsegrecovery.py
@@ -6,6 +6,7 @@ from recovery_base import RecoveryBase, set_recovery_cmd_results
 from gppylib.commands.base import Command
 from gppylib.commands.gp import SegmentStart
 from gppylib.gparray import Segment
+from gppylib.commands.gp import ModifyConfSetting
 
 
 class FullRecovery(Command):
@@ -59,6 +60,11 @@ class FullRecovery(Command):
         self.error_type = RecoveryErrorType.DEFAULT_ERROR
         self.logger.info("Successfully ran pg_basebackup for dbid: {}".format(
             self.recovery_info.target_segment_dbid))
+
+        # Updating port number on conf after recovery
+        self.error_type = RecoveryErrorType.UPDATE_ERROR
+        update_port_in_conf(self.recovery_info, self.logger)
+
         self.error_type = RecoveryErrorType.START_ERROR
         start_segment(self.recovery_info, self.logger, self.era)
 
@@ -83,6 +89,10 @@ class IncrementalRecovery(Command):
         cmd.run(validateAfter=True)
         self.logger.info("Successfully ran pg_rewind for dbid: {}".format(self.recovery_info.target_segment_dbid))
 
+        # Updating port number on conf after recovery
+        self.error_type = RecoveryErrorType.UPDATE_ERROR
+        update_port_in_conf(self.recovery_info, self.logger)
+
         self.error_type = RecoveryErrorType.START_ERROR
         start_segment(self.recovery_info, self.logger, self.era)
 
@@ -99,6 +109,14 @@ def start_segment(recovery_info, logger, era):
         , utilityMode=True)
     logger.info(str(cmd))
     cmd.run(validateAfter=True)
+
+
+def update_port_in_conf(recovery_info, logger):
+    logger.info("Updating %s/postgresql.conf" % recovery_info.target_datadir)
+    modifyConfCmd = ModifyConfSetting('Updating %s/postgresql.conf' % recovery_info.target_datadir,
+                                      "{}/{}".format(recovery_info.target_datadir, 'postgresql.conf'),
+                                      'port', recovery_info.target_port, optType='number')
+    modifyConfCmd.run(validateAfter=True)
 
 
 #FIXME we may not need this class

--- a/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
@@ -51,6 +51,7 @@ Feature: Tests for gpaddmirrors
         Then gpaddmirrors should return a return code of 0
         And verify the database has mirrors
         And the segments are synchronized
+        And check segment conf: postgresql.conf
         And user can start transactions
 
     Scenario: gpaddmirrors setup recovery part two
@@ -174,7 +175,7 @@ Feature: Tests for gpaddmirrors
 
         And all the segments are running
         And the segments are synchronized
-
+        And check segment conf: postgresql.conf
         And all files in gpAdminLogs directory are deleted
 
 
@@ -221,6 +222,7 @@ Feature: Tests for gpaddmirrors
         Then gprecoverseg should return a return code of 0
         And all the segments are running
         And the segments are synchronized
+        And check segment conf: postgresql.conf
         And the user runs "gpstop -aqM fast"
 
     @concourse_cluster
@@ -395,6 +397,7 @@ Feature: Tests for gpaddmirrors
         Then gpinitstandby should return a return code of 0
         And gpaddmirrors adds mirrors
         Then mirror hostlist matches the one saved in context
+        And check segment conf: postgresql.conf
         And the user runs "gpstop -aqM fast"
 
     @concourse_cluster
@@ -404,6 +407,7 @@ Feature: Tests for gpaddmirrors
         And a cluster is created with no mirrors on "mdw" and "sdw1, sdw2, sdw3"
         And gpaddmirrors adds mirrors in spread configuration
         Then verify that mirror segments are in "spread" configuration
+        And check segment conf: postgresql.conf
         And the user runs "gpstop -aqM fast"
 
     @concourse_cluster
@@ -413,6 +417,7 @@ Feature: Tests for gpaddmirrors
         And a cluster is created with no mirrors on "mdw" and "sdw1"
         And gpaddmirrors adds mirrors
         Then verify the database has mirrors
+        And check segment conf: postgresql.conf
         And the user runs "gpstop -aqM fast"
 
     @concourse_cluster
@@ -422,6 +427,7 @@ Feature: Tests for gpaddmirrors
         And a cluster is created with no mirrors on "mdw" and "sdw1"
         And gpaddmirrors adds mirrors with temporary data dir
         Then verify the database has mirrors
+        And check segment conf: postgresql.conf
         And the user runs "gpstop -aqM fast"
 
     @concourse_cluster
@@ -438,6 +444,17 @@ Feature: Tests for gpaddmirrors
         And wait until the process "gpstart" goes down
         Then all the segments are running
         And the segments are synchronized
+        And check segment conf: postgresql.conf
+        And the user runs "gpstop -aqM fast"
+
+    @concourse_cluster
+    Scenario: gpaddmirrors should create consistent port entry on mirrors postgresql.conf file
+        Given a working directory of the test as '/tmp/gpaddmirrors'
+        And the database is not running
+        And a cluster is created with no mirrors on "mdw" and "sdw1"
+        When gpaddmirrors adds mirrors
+        Then verify the database has mirrors
+        And check segment conf: postgresql.conf
         And the user runs "gpstop -aqM fast"
 
     @concourse_cluster

--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -269,3 +269,9 @@ Feature: gpinitsystem tests
         And a demo cluster is created using gpinitsystem args " "
         And gpinitsystem should return a return code of 0
 
+    Scenario: gpinitsystem should create consistent port entry on segments postgresql.conf file
+        Given the database is not running
+        When a demo cluster is created using gpinitsystem args " "
+        And gpinitsystem should return a return code of 0
+        Then gpstate should return a return code of 0
+        And check segment conf: postgresql.conf

--- a/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
@@ -31,6 +31,7 @@ Feature: Tests for gpmovemirrors
         And verify the database has mirrors
         And all the segments are running
         And the segments are synchronized
+        And check segment conf: postgresql.conf
         And verify that mirrors are recognized after a restart
 
     Scenario: gpmovemirrors can change the port of mirrors within a single host
@@ -43,6 +44,7 @@ Feature: Tests for gpmovemirrors
         And all the segments are running
         And the segments are synchronized
         And verify that mirrors are recognized after a restart
+        And check segment conf: postgresql.conf
 
     Scenario: gpmovemirrors gives a warning when passed identical attributes for new and old mirrors
         Given a standard local demo cluster is created
@@ -177,6 +179,7 @@ Feature: Tests for gpmovemirrors
         And gprecoverseg should return a return code of 0
         And all the segments are running
         And the segments are synchronized
+        And check segment conf: postgresql.conf
         And user can start transactions
 
 
@@ -267,6 +270,7 @@ Feature: Tests for gpmovemirrors
         Then gprecoverseg should return a return code of 0
         And all the segments are running
         And the segments are synchronized
+        And check segment conf: postgresql.conf
 
     @concourse_cluster
     Scenario: gpmovemirrors can change from spread mirroring to group mirroring
@@ -304,6 +308,7 @@ Feature: Tests for gpmovemirrors
         Then gprecoverseg should return a return code of 0
         And all the segments are running
         And the segments are synchronized
+        And check segment conf: postgresql.conf
 
     @concourse_cluster
     Scenario: tablespaces work on a multi-host environment
@@ -359,6 +364,7 @@ Feature: Tests for gpmovemirrors
 
         And the mode of all the created data directories is changed to 0700
         And the cluster is recovered in full and rebalanced
+        And check segment conf: postgresql.conf
         And the row count from table "test_movemirrors" in "postgres" is verified against the saved data
 
     @concourse_cluster
@@ -369,6 +375,7 @@ Feature: Tests for gpmovemirrors
         And the segments are synchronized
         And all files in gpAdminLogs directory are deleted on all hosts in the cluster
         And the information of contents 0,1,2 is saved
+        And check segment conf: postgresql.conf
 
         And sql "DROP TABLE if exists test_movemirrors; CREATE TABLE test_movemirrors AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
         And the "test_movemirrors" table row count in "postgres" is saved
@@ -390,9 +397,11 @@ Feature: Tests for gpmovemirrors
         And gpAdminLogs directory has no "pg_rewind*" files on all segment hosts
         And gpAdminLogs directory has "gpsegsetuprecovery*" files on all segment hosts
         And gpAdminLogs directory has "gpsegrecovery*" files on all segment hosts
+        And check segment conf: postgresql.conf
 
         And the mode of all the created data directories is changed to 0700
         And the cluster is recovered in full and rebalanced
+        And check segment conf: postgresql.conf
         And the row count from table "test_movemirrors" in "postgres" is verified against the saved data
 
     @concourse_cluster
@@ -403,6 +412,7 @@ Feature: Tests for gpmovemirrors
         And the segments are synchronized
         And all files in gpAdminLogs directory are deleted on all hosts in the cluster
         And the information of contents 0,1,2,3,4,5 is saved
+        And check segment conf: postgresql.conf
 
         And sql "DROP TABLE if exists test_movemirrors; CREATE TABLE test_movemirrors AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
         And the "test_movemirrors" table row count in "postgres" is saved
@@ -423,9 +433,11 @@ Feature: Tests for gpmovemirrors
         And gpAdminLogs directory has no "pg_rewind*" files on all segment hosts
         And gpAdminLogs directory has "gpsegsetuprecovery*" files on all segment hosts
         And gpAdminLogs directory has "gpsegrecovery*" files on all segment hosts
+        And check segment conf: postgresql.conf
 
         And the mode of all the created data directories is changed to 0700
         And the cluster is recovered in full and rebalanced
+        And check segment conf: postgresql.conf
         And the row count from table "test_movemirrors" in "postgres" is verified against the saved data
 
     @concourse_cluster
@@ -436,6 +448,7 @@ Feature: Tests for gpmovemirrors
         And the segments are synchronized
         And all files in gpAdminLogs directory are deleted on all hosts in the cluster
         And the information of contents 0,1,2,3,4,5 is saved
+        And check segment conf: postgresql.conf
 
         And sql "DROP TABLE if exists test_movemirrors; CREATE TABLE test_movemirrors AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
         And the "test_movemirrors" table row count in "postgres" is saved
@@ -458,7 +471,9 @@ Feature: Tests for gpmovemirrors
         And gpAdminLogs directory has no "pg_rewind*" files on all segment hosts
         And gpAdminLogs directory has "gpsegsetuprecovery*" files on all segment hosts
         And gpAdminLogs directory has "gpsegrecovery*" files on all segment hosts
+        And check segment conf: postgresql.conf
 
         And the mode of all the created data directories is changed to 0700
         And the cluster is recovered in full and rebalanced
+        And check segment conf: postgresql.conf
         And the row count from table "test_movemirrors" in "postgres" is verified against the saved data

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -48,6 +48,7 @@ Feature: gprecoverseg tests
         And gpsegrecovery should only spawn up to <segHost_workers> workers in WorkerPool
         And check if gprecoverseg ran "$GPHOME/sbin/gpsegstop.py" 1 times with args "-b <segHost_workers>"
         And the segments are synchronized
+        And check segment conf: postgresql.conf
 
       Examples:
         | args      | coordinator_workers | segHost_workers |
@@ -71,6 +72,7 @@ Feature: gprecoverseg tests
       And check if gprecoverseg ran "$GPHOME/sbin/gpsegrecovery.py" 1 times with args "-b <segHost_workers>"
       And check if gprecoverseg ran "$GPHOME/sbin/gpsegstop.py" 1 times with args "-b <segHost_workers>"
       And the segments are synchronized
+      And check segment conf: postgresql.conf
 
     Examples:
       | args      | coordinator_workers | segHost_workers |
@@ -91,7 +93,7 @@ Feature: gprecoverseg tests
         When the user runs "gprecoverseg -ra"
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should not print "Unhandled exception in thread started by <bound method Worker.__bootstrap" to stdout
-	And the segments are synchronized
+	    And the segments are synchronized
 
     Scenario: gprecoverseg full recovery displays pg_basebackup progress to the user
         Given the database is running
@@ -109,6 +111,7 @@ Feature: gprecoverseg tests
         And gpAdminLogs directory has "gpsegsetuprecovery*" files
         And all the segments are running
         And the segments are synchronized
+        And check segment conf: postgresql.conf
 
     Scenario: gprecoverseg mixed recovery displays pg_basebackup and rewind progress to the user
       Given the database is running
@@ -497,6 +500,7 @@ Feature: gprecoverseg tests
     And the user waits until mirror on content 0,1,2 is up
     And the old data directories are cleaned up for content 0
     And user can start transactions
+    And check segment conf: postgresql.conf
     And all files in gpAdminLogs directory are deleted on all hosts in the cluster
 
   @demo_cluster
@@ -602,6 +606,8 @@ Feature: gprecoverseg tests
     When the user runs gprecoverseg with input file and additional args "-a"
     Then gprecoverseg should return a return code of 1
     And user can start transactions
+    And check segment conf: postgresql.conf
+
 
     And check if incremental recovery failed for mirrors with content 0 for gprecoverseg
     And check if full recovery was successful for mirrors with content 1
@@ -612,9 +618,11 @@ Feature: gprecoverseg tests
 
     And gpAdminLogs directory has "gpsegsetuprecovery*" files on all segment hosts
     And gpAdminLogs directory has "gpsegrecovery*" files on all segment hosts
+    And check segment conf: postgresql.conf
 
     And the mode of all the created data directories is changed to 0700
     And the cluster is recovered in full and rebalanced
+    And check segment conf: postgresql.conf
     And the row count from table "test_recoverseg" in "postgres" is verified against the saved data
 
   @demo_cluster
@@ -661,6 +669,7 @@ Feature: gprecoverseg tests
     And user can start transactions
     And the segments are synchronized
     And the cluster is rebalanced
+    And check segment conf: postgresql.conf
     And the row count from table "test_recoverseg" in "postgres" is verified against the saved data
 
   @demo_cluster
@@ -705,6 +714,7 @@ Feature: gprecoverseg tests
     And user can start transactions
     And the segments are synchronized
     And the cluster is rebalanced
+    And check segment conf: postgresql.conf
     And the row count from table "test_recoverseg" in "postgres" is verified against the saved data
 
   @concourse_cluster
@@ -753,6 +763,7 @@ Feature: gprecoverseg tests
         And gprecoverseg should print "Segments successfully recovered" to stdout
         And all the segments are running
         And the segments are synchronized
+        And check segment conf: postgresql.conf
 
     @concourse_cluster
     Scenario: gprecoverseg with -i and -o option
@@ -835,6 +846,7 @@ Feature: gprecoverseg tests
        Then gprecoverseg should return a return code of 0
         And all the segments are running
         And the segments are synchronized
+        And check segment conf: postgresql.conf
 
     @concourse_cluster
     Scenario: gprecoverseg does not create backout scripts if a segment recovery fails before the catalog is changed
@@ -858,6 +870,7 @@ Feature: gprecoverseg tests
          Then gprecoverseg should return a return code of 0
           And all the segments are running
           And the segments are synchronized
+          And check segment conf: postgresql.conf
 
 
     @concourse_cluster
@@ -893,6 +906,7 @@ Feature: gprecoverseg tests
       And all the segments are running
       And the segments are synchronized
       Then the cluster is rebalanced
+      And check segment conf: postgresql.conf
 
   @demo_cluster
   @concourse_cluster
@@ -934,6 +948,7 @@ Feature: gprecoverseg tests
     And all the segments are running
     And the segments are synchronized
     And the cluster is rebalanced
+    And check segment conf: postgresql.conf
 
   @demo_cluster
   @concourse_cluster
@@ -973,6 +988,7 @@ Feature: gprecoverseg tests
     And all the segments are running
     And the segments are synchronized
     And the cluster is rebalanced
+    And check segment conf: postgresql.conf
 
     @concourse_cluster
     Scenario: gprecoverseg cleans up backout scripts upon successful segment recovery

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg_newhost.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg_newhost.feature
@@ -54,6 +54,7 @@ Feature: gprecoverseg tests involving migrating to a new host
     And datadirs from "before" configuration for "sdw1" are created on "sdw5" with mode 700
     And the user runs "gprecoverseg -aF"
     And gprecoverseg should return a return code of 0
+    And check segment conf: postgresql.conf
     And the cluster configuration is saved for "one_host_down"
     And the "before" and "one_host_down" cluster configuration matches with the expected for gprecoverseg newhost
     And the mirrors replicate and fail over and back correctly
@@ -88,6 +89,7 @@ Feature: gprecoverseg tests involving migrating to a new host
     And datadirs from "before_recoverseg" configuration for "sdw1" are created on "sdw5" with mode 700
     And the user runs "gprecoverseg -a -p sdw5 --hba-hostnames"
     And gprecoverseg should return a return code of 0
+    And check segment conf: postgresql.conf
     And the cluster configuration is saved for "one_host_down"
     And the "before" and "one_host_down" cluster configuration matches with the expected for gprecoverseg newhost
     And the mirrors replicate and fail over and back correctly


### PR DESCRIPTION
    Problem Statement: port on mirror segment's postgresql.conf is not in
    sync with the port listed in gp_segment_configuration table. this
    creates problem while starting mirror segment without providing the port
    number in pgctl command(required for gpv).
    Fix: to fix this problem we have identified the blocks where we need to
    make changes to keep the port in sync between mirror conf and
    gp_segment_configuration. This commit consist of following changes:
    
    1. Updated SED_PG_CONF for the search regex which was causing issue in
       find and replace while changing the port.
    2. Updated CREATE_QES_MIRROR() to update the port number in conf file
       after mirror gets created.
    3. Added port update call in FullRecovery and IncrementalRecovery class
       as this is the place which is common for gpaddmirrors/gpmovemirrors/gprecoverseg.
    4. Added support for update warning type on port update failure (as this commit will be
       cherry-pick to 6x because we are not removing port dependency on start_segment for 6x)
    5. Updated gpsegrecovery unit test to cover new changes.
    6. Updated feature test for gprecoverseg/gpaddmirrors/gpmovemirrors/gprecoverseg_newhost
       to validate that the port are in sync.
    7. Removed port dependency from pg_ctl start call for segment and master
    


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
