### PR TITLE
ORCA: Explicitly fallback to planner if target list is empty

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -2874,6 +2874,38 @@ CTranslatorQueryToDXL::TranslateSetOpChild(Node *child_node,
 	GPOS_ASSERT(NULL != colids);
 	GPOS_ASSERT(NULL != input_col_mdids);
 
+	// We have to fallback here because otherwise we trip the following assert in ORCA:
+	//
+	// INFO:  GPORCA failed to produce a plan, falling back to planner
+	// DETAIL:  CKeyCollection.cpp:84: Failed assertion: __null != colref_array && 0 < colref_array->Size()
+	// Stack trace:
+	// 1    0x000055c239243b8a gpos::CException::Raise + 278
+	// 2    0x000055c2393ab075 gpopt::CKeyCollection::CKeyCollection + 221
+	// 3    0x000055c239449ab6 gpopt::CLogicalSetOp::DeriveKeyCollection + 98
+	// 4    0x000055c2393a5a67 gpopt::CDrvdPropRelational::DeriveKeyCollection + 135
+	// 5    0x000055c2393a4937 gpopt::CDrvdPropRelational::Derive + 197
+	// 6    0x000055c239405d9f gpopt::CExpression::PdpDerive + 703
+	// 7    0x000055c2394d1e14 gpopt::CMemo::PgroupInsert + 512
+	// 8    0x000055c2393dd734 gpopt::CEngine::PgroupInsert + 632
+	// 9    0x000055c2393dcd73 gpopt::CEngine::InitLogicalExpression + 225
+	// 10   0x000055c2393dd106 gpopt::CEngine::Init + 884
+	// 11   0x000055c23949da9f gpopt::COptimizer::PexprOptimize + 103
+	// 12   0x000055c23949d3d8 gpopt::COptimizer::PdxlnOptimize + 1414
+	// 13   0x000055c23960e55e COptTasks::OptimizeTask + 1530
+	// 14   0x000055c2392572b6 gpos::CTask::Execute + 196
+	// 15   0x000055c239259dbf gpos::CWorker::Execute + 191
+	// 16   0x000055c2392556b5 gpos::CAutoTaskProxy::Execute + 221
+	// 17   0x000055c23925c0c0 gpos_exec + 876
+	//
+	// Currently there are a lot of asserts on NULL != target_list in the
+	// translator, but most of them are unnecessary. We should instead fix ORCA
+	// to handle empty target list.
+	if (NIL == target_list)
+	{
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
+				   GPOS_WSZ_LIT("Empty target list"));
+	}
+
 	if (IsA(child_node, RangeTblRef))
 	{
 		RangeTblRef *range_tbl_ref = (RangeTblRef *) child_node;

--- a/src/test/regress/expected/union.out
+++ b/src/test/regress/expected/union.out
@@ -1,3 +1,4 @@
+set optimizer_trace_fallback to on;
 --
 -- UNION (also INTERSECT, EXCEPT)
 --
@@ -437,6 +438,64 @@ SELECT q1 FROM int8_tbl EXCEPT (((SELECT q2 FROM int8_tbl ORDER BY q2 LIMIT 1)))
 (5 rows)
 
 --
+-- Check behavior with empty select list (allowed since 9.4)
+-- ORCA should fall back to planner when target list is empty
+--
+select union select;
+ERROR:  UNION over no columns is not supported
+select intersect select;
+ERROR:  INTERSECT over no columns is not supported
+select except select;
+ERROR:  EXCEPT over no columns is not supported
+-- check hashed implementation
+set enable_hashagg = true;
+set enable_sort = false;
+explain (costs off)
+select from generate_series(1,5) union select from generate_series(1,3);
+ERROR:  UNION over no columns is not supported
+explain (costs off)
+select from generate_series(1,5) intersect select from generate_series(1,3);
+ERROR:  INTERSECT over no columns is not supported
+select from generate_series(1,5) union select from generate_series(1,3);
+ERROR:  UNION over no columns is not supported
+select from generate_series(1,5) union all select from generate_series(1,3);
+--
+(8 rows)
+
+select from generate_series(1,5) intersect select from generate_series(1,3);
+ERROR:  INTERSECT over no columns is not supported
+select from generate_series(1,5) intersect all select from generate_series(1,3);
+ERROR:  INTERSECT over no columns is not supported
+select from generate_series(1,5) except select from generate_series(1,3);
+ERROR:  EXCEPT over no columns is not supported
+select from generate_series(1,5) except all select from generate_series(1,3);
+ERROR:  EXCEPT over no columns is not supported
+-- check sorted implementation
+set enable_hashagg = false;
+set enable_sort = true;
+explain (costs off)
+select from generate_series(1,5) union select from generate_series(1,3);
+ERROR:  UNION over no columns is not supported
+explain (costs off)
+select from generate_series(1,5) intersect select from generate_series(1,3);
+ERROR:  INTERSECT over no columns is not supported
+select from generate_series(1,5) union select from generate_series(1,3);
+ERROR:  UNION over no columns is not supported
+select from generate_series(1,5) union all select from generate_series(1,3);
+--
+(8 rows)
+
+select from generate_series(1,5) intersect select from generate_series(1,3);
+ERROR:  INTERSECT over no columns is not supported
+select from generate_series(1,5) intersect all select from generate_series(1,3);
+ERROR:  INTERSECT over no columns is not supported
+select from generate_series(1,5) except select from generate_series(1,3);
+ERROR:  EXCEPT over no columns is not supported
+select from generate_series(1,5) except all select from generate_series(1,3);
+ERROR:  EXCEPT over no columns is not supported
+reset enable_hashagg;
+reset enable_sort;
+--
 -- Check handling of a case with unknown constants.  We don't guarantee
 -- an undecorated constant will work in all cases, but historically this
 -- usage has worked, so test we don't break it.
@@ -737,5 +796,6 @@ select * from
  0 |  0
 (2 rows)
 
+reset optimizer_trace_fallback;
 drop table t3;
 drop function expensivefunc(int);

--- a/src/test/regress/expected/union_optimizer.out
+++ b/src/test/regress/expected/union_optimizer.out
@@ -1,3 +1,4 @@
+set optimizer_trace_fallback to on;
 --
 -- UNION (also INTERSECT, EXCEPT)
 --
@@ -437,6 +438,102 @@ SELECT q1 FROM int8_tbl EXCEPT (((SELECT q2 FROM int8_tbl ORDER BY q2 LIMIT 1)))
 (5 rows)
 
 --
+-- Check behavior with empty select list (allowed since 9.4)
+-- ORCA should fall back to planner when target list is empty
+--
+select union select;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Empty target list
+ERROR:  UNION over no columns is not supported
+select intersect select;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Empty target list
+ERROR:  INTERSECT over no columns is not supported
+select except select;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Empty target list
+ERROR:  EXCEPT over no columns is not supported
+-- check hashed implementation
+set enable_hashagg = true;
+set enable_sort = false;
+explain (costs off)
+select from generate_series(1,5) union select from generate_series(1,3);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Empty target list
+ERROR:  UNION over no columns is not supported
+explain (costs off)
+select from generate_series(1,5) intersect select from generate_series(1,3);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Empty target list
+ERROR:  INTERSECT over no columns is not supported
+select from generate_series(1,5) union select from generate_series(1,3);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Empty target list
+ERROR:  UNION over no columns is not supported
+select from generate_series(1,5) union all select from generate_series(1,3);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Empty target list
+--
+(8 rows)
+
+select from generate_series(1,5) intersect select from generate_series(1,3);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Empty target list
+ERROR:  INTERSECT over no columns is not supported
+select from generate_series(1,5) intersect all select from generate_series(1,3);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Empty target list
+ERROR:  INTERSECT over no columns is not supported
+select from generate_series(1,5) except select from generate_series(1,3);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Empty target list
+ERROR:  EXCEPT over no columns is not supported
+select from generate_series(1,5) except all select from generate_series(1,3);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Empty target list
+ERROR:  EXCEPT over no columns is not supported
+-- check sorted implementation
+set enable_hashagg = false;
+set enable_sort = true;
+explain (costs off)
+select from generate_series(1,5) union select from generate_series(1,3);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Empty target list
+ERROR:  UNION over no columns is not supported
+explain (costs off)
+select from generate_series(1,5) intersect select from generate_series(1,3);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Empty target list
+ERROR:  INTERSECT over no columns is not supported
+select from generate_series(1,5) union select from generate_series(1,3);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Empty target list
+ERROR:  UNION over no columns is not supported
+select from generate_series(1,5) union all select from generate_series(1,3);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Empty target list
+--
+(8 rows)
+
+select from generate_series(1,5) intersect select from generate_series(1,3);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Empty target list
+ERROR:  INTERSECT over no columns is not supported
+select from generate_series(1,5) intersect all select from generate_series(1,3);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Empty target list
+ERROR:  INTERSECT over no columns is not supported
+select from generate_series(1,5) except select from generate_series(1,3);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Empty target list
+ERROR:  EXCEPT over no columns is not supported
+select from generate_series(1,5) except all select from generate_series(1,3);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Empty target list
+ERROR:  EXCEPT over no columns is not supported
+reset enable_hashagg;
+reset enable_sort;
+--
 -- Check handling of a case with unknown constants.  We don't guarantee
 -- an undecorated constant will work in all cases, but historically this
 -- usage has worked, so test we don't break it.
@@ -536,6 +633,8 @@ explain (costs off)
    UNION ALL
    SELECT ab FROM t2) t
   ORDER BY 1 LIMIT 8;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Inherited tables
                    QUERY PLAN                   
 ------------------------------------------------
  Limit
@@ -557,6 +656,8 @@ explain (costs off)
    UNION ALL
    SELECT ab FROM t2) t
   ORDER BY 1 LIMIT 8;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Inherited tables
  ab 
 ----
  ab
@@ -583,6 +684,8 @@ select event_id
        union all
        select event_id from other_events) ss
  order by event_id;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Inherited tables
                  QUERY PLAN                 
 --------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -694,6 +797,8 @@ SELECT * FROM
    UNION
    SELECT 2 AS t, 4 AS x) ss
 WHERE x > 3;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: SIRV functions
                                       QUERY PLAN                                       
 ---------------------------------------------------------------------------------------
  Subquery Scan on ss
@@ -715,6 +820,8 @@ SELECT * FROM
    UNION
    SELECT 2 AS t, 4 AS x) ss
 WHERE x > 3;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: SIRV functions
  t | x 
 ---+---
  2 | 4
@@ -755,5 +862,6 @@ select * from
  0 |  0
 (2 rows)
 
+reset optimizer_trace_fallback;
 drop table t3;
 drop function expensivefunc(int);

--- a/src/test/regress/sql/union.sql
+++ b/src/test/regress/sql/union.sql
@@ -1,3 +1,5 @@
+set optimizer_trace_fallback to on;
+
 --
 -- UNION (also INTERSECT, EXCEPT)
 --
@@ -154,6 +156,50 @@ SELECT q1 FROM int8_tbl EXCEPT (((SELECT q2 FROM int8_tbl ORDER BY q2 LIMIT 1)))
 --
 
 (((((select * from int8_tbl)))));
+
+--
+-- Check behavior with empty select list (allowed since 9.4)
+-- ORCA should fall back to planner when target list is empty
+--
+
+select union select;
+select intersect select;
+select except select;
+
+-- check hashed implementation
+set enable_hashagg = true;
+set enable_sort = false;
+
+explain (costs off)
+select from generate_series(1,5) union select from generate_series(1,3);
+explain (costs off)
+select from generate_series(1,5) intersect select from generate_series(1,3);
+
+select from generate_series(1,5) union select from generate_series(1,3);
+select from generate_series(1,5) union all select from generate_series(1,3);
+select from generate_series(1,5) intersect select from generate_series(1,3);
+select from generate_series(1,5) intersect all select from generate_series(1,3);
+select from generate_series(1,5) except select from generate_series(1,3);
+select from generate_series(1,5) except all select from generate_series(1,3);
+
+-- check sorted implementation
+set enable_hashagg = false;
+set enable_sort = true;
+
+explain (costs off)
+select from generate_series(1,5) union select from generate_series(1,3);
+explain (costs off)
+select from generate_series(1,5) intersect select from generate_series(1,3);
+
+select from generate_series(1,5) union select from generate_series(1,3);
+select from generate_series(1,5) union all select from generate_series(1,3);
+select from generate_series(1,5) intersect select from generate_series(1,3);
+select from generate_series(1,5) intersect all select from generate_series(1,3);
+select from generate_series(1,5) except select from generate_series(1,3);
+select from generate_series(1,5) except all select from generate_series(1,3);
+
+reset enable_hashagg;
+reset enable_sort;
 
 --
 -- Check handling of a case with unknown constants.  We don't guarantee
@@ -316,6 +362,8 @@ select * from
 select * from
   (select * from t3 a union all select * from t3 b) ss
   join int4_tbl on f1 = expensivefunc(x);
+
+reset optimizer_trace_fallback;
 
 drop table t3;
 drop function expensivefunc(int);


### PR DESCRIPTION
Co-authored-by: Jesse Zhang <sbjesse@gmail.com>

cherry-picked
https://github.com/greenplum-db/gpdb-postgres-merge/commit/98154a8f6c47fc6007638ffe84e7ae8999b19f2a

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
