### PR TITLE
Restore DISTINCT-qualified window aggregates in ORCA

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -1534,13 +1534,6 @@ CTranslatorScalarToDXL::TranslateWindowFuncToDXL(
 				   GPOS_WSZ_LIT("Aggregate functions with FILTER"));
 	}
 
-	// FIXME: DISTINCT-qualified window aggregates are currently broken in ORCA.
-	if (window_func->windistinct)
-	{
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
-				   GPOS_WSZ_LIT("DISTINCT-qualified Window Aggregate"));
-	}
-
 	if (!m_context)
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
 				   GPOS_WSZ_LIT("Window function in a stand-alone expression"));

--- a/src/backend/gporca/libgpopt/src/operators/CWindowPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CWindowPreprocessor.cpp
@@ -98,14 +98,14 @@ CWindowPreprocessor::SplitPrjList(
 		{
 			if (fHasOrderSpecs)
 			{
-				(*pdrgpos)[ul]->AddRef();
-				pdrgposOther->Append((*pdrgpos)[ul]);
+				(*pdrgpos)[0]->AddRef();
+				pdrgposOther->Append((*pdrgpos)[0]);
 			}
 
 			if (fHasFrameSpecs)
 			{
-				(*pdrgpwf)[ul]->AddRef();
-				pdrgpwfOther->Append((*pdrgpwf)[ul]);
+				(*pdrgpwf)[0]->AddRef();
+				pdrgpwfOther->Append((*pdrgpwf)[0]);
 			}
 
 			pexprWinFunc->AddRef();

--- a/src/test/regress/expected/statement_mem_for_windowagg.out
+++ b/src/test/regress/expected/statement_mem_for_windowagg.out
@@ -81,9 +81,6 @@ SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
 
 SELECT COUNT(*)
   FROM (SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table) tt;
-NOTICE:  distinct winagg sortstats: sort operation (mk-sort) spilled to disk  (seg0 slice1 127.0.0.1:6002 pid=237567)
-NOTICE:  distinct winagg sortstats: sort operation (mk-sort) spilled to disk  (seg1 slice1 127.0.0.1:6003 pid=237568)
-NOTICE:  distinct winagg sortstats: sort operation (mk-sort) spilled to disk  (seg2 slice1 127.0.0.1:6004 pid=237569)
  count 
 -------
  60003
@@ -111,9 +108,6 @@ SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
 
 SELECT COUNT(*)
   FROM (SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table) tt;
-NOTICE:  distinct winagg sortstats: sort operation (pg-sort) spilled to disk  (seg0 slice1 127.0.0.1:6002 pid=237567)
-NOTICE:  distinct winagg sortstats: sort operation (pg-sort) spilled to disk  (seg1 slice1 127.0.0.1:6003 pid=237568)
-NOTICE:  distinct winagg sortstats: sort operation (pg-sort) spilled to disk  (seg2 slice1 127.0.0.1:6004 pid=237569)
  count 
 -------
  60003
@@ -144,9 +138,6 @@ SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
 
 SELECT COUNT(*)
   FROM (SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table) tt;
-NOTICE:  distinct winagg sortstats: sort operation (mk-sort) fitted in memory  (seg0 slice1 127.0.0.1:6002 pid=237567)
-NOTICE:  distinct winagg sortstats: sort operation (mk-sort) fitted in memory  (seg1 slice1 127.0.0.1:6003 pid=237568)
-NOTICE:  distinct winagg sortstats: sort operation (mk-sort) fitted in memory  (seg2 slice1 127.0.0.1:6004 pid=237569)
  count 
 -------
  60003
@@ -174,9 +165,6 @@ SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
 
 SELECT COUNT(*)
   FROM (SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table) tt;
-NOTICE:  distinct winagg sortstats: sort operation (pg-sort) fitted in memory  (seg2 slice1 127.0.0.1:6004 pid=237569)
-NOTICE:  distinct winagg sortstats: sort operation (pg-sort) fitted in memory  (seg0 slice1 127.0.0.1:6002 pid=237567)
-NOTICE:  distinct winagg sortstats: sort operation (pg-sort) fitted in memory  (seg1 slice1 127.0.0.1:6003 pid=237568)
  count 
 -------
  60003


### PR DESCRIPTION
Aggregates were disabled by 386d54232, but a lot of fixes were already
applied, so maybe it's time to exercise CI against DQWA.
May be related to #12641.