### PR TITLE
Replace wrong target name with valid one

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,13 @@ make create-demo-cluster
 source gpAux/gpdemo/gpdemo-env.sh
 ```
 
-The directory and the TCP ports for the demo cluster can be changed on the fly.
-Instead of `make cluster`, consider:
+The directory, the TCP ports, the number of segments, and the existence of
+standbys for segments and coordinator for the demo cluster can be changed
+on the fly.
+Instead of `make create-demo-cluster`, consider:
 
 ```
-DATADIRS=/tmp/gpdb-cluster PORT_BASE=5555 make cluster
+DATADIRS=/tmp/gpdb-cluster PORT_BASE=5555 NUM_PRIMARY_MIRROR_PAIRS=1 WITH_MIRRORS=false make create-demo-cluster
 ```
 
 The TCP port for the regression test can be changed on the fly:


### PR DESCRIPTION
'make cluster' with enviroment variables was added after 'make cluster' in
fd2e045, but was not changed to 'make create-demo-cluster' in either c3d74c6
or bb022db. Add environment variables to the demo cluster creation command.
