### PR TITLE
Fix gpfdist report "unknown meta type 108" error 5X.

### DIFF
--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -1568,7 +1568,7 @@ gp_proto1_read(char *buf, int bufsz, URL_CURL_FILE *file, CopyState pstate, char
 				char x = file->in.ptr[file->in.bot + n - 1];
 				file->in.ptr[file->in.bot + n - 1] = 0;
 				ereport(ERROR,
-						(errcode(ERRCODE_DATA_EXCEPTION),
+						(errcode(ERRCODE_CONNECTION_FAILURE),
 						 errmsg("gpfdist error - %s%c", &file->in.ptr[file->in.bot], x)));
 			}
 

--- a/src/bin/gpfdist/regress/input/gpfdist2.source
+++ b/src/bin/gpfdist/regress/input/gpfdist2.source
@@ -925,7 +925,7 @@ LOCATION
 FORMAT 'text'
 (
         DELIMITER AS ','
-)
+) LOG ERRORS SEGMENT REJECT LIMIT 2
 ;
 SELECT count(*) FROM ext_test;
 DROP EXTERNAL TABLE ext_test;

--- a/src/bin/gpfdist/regress/output/gpfdist2.source
+++ b/src/bin/gpfdist/regress/output/gpfdist2.source
@@ -957,7 +957,7 @@ LOCATION
 FORMAT 'text'
 (
         DELIMITER AS ','
-)
+) LOG ERRORS SEGMENT REJECT LIMIT 2
 ;
 SELECT count(*) FROM ext_test;
 ERROR:  gpfdist error - line too long in file @abs_srcdir@/data/gpfdist2/longline.txt near (0 bytes)  (seg1 slice1 172.17.0.4:25433 pid=36416)


### PR DESCRIPTION
Psql may report "unknown meta type 108" sometimes when error happens
at the gpfdist side. But from the perspective of error handling, this
error message should never be reported. If the message is reported,
it hints that a bug exists in the gpfdist external table subsystem.

After debugging the bug, I have found two essential conditions that
could trigger this error message to be reported.
1. Error happened at gpfdist side and an error was reported to the
segment with GP-PROTO:1 protocol.
2. "LOG ERRORS SEGMENT REJECT LIMIT" should be set in the readable
external table.

This bug may be introduced by this commit 522c7c09e5. Because
when sreh is enabled, when gpfdist reports an error by GP-PROTO:1
protocol, it is handled by single row error handling. And after it
is handled, `NextCopyFrom` tries to get next line, so `gp_proto1_read`
is called again, but at last call, the `file->in.bot` is the first
position of the error message, so at this loop, no new data is read
and the `type` will be set to the first char of the error message
reported by the gpfist. Yet if gpfdist reports an error, it is reading
or writing error which shall not be handled by sreh.

The solution is to change the error type from `ERRCODE_DATA_EXCEPTION` to
`ERRCODE_CONNECTION_FAILURE`, so that real error messages could be reported.

Related Issue: https://github.com/greenplum-db/gpdb/issues/9864
cherry picked from commit aea3db2d4d6016bc5f35b3618cd40b4c569edbfd

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
