### PR TITLE
[6x] Fix flaky test checkpoint_dtx_info

### DIFF
--- a/src/test/isolation2/expected/checkpoint_dtx_info.out
+++ b/src/test/isolation2/expected/checkpoint_dtx_info.out
@@ -36,6 +36,12 @@ BEGIN
 1: create table twopcbug(i int, j int);
 CREATE
 1&: commit;  <waiting ...>
+-- wait to make sure the commit is taking place and blocked at start_insertedDistributedCommitted
+2: select gp_wait_until_triggered_fault('start_insertedDistributedCommitted', 1, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
 2: select gp_inject_fault_infinite('before_wait_VirtualXIDsDelayingChkpt', 'skip', 1);
  gp_inject_fault_infinite 
 --------------------------

--- a/src/test/isolation2/sql/checkpoint_dtx_info.sql
+++ b/src/test/isolation2/sql/checkpoint_dtx_info.sql
@@ -30,6 +30,8 @@
 1: begin;
 1: create table twopcbug(i int, j int);
 1&: commit;
+-- wait to make sure the commit is taking place and blocked at start_insertedDistributedCommitted
+2: select gp_wait_until_triggered_fault('start_insertedDistributedCommitted', 1, 1);
 2: select gp_inject_fault_infinite('before_wait_VirtualXIDsDelayingChkpt', 'skip', 1);
 33&: checkpoint;
 2: select gp_inject_fault_infinite('keep_log_seg', 'panic', 1);


### PR DESCRIPTION
Backporting 0d94a486e0cbe47a24fe23cf7a3d9ec3a424741f (PR #13441).
It is a straightforward merge, no conflict.

Original description
---------------
The test is flaky w/ this failure diff:

```
--- \/tmp\/build\/e18b2f02\/gpdb_src\/src\/test\/isolation2\/expected\/checkpoint_dtx_info\.out	2022-04-27 20:34:00.072018951 +0000
+++ \/tmp\/build\/e18b2f02\/gpdb_src\/src\/test\/isolation2\/results\/checkpoint_dtx_info\.out	2022-04-27 20:34:00.076018949 +0000
@@ -43,6 +43,7 @@
  Success:
 (1 row)
 33&: checkpoint;  <waiting ...>
+FAILED:  Forked command is not blocking; got output: CHECKPOINT
 2: select gp_inject_fault_infinite('keep_log_seg', 'panic', 1);
  gp_inject_fault_infinite
 --------------------------
@@ -74,9 +75,7 @@
 	This probably means the server terminated abnormally
 	before or while processing the request.
 33<:  <... completed>
-server closed the connection unexpectedly
-	This probably means the server terminated abnormally
-	before or while processing the request.
+FAILED:  Execution failed
 -- wait until coordinator is up for querying.
 3: select 1;
  ?column?
```

The reason is that sometimes the first commit command was not taking
place fast enough to block the following checkpoint command.
The fix is to wait until the `start_insertedDistributedCommitted` fault
is hit before doing checkpoint.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
