### PR TITLE
[6X] [Re-commit] Make sendControlMessage to retry when interrupted

### DIFF
--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -774,6 +774,8 @@ static void aggregateStatistics(ChunkTransportStateEntry *pEntry);
 
 static inline bool pollAcks(ChunkTransportState *transportStates, int fd, int timeout);
 
+static ssize_t sendtoWithRetry(int socket, const void *message, size_t length, int flags, const struct sockaddr *dest_addr, socklen_t dest_len, int retry, const char *errDetail);
+
 /* #define TRANSFER_PROTOCOL_STATS */
 
 #ifdef TRANSFER_PROTOCOL_STATS
@@ -1780,9 +1782,6 @@ destroyConnHashTable(ConnHashTable *ht)
 /*
  * sendControlMessage
  * 		Helper function to send a control message.
- *
- * It is different from sendOnce which retries on interrupts...
- * Here, we leave it to retransmit logic to handle these cases.
  */
 static inline void
 sendControlMessage(icpkthdr *pkt, int fd, struct sockaddr *addr, socklen_t peerLen)
@@ -1803,13 +1802,10 @@ sendControlMessage(icpkthdr *pkt, int fd, struct sockaddr *addr, socklen_t peerL
 	if (gp_interconnect_full_crc)
 		addCRC(pkt);
 
-	n = sendto(fd, (const char *) pkt, pkt->len, 0, addr, peerLen);
-
-	/*
-	 * No need to handle EAGAIN here: no-space just means that we dropped the
-	 * packet: our ordinary retransmit mechanism will handle that case
-	 */
-
+	char errDetail[100];
+	snprintf(errDetail, sizeof(errDetail), "Send control message: got error with seq %u", pkt->seq);
+	/* Retry for infinite times since we have no retransmit mechanism for control message */
+	n = sendtoWithRetry(fd, (const char *) pkt, pkt->len, 0, addr, peerLen, -1, errDetail);
 	if (n < pkt->len)
 		write_log("sendcontrolmessage: got error %d errno %d seq %d", n, errno, pkt->seq);
 }
@@ -4549,34 +4545,41 @@ prepareXmit(MotionConn *conn)
 }
 
 /*
- * sendOnce
- * 		Send a packet.
+ * sendtoWithRetry
+ * 		Retry sendto logic and send the packets.
  */
-static void
-sendOnce(ChunkTransportState *transportStates, ChunkTransportStateEntry *pEntry, ICBuffer *buf, MotionConn *conn)
+static ssize_t
+sendtoWithRetry(int socket, const void *message, size_t length,
+           int flags, const struct sockaddr *dest_addr,
+           socklen_t dest_len, int retry, const char *errDetail)
 {
 	int32		n;
-
-#ifdef USE_ASSERT_CHECKING
-	if (testmode_inject_fault(gp_udpic_dropxmit_percent))
-	{
-#ifdef AMS_VERBOSE_LOGGING
-		write_log("THROW PKT with seq %d srcpid %d despid %d", buf->pkt->seq, buf->pkt->srcPid, buf->pkt->dstPid);
-#endif
-		return;
-	}
-#endif
+	int count = 0;
 
 xmit_retry:
-	n = sendto(pEntry->txfd, buf->pkt, buf->pkt->len, 0,
-			   (struct sockaddr *) &conn->peer, conn->peer_len);
+	/*
+	 * If given retry count is positive, retry up to the limited times.
+	 * Otherwise, retry for unlimited times until succeed. 
+	 */
+	if (retry > 0 && ++count > retry)
+		return n;
+	n = sendto(socket, message, length, flags, dest_addr, dest_len);
 	if (n < 0)
 	{
+		int	save_errno = errno;
+
 		if (errno == EINTR)
 			goto xmit_retry;
 
-		if (errno == EAGAIN)	/* no space ? not an error. */
-			return;
+		/* 
+		 * EAGAIN: no space ? not an error.
+		 * 
+		 * EFAULT: In Linux system call, it only happens when copying a socket 
+		 * address into kernel space failed, which is less likely to happen, 
+		 * but mocked heavily by our fault injection in regression tests. 
+		 */
+		if (errno == EAGAIN || errno == EFAULT)
+			return n;
 
 		/*
 		 * If Linux iptables (nf_conntrack?) drops an outgoing packet, it may
@@ -4588,20 +4591,45 @@ xmit_retry:
 			ereport(LOG,
 					(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
 					 errmsg("Interconnect error writing an outgoing packet: %m"),
-					 errdetail("error during sendto() for Remote Connection: contentId=%d at %s",
-							   conn->remoteContentId, conn->remoteHostAndPort)));
-			return;
+					 errdetail("error during sendto() %s", errDetail)));
+			return n;
 		}
 
 		ereport(ERROR, (errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
 						errmsg("Interconnect error writing an outgoing packet: %m"),
 						errdetail("error during sendto() call (error:%d).\n"
-								  "For Remote Connection: contentId=%d at %s",
-								  errno, conn->remoteContentId,
-								  conn->remoteHostAndPort)));
+								  "%s", save_errno, errDetail)));
 		/* not reached */
 	}
 
+	return n;
+}
+
+/*
+ * sendOnce
+ * 		Send a packet.
+ */
+static void
+sendOnce(ChunkTransportState *transportStates, ChunkTransportStateEntry *pEntry, ICBuffer *buf, MotionConn *conn)
+{
+	int32 n;
+
+#ifdef USE_ASSERT_CHECKING
+	if (testmode_inject_fault(gp_udpic_dropxmit_percent))
+	{
+#ifdef AMS_VERBOSE_LOGGING
+		write_log("THROW PKT with seq %d srcpid %d despid %d", buf->pkt->seq, buf->pkt->srcPid, buf->pkt->dstPid);
+#endif
+		return;
+	}
+#endif
+
+	char errDetail[100];
+	snprintf(errDetail, sizeof(errDetail), "For Remote Connection: contentId=%d at %s",
+					  conn->remoteContentId,
+					  conn->remoteHostAndPort);
+	n = sendtoWithRetry(pEntry->txfd, buf->pkt, buf->pkt->len, 0,
+                          (struct sockaddr *) &conn->peer, conn->peer_len, -1, errDetail);
 	if (n != buf->pkt->len)
 	{
 		if (DEBUG1 >= log_min_messages)
@@ -4613,7 +4641,6 @@ xmit_retry:
 		logPkt("PKT DETAILS ", buf->pkt);
 #endif
 	}
-
 	return;
 }
 
@@ -5075,7 +5102,7 @@ checkNetworkTimeout(ICBuffer *buf, uint64 now, bool *networkTimeoutIsLogged)
 		ereport(ERROR,
 				(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
 				 errmsg("interconnect encountered a network error, please check your network"),
-				 errdetail("Failed to send packet (seq %d) to %s (pid %d cid %d) after %d retries in %d seconds.",
+				 errdetail("Failed to send packet (seq %u) to %s (pid %d cid %d) after %u retries in %d seconds.",
 						   buf->pkt->seq, buf->conn->remoteHostAndPort,
 						   buf->pkt->dstPid, buf->pkt->dstContentId,
 						   buf->nRetry, Gp_interconnect_transmit_timeout)));
@@ -5096,7 +5123,7 @@ checkNetworkTimeout(ICBuffer *buf, uint64 now, bool *networkTimeoutIsLogged)
 	{
 		ereport(WARNING,
 				(errmsg("interconnect may encountered a network error, please check your network"),
-				 errdetail("Failed to send packet (seq %d) to %s (pid %d cid %d) after %d retries.",
+				 errdetail("Failing to send packet (seq %u) to %s (pid %d cid %d) after %u retries.",
 						   buf->pkt->seq, buf->conn->remoteHostAndPort,
 						   buf->pkt->dstPid, buf->pkt->dstContentId,
 						   buf->nRetry)));
@@ -6952,7 +6979,7 @@ SendDummyPacket(void)
 
 	if (counter >= 10)
 	{
-		elog(LOG, "send dummy packet failed, sendto failed: %m");
+		elog(LOG, "send dummy packet failed, sendto failed with 10 times: %m");
 		goto send_error;
 	}
 

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -80,6 +80,11 @@ m/^NOTICE:  resource group required -- using .* resource group ".*"$/
 # be raised, and it is expected.  This could happen normally on the
 # random_numsegments pipeline job, so ignore this WARNING.
 m/^WARNING:  table ".*" contains rows in segment .*, which is outside the # of segments for the table's policy \(\d+ segments\)$/
+
+# The following output is an interconnect network warning, but still not error out, so ignore it.
+m/WARNING:  interconnect may encountered a network error, please check your network/
+m/Failing to send packet/
+
 -- end_matchignore
 
 -- start_matchsubs


### PR DESCRIPTION
`sendControlMessage()` method has no retry attempts, this refactor abstracted a `sendto` system call wrapper with retry enabled.

Co-authored-by: zwenlin <zwenlin@vmware.com>

This is a re-commit of PR #12968, fixing the flaky case in `icudp_schedule` test suites.

Notice the flaky happened at :

```
SET gp_udpic_fault_inject_bitmap = 524288;
SELECT system_call_fault_injection_test();
```

By the fault inject definition:

```
FINC_OS_NET_INTERFACE = 19,

#define FINC_HAS_FAULT(type) (gp_udpic_fault_inject_bitmap & (1U << (type)))
```

The `FINC_HAS_FAULT` macro will hit at fault type: `FINC_OS_NET_INTERFACE`.

This PR commit changed the behavior around sendto system call, look into [static ssize_t testmode_sendto(const char caller_name, int socket, const void buffer, size_t length, int flags, const struct sockaddr *dest_addr, socklen_t dest_len)](https://github.com/greenplum-db/gpdb/blob/2b61d021f4f872e16e112e48f5aa70630263b575/src/include/cdb/cdbicudpfaultinjection.h#L141):


```
case FINC_OS_NET_INTERFACE:
            if (!FINC_HAS_FAULT(fault_type))
                break;
            write_log("inject fault to sendto: FINC_OS_NET_INTERFACE");
            errno = EFAULT;
            return -1;
```


[It will set EFAULT as the errno.](https://github.com/greenplum-db/gpdb/blob/2b61d021f4f872e16e112e48f5aa70630263b575/src/include/cdb/cdbicudpfaultinjection.h#L246)

According the man page of `sendto()` system call, Upon successful completion, `sendto()` shall return the number of bytes sent. Otherwise, -1 shall be returned and errno set to indicate the error.
And the original implementation of `sendControlMessage()` only by the returned value: https://github.com/greenplum-db/gpdb/blob/master/src/backend/cdb/motion/ic_udpifc.c#L1807

But after [the refactor](https://github.com/greenplum-db/gpdb/commit/55ce8ba70f21d7864171a0ebf7dca137c533ceb6), we changed our logic, not judge by the returned value, but by the errno, what is unlucky, we didn't handle the `EFAULT` type errno, so it will hit a ERROR-level `ereport(ERROR, (errcode(ERRCODE_GP_INTERCONNECTION_ERROR)`: https://github.com/greenplum-db/gpdb/blob/55ce8ba70f21d7864171a0ebf7dca137c533ceb6/src/backend/cdb/motion/ic_udpifc.c#L4583. We should change the code here.


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
