### PR TITLE
remove fixme in gang_reuse.sql

### DIFF
--- a/src/test/regress/expected/gang_reuse.out
+++ b/src/test/regress/expected/gang_reuse.out
@@ -16,12 +16,6 @@ set gp_cached_segworkers_threshold to 10;
 set gp_vmem_idle_resource_timeout to '60s';
 set optimizer_enable_motion_broadcast to off;
 set optimizer_force_multistage_agg to on;
--- GPDB_12_MERGE_FIXME: some of the following cases will fallback
--- to planner in without-cassert pipeline with orca-enabled, this
--- leads to this case's failure. But locally, I cannot reproduce
--- the fallback. Turn orca off before running the following cases
--- to make the case pass. We should address this after merging.
-set optimizer to off;
 create table test_gang_reuse_t1 (c1 int, c2 int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -156,4 +150,3 @@ explain analyze select count(*) from test_gang_reuse_t1 a
 (20 rows)
 
 reset optimizer_force_multistage_agg;
-reset optimizer;

--- a/src/test/regress/expected/gang_reuse_optimizer.out
+++ b/src/test/regress/expected/gang_reuse_optimizer.out
@@ -16,12 +16,6 @@ set gp_cached_segworkers_threshold to 10;
 set gp_vmem_idle_resource_timeout to '60s';
 set optimizer_enable_motion_broadcast to off;
 set optimizer_force_multistage_agg to on;
--- GPDB_12_MERGE_FIXME: some of the following cases will fallback
--- to planner in without-cassert pipeline with orca-enabled, this
--- leads to this case's failure. But locally, I cannot reproduce
--- the fallback. Turn orca off before running the following cases
--- to make the case pass. We should address this after merging.
-set optimizer to off;
 create table test_gang_reuse_t1 (c1 int, c2 int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -32,128 +26,133 @@ explain analyze select count(*) from test_gang_reuse_t1 a
   join test_gang_reuse_t1 b using (c2)
   join test_gang_reuse_t1 c using (c2)
 ;
-                                                               QUERY PLAN                                                               
-----------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=3.20..3.21 rows=1 width=8) (actual time=5.284..5.284 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; gang0; segments: 3)  (cost=2.08..3.19 rows=3 width=0) (actual time=5.279..5.279 rows=0 loops=1)
-         ->  Hash Join  (cost=2.08..3.15 rows=1 width=0) (never executed)
-               Hash Cond: (a.c2 = c.c2)
-               ->  Hash Join  (cost=1.04..2.09 rows=1 width=8) (never executed)
-                     Hash Cond: (a.c2 = b.c2)
-                     ->  Redistribute Motion 3:3  (slice2; gang3; segments: 3)  (cost=0.00..1.03 rows=1 width=4) (never executed)
-                           Hash Key: a.c2
-                           ->  Seq Scan on test_gang_reuse_t1 a  (cost=0.00..1.01 rows=1 width=4) (never executed)
-                     ->  Hash  (cost=1.03..1.03 rows=1 width=4) (never executed)
-                           ->  Redistribute Motion 3:3  (slice3; gang6; segments: 3)  (cost=0.00..1.03 rows=1 width=4) (never executed)
-                                 Hash Key: b.c2
-                                 ->  Seq Scan on test_gang_reuse_t1 b  (cost=0.00..1.01 rows=1 width=4) (never executed)
-               ->  Hash  (cost=1.03..1.03 rows=1 width=4) (never executed)
-                     Buckets: 262144  Batches: 1  Memory Usage: 2048kB
-                     ->  Redistribute Motion 3:3  (slice4; gang9; segments: 3)  (cost=0.00..1.03 rows=1 width=4) (never executed)
-                           Hash Key: c.c2
-                           ->  Seq Scan on test_gang_reuse_t1 c  (cost=0.00..1.01 rows=1 width=4) (never executed)
- Planning Time: 0.836 ms
-   (slice0)    Executor memory: 59K bytes.
-   (slice1)    Executor memory: 2077K bytes avg x 3 workers, 2077K bytes max (seg0).  Work_mem: 2048K bytes max.
-   (slice2)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
-   (slice3)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
-   (slice4)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
- Memory used:  128000kB
- Optimizer: Postgres query optimizer
- Execution Time: 42.202 ms
-(27 rows)
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..1293.00 rows=1 width=8) (actual time=12.198..12.199 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice1; gang0; segments: 3)  (cost=0.00..1293.00 rows=1 width=8) (actual time=9.198..12.182 rows=3 loops=1)
+         ->  Partial Aggregate  (cost=0.00..1293.00 rows=1 width=8) (actual time=10.824..10.824 rows=1 loops=1)
+               ->  Hash Join  (cost=0.00..1293.00 rows=1 width=1) (never executed)
+                     Hash Cond: (test_gang_reuse_t1.c2 = test_gang_reuse_t1_1.c2)
+                     ->  Redistribute Motion 3:3  (slice2; gang3; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                           Hash Key: test_gang_reuse_t1.c2
+                           ->  Seq Scan on test_gang_reuse_t1  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                     ->  Hash  (cost=862.00..862.00 rows=1 width=4) (never executed)
+                           Buckets: 262144  Batches: 1  Memory Usage: 2048kB
+                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4) (never executed)
+                                 Hash Cond: (test_gang_reuse_t1_1.c2 = test_gang_reuse_t1_2.c2)
+                                 ->  Redistribute Motion 3:3  (slice3; gang6; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                                       Hash Key: test_gang_reuse_t1_1.c2
+                                       ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_1  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4) (never executed)
+                                       Buckets: 262144  Batches: 1  Memory Usage: 2048kB
+                                       ->  Redistribute Motion 3:3  (slice4; gang9; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                                             Hash Key: test_gang_reuse_t1_2.c2
+                                             ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_2  (cost=0.00..431.00 rows=1 width=4) (never executed)
+ Planning Time: 136.820 ms
+   (slice0)    Executor memory: 68K bytes.
+   (slice1)    Executor memory: 4133K bytes avg x 3 workers, 4133K bytes max (seg0).  Work_mem: 2048K bytes max.
+   (slice2)    Executor memory: 38K bytes avg x 3 workers, 38K bytes max (seg0).
+   (slice3)    Executor memory: 38K bytes avg x 3 workers, 38K bytes max (seg0).
+   (slice4)    Executor memory: 38K bytes avg x 3 workers, 38K bytes max (seg0).
+ Memory used:  129024kB
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution Time: 37.723 ms
+(29 rows)
 
 -- so in this query the gangs C and D should be used
 explain analyze select count(*) from test_gang_reuse_t1 a
   join test_gang_reuse_t1 b using (c2)
 ;
-                                                            QUERY PLAN                                                             
------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=2.14..2.15 rows=1 width=8) (actual time=5.379..5.379 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; gang0; segments: 3)  (cost=1.04..2.13 rows=3 width=0) (actual time=5.375..5.375 rows=0 loops=1)
-         ->  Hash Join  (cost=1.04..2.09 rows=1 width=0) (never executed)
-               Hash Cond: (a.c2 = b.c2)
-               ->  Redistribute Motion 3:3  (slice2; gang3; segments: 3)  (cost=0.00..1.03 rows=1 width=4) (never executed)
-                     Hash Key: a.c2
-                     ->  Seq Scan on test_gang_reuse_t1 a  (cost=0.00..1.01 rows=1 width=4) (never executed)
-               ->  Hash  (cost=1.03..1.03 rows=1 width=4) (never executed)
-                     Buckets: 524288  Batches: 1  Memory Usage: 4096kB
-                     ->  Redistribute Motion 3:3  (slice3; gang6; segments: 3)  (cost=0.00..1.03 rows=1 width=4) (never executed)
-                           Hash Key: b.c2
-                           ->  Seq Scan on test_gang_reuse_t1 b  (cost=0.00..1.01 rows=1 width=4) (never executed)
- Planning Time: 0.150 ms
-   (slice0)    Executor memory: 41K bytes.
-   (slice1)    Executor memory: 4113K bytes avg x 3 workers, 4113K bytes max (seg0).  Work_mem: 4096K bytes max.
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=6.712..6.712 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice1; gang0; segments: 3)  (cost=0.00..862.00 rows=1 width=8) (actual time=6.243..6.696 rows=3 loops=1)
+         ->  Partial Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=6.384..6.385 rows=1 loops=1)
+               ->  Hash Join  (cost=0.00..862.00 rows=1 width=1) (never executed)
+                     Hash Cond: (test_gang_reuse_t1.c2 = test_gang_reuse_t1_1.c2)
+                     ->  Redistribute Motion 3:3  (slice2; gang3; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                           Hash Key: test_gang_reuse_t1.c2
+                           ->  Seq Scan on test_gang_reuse_t1  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=4) (never executed)
+                           Buckets: 524288  Batches: 1  Memory Usage: 4096kB
+                           ->  Redistribute Motion 3:3  (slice3; gang6; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                                 Hash Key: test_gang_reuse_t1_1.c2
+                                 ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_1  (cost=0.00..431.00 rows=1 width=4) (never executed)
+ Planning Time: 43.425 ms
+   (slice0)    Executor memory: 49K bytes.
+   (slice1)    Executor memory: 4121K bytes avg x 3 workers, 4121K bytes max (seg0).  Work_mem: 4096K bytes max.
    (slice2)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
    (slice3)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
- Memory used:  128000kB
- Optimizer: Postgres query optimizer
- Execution Time: 6.358 ms
-(20 rows)
+ Memory used:  129024kB
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution Time: 10.260 ms
+(21 rows)
 
 -- so in this query the gangs C, D and E should be used
 explain analyze select count(*) from test_gang_reuse_t1 a
   join test_gang_reuse_t1 b using (c2)
   join test_gang_reuse_t1 c using (c2)
 ;
-                                                               QUERY PLAN                                                               
-----------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=3.20..3.21 rows=1 width=8) (actual time=2.610..2.610 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; gang0; segments: 3)  (cost=2.08..3.19 rows=3 width=0) (actual time=2.607..2.607 rows=0 loops=1)
-         ->  Hash Join  (cost=2.08..3.15 rows=1 width=0) (never executed)
-               Hash Cond: (a.c2 = c.c2)
-               ->  Hash Join  (cost=1.04..2.09 rows=1 width=8) (never executed)
-                     Hash Cond: (a.c2 = b.c2)
-                     ->  Redistribute Motion 3:3  (slice2; gang3; segments: 3)  (cost=0.00..1.03 rows=1 width=4) (never executed)
-                           Hash Key: a.c2
-                           ->  Seq Scan on test_gang_reuse_t1 a  (cost=0.00..1.01 rows=1 width=4) (never executed)
-                     ->  Hash  (cost=1.03..1.03 rows=1 width=4) (never executed)
-                           ->  Redistribute Motion 3:3  (slice3; gang6; segments: 3)  (cost=0.00..1.03 rows=1 width=4) (never executed)
-                                 Hash Key: b.c2
-                                 ->  Seq Scan on test_gang_reuse_t1 b  (cost=0.00..1.01 rows=1 width=4) (never executed)
-               ->  Hash  (cost=1.03..1.03 rows=1 width=4) (never executed)
-                     Buckets: 262144  Batches: 1  Memory Usage: 2048kB
-                     ->  Redistribute Motion 3:3  (slice4; gang9; segments: 3)  (cost=0.00..1.03 rows=1 width=4) (never executed)
-                           Hash Key: c.c2
-                           ->  Seq Scan on test_gang_reuse_t1 c  (cost=0.00..1.01 rows=1 width=4) (never executed)
- Planning Time: 0.262 ms
-   (slice0)    Executor memory: 59K bytes.
-   (slice1)    Executor memory: 2077K bytes avg x 3 workers, 2077K bytes max (seg0).  Work_mem: 2048K bytes max.
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..1293.00 rows=1 width=8) (actual time=4.574..4.575 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice1; gang0; segments: 3)  (cost=0.00..1293.00 rows=1 width=8) (actual time=3.877..4.560 rows=3 loops=1)
+         ->  Partial Aggregate  (cost=0.00..1293.00 rows=1 width=8) (actual time=4.987..4.988 rows=1 loops=1)
+               ->  Hash Join  (cost=0.00..1293.00 rows=1 width=1) (never executed)
+                     Hash Cond: (test_gang_reuse_t1.c2 = test_gang_reuse_t1_1.c2)
+                     ->  Redistribute Motion 3:3  (slice2; gang3; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                           Hash Key: test_gang_reuse_t1.c2
+                           ->  Seq Scan on test_gang_reuse_t1  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                     ->  Hash  (cost=862.00..862.00 rows=1 width=4) (never executed)
+                           Buckets: 262144  Batches: 1  Memory Usage: 2048kB
+                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4) (never executed)
+                                 Hash Cond: (test_gang_reuse_t1_1.c2 = test_gang_reuse_t1_2.c2)
+                                 ->  Redistribute Motion 3:3  (slice3; gang6; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                                       Hash Key: test_gang_reuse_t1_1.c2
+                                       ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_1  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4) (never executed)
+                                       Buckets: 262144  Batches: 1  Memory Usage: 2048kB
+                                       ->  Redistribute Motion 3:3  (slice4; gang9; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                                             Hash Key: test_gang_reuse_t1_2.c2
+                                             ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_2  (cost=0.00..431.00 rows=1 width=4) (never executed)
+ Planning Time: 68.273 ms
+   (slice0)    Executor memory: 68K bytes.
+   (slice1)    Executor memory: 4133K bytes avg x 3 workers, 4133K bytes max (seg1).  Work_mem: 2048K bytes max.
    (slice2)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
    (slice3)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
    (slice4)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
- Memory used:  128000kB
- Optimizer: Postgres query optimizer
- Execution Time: 4.945 ms
-(27 rows)
+ Memory used:  129024kB
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution Time: 8.619 ms
+(29 rows)
 
 -- so in this query the gangs C and D should be used
 explain analyze select count(*) from test_gang_reuse_t1 a
   join test_gang_reuse_t1 b using (c2)
 ;
-                                                            QUERY PLAN                                                             
------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=2.14..2.15 rows=1 width=8) (actual time=2.449..2.450 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; gang0; segments: 3)  (cost=1.04..2.13 rows=3 width=0) (actual time=2.445..2.445 rows=0 loops=1)
-         ->  Hash Join  (cost=1.04..2.09 rows=1 width=0) (never executed)
-               Hash Cond: (a.c2 = b.c2)
-               ->  Redistribute Motion 3:3  (slice2; gang3; segments: 3)  (cost=0.00..1.03 rows=1 width=4) (never executed)
-                     Hash Key: a.c2
-                     ->  Seq Scan on test_gang_reuse_t1 a  (cost=0.00..1.01 rows=1 width=4) (never executed)
-               ->  Hash  (cost=1.03..1.03 rows=1 width=4) (never executed)
-                     Buckets: 524288  Batches: 1  Memory Usage: 4096kB
-                     ->  Redistribute Motion 3:3  (slice3; gang6; segments: 3)  (cost=0.00..1.03 rows=1 width=4) (never executed)
-                           Hash Key: b.c2
-                           ->  Seq Scan on test_gang_reuse_t1 b  (cost=0.00..1.01 rows=1 width=4) (never executed)
- Planning Time: 0.122 ms
-   (slice0)    Executor memory: 41K bytes.
-   (slice1)    Executor memory: 4114K bytes avg x 3 workers, 4114K bytes max (seg0).  Work_mem: 4096K bytes max.
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=5.348..5.348 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice1; gang0; segments: 3)  (cost=0.00..862.00 rows=1 width=8) (actual time=4.292..5.335 rows=3 loops=1)
+         ->  Partial Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=3.496..3.497 rows=1 loops=1)
+               ->  Hash Join  (cost=0.00..862.00 rows=1 width=1) (never executed)
+                     Hash Cond: (test_gang_reuse_t1.c2 = test_gang_reuse_t1_1.c2)
+                     ->  Redistribute Motion 3:3  (slice2; gang3; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                           Hash Key: test_gang_reuse_t1.c2
+                           ->  Seq Scan on test_gang_reuse_t1  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=4) (never executed)
+                           Buckets: 524288  Batches: 1  Memory Usage: 4096kB
+                           ->  Redistribute Motion 3:3  (slice3; gang6; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                                 Hash Key: test_gang_reuse_t1_1.c2
+                                 ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_1  (cost=0.00..431.00 rows=1 width=4) (never executed)
+ Planning Time: 35.557 ms
+   (slice0)    Executor memory: 49K bytes.
+   (slice1)    Executor memory: 4121K bytes avg x 3 workers, 4121K bytes max (seg0).  Work_mem: 4096K bytes max.
    (slice2)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
    (slice3)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
- Memory used:  128000kB
- Optimizer: Postgres query optimizer
- Execution Time: 3.203 ms
-(20 rows)
+ Memory used:  129024kB
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution Time: 7.474 ms
+(21 rows)
 
 reset optimizer_force_multistage_agg;
-reset optimizer;

--- a/src/test/regress/sql/gang_reuse.sql
+++ b/src/test/regress/sql/gang_reuse.sql
@@ -18,13 +18,6 @@ set gp_vmem_idle_resource_timeout to '60s';
 set optimizer_enable_motion_broadcast to off;
 set optimizer_force_multistage_agg to on;
 
--- GPDB_12_MERGE_FIXME: some of the following cases will fallback
--- to planner in without-cassert pipeline with orca-enabled, this
--- leads to this case's failure. But locally, I cannot reproduce
--- the fallback. Turn orca off before running the following cases
--- to make the case pass. We should address this after merging.
-set optimizer to off;
-
 create table test_gang_reuse_t1 (c1 int, c2 int);
 analyze test_gang_reuse_t1;
 
@@ -52,4 +45,3 @@ explain analyze select count(*) from test_gang_reuse_t1 a
 ;
 
 reset optimizer_force_multistage_agg;
-reset optimizer;


### PR DESCRIPTION
Build a local dev pipeline without cassert, it not failed at `gang_reuse`, so maybe we can
consider remove this FIXME and make things the way they should be.