### PR TITLE
Include the implementation identifier in the SMGR WAL record

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -949,7 +949,7 @@ aoco_relation_set_new_filenode(Relation rel,
 			   rel->rd_rel->relkind == RELKIND_MATVIEW ||
 			   rel->rd_rel->relkind == RELKIND_TOASTVALUE);
 		smgrcreate(srel, INIT_FORKNUM, false);
-		log_smgrcreate(newrnode, INIT_FORKNUM);
+		log_smgrcreate(newrnode, INIT_FORKNUM, SMGR_AO);
 		smgrimmedsync(srel, INIT_FORKNUM);
 	}
 
@@ -1027,7 +1027,7 @@ aoco_relation_copy_data(Relation rel, const RelFileNode *newrnode)
 		 */
 		smgrcreate(dstrel, INIT_FORKNUM, false);
 
-		log_smgrcreate(newrnode, INIT_FORKNUM);
+		log_smgrcreate(newrnode, INIT_FORKNUM, SMGR_AO);
 	}
 
 	/* drop old relation, and close new one */

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -767,7 +767,7 @@ appendonly_relation_set_new_filenode(Relation rel,
 			   rel->rd_rel->relkind == RELKIND_MATVIEW ||
 			   rel->rd_rel->relkind == RELKIND_TOASTVALUE);
 		smgrcreate(srel, INIT_FORKNUM, false);
-		log_smgrcreate(newrnode, INIT_FORKNUM);
+		log_smgrcreate(newrnode, INIT_FORKNUM, SMGR_AO);
 		smgrimmedsync(srel, INIT_FORKNUM);
 	}
 
@@ -834,7 +834,7 @@ appendonly_relation_copy_data(Relation rel, const RelFileNode *newrnode)
 		 */
 		smgrcreate(dstrel, INIT_FORKNUM, false);
 
-		log_smgrcreate(newrnode, INIT_FORKNUM);
+		log_smgrcreate(newrnode, INIT_FORKNUM, SMGR_AO);
 	}
 
 	/* drop old relation, and close new one */

--- a/src/backend/access/heap/heapam_handler.c
+++ b/src/backend/access/heap/heapam_handler.c
@@ -635,7 +635,7 @@ heapam_relation_set_new_filenode(Relation rel,
 			   rel->rd_rel->relkind == RELKIND_AOVISIMAP ||
 			   rel->rd_rel->relkind == RELKIND_AOBLOCKDIR);
 		smgrcreate(srel, INIT_FORKNUM, false);
-		log_smgrcreate(newrnode, INIT_FORKNUM);
+		log_smgrcreate(newrnode, INIT_FORKNUM, SMGR_MD);
 		smgrimmedsync(srel, INIT_FORKNUM);
 	}
 
@@ -692,7 +692,7 @@ heapam_relation_copy_data(Relation rel, const RelFileNode *newrnode)
 			if (rel->rd_rel->relpersistence == RELPERSISTENCE_PERMANENT ||
 				(rel->rd_rel->relpersistence == RELPERSISTENCE_UNLOGGED &&
 				 forkNum == INIT_FORKNUM))
-				log_smgrcreate(newrnode, forkNum);
+				log_smgrcreate(newrnode, forkNum, SMGR_MD);
 			RelationCopyStorage(rel->rd_smgr, dstrel, forkNum,
 								rel->rd_rel->relpersistence);
 		}

--- a/src/backend/access/rmgrdesc/smgrdesc.c
+++ b/src/backend/access/rmgrdesc/smgrdesc.c
@@ -27,8 +27,7 @@ smgr_desc(StringInfo buf, XLogReaderState *record)
 	{
 		xl_smgr_create *xlrec = (xl_smgr_create *) rec;
 		char	   *path = relpathperm(xlrec->rnode, xlrec->forkNum);
-
-		appendStringInfoString(buf, path);
+		appendStringInfo(buf, "%s; smgr: %s", path, xlrec->impl == SMGR_MD ? "heap" : "ao");
 		pfree(path);
 	}
 	else if (info == XLOG_SMGR_TRUNCATE)

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14800,7 +14800,7 @@ index_copy_data(Relation rel, RelFileNode newrnode)
 			if (rel->rd_rel->relpersistence == RELPERSISTENCE_PERMANENT ||
 				(rel->rd_rel->relpersistence == RELPERSISTENCE_UNLOGGED &&
 				 forkNum == INIT_FORKNUM))
-				log_smgrcreate(&newrnode, forkNum);
+				log_smgrcreate(&newrnode, forkNum, smgr_which);
 			RelationCopyStorage(rel->rd_smgr, dstrel, forkNum,
 								rel->rd_rel->relpersistence);
 		}

--- a/src/backend/storage/smgr/smgr.c
+++ b/src/backend/storage/smgr/smgr.c
@@ -220,20 +220,6 @@ smgropen(RelFileNode rnode, BackendId backend, SMgrImpl which)
 		/* it has no owner yet */
 		dlist_push_tail(&unowned_relns, &reln->node);
 	}
-	else if (reln->smgr_which != which)
-	{
-		/*
-		 * GPDB_12_MERGE_FIXME: SMGR WAL record does not have a way to
-		 * identify a specific SMGR implementation.  If the SMGR
-		 * implementation that the caller expects does not match the
-		 * implementation we already have in the hash table, it is most likely
-		 * due to calling smgropen when replaying a SMGR WAL record.  Fix the
-		 * expectation as a workaround for now.  A proper fix should include
-		 * the implementation identifier (smgr_which) in the SMGR WAL record.
-		 */
-		Assert(reln->smgr_which == 0);
-		reln->smgr_which = which;
-	}
 
 	return reln;
 }

--- a/src/include/catalog/storage_xlog.h
+++ b/src/include/catalog/storage_xlog.h
@@ -18,6 +18,7 @@
 #include "lib/stringinfo.h"
 #include "storage/block.h"
 #include "storage/relfilenode.h"
+#include "storage/smgr.h"
 
 /*
  * Declarations for smgr-related XLOG records
@@ -34,6 +35,7 @@ typedef struct xl_smgr_create
 {
 	RelFileNode rnode;
 	ForkNumber	forkNum;
+	SMgrImpl	impl;
 } xl_smgr_create;
 
 /* flags for xl_smgr_truncate */
@@ -50,7 +52,7 @@ typedef struct xl_smgr_truncate
 	int			flags;
 } xl_smgr_truncate;
 
-extern void log_smgrcreate(const RelFileNode *rnode, ForkNumber forkNum);
+extern void log_smgrcreate(const RelFileNode *rnode, ForkNumber forkNum, SMgrImpl impl);
 
 extern void smgr_redo(XLogReaderState *record);
 extern void smgr_desc(StringInfo buf, XLogReaderState *record);


### PR DESCRIPTION
>  GPDB_12_MERGE_FIXME: SMGR WAL record does not have a way to
>  identify a specific SMGR implementation.  If the SMGR
>  implementation that the caller expects does not match the
>  implementation we already have in the hash table, it is most likely
>  due to calling smgropen when replaying a SMGR WAL record.  Fix the
>  expectation as a workaround for now.  A proper fix should include
>  the implementation identifier (smgr_which) in the SMGR WAL record.

This commit appended the implementation identifier into the SMGR WAL record.
pg_waldump:
```
rmgr: Storage     len (rec/tot):     46/    46, tx:          0, lsn: 0/04FDF640, prev 0/04FDF620, desc: CREATE base/13379/16384; smgr: ao
rmgr: Storage     len (rec/tot):     46/    46, tx:          0, lsn: 0/050426C8, prev 0/05042690, desc: CREATE base/13379/16388; smgr: heap
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
