### PR TITLE
Use hostname instead of ip to compute the host_segments.

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -89,7 +89,7 @@ static GpSegConfigEntry * readGpSegConfigFromCatalog(int *total_dbs);
 static GpSegConfigEntry * readGpSegConfigFromFTSFiles(int *total_dbs);
 
 static void getAddressesForDBid(GpSegConfigEntry *c, int elevel);
-static HTAB *hostSegsHashTableInit(void);
+static HTAB *hostPrimaryCountHashTableInit(void);
 
 static int nextQEIdentifer(CdbComponentDatabases *cdbs);
 
@@ -103,11 +103,11 @@ typedef struct SegIpEntry
 	char		hostinfo[NI_MAXHOST];
 } SegIpEntry;
 
-typedef struct HostSegsEntry
+typedef struct HostPrimaryCountEntry
 {
-	char		hostip[INET6_ADDRSTRLEN];
+	char		hostname[MAXHOSTNAMELEN];
 	int			segmentCount;
-} HostSegsEntry;
+} HostPrimaryCountEntry;
 
 /*
  * Helper functions for fetching latest gp_segment_configuration outside of
@@ -340,7 +340,7 @@ getCdbComponentInfo(void)
 	int			total_dbs = 0;
 
 	bool		found;
-	HostSegsEntry *hsEntry;
+	HostPrimaryCountEntry *hsEntry;
 
 	if (!CdbComponentsContext)
 		CdbComponentsContext = AllocSetContextCreate(TopMemoryContext, "cdb components Context",
@@ -350,7 +350,7 @@ getCdbComponentInfo(void)
 
 	oldContext = MemoryContextSwitchTo(CdbComponentsContext);
 
-	HTAB	   *hostSegsHash = hostSegsHashTableInit();
+	HTAB	   *hostPrimaryCountHash = hostPrimaryCountHashTableInit();
 
 	if (IsTransactionState())
 		configs = readGpSegConfigFromCatalog(&total_dbs);
@@ -374,6 +374,19 @@ getCdbComponentInfo(void)
 	{
 		CdbComponentDatabaseInfo	*pRow;
 		GpSegConfigEntry	*config = &configs[i];
+
+		if (config->hostname == NULL || strlen(config->hostname) > MAXHOSTNAMELEN)
+		{
+			/*
+			 * We should never reach here, but add sanity check
+			 * The reason we check length is we find MAXHOSTNAMELEN might be
+			 * smaller than the ones defined in /etc/hosts. Those are rare cases.
+			 */
+			elog(ERROR,
+				 "Invalid length (%d) of hostname (%s)",
+				 config->hostname == NULL ? 0 : (int) strlen(config->hostname),
+				 config->hostname == NULL ? "" : config->hostname);
+		}
 
 		/* lookup hostip/hostaddrs cache */
 		config->hostip= NULL;
@@ -415,10 +428,10 @@ getCdbComponentInfo(void)
 		pRow->numIdleQEs = 0;
 		pRow->numActiveQEs = 0;
 
-		if (config->role != GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY || config->hostip == NULL)
+		if (config->role != GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY)
 			continue;
 
-		hsEntry = (HostSegsEntry *) hash_search(hostSegsHash, config->hostip, HASH_ENTER, &found);
+		hsEntry = (HostPrimaryCountEntry *) hash_search(hostPrimaryCountHash, config->hostname, HASH_ENTER, &found);
 		if (found)
 			hsEntry->segmentCount++;
 		else
@@ -529,27 +542,27 @@ getCdbComponentInfo(void)
 	{
 		cdbInfo = &component_databases->segment_db_info[i];
 
-		if (cdbInfo->config->role != GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY || cdbInfo->config->hostip == NULL)
+		if (cdbInfo->config->role != GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY)
 			continue;
 
-		hsEntry = (HostSegsEntry *) hash_search(hostSegsHash, cdbInfo->config->hostip, HASH_FIND, &found);
+		hsEntry = (HostPrimaryCountEntry *) hash_search(hostPrimaryCountHash, cdbInfo->config->hostname, HASH_FIND, &found);
 		Assert(found);
-		cdbInfo->hostSegs = hsEntry->segmentCount;
+		cdbInfo->hostPrimaryCount = hsEntry->segmentCount;
 	}
 
 	for (i = 0; i < component_databases->total_entry_dbs; i++)
 	{
 		cdbInfo = &component_databases->entry_db_info[i];
 
-		if (cdbInfo->config->role != GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY || cdbInfo->config->hostip == NULL)
+		if (cdbInfo->config->role != GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY)
 			continue;
 
-		hsEntry = (HostSegsEntry *) hash_search(hostSegsHash, cdbInfo->config->hostip, HASH_FIND, &found);
+		hsEntry = (HostPrimaryCountEntry *) hash_search(hostPrimaryCountHash, cdbInfo->config->hostname, HASH_FIND, &found);
 		Assert(found);
-		cdbInfo->hostSegs = hsEntry->segmentCount;
+		cdbInfo->hostPrimaryCount = hsEntry->segmentCount;
 	}
 
-	hash_destroy(hostSegsHash);
+	hash_destroy(hostPrimaryCountHash);
 
 	MemoryContextSwitchTo(oldContext);
 
@@ -1386,18 +1399,18 @@ getAddressesForDBid(GpSegConfigEntry *c, int elevel)
 }
 
 /*
- * hostSegsHashTableInit()
- *    Construct a hash table of HostSegsEntry
+ * hostPrimaryCountHashTableInit()
+ *    Construct a hash table of HostPrimaryCountEntry
  */
 static HTAB *
-hostSegsHashTableInit(void)
+hostPrimaryCountHashTableInit(void)
 {
 	HASHCTL		info;
 
 	/* Set key and entry sizes. */
 	MemSet(&info, 0, sizeof(info));
-	info.keysize = INET6_ADDRSTRLEN;
-	info.entrysize = sizeof(HostSegsEntry);
+	info.keysize = MAXHOSTNAMELEN;
+	info.entrysize = sizeof(HostPrimaryCountEntry);
 
 	return hash_create("HostSegs", 32, &info, HASH_ELEM);
 }

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -279,7 +279,7 @@ CdbDispatchPlan(struct QueryDesc *queryDesc,
 		 * fall back mode (use statement_mem).
 		 */
 		stmt->total_memory_coordinator = ResGroupOps_GetTotalMemory();
-		stmt->nsegments_coordinator = ResGroupGetSegmentNum();
+		stmt->nsegments_coordinator = ResGroupGetHostPrimaryCount();
 	}
 
 	cdbdisp_dispatchX(queryDesc, planRequiresTxn, cancelOnError);

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -59,9 +59,11 @@
 int			qe_identifier = 0;
 
 /*
- * number of primary segments on this host
+ * Number of primary segments on this host.
+ * Note: This is only set on the segments and not on the coordinator. It is
+ * used primarily by resource groups.
  */
-int			host_segments = 0;
+int			host_primary_segment_count = 0;
 
 /*
  * size of hash table of interconnect connections
@@ -529,7 +531,7 @@ cdbgang_parse_gpqeid_params(struct Port *port pg_attribute_unused(),
 
 	if (gpqeid_next_param(&cp, &np))
 	{
-		host_segments = (int) strtol(cp, NULL, 10);
+		host_primary_segment_count = (int) strtol(cp, NULL, 10);
 	}
 
 	if (gpqeid_next_param(&cp, &np))
@@ -541,7 +543,8 @@ cdbgang_parse_gpqeid_params(struct Port *port pg_attribute_unused(),
 	if (!cp || np)
 		goto bad;
 
-	if (gp_session_id <= 0 || PgStartTime <= 0 || qe_identifier < 0 || host_segments <= 0 || ic_htab_size <= 0)
+	if (gp_session_id <= 0 || PgStartTime <= 0 || qe_identifier < 0 ||
+		host_primary_segment_count <= 0 || ic_htab_size <= 0)
 		goto bad;
 
 	pfree(gpqeid);

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -154,7 +154,7 @@ create_gang_retry:
 			ret = build_gpqeid_param(gpqeid, sizeof(gpqeid),
 									 segdbDesc->isWriter,
 									 segdbDesc->identifier,
-									 segdbDesc->segment_database_info->hostSegs,
+									 segdbDesc->segment_database_info->hostPrimaryCount,
 									 totalSegs * 2);
 
 			if (!ret)

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -276,7 +276,7 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 
 					/* Get total system memory on the QE in MB */
 					int 	total_memory_segment = ResGroupOps_GetTotalMemory();
-					int 	nsegments_segment = ResGroupGetSegmentNum();
+					int 	nsegments_segment = ResGroupGetHostPrimaryCount();
 					uint64	coordinator_query_mem = queryDesc->plannedstmt->query_mem;
 
 					/*

--- a/src/backend/utils/resgroup/resgroup-ops-linux.c
+++ b/src/backend/utils/resgroup/resgroup-ops-linux.c
@@ -1760,7 +1760,7 @@ ResGroupOps_SetMemoryLimit(Oid group, int memory_limit)
 	int32 memory_limit_in_chunks;
 
 	memory_limit_in_chunks = ResGroupGetVmemLimitChunks() * memory_limit / 100;
-	memory_limit_in_chunks *= ResGroupGetSegmentNum();
+	memory_limit_in_chunks *= ResGroupGetHostPrimaryCount();
 
 	fd = ResGroupOps_LockGroup(group, comp, true);
 	ResGroupOps_SetMemoryLimitByValue(group, memory_limit_in_chunks);

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -567,7 +567,7 @@ InitResGroups(void)
 	{
 		Assert(IS_QUERY_DISPATCHER());
 		qdinfo = cdbcomponent_getComponentInfo(MASTER_CONTENT_ID); 
-		pResGroupControl->segmentsOnMaster = qdinfo->hostSegs;
+		pResGroupControl->segmentsOnMaster = qdinfo->hostPrimaryCount;
 		Assert(pResGroupControl->segmentsOnMaster > 0);
 	}
 
@@ -1072,9 +1072,9 @@ ResGroupGetStat(Oid groupId, ResGroupStatType type)
  * Get the number of primary segments on this host
  */
 int
-ResGroupGetSegmentNum()
+ResGroupGetHostPrimaryCount()
 {
-	return (Gp_role == GP_ROLE_EXECUTE ? host_segments : pResGroupControl->segmentsOnMaster);
+	return (Gp_role == GP_ROLE_EXECUTE ? host_primary_segment_count : pResGroupControl->segmentsOnMaster);
 }
 
 static char *
@@ -2111,7 +2111,7 @@ decideTotalChunks(int32 *totalChunks, int32 *chunkSizeInBits)
 	int32 tmptotalChunks;
 	int32 tmpchunkSizeInBits;
 
-	nsegments = Gp_role == GP_ROLE_EXECUTE ? host_segments : pResGroupControl->segmentsOnMaster;
+	nsegments = Gp_role == GP_ROLE_EXECUTE ? host_primary_segment_count : pResGroupControl->segmentsOnMaster;
 	Assert(nsegments > 0);
 
 	tmptotalChunks = ResGroupOps_GetTotalMemory() * gp_resource_group_memory_limit / nsegments;
@@ -2822,7 +2822,7 @@ SwitchResGroupOnSegment(const char *buf, int len)
 	Assert(group != NULL);
 
 	/* Init self */
-	Assert(host_segments > 0);
+	Assert(host_primary_segment_count > 0);
 	Assert(caps.concurrency > 0);
 	self->caps = caps;
 
@@ -4192,10 +4192,10 @@ groupMemOnDumpForCgroup(ResGroupData *group, StringInfo str)
 	appendStringInfo(str, "{");
 	appendStringInfo(str, "\"used\":%d, ",
 			VmemTracker_ConvertVmemChunksToMB(
-				ResGroupOps_GetMemoryUsage(group->groupId) / ResGroupGetSegmentNum()));
+				ResGroupOps_GetMemoryUsage(group->groupId) / ResGroupGetHostPrimaryCount()));
 	appendStringInfo(str, "\"limit_granted\":%d",
 			VmemTracker_ConvertVmemChunksToMB(
-				ResGroupOps_GetMemoryLimit(group->groupId) / ResGroupGetSegmentNum()));
+				ResGroupOps_GetMemoryLimit(group->groupId) / ResGroupGetHostPrimaryCount()));
 	appendStringInfo(str, "}");
 }
 

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -46,7 +46,7 @@ typedef struct Gang
 
 extern int qe_identifier;
 
-extern int host_segments;
+extern int host_primary_segment_count;
 extern int ic_htab_size;
 
 extern MemoryContext GangContext;

--- a/src/include/cdb/cdbutil.h
+++ b/src/include/cdb/cdbutil.h
@@ -67,7 +67,7 @@ struct CdbComponentDatabaseInfo
 
 	CdbComponentDatabases	*cdbs; /* point to owners */
 
-	int16		hostSegs;	/* number of primary segments on the same hosts */
+	int16		hostPrimaryCount;	/* number of primary segments on the same hosts */
 	List		*freelist;	/* list of idle segment dbs */
 	int			numIdleQEs;
 	List		*activelist;	/* list of active segment dbs */

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -206,7 +206,7 @@ extern int64 ResourceGroupGetQueryMemoryLimit(void);
 
 extern void ResGroupDumpInfo(StringInfo str);
 
-extern int ResGroupGetSegmentNum(void);
+extern int ResGroupGetHostPrimaryCount(void);
 
 extern Bitmapset *CpusetToBitset(const char *cpuset,
 								 int len);


### PR DESCRIPTION
The global variable host_segments is **only** used on QEs under resource
group mode and the value is dispatched to QEs from QD. Previously in
the function getCdbComponentInfo(), QD make a hashtable, and count host_segments
group by the key of ip address. This is not correct. A typical
Greenplum deployment environment may have different ip addresses point
to the same machine. Use ip address as hash key will lead to wrong
number of host_segments and lead to more memory limit of a segment
than user's intent.

This commit use hostname as a machine's unique identifier to fix the issue.

-------

It is not easy to add a test case for this. I have manually test under my local env (demo cluster in a single VM), host_segments should be 4:

I directly update `gp_segment_configuration` to modify some address from hostname to localhost, and then run a SQL

* without this patch, some QEs's `host_segments` become a value not 4
* with this patch, after the update of `gp_segment_configuration`, each QE's host_segments is still 4.
