### PR TITLE
Fixed 'select distinct <tbl_name> from <tbl_name>' for inheritance/partition table in GP7 

### DIFF
--- a/src/test/regress/expected/select_distinct.out
+++ b/src/test/regress/expected/select_distinct.out
@@ -323,3 +323,74 @@ SELECT null IS NOT DISTINCT FROM null as "yes";
  t
 (1 row)
 
+-- gpdb start: test inherit/partition table distinct when gp_statistics_pullup_from_child_partition is on
+set gp_statistics_pullup_from_child_partition to on;
+CREATE TABLE sales (id int, date date, amt decimal(10,2))
+DISTRIBUTED BY (id);
+insert into sales values (1,'20210202',20), (2,'20210602',9) ,(3,'20211002',100);
+select distinct * from sales order by 1;
+ id |    date    |  amt   
+----+------------+--------
+  1 | 02-02-2021 |  20.00
+  2 | 06-02-2021 |   9.00
+  3 | 10-02-2021 | 100.00
+(3 rows)
+
+select distinct sales from sales order by 1;
+         sales         
+-----------------------
+ (1,02-02-2021,20.00)
+ (2,06-02-2021,9.00)
+ (3,10-02-2021,100.00)
+(3 rows)
+
+CREATE TABLE sales_partition (id int, date date, amt decimal(10,2))
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (date)
+( START (date '2021-01-01') INCLUSIVE
+  END (date '2022-01-01') EXCLUSIVE
+  EVERY (INTERVAL '1 month') );
+insert into sales_partition values (1,'20210202',20), (2,'20210602',9) ,(3,'20211002',100);
+select distinct * from sales_partition order by 1;
+ id |    date    |  amt   
+----+------------+--------
+  1 | 02-02-2021 |  20.00
+  2 | 06-02-2021 |   9.00
+  3 | 10-02-2021 | 100.00
+(3 rows)
+
+select distinct sales_partition from sales_partition order by 1;
+    sales_partition    
+-----------------------
+ (1,02-02-2021,20.00)
+ (2,06-02-2021,9.00)
+ (3,10-02-2021,100.00)
+(3 rows)
+
+DROP TABLE sales;
+DROP TABLE sales_partition;
+CREATE TABLE cities (
+    name            text,
+    population      float,
+    altitude        int
+); 
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'name' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE capitals (
+    state           char(2)
+) INHERITS (cities);
+NOTICE:  table has parent, setting distribution columns to match parent table
+select distinct * from cities;
+ name | population | altitude 
+------+------------+----------
+(0 rows)
+
+select distinct cities from cities;
+ cities 
+--------
+(0 rows)
+
+DROP TABLE capitals;
+DROP TABLE cities;
+set gp_statistics_pullup_from_child_partition to off;
+-- gpdb end: test inherit/partition table distinct when gp_statistics_pullup_from_child_partition is on

--- a/src/test/regress/expected/select_distinct_optimizer.out
+++ b/src/test/regress/expected/select_distinct_optimizer.out
@@ -330,3 +330,74 @@ SELECT null IS NOT DISTINCT FROM null as "yes";
  t
 (1 row)
 
+-- gpdb start: test inherit/partition table distinct when gp_statistics_pullup_from_child_partition is on
+set gp_statistics_pullup_from_child_partition to on;
+CREATE TABLE sales (id int, date date, amt decimal(10,2))
+DISTRIBUTED BY (id);
+insert into sales values (1,'20210202',20), (2,'20210602',9) ,(3,'20211002',100);
+select distinct * from sales order by 1;
+ id |    date    |  amt   
+----+------------+--------
+  1 | 02-02-2021 |  20.00
+  2 | 06-02-2021 |   9.00
+  3 | 10-02-2021 | 100.00
+(3 rows)
+
+select distinct sales from sales order by 1;
+         sales         
+-----------------------
+ (1,02-02-2021,20.00)
+ (2,06-02-2021,9.00)
+ (3,10-02-2021,100.00)
+(3 rows)
+
+CREATE TABLE sales_partition (id int, date date, amt decimal(10,2))
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (date)
+( START (date '2021-01-01') INCLUSIVE
+  END (date '2022-01-01') EXCLUSIVE
+  EVERY (INTERVAL '1 month') );
+insert into sales_partition values (1,'20210202',20), (2,'20210602',9) ,(3,'20211002',100);
+select distinct * from sales_partition order by 1;
+ id |    date    |  amt   
+----+------------+--------
+  1 | 02-02-2021 |  20.00
+  2 | 06-02-2021 |   9.00
+  3 | 10-02-2021 | 100.00
+(3 rows)
+
+select distinct sales_partition from sales_partition order by 1;
+    sales_partition    
+-----------------------
+ (1,02-02-2021,20.00)
+ (2,06-02-2021,9.00)
+ (3,10-02-2021,100.00)
+(3 rows)
+
+DROP TABLE sales;
+DROP TABLE sales_partition;
+CREATE TABLE cities (
+    name            text,
+    population      float,
+    altitude        int
+); 
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'name' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE capitals (
+    state           char(2)
+) INHERITS (cities);
+NOTICE:  table has parent, setting distribution columns to match parent table
+select distinct * from cities;
+ name | population | altitude 
+------+------------+----------
+(0 rows)
+
+select distinct cities from cities;
+ cities 
+--------
+(0 rows)
+
+DROP TABLE capitals;
+DROP TABLE cities;
+set gp_statistics_pullup_from_child_partition to off;
+-- gpdb end: test inherit/partition table distinct when gp_statistics_pullup_from_child_partition is on


### PR DESCRIPTION
related GitHub issue: #13467
fixed ERROR: cache lookup failed for attribute 0 of relation xxx (lsyscache.c:943). when SELECT DISTINCT <father_table> FROM <father_table>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Document changes
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
