### PR TITLE
Fix improper use of waived vmem chunks when reserving vmem chunks

### DIFF
--- a/src/backend/utils/init/globals.c
+++ b/src/backend/utils/init/globals.c
@@ -184,4 +184,5 @@ bool	pljava_classpath_insecure = false;
 
 /* Memory protection GUCs*/
 int gp_vmem_protect_limit = 8192;
+int gp_vmem_waiver_limit = 5;
 int gp_vmem_protect_gang_cache_limit = 500;

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3707,6 +3707,16 @@ struct config_int ConfigureNamesInt_gp[] =
 	},
 
 	{
+		{"gp_vmem_waiver_limit", PGC_POSTMASTER, RESOURCES_MEM,
+			gettext_noop("Virtual memory limit (in MB) reserved for waiver."),
+			NULL,
+		},
+		&gp_vmem_waiver_limit,
+		5, 0, 10,
+		NULL, NULL, NULL
+	},
+
+	{
 		{"runaway_detector_activation_percent", PGC_POSTMASTER, RESOURCES_MEM,
 			gettext_noop("The runaway detector activates if the used vmem exceeds this percentage of the vmem quota. Set to 100 to disable runaway detection."),
 			NULL,

--- a/src/backend/utils/mmgr/memprot.c
+++ b/src/backend/utils/mmgr/memprot.c
@@ -315,7 +315,15 @@ static void gp_failed_to_alloc(MemoryAllocationStatus ec, int en, int sz)
 	}
 	else if (ec == MemoryFailure_VmemExhausted)
 	{
-		elog(LOG, "Logging memory usage for reaching Vmem limit");
+		/*
+		 * If no available waived chunks left, write_stderr should be used to
+		 * prevent the QE from stucking in "gp_malloc_internal -> gp_failed_to_alloc
+		 * -> gp_malloc_internal" infinite loop.
+		 */
+		if (VmemTracker_HasFreeWaivedVmemChunks())
+			elog(LOG, "Logging memory usage for reaching Vmem limit");
+		else
+			write_stderr("Logging memory usage for reaching Vmem limit\n");
 	}
 	else if (ec == MemoryFailure_SystemMemoryExhausted)
 	{
@@ -330,7 +338,15 @@ static void gp_failed_to_alloc(MemoryAllocationStatus ec, int en, int sz)
 	}
 	else if (ec == MemoryFailure_ResourceGroupMemoryExhausted)
 	{
-		elog(LOG, "Logging memory usage for reaching resource group limit");
+		/*
+		 * If no available waived chunks left, write_stderr should be used to
+		 * prevent the QE from stucking in "gp_malloc_internal -> gp_failed_to_alloc
+		 * -> gp_malloc_internal" infinite loop.
+		 */
+		if (VmemTracker_HasFreeWaivedVmemChunks())
+			elog(LOG, "Logging memory usage for reaching resource group limit");
+		else
+			write_stderr("Logging memory usage for reaching resource group limit\n");
 	}
 	else
 		elog(ERROR, "Unknown memory failure error code");

--- a/src/backend/utils/mmgr/redzone_handler.c
+++ b/src/backend/utils/mmgr/redzone_handler.c
@@ -28,6 +28,7 @@
 /* External dependencies within the runaway cleanup framework */
 extern bool vmemTrackerInited;
 extern volatile int32 *segmentVmemChunks;
+extern volatile int32 *freeWaivedVmemChunks;
 extern volatile EventVersion *CurrentVersion;
 extern volatile EventVersion *latestRunawayVersion;
 extern void RunawayCleaner_StartCleanup(void);

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -339,6 +339,7 @@ extern bool VacuumCostActive;
 extern double vacuum_cleanup_index_scale_factor;
 
 extern int gp_vmem_protect_limit;
+extern int gp_vmem_waiver_limit;
 extern int gp_vmem_protect_gang_cache_limit;
 
 /* in tcop/postgres.c */

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -176,7 +176,7 @@ extern Datum ResGroupGetStat(Oid groupId, ResGroupStatType type);
 extern void ResGroupDumpMemoryInfo(void);
 
 /* Check the memory limit of resource group */
-extern bool ResGroupReserveMemory(int32 memoryChunks, int32 overuseChunks, bool *waiverUsed);
+extern bool ResGroupReserveMemory(int32 memoryChunks, int32 overuseChunks, int32 *expectWaivedChunks, bool *waiverUsed);
 /* Update the memory usage of resource group */
 extern void ResGroupReleaseMemory(int32 memoryChunks);
 

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -268,6 +268,7 @@
 		"gp_vmem_limit_per_query",
 		"gp_vmem_protect_limit",
 		"gp_vmem_protect_segworker_cache_limit",
+		"gp_vmem_waiver_limit",
 		"gp_pause_on_restore_point_replay",
 		"gp_workfile_limit_per_segment",
 		"gp_workfile_max_entries",

--- a/src/include/utils/vmem_tracker.h
+++ b/src/include/utils/vmem_tracker.h
@@ -63,6 +63,7 @@ extern MemoryAllocationStatus VmemTracker_ReserveVmem(int64 newly_requested);
 extern void VmemTracker_ReleaseVmem(int64 to_be_freed_requested);
 extern MemoryAllocationStatus VmemTracker_RegisterStartupMemory(int64 bytes);
 extern void VmemTracker_UnregisterStartupMemory(void);
+extern bool VmemTracker_HasFreeWaivedVmemChunks(void);
 extern void VmemTracker_RequestWaiver(int64 waiver_bytes);
 extern void VmemTracker_ResetWaiver(void);
 
@@ -77,5 +78,9 @@ extern void RedZoneHandler_LogVmemUsageOfAllSessions(void);
 extern void IdleTracker_ActivateProcess(void);
 extern void IdleTracker_DeactivateProcess(void);
 extern bool VmemTrackerIsActivated(void);
+
+#ifdef FAULT_INJECTOR
+extern void VmemTracker_SetTrackedBytes(int32 newTrackedBytes);
+#endif
 
 #endif   /* VMEMTRACKER_H */

--- a/src/test/isolation2/expected/oom_elog_message.out
+++ b/src/test/isolation2/expected/oom_elog_message.out
@@ -1,0 +1,271 @@
+-- This case tests OOM when writting elog messages into server log files.
+-- - First, we manually set currently used memory 'segmentVmemChunks' to
+-- - 'gp_vmem_protect_limit + waivedChunks' in a QE session, then issue
+-- - another session which will also request some memory chunks. However,
+-- - since we used out all of the memory chunks, it will throw OOM error, when
+-- - writting error messages into server logs, it may also request some
+-- - extra memory chunks, but under previouse reserving memory logic,
+-- - OOM error will be raised again and again..., until abort or panic.
+
+-- start_matchsubs
+--
+-- m/DETAIL:  Per-query memory limit reached: current limit is \d+ kB, requested \d+ bytes, has \d+ MB available for this query/
+-- s/\d+/XXX/g
+--
+-- m/DETAIL:  Vmem limit reached, failed to allocate \d+ bytes from tracker, which has \d+ MB available/
+-- s/\d+/XXX/g
+--
+-- m/DETAIL:  System memory limit reached, failed to allocate \d+ bytes from system/
+-- s/\d+/XXX/g
+--
+-- m/(seg\d+ \d+.\d+.\d+.\d+:\d+)/
+-- s/(.*)/(seg<ID> IP:PORT)/
+--
+-- end_matchsubs
+
+-- Set the gp_log_format to text format, which will call palloc when writting
+-- error log message to server log files.
+-- start_ignore
+!\retcode gpconfig -c gp_log_format -v text;
+-- start_ignore
+20220506:17:31:59:063308 gpconfig:chenwen-gpdb-test011158187228:gpuser-[INFO]:-completed successfully with parameters '-c gp_log_format -v text'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -ari;
+-- start_ignore
+20220506:17:31:59:063707 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Starting gpstop with args: -ari
+20220506:17:31:59:063707 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Gathering information and validating the environment...
+20220506:17:31:59:063707 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20220506:17:31:59:063707 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Obtaining Segment details from coordinator...
+20220506:17:31:59:063707 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.15298.g21c8f4d0dd build dev'
+20220506:17:31:59:063707 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Commencing Coordinator instance shutdown with mode='immediate'
+20220506:17:31:59:063707 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Coordinator segment instance directory=/home/gpuser/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20220506:17:31:59:063707 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Attempting forceful termination of any leftover coordinator process
+20220506:17:31:59:063707 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Terminating processes for segment /home/gpuser/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20220506:17:31:59:063707 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Stopping coordinator standby host chenwen-gpdb-test011158187228.na62 mode=immediate
+20220506:17:32:00:063707 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Successfully shutdown standby process on chenwen-gpdb-test011158187228.na62
+20220506:17:32:00:063707 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
+20220506:17:32:00:063707 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20220506:17:32:00:063707 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-0.00% of jobs completed
+20220506:17:32:00:063707 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-100.00% of jobs completed
+20220506:17:32:00:063707 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20220506:17:32:00:063707 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-0.00% of jobs completed
+20220506:17:32:01:063707 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-100.00% of jobs completed
+20220506:17:32:01:063707 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-----------------------------------------------------
+20220506:17:32:01:063707 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-   Segments stopped successfully      = 6
+20220506:17:32:01:063707 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-   Segments with errors during stop   = 0
+20220506:17:32:01:063707 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-----------------------------------------------------
+20220506:17:32:01:063707 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20220506:17:32:01:063707 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Database successfully shutdown with no errors reported
+20220506:17:32:01:063707 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Restarting System...
+
+-- end_ignore
+(exited with code 0)
+-- end_ignore
+
+-- case 1: QE has sufficient waived chunks
+1: show gp_vmem_waiver_limit;
+ gp_vmem_waiver_limit 
+----------------------
+ 5                    
+(1 row)
+1: create table test_vmem_tbl(c1 int, c2 int, c3 int, c4 int, c5 int, c6 int, c7 int, c8 int, c9 int, c10 int);
+CREATE
+2: select gp_inject_fault_infinite('vmem_oom_set_startup_chunks', 'skip', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+2: select gp_inject_fault_infinite('vmem_oom_startup', 'suspend', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+2&: select gp_wait_until_triggered_fault('vmem_oom_startup', 1, dbid) from gp_segment_configuration where content =0 and role = 'p';  <waiting ...>
+-- The QE session will used out all of the segment's vmem chunks, including waivedChunks
+3&: set gp_vmem_idle_resource_timeout to '1h';  <waiting ...>
+2<:  <... completed>
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+-- Issue a query with very long sql plain text, so that it will call palloc to request memory chunk when
+-- writting the statement's text to the server log files
+2: select gp_inject_fault_infinite('vmem_oom_set_tracked_bytes', 'skip', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1: select temp_t3.c1, temp_t3.c2, temp_t3.c3, temp_t3.c4, temp_t3.c5, temp_t3.c6, temp_t3.c7, temp_t3.c8, temp_t3.c9, temp_t3.c10, temp_t3.c1+temp_t3.c2, temp_t3.c2+temp_t3.c3, temp_t3.c3+temp_t3.c4, temp_t3.c4+temp_t3.c5, temp_t3.c6+temp_t3.c7, temp_t3.c7+temp_t3.c8, temp_t3.c9+temp_t3.c10 from (select temp_t2.c1, temp_t2.c2, temp_t2.c3, temp_t2.c4, temp_t2.c5, temp_t2.c6, temp_t2.c7, temp_t2.c8, temp_t2.c9, temp_t2.c10, temp_t2.c1+temp_t2.c2, temp_t2.c2+temp_t2.c3, temp_t2.c3+temp_t2.c4, temp_t2.c4+temp_t2.c5, temp_t2.c6+temp_t2.c7, temp_t2.c7+temp_t2.c8, temp_t2.c9+temp_t2.c10 from (select temp_t1.c1, temp_t1.c2, temp_t1.c3, temp_t1.c4, temp_t1.c5, temp_t1.c6, temp_t1.c7, temp_t1.c8, temp_t1.c9, temp_t1.c10, temp_t1.c1+temp_t1.c2, temp_t1.c2+temp_t1.c3, temp_t1.c3+temp_t1.c4, temp_t1.c4+temp_t1.c5, temp_t1.c6+temp_t1.c7, temp_t1.c7+temp_t1.c8, temp_t1.c9+temp_t1.c10 from (select c1, c2, c3, c4, c5, c6, c7, c8, c9, c10 from test_vmem_tbl limit 1000000000) temp_t1 limit 1000000000) temp_t2 limit 100000) temp_t3 limit 10000;
+ERROR:  Out of memory  (seg0 slice1 11.158.187.228:7002 pid=64515)
+DETAIL:  Vmem limit reached, failed to allocate 16408 bytes from tracker, which has 0 MB available
+2: select gp_inject_fault_infinite('vmem_oom_set_startup_chunks', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+2: select gp_inject_fault_infinite('vmem_oom_set_tracked_bytes', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+2: select gp_inject_fault_infinite('vmem_oom_startup', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+3<:  <... completed>
+ERROR:  failed to acquire resources on one or more segments
+DETAIL:  FATAL:  Out of memory
+DETAIL:  Per-query memory limit reached: current limit is 20480 kB, requested 12582912 bytes, has 0 MB available for this query
+ (seg0 11.158.187.228:7002)
+1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>
+
+-- case 2: QE doesn't have sufficient waived chunks
+-- start_ignore
+!\retcode gpconfig -c gp_vmem_waiver_limit -v 0;
+-- start_ignore
+20220506:17:32:06:064551 gpconfig:chenwen-gpdb-test011158187228:gpuser-[INFO]:-completed successfully with parameters '-c gp_vmem_waiver_limit -v 0'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -ari;
+-- start_ignore
+20220506:17:32:07:064954 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Starting gpstop with args: -ari
+20220506:17:32:07:064954 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Gathering information and validating the environment...
+20220506:17:32:07:064954 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20220506:17:32:07:064954 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Obtaining Segment details from coordinator...
+20220506:17:32:07:064954 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.15298.g21c8f4d0dd build dev'
+20220506:17:32:07:064954 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Commencing Coordinator instance shutdown with mode='immediate'
+20220506:17:32:07:064954 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Coordinator segment instance directory=/home/gpuser/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20220506:17:32:07:064954 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Attempting forceful termination of any leftover coordinator process
+20220506:17:32:07:064954 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Terminating processes for segment /home/gpuser/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20220506:17:32:07:064954 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Stopping coordinator standby host chenwen-gpdb-test011158187228.na62 mode=immediate
+20220506:17:32:07:064954 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Successfully shutdown standby process on chenwen-gpdb-test011158187228.na62
+20220506:17:32:07:064954 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
+20220506:17:32:07:064954 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20220506:17:32:07:064954 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-0.00% of jobs completed
+20220506:17:32:08:064954 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-100.00% of jobs completed
+20220506:17:32:08:064954 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20220506:17:32:08:064954 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-0.00% of jobs completed
+20220506:17:32:08:064954 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-100.00% of jobs completed
+20220506:17:32:08:064954 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-----------------------------------------------------
+20220506:17:32:08:064954 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-   Segments stopped successfully      = 6
+20220506:17:32:08:064954 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-   Segments with errors during stop   = 0
+20220506:17:32:08:064954 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-----------------------------------------------------
+20220506:17:32:08:064954 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20220506:17:32:08:064954 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Database successfully shutdown with no errors reported
+20220506:17:32:08:064954 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Restarting System...
+
+-- end_ignore
+(exited with code 0)
+-- end_ignore
+1: show gp_vmem_waiver_limit;
+ gp_vmem_waiver_limit 
+----------------------
+ 0                    
+(1 row)
+1: set gp_vmem_idle_resource_timeout to '1h';
+SET
+2: select gp_inject_fault_infinite('vmem_oom_set_startup_chunks', 'skip', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+2: select gp_inject_fault_infinite('vmem_oom_startup', 'suspend', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+2&: select gp_wait_until_triggered_fault('vmem_oom_startup', 1, dbid) from gp_segment_configuration where content =0 and role = 'p';  <waiting ...>
+-- The QE session will used out all of the segment's vmem chunks, including waivedChunks
+3&: set gp_vmem_idle_resource_timeout to '1h';  <waiting ...>
+2<:  <... completed>
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+-- Issue a query with very long sql plain text, so that it will call palloc to request memory chunk when
+-- writting the statement's text to the server log files
+2: select gp_inject_fault_infinite('vmem_oom_set_tracked_bytes', 'skip', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1: select temp_t3.c1, temp_t3.c2, temp_t3.c3, temp_t3.c4, temp_t3.c5, temp_t3.c6, temp_t3.c7, temp_t3.c8, temp_t3.c9, temp_t3.c10, temp_t3.c1+temp_t3.c2, temp_t3.c2+temp_t3.c3, temp_t3.c3+temp_t3.c4, temp_t3.c4+temp_t3.c5, temp_t3.c6+temp_t3.c7, temp_t3.c7+temp_t3.c8, temp_t3.c9+temp_t3.c10 from (select temp_t2.c1, temp_t2.c2, temp_t2.c3, temp_t2.c4, temp_t2.c5, temp_t2.c6, temp_t2.c7, temp_t2.c8, temp_t2.c9, temp_t2.c10, temp_t2.c1+temp_t2.c2, temp_t2.c2+temp_t2.c3, temp_t2.c3+temp_t2.c4, temp_t2.c4+temp_t2.c5, temp_t2.c6+temp_t2.c7, temp_t2.c7+temp_t2.c8, temp_t2.c9+temp_t2.c10 from (select temp_t1.c1, temp_t1.c2, temp_t1.c3, temp_t1.c4, temp_t1.c5, temp_t1.c6, temp_t1.c7, temp_t1.c8, temp_t1.c9, temp_t1.c10, temp_t1.c1+temp_t1.c2, temp_t1.c2+temp_t1.c3, temp_t1.c3+temp_t1.c4, temp_t1.c4+temp_t1.c5, temp_t1.c6+temp_t1.c7, temp_t1.c7+temp_t1.c8, temp_t1.c9+temp_t1.c10 from (select c1, c2, c3, c4, c5, c6, c7, c8, c9, c10 from test_vmem_tbl limit 1000000000) temp_t1 limit 1000000000) temp_t2 limit 100000) temp_t3 limit 10000;
+ERROR:  Out of memory  (seg0 slice1 11.158.187.228:7002 pid=65736)
+DETAIL:  Vmem limit reached, failed to allocate 2136 bytes from tracker, which has 0 MB available
+2: select gp_inject_fault_infinite('vmem_oom_set_startup_chunks', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+2: select gp_inject_fault_infinite('vmem_oom_set_tracked_bytes', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+2: select gp_inject_fault_infinite('vmem_oom_startup', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+3<:  <... completed>
+ERROR:  failed to acquire resources on one or more segments
+DETAIL:  FATAL:  Out of memory
+DETAIL:  Per-query memory limit reached: current limit is 20480 kB, requested 12582912 bytes, has 0 MB available for this query
+ (seg0 11.158.187.228:7002)
+1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>
+
+1: drop table test_vmem_tbl;
+DROP
+-- start_ignore
+!\retcode gpconfig -c gp_log_format -v csv;
+-- start_ignore
+20220506:17:32:14:065794 gpconfig:chenwen-gpdb-test011158187228:gpuser-[INFO]:-completed successfully with parameters '-c gp_log_format -v csv'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpconfig -r gp_vmem_waiver_limit;
+-- start_ignore
+20220506:17:32:15:066205 gpconfig:chenwen-gpdb-test011158187228:gpuser-[INFO]:-completed successfully with parameters '-r gp_vmem_waiver_limit'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -ari;
+-- start_ignore
+20220506:17:32:15:066632 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Starting gpstop with args: -ari
+20220506:17:32:15:066632 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Gathering information and validating the environment...
+20220506:17:32:15:066632 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20220506:17:32:15:066632 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Obtaining Segment details from coordinator...
+20220506:17:32:15:066632 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.15298.g21c8f4d0dd build dev'
+20220506:17:32:15:066632 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Commencing Coordinator instance shutdown with mode='immediate'
+20220506:17:32:15:066632 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Coordinator segment instance directory=/home/gpuser/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20220506:17:32:15:066632 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Attempting forceful termination of any leftover coordinator process
+20220506:17:32:15:066632 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Terminating processes for segment /home/gpuser/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20220506:17:32:15:066632 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Stopping coordinator standby host chenwen-gpdb-test011158187228.na62 mode=immediate
+20220506:17:32:16:066632 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Successfully shutdown standby process on chenwen-gpdb-test011158187228.na62
+20220506:17:32:16:066632 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
+20220506:17:32:16:066632 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20220506:17:32:16:066632 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-0.00% of jobs completed
+20220506:17:32:16:066632 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-100.00% of jobs completed
+20220506:17:32:16:066632 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20220506:17:32:16:066632 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-0.00% of jobs completed
+20220506:17:32:17:066632 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-100.00% of jobs completed
+20220506:17:32:17:066632 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-----------------------------------------------------
+20220506:17:32:17:066632 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-   Segments stopped successfully      = 6
+20220506:17:32:17:066632 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-   Segments with errors during stop   = 0
+20220506:17:32:17:066632 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-----------------------------------------------------
+20220506:17:32:17:066632 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20220506:17:32:17:066632 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Database successfully shutdown with no errors reported
+20220506:17:32:17:066632 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Restarting System...
+
+-- end_ignore
+(exited with code 0)
+-- end_ignore
+

--- a/src/test/isolation2/expected/resgroup/resgroup_oom_elog.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_oom_elog.out
@@ -1,0 +1,130 @@
+-- This case tests resgroup OOM when writting elog messages into server log files.
+-- - First, we manually set currently free chunks of a group 'pResGroupControl->freeChunks'
+-- - to '0 - waivedChunks' in a QE session, then set the 'slot->memUsage' to 'slot->memQuota.
+-- - So when the QE session goes further, it may request chunks from freeChunks, since we
+-- - used out all of the free chunks of the group, it will throw OOM error, when writting
+-- - error messages into server logs, it may also request some extra memory chunks, but
+-- - under previouse reserving memory logic, OOM error will be raised again and again...,
+-- - until abort or panic.
+
+-- Set the gp_log_format to text format, which will call palloc when writting
+-- error log message to server log files.
+-- start_ignore
+!\retcode gpconfig -c gp_log_format -v text;
+-- start_ignore
+20220324:20:30:46:026409 gpconfig:chenwen-gpdb-test011158187228:gpuser-[INFO]:-completed successfully with parameters '-c gp_log_format -v text'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -ari;
+-- start_ignore
+20220324:20:30:46:026791 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Starting gpstop with args: -ari
+20220324:20:30:46:026791 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Gathering information and validating the environment...
+20220324:20:30:46:026791 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20220324:20:30:46:026791 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Obtaining Segment details from coordinator...
+20220324:20:30:46:026791 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.15182.gd4a2c6d3cf build dev'
+20220324:20:30:46:026791 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Commencing Coordinator instance shutdown with mode='immediate'
+20220324:20:30:46:026791 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Coordinator segment instance directory=/home/gpuser/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20220324:20:30:46:026791 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Attempting forceful termination of any leftover coordinator process
+20220324:20:30:46:026791 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Terminating processes for segment /home/gpuser/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20220324:20:30:46:026791 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Stopping coordinator standby host chenwen-gpdb-test011158187228.na62 mode=immediate
+20220324:20:30:47:026791 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Successfully shutdown standby process on chenwen-gpdb-test011158187228.na62
+20220324:20:30:47:026791 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
+20220324:20:30:47:026791 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20220324:20:30:47:026791 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-0.00% of jobs completed
+20220324:20:30:47:026791 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-100.00% of jobs completed
+20220324:20:30:47:026791 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20220324:20:30:47:026791 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-0.00% of jobs completed
+20220324:20:30:48:026791 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-100.00% of jobs completed
+20220324:20:30:48:026791 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-----------------------------------------------------
+20220324:20:30:48:026791 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-   Segments stopped successfully      = 6
+20220324:20:30:48:026791 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-   Segments with errors during stop   = 0
+20220324:20:30:48:026791 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-----------------------------------------------------
+20220324:20:30:48:026791 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20220324:20:30:48:026791 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Database successfully shutdown with no errors reported
+20220324:20:30:48:026791 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Restarting System...
+
+-- end_ignore
+(exited with code 0)
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_test_mem WITH (concurrency=2, cpu_rate_limit=10, memory_limit=10);
+CREATE
+CREATE ROLE role_test_mem RESOURCE GROUP rg_test_mem;
+CREATE
+
+1: SET ROLE TO role_test_mem;
+SET
+1: create table test_vmem_tbl(c1 int, c2 int, c3 int, c4 int, c5 int, c6 int, c7 int, c8 int, c9 int, c10 int);
+CREATE
+1: select gp_inject_fault_infinite('vmem_oom_set_tracked_bytes', 'skip', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1: select gp_inject_fault_infinite('resgroup_set_mem_chunks', 'skip', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1: select temp_t3.c1, temp_t3.c2, temp_t3.c3, temp_t3.c4, temp_t3.c5, temp_t3.c6, temp_t3.c7, temp_t3.c8, temp_t3.c9, temp_t3.c10, temp_t3.c1+temp_t3.c2, temp_t3.c2+temp_t3.c3, temp_t3.c3+temp_t3.c4, temp_t3.c4+temp_t3.c5, temp_t3.c6+temp_t3.c7, temp_t3.c7+temp_t3.c8, temp_t3.c9+temp_t3.c10 from (select temp_t2.c1, temp_t2.c2, temp_t2.c3, temp_t2.c4, temp_t2.c5, temp_t2.c6, temp_t2.c7, temp_t2.c8, temp_t2.c9, temp_t2.c10, temp_t2.c1+temp_t2.c2, temp_t2.c2+temp_t2.c3, temp_t2.c3+temp_t2.c4, temp_t2.c4+temp_t2.c5, temp_t2.c6+temp_t2.c7, temp_t2.c7+temp_t2.c8, temp_t2.c9+temp_t2.c10 from (select temp_t1.c1, temp_t1.c2, temp_t1.c3, temp_t1.c4, temp_t1.c5, temp_t1.c6, temp_t1.c7, temp_t1.c8, temp_t1.c9, temp_t1.c10, temp_t1.c1+temp_t1.c2, temp_t1.c2+temp_t1.c3, temp_t1.c3+temp_t1.c4, temp_t1.c4+temp_t1.c5, temp_t1.c6+temp_t1.c7, temp_t1.c7+temp_t1.c8, temp_t1.c9+temp_t1.c10 from (select c1, c2, c3, c4, c5, c6, c7, c8, c9, c10 from test_vmem_tbl limit 1000000000) temp_t1 limit 1000000000) temp_t2 limit 100000) temp_t3 limit 10000;
+ERROR:  Out of memory  (seg0 slice1 11.158.187.228:7002 pid=27679)
+DETAIL:  Resource group memory limit reached
+1: select gp_inject_fault_infinite('vmem_oom_set_tracked_bytes', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1: select gp_inject_fault_infinite('resgroup_set_mem_chunks', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1q: ... <quitting>
+
+-- start_ignore
+!\retcode gpconfig -c gp_log_format -v csv;
+-- start_ignore
+20220324:20:30:52:027698 gpconfig:chenwen-gpdb-test011158187228:gpuser-[INFO]:-completed successfully with parameters '-c gp_log_format -v csv'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -ari;
+-- start_ignore
+20220324:20:30:52:028082 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Starting gpstop with args: -ari
+20220324:20:30:52:028082 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Gathering information and validating the environment...
+20220324:20:30:52:028082 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20220324:20:30:52:028082 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Obtaining Segment details from coordinator...
+20220324:20:30:52:028082 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.15182.gd4a2c6d3cf build dev'
+20220324:20:30:52:028082 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Commencing Coordinator instance shutdown with mode='immediate'
+20220324:20:30:52:028082 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Coordinator segment instance directory=/home/gpuser/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20220324:20:30:52:028082 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Attempting forceful termination of any leftover coordinator process
+20220324:20:30:52:028082 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Terminating processes for segment /home/gpuser/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20220324:20:30:52:028082 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Stopping coordinator standby host chenwen-gpdb-test011158187228.na62 mode=immediate
+20220324:20:30:53:028082 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Successfully shutdown standby process on chenwen-gpdb-test011158187228.na62
+20220324:20:30:53:028082 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
+20220324:20:30:53:028082 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20220324:20:30:53:028082 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-0.00% of jobs completed
+20220324:20:30:53:028082 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-100.00% of jobs completed
+20220324:20:30:53:028082 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20220324:20:30:53:028082 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-0.00% of jobs completed
+20220324:20:30:54:028082 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-100.00% of jobs completed
+20220324:20:30:54:028082 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-----------------------------------------------------
+20220324:20:30:54:028082 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-   Segments stopped successfully      = 6
+20220324:20:30:54:028082 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-   Segments with errors during stop   = 0
+20220324:20:30:54:028082 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-----------------------------------------------------
+20220324:20:30:54:028082 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20220324:20:30:54:028082 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Database successfully shutdown with no errors reported
+20220324:20:30:54:028082 gpstop:chenwen-gpdb-test011158187228:gpuser-[INFO]:-Restarting System...
+
+-- end_ignore
+(exited with code 0)
+-- end_ignore
+
+1: drop table test_vmem_tbl;
+DROP
+1: drop role role_test_mem;
+DROP
+1: drop resource group rg_test_mem;
+DROP
+

--- a/src/test/isolation2/isolation2_resgroup_schedule
+++ b/src/test/isolation2/isolation2_resgroup_schedule
@@ -40,6 +40,9 @@ test: resgroup/resgroup_move_query
 #test: resgroup/resgroup_memory_sort_spill
 #test: resgroup/resgroup_memory_spilltodisk
 
+# test resource group elog oom
+test: resgroup/resgroup_oom_elog
+
 # regression tests
 test: resgroup/resgroup_recreate
 test: resgroup/resgroup_operator_memory

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -273,6 +273,7 @@ ignore: restore_memory_accounting_default
 # Startup OOM tests start
 test: setup_startup_memory_accounting
 test: oom_startup_memory
+test: oom_elog_message
 test: restore_memory_accounting_default
 test: runaway_query
 

--- a/src/test/isolation2/sql/oom_elog_message.sql
+++ b/src/test/isolation2/sql/oom_elog_message.sql
@@ -1,0 +1,119 @@
+-- This case tests OOM when writting elog messages into server log files.
+-- - First, we manually set currently used memory 'segmentVmemChunks' to
+-- - 'gp_vmem_protect_limit + waivedChunks' in a QE session, then issue
+-- - another session which will also request some memory chunks. However,
+-- - since we used out all of the memory chunks, it will throw OOM error, when
+-- - writting error messages into server logs, it may also request some
+-- - extra memory chunks, but under previouse reserving memory logic,
+-- - OOM error will be raised again and again..., until abort or panic.
+
+-- start_matchsubs
+--
+-- m/DETAIL:  Per-query memory limit reached: current limit is \d+ kB, requested \d+ bytes, has \d+ MB available for this query/
+-- s/\d+/XXX/g
+--
+-- m/DETAIL:  Vmem limit reached, failed to allocate \d+ bytes from tracker, which has \d+ MB available/
+-- s/\d+/XXX/g
+--
+-- m/DETAIL:  System memory limit reached, failed to allocate \d+ bytes from system/
+-- s/\d+/XXX/g
+--
+-- m/(seg\d+ \d+.\d+.\d+.\d+:\d+)/
+-- s/(.*)/(seg<ID> IP:PORT)/
+--
+-- end_matchsubs
+
+-- Set the gp_log_format to text format, which will call palloc when writting
+-- error log message to server log files.
+-- start_ignore
+!\retcode gpconfig -c gp_log_format -v text;
+!\retcode gpstop -ari;
+-- end_ignore
+
+-- case 1: QE has sufficient waived chunks
+1: show gp_vmem_waiver_limit;
+1: create table test_vmem_tbl(c1 int, c2 int, c3 int, c4 int, c5 int, c6 int, c7 int, c8 int, c9 int, c10 int);
+2: select gp_inject_fault_infinite('vmem_oom_set_startup_chunks', 'skip', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+2: select gp_inject_fault_infinite('vmem_oom_startup', 'suspend', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+2&: select gp_wait_until_triggered_fault('vmem_oom_startup', 1, dbid) from gp_segment_configuration where content =0 and role = 'p';
+-- The QE session will used out all of the segment's vmem chunks, including waivedChunks 
+3&: set gp_vmem_idle_resource_timeout to '1h'; 
+2<:
+-- Issue a query with very long sql plain text, so that it will call palloc to request memory chunk when
+-- writting the statement's text to the server log files
+2: select gp_inject_fault_infinite('vmem_oom_set_tracked_bytes', 'skip', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+1: select temp_t3.c1, temp_t3.c2, temp_t3.c3, temp_t3.c4, temp_t3.c5, temp_t3.c6, temp_t3.c7, temp_t3.c8, temp_t3.c9,
+   temp_t3.c10, temp_t3.c1+temp_t3.c2, temp_t3.c2+temp_t3.c3, temp_t3.c3+temp_t3.c4, temp_t3.c4+temp_t3.c5,
+   temp_t3.c6+temp_t3.c7, temp_t3.c7+temp_t3.c8, temp_t3.c9+temp_t3.c10
+   from
+   (select temp_t2.c1, temp_t2.c2, temp_t2.c3, temp_t2.c4, temp_t2.c5, temp_t2.c6, temp_t2.c7, temp_t2.c8, temp_t2.c9,
+    temp_t2.c10, temp_t2.c1+temp_t2.c2, temp_t2.c2+temp_t2.c3, temp_t2.c3+temp_t2.c4, temp_t2.c4+temp_t2.c5,
+    temp_t2.c6+temp_t2.c7, temp_t2.c7+temp_t2.c8, temp_t2.c9+temp_t2.c10
+    from
+    (select temp_t1.c1, temp_t1.c2, temp_t1.c3, temp_t1.c4, temp_t1.c5, temp_t1.c6, temp_t1.c7, temp_t1.c8, temp_t1.c9,
+     temp_t1.c10, temp_t1.c1+temp_t1.c2, temp_t1.c2+temp_t1.c3, temp_t1.c3+temp_t1.c4, temp_t1.c4+temp_t1.c5,
+     temp_t1.c6+temp_t1.c7, temp_t1.c7+temp_t1.c8, temp_t1.c9+temp_t1.c10
+     from
+     (select c1, c2, c3, c4, c5, c6, c7, c8, c9, c10
+      from
+      test_vmem_tbl limit 1000000000)
+     temp_t1 limit 1000000000)
+    temp_t2 limit 100000)
+   temp_t3 limit 10000;
+2: select gp_inject_fault_infinite('vmem_oom_set_startup_chunks', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+2: select gp_inject_fault_infinite('vmem_oom_set_tracked_bytes', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+2: select gp_inject_fault_infinite('vmem_oom_startup', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+3<:
+1q:
+2q:
+3q:
+
+-- case 2: QE doesn't have sufficient waived chunks
+-- start_ignore
+!\retcode gpconfig -c gp_vmem_waiver_limit -v 0;
+!\retcode gpstop -ari;
+-- end_ignore
+1: show gp_vmem_waiver_limit;
+1: set gp_vmem_idle_resource_timeout to '1h';
+2: select gp_inject_fault_infinite('vmem_oom_set_startup_chunks', 'skip', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+2: select gp_inject_fault_infinite('vmem_oom_startup', 'suspend', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+2&: select gp_wait_until_triggered_fault('vmem_oom_startup', 1, dbid) from gp_segment_configuration where content =0 and role = 'p';
+-- The QE session will used out all of the segment's vmem chunks, including waivedChunks 
+3&: set gp_vmem_idle_resource_timeout to '1h'; 
+2<:
+-- Issue a query with very long sql plain text, so that it will call palloc to request memory chunk when
+-- writting the statement's text to the server log files
+2: select gp_inject_fault_infinite('vmem_oom_set_tracked_bytes', 'skip', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+1: select temp_t3.c1, temp_t3.c2, temp_t3.c3, temp_t3.c4, temp_t3.c5, temp_t3.c6, temp_t3.c7, temp_t3.c8, temp_t3.c9,
+   temp_t3.c10, temp_t3.c1+temp_t3.c2, temp_t3.c2+temp_t3.c3, temp_t3.c3+temp_t3.c4, temp_t3.c4+temp_t3.c5,
+   temp_t3.c6+temp_t3.c7, temp_t3.c7+temp_t3.c8, temp_t3.c9+temp_t3.c10
+   from
+   (select temp_t2.c1, temp_t2.c2, temp_t2.c3, temp_t2.c4, temp_t2.c5, temp_t2.c6, temp_t2.c7, temp_t2.c8, temp_t2.c9,
+    temp_t2.c10, temp_t2.c1+temp_t2.c2, temp_t2.c2+temp_t2.c3, temp_t2.c3+temp_t2.c4, temp_t2.c4+temp_t2.c5,
+    temp_t2.c6+temp_t2.c7, temp_t2.c7+temp_t2.c8, temp_t2.c9+temp_t2.c10
+    from
+    (select temp_t1.c1, temp_t1.c2, temp_t1.c3, temp_t1.c4, temp_t1.c5, temp_t1.c6, temp_t1.c7, temp_t1.c8, temp_t1.c9,
+     temp_t1.c10, temp_t1.c1+temp_t1.c2, temp_t1.c2+temp_t1.c3, temp_t1.c3+temp_t1.c4, temp_t1.c4+temp_t1.c5,
+     temp_t1.c6+temp_t1.c7, temp_t1.c7+temp_t1.c8, temp_t1.c9+temp_t1.c10
+     from
+     (select c1, c2, c3, c4, c5, c6, c7, c8, c9, c10
+      from
+      test_vmem_tbl limit 1000000000)
+     temp_t1 limit 1000000000)
+    temp_t2 limit 100000)
+   temp_t3 limit 10000;
+2: select gp_inject_fault_infinite('vmem_oom_set_startup_chunks', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+2: select gp_inject_fault_infinite('vmem_oom_set_tracked_bytes', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+2: select gp_inject_fault_infinite('vmem_oom_startup', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+3<:
+1q:
+2q:
+3q:
+
+1: drop table test_vmem_tbl;
+-- start_ignore
+!\retcode gpconfig -c gp_log_format -v csv;
+!\retcode gpconfig -r gp_vmem_waiver_limit;
+!\retcode gpstop -ari;
+-- end_ignore
+

--- a/src/test/isolation2/sql/resgroup/resgroup_oom_elog.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_oom_elog.sql
@@ -1,0 +1,54 @@
+-- This case tests resgroup OOM when writting elog messages into server log files.
+-- - First, we manually set currently free chunks of a group 'pResGroupControl->freeChunks'
+-- - to '0 - waivedChunks' in a QE session, then set the 'slot->memUsage' to 'slot->memQuota.
+-- - So when the QE session goes further, it may request chunks from freeChunks, since we
+-- - used out all of the free chunks of the group, it will throw OOM error, when writting
+-- - error messages into server logs, it may also request some extra memory chunks, but
+-- - under previouse reserving memory logic, OOM error will be raised again and again...,
+-- - until abort or panic.
+
+-- Set the gp_log_format to text format, which will call palloc when writting
+-- error log message to server log files.
+-- start_ignore
+!\retcode gpconfig -c gp_log_format -v text;
+!\retcode gpstop -ari;
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_test_mem WITH (concurrency=2, cpu_rate_limit=10, memory_limit=10);
+CREATE ROLE role_test_mem RESOURCE GROUP rg_test_mem;
+
+1: SET ROLE TO role_test_mem;
+1: create table test_vmem_tbl(c1 int, c2 int, c3 int, c4 int, c5 int, c6 int, c7 int, c8 int, c9 int, c10 int);
+1: select gp_inject_fault_infinite('vmem_oom_set_tracked_bytes', 'skip', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+1: select gp_inject_fault_infinite('resgroup_set_mem_chunks', 'skip', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+1: select temp_t3.c1, temp_t3.c2, temp_t3.c3, temp_t3.c4, temp_t3.c5, temp_t3.c6, temp_t3.c7, temp_t3.c8, temp_t3.c9,
+   temp_t3.c10, temp_t3.c1+temp_t3.c2, temp_t3.c2+temp_t3.c3, temp_t3.c3+temp_t3.c4, temp_t3.c4+temp_t3.c5,
+   temp_t3.c6+temp_t3.c7, temp_t3.c7+temp_t3.c8, temp_t3.c9+temp_t3.c10
+   from
+   (select temp_t2.c1, temp_t2.c2, temp_t2.c3, temp_t2.c4, temp_t2.c5, temp_t2.c6, temp_t2.c7, temp_t2.c8, temp_t2.c9,
+    temp_t2.c10, temp_t2.c1+temp_t2.c2, temp_t2.c2+temp_t2.c3, temp_t2.c3+temp_t2.c4, temp_t2.c4+temp_t2.c5,
+    temp_t2.c6+temp_t2.c7, temp_t2.c7+temp_t2.c8, temp_t2.c9+temp_t2.c10
+    from
+    (select temp_t1.c1, temp_t1.c2, temp_t1.c3, temp_t1.c4, temp_t1.c5, temp_t1.c6, temp_t1.c7, temp_t1.c8, temp_t1.c9,
+     temp_t1.c10, temp_t1.c1+temp_t1.c2, temp_t1.c2+temp_t1.c3, temp_t1.c3+temp_t1.c4, temp_t1.c4+temp_t1.c5,
+     temp_t1.c6+temp_t1.c7, temp_t1.c7+temp_t1.c8, temp_t1.c9+temp_t1.c10
+     from
+     (select c1, c2, c3, c4, c5, c6, c7, c8, c9, c10
+      from
+      test_vmem_tbl limit 1000000000)
+     temp_t1 limit 1000000000)
+    temp_t2 limit 100000)
+   temp_t3 limit 10000;
+1: select gp_inject_fault_infinite('vmem_oom_set_tracked_bytes', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+1: select gp_inject_fault_infinite('resgroup_set_mem_chunks', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+1q:
+
+-- start_ignore
+!\retcode gpconfig -c gp_log_format -v csv;
+!\retcode gpstop -ari;
+-- end_ignore
+
+1: drop table test_vmem_tbl;
+1: drop role role_test_mem;
+1: drop resource group rg_test_mem;
+


### PR DESCRIPTION
When a QE process has used out the waived chunks, and didn't
release any chunks yet, at this very moment, another QE may
also need waived chunks to process error messages. However,
with previouse vmem reserving logic, the second QE will loop
in gp_malloc and gp_failed_to_alloc again and again, and finally
exit abnormally.

This fix reserves a global waived chunks on segments controled by
GUC gp_vmem_waiver_limit, each QE requests the required waived chunks
from it whenever they need. If global waived chunks are used out,
afterwards requests won't get any waived chunks. Henceforth, they
will use write_stderr to print error messages instead of elog in
case OOM again.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community

Co-authored-by: Yao Wang <wayao@vmware.com>