### PR TITLE
fix incorrect scan position during bitmap index words scan

### DIFF
--- a/src/backend/access/bitmap/bitmap.c
+++ b/src/backend/access/bitmap/bitmap.c
@@ -925,7 +925,7 @@ restart:
 	 * start tid exceeds block's start tid.
 	 */
 	if (words->firstTid < result->nextTid)
-		_bitmap_catchup_to_next_tid(words, result);
+		_bitmap_catchup_to_next_tid(words, result, true);
 	else if (words->firstTid > result->nextTid)
 		result->nextTid = words->firstTid;
 
@@ -935,7 +935,10 @@ restart:
 	 * the blockno that can not be matched.
 	 */
 	if (words->firstTid < result->nextTid)
+	{
+		Assert(words->nwords == 0);
 		return false;
+	}
 
 	/*
 	 * If the catch up processd all unmatch words that exceed current block's

--- a/src/backend/access/bitmap/bitmap.c
+++ b/src/backend/access/bitmap/bitmap.c
@@ -866,6 +866,9 @@ copy_scan_desc(IndexScanDesc scan)
  *
  * If newentry is false, we're calling the function with a partially filled
  * page table entry. Otherwise, the entry is empty.
+ *
+ * This function is only used in stream bitmap scan, more specifically, it's
+ * BitmapIndexScan + BitmapHeapScan.
  */
 
 static bool
@@ -925,7 +928,7 @@ restart:
 	 * start tid exceeds block's start tid.
 	 */
 	if (words->firstTid < result->nextTid)
-		_bitmap_catchup_to_next_tid(words, result, true);
+		_bitmap_catchup_to_next_tid(words, result);
 	else if (words->firstTid > result->nextTid)
 		result->nextTid = words->firstTid;
 

--- a/src/backend/access/bitmap/bitmap.c
+++ b/src/backend/access/bitmap/bitmap.c
@@ -935,10 +935,7 @@ restart:
 	 * the blockno that can not be matched.
 	 */
 	if (words->firstTid < result->nextTid)
-	{
-		Assert(words->nwords < 1);
 		return false;
-	}
 
 	/*
 	 * If the catch up processd all unmatch words that exceed current block's

--- a/src/backend/access/bitmap/bitmaputil.c
+++ b/src/backend/access/bitmap/bitmaputil.c
@@ -374,6 +374,15 @@ _bitmap_catchup_to_next_tid(BMBatchWords *words, BMIterateResult *result)
 		return;
 
 	/*
+	 * if result->lastScanWordNo is equal to words->startNo, a new batch words
+	 * will be geneerated from next_batch_words(), and at this time if words->firstTid
+	 * is less than result->nextTid, then we should adjust result->lastScanWordNo to
+	 * the correct position.
+	 */
+	if (result->lastScanWordNo != words->startNo)
+		return;
+
+	/*
 	 * Iterate each word until catch up to the next tid to search.
 	 */
 	for(; words->nwords > 0 && words->firstTid < result->nextTid;

--- a/src/backend/access/bitmap/bitmaputil.c
+++ b/src/backend/access/bitmap/bitmaputil.c
@@ -262,8 +262,6 @@ _bitmap_findnexttids(BMBatchWords *words, BMIterateResult *result,
 
 	_bitmap_catchup_to_next_tid(words, result);
 
-	Assert(words->firstTid == result->nextTid);
-
 	while (words->nwords > 0 && result->numOfTids < maxTids && !done)
 	{
 		uint8 oldScanPos = result->lastScanPos;

--- a/src/include/access/bitmap_private.h
+++ b/src/include/access/bitmap_private.h
@@ -307,7 +307,7 @@ extern uint64 _bitmap_findnexttid(BMBatchWords *words,
 								  BMIterateResult *result);
 extern void _bitmap_findnexttids(BMBatchWords *words,
 								 BMIterateResult *result, uint32 maxTids);
-extern void _bitmap_catchup_to_next_tid(BMBatchWords *words, BMIterateResult *result, bool isStream);
+extern void _bitmap_catchup_to_next_tid(BMBatchWords *words, BMIterateResult *result);
 #ifdef NOT_USED /* we might use this later */
 extern void _bitmap_intersect(BMBatchWords **batches, uint32 numBatches,
 						   BMBatchWords *result);

--- a/src/include/access/bitmap_private.h
+++ b/src/include/access/bitmap_private.h
@@ -307,7 +307,7 @@ extern uint64 _bitmap_findnexttid(BMBatchWords *words,
 								  BMIterateResult *result);
 extern void _bitmap_findnexttids(BMBatchWords *words,
 								 BMIterateResult *result, uint32 maxTids);
-extern void _bitmap_catchup_to_next_tid(BMBatchWords *words, BMIterateResult *result);
+extern void _bitmap_catchup_to_next_tid(BMBatchWords *words, BMIterateResult *result, bool isStream);
 #ifdef NOT_USED /* we might use this later */
 extern void _bitmap_intersect(BMBatchWords **batches, uint32 numBatches,
 						   BMBatchWords *result);

--- a/src/test/regress/expected/bitmap_index.out
+++ b/src/test/regress/expected/bitmap_index.out
@@ -934,3 +934,23 @@ explain (analyze, verbose) select * from test_bmsparse where type > 500;
 (12 rows)
 
 DROP TABLE test_bmsparse;
+-- test the scenario that we need read the same batch words many times
+-- more detials can be found at https://github.com/greenplum-db/gpdb/issues/13446
+SET enable_seqscan = OFF;
+SET enable_bitmapscan = OFF;
+create table foo_13446(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index idx_13446 on foo_13446 using bitmap(b);
+insert into foo_13446 select 1, 1 from generate_series(0, 16384);
+-- At current implementation, BMIterateResult can only store 16*1024=16384 TIDs,
+-- if we have 13685 TIDs to read, it must scan same batch words twice, that's what we want
+select count(*) from foo_13446 where b = 1;
+ count 
+-------
+ 16385
+(1 row)
+
+drop table foo_13446;
+SET enable_seqscan = ON;
+SET enable_bitmapscan = ON;

--- a/src/test/regress/expected/bitmap_index_optimizer.out
+++ b/src/test/regress/expected/bitmap_index_optimizer.out
@@ -940,3 +940,23 @@ explain (analyze, verbose) select * from test_bmsparse where type > 500;
 (13 rows)
 
 DROP TABLE test_bmsparse;
+-- test the scenario that we need read the same batch words many times
+-- more detials can be found at https://github.com/greenplum-db/gpdb/issues/13446
+SET enable_seqscan = OFF;
+SET enable_bitmapscan = OFF;
+create table foo_13446(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index idx_13446 on foo_13446 using bitmap(b);
+insert into foo_13446 select 1, 1 from generate_series(0, 16384);
+-- At current implementation, BMIterateResult can only store 16*1024=16384 TIDs,
+-- if we have 13685 TIDs to read, it must scan same batch words twice, that's what we want
+select count(*) from foo_13446 where b = 1;
+ count 
+-------
+ 16385
+(1 row)
+
+drop table foo_13446;
+SET enable_seqscan = ON;
+SET enable_bitmapscan = ON;

--- a/src/test/regress/sql/bitmap_index.sql
+++ b/src/test/regress/sql/bitmap_index.sql
@@ -391,3 +391,22 @@ SET enable_bitmapscan = OFF;
 explain (analyze, verbose) select * from test_bmsparse where type > 500;
 
 DROP TABLE test_bmsparse;
+
+
+-- test the scenario that we need read the same batch words many times
+-- more detials can be found at https://github.com/greenplum-db/gpdb/issues/13446
+SET enable_seqscan = OFF;
+SET enable_bitmapscan = OFF;
+
+create table foo_13446(a int, b int);
+create index idx_13446 on foo_13446 using bitmap(b);
+insert into foo_13446 select 1, 1 from generate_series(0, 16384);
+-- At current implementation, BMIterateResult can only store 16*1024=16384 TIDs,
+-- if we have 13685 TIDs to read, it must scan same batch words twice, that's what we want
+select count(*) from foo_13446 where b = 1;
+
+drop table foo_13446;
+
+SET enable_seqscan = ON;
+SET enable_bitmapscan = ON;
+


### PR DESCRIPTION
Since this PR #11377 has fixed bitmap index scan when concurrent insert update full 
bitmap page, which resolved concurrent read on bitmap index when there's insert running 
in the backend may cause the bitmap scan read wrong tid:

1. Query on bitmap: A query starts and reads all bitmap pages to `PAGE_FULL`, increases
the next tid to fetch, and releases the lock after reading each page.
2. Concurrent insert: insert a tid into `PAGE_FULL` cause expand compressed words to
new words, and rearrange words into `PAGE_NEXT`.
3. Query on bitmap: fetch `PAGE_NEXT` and expect the first tid in it should equal the
saved next tid. But actually `PAGE_NEXT` now contains words used to belong in PAGE_FULL.
This causes the real next tid less than the expected next tid. But our scan keeps increasing
the wrong tid. And then this leads to a wrong result.

The PR used `_bitmap_catchup_to_next_tid()` function to adjust `result->lastScanWordNo`
to the correct position if there has concurrent read/write and causes rearranging words into the 
next bitmap index page, it used the value of `words->firstTid` and `result->nextTid` to judge
whether rearranging words into the next bitmap index page happened or not, this is not entirely
right.

This is because `BMIterateResult` can only store 16*1024=16384 TIDs, but `BMBatchWords`
can save 3968 words by default, a words is 64bit, even in the worst case (all words not 
compressed) , `BMBatchWords` can hold 3968 * 64 = 253952 TIDs. So if there has a `PAGE_FULL`,
the `PAGE_FULL` must scan it more than one time, **but the value of BMBatchWords->firstTid will 
not be updated during each scan, it will only be updated when new bitmap index pages are read**. 

Therefore, in the absence of concurrent read/write, if we need to scan the same `BMBatchWords` 
multiple times, it will lead to the wrong scan position, resulting in wrong output results, as #13446.

To summarize, we just need to check for a rearranged condition when the new bitmap index page is 
read from disk, we should do nothing when we scan the same `BMBatchWords`.