### PR TITLE
[6X] Add distributed snapshot support to pg_export_snapshot

### DIFF
--- a/src/backend/cdb/cdbdistributedsnapshot.c
+++ b/src/backend/cdb/cdbdistributedsnapshot.c
@@ -21,6 +21,13 @@
 #include "cdb/cdbvars.h"
 #include "utils/guc.h"
 #include "utils/snapmgr.h"
+#include "storage/procarray.h"
+
+int
+GetMaxSnapshotDistributedXidCount()
+{
+	return GetMaxSnapshotXidCount();
+}
 
 /*
  * DistributedSnapshotWithLocalMapping_CommittedTest

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -133,19 +133,12 @@ static void sendWaitGxidsToQD(List *waitGxids);
 
 extern void CheckForResetSession(void);
 
-/**
- * All assignments of the global DistributedTransactionContext should go through this function
- *   (so we can add logging here to see all assignments)
- *
- * @param context the new value for DistributedTransactionContext
- */
-static void
+void
 setDistributedTransactionContext(DtxContext context)
 {
-	/*
-	 * elog(INFO, "Setting DistributedTransactionContext to '%s'",
-	 * DtxContextToString(context));
-	 */
+	elog((Debug_print_full_dtm ? LOG : DEBUG5),
+		  "Setting DistributedTransactionContext to '%s'",
+		  DtxContextToString(context));
 	DistributedTransactionContext = context;
 }
 

--- a/src/backend/storage/ipc/sinval.c
+++ b/src/backend/storage/ipc/sinval.c
@@ -360,12 +360,12 @@ ProcessCatchupEvent(void)
 		 * Save distributed transaction context first.
 		 */
 		saveDistributedTransactionContext = DistributedTransactionContext;
-		DistributedTransactionContext = DTX_CONTEXT_LOCAL_ONLY;
+		setDistributedTransactionContext(DTX_CONTEXT_LOCAL_ONLY);
 
 		StartTransactionCommand();
 		CommitTransactionCommand();
 
-		DistributedTransactionContext = saveDistributedTransactionContext;
+		setDistributedTransactionContext(saveDistributedTransactionContext);
 	}
 
 	if (notify_enabled)

--- a/src/include/cdb/cdbdistributedsnapshot.h
+++ b/src/include/cdb/cdbdistributedsnapshot.h
@@ -74,6 +74,8 @@ typedef enum
 	DISTRIBUTEDSNAPSHOT_COMMITTED_IGNORE
 } DistributedSnapshotCommitted;
 
+extern int GetMaxSnapshotDistributedXidCount(void);
+
 extern DistributedSnapshotCommitted DistributedSnapshotWithLocalMapping_CommittedTest(
 	DistributedSnapshotWithLocalMapping		*dslm,
 	TransactionId 							localXid,

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -285,6 +285,8 @@ extern DistributedTransactionTimeStamp getDistributedTransactionTimestamp(void);
 extern bool getDistributedTransactionIdentifier(char *id);
 
 extern void resetGxact(void);
+extern void setDistributedTransactionContext(DtxContext context);
+
 extern void	prepareDtxTransaction(void);
 extern bool isPreparedDtxTransaction(void);
 extern bool notifyCommittedDtxTransactionIsNeeded(void);

--- a/src/test/isolation2/expected/export_distributed_snapshot.out
+++ b/src/test/isolation2/expected/export_distributed_snapshot.out
@@ -1,0 +1,344 @@
+-- Export distributed snapshot tests
+
+-- start_matchsubs
+-- m/[0-9a-fA-F]+-\d/
+-- s/[0-9a-fA-F]+-\d/########-#/
+
+-- m/^DETAIL:  The source transaction \d+ is not running anymore./
+-- s/^DETAIL:  The source transaction \d+ is not running anymore./DETAIL:  The source transaction is not running anymore./
+-- end_matchsubs
+
+-- start_ignore
+DROP FUNCTION IF EXISTS corrupt_snapshot_file(text, text);
+DROP
+DROP FUNCTION IF EXISTS snapshot_file_ds_fields_exist(text);
+DROP
+DROP LANGUAGE IF EXISTS plpythonu cascade;
+DROP
+DROP TABLE IF EXISTS export_distributed_snapshot_test1;
+DROP
+-- end_ignore
+
+CREATE LANGUAGE plpythonu;
+CREATE
+
+-- Corrupt field entry for given snapshot file
+CREATE OR REPLACE FUNCTION  corrupt_snapshot_file(token text, field text) RETURNS integer as $$ import os content = bytearray() query = "SELECT (SELECT datadir FROM gp_segment_configuration WHERE role='p' and content=-1) || '/pg_snapshots/' as path" rv = plpy.execute(query) abs_path = rv[0]['path'] snapshot_file = abs_path + token if not os.path.isfile(snapshot_file): plpy.info('skipping non-existent file %s' % (snapshot_file)) else: plpy.info('corrupting file %s for field %s' % (snapshot_file, field)) with open(snapshot_file , "rb+") as f: for line in f: l = line.decode() id = l.split(":")[0] if field == id: corrupt = l[:-2] + '*' + l[len(l)-1:] content.extend(corrupt.encode()) else: content.extend(line) f.seek(0) f.truncate f.write(content) f.close() return 0 $$ LANGUAGE plpythonu;
+CREATE
+
+-- Determine if field exists for given snapshot file
+CREATE OR REPLACE FUNCTION  snapshot_file_ds_fields_exist(token text) RETURNS boolean as $$ import os content = bytearray() query = "SELECT (SELECT datadir FROM gp_segment_configuration WHERE role='p' and content=-1) || '/pg_snapshots/' as path" rv = plpy.execute(query) abs_path = rv[0]['path'] snapshot_file = abs_path + token if not os.path.isfile(snapshot_file): plpy.info('snapshot file %s does not exist' % (snapshot_file)) return -1 else: plpy.info('checking file %s for ds fields' % (snapshot_file)) with open(snapshot_file , "rb+") as f: for line in f: l = line.decode() if "ds" in l: return True return False $$ LANGUAGE plpythonu;
+CREATE
+
+-- INSERT test
+CREATE TABLE export_distributed_snapshot_test1 (a int);
+CREATE
+INSERT INTO export_distributed_snapshot_test1 values(1);
+INSERT 1
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+ pg_export_snapshot
+--------------------
+ 000003CB-1
+(1 row)
+
+INSERT INTO export_distributed_snapshot_test1 values(2);
+INSERT 1
+SELECT * FROM  export_distributed_snapshot_test1;
+ a 
+---
+ 2 
+ 1 
+(2 rows)
+
+-- Transaction 2 should return 2 rows
+2: SELECT * FROM  export_distributed_snapshot_test1;
+ a 
+---
+ 2 
+ 1 
+(2 rows)
+2: COMMIT;
+COMMIT
+
+2: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+SET
+-- Transaction 2 should now return 1 row
+2: SELECT * FROM  export_distributed_snapshot_test1;
+ a 
+---
+ 1 
+(1 row)
+2: COMMIT;
+COMMIT
+
+1: COMMIT;
+COMMIT
+
+-- DELETE test
+CREATE TABLE export_distributed_snapshot_test2 (a int);
+CREATE
+INSERT INTO export_distributed_snapshot_test2 SELECT a FROM generate_series(1,3) a;
+INSERT 3
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+ pg_export_snapshot
+--------------------
+ 0000ABF8-1
+(1 row)
+
+DELETE FROM export_distributed_snapshot_test2 WHERE a=1;
+DELETE 1
+
+-- Should return 3 rows
+1: SELECT * FROM export_distributed_snapshot_test2 ;
+ a 
+---
+ 1 
+ 2 
+ 3 
+(3 rows)
+
+-- Should return 2 rows
+2: SELECT * FROM  export_distributed_snapshot_test2;
+ a 
+---
+ 2 
+ 3 
+(2 rows)
+
+2: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+SET
+
+-- Should return 3 rows
+2: SELECT * FROM  export_distributed_snapshot_test2;
+ a 
+---
+ 2 
+ 3 
+ 1 
+(3 rows)
+2: COMMIT;
+COMMIT
+
+1: COMMIT;
+COMMIT
+
+-- UPDATE test
+CREATE TABLE export_distributed_snapshot_test3 (a int);
+CREATE
+INSERT INTO export_distributed_snapshot_test3 SELECT a FROM generate_series(1,5) a;
+INSERT 5
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+ pg_export_snapshot
+--------------------
+ 0000ABFB-1
+(1 row)
+
+UPDATE export_distributed_snapshot_test3 SET a=99 WHERE a=1;
+UPDATE 1
+
+-- Should return 0 rows
+1: SELECT * FROM export_distributed_snapshot_test3 WHERE a=99;
+ a 
+---
+(0 rows)
+
+-- Should return 1 row
+2: SELECT * FROM export_distributed_snapshot_test3 WHERE a=99;
+ a  
+----
+ 99 
+(1 row)
+
+2: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+SET
+
+-- Should return 0 rows
+2: SELECT * FROM export_distributed_snapshot_test3 WHERE a=99;
+ a 
+---
+(0 rows)
+2: COMMIT;
+COMMIT
+
+-- Should return 1 row
+2: SELECT * FROM export_distributed_snapshot_test3 WHERE a=99;
+ a  
+----
+ 99 
+(1 row)
+
+1: COMMIT;
+COMMIT
+
+-- Test corrupt fields in snapshot file
+
+-- xmin
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+ pg_export_snapshot
+--------------------
+ 000003CF-1
+(1 row)
+
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SELECT corrupt_snapshot_file('@TOKEN', 'xmin');
+ corrupt_snapshot_file 
+-----------------------
+ 0                     
+(1 row)
+
+2: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+ERROR:  could not import the requested snapshot
+DETAIL:  The source transaction 975 is not running anymore.
+
+1: END;
+END
+2: END;
+END
+
+-- dsxminall
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+ pg_export_snapshot
+--------------------
+ 000003D0-1
+(1 row)
+
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SELECT corrupt_snapshot_file('@TOKEN', 'dsxminall');
+ corrupt_snapshot_file 
+-----------------------
+ 0                     
+(1 row)
+
+2: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+SET
+
+1: END;
+END
+2: END;
+END
+
+-- dsxmin
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+ pg_export_snapshot
+--------------------
+ 000003D1-1
+(1 row)
+
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SELECT corrupt_snapshot_file('@TOKEN', 'dsxmin');
+ corrupt_snapshot_file 
+-----------------------
+ 0                     
+(1 row)
+
+2: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+ERROR:  invalid snapshot data in file "pg_snapshots/000003D1-1"
+
+1: END;
+END
+2: END;
+END
+
+-- Test export snapshot in utility mode does not export distributed snapshot fields
+
+-1U: BEGIN;
+BEGIN
+-1U: BEGIN;
+BEGIN
+-1U: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+ pg_export_snapshot
+--------------------
+ 000003D2-1
+(1 row)
+
+-- Should return false
+1: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SELECT snapshot_file_ds_fields_exist('@TOKEN');
+ snapshot_file_ds_fields_exist 
+-------------------------------
+ f                             
+(1 row)
+
+-1Uq: ... <quitting>
+1: END;
+END
+
+-- Test import snapshot in utility mode fails if distributed snapshot fields exist
+1: BEGIN;
+BEGIN
+1: BEGIN;
+BEGIN
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+ pg_export_snapshot
+--------------------
+ 000003D3-1
+(1 row)
+
+-- Open utility mode connection on coordinator and set snapshot
+-1U: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+-1U: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+ERROR:  cannot import distributed snapshot in utility mode
+HINT:  export the snapshot in utility mode
+
+-1Uq: ... <quitting>
+1: END;
+END
+
+-- Test export snapshot in utility mode and import snapshot in utility mode succeeds
+-1U: @db_name postgres: BEGIN;
+BEGIN
+-1U: BEGIN;
+BEGIN
+-1U: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+ pg_export_snapshot
+--------------------
+ 000003D4-1
+(1 row)
+
+-- Should return false
+1: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SELECT snapshot_file_ds_fields_exist('@TOKEN');
+ snapshot_file_ds_fields_exist 
+-------------------------------
+ f                             
+(1 row)
+
+-- Open another utility mode connection and set the snapshot
+! TOKEN=$(find ${MASTER_DATA_DIRECTORY}/pg_snapshots/ -name "0*" -exec basename {} \;) \ && echo ${TOKEN} \ && PGOPTIONS='-c gp_session_role=utility' psql postgres -Atc "BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ; SET TRANSACTION SNAPSHOT '${TOKEN}';";
+########-#
+SET
+
+-1Uq: ... <quitting>

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -299,3 +299,6 @@ test: concurrent_vacuum_with_delete
 
 # test if GUC is synchronized from the QD to QEs.
 test: sync_guc
+
+# test pg_export_snapshot with distributed snapshot functionality
+test: export_distributed_snapshot

--- a/src/test/isolation2/sql/export_distributed_snapshot.sql
+++ b/src/test/isolation2/sql/export_distributed_snapshot.sql
@@ -1,0 +1,225 @@
+-- Export distributed snapshot tests
+
+-- start_matchsubs
+-- m/[0-9a-fA-F]+-\d/
+-- s/[0-9a-fA-F]+-\d/########-#/
+
+-- m/^DETAIL:  The source transaction \d+ is not running anymore./
+-- s/^DETAIL:  The source transaction \d+ is not running anymore./DETAIL:  The source transaction is not running anymore./
+-- end_matchsubs
+
+-- start_ignore
+DROP FUNCTION IF EXISTS corrupt_snapshot_file(text, text);
+DROP FUNCTION IF EXISTS snapshot_file_ds_fields_exist(text);
+DROP LANGUAGE IF EXISTS plpythonu cascade;
+DROP TABLE IF EXISTS export_distributed_snapshot_test1;
+-- end_ignore
+
+CREATE LANGUAGE plpythonu;
+
+-- Corrupt field entry for given snapshot file
+CREATE OR REPLACE FUNCTION  corrupt_snapshot_file(token text, field text) RETURNS integer as
+$$
+  import os
+  content = bytearray()
+  query = "SELECT (SELECT datadir FROM gp_segment_configuration WHERE role='p' and content=-1) || '/pg_snapshots/' as path"
+  rv = plpy.execute(query)
+  abs_path = rv[0]['path']
+  snapshot_file = abs_path + token
+  if not os.path.isfile(snapshot_file):
+    plpy.info('skipping non-existent file %s' % (snapshot_file))
+  else:
+    plpy.info('corrupting file %s for field %s' % (snapshot_file, field))
+    with open(snapshot_file , "rb+") as f:
+      for line in f:
+        l = line.decode()
+        id = l.split(":")[0]
+        if field == id:
+          corrupt = l[:-2] + '*' + l[len(l)-1:]
+          content.extend(corrupt.encode())
+        else:
+          content.extend(line)
+      f.seek(0)
+      f.truncate
+      f.write(content)
+      f.close()
+  return 0
+$$ LANGUAGE plpythonu;
+
+-- Determine if field exists for given snapshot file
+CREATE OR REPLACE FUNCTION  snapshot_file_ds_fields_exist(token text) RETURNS boolean as
+$$
+  import os
+  content = bytearray()
+  query = "SELECT (SELECT datadir FROM gp_segment_configuration WHERE role='p' and content=-1) || '/pg_snapshots/' as path"
+  rv = plpy.execute(query)
+  abs_path = rv[0]['path']
+  snapshot_file = abs_path + token
+  if not os.path.isfile(snapshot_file):
+    plpy.info('snapshot file %s does not exist' % (snapshot_file))
+    return -1
+  else:
+    plpy.info('checking file %s for ds fields' % (snapshot_file))
+    with open(snapshot_file , "rb+") as f:
+      for line in f:
+        l = line.decode()
+        if "ds" in l:
+          return True
+  return False
+$$ LANGUAGE plpythonu;
+
+-- INSERT test
+CREATE TABLE export_distributed_snapshot_test1 (a int);
+INSERT INTO export_distributed_snapshot_test1 values(1);
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+
+INSERT INTO export_distributed_snapshot_test1 values(2);
+SELECT * FROM  export_distributed_snapshot_test1;
+
+-- Transaction 2 should return 2 rows
+2: SELECT * FROM  export_distributed_snapshot_test1;
+2: COMMIT;
+
+2: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+-- Transaction 2 should now return 1 row
+2: SELECT * FROM  export_distributed_snapshot_test1;
+2: COMMIT;
+
+1: COMMIT;
+
+-- DELETE test
+CREATE TABLE export_distributed_snapshot_test2 (a int);
+INSERT INTO export_distributed_snapshot_test2 SELECT a FROM generate_series(1,3) a;
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+
+DELETE FROM export_distributed_snapshot_test2 WHERE a=1;
+
+-- Should return 3 rows
+1: SELECT * FROM export_distributed_snapshot_test2 ;
+
+-- Should return 2 rows
+2: SELECT * FROM  export_distributed_snapshot_test2;
+
+2: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+
+-- Should return 3 rows
+2: SELECT * FROM  export_distributed_snapshot_test2;
+2: COMMIT;
+
+1: COMMIT;
+
+-- UPDATE test
+CREATE TABLE export_distributed_snapshot_test3 (a int);
+INSERT INTO export_distributed_snapshot_test3 SELECT a FROM generate_series(1,5) a;
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+
+UPDATE export_distributed_snapshot_test3 SET a=99 WHERE a=1;
+
+-- Should return 0 rows
+1: SELECT * FROM export_distributed_snapshot_test3 WHERE a=99;
+
+-- Should return 1 row
+2: SELECT * FROM export_distributed_snapshot_test3 WHERE a=99;
+
+2: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+
+-- Should return 0 rows
+2: SELECT * FROM export_distributed_snapshot_test3 WHERE a=99;
+2: COMMIT;
+
+-- Should return 1 row
+2: SELECT * FROM export_distributed_snapshot_test3 WHERE a=99;
+
+1: COMMIT;
+
+-- Test corrupt fields in snapshot file
+
+-- xmin
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SELECT corrupt_snapshot_file('@TOKEN', 'xmin');
+
+2: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+
+1: END;
+2: END;
+
+-- dsxminall
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SELECT corrupt_snapshot_file('@TOKEN', 'dsxminall');
+
+2: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+
+1: END;
+2: END;
+
+-- dsxmin
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SELECT corrupt_snapshot_file('@TOKEN', 'dsxmin');
+
+2: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+
+1: END;
+2: END;
+
+-- Test export snapshot in utility mode does not export distributed snapshot fields
+
+-1U: BEGIN;
+-1U: BEGIN;
+-1U: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+
+-- Should return false
+1: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SELECT snapshot_file_ds_fields_exist('@TOKEN');
+
+-1Uq:
+1: END;
+
+-- Test import snapshot in utility mode fails if distributed snapshot fields exist
+1: BEGIN;
+1: BEGIN;
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+
+-- Open utility mode connection on coordinator and set snapshot
+-1U: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+-1U: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+
+-1Uq:
+1: END;
+
+-- Test export snapshot in utility mode and import snapshot in utility mode succeeds
+-1U: @db_name postgres: BEGIN;
+-1U: BEGIN;
+-1U: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+
+-- Should return false
+1: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SELECT snapshot_file_ds_fields_exist('@TOKEN');
+
+-- Open another utility mode connection and set the snapshot
+! TOKEN=$(find ${MASTER_DATA_DIRECTORY}/pg_snapshots/ -name "0*" -exec basename {} \;) \
+&& echo ${TOKEN} \
+&& PGOPTIONS='-c gp_session_role=utility' psql postgres -Atc "BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ; SET TRANSACTION SNAPSHOT '${TOKEN}';";
+-1Uq:


### PR DESCRIPTION
Backport from https://github.com/greenplum-db/gpdb/pull/13201

Add distributed snapshot support to pg_export_snapshot
    
pg_export_snapshot now exports distributed snapshot metadata, enabling cluster-wide data visibility consistency via `SET TRANSACTION SNAPSHOT`
    
Calling `select pg_export_snapshot()` from the QD will write the
following fields to the snapshot file in `pg_snapshots` in the
coordinator data directory.
    
```
dsxminall
dsid
dsxmin
dsxmax
dscnt
dsxip
 ```
    
When a snapshot is imported via SET TRANSACTION SNAPSHOT from the QD, subsequent
queries will have the distributed snapshot metadata dispatched to the QEs.
  
Reference: https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/C6cY8yIbcps