### PR TITLE
Use winner QE's nfiltered1 and nfiltered2 in the output of EXPLAIN ANALYZE

### DIFF
--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1086,32 +1086,8 @@ cdbexplain_depositStatsToNode(PlanState *planstate, CdbExplain_RecvStatCtx *ctx)
 	instr->total = ntuples.max_total;
 	INSTR_TIME_ASSIGN(instr->firststart, ntuples.firststart_of_max_total);
 
-	/* Put winner's stats into qDisp PlanState's Instrument node. */
 	/*
-	 * GPDB_12_MERGE_FIXME: does it make sense to also print 'nfiltered1'
-	 * 'nfiltered2' from the "winner", i.e. the QE that returned most rows?
-	 * There's this test case in the upstream 'partition_prune' test:
-	 *
-	 * explain (analyze, costs off, summary off, timing off) select * from list_part where a = list_part_fn(1) + a;
-	 *                       QUERY PLAN                      
-	 * ------------------------------------------------------
-	 *  Append (actual rows=0 loops=1)
-	 *    ->  Seq Scan on list_part1 (actual rows=0 loops=1)
-	 *          Filter: (a = (list_part_fn(1) + a))
-	 *          Rows Removed by Filter: 1
-	 *    ->  Seq Scan on list_part2 (actual rows=0 loops=1)
-	 *          Filter: (a = (list_part_fn(1) + a))
-	 *          Rows Removed by Filter: 1
-	 *    ->  Seq Scan on list_part3 (actual rows=0 loops=1)
-	 *          Filter: (a = (list_part_fn(1) + a))
-	 *          Rows Removed by Filter: 1
-	 *    ->  Seq Scan on list_part4 (actual rows=0 loops=1)
-	 *          Filter: (a = (list_part_fn(1) + a))
-	 *          Rows Removed by Filter: 1
-	 * (13 rows)
-	 *
-	 * We don't print those "Rows Removed by Filter" rows in GPDB, because
-	 * they don't come from the "winner" QE.
+	 * Put winner's stats into qDisp PlanState's Instrument node.
 	 */
 	if (ntuples.agg.vcnt > 0)
 	{


### PR DESCRIPTION
In the implementation of EXPLAIN ANALYZE of Greenplum Database, it will aggregate all
execution results from all QEs, these results will be stored in the struct `CdbExplain_StatInst`,
used by function `cdbexplain_depositStatsToNode`. 

`nfiltered1` and `nfiltered2` are not a crucial results to indicate the bottleneck from the output
of EXPLAIN ANALYZE, so we can just use winner QE's `nfiltered1` and `nfiltered2` directly, which
 has the largest number of rows returned.

Otherwise, we only print the non-zero filter value, which is `Rows Removed by Filter`:

```
postgres=# create table foo(
	id int,
	t int
) distributed by (id)
partition by range(t)
(
	partition p1 start (0) end (1000),
	partition p2 start (1000) end (2000)
);

postgres=# explain (analyze, costs off, summary off, timing off) select * from foo 
where id > 800;
                             QUERY PLAN                             
--------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3) (actual rows=700 loops=1)
   ->  Append (actual rows=237 loops=1)
         ->  Seq Scan on foo_1_prt_p1 (actual rows=70 loops=1)
               Filter: (id > 800)
               Rows Removed by Filter: 267
         ->  Seq Scan on foo_1_prt_p2 (actual rows=170 loops=1)
               Filter: (id > 800)
 Optimizer: Postgres query optimizer
(8 rows)
```

The filter information for `foo_1_prt_p2` is not printed because its `nfiltered1` is 0, and we will 
suppress zero counts, this is the design of function `show_instrumentation_count`, so the 
comments about we don't print "Rows Removed by Filter" are not accurate, just remove it.
