### PR TITLE
(6x backport) Fix master crash when there is an error during cdbdisp_destroyDispatherState

### DIFF
--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -920,12 +920,40 @@ RecycleGang(Gang *gp, bool forceDestroy)
 
 	if (!gp)
 		return;
-
+	/*
+	 *
+	 * Callers of RecycleGang should not throw ERRORs by design. This is
+	 * because RecycleGang is not re-entrant: For example, an ERROR could be
+	 * thrown whilst the gang's segdbDesc is already freed. This would cause
+	 * RecycleGang to be called again during abort processing, giving rise to
+	 * potential double freeing of the gang's segdbDesc.
+	 *
+	 * Thus, we hold off interrupts until the gang is fully cleaned here to prevent
+	 * throwing an ERROR here.
+	 *
+	 * details See github issue: https://github.com/greenplum-db/gpdb/issues/13393
+	 */
+	HOLD_INTERRUPTS();
 	/*
 	 * Loop through the segment_database_descriptors array and, for each
 	 * SegmentDatabaseDescriptor: 1) discard the query results (if any), 2)
 	 * disconnect the session, and 3) discard any connection error message.
 	 */
+#ifdef FAULT_INJECTOR
+	/*
+	 * select * from gp_segment_configuration a, t13393,
+	 * gp_segment_configuration b where a.dbid = t13393.tc1 limit 0;
+	 *
+	 * above sql has 3 gangs, the first and second gangtype is ENTRYDB_READER
+	 * and the third gang is PRIMARY_READER, the second gang will be destroyed.
+	 * inject an interrupt fault during RecycleGang PRIMARY_READER gang.
+	 */
+	if (gp->size >= 3)
+	{
+		SIMPLE_FAULT_INJECTOR("cdbcomponent_recycle_idle_qe_error");
+		CHECK_FOR_INTERRUPTS();
+	}
+#endif
 	for (i = 0; i < gp->size; i++)
 	{
 		SegmentDatabaseDescriptor *segdbDesc = gp->db_descriptors[i];
@@ -934,4 +962,5 @@ RecycleGang(Gang *gp, bool forceDestroy)
 
 		cdbcomponent_recycleIdleQE(segdbDesc, forceDestroy);
 	}
+	RESUME_INTERRUPTS();
 }

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -575,3 +575,17 @@ select fault_exec_plan(true);
 
 \c regression
 DROP DATABASE dispatch_test_db;
+
+-- issue: https://github.com/greenplum-db/gpdb/issues/13393
+-- We should avoid a double free and resultant PANIC if the
+-- process of recycling the gang is interrupted by a signal
+CREATE EXTENSION if not exists gp_inject_fault;
+create table t13393(tc1 int);
+insert into t13393 select generate_series(1,10000);
+analyze gp_segment_configuration;
+SELECT gp_inject_fault('cdbcomponent_recycle_idle_qe_error', 'interrupt', dbid, current_setting('gp_session_id')::int)
+ from gp_segment_configuration where content=-1 and role='p';
+select * from gp_segment_configuration a, t13393 ,gp_segment_configuration b where a.dbid = t13393.tc1 limit 0;
+SELECT gp_inject_fault('cdbcomponent_recycle_idle_qe_error', 'reset', dbid, current_setting('gp_session_id')::int)
+ from gp_segment_configuration where content=-1 and role='p';
+drop table t13393;

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -939,3 +939,32 @@ select fault_exec_plan(true);
 ERROR:  'executor_pre_tuple_processed' fault triggered
 \c regression
 DROP DATABASE dispatch_test_db;
+-- issue: https://github.com/greenplum-db/gpdb/issues/13393
+-- We should avoid a double free and resultant PANIC if the
+-- process of recycling the gang is interrupted by a signal
+CREATE EXTENSION if not exists gp_inject_fault;
+create table t13393(tc1 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'tc1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t13393 select generate_series(1,10000);
+analyze gp_segment_configuration;
+SELECT gp_inject_fault('cdbcomponent_recycle_idle_qe_error', 'interrupt', dbid, current_setting('gp_session_id')::int)
+ from gp_segment_configuration where content=-1 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+select * from gp_segment_configuration a, t13393 ,gp_segment_configuration b where a.dbid = t13393.tc1 limit 0;
+ dbid | content | role | preferred_role | mode | status | port | hostname | address | datadir | tc1 | dbid | content | role | preferred_role | mode | status | port | hostname | address | datadir 
+------+---------+------+----------------+------+--------+------+----------+---------+---------+-----+------+---------+------+----------------+------+--------+------+----------+---------+---------
+(0 rows)
+
+SELECT gp_inject_fault('cdbcomponent_recycle_idle_qe_error', 'reset', dbid, current_setting('gp_session_id')::int)
+ from gp_segment_configuration where content=-1 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+drop table t13393;


### PR DESCRIPTION
related GitHub issue: https://github.com/greenplum-db/gpdb/issues/13393
cdbdisp_destroyDispatcherState should not throw errors by design.
but it may be interrupted by a signal while RecycleGang, details please refer to the GitHub issue,
some gangs are destroyed in cdbdisp_destroyDispatcherState, before the end of
cdbdisp_destroyDispatcherState some error is thrown, we call AbortTransaction to rollback this
transaction, and enter cdbdisp_destroyDispatcherState the second time, some segdbDesc of
the destroyed gang will be freed twice, or we may use some freed struct somewhere else.
all the two above situations may be due to panic.

we use HOLD_INTERRUPTS in RecycleGang to prevent an interrupt, so cdbdisp_destroyDispatcherState
can execute without interruption.

cherry-picked from a3a7b0b8592a959370ffb69c667fe16f10e65dad