### PR TITLE
 [6X] Add MASTER ONLY option for LOCK TABLE

### DIFF
--- a/src/backend/commands/lockcmds.c
+++ b/src/backend/commands/lockcmds.c
@@ -81,7 +81,7 @@ LockTableCommand(LockStmt *lockstmt)
 			LockTableRecurse(reloid, lockstmt->mode, lockstmt->nowait);
 	}
 
-	if (Gp_role == GP_ROLE_DISPATCH)
+	if (Gp_role == GP_ROLE_DISPATCH && !lockstmt->masteronly)
 	{
 		CdbDispatchUtilityStatement((Node *) lockstmt,
 									DF_CANCEL_ON_ERROR|

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -4699,6 +4699,7 @@ _copyLockStmt(const LockStmt *from)
 	COPY_NODE_FIELD(relations);
 	COPY_SCALAR_FIELD(mode);
 	COPY_SCALAR_FIELD(nowait);
+	COPY_SCALAR_FIELD(masteronly);
 
 	return newnode;
 }

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -2081,6 +2081,7 @@ _equalLockStmt(const LockStmt *a, const LockStmt *b)
 	COMPARE_NODE_FIELD(relations);
 	COMPARE_SCALAR_FIELD(mode);
 	COMPARE_SCALAR_FIELD(nowait);
+	COMPARE_SCALAR_FIELD(masteronly);
 
 	return true;
 }

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -3246,6 +3246,7 @@ typedef struct LockStmt
 	List	   *relations;		/* relations to lock */
 	int			mode;			/* lock mode */
 	bool		nowait;			/* no wait mode */
+	bool		masteronly;		/* GPDB: lock only on master */
 } LockStmt;
 
 /* ----------------------

--- a/src/test/regress/expected/gp_lock.out
+++ b/src/test/regress/expected/gp_lock.out
@@ -1,0 +1,35 @@
+CREATE TABLE gp_lock_test (a int);
+BEGIN;
+LOCK TABLE gp_lock_test IN ACCESS SHARE MODE;
+-- This resultset could be different in ORCA/planner, adding DISTINCT
+-- to make sure test passes in both
+SELECT DISTINCT l.gp_segment_id, c.relname, l.mode, l.granted
+FROM pg_locks l, pg_class c WHERE l.relation = c.oid and c.relname = 'gp_lock_test';
+ gp_segment_id |   relname    |      mode       | granted 
+---------------+--------------+-----------------+---------
+             0 | gp_lock_test | AccessShareLock | t
+             1 | gp_lock_test | AccessShareLock | t
+             2 | gp_lock_test | AccessShareLock | t
+            -1 | gp_lock_test | AccessShareLock | t
+(4 rows)
+
+ROLLBACK;
+BEGIN;
+LOCK TABLE gp_lock_test IN ACCESS SHARE MODE MASTER ONLY;
+SELECT l.gp_segment_id, c.relname, l.mode, l.granted
+FROM pg_locks l, pg_class c WHERE l.relation = c.oid and c.relname = 'gp_lock_test';
+ gp_segment_id |   relname    |      mode       | granted 
+---------------+--------------+-----------------+---------
+            -1 | gp_lock_test | AccessShareLock | t
+(1 row)
+
+ROLLBACK;
+-- other modes are not supported
+BEGIN;
+LOCK TABLE gp_lock_test IN EXCLUSIVE MODE MASTER ONLY;
+ERROR:  provided lock mode is not supported for MASTER ONLY
+LINE 1: LOCK TABLE gp_lock_test IN EXCLUSIVE MODE MASTER ONLY;
+                                ^
+HINT:  Only ACCESS SHARE mode is supported for MASTER ONLY.
+ROLLBACK;
+DROP TABLE gp_lock_test;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -39,7 +39,7 @@ test: instr_in_shmem_setup
 test: instr_in_shmem
 
 test: createdb
-test: gp_aggregates gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml update_gp returning_gp resource_queue_with_rule gp_types gp_index
+test: gp_aggregates gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml update_gp returning_gp resource_queue_with_rule gp_types gp_index gp_lock
 test: shared_scan
 test: spi_processed64bit
 test: python_processed64bit

--- a/src/test/regress/sql/gp_lock.sql
+++ b/src/test/regress/sql/gp_lock.sql
@@ -1,0 +1,24 @@
+CREATE TABLE gp_lock_test (a int);
+
+BEGIN;
+LOCK TABLE gp_lock_test IN ACCESS SHARE MODE;
+
+-- This resultset could be different in ORCA/planner, adding DISTINCT
+-- to make sure test passes in both
+SELECT DISTINCT l.gp_segment_id, c.relname, l.mode, l.granted
+FROM pg_locks l, pg_class c WHERE l.relation = c.oid and c.relname = 'gp_lock_test';
+ROLLBACK;
+
+BEGIN;
+LOCK TABLE gp_lock_test IN ACCESS SHARE MODE MASTER ONLY;
+
+SELECT l.gp_segment_id, c.relname, l.mode, l.granted
+FROM pg_locks l, pg_class c WHERE l.relation = c.oid and c.relname = 'gp_lock_test';
+ROLLBACK;
+
+-- other modes are not supported
+BEGIN;
+LOCK TABLE gp_lock_test IN EXCLUSIVE MODE MASTER ONLY;
+ROLLBACK;
+
+DROP TABLE gp_lock_test;


### PR DESCRIPTION
Backporting from #8703
`COORDINATOR ONLY` in 7x is the same thing. We'll just support and document `MASTER ONLY` in 6x for keyword coherency.

-----------
Currently, LOCK TABLE will always dispatch the lock statement to the
segments. However, the dispatch is unnecessary in many common cases
(e.g. when you just want to prevent DDL changes from ALTER TABLE or
DROP TABLE). Having the ability to not dispatch would give a small
performance boost in large Greenplum clusters when explicitly locking
a large amount of tables in a transaction.

To skip the dispatch, we introduce a new option to LOCK TABLE called
MASTER ONLY.  When added to the LOCK TABLE query, the lock will only
be taken on the master. And to limit the possible misuses, currently
we support MASTER ONLY only for AccessShareLock.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
