### PR TITLE
Remove the gpdb_12_merge_fixmes in workfile_mgr_test.c

### DIFF
--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -2696,7 +2696,7 @@ ExecHashTableExplainBatchEnd(HashState *hashState, HashJoinTable hashtable)
 			if (hashtable->outerBatchFile &&
 					hashtable->outerBatchFile[curbatch] != NULL)
 			{
-				batchstats->ordbytes = BufFileSize(hashtable->outerBatchFile[curbatch]);
+				batchstats->ordbytes = BufFileGetSize(hashtable->outerBatchFile[curbatch]);
 			}
 
 			/* for curbatch=0, the tuple which is not belong to the batch 0 is put into the temp
@@ -2715,7 +2715,7 @@ ExecHashTableExplainBatchEnd(HashState *hashState, HashJoinTable hashtable)
 				if (hashtable->outerBatchFile &&
 						hashtable->outerBatchFile[i] != NULL)
 				{
-					filebytes = BufFileSize(hashtable->outerBatchFile[i]);
+					filebytes = BufFileGetSize(hashtable->outerBatchFile[i]);
 				}
 
 				Assert(filebytes >= bs->outerfilesize);
@@ -2727,7 +2727,7 @@ ExecHashTableExplainBatchEnd(HashState *hashState, HashJoinTable hashtable)
 				if (hashtable->innerBatchFile &&
 						hashtable->innerBatchFile[i])
 				{
-					filebytes = BufFileSize(hashtable->innerBatchFile[i]);
+					filebytes = BufFileGetSize(hashtable->innerBatchFile[i]);
 				}
 
 				Assert(filebytes >= bs->innerfilesize);

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -1872,7 +1872,7 @@ ExecHashJoinReloadHashTable(HashJoinState *hjstate)
 		{
 			Assert(hashtable->stats);
 			hashtable->stats->batchstats[curbatch].innerfilesize =
-				BufFileSize(hashtable->innerBatchFile[curbatch]);
+				BufFileGetSize(hashtable->innerBatchFile[curbatch]);
 		}
 
 		SIMPLE_FAULT_INJECTOR("workfile_hashjoin_failure");

--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -243,8 +243,11 @@ extendBufFile(BufFile *file)
 	 * queries from destroying the entire system. Counting each segment file is
 	 * reasonable for this scenario.
 	 */
-	FileSetIsWorkfile(pfile);
-	RegisterFileWithSet(pfile, file->work_set);
+	if (file->work_set)
+	{
+		FileSetIsWorkfile(pfile);
+		RegisterFileWithSet(pfile, file->work_set);
+	}
 }
 
 /*
@@ -286,9 +289,12 @@ BufFileCreateTempInSet(char *operation_name, bool interXact, workfile_set *work_
 	 * Register the file as a "work file", so that the Greenplum workfile
 	 * limits apply to it.
 	 */
-	file->work_set = work_set;
-	FileSetIsWorkfile(pfile);
-	RegisterFileWithSet(pfile, work_set);
+	if (work_set)
+	{
+		file->work_set = work_set;
+		FileSetIsWorkfile(pfile);
+		RegisterFileWithSet(pfile, work_set);
+	}
 
 	SIMPLE_FAULT_INJECTOR("workfile_creation_failure");
 
@@ -1024,7 +1030,7 @@ BufFileTellBlock(BufFile *file)
 #endif
 
 /*
- * Return the current shared BufFile size.
+ * Return the current fileset based BufFile size.
  *
  * Counts any holes left behind by BufFileAppend as part of the size.
  * ereport()s on failure.
@@ -1049,6 +1055,29 @@ BufFileSize(BufFile *file)
 
 	return ((file->numFiles - 1) * (int64) MAX_PHYSICAL_FILESIZE) +
 		lastFileSize;
+}
+
+/*
+ * Return the current shared BufFile size.
+ *
+ * When the BuffileFlush on Disk, BufFileGetSize() returns the same result
+ * as BufFileSize().
+ * But when the buffer is not full, BufFileSize() only returns the file size
+ * that flushed on Disk, not counting the size in buffer.
+ *
+ * Therefore, the BufFileGetSize() is used to return the whole size.
+ */
+int64
+BufFileGetSize(BufFile *file)
+{
+	int64 fileSizeWithoutBuffer;
+	fileSizeWithoutBuffer = BufFileSize(file);
+	/* When seek back then write some data, and the write doesn't add size. */
+	if (fileSizeWithoutBuffer > (file->curOffset + file->pos))
+	{
+		return fileSizeWithoutBuffer;
+	}
+	return file->curOffset + file->pos;
 }
 
 /*

--- a/src/include/storage/buffile.h
+++ b/src/include/storage/buffile.h
@@ -51,6 +51,7 @@ extern int	BufFileSeek(BufFile *file, int fileno, off_t offset, int whence);
 extern void BufFileTell(BufFile *file, int *fileno, off_t *offset);
 extern int	BufFileSeekBlock(BufFile *file, int64 blknum);
 extern int64 BufFileSize(BufFile *file);
+extern int64 BufFileGetSize(BufFile *file);
 extern long BufFileAppend(BufFile *target, BufFile *source);
 
 extern BufFile *BufFileCreateShared(SharedFileSet *fileset, const char *name, struct workfile_set *work_set);

--- a/src/test/isolation2/input/workfile_mgr_test.source
+++ b/src/test/isolation2/input/workfile_mgr_test.source
@@ -66,6 +66,11 @@ language plpgsql volatile execute on all segments;
 1: CREATE TABLESPACE work_file_test_ts LOCATION '@testtablespace@/workfile_mgr';
 
 1: select gp_workfile_mgr_test('atomic_test', 0);
+1: select gp_workfile_mgr_test('buffile_size_test', 0);
+1: select gp_workfile_mgr_test('buffile_large_file_test', 0);
+1: select gp_workfile_mgr_test('execworkfile_buffile_test', 0);
+1: select gp_workfile_mgr_test('execworkfile_create_one_MB_file', 0);
+1: select gp_workfile_mgr_test('logicaltape_test', 0);
 
 -- test will fail when the workset exceeds gp_workfile_max_entries, the workset will be released at the end of transaction.
 1: select gp_workfile_mgr_test('workfile_fill_sharedcache', 0);

--- a/src/test/isolation2/output/workfile_mgr_test.source
+++ b/src/test/isolation2/output/workfile_mgr_test.source
@@ -79,6 +79,46 @@ CREATE
  f                    
  f                    
 (4 rows)
+1: select gp_workfile_mgr_test('buffile_size_test', 0);
+ gp_workfile_mgr_test 
+----------------------
+ t                    
+ t                    
+ t                    
+ t                    
+(4 rows)
+1: select gp_workfile_mgr_test('buffile_large_file_test', 0);
+ gp_workfile_mgr_test 
+----------------------
+ t                    
+ t                    
+ t                    
+ t                    
+(4 rows)
+1: select gp_workfile_mgr_test('execworkfile_buffile_test', 0);
+ gp_workfile_mgr_test 
+----------------------
+ t                    
+ t                    
+ t                    
+ t                    
+(4 rows)
+1: select gp_workfile_mgr_test('execworkfile_create_one_MB_file', 0);
+ gp_workfile_mgr_test 
+----------------------
+ t                    
+ t                    
+ t                    
+ t                    
+(4 rows)
+1: select gp_workfile_mgr_test('logicaltape_test', 0);
+ gp_workfile_mgr_test 
+----------------------
+ t                    
+ t                    
+ t                    
+ t                    
+(4 rows)
 
 -- test will fail when the workset exceeds gp_workfile_max_entries, the workset will be released at the end of transaction.
 1: select gp_workfile_mgr_test('workfile_fill_sharedcache', 0);


### PR DESCRIPTION
This commit is to remove GPDB_12_MERGE_FIXMEs in `workfile_mgr_test.c`, which
are noted about the breakage of BufFile API changes.

BufFileSize() now has a different behavior compared to 6X, it was like:
```
BufFileGetSize(BufFile *buffile)
{
     returns buffile->maxoffset; // buffile->maxoffset = buffile->offset + buffile->pos;
}
```

After the merge, BufFileSize() only returns the size on disk, not including the
buffer.

Upstream is safe because it's used only once, and it's after BufFileOpenFileSet().
```
file = BufFileOpenFileSet(&lts->fileset->fs, filename, O_RDONLY, false);
filesize = BufFileSize(file);
```

But Greenplum uses it in `ExecHashTableExplainBatchEnd()` to collect inner and
outer batch size.

Therefore, add the function `BufFileGetSize()` back to get the real BufFile size.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change