### PR TITLE
[6X] fix compiler warning for util.c and nodeShareInputScan.c

### DIFF
--- a/contrib/pg_upgrade/pg_upgrade.h
+++ b/contrib/pg_upgrade/pg_upgrade.h
@@ -579,7 +579,8 @@ void		check_ok(void);
 const char *getErrorText(void);
 unsigned int str2uint(const char *str);
 void		pg_putenv(const char *var, const char *val);
-void 		gp_fatal_log(const char *fmt,...);
+void 		gp_fatal_log(const char *fmt,...)
+__attribute__((format(PG_PRINTF_ATTRIBUTE, 1, 2)));
 
 
 /* version.c */

--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -178,8 +178,8 @@ ExecShareInputScan(ShareInputScanState *node)
 	 * do not need to read tuple from tuplestore when discard_output is true, which means current
 	 * ShareInputScan is one but not the last one of Sequence's subplans.
 	 */
-    if (sisc->discard_output)
-        return NULL;
+	if (sisc->discard_output)
+		return NULL;
 
 	slot = node->ss.ps.ps_ResultTupleSlot;
 


### PR DESCRIPTION
1.util.c: function ‘gp_fatal_log’ might be a candidate for ‘gnu_printf’ format attribute
[-Wsuggest-attribute=format], add the attribute gnu_printf to function gp_fatal_log.
2.nodeShareInputScan.c: the format issue, change the indents.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
