### PR TITLE
Do not brew install python3 on macOS

### DIFF
--- a/README.macOS.bash
+++ b/README.macOS.bash
@@ -28,8 +28,6 @@ brew link --force apr-util
 # Needed for pygresql, or you can source greenplum_path.sh after compiling database and installing python-dependencies then
 brew install postgresql
 
-brew install python3
-
 # Due to recent update on OS net-tools package. Mac doesn't have support for ss and ip by default.
 # Hence as a workaround installing iproute2mac for ip support and creating soft link for ss support
 brew install iproute2mac


### PR DESCRIPTION
The python3 is shipped with macOS, do not brew install python3, otherwise it
will cause confusion when starting up gpdb.

