### PR TITLE
Fix writable gpfdist transformation external table cannot report error for 7X

### DIFF
--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -279,7 +279,7 @@ url_curl_abort_callback(ResourceReleasePhase phase,
 static size_t
 header_callback(void *ptr_, size_t size, size_t nmemb, void *userp)
 {
-    URL_CURL_FILE *url = (URL_CURL_FILE *) userp;
+	URL_CURL_FILE *url = (URL_CURL_FILE *) userp;
 	char*		ptr = ptr_;
 	int 		len = size * nmemb;
 	int 		i;
@@ -295,12 +295,16 @@ header_callback(void *ptr_, size_t size, size_t nmemb, void *userp)
 	 * gpfdist, and later use it to report the error string in
 	 * check_response() to the database user.
 	 */
-	if (url->http_response == 0)
+	if (nmemb > 5 && strncmp(ptr, "HTTP/", strlen("HTTP/")) == 0)
 	{
+		if (url->http_response != NULL)
+		{
+			pfree(url->http_response);
+		}
 		int 	n = nmemb;
 		char* 	p;
 
-		if (n > 0 && 0 != (p = palloc(n+1)))
+		if (0 != (p = palloc(n+1)))
 		{
 			memcpy(p, ptr, n);
 			p[n] = 0;

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -3566,7 +3566,7 @@ static int request_set_transform(request_t *r)
 	 * we prepare a temporary file to hold it.	when the request is
 	 * done we'll forward the output as error messages.
 	 */
-	if (transform_stderr_server(tr))
+	if (r->is_get && transform_stderr_server(tr))
 	{
 		apr_pool_t*	 mp = r->pool;
 		apr_file_t*	 f = NULL;

--- a/src/bin/gpfdist/regress/data/errexe.yml
+++ b/src/bin/gpfdist/regress/data/errexe.yml
@@ -1,0 +1,7 @@
+TRANSFORMATIONS:
+    write:
+        TYPE: output
+        COMMAND: /usr/bin/env /home/gpadmin/workspace/6_greenplum/gpfdist/error.sh %filename%
+    read:
+        TYPE: input
+        COMMAND: /usr/bin/env /home/gpadmin/workspace/6_greenplum/gpfdist/error.sh %filename%

--- a/src/bin/gpfdist/regress/input/exttab1.source
+++ b/src/bin/gpfdist/regress/input/exttab1.source
@@ -546,21 +546,29 @@ CREATE EXTERNAL WEB TABLE gpfdist2_transform_start (x text)
 execute E'((@bindir@/gpfdist -p 7080 -d @abs_srcdir@/data/transform -c @abs_srcdir@/data/catfile.yml </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
+-- Test writable transform table report error.
+CREATE WRITABLE EXTERNAL TABLE writable_transform (a text) location('gpfdist://localhost:7081/filename#transform=write') format 'text';
+CREATE EXTERNAL WEB TABLE gpfdist3_transform_start (x text)
+execute E'((@bindir@/gpfdist -p 7081 -d @abs_srcdir@/data/transform -c @abs_srcdir@/data/errexe.yml </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7081 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
 
 -- start_ignore
 select * from exttab1_gpfdist_stop;
 select * from gpfdist1_transform_start;
 select * from gpfdist2_transform_start;
+select * from gpfdist3_transform_start;
 -- end_ignore
 
 select count(*) from ext_transform;
-
+insert into writable_transform values('hello');
 -- start_ignore
 select * from exttab1_gpfdist_stop;
 -- end_ignore
 
 -- drop tables
 DROP EXTERNAL TABLE ext_transform;
+drop external table writable_transform;
 
 --
 -- get an error for missing gpfdist

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -734,6 +734,12 @@ CREATE EXTERNAL WEB TABLE gpfdist2_transform_start (x text)
 execute E'((@bindir@/gpfdist -p 7080 -d @abs_srcdir@/data/transform -c @abs_srcdir@/data/catfile.yml </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
+-- Test writable transform table report error.
+CREATE WRITABLE EXTERNAL TABLE writable_transform (a text) location('gpfdist://localhost:7081/filename#transform=write') format 'text';
+CREATE EXTERNAL WEB TABLE gpfdist3_transform_start (x text)
+execute E'((@bindir@/gpfdist -p 7081 -d @abs_srcdir@/data/transform -c @abs_srcdir@/data/errexe.yml </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7081 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
 -- start_ignore
 -- end_ignore
 select count(*) from ext_transform;
@@ -742,10 +748,13 @@ select count(*) from ext_transform;
     14
 (1 row)
 
+insert into writable_transform values('hello');
+ERROR:  http response code 500 from gpfdist (gpfdist://localhost:7081/filename#transform=write): HTTP/1.0 500 /usr/bin/env: /home/gpadmin/workspace/6_greenplum/gpfdist/error.sh: No such file or directory  (seg1 127.0.0.1:6003 pid=4875)
 -- start_ignore
 -- end_ignore
 -- drop tables
 DROP EXTERNAL TABLE ext_transform;
+drop external table writable_transform;
 --
 -- get an error for missing gpfdist
 --


### PR DESCRIPTION

1. Modify function write_subprocess to report error.
2. Fix header_callback to update response content.
3. Save errfile for writable tranformations.

For writable external tables, gpfdist protocol uses X-GP-PROTO:0,
so it is hard to report error for segments. Yet we can use INTERNAL_ERROR
to report(function check_response). The file->http_response is updated
by header_callback, but the content can only be updated only once. So
we change the code to update the file->http_response if the header line
starts with "HTTP/".

Issue: https://github.com/greenplum-db/gpdb/issues/9497

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community