### PR TITLE
WIP : Handle case when CScalarIdent is a project elem

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorDXLToExpr.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorDXLToExpr.h
@@ -85,6 +85,9 @@ private:
 	// mappings CTE Id (in DXL) -> CTE Id (in expr)
 	UlongToUlongMap *m_phmululCTE;
 
+	// mapping from colid to CExpression(pointing to project elem)
+	UlongToExprMap *m_colidToExprMap;
+
 	// array of output ColRefId
 	ULongPtrArray *m_pdrgpulOutputColRefs;
 
@@ -99,6 +102,9 @@ private:
 
 	// a copy of the pointer to column factory, obtained at construction time
 	CColumnFactory *m_pcf;
+
+	BOOL m_translateScalarCmp;
+	BOOL m_translateSetOp;
 
 	// private copy ctor
 	CTranslatorDXLToExpr(const CTranslatorDXLToExpr &);
@@ -397,6 +403,43 @@ public:
 	{
 		GPOS_ASSERT(nullptr != m_pdrgpmdname);
 		return m_pdrgpmdname;
+	}
+
+	void
+	SetTranslateScalarCmp()
+	{
+		m_translateScalarCmp = true;
+	}
+
+	void
+	UnsetTranslateScalarCmp()
+	{
+		m_translateScalarCmp = false;
+	}
+	void
+	SetTranslateSetOp()
+	{
+		m_translateSetOp = true;
+	}
+
+	void
+	UnsetTranslateSetOp()
+	{
+		m_translateSetOp = false;
+	}
+	BOOL
+	IsSetOp()
+	{
+		if (!m_translateSetOp)
+			return false;
+		return true;
+	}
+	BOOL
+	IsSetScalarcmp()
+	{
+		if (!m_translateScalarCmp)
+			return false;
+		return true;
 	}
 };
 }  // namespace gpopt


### PR DESCRIPTION
If the ScalarIdent refers to a project element, and the ScalarIdent is not
replaced by it while its under a ScalarCmp, then Normalizer fails to push it
below.

Consider a case like below :

```
create table foo ( a text, b text);

create table bar ( c text, d text);

create view foobar as select foo.b::character varying(100) as b, foo.a, bar.c,
bar.d from foo join bar on foo.a = bar.c;

explain select * from foobar where b = 'meh';
```

This will give a plan like below

```
+--CLogicalSelect
   |--CLogicalProject
   |  |--CLogicalNAryJoin
   |  |  |--CLogicalGet "foo" ("foo"), Columns: ["a" (0), "b" (1), "ctid" (2), "xmin" (3), "cmin" (4), "xmax" (5), "cmax" (6), "tableoid" (7), "gp_segment_id" (8)] Key sets: {[2,8]}
   |  |  |--CLogicalGet "bar" ("bar"), Columns: ["c" (9), "d" (10), "ctid" (11), "xmin" (12), "cmin" (13), "xmax" (14), "cmax" (15), "tableoid" (16), "gp_segment_id" (17)] Key sets: {[2,8]}
   |  |  +--CScalarCmp (=)
   |  |     |--CScalarIdent "a" (0)
   |  |     +--CScalarIdent "c" (9)
   |  +--CScalarProjectList
   |     +--CScalarProjectElement "b" (18)
   |        +--CScalarFunc (varchar)
   |           |--CScalarCast
   |           |  +--CScalarIdent "b" (1)
   |           |--CScalarConst (104)
   |           +--CScalarConst (1)
   +--CScalarCmp (=)
      |--CScalarCast
      |  +--CScalarIdent "b" (18)   <---------------------- When we reach FPushable, there is no way for us to know this b(18) is the same as b(1) with a cast. Orca thinks it is an entirely different column.
      +--CScalarConst (1828233457.000)
```

So during Translation, wherever appropriate, we replace the ScalarIdent with
the corresponding project element. Something like below :

```
+--CScalarCmp (=)
      |--CScalarCast
      |  +--CScalarIdent "b" (18)
      +--CScalarConst (1828233457.000)
```

with

```
+--CScalarCmp (=)
      |--CScalarCast
      |  +--+--CScalarFunc (varchar)
      |           |--CScalarCast
      |           |  +--CScalarIdent "b" (1)
      |           |--CScalarConst (104)
      |           +--CScalarConst (1)
      +--CScalarConst
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
