### PR TITLE
remove GPDB_12_MERGE_FIXME in tidbitmap.h: make sure TBM_BITS_PER_BITMAPWORD is 64-bit

### DIFF
--- a/src/include/nodes/tidbitmap.h
+++ b/src/include/nodes/tidbitmap.h
@@ -67,11 +67,6 @@ struct Instrumentation;                 /* #include "executor/instrument.h" */
 #define BITMAP_IS_LOSSY -1
 
 /* The bitmap unit size can be adjusted by changing these declarations: */
-/*
- * GPDB_12_MERGE_FIXME The bitmapword type in bitmapset.h can now be 64-bit
- * wide.  Does it make sense to remove this Greenplum specific type to better
- * align with upstream?
- */
 #define TBM_BITS_PER_BITMAPWORD 64
 typedef uint64 tbm_bitmapword;		/* must be an unsigned type */
 


### PR DESCRIPTION
In PostgreSQL 12, it will use the size of a pointer to define the size of a bitmap word, just 
like:

```
/*
 * Data representation
 *
 * Larger bitmap word sizes generally give better performance, so long as
 * they're not wider than the processor can handle efficiently.  We use
 * 64-bit words if pointers are that large, else 32-bit words.
 */
#if SIZEOF_VOID_P >= 8

#define BITS_PER_BITMAPWORD 64
typedef uint64 bitmapword;		/* must be an unsigned type */
typedef int64 signedbitmapword; /* must be the matching signed type */

#else

#define BITS_PER_BITMAPWORD 32
typedef uint32 bitmapword;		/* must be an unsigned type */
typedef int32 signedbitmapword; /* must be the matching signed type */

#endif
```

So, `bitmapword` will be 32 bits on some 32-bit-platform.

For the functions and methods in the `bitmap.c` file, the length of the bitmap only affects its 
efficiency, not the correctness of its functions. But for the bitmap in the bitmap index, using 
32 bits can lead to fundamental errors.

This is because in the implementation of the greenplum bitmap index, the bitmap compresses 
it using the HRL method as follows:

Before compression:
````
before compression:
00000000 00000000 01000000 11111111 11111111 11111111

after compression using HRL method:
Header Section: 101
Content Section: 00000010 01000000 10000011
````

We judge whether a word in the Content Section is compressed by judging the bit in the Header 
Section, 1 is compressed, 0 is not compressed. At the same time, the first bit of the compressed 
word indicates whether the value before compression is 0 or 1, and **the rest represents the original 
length of the value before compression**.

So, if we use a 32-bit bitmap, then a compressed word can represent a maximum length of 
`2^(32 - 1) = 2147483648` , so there is a risk of overflow, resulting in data errors.

In summary, we must use a 64-bit bitmap to avoid the compressed word length overflow problem.
We cannot use `BITS_PER_BITMAPWORD` in `tidbitmap.h`
