### PR TITLE
[7X] pg_upgrade --check fixups

### DIFF
--- a/src/bin/pg_upgrade/check.c
+++ b/src/bin/pg_upgrade/check.c
@@ -251,6 +251,8 @@ report_clusters_compatible(void)
 
 		/* stops new cluster */
 		stop_postmaster(false);
+		if (get_check_fatal_occurred())
+			exit(1);
 		exit(0);
 	}
 

--- a/src/bin/pg_upgrade/check.c
+++ b/src/bin/pg_upgrade/check.c
@@ -246,8 +246,16 @@ report_clusters_compatible(void)
 {
 	if (user_opts.check)
 	{
-		pg_log(PG_REPORT, (get_check_fatal_occurred() ?
-			"\n*Some cluster objects are not compatible*\n" : "\n*Clusters are compatible*\n"));
+		if (get_check_fatal_occurred())
+		{
+			char		cwd[MAXPGPATH];
+			if (!getcwd(cwd, MAXPGPATH))
+				pg_fatal("could not determine current directory: %m\n");
+			canonicalize_path(cwd);
+
+			pg_log(PG_REPORT, "\n*Some cluster objects are not compatible*\n\npg_upgrade check output files are located:\n%s\n\n", cwd);
+		} else
+			pg_log(PG_REPORT, "\n*Clusters are compatible*\n");
 
 		/* stops new cluster */
 		stop_postmaster(false);


### PR DESCRIPTION
Two commits:

1) pg_upgrade --continue-check-on-fatal exit status 1 on fatal

gpupgrade relies on a non-zero exit status code when there are errors in pg_upgrade in order to correctly bubble up errors. Thus, when there is at least one fatal error during check return a non-zero exit status.

2) pg_upgrade: print check output file location

The primary user of pg_upgrade is gpupgrade where users need to know the full path location to the pg_upgrade check output files.


Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/pgUpgradeCheckFixups_7X
Backport: https://github.com/greenplum-db/gpdb/pull/13475