### PR TITLE
Fix master crash when there is an error during cdbdisp_destroyDispatcherState

### DIFF
--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -536,3 +536,17 @@ select fault_exec_plan(false);
 select fault_exec_plan(true);
 \c regression
 DROP DATABASE dispatch_test_db;
+
+-- issue: https://github.com/greenplum-db/gpdb/issues/13393
+-- if there is an interrupt while we destroying dispacher state,
+-- we should ignore it, and cleanup normaly
+CREATE EXTENSION if not exists gp_inject_fault;
+create table t13393(tc1 int);
+insert into t13393 select generate_series(1,10000);
+analyze gp_segment_configuration;
+SELECT gp_inject_fault('cdbcomponent_recycle_idle_qe_error', 'skip', dbid, current_setting('gp_session_id')::int)
+ from gp_segment_configuration where content=-1 and role='p';
+select * from gp_segment_configuration a, t13393 ,gp_segment_configuration b where a.dbid = t13393.tc1 limit 0;
+SELECT gp_inject_fault('cdbcomponent_recycle_idle_qe_error', 'reset', dbid, current_setting('gp_session_id')::int)
+ from gp_segment_configuration where content=-1 and role='p';
+drop table t13393;

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -538,13 +538,13 @@ select fault_exec_plan(true);
 DROP DATABASE dispatch_test_db;
 
 -- issue: https://github.com/greenplum-db/gpdb/issues/13393
--- if there is an interrupt while we destroying dispacher state,
--- we should ignore it, and cleanup normaly
+-- We should avoid a double free and resultant PANIC if the
+-- process of recycling the gang is interrupted by a signal
 CREATE EXTENSION if not exists gp_inject_fault;
 create table t13393(tc1 int);
 insert into t13393 select generate_series(1,10000);
 analyze gp_segment_configuration;
-SELECT gp_inject_fault('cdbcomponent_recycle_idle_qe_error', 'skip', dbid, current_setting('gp_session_id')::int)
+SELECT gp_inject_fault('cdbcomponent_recycle_idle_qe_error', 'interrupt', dbid, current_setting('gp_session_id')::int)
  from gp_segment_configuration where content=-1 and role='p';
 select * from gp_segment_configuration a, t13393 ,gp_segment_configuration b where a.dbid = t13393.tc1 limit 0;
 SELECT gp_inject_fault('cdbcomponent_recycle_idle_qe_error', 'reset', dbid, current_setting('gp_session_id')::int)

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -874,3 +874,32 @@ select fault_exec_plan(true);
 ERROR:  'executor_pre_tuple_processed' fault triggered
 \c regression
 DROP DATABASE dispatch_test_db;
+-- issue: https://github.com/greenplum-db/gpdb/issues/13393
+-- if there is an interrupt while we destroying dispacher state,
+-- we should ignore it, and cleanup normaly
+CREATE EXTENSION if not exists gp_inject_fault;
+create table t13393(tc1 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'tc1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t13393 select generate_series(1,10000);
+analyze gp_segment_configuration;
+SELECT gp_inject_fault('cdbcomponent_recycle_idle_qe_error', 'skip', dbid, current_setting('gp_session_id')::int)
+ from gp_segment_configuration where content=-1 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+select * from gp_segment_configuration a, t13393 ,gp_segment_configuration b where a.dbid = t13393.tc1 limit 0;
+ dbid | content | role | preferred_role | mode | status | port | hostname | address | datadir | tc1 | dbid | content | role | preferred_role | mode | status | port | hostname | address | datadir 
+------+---------+------+----------------+------+--------+------+----------+---------+---------+-----+------+---------+------+----------------+------+--------+------+----------+---------+---------
+(0 rows)
+
+SELECT gp_inject_fault('cdbcomponent_recycle_idle_qe_error', 'reset', dbid, current_setting('gp_session_id')::int)
+ from gp_segment_configuration where content=-1 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+drop table t13393;

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -875,15 +875,15 @@ ERROR:  'executor_pre_tuple_processed' fault triggered
 \c regression
 DROP DATABASE dispatch_test_db;
 -- issue: https://github.com/greenplum-db/gpdb/issues/13393
--- if there is an interrupt while we destroying dispacher state,
--- we should ignore it, and cleanup normaly
+-- We should avoid a double free and resultant PANIC if the
+-- process of recycling the gang is interrupted by a signal
 CREATE EXTENSION if not exists gp_inject_fault;
 create table t13393(tc1 int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'tc1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into t13393 select generate_series(1,10000);
 analyze gp_segment_configuration;
-SELECT gp_inject_fault('cdbcomponent_recycle_idle_qe_error', 'skip', dbid, current_setting('gp_session_id')::int)
+SELECT gp_inject_fault('cdbcomponent_recycle_idle_qe_error', 'interrupt', dbid, current_setting('gp_session_id')::int)
  from gp_segment_configuration where content=-1 and role='p';
  gp_inject_fault 
 -----------------


### PR DESCRIPTION
related GitHub issue: https://github.com/greenplum-db/gpdb/issues/13393
cdbdisp_destroyDispatcherState should not throw errors by design.
but there may be some errors in RecycleGang, details please refer to the GitHub issue,
some gangs are destroyed in cdbdisp_destroyDispatcherState, before the end of
cdbdisp_destroyDispatcherState some error is thrown, we call AbortTransaction to rollback this
transaction, and enter cdbdisp_destroyDispatcherState the second time, some segdbDesc of
the destroyed gang will be freed twice, or we may use some freed struct somewhere else.
all the two above situations may be due to panic.

we use HOLD_INTERRUPTS in RecycleGang to prevent an interrupt, so cdbdisp_destroyDispatcherState
can execute without interruption.
