### PR TITLE
Support Const TVF returning composite type in ORCA

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -54,6 +54,7 @@ extern "C" {
 #include "gpopt/translate/CPartPruneStepsBuilder.h"
 #include "gpopt/translate/CTranslatorDXLToPlStmt.h"
 #include "gpopt/translate/CTranslatorUtils.h"
+#include "naucrates/dxl/operators/CDXLDatumGeneric.h"
 #include "naucrates/dxl/operators/CDXLDirectDispatchInfo.h"
 #include "naucrates/dxl/operators/CDXLNode.h"
 #include "naucrates/dxl/operators/CDXLPhysicalAgg.h"
@@ -1509,19 +1510,9 @@ CTranslatorDXLToPlStmt::TranslateDXLTvfToRangeTblEntry(
 	RangeTblEntry *rte = MakeNode(RangeTblEntry);
 	rte->rtekind = RTE_FUNCTION;
 
-	FuncExpr *func_expr = MakeNode(FuncExpr);
-
-	func_expr->funcid = CMDIdGPDB::CastMdid(dxlop->FuncMdId())->Oid();
-	func_expr->funcretset = gpdb::GetFuncRetset(func_expr->funcid);
-	// this is a function call, as opposed to a cast
-	func_expr->funcformat = COERCE_EXPLICIT_CALL;
-	func_expr->funcresulttype =
-		CMDIdGPDB::CastMdid(dxlop->ReturnTypeMdId())->Oid();
-
+	// get function alias
 	Alias *alias = MakeNode(Alias);
 	alias->colnames = NIL;
-
-	// get function alias
 	alias->aliasname = CTranslatorUtils::CreateMultiByteCharStringFromWCString(
 		dxlop->Pstr()->GetBuffer());
 
@@ -1548,47 +1539,91 @@ CTranslatorDXLToPlStmt::TranslateDXLTvfToRangeTblEntry(
 												 ul + 1 /*attno*/);
 	}
 
-	// function arguments
-	const ULONG num_of_child = tvf_dxlnode->Arity();
-	for (ULONG ul = 1; ul < num_of_child; ++ul)
-	{
-		CDXLNode *func_arg_dxlnode = (*tvf_dxlnode)[ul];
-
-		CMappingColIdVarPlStmt colid_var_mapping(m_mp, base_table_context,
-												 nullptr, output_context,
-												 m_dxl_to_plstmt_context);
-
-		Expr *pexprFuncArg = m_translator_dxl_to_scalar->TranslateDXLToScalar(
-			func_arg_dxlnode, &colid_var_mapping);
-		func_expr->args = gpdb::LAppend(func_expr->args, pexprFuncArg);
-	}
-
-	// GPDB_91_MERGE_FIXME: collation
-	func_expr->inputcollid = gpdb::ExprCollation((Node *) func_expr->args);
-	func_expr->funccollid = gpdb::TypeCollation(func_expr->funcresulttype);
-
-	// Populate RangeTblFunction::funcparams, by walking down the entire
-	// func_expr to capture ids of all the PARAMs
-	ListCell *lc = nullptr;
-	List *param_exprs = gpdb::ExtractNodesExpression(
-		(Node *) func_expr, T_Param, false /*descend_into_subqueries */);
-	Bitmapset *funcparams = nullptr;
-	ForEach(lc, param_exprs)
-	{
-		Param *param = (Param *) lfirst(lc);
-		funcparams = gpdb::BmsAddMember(funcparams, param->paramid);
-	}
-
 	RangeTblFunction *rtfunc = MakeNode(RangeTblFunction);
-	rtfunc->funcexpr = (Node *) func_expr;
+	Bitmapset *funcparams = nullptr;
+
+	// invalid funcid indicates TVF evaluates to const
+	if (!dxlop->FuncMdId()->IsValid())
+	{
+		Const *const_expr = MakeNode(Const);
+
+		const_expr->consttype =
+			CMDIdGPDB::CastMdid(dxlop->ReturnTypeMdId())->Oid();
+		const_expr->consttypmod = -1;
+
+		CDXLNode *constVa = (*tvf_dxlnode)[1];
+		CDXLScalarConstValue *constValue =
+			CDXLScalarConstValue::Cast(constVa->GetOperator());
+		const CDXLDatum *datum_dxl = constValue->GetDatumVal();
+		CDXLDatumGeneric *datum_generic_dxl =
+			CDXLDatumGeneric::Cast(const_cast<gpdxl::CDXLDatum *>(datum_dxl));
+		const IMDType *type =
+			m_md_accessor->RetrieveType(datum_generic_dxl->MDId());
+		const_expr->constlen = type->Length();
+		Datum val = gpdb::DatumFromPointer(datum_generic_dxl->GetByteArray());
+		ULONG length =
+			(ULONG) gpdb::DatumSize(val, false, const_expr->constlen);
+		CHAR *str = (CHAR *) gpdb::GPDBAlloc(length + 1);
+		memcpy(str, datum_generic_dxl->GetByteArray(), length);
+		str[length] = '\0';
+		const_expr->constvalue = gpdb::DatumFromPointer(str);
+
+		rtfunc->funcexpr = (Node *) const_expr;
+		rtfunc->funccolcount = (int) num_of_cols;
+	}
+	else
+	{
+		FuncExpr *func_expr = MakeNode(FuncExpr);
+
+		func_expr->funcid = CMDIdGPDB::CastMdid(dxlop->FuncMdId())->Oid();
+		func_expr->funcretset = gpdb::GetFuncRetset(func_expr->funcid);
+		// this is a function call, as opposed to a cast
+		func_expr->funcformat = COERCE_EXPLICIT_CALL;
+		func_expr->funcresulttype =
+			CMDIdGPDB::CastMdid(dxlop->ReturnTypeMdId())->Oid();
+
+		// function arguments
+		const ULONG num_of_child = tvf_dxlnode->Arity();
+		for (ULONG ul = 1; ul < num_of_child; ++ul)
+		{
+			CDXLNode *func_arg_dxlnode = (*tvf_dxlnode)[ul];
+
+			CMappingColIdVarPlStmt colid_var_mapping(m_mp, base_table_context,
+													 nullptr, output_context,
+													 m_dxl_to_plstmt_context);
+
+			Expr *pexprFuncArg =
+				m_translator_dxl_to_scalar->TranslateDXLToScalar(
+					func_arg_dxlnode, &colid_var_mapping);
+			func_expr->args = gpdb::LAppend(func_expr->args, pexprFuncArg);
+		}
+
+		// GPDB_91_MERGE_FIXME: collation
+		func_expr->inputcollid = gpdb::ExprCollation((Node *) func_expr->args);
+		func_expr->funccollid = gpdb::TypeCollation(func_expr->funcresulttype);
+
+		// Populate RangeTblFunction::funcparams, by walking down the entire
+		// func_expr to capture ids of all the PARAMs
+		ListCell *lc = nullptr;
+		List *param_exprs = gpdb::ExtractNodesExpression(
+			(Node *) func_expr, T_Param, false /*descend_into_subqueries */);
+		ForEach(lc, param_exprs)
+		{
+			Param *param = (Param *) lfirst(lc);
+			funcparams = gpdb::BmsAddMember(funcparams, param->paramid);
+		}
+
+		rtfunc->funcexpr = (Node *) func_expr;
+	}
+
 	rtfunc->funcparams = funcparams;
 	// GPDB_91_MERGE_FIXME: collation
 	// set rtfunc->funccoltypemods & rtfunc->funccolcollations?
 	rte->functions = ListMake1(rtfunc);
 
 	rte->inFromCl = true;
-	rte->eref = alias;
 
+	rte->eref = alias;
 	return rte;
 }
 

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -3647,26 +3647,21 @@ CTranslatorQueryToDXL::TranslateTVFToDXL(const RangeTblEntry *rte,
 				   GPOS_WSZ_LIT("Multi-argument UNNEST() or TABLE()"));
 	}
 	RangeTblFunction *rtfunc = (RangeTblFunction *) linitial(rte->functions);
-	FuncExpr *funcexpr = (FuncExpr *) rtfunc->funcexpr;
-	GPOS_ASSERT(funcexpr);
+
+	BOOL is_composite_const =
+		CTranslatorUtils::IsCompositeConst(m_mp, m_md_accessor, rtfunc);
 
 	// if this is a folded function expression, generate a project over a CTG
-	if (!IsA(funcexpr, FuncExpr))
+	if (!IsA(rtfunc->funcexpr, FuncExpr) && !is_composite_const)
 	{
-		if (gpdb::IsCompositeType(funcexpr->funcid))
-		{
-			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
-					   GPOS_WSZ_LIT("Whole-row variable"));
-		}
-
 		CDXLNode *const_tbl_get_dxlnode = DXLDummyConstTableGet();
 
 		CDXLNode *project_list_dxlnode = GPOS_NEW(m_mp)
 			CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarProjList(m_mp));
 
-		CDXLNode *project_elem_dxlnode =
-			TranslateExprToDXLProject((Expr *) funcexpr, rte->eref->aliasname,
-									  true /* insist_new_colids */);
+		CDXLNode *project_elem_dxlnode = TranslateExprToDXLProject(
+			(Expr *) rtfunc->funcexpr, rte->eref->aliasname,
+			true /* insist_new_colids */);
 		project_list_dxlnode->AddChild(project_elem_dxlnode);
 
 		CDXLNode *project_dxlnode = GPOS_NEW(m_mp)
@@ -3689,6 +3684,19 @@ CTranslatorQueryToDXL::TranslateTVFToDXL(const RangeTblEntry *rte,
 									tvf_dxlop->GetDXLColumnDescrArray());
 
 	BOOL is_subquery_in_args = false;
+
+	// funcexpr evaluates to const and returns composite type
+	if (IsA(rtfunc->funcexpr, Const))
+	{
+		CDXLNode *constValue = m_scalar_translator->TranslateScalarToDXL(
+			(Expr *) (rtfunc->funcexpr), m_var_to_colid_map);
+		tvf_dxlnode->AddChild(constValue);
+		return tvf_dxlnode;
+	}
+
+	GPOS_ASSERT(IsA(rtfunc->funcexpr, FuncExpr));
+
+	FuncExpr *funcexpr = (FuncExpr *) rtfunc->funcexpr;
 
 	// check if arguments contain SIRV functions
 	if (NIL != funcexpr->args && HasSirvFunctions((Node *) funcexpr->args))

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -2440,7 +2440,11 @@ CTranslatorRelcacheToDXL::RetrieveRelStorageType(Relation rel)
 			break;
 		case 0:
 
-			if (rel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE)
+			if (rel->rd_rel->relkind == RELKIND_COMPOSITE_TYPE)
+			{
+				rel_storage_type = IMDRelation::ErelstorageCompositeType;
+			}
+			else if (rel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE)
 				rel_storage_type = RetrieveStorageTypeForPartitionedTable(rel);
 			else if (gpdb::RelIsExternalTable(rel->rd_id))
 				rel_storage_type = IMDRelation::ErelstorageExternal;

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -268,10 +268,33 @@ CTranslatorUtils::ConvertToCDXLLogicalTVF(CMemoryPool *mp,
 	 */
 
 	RangeTblFunction *rtfunc = (RangeTblFunction *) linitial(rte->functions);
-	FuncExpr *funcexpr = (FuncExpr *) rtfunc->funcexpr;
-	GPOS_ASSERT(funcexpr);
-	GPOS_ASSERT(IsA(funcexpr, FuncExpr));
 
+
+	// TVF evaluates to const, return const DXL node
+	if (IsA(rtfunc->funcexpr, Const))
+	{
+		Const *constExpr = (Const *) rtfunc->funcexpr;
+
+		CMDIdGPDB *mdid_return_type =
+			GPOS_NEW(mp) CMDIdGPDB(constExpr->consttype);
+
+		const IMDType *type = md_accessor->RetrieveType(mdid_return_type);
+		CDXLColDescrArray *column_descrs = GetColumnDescriptorsFromComposite(
+			mp, md_accessor, id_generator, type);
+
+		CMDName *func_name =
+			CDXLUtils::CreateMDNameFromCharArray(mp, rte->eref->aliasname);
+		mdid_return_type->AddRef();
+
+		// if TVF evaluates to const, pass invalid key as funcid
+		CDXLLogicalTVF *tvf_dxl = GPOS_NEW(mp)
+			CDXLLogicalTVF(mp, GPOS_NEW(mp) CMDIdGPDB(0), mdid_return_type,
+						   func_name, column_descrs);
+
+		return tvf_dxl;
+	}
+
+	FuncExpr *funcexpr = (FuncExpr *) rtfunc->funcexpr;
 	// In the planner, scalar functions that are volatile (SIRV) or read or modify SQL
 	// data get patched into an InitPlan. This is not supported in the optimizer
 	if (IsSirvFunc(mp, md_accessor, funcexpr->funcid))
@@ -279,7 +302,6 @@ CTranslatorUtils::ConvertToCDXLLogicalTVF(CMemoryPool *mp,
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
 				   GPOS_WSZ_LIT("SIRV functions"));
 	}
-
 	// get function id
 	CMDIdGPDB *mdid_func = GPOS_NEW(mp) CMDIdGPDB(funcexpr->funcid);
 	CMDIdGPDB *mdid_return_type =
@@ -2468,6 +2490,26 @@ CTranslatorUtils::GetAggKind(EdxlAggrefKind aggkind)
 					   GPOS_WSZ_LIT("Unknown aggkind value"));
 		}
 	}
+}
+
+//---------------------------------------------------------------------------
+// CTranslatorUtils::IsCompositeConst
+// Check if const func returns composite type
+//---------------------------------------------------------------------------
+BOOL
+CTranslatorUtils::IsCompositeConst(CMemoryPool *mp, CMDAccessor *md_accessor,
+								   const RangeTblFunction *rtfunc)
+{
+	if (!IsA(rtfunc->funcexpr, Const))
+		return false;
+
+	Const *constExpr = (Const *) rtfunc->funcexpr;
+
+	CMDIdGPDB *mdid_return_type = GPOS_NEW(mp) CMDIdGPDB(constExpr->consttype);
+
+	const IMDType *type = md_accessor->RetrieveType(mdid_return_type);
+
+	return type->IsComposite();
 }
 
 // EOF

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalTVF.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalTVF.cpp
@@ -42,14 +42,16 @@ CPhysicalTVF::CPhysicalTVF(CMemoryPool *mp, IMDId *mdid_func,
 	  m_pdrgpcoldesc(pdrgpcoldesc),
 	  m_pcrsOutput(pcrsOutput)
 {
-	GPOS_ASSERT(m_func_mdid->IsValid());
 	GPOS_ASSERT(m_return_type_mdid->IsValid());
 	GPOS_ASSERT(nullptr != m_pstr);
 	GPOS_ASSERT(nullptr != m_pdrgpcoldesc);
 	GPOS_ASSERT(nullptr != m_pcrsOutput);
 
 	CMDAccessor *md_accessor = COptCtxt::PoctxtFromTLS()->Pmda();
-	m_pmdfunc = md_accessor->RetrieveFunc(m_func_mdid);
+	if (m_func_mdid->IsValid())
+		m_pmdfunc = md_accessor->RetrieveFunc(m_func_mdid);
+	else
+		m_pmdfunc = nullptr;
 }
 
 

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -544,6 +544,9 @@ CTranslatorDXLToExpr::PexprLogicalTVF(const CDXLNode *dxlnode)
 	ConstructDXLColId2ColRefMapping(dxl_op->GetDXLColumnDescrArray(),
 									popTVF->PdrgpcrOutput());
 
+	if (!popTVF->FuncMdId()->IsValid())
+		return pexpr;
+
 	const IMDFunction *pmdfunc = m_pmda->RetrieveFunc(mdid_func);
 
 	if (IMDFunction::EfsVolatile == pmdfunc->GetFuncStability())

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -468,6 +468,7 @@ enum Edxltoken
 	EdxltokenRelStorageAppendOnlyRows,
 	EdxltokenRelStorageMixedPartitioned,
 	EdxltokenRelStorageExternal,
+	EdxltokenRelStorageCompositeType,
 
 	EdxltokenPartKeys,
 	EdxltokenPartTypes,

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/IMDRelation.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/IMDRelation.h
@@ -52,6 +52,7 @@ public:
 		ErelstorageAppendOnlyRows,
 		ErelstorageExternal,
 		ErelstorageMixedPartitioned,
+		ErelstorageCompositeType,
 		ErelstorageSentinel
 	};
 

--- a/src/backend/gporca/libnaucrates/src/md/IMDRelation.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/IMDRelation.cpp
@@ -70,6 +70,8 @@ IMDRelation::GetStorageTypeStr(IMDRelation::Erelstoragetype rel_storage_type)
 		case ErelstorageMixedPartitioned:
 			return CDXLTokens::GetDXLTokenStr(
 				EdxltokenRelStorageMixedPartitioned);
+		case ErelstorageCompositeType:
+			return CDXLTokens::GetDXLTokenStr(EdxltokenRelStorageCompositeType);
 		default:
 			return nullptr;
 	}

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLLogicalTVF.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLLogicalTVF.cpp
@@ -36,7 +36,6 @@ CDXLLogicalTVF::CDXLLogicalTVF(CMemoryPool *mp, IMDId *mdid_func,
 	  m_mdname(mdname),
 	  m_dxl_col_descr_array(pdrgdxlcd)
 {
-	GPOS_ASSERT(m_func_mdid->IsValid());
 	GPOS_ASSERT(m_return_type_mdid->IsValid());
 }
 

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLPhysicalTVF.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLPhysicalTVF.cpp
@@ -35,7 +35,6 @@ CDXLPhysicalTVF::CDXLPhysicalTVF(CMemoryPool *mp, IMDId *mdid_func,
 	  func_name(str)
 {
 	GPOS_ASSERT(nullptr != m_func_mdid);
-	GPOS_ASSERT(m_func_mdid->IsValid());
 	GPOS_ASSERT(nullptr != m_return_type_mdid);
 	GPOS_ASSERT(m_return_type_mdid->IsValid());
 	GPOS_ASSERT(nullptr != func_name);

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -519,6 +519,7 @@ CDXLTokens::Init(CMemoryPool *mp)
 		 GPOS_WSZ_LIT("AppendOnly, Row-oriented")},
 		{EdxltokenRelStorageMixedPartitioned, GPOS_WSZ_LIT("MixedPartitioned")},
 		{EdxltokenRelStorageExternal, GPOS_WSZ_LIT("External")},
+		{EdxltokenRelStorageCompositeType, GPOS_WSZ_LIT("Composite")},
 
 		{EdxltokenRelDistrPolicy, GPOS_WSZ_LIT("DistributionPolicy")},
 		{EdxltokenRelDistrMasterOnly, GPOS_WSZ_LIT("MasterOnly")},

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -383,6 +383,10 @@ public:
 
 	// return agg kind as a CHAR
 	static CHAR GetAggKind(EdxlAggrefKind aggkind);
+
+	// check if const func returns composite type
+	static BOOL IsCompositeConst(CMemoryPool *mp, CMDAccessor *md_accessor,
+								 const RangeTblFunction *rtfunc);
 };
 }  // namespace gpdxl
 

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14309,3 +14309,103 @@ where t.j = tt.j;
  Optimizer: Postgres query optimizer
 (19 rows)
 
+----------------------------------
+-- Test ORCA support for const TVF
+----------------------------------
+create type complex_t as (r float8, i float8);
+-- Nested composite
+create type quad as (c1 complex_t, c2 complex_t);
+create function quad_func_cast() returns quad immutable as $$ select ((1.1,null),(2.2,null))::quad $$ language sql;
+explain select c1 from quad_func_cast();
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Function Scan on quad_func_cast  (cost=0.00..0.01 rows=1 width=32)
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+explain select c2 from quad_func_cast();
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Function Scan on quad_func_cast  (cost=0.00..0.01 rows=1 width=32)
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+explain select (c1).r from quad_func_cast();
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Function Scan on quad_func_cast  (cost=0.00..0.01 rows=1 width=32)
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+explain select (c2).i from quad_func_cast();
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Function Scan on quad_func_cast  (cost=0.00..0.01 rows=1 width=32)
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+select c1 from quad_func_cast();
+   c1   
+--------
+ (1.1,)
+(1 row)
+
+select c2 from quad_func_cast();
+   c2   
+--------
+ (2.2,)
+(1 row)
+
+select (c1).r from quad_func_cast();
+  r  
+-----
+ 1.1
+(1 row)
+
+select (c2).i from quad_func_cast();
+ i 
+---
+  
+(1 row)
+
+create type mix_type as (a text, b integer, c bool);
+create function mix_func_cast() returns mix_type immutable as $$ select ('column1', 1, true)::mix_type $$ language sql;
+explain select a from mix_func_cast();
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Function Scan on mix_func_cast  (cost=0.00..0.01 rows=1 width=32)
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+explain select b from mix_func_cast();
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Function Scan on mix_func_cast  (cost=0.00..0.01 rows=1 width=4)
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+explain select c from mix_func_cast();
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Function Scan on mix_func_cast  (cost=0.00..0.01 rows=1 width=1)
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+select a from mix_func_cast();
+    a    
+---------
+ column1
+(1 row)
+
+select b from mix_func_cast();
+ b 
+---
+ 1
+(1 row)
+
+select c from mix_func_cast();
+ c 
+---
+ t
+(1 row)
+

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14680,3 +14680,103 @@ where t.j = tt.j;
  Optimizer: Pivotal Optimizer (GPORCA)
 (17 rows)
 
+----------------------------------
+-- Test ORCA support for const TVF
+----------------------------------
+create type complex_t as (r float8, i float8);
+-- Nested composite
+create type quad as (c1 complex_t, c2 complex_t);
+create function quad_func_cast() returns quad immutable as $$ select ((1.1,null),(2.2,null))::quad $$ language sql;
+explain select c1 from quad_func_cast();
+                               QUERY PLAN                                
+-------------------------------------------------------------------
+ Function Scan on quad_func_cast  (cost=0.00..0.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(2 rows)
+
+explain select c2 from quad_func_cast();
+                               QUERY PLAN                                
+-------------------------------------------------------------------
+ Function Scan on quad_func_cast  (cost=0.00..0.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(2 rows)
+
+explain select (c1).r from quad_func_cast();
+                             QUERY PLAN                             
+-------------------------------------------------------------------
+ Function Scan on quad_func_cast  (cost=0.00..0.01 rows=1 width=8)
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+explain select (c2).i from quad_func_cast();
+                             QUERY PLAN                             
+-------------------------------------------------------------------
+ Function Scan on quad_func_cast  (cost=0.00..0.01 rows=1 width=8)
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+select c1 from quad_func_cast();
+   c1   
+--------
+ (1.1,)
+(1 row)
+
+select c2 from quad_func_cast();
+   c2   
+--------
+ (2.2,)
+(1 row)
+
+select (c1).r from quad_func_cast();
+  r  
+-----
+ 1.1
+(1 row)
+
+select (c2).i from quad_func_cast();
+ i 
+---
+  
+(1 row)
+
+create type mix_type as (a text, b integer, c bool);
+create function mix_func_cast() returns mix_type immutable as $$ select ('column1', 1, true)::mix_type $$ language sql;
+explain select a from mix_func_cast();
+                               QUERY PLAN                               
+------------------------------------------------------------------
+ Function Scan on mix_func_cast  (cost=0.00..0.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(2 rows)
+
+explain select b from mix_func_cast();
+                               QUERY PLAN                               
+------------------------------------------------------------------
+ Function Scan on mix_func_cast  (cost=0.00..0.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(2 rows)
+
+explain select c from mix_func_cast();
+                               QUERY PLAN                               
+------------------------------------------------------------------
+ Function Scan on mix_func_cast  (cost=0.00..0.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(2 rows)
+
+select a from mix_func_cast();
+    a    
+---------
+ column1
+(1 row)
+
+select b from mix_func_cast();
+ b 
+---
+ 1
+(1 row)
+
+select c from mix_func_cast();
+ c 
+---
+ t
+(1 row)
+

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3479,6 +3479,31 @@ set i = tt.i
 from (select (min(i) over (order by j)) as i, j from window_agg_test) tt
 where t.j = tt.j;
 
+----------------------------------
+-- Test ORCA support for const TVF
+----------------------------------
+create type complex_t as (r float8, i float8);
+-- Nested composite
+create type quad as (c1 complex_t, c2 complex_t);
+create function quad_func_cast() returns quad immutable as $$ select ((1.1,null),(2.2,null))::quad $$ language sql;
+explain select c1 from quad_func_cast();
+explain select c2 from quad_func_cast();
+explain select (c1).r from quad_func_cast();
+explain select (c2).i from quad_func_cast();
+select c1 from quad_func_cast();
+select c2 from quad_func_cast();
+select (c1).r from quad_func_cast();
+select (c2).i from quad_func_cast();
+
+create type mix_type as (a text, b integer, c bool);
+create function mix_func_cast() returns mix_type immutable as $$ select ('column1', 1, true)::mix_type $$ language sql;
+explain select a from mix_func_cast();
+explain select b from mix_func_cast();
+explain select c from mix_func_cast();
+select a from mix_func_cast();
+select b from mix_func_cast();
+select c from mix_func_cast();
+
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 -- end_ignore


### PR DESCRIPTION
Objective: Support Const TVF returning composite type in ORCA.
Background: Const TVF returning multi-column composite type returns incorrect result in 6X. TVF returning composite type falls back on planner in 7X.
Implementation:
1. Use invalid funcid to indicate TVF evaluates to const. Remove all valid funcid assertions.
2. Refactored code. Query -> DXL translation cases divided into three categories (i) non TVF && non const composite (eg. Var, Const returning simple type), (ii) const TVF returning composite type, (3) TVF.
3. Add relation storage type and token for composite type, similar to "virtual" storage type in 6X.
4. Remove tests for const TVF fall back. Add tests for const TVF