### PR TITLE
docs - add reference doc for new gp_log_endpoints guc

### DIFF
--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -867,6 +867,17 @@ Specifies the executing interval \(in seconds\) of the global deadlock detector 
 |-----------|-------|-------------------|
 |5 - `INT_MAX` secs|120 secs|master, system, reload|
 
+## <a id="gp_log_endpoints"></a>gp\_log\_endpoints
+
+Controls the amount of parallel retrieve cursor endpoint detail that Greenplum Database writes to the server log file.
+
+The default value is `false`, Greenplum Database does not log endpoint details to the log file. When set to `true`, Greenplum writes endpoint detail information to the log file.
+
+|Value Range|Default|Set Classifications|
+|-----------|-------|-------------------|
+|Boolean|false|master, session, reload|
+
+
 ## <a id="gp_log_fts"></a>gp\_log\_fts 
 
 Controls the amount of detail the fault detection process \(`ftsprobe`\) writes to the log file.

--- a/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
@@ -253,6 +253,7 @@ These configuration parameters control Greenplum Database logging.
 - [log\_duration](guc-list.html)
 - [log\_executor\_stats](guc-list.html)
 - [log\_hostname](guc-list.html)
+- [gp\_log\_endpoints](guc-list.html)
 - [gp\_log\_interconnect](guc-list.html)
 - [log\_parser\_stats](guc-list.html)
 - [log\_planner\_stats](guc-list.html)


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/13254 and https://github.com/greenplum-db/gpdb/pull/13253.
there is a new guc, gp_log_endpints, that controls the logging of parallel retrieve cursor endpoints to the server log.

will be backported to 6X_STABLE

question:  do we want to mention this guc in the parallel retrieve cursor docs?  (i chose not to because it is superuser only.)
