### PR TITLE
6X: Preserve AO storage options during internal CTAS

### DIFF
--- a/src/test/regress/expected/expand_table_ao.out
+++ b/src/test/regress/expected/expand_table_ao.out
@@ -834,6 +834,38 @@ Select gp_segment_id, count(*) from part_t1 group by gp_segment_id;
 (3 rows)
 
 drop table part_t1;
+-- Test expanding an AO table without index, and current gp_default_storage_options is different
+-- from the table created.
+select gp_debug_set_create_table_default_numsegments(2);
+ gp_debug_set_create_table_default_numsegments 
+-----------------------------------------------
+ 2
+(1 row)
+
+set gp_default_storage_options = '';
+-- Create a AO table with default row-oriented storage
+create table t_9526 (a int, b text) WITH (appendoptimized=true) distributed by (a);
+-- Set default storage method to column-oriented, and change the default value of blocksize, compresstype, etc.
+SET gp_default_storage_options = 'blocksize=65536, compresstype=zstd, compresslevel=12, checksum=true, appendoptimized=true, orientation=column';
+-- Should successful and the table is still row-oriented
+alter table t_9526 expand table;
+select localoid::regclass::name, policytype, numsegments, distkey, distclass
+from gp_distribution_policy where localoid = 't_9526'::regclass::oid;
+ localoid | policytype | numsegments | distkey | distclass 
+----------+------------+-------------+---------+-----------
+ t_9526   | p          |           3 | 1       | 10027
+(1 row)
+
+-- storage paramter should be same with before
+select blocksize,compresslevel,checksum,compresstype,columnstore from pg_appendonly where relid='t_9526'::regclass::oid;
+ blocksize | compresslevel | checksum | compresstype | columnstore 
+-----------+---------------+----------+--------------+-------------
+     32768 |             0 | t        | none         | f
+(1 row)
+
+-- set back
+set gp_default_storage_options = '';
+drop table t_9526;
 -- Test expanding an AO table with index, and current gp_default_storage_options is different
 -- from the table created.
 select gp_debug_set_create_table_default_numsegments(2);

--- a/src/test/regress/sql/expand_table_ao.sql
+++ b/src/test/regress/sql/expand_table_ao.sql
@@ -337,6 +337,28 @@ Select gp_segment_id, count(*) from part_t1 group by gp_segment_id;
 
 drop table part_t1;
 
+-- Test expanding an AO table without index, and current gp_default_storage_options is different
+-- from the table created.
+select gp_debug_set_create_table_default_numsegments(2);
+set gp_default_storage_options = '';
+
+-- Create a AO table with default row-oriented storage
+create table t_9526 (a int, b text) WITH (appendoptimized=true) distributed by (a);
+
+-- Set default storage method to column-oriented, and change the default value of blocksize, compresstype, etc.
+SET gp_default_storage_options = 'blocksize=65536, compresstype=zstd, compresslevel=12, checksum=true, appendoptimized=true, orientation=column';
+
+-- Should successful and the table is still row-oriented
+alter table t_9526 expand table;
+
+select localoid::regclass::name, policytype, numsegments, distkey, distclass
+from gp_distribution_policy where localoid = 't_9526'::regclass::oid;
+-- storage paramter should be same with before
+select blocksize,compresslevel,checksum,compresstype,columnstore from pg_appendonly where relid='t_9526'::regclass::oid;
+
+-- set back
+set gp_default_storage_options = '';
+drop table t_9526;
 
 -- Test expanding an AO table with index, and current gp_default_storage_options is different
 -- from the table created.


### PR DESCRIPTION
This change is an extension of the PR #13248.
The commit 0fb3faf896 fixes the bug for
ALTER TABLE EXPAND TABLE and ALTER TABLE SET DISTRIBUTED BY
operations on AO tables with indexes.

These operations on AO tables with indexes are executed with CT + IIS
whereas on AO tables without indexes which are executed with CTAS

The bug about not preserving storage options is also present
for ALTER TABLE on AO tables without indexes case.
This change fixes that bug by adding the storage options preservation
logic to AT calls for AO tables which go through an internal CTAS.

Co-authored-by: Soumyadeep Chakraborty <soumyadeep2007@gmail.com>
(cherry picked from commit 10130c5d1d1d054e1fb4b258e638b02b073ab9c3, minor changes to the tests)
