### PR TITLE
fix compiler warning for genfile.c

### DIFF
--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -373,7 +373,7 @@ ExecShareInputScan(PlanState *pstate)
 	 * ShareInputScan is one but not the last one of Sequence's subplans.
 	 */
 	if (sisc->discard_output)
-	  return NULL;
+		return NULL;
 
 	slot = node->ss.ps.ps_ResultTupleSlot;
 

--- a/src/bin/pg_upgrade/pg_upgrade.h
+++ b/src/bin/pg_upgrade/pg_upgrade.h
@@ -556,7 +556,7 @@ void		check_ok(void);
 unsigned int str2uint(const char *str);
 uint64		str2uint64(const char *str);
 void		pg_putenv(const char *var, const char *val);
-void 		gp_fatal_log(const char *fmt,...);
+void 		gp_fatal_log(const char *fmt,...) pg_attribute_printf(1, 2);
 
 
 /* version.c */

--- a/src/include/utils/builtins.h
+++ b/src/include/utils/builtins.h
@@ -142,4 +142,10 @@ extern Datum gp_instrument_shmem_summary(PG_FUNCTION_ARGS);
 /* utils/gp/segadmin.c */
 extern bool gp_activate_standby(void);
 
+/* utils/adt/genfile.c */
+extern Datum pg_file_write(PG_FUNCTION_ARGS);
+extern Datum pg_file_rename(PG_FUNCTION_ARGS);
+extern Datum pg_file_unlink(PG_FUNCTION_ARGS);
+extern Datum pg_logdir_ls(PG_FUNCTION_ARGS);
+
 #endif							/* BUILTINS_H */


### PR DESCRIPTION
Commit b554f888881949de1952537978e727f88f458e3d upgrade the adminpack functions to new version,
the old version function won’t be used. And postgres keep the old version functions in backend,
so add the declaration of these functions in builtins.h file to fix the compiler warning.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
