### PR TITLE
Fix export snapshot test

### DIFF
--- a/src/test/isolation2/expected/export_distributed_snapshot.out
+++ b/src/test/isolation2/expected/export_distributed_snapshot.out
@@ -23,11 +23,11 @@ CREATE LANGUAGE plpython3u;
 CREATE
 
 -- Corrupt field entry for given snapshot file
-CREATE OR REPLACE FUNCTION  corrupt_snapshot_file(token text, field text) RETURNS integer as $$ import os content = bytearray() query = "select (select datadir from gp_segment_configuration where role='p' and content=-1) || '/pg_snapshots/' as path" rv = plpy.execute(query) abs_path = rv[0]['path'] snapshot_file = abs_path + token if not os.path.isfile(snapshot_file): plpy.info('skipping non-existent file %s' % (snapshot_file)) else: plpy.info('corrupting file %s for field %s' % (snapshot_file, field)) with open(snapshot_file , "rb+") as f: for line in f: l = line.decode() id = l.split(":")[0] if field == id: corrupt = l[:-2] + '*' + l[len(l)-1:] content.extend(corrupt.encode()) else: content.extend(line) f.seek(0) f.truncate f.write(content) f.close() return 0 $$ LANGUAGE plpython3u EXECUTE ON MASTER;
+CREATE OR REPLACE FUNCTION  corrupt_snapshot_file(token text, field text) RETURNS integer as $$ import os content = bytearray() query = "select (select datadir from gp_segment_configuration where role='p' and content=-1) || '/pg_snapshots/' as path" rv = plpy.execute(query) abs_path = rv[0]['path'] snapshot_file = abs_path + token if not os.path.isfile(snapshot_file): plpy.info('skipping non-existent file %s' % (snapshot_file)) else: plpy.info('corrupting file %s for field %s' % (snapshot_file, field)) with open(snapshot_file , "rb+") as f: for line in f: l = line.decode() id = l.split(":")[0] if field == id: corrupt = l[:-2] + '*' + l[len(l)-1:] content.extend(corrupt.encode()) else: content.extend(line) f.seek(0) f.truncate f.write(content) f.close() return 0 $$ LANGUAGE plpython3u;
 CREATE
 
 -- Determine if field exists for given snapshot file
-CREATE OR REPLACE FUNCTION  snapshot_file_ds_fields_exist(token text) RETURNS boolean as $$ import os content = bytearray() query = "select (select datadir from gp_segment_configuration where role='p' and content=-1) || '/pg_snapshots/' as path" rv = plpy.execute(query) abs_path = rv[0]['path'] snapshot_file = abs_path + token if not os.path.isfile(snapshot_file): plpy.info('snapshot file %s does not exist' % (snapshot_file)) return -1 else: plpy.info('checking file %s for ds fields' % (snapshot_file)) with open(snapshot_file , "rb+") as f: for line in f: l = line.decode() if "ds" in l: return True return False $$ LANGUAGE plpython3u EXECUTE ON MASTER;
+CREATE OR REPLACE FUNCTION  snapshot_file_ds_fields_exist(token text) RETURNS boolean as $$ import os content = bytearray() query = "select (select datadir from gp_segment_configuration where role='p' and content=-1) || '/pg_snapshots/' as path" rv = plpy.execute(query) abs_path = rv[0]['path'] snapshot_file = abs_path + token if not os.path.isfile(snapshot_file): plpy.info('snapshot file %s does not exist' % (snapshot_file)) return -1 else: plpy.info('checking file %s for ds fields' % (snapshot_file)) with open(snapshot_file , "rb+") as f: for line in f: l = line.decode() if "ds" in l: return True return False $$ LANGUAGE plpython3u;
 CREATE
 
 -- INSERT test
@@ -79,8 +79,114 @@ COMMIT
 1: COMMIT;
 COMMIT
 
--- DROP test
+-- DELETE test
 CREATE TABLE export_distributed_snapshot_test2 (a int);
+CREATE
+INSERT INTO export_distributed_snapshot_test2 SELECT a FROM generate_series(1,3) a;
+INSERT 3
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+ pg_export_snapshot
+---------------------
+ 00000007-0000007C-1
+(1 row)
+
+DELETE FROM export_distributed_snapshot_test2 WHERE a=1;
+DELETE 1
+
+-- Should return 3 rows
+1: SELECT * FROM export_distributed_snapshot_test2 ;
+ a 
+---
+ 1 
+ 2 
+ 3 
+(3 rows)
+
+-- Should return 2 rows
+2: SELECT * FROM  export_distributed_snapshot_test2;
+ a 
+---
+ 2 
+ 3 
+(2 rows)
+
+2: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+SET
+
+-- Should return 3 rows
+2: SELECT * FROM  export_distributed_snapshot_test2;
+ a 
+---
+ 2 
+ 3 
+ 1 
+(3 rows)
+2: COMMIT;
+COMMIT
+
+1: COMMIT;
+COMMIT
+
+-- UPDATE test
+CREATE TABLE export_distributed_snapshot_test3 (a int);
+CREATE
+INSERT INTO export_distributed_snapshot_test3 SELECT a FROM generate_series(1,5) a;
+INSERT 5
+
+1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+ pg_export_snapshot
+---------------------
+ 00000007-0000007D-1
+(1 row)
+
+UPDATE export_distributed_snapshot_test3 SET a=99 WHERE a=1;
+UPDATE 1
+
+-- Should return 0 rows
+1: SELECT * FROM export_distributed_snapshot_test3 WHERE a=99;
+ a 
+---
+(0 rows)
+
+-- Should return 1 row
+2: SELECT * FROM export_distributed_snapshot_test3 WHERE a=99;
+ a  
+----
+ 99 
+(1 row)
+
+2: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+2: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+SET
+
+-- Should return 0 rows
+2: SELECT * FROM export_distributed_snapshot_test3 WHERE a=99;
+ a 
+---
+(0 rows)
+2: COMMIT;
+COMMIT
+
+-- Should return 1 row
+2: SELECT * FROM export_distributed_snapshot_test3 WHERE a=99;
+ a  
+----
+ 99 
+(1 row)
+
+1: COMMIT;
+COMMIT
+
+-- DROP test
+CREATE TABLE export_distributed_snapshot_test4 (a int);
 CREATE
 
 1: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
@@ -93,16 +199,16 @@ BEGIN
 ---------------------
  00000007-00000012-1
 (1 row)
-1: SELECT gp_segment_id, relname from gp_dist_random('pg_class') where relname = 'export_distributed_snapshot_test2';
+1: SELECT gp_segment_id, relname from gp_dist_random('pg_class') where relname = 'export_distributed_snapshot_test4';
  gp_segment_id | relname                           
 ---------------+-----------------------------------
- 1             | export_distributed_snapshot_test2 
- 2             | export_distributed_snapshot_test2 
- 0             | export_distributed_snapshot_test2 
+ 1             | export_distributed_snapshot_test4 
+ 2             | export_distributed_snapshot_test4 
+ 0             | export_distributed_snapshot_test4 
 (3 rows)
 
 -- Drop table in transaction
-2: DROP TABLE export_distributed_snapshot_test2;
+2: DROP TABLE export_distributed_snapshot_test4;
 DROP
 2: COMMIT;
 COMMIT
@@ -112,17 +218,17 @@ BEGIN
 3: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
 SET
 -- The table should still be visible to transaction 3 using transaction 1's snapshot.
-3: SELECT gp_segment_id, relname from gp_dist_random('pg_class') where relname = 'export_distributed_snapshot_test2';
+3: SELECT gp_segment_id, relname from gp_dist_random('pg_class') where relname = 'export_distributed_snapshot_test4';
  gp_segment_id | relname                           
 ---------------+-----------------------------------
- 1             | export_distributed_snapshot_test2 
- 2             | export_distributed_snapshot_test2 
- 0             | export_distributed_snapshot_test2 
+ 1             | export_distributed_snapshot_test4 
+ 2             | export_distributed_snapshot_test4 
+ 0             | export_distributed_snapshot_test4 
 (3 rows)
 3: COMMIT;
 COMMIT
 -- The table should no longer be visible to transaction 3.
-3: SELECT gp_segment_id, relname from gp_dist_random('pg_class') where relname = 'export_distributed_snapshot_test2';
+3: SELECT gp_segment_id, relname from gp_dist_random('pg_class') where relname = 'export_distributed_snapshot_test4';
  gp_segment_id | relname 
 ---------------+---------
 (0 rows)


### PR DESCRIPTION
Commit 8eaa3b682efb050ccdd7b22c0f0b7087b8ea6efd updated the
behavior of ON [COORDINATOR | ALL SEGMENTS] to only allow
set returning functions.

This commit updates the export snapshot isolation tests
to reflect that change.

Add tests for UPDATE and DELETE table

Authored-by: Brent Doil <bdoil@vmware.com>