### PR TITLE
Clean up logic in CdbTryOpenTable.

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -2820,13 +2820,20 @@ gpdb::GetRelChildIndexes(Oid reloid)
 	return partoids;
 }
 
+// Locks on partition leafs and indexes are held during optimizer (after
+// parse-analyze stage). ORCA need this function to lock relation. Here
+// we do not need to consider lock-upgrade issue, reasons are:
+//   1. Only UPDATE|DELETE statement may upgrade lock level
+//   2. ORCA currently does not support DML on partition tables
+//   3. If not partition table, then parser should have already locked
+//   4. Even later ORCA support DML on partition tables, the lock mode
+//      of leafs should be the same as the mode in root's RTE's rellockmode
+//   5. Index does not have lock-upgrade problem.
 void
 gpdb::GPDBLockRelationOid(Oid reloid, LOCKMODE lockmode)
 {
 	GP_WRAP_START;
 	{
-		lockmode =
-			UpgradeRelLockAndReuseRelIfNecessary(reloid, nullptr, lockmode);
 		LockRelationOid(reloid, lockmode);
 	}
 	GP_WRAP_END;

--- a/src/include/storage/lmgr.h
+++ b/src/include/storage/lmgr.h
@@ -115,8 +115,6 @@ extern const char *GetLockNameFromTagType(uint16 locktag_type);
 /* Knowledge about which locktags describe temp objects */
 extern bool LockTagIsTemp(const LOCKTAG *tag);
 
-extern LOCKMODE UpgradeRelLockAndReuseRelIfNecessary(Oid relid, Relation *relptr, LOCKMODE lockmode);
-
 extern void GxactLockTableInsert(DistributedTransactionId xid);
 extern void GxactLockTableWait(DistributedTransactionId xid);
 #endif							/* LMGR_H */


### PR DESCRIPTION
This commit removes the function UpgradeRelLockAndReuseRelIfNecessary
and clean up the implementation of CdbTryOpenTable. Now the logic is:

1. open the relation using some lockmode
2. if need correct lockmode (AO|AOCO with GDD enabled), then close and
   reopen it using upgraded lockmode
3. if need lockUpgraded information, deduce this using actually mode
   with request mode.

Also we remove the post-check for AO table not upgrade, because under
the new implementation that's impossible to happen and NOTE Greenplum
does not support change table's storage kind yet (Even support some
day, there will not be any problem).

The other place that uses UpgradeRelLockAndReuseRelIfNecessary is
gpdbwrappers.cpp:GPDBLockRelationOid. Before this commit, it passes
nullptr to UpgradeRelLockAndReuseRelIfNecessary, thus will open, lock,
close the relation, and then lock the relation oid again. This commit
implement this by just calling LockRelationOid since there is no need
to test lock-upgrade here:
   1. Greenplum only need to upgrade lock level for target relation of
      DELETE | UPDATE statement
   2. Parse-Analyze stage will always handle root partition correctly
      and store the lockmode in RTE
   3. ORCA does not support DML on partiton table yet, and in future
      when implementing this, ORCA should use the lockmode in RTE of
      root so no need to deduce lock-upgrade
   4. Index does not have lock-upgrade issue.

------------------

Refactor of code, no case added (already have cases covered). 