### PR TITLE
Reduce TCP port usage on the QD

### DIFF
--- a/src/interfaces/libpq/fe-connect.c
+++ b/src/interfaces/libpq/fe-connect.c
@@ -2581,6 +2581,7 @@ keep_going:						/* We will come back to here until there is
 #endif
 						int			usekeepalives = useKeepalives(conn);
 						int			err = 0;
+						int			reuse = 1;
 
 						if (usekeepalives < 0)
 						{
@@ -2615,6 +2616,19 @@ keep_going:						/* We will come back to here until there is
 #endif							/* WIN32 */
 						else if (!setTCPUserTimeout(conn))
 							err = 1;
+
+						/*
+						 * Set SO_REUSEADDR option to reuse the TCP port
+						 */
+						if (setsockopt(conn->sock,
+									   SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) == -1)
+						{
+							appendPQExpBuffer(&conn->errorMessage,
+											  libpq_gettext("setsockopt(%s) failed: %s\n"),
+											  "SO_REUSEADDR",
+											  SOCK_STRERROR(SOCK_ERRNO, sebuf, sizeof(sebuf)));
+							err = 1;
+						}
 
 						if (err)
 						{

--- a/src/interfaces/libpq/fe-connect.c
+++ b/src/interfaces/libpq/fe-connect.c
@@ -2618,7 +2618,10 @@ keep_going:						/* We will come back to here until there is
 							err = 1;
 
 						/*
-						 * Set SO_REUSEADDR option to reuse the TCP port
+						 * GPDB: For large clusters running large workloads, the
+						 * number of QEs can be very high. To reduce the chances
+						 * of running out of TCP ports for dispatch, we use
+						 * SO_REUSEADDR.
 						 */
 						if (setsockopt(conn->sock,
 									   SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) == -1)


### PR DESCRIPTION
QD will establish TCP connections to each QE, each connection has a unique
`<source address, source port, destination address, destination port>` quadruple.

To reduce the usage of TCP ports on QD, this commit sets the `SO_REUSEADDR`
option on sockets, to share the same port for connections that `AllocateGang()`
connects to QEs on different hosts.

This was introduced by https://github.com/greenplum-db/gpdb/pull/577, but
accidentally removed by https://github.com/greenplum-db/gpdb/pull/3608.

It's harmless for frontends too, so enable it for both.
