### PR TITLE
docs - remove beta designation from parallel retrieve cursor

### DIFF
--- a/gpdb-doc/markdown/admin_guide/parallel_retrieve_cursor.html.md
+++ b/gpdb-doc/markdown/admin_guide/parallel_retrieve_cursor.html.md
@@ -1,5 +1,5 @@
 ---
-title: Retrieving Query Results with a Parallel Retrieve Cursor (Beta)</title>
+title: Retrieving Query Results with a Parallel Retrieve Cursor</title>
 ---
 
 A *parallel retrieve cursor* is an enhanced cursor implementation that you can use to create a special kind of cursor on the Greenplum Database coordinator node, and retrieve query results, on demand and in parallel, directly from the Greenplum segments.


### PR DESCRIPTION
parallel retrieve cursor functionality is no longer beta.  (master)
