### PR TITLE
Resolve GPDB_12_MERGE_FIXME in pathnode.c

### DIFF
--- a/src/test/regress/expected/qp_functions_in_contexts_setup.out
+++ b/src/test/regress/expected/qp_functions_in_contexts_setup.out
@@ -292,3 +292,8 @@ UPDATE bar SET d = d+1 WHERE c = $1;
 RETURN $1 + 1;
 END
 $$ LANGUAGE plpgsql VOLATILE MODIFIES SQL DATA;
+CREATE FUNCTION func_nosql_record_imm(x int) RETURNS record as $$
+BEGIN
+    return (x, x + 1);
+END
+$$ LANGUAGE plpgsql NO SQL IMMUTABLE;

--- a/src/test/regress/expected/qp_functions_in_subquery.out
+++ b/src/test/regress/expected/qp_functions_in_subquery.out
@@ -3795,3 +3795,24 @@ ERROR:  UPDATE is not allowed in a non-volatile function
 CONTEXT:  SQL statement "UPDATE bar SET d = d+1 WHERE c = $1"
 PL/pgSQL function func2_mod_int_stb(integer) line 3 at SQL statement
 rollback;
+-- Test for the target list of RTE_RESULT relation contains unevaluated functions.
+-- Functions that return record cannot eval to const during planning time.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT func_nosql_record_imm(1) union all select func_nosql_record_imm(2);
+                QUERY PLAN
+------------------------------------------
+ Append
+   ->  Result
+         Output: func_nosql_record_imm(1)
+   ->  Result
+         Output: func_nosql_record_imm(2)
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(7 rows)
+
+SELECT func_nosql_record_imm(1) union all select func_nosql_record_imm(2);
+ func_nosql_record_imm 
+-----------------------
+ (1,2)
+ (2,3)
+(2 rows)
+

--- a/src/test/regress/sql/qp_functions_in_contexts_setup.sql
+++ b/src/test/regress/sql/qp_functions_in_contexts_setup.sql
@@ -332,3 +332,9 @@ UPDATE bar SET d = d+1 WHERE c = $1;
 RETURN $1 + 1;
 END
 $$ LANGUAGE plpgsql VOLATILE MODIFIES SQL DATA;
+
+CREATE FUNCTION func_nosql_record_imm(x int) RETURNS record as $$
+BEGIN
+    return (x, x + 1);
+END
+$$ LANGUAGE plpgsql NO SQL IMMUTABLE;

--- a/src/test/regress/sql/qp_functions_in_subquery.sql
+++ b/src/test/regress/sql/qp_functions_in_subquery.sql
@@ -662,3 +662,8 @@ rollback;
 begin;
 SELECT * FROM foo, (SELECT func1_mod_setint_stb(func2_mod_int_stb(5))) r order by 1,2,3;
 rollback;
+
+-- Test for the target list of RTE_RESULT relation contains unevaluated functions.
+-- Functions that return record cannot eval to const during planning time.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT func_nosql_record_imm(1) union all select func_nosql_record_imm(2);
+SELECT func_nosql_record_imm(1) union all select func_nosql_record_imm(2);


### PR DESCRIPTION
These are limitations for functions defined with the `EXECUTE ON MASTER` or
`EXECUTE ON ALL SEGMENTS` attribute in Greenplum doc, one of them is: The
function must be a set-returning function. We can't pull up a subquery
has set-returning functions in target list as `RTE_RESULT` relation. Therefore,
we don't need check execute location for functions in RTE_RESULT
relation's target list.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
