### PR TITLE
Use pg_ctl -t secs option for promote in gpactivatestandby

### DIFF
--- a/gpMgmt/bin/gpactivatestandby
+++ b/gpMgmt/bin/gpactivatestandby
@@ -316,28 +316,11 @@ def promote_standby(coordinator_data_dir):
     """Promote standby"""
 
     logger.info('Promoting standby...')
+    # Keeping the timeout here consistent with
+    # MIRROR_PROMOTION_TIMEOUT which is defined as 10 mins
     cmd = gp.Command('pg_ctl promote',
-                     'pg_ctl promote -D %s' % coordinator_data_dir)
+                     'pg_ctl promote -D %s -t 600' % coordinator_data_dir)
     cmd.run(validateAfter=True)
-
-    logger.debug('Waiting for connection...')
-    for i in range(50):
-        try:
-            dburl = dbconn.DbURL()
-            conn = dbconn.connect(dburl, utility=True, logConn=False)
-            # When the new coordinator is available for connections, we should
-            # run a CHECKPOINT to force the new TimeLineID to be written to
-            # the pg_control file.
-            dbconn.execSQL(conn, 'CHECKPOINT')
-            logger.info('Standby coordinator is promoted')
-            conn.close()
-            return True
-        except pygresql.InternalError as e:
-            pass
-        time.sleep(1)
-
-    return False
-
 
 #-------------------------------------------------------------------------
 # Main
@@ -369,10 +352,7 @@ try:
 
     # promote standby, only if the standby is running in recovery
     if not requires_restart:
-        res = promote_standby(options_.coordinator_data_dir)
-        if not res:
-            raise GpActivateStandbyException('Either the set port is incorrect or '
-                                             'the postmaster could not come up.')
+        promote_standby(options_.coordinator_data_dir)
 
     # now we can access the catalog.  promote action has already updated
     # catalog, so array.coordinator is the old (promoted) standby at this point.


### PR DESCRIPTION
Since commit e7010c "pg_ctl: Add wait option to promote action" have
option -t to wait for required number of secs for promotion. Hence,
deleting the retry loop with dbconn.execSQL() logic to check for
promotion completion via connection acceptance.

Using -t option with 10 mins as timeout to align the value with
MIRROR_PROMOTION_TIMEOUT used in other part of codebase. Having
consistent timeout value for same operation is helpful.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
