### PR TITLE
Enable direct dispatch for DML statements with ORCA

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -256,7 +256,8 @@ CTranslatorDXLToPlStmt::GetPlannedStmtFromDXL(const CDXLNode *dxlnode,
 		}
 	}
 
-	if (CMD_INSERT == m_cmd_type && planned_stmt->numSlices == 1 &&
+	if ((CMD_INSERT == m_cmd_type || CMD_DELETE == m_cmd_type) &&
+		planned_stmt->numSlices == 1 &&
 		dxlnode->GetOperator()->GetDXLOperator() == EdxlopPhysicalDML)
 	{
 		CDXLPhysicalDML *phy_dml_dxlop =

--- a/src/backend/gporca/data/dxl/minidump/DeleteWithTriggers.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeleteWithTriggers.mdp
@@ -237,7 +237,11 @@
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.050887" Rows="1.000000" Width="12"/>
             </dxl:Properties>
-            <dxl:DirectDispatchInfo/>
+            <dxl:DirectDispatchInfo>
+              <dxl:KeyValue>
+                <dxl:Datum TypeMdid="0.23.1.0" Value="6"/>
+              </dxl:KeyValue>
+            </dxl:DirectDispatchInfo>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="t1">
                 <dxl:Ident ColId="0" ColName="t1" TypeMdid="0.23.1.0"/>

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -5208,13 +5208,13 @@ CTranslatorExprToDXL::GetDXLDirectDispatchInfo(CExpression *pexprDML)
 	CTableDescriptor *ptabdesc = popDML->Ptabdesc();
 	const CColumnDescriptorArray *pdrgpcoldescDist =
 		ptabdesc->PdrgpcoldescDist();
-
-	if (CLogicalDML::EdmlInsert != popDML->Edmlop() ||
+	if ((CLogicalDML::EdmlUpdate == popDML->Edmlop()) ||
 		IMDRelation::EreldistrHash != ptabdesc->GetRelDistribution() ||
 		1 < pdrgpcoldescDist->Size())
 	{
-		// directed dispatch only supported for insert statements on hash-distributed tables
-		// with a single distribution column
+		// directed dispatch only supported for insert and delete statements
+		// on hash-distributed tables with a single distribution column
+
 		return nullptr;
 	}
 

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -5208,7 +5208,8 @@ CTranslatorExprToDXL::GetDXLDirectDispatchInfo(CExpression *pexprDML)
 	CTableDescriptor *ptabdesc = popDML->Ptabdesc();
 	const CColumnDescriptorArray *pdrgpcoldescDist =
 		ptabdesc->PdrgpcoldescDist();
-	if ((CLogicalDML::EdmlUpdate == popDML->Edmlop()) ||
+	if ((CLogicalDML::EdmlInsert != popDML->Edmlop() &&
+		 CLogicalDML::EdmlDelete != popDML->Edmlop()) ||
 		IMDRelation::EreldistrHash != ptabdesc->GetRelDistribution() ||
 		1 < pdrgpcoldescDist->Size())
 	{

--- a/src/test/isolation2/output/uao/parallel_delete_optimizer.source
+++ b/src/test/isolation2/output/uao/parallel_delete_optimizer.source
@@ -21,9 +21,9 @@ DELETE 1
  ao       | ExclusiveLock | relation | master 
 (1 row)
 2: SELECT * FROM locktest_segments WHERE coalesce = 'ao';
- coalesce | mode          | locktype | node       
-----------+---------------+----------+------------
- ao       | ExclusiveLock | relation | n segments 
+ coalesce | mode          | locktype | node      
+----------+---------------+----------+-----------
+ ao       | ExclusiveLock | relation | 1 segment 
 (1 row)
 -- The case here should delete a tuple at the same seg with(2).
 -- Under jump hash, (2) and (3) are on the same seg(seg0).

--- a/src/test/regress/expected/ao_locks_optimizer.out
+++ b/src/test/regress/expected/ao_locks_optimizer.out
@@ -80,9 +80,9 @@ SELECT * FROM locktest_master where coalesce = 'ao_locks_table' or
 
 SELECT * FROM locktest_segments where coalesce = 'ao_locks_table' or
  coalesce like 'aovisimap%' or coalesce like 'aoseg%';
-    coalesce     |       mode       | locktype |    node    
------------------+------------------+----------+------------
- ao_locks_table  | ExclusiveLock    | relation | n segments
+    coalesce     |       mode       | locktype |   node    
+-----------------+------------------+----------+-----------
+ ao_locks_table  | ExclusiveLock    | relation | 1 segment
  aovisimap table | RowExclusiveLock | relation | 1 segment
  aovisimap index | RowExclusiveLock | relation | 1 segment
 (3 rows)

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -65,9 +65,8 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- DO direct dispatch
 -- Known_opt_diff: MPP-21346
 delete from direct_test where key = 100;
-INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
-INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 -- verify
 select * from direct_test order by key, value;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
@@ -91,9 +90,8 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- DELETE with an IS NULL predicate
 -- DO direct dispatch
 delete from direct_test where key is null;
-INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
-INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
-INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 -- Same single-row insert as above, but with DEFAULT instead of an explicit values.
 -- DO direct dispatch
 insert into direct_test values (default, 'cow');
@@ -895,9 +893,9 @@ INFO:  Distributed transaction command 'Distributed Abort (No Prepared)' to SING
 begin;
 -- orca does not handle direct dispatch for DELETE or UPDATE now
 delete from t_hash_partition_1_prt_region1 where r_regionkey=1;
-INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 0) Dispatch command to SINGLE content
 abort;
-INFO:  Distributed transaction command 'Distributed Abort (No Prepared)' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Abort (No Prepared)' to SINGLE content
 -- update: root & leaf are all the same hash dist, will direct dispatch
 begin;
 -- orca does not handle direct dispatch for DELETE or UPDATE now


### PR DESCRIPTION
It was observed that, in response to a DELETE based DML query wherein we
know that the data resides on a particular segment, the commands should
be issued by Orca to that segment only. However, it was found that the
commands were issued to all the segment.  This behaviour was
cross-checked with the Legacy Planner, it was found that Legacy Planner
was sending the query to single segment only.

To correct this behaviour changes were done in the following files:

1. FILE NAME : CTranslatorExprToDXL.cpp

In function CtranslatorExprToDXL::PdxlnDML , object for
CDXLDirectDispatchInfo is created by calling GetDXLDirectDispatchInfo
function.

Before the update, in the GetDXLDirectDispatchInfo function, null
pointer was returned for any DML command other than INSERT.

Now, this condition has been changed to include DELETE command also,
thus now for INSERT and DELETE, nullpointer shall not be returned and
object for CDXLDirectDispatchInfoclass shall be created.

2. FILE NAME :: CTranslatorDXLToPlStmt.cpp

The above created object is checked while creating the planned statement
for the query to enable the direct dispatch flag in the planned
statment.

Earlier this was allowed for INSERT command only, changes were done to
enable this logic for DELETE command also.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
