### PR TITLE
[6X] Fix 'cache lookup failed for attribute 0 of relation xxx'

### DIFF
--- a/src/test/regress/expected/select_distinct.out
+++ b/src/test/regress/expected/select_distinct.out
@@ -220,3 +220,86 @@ SELECT null IS NOT DISTINCT FROM null as "yes";
  t
 (1 row)
 
+-- gpdb start: test inherit/partition table distinct when gp_statistics_pullup_from_child_partition is on
+set gp_statistics_pullup_from_child_partition to on;
+CREATE TABLE sales (id int, date date, amt decimal(10,2))
+DISTRIBUTED BY (id);
+insert into sales values (1,'20210202',20), (2,'20210602',9) ,(3,'20211002',100);
+select distinct * from sales order by 1;
+ id |    date    |  amt   
+----+------------+--------
+  1 | 02-02-2021 |  20.00
+  2 | 06-02-2021 |   9.00
+  3 | 10-02-2021 | 100.00
+(3 rows)
+
+select distinct sales from sales order by 1;
+         sales         
+-----------------------
+ (1,02-02-2021,20.00)
+ (2,06-02-2021,9.00)
+ (3,10-02-2021,100.00)
+(3 rows)
+
+CREATE TABLE sales_partition (id int, date date, amt decimal(10,2))
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (date)
+( START (date '2021-01-01') INCLUSIVE
+  END (date '2022-01-01') EXCLUSIVE
+  EVERY (INTERVAL '1 month') );
+NOTICE:  CREATE TABLE will create partition "sales_partition_1_prt_1" for table "sales_partition"
+NOTICE:  CREATE TABLE will create partition "sales_partition_1_prt_2" for table "sales_partition"
+NOTICE:  CREATE TABLE will create partition "sales_partition_1_prt_3" for table "sales_partition"
+NOTICE:  CREATE TABLE will create partition "sales_partition_1_prt_4" for table "sales_partition"
+NOTICE:  CREATE TABLE will create partition "sales_partition_1_prt_5" for table "sales_partition"
+NOTICE:  CREATE TABLE will create partition "sales_partition_1_prt_6" for table "sales_partition"
+NOTICE:  CREATE TABLE will create partition "sales_partition_1_prt_7" for table "sales_partition"
+NOTICE:  CREATE TABLE will create partition "sales_partition_1_prt_8" for table "sales_partition"
+NOTICE:  CREATE TABLE will create partition "sales_partition_1_prt_9" for table "sales_partition"
+NOTICE:  CREATE TABLE will create partition "sales_partition_1_prt_10" for table "sales_partition"
+NOTICE:  CREATE TABLE will create partition "sales_partition_1_prt_11" for table "sales_partition"
+NOTICE:  CREATE TABLE will create partition "sales_partition_1_prt_12" for table "sales_partition"
+insert into sales_partition values (1,'20210202',20), (2,'20210602',9) ,(3,'20211002',100);
+select distinct * from sales_partition order by 1;
+ id |    date    |  amt   
+----+------------+--------
+  1 | 02-02-2021 |  20.00
+  2 | 06-02-2021 |   9.00
+  3 | 10-02-2021 | 100.00
+(3 rows)
+
+select distinct sales_partition from sales_partition order by 1;
+    sales_partition    
+-----------------------
+ (1,02-02-2021,20.00)
+ (2,06-02-2021,9.00)
+ (3,10-02-2021,100.00)
+(3 rows)
+
+DROP TABLE sales;
+DROP TABLE sales_partition;
+CREATE TABLE cities (
+    name            text,
+    population      float,
+    altitude        int
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'name' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE capitals (
+    state           char(2)
+) INHERITS (cities);
+NOTICE:  table has parent, setting distribution columns to match parent table
+select distinct * from cities;
+ name | population | altitude 
+------+------------+----------
+(0 rows)
+
+select distinct cities from cities;
+ cities 
+--------
+(0 rows)
+
+DROP TABLE capitals;
+DROP TABLE cities;
+set gp_statistics_pullup_from_child_partition to off;
+-- gpdb end: test inherit/partition table distinct when gp_statistics_pullup_from_child_partition is on

--- a/src/test/regress/sql/select_distinct.sql
+++ b/src/test/regress/sql/select_distinct.sql
@@ -62,3 +62,37 @@ SELECT 1 IS NOT DISTINCT FROM 2 as "no";
 SELECT 2 IS NOT DISTINCT FROM 2 as "yes";
 SELECT 2 IS NOT DISTINCT FROM null as "no";
 SELECT null IS NOT DISTINCT FROM null as "yes";
+
+-- gpdb start: test inherit/partition table distinct when gp_statistics_pullup_from_child_partition is on
+set gp_statistics_pullup_from_child_partition to on;
+CREATE TABLE sales (id int, date date, amt decimal(10,2))
+DISTRIBUTED BY (id);
+insert into sales values (1,'20210202',20), (2,'20210602',9) ,(3,'20211002',100);
+select distinct * from sales order by 1;
+select distinct sales from sales order by 1;
+CREATE TABLE sales_partition (id int, date date, amt decimal(10,2))
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (date)
+( START (date '2021-01-01') INCLUSIVE
+  END (date '2022-01-01') EXCLUSIVE
+  EVERY (INTERVAL '1 month') );
+insert into sales_partition values (1,'20210202',20), (2,'20210602',9) ,(3,'20211002',100);
+select distinct * from sales_partition order by 1;
+select distinct sales_partition from sales_partition order by 1;
+DROP TABLE sales;
+DROP TABLE sales_partition;
+
+CREATE TABLE cities (
+    name            text,
+    population      float,
+    altitude        int
+);
+CREATE TABLE capitals (
+    state           char(2)
+) INHERITS (cities);
+select distinct * from cities;
+select distinct cities from cities;
+DROP TABLE capitals;
+DROP TABLE cities;
+set gp_statistics_pullup_from_child_partition to off;
+-- gpdb end: test inherit/partition table distinct when gp_statistics_pullup_from_child_partition is on


### PR DESCRIPTION
When the GUC gp_statistics_pullup_from_child_partition is on,
we run 'SELECT DISTINCT <father_table> FROM <father_table>'
for an inheritance/partition table will meet the error:
'cache lookup failed for attribute 0 of relation xxx (lsyscache.c:xxx)'.
See Github Issue 13467 for details.

This commit fixes the issue by taking 0 varnoatto into consideration when
get_attname and get_attnum.

Co-authored-by: juyi.lmz <juyi.lmz@alibaba-inc.com>
backport PR #13468 to 6X_STABLE.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
