### PR TITLE
Check the return value of get_database_name() in external_set_env_vars_ext()

### DIFF
--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -2515,6 +2515,11 @@ external_set_env_vars_ext(extvar_t *extvar, char *uri, bool csv, char *escape, c
 		extvar->GP_USER = "";
 
 	extvar->GP_DATABASE = get_database_name(MyDatabaseId);
+	if (extvar->GP_DATABASE == NULL)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("cannot get database name, id: %d", MyDatabaseId)));
+
 	extvar->GP_SEG_PG_CONF = ConfigFileName;	/* location of the segments
 												 * pg_conf file  */
 	extvar->GP_SEG_DATADIR = data_directory;	/* location of the segments


### PR DESCRIPTION
In `external_set_env_vars_ext()`, it sets many env variables for external table, one of them is database name:
```c
// get pg_database tuple by SearchSysCache(DATABASEOID,...)
extvar->GP_DATABASE = get_database_name(MyDatabaseId);

extvar->GP_SEG_PG_CONF = ConfigFileName;
...
```
Though `MyDatabaseId` is always a valid value, but `get_database_name()` may return NULL in some rare cases.

Brief background:
In 5x stable (postgres version < 9.4), it uses SnapshotNow to scan catalog table, but: 
> "A concurrent SnapshotNow scan could see both old and new versions of an updated row as valid, or neither of them, if the commit happens between scanning the two versions."

Details pls see:
https://github.com/postgres/postgres/commit/568d4138c646cd7cd8a837ac244ef2caf27c6bb8
https://github.com/postgres/postgres/commit/813fb0315587d32e3b77af1051a0ef517d187763
and
http://rhaas.blogspot.com/2013/07/mvcc-catalog-access.html

In my PR, just do a simple check NULL to prevent PANIC.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
