### PR TITLE
Fix writable gpfdist transformation external table can not report error

### DIFF
--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -482,6 +482,19 @@ check_response(URL_CURL_FILE *file, int *rc, char **response_string)
 							file->http_response ? file->http_response : "?")));
 		}
 	}
+	else
+	{
+		/* If there is no error, free http_response header message to avoid this condition:
+		 * 1- seg X gets HTTP OK, http_response is set.
+		 * 2- seg X gets a 500 error, http_response is not NULL, so it won't be updated.
+		 * 3- seg X report error but the http_response is HTTP 200 OK.
+		 */
+		if (file->http_response)
+		{
+			pfree(file->http_response);
+			file->http_response = NULL;
+		}
+	}
 
 	return 0;
 }

--- a/src/backend/utils/misc/fstream/fstream.c
+++ b/src/backend/utils/misc/fstream/fstream.c
@@ -321,7 +321,7 @@ int fstream_get_stderr(fstream_t* fs)
 {
 	int ret = 0;
 #ifdef GPFXDIST
-	if (fs->fd.transform)
+	if (fs->fd.transform && fs->fd.transform->for_write)
 	{
 		ret = gfile_wait_subprocess(&fs->fd);
 		if (ret)
@@ -330,7 +330,6 @@ int fstream_get_stderr(fstream_t* fs)
 			memset(errmsg_buffer, 0, FILE_ERROR_SZ-1);
 			get_writable_transform_err(&fs->fd, errmsg_buffer, FILE_ERROR_SZ-2);
 			fs->ferror = format_error(errmsg_buffer, "");
-			gfile_printf_then_putc_newline("get err from stderr %s", fs->ferror);
 		}
 		return ret;
 	}

--- a/src/backend/utils/misc/fstream/gfile.c
+++ b/src/backend/utils/misc/fstream/gfile.c
@@ -832,7 +832,7 @@ subprocess_open(gfile_t* fd, const char* fpath, int for_write, int* rcode, const
 	{
 		/* writable external table, so child will be reading from standard input */
 
-		if ((rv = apr_procattr_io_set(pattr, APR_FULL_BLOCK, APR_NO_PIPE, APR_FULL_BLOCK)) != APR_SUCCESS)
+		if ((rv = apr_procattr_io_set(pattr, APR_FULL_BLOCK, APR_NO_PIPE, APR_READ_BLOCK)) != APR_SUCCESS)
 		{
 			return subprocess_open_failed(rcode, rstring, "subprocess_open: apr_procattr_io_set (full,no,full) failed");
 		}

--- a/src/backend/utils/misc/fstream/gfile.c
+++ b/src/backend/utils/misc/fstream/gfile.c
@@ -929,7 +929,7 @@ close_subprocess(gfile_t *fd)
 	} 
 	else 
 	{
-		gfile_printf_then_putc_newline("close_subprocess: notdone");
+		gfile_printf_then_putc_newline("close_subprocess: rv = %d", rv);
 		return 1;
 	}
 }

--- a/src/backend/utils/misc/fstream/gfile.c
+++ b/src/backend/utils/misc/fstream/gfile.c
@@ -832,9 +832,9 @@ subprocess_open(gfile_t* fd, const char* fpath, int for_write, int* rcode, const
 	{
 		/* writable external table, so child will be reading from standard input */
 
-		if ((rv = apr_procattr_io_set(pattr, APR_FULL_BLOCK, APR_NO_PIPE, APR_NO_PIPE)) != APR_SUCCESS) 
+		if ((rv = apr_procattr_io_set(pattr, APR_FULL_BLOCK, APR_NO_PIPE, APR_FULL_BLOCK)) != APR_SUCCESS)
 		{
-			return subprocess_open_failed(rcode, rstring, "subprocess_open: apr_procattr_io_set (full,no,no) failed");
+			return subprocess_open_failed(rcode, rstring, "subprocess_open: apr_procattr_io_set (full,no,full) failed");
 		}
 		fd->transform->for_write = 1;
 	} 
@@ -1280,8 +1280,8 @@ gfile_close(gfile_t*fd)
 	{
 #ifdef GPFXDIST
 		if (fd->transform)
-        {
-			fd->close(fd);
+        	{
+			ret = fd->close(fd);
 		} 
         else
 #endif

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -1392,12 +1392,12 @@ static void session_free(session_t* session)
 
 static int session_error_detect(request_t* r)
 {
-	gprintlnif(r, "detect error message in session");
 	session_t* session = r->session;
 
 	/* fetch fstream error in the last request */
 	if (session->nrequest == 1 && r->is_final)
 	{
+		gdebug(r, "detect error message in session");
 		return fstream_get_stderr(session->fstream);
 	}
 
@@ -3212,11 +3212,14 @@ done_processing_request:
 		http_error(r, FDIST_INTERNAL_ERROR, ferror);
 		request_end(r, 1, 0);
 	}
-	/* send our success response and end the request */
-	if (0 != http_ok(r))
-		request_end(r, 1, 0);
 	else
-		request_end(r, 0, 0); /* we're done! */
+	{
+		/* send our success response and end the request */
+		if (0 != http_ok(r))
+			request_end(r, 1, 0);
+		else
+			request_end(r, 0, 0); /* we're done! */
+	}
 
 }
 

--- a/src/bin/gpfdist/regress/data/errexe.yml
+++ b/src/bin/gpfdist/regress/data/errexe.yml
@@ -1,0 +1,7 @@
+TRANSFORMATIONS:
+    write:
+        TYPE: output
+        COMMAND: /usr/bin/env /home/gpadmin/workspace/6_greenplum/gpfdist/error.sh %filename%
+    read:
+        TYPE: input
+        COMMAND: /usr/bin/env /home/gpadmin/workspace/6_greenplum/gpfdist/error.sh %filename%

--- a/src/bin/gpfdist/regress/input/exttab1.source
+++ b/src/bin/gpfdist/regress/input/exttab1.source
@@ -546,21 +546,29 @@ CREATE EXTERNAL WEB TABLE gpfdist2_transform_start (x text)
 execute E'((@bindir@/gpfdist -p 7080 -d @abs_srcdir@/data/transform -c @abs_srcdir@/data/catfile.yml </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
+-- Test writable transform table report error.
+CREATE WRITABLE EXTERNAL TABLE writable_transform (a text) location('gpfdist://localhost:7081/filename#transform=write') format 'text';
+CREATE EXTERNAL WEB TABLE gpfdist3_transform_start (x text)
+execute E'((@bindir@/gpfdist -p 7081 -d @abs_srcdir@/data/transform -c @abs_srcdir@/data/errexe.yml </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7081 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
 
 -- start_ignore
 select * from exttab1_gpfdist_stop;
 select * from gpfdist1_transform_start;
 select * from gpfdist2_transform_start;
+select * from gpfdist3_transform_start;
 -- end_ignore
 
 select count(*) from ext_transform;
-
+insert into writable_transform values('hello');
 -- start_ignore
 select * from exttab1_gpfdist_stop;
 -- end_ignore
 
 -- drop tables
 DROP EXTERNAL TABLE ext_transform;
+drop external table writable_transform;
 
 --
 -- get an error for missing gpfdist

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -734,6 +734,12 @@ CREATE EXTERNAL WEB TABLE gpfdist2_transform_start (x text)
 execute E'((@bindir@/gpfdist -p 7080 -d @abs_srcdir@/data/transform -c @abs_srcdir@/data/catfile.yml </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
+-- Test writable transform table report error.
+CREATE WRITABLE EXTERNAL TABLE writable_transform (a text) location('gpfdist://localhost:7081/filename#transform=write') format 'text';
+CREATE EXTERNAL WEB TABLE gpfdist3_transform_start (x text)
+execute E'((@bindir@/gpfdist -p 7081 -d @abs_srcdir@/data/transform -c @abs_srcdir@/data/errexe.yml </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7081 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
 -- start_ignore
 -- end_ignore
 select count(*) from ext_transform;
@@ -742,10 +748,13 @@ select count(*) from ext_transform;
     14
 (1 row)
 
+insert into writable_transform values('hello');
+ERROR:  http response code 500 from gpfdist (gpfdist://localhost:7081/filename#transform=write): HTTP/1.0 500 /usr/bin/env: /home/gpadmin/workspace/6_greenplum/gpfdist/error.sh: No such file or directory  (seg1 127.0.0.1:6003 pid=4875)
 -- start_ignore
 -- end_ignore
 -- drop tables
 DROP EXTERNAL TABLE ext_transform;
+drop external table writable_transform;
 --
 -- get an error for missing gpfdist
 --

--- a/src/include/fstream/fstream.h
+++ b/src/include/fstream/fstream.h
@@ -51,6 +51,7 @@ const char* fstream_get_error(fstream_t* fs);
 fstream_t* fstream_open(const char* path, const struct fstream_options* options,
 						int* response_code, const char** response_string);
 void fstream_close(fstream_t* fs);
+int fstream_get_stderr(fstream_t* fs);
 bool_t fstream_is_win_pipe(fstream_t *fs);
 
 #endif


### PR DESCRIPTION
1. enable stderr file for writable gpfdist transform subprocess
2. wait subprocess done before sending HTTP response for the last request
3. check stderr after waiting subprocess done
4. report the error before request end

This patch is another solution besides #13442 

issue #9497

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
