### PR TITLE
Remove FIXME about maxdistinct/sort_flags

### DIFF
--- a/src/backend/executor/nodeSort.c
+++ b/src/backend/executor/nodeSort.c
@@ -123,19 +123,6 @@ ExecSort(PlanState *pstate)
 		node->tuplesortstate = (void *) tuplesortstate;
 
 		/* CDB */
-		/* GPDB_12_MERGE_FIXME: these optimizations are currently broken */
-#if 0
-		{
-			int 		unique = 0;
-			int 		sort_flags = gp_sort_flags; /* get the guc */
-			int         maxdistinct = gp_sort_max_distinct; /* get the guc */
-
-			if (node->noduplicates)
-				unique = 1;
-			
-			cdb_tuplesort_init(tuplesortstate, unique, sort_flags, maxdistinct);
-		}
-#endif
 
 		/* If EXPLAIN ANALYZE, share our Instrumentation object with sort. */
 		/* GPDB_12_MERGE_FIXME: broken */


### PR DESCRIPTION
In ancient time (GPDB3) gp_sort_max_distinct was added as a patch for mechanism to 
choose heap sort or insertion sort when sorting tuple.

In GPDB6 (and older versions) there is mechanism to choose heap sort or insertion sort 
when sorting tuple: heap sort is used for sort without limit or duplicate elimination, or 
discard_ratio < 50, otherwise insertion sort is used. However, insertion sort is less 
efficient for large numbers of distinct values. In GPDB3 Cohen Jeffrey patched the sort 
to forcedly fallback to heap sort if the number of distinct values exceeds 20K. 
Tuplesortstate->gpmaxdistinct (and GUC gp_sort_max_distinct) with default value 20000 
indicates maximum distinct values.

The patch is meaningless for now because the entire mechanism is disappeared in GPDB7. 
The reason should be no insertion sort at all (tuplesort_sorted_insert() was removed). In 
addition, performance test shows that the code is useless even in GPDB6. So we just 
removed the FIXME.