### PR TITLE
fix incorrect Redistribute Motion in partition table join

### DIFF
--- a/src/backend/optimizer/path/equivclass.c
+++ b/src/backend/optimizer/path/equivclass.c
@@ -684,6 +684,14 @@ get_eclass_for_sort_expr(PlannerInfo *root,
 				cur_em->em_is_const)
 				continue;
 
+			/*
+			 * CDB: if cur_em->em_expr is a RelabelType, we compare the actual
+			 * expr wrapped.
+			 */
+			if (IsA(cur_em->em_expr, RelabelType) &&
+				equal(expr, ((RelabelType *)cur_em->em_expr)->arg))
+				return cur_ec;
+
 			if (opcintype == cur_em->em_datatype &&
 				equal(expr, cur_em->em_expr))
 				return cur_ec;	/* Match! */

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -5917,3 +5917,29 @@ RESET ROLE;
 DROP TABLE public.t_part_acl;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE SELECT ON TABLES FROM user_prt_acl;
 DROP ROLE user_prt_acl;
+-- test outer join in partition table and the partition key is varchar,
+-- more details can be found at https://github.com/greenplum-db/gpdb/issues/13402#issuecomment-1102147978
+create table foo_13402 (id varchar(32), t varchar(32))
+	distributed by (id)
+	partition by range(t)
+	(
+		partition p1 start ('0') end ('100'),
+		partition p2 start ('101') end ('201') 
+	);
+create table bar_13402 (id varchar(32), t varchar(32))
+	distributed by (id);
+-- should not have Redistribute Motion node in the output
+explain select * from bar_13402 a left join foo_13402 b on a.id=b.id;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=160.00..17672.00 rows=564480 width=328)
+   ->  Hash Right Join  (cost=160.00..10145.60 rows=188160 width=328)
+         Hash Cond: ((b.id)::text = (a.id)::text)
+         ->  Append  (cost=0.00..236.00 rows=11200 width=164)
+               ->  Seq Scan on foo_13402_1_prt_p1 b  (cost=0.00..90.00 rows=5600 width=164)
+               ->  Seq Scan on foo_13402_1_prt_p2 b_1  (cost=0.00..90.00 rows=5600 width=164)
+         ->  Hash  (cost=90.00..90.00 rows=5600 width=164)
+               ->  Seq Scan on bar_13402 a  (cost=0.00..90.00 rows=5600 width=164)
+ Optimizer: Postgres query optimizer
+(9 rows)
+

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -5917,3 +5917,29 @@ RESET ROLE;
 DROP TABLE public.t_part_acl;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE SELECT ON TABLES FROM user_prt_acl;
 DROP ROLE user_prt_acl;
+-- test outer join in partition table and the partition key is varchar,
+-- more details can be found at https://github.com/greenplum-db/gpdb/issues/13402#issuecomment-1102147978
+create table foo_13402 (id varchar(32), t varchar(32))
+	distributed by (id)
+	partition by range(t)
+	(
+		partition p1 start ('0') end ('100'),
+		partition p2 start ('101') end ('201') 
+	);
+create table bar_13402 (id varchar(32), t varchar(32))
+	distributed by (id);
+-- should not have Redistribute Motion node in the output
+explain select * from bar_13402 a left join foo_13402 b on a.id=b.id;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=80)
+   ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=80)
+         Hash Cond: ((bar_13402.id)::text = (foo_13402_1_prt_p1.id)::text)
+         ->  Seq Scan on bar_13402  (cost=0.00..431.00 rows=1 width=40)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=40)
+               ->  Append  (cost=0.00..431.00 rows=1 width=40)
+                     ->  Seq Scan on foo_13402_1_prt_p1  (cost=0.00..431.00 rows=1 width=40)
+                     ->  Seq Scan on foo_13402_1_prt_p2  (cost=0.00..431.00 rows=1 width=40)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -3793,3 +3793,19 @@ RESET ROLE;
 DROP TABLE public.t_part_acl;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE SELECT ON TABLES FROM user_prt_acl;
 DROP ROLE user_prt_acl;
+
+
+-- test outer join in partition table and the partition key is varchar,
+-- more details can be found at https://github.com/greenplum-db/gpdb/issues/13402#issuecomment-1102147978
+create table foo_13402 (id varchar(32), t varchar(32))
+	distributed by (id)
+	partition by range(t)
+	(
+		partition p1 start ('0') end ('100'),
+		partition p2 start ('101') end ('201') 
+	);
+create table bar_13402 (id varchar(32), t varchar(32))
+	distributed by (id);
+-- should not have Redistribute Motion node in the output
+explain select * from bar_13402 a left join foo_13402 b on a.id=b.id;
+


### PR DESCRIPTION
There will have a `Redistribute Motion` node, if we join a partition table to another normal table, 
and the distributed key is `varchar()`, and the join restriction is distributed key, just like this:

```
postgres=# create table foo (id varchar(32), t varchar(32))
distributed by (id)
partition by range(t)
(
  partition p1 start ('0') end ('100'),
  partition p2 start ('101') end ('201') 
);

postgres=# create table bar (id varchar(32), t varchar(32))
distributed by (id);

postgres=# explain (costs off) select * from bar a join foo b on a.id=b.id;
                         QUERY PLAN                         
------------------------------------------------------------
 Gather Motion 3:1  (slice2; segments: 3)
   ->  Hash Join
         Hash Cond: ((b.id)::text = (a.id)::text)
         ->  Redistribute Motion 3:3  (slice1; segments: 3)
               Hash Key: b.id
               ->  Append
                     ->  Seq Scan on foo_1_prt_p1 b
                     ->  Seq Scan on foo_1_prt_p2 b_1
         ->  Hash
               ->  Seq Scan on bar a
 Optimizer: Postgres query optimizer
```

The reason is that when we use `cdb_pull_up_eclass` to upgrade the equivalence class in the append 
path, the `RelabelType` is ignored, resulting in the creation of unnecessary equivalence members, 
resulting in a wrong judgment in the subsequent `cdbpath_match_preds_to_both_distkeys`, and then 
adds the wrong motion node.






