### PR TITLE
Updated CPhysicalJoin to derive the inner distribution in the case of tainted replicated (6X)

### DIFF
--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -714,9 +714,6 @@ intorel_receive(TupleTableSlot *slot, DestReceiver *self)
 	DR_intorel *myState = (DR_intorel *) self;
 	Relation    into_rel = myState->rel;
 
-	if (into_rel == NULL)
-		return;
-
 	if (RelationIsAoRows(into_rel))
 	{
 		AOTupleId	aoTupleId;

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -714,6 +714,9 @@ intorel_receive(TupleTableSlot *slot, DestReceiver *self)
 	DR_intorel *myState = (DR_intorel *) self;
 	Relation    into_rel = myState->rel;
 
+	if (into_rel == NULL)
+		return;
+
 	if (RelationIsAoRows(into_rel))
 	{
 		AOTupleId	aoTupleId;

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpec.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpec.h
@@ -41,7 +41,7 @@ public:
 		EdtStrictHashed,  // same as hashed, used to force multiple slices for parallel union all. The motions mirror the distribution of the output columns.
 		EdtStrictReplicated,  // data is strictly replicated across all segments
 		EdtReplicated,	// data is strict or tainted replicated (required only)
-		EdtTaintedReplicated,  // data once-replicated, after being processed by an input-order-sensitive operator (derived only)
+		EdtTaintedReplicated,  // data once-replicated, after being processed by an input-order-sensitive operator or volatile function (derived only)
 		EdtAny,		   // data can be anywhere on the segments (required only)
 		EdtSingleton,  // data is on a single segment or the master
 		EdtStrictSingleton,	 // data is on a single segment or the master (derived only, only compatible with other singleton distributions)

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalJoin.cpp
@@ -445,6 +445,7 @@ CPhysicalJoin::PdsDerive(CMemoryPool *mp, CExpressionHandle &exprhdl) const
 	CDistributionSpec *pds;
 
 	if (CDistributionSpec::EdtStrictReplicated == pdsOuter->Edt() ||
+		CDistributionSpec::EdtTaintedReplicated == pdsOuter->Edt() ||
 		CDistributionSpec::EdtUniversal == pdsOuter->Edt())
 	{
 		// if outer is replicated/universal, return inner distribution

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -704,8 +704,6 @@ DROP TABLE foopart;
 -- we correctly handle all these cases.
 -- FIXME: ORCA does not consider this, we need to fix the cases when ORCA
 -- consider this.
-set optimizer = off;
-set enable_bitmapscan = off;
 create table t_hashdist(a int, b int, c int) distributed by (a);
 create table t_replicate_volatile(a int, b int, c int) distributed replicated;
 ---- pushed down filter
@@ -937,6 +935,8 @@ explain (costs off) select * from t_hashdist cross join (select * from t_replica
 create table rtbl (a int, b int, c int, t text) distributed replicated;
 insert into t_hashdist values (1, 1, 1);
 insert into rtbl values (1, 1, 1, 'rtbl');
+analyze t_hashdist;
+analyze rtbl;
 -- The below tests used to do replicated table scan on entry db which contains empty data.
 -- So a motion node is needed to gather replicated table on entry db.
 -- See issue: https://github.com/greenplum-db/gpdb/issues/11945
@@ -966,6 +966,7 @@ select count(*) from tmp; -- should contain 1 row
      1
 (1 row)
 
+set enable_bitmapscan=off;
 -- 2. Join hashed table with (replicated table join catalog) should return 1 row
 explain (costs off) select relname from t_hashdist, (select * from pg_class c join rtbl on c.relname = rtbl.t) vtest where t_hashdist.a = vtest.a;
                                        QUERY PLAN                                       
@@ -1010,43 +1011,201 @@ explain (costs off) select a from t_hashdist, (select oid from pg_class union al
  Optimizer: Postgres query optimizer
 (12 rows)
 
-reset optimizer;
 reset enable_bitmapscan;
--- Github Issue 13532
-create table t1_13532(a int, b int) distributed replicated;
-create table t2_13532(a int, b int) distributed replicated;
-create index idx_t2_13532 on t2_13532(b);
-explain (costs off) select * from t1_13532 x, t2_13532 y where y.a < random() and x.b = y.b;
-                              QUERY PLAN                              
-----------------------------------------------------------------------
- Hash Join
-   Hash Cond: (x.b = y.b)
-   ->  Gather Motion 1:1  (slice1; segments: 1)
-         ->  Seq Scan on t1_13532 x
-   ->  Hash
-         ->  Result
-               ->  Gather Motion 1:1  (slice2; segments: 1)
-                     ->  Bitmap Heap Scan on t2_13532 y
-                           Filter: ((a)::double precision < random())
-                           ->  Bitmap Index Scan on idx_t2_13532
+-- ORCA
+-- verify that JOIN derives the inner child distribution if the outer is tainted replicated (in this
+-- case, the inner child is the hash distributed table, but the distribution is random because the
+-- hash distribution key is not the JOIN key. we want to return the inner distribution because the
+-- JOIN key determines the distribution of the JOIN output).
+create table dist_tab (a integer, b integer) distributed by (a);
+create table rep_tab (c integer) distributed replicated;
+create index idx on dist_tab (b);
+insert into dist_tab values (1, 2), (2, 2), (2, 1), (1, 1);
+insert into rep_tab values (1), (2);
+analyze dist_tab;
+analyze rep_tab;
+set optimizer_enable_hashjoin=off;
+set enable_hashjoin=off;
+set enable_nestloop=on;
+explain select b from dist_tab where b in (select distinct c from rep_tab);
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000501.18..10000000503.40 rows=4 width=4)
+   ->  Nested Loop Semi Join  (cost=10000000501.18..10000000503.40 rows=2 width=4)
+         Join Filter: (dist_tab.b = rep_tab.c)
+         ->  Bitmap Heap Scan on dist_tab  (cost=500.15..502.19 rows=2 width=4)
+               ->  Bitmap Index Scan on idx  (cost=0.00..500.15 rows=2 width=0)
+         ->  Materialize  (cost=10000000001.03..10000000001.09 rows=1 width=4)
+               ->  GroupAggregate  (cost=10000000001.03..10000000001.06 rows=2 width=4)
+                     Group Key: rep_tab.c
+                     ->  Sort  (cost=10000000001.03..10000000001.03 rows=2 width=4)
+                           Sort Key: rep_tab.c
+                           ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+select b from dist_tab where b in (select distinct c from rep_tab);
+ b 
+---
+ 2
+ 1
+ 2
+ 1
+(4 rows)
+
+reset optimizer_enable_hashjoin;
+reset enable_hashjoin;
+reset enable_nestloop;
+create table rand_tab (d integer) distributed randomly;
+insert into rand_tab values (1), (2);
+analyze rand_tab;
+-- Table	Side		Derives
+-- rep_tab	pdsOuter	EdtTaintedReplicated
+-- rep_tab	pdsInner	EdtHashed
+--
+-- join derives EdtHashed
+explain select c from rep_tab where c in (select distinct c from rep_tab);
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=20000000001.11..20000000002.17 rows=4 width=4)
+   ->  Hash Semi Join  (cost=20000000001.11..20000000002.17 rows=4 width=4)
+         Hash Cond: (rep_tab.c = rep_tab_1.c)
+         ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
+         ->  Hash  (cost=10000000001.08..10000000001.08 rows=1 width=4)
+               ->  GroupAggregate  (cost=10000000001.03..10000000001.06 rows=2 width=4)
+                     Group Key: rep_tab_1.c
+                     ->  Sort  (cost=10000000001.03..10000000001.03 rows=2 width=4)
+                           Sort Key: rep_tab_1.c
+                           ->  Seq Scan on rep_tab rep_tab_1  (cost=10000000000.00..10000000001.02 rows=2 width=4)
  Optimizer: Postgres query optimizer
 (11 rows)
 
-set enable_bitmapscan = off;
-explain (costs off) select * from t1_13532 x, t2_13532 y where y.a < random() and x.b = y.b;
-                              QUERY PLAN                              
-----------------------------------------------------------------------
- Hash Join
-   Hash Cond: (x.b = y.b)
-   ->  Gather Motion 1:1  (slice1; segments: 1)
-         ->  Seq Scan on t1_13532 x
-   ->  Hash
-         ->  Result
-               ->  Gather Motion 1:1  (slice2; segments: 1)
-                     ->  Index Scan using idx_t2_13532 on t2_13532 y
-                           Filter: ((a)::double precision < random())
+select c from rep_tab where c in (select distinct c from rep_tab);
+ c 
+---
+ 1
+ 2
+(2 rows)
+
+-- Table	Side		Derives
+-- dist_tab	pdsOuter	EdtHashed
+-- rep_tab	pdsInner	EdtTaintedReplicated 
+--
+-- join derives EdtHashed
+explain select a from dist_tab where a in (select distinct c from rep_tab);
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=20000000001.11..20000000003.20 rows=4 width=4)
+   ->  Hash Semi Join  (cost=20000000001.11..20000000003.20 rows=2 width=4)
+         Hash Cond: (dist_tab.a = rep_tab.c)
+         ->  Seq Scan on dist_tab  (cost=10000000000.00..10000000002.04 rows=2 width=4)
+         ->  Hash  (cost=10000000001.08..10000000001.08 rows=1 width=4)
+               ->  GroupAggregate  (cost=10000000001.03..10000000001.06 rows=2 width=4)
+                     Group Key: rep_tab.c
+                     ->  Sort  (cost=10000000001.03..10000000001.03 rows=2 width=4)
+                           Sort Key: rep_tab.c
+                           ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select a from dist_tab where a in (select distinct c from rep_tab);
+ a 
+---
+ 2
+ 2
+ 1
+ 1
+(4 rows)
+
+-- Table	Side		Derives
+-- rand_tab	pdsOuter	EdtRandom
+-- rep_tab	pdsInner	EdtTaintedReplicated
+--
+-- join derives EdtRandom
+explain select d from rand_tab where d in (select distinct c from rep_tab);
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=20000000001.11..20000000002.17 rows=4 width=4)
+   ->  Hash Semi Join  (cost=20000000001.11..20000000002.17 rows=2 width=4)
+         Hash Cond: (rand_tab.d = rep_tab.c)
+         ->  Seq Scan on rand_tab  (cost=10000000000.00..10000000001.02 rows=1 width=4)
+         ->  Hash  (cost=10000000001.08..10000000001.08 rows=1 width=4)
+               ->  GroupAggregate  (cost=10000000001.03..10000000001.06 rows=2 width=4)
+                     Group Key: rep_tab.c
+                     ->  Sort  (cost=10000000001.03..10000000001.03 rows=2 width=4)
+                           Sort Key: rep_tab.c
+                           ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select d from rand_tab where d in (select distinct c from rep_tab);
+ d 
+---
+ 1
+ 2
+(2 rows)
+
+-- Table	Side		Derives
+-- rep_tab	pdsOuter	EdtTaintedReplicated
+-- dist_tab	pdsInner	EdtHashed
+--
+-- join derives EdtHashed
+explain select c from rep_tab where c in (select distinct a from dist_tab);
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Hash Semi Join  (cost=20000000003.18..20000000003.22 rows=4 width=4)
+   Hash Cond: (rep_tab.c = dist_tab.a)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=10000000001.02..10000000001.02 rows=2 width=4)
+         ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
+   ->  Hash  (cost=10000000002.13..10000000002.13 rows=1 width=4)
+         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000002.05..10000000002.13 rows=2 width=4)
+               ->  HashAggregate  (cost=10000000002.05..10000000002.07 rows=1 width=4)
+                     Group Key: dist_tab.a
+                     ->  Seq Scan on dist_tab  (cost=10000000000.00..10000000002.04 rows=2 width=4)
  Optimizer: Postgres query optimizer
 (10 rows)
+
+select c from rep_tab where c in (select distinct a from dist_tab);
+ c 
+---
+ 1
+ 2
+(2 rows)
+
+-- Table	Side		Derives
+-- rep_tab	pdsOuter	EdtTaintedReplicated
+-- rand_tab	pdsInner	EdtHashed
+--
+-- join derives EdtHashed
+explain select c from rep_tab where c in (select distinct d from rand_tab);
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Hash Semi Join  (cost=20000000002.27..20000000002.31 rows=4 width=4)
+   Hash Cond: (rep_tab.c = rand_tab.d)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=10000000001.02..10000000001.02 rows=2 width=4)
+         ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
+   ->  Hash  (cost=10000000001.22..10000000001.22 rows=1 width=4)
+         ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=10000000001.11..10000000001.22 rows=2 width=4)
+               ->  GroupAggregate  (cost=10000000001.11..10000000001.16 rows=1 width=4)
+                     Group Key: rand_tab.d
+                     ->  Sort  (cost=10000000001.11..10000000001.11 rows=1 width=4)
+                           Sort Key: rand_tab.d
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=10000000001.03..10000000001.10 rows=1 width=4)
+                                 Hash Key: rand_tab.d
+                                 ->  GroupAggregate  (cost=10000000001.03..10000000001.06 rows=1 width=4)
+                                       Group Key: rand_tab.d
+                                       ->  Sort  (cost=10000000001.03..10000000001.03 rows=1 width=4)
+                                             Sort Key: rand_tab.d
+                                             ->  Seq Scan on rand_tab  (cost=10000000000.00..10000000001.02 rows=1 width=4)
+ Optimizer: Postgres query optimizer
+(18 rows)
+
+select c from rep_tab where c in (select distinct d from rand_tab);
+ c 
+---
+ 1
+ 2
+(2 rows)
 
 -- start_ignore
 drop schema rpt cascade;

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -704,6 +704,8 @@ DROP TABLE foopart;
 -- we correctly handle all these cases.
 -- FIXME: ORCA does not consider this, we need to fix the cases when ORCA
 -- consider this.
+set optimizer = off;
+set enable_bitmapscan = off;
 create table t_hashdist(a int, b int, c int) distributed by (a);
 create table t_replicate_volatile(a int, b int, c int) distributed replicated;
 ---- pushed down filter
@@ -964,7 +966,6 @@ select count(*) from tmp; -- should contain 1 row
      1
 (1 row)
 
-set enable_bitmapscan=off;
 -- 2. Join hashed table with (replicated table join catalog) should return 1 row
 explain (costs off) select relname from t_hashdist, (select * from pg_class c join rtbl on c.relname = rtbl.t) vtest where t_hashdist.a = vtest.a;
                                        QUERY PLAN                                       
@@ -1009,6 +1010,7 @@ explain (costs off) select a from t_hashdist, (select oid from pg_class union al
  Optimizer: Postgres query optimizer
 (12 rows)
 
+reset optimizer;
 reset enable_bitmapscan;
 -- Github Issue 13532
 create table t1_13532(a int, b int) distributed replicated;

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -935,8 +935,6 @@ explain (costs off) select * from t_hashdist cross join (select * from t_replica
 create table rtbl (a int, b int, c int, t text) distributed replicated;
 insert into t_hashdist values (1, 1, 1);
 insert into rtbl values (1, 1, 1, 'rtbl');
-analyze t_hashdist;
-analyze rtbl;
 -- The below tests used to do replicated table scan on entry db which contains empty data.
 -- So a motion node is needed to gather replicated table on entry db.
 -- See issue: https://github.com/greenplum-db/gpdb/issues/11945
@@ -1012,6 +1010,42 @@ explain (costs off) select a from t_hashdist, (select oid from pg_class union al
 (12 rows)
 
 reset enable_bitmapscan;
+-- Github Issue 13532
+create table t1_13532(a int, b int) distributed replicated;
+create table t2_13532(a int, b int) distributed replicated;
+create index idx_t2_13532 on t2_13532(b);
+explain (costs off) select * from t1_13532 x, t2_13532 y where y.a < random() and x.b = y.b;
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Hash Join
+   Hash Cond: (x.b = y.b)
+   ->  Gather Motion 1:1  (slice1; segments: 1)
+         ->  Seq Scan on t1_13532 x
+   ->  Hash
+         ->  Result
+               ->  Gather Motion 1:1  (slice2; segments: 1)
+                     ->  Bitmap Heap Scan on t2_13532 y
+                           Filter: ((a)::double precision < random())
+                           ->  Bitmap Index Scan on idx_t2_13532
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+set enable_bitmapscan = off;
+explain (costs off) select * from t1_13532 x, t2_13532 y where y.a < random() and x.b = y.b;
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Hash Join
+   Hash Cond: (x.b = y.b)
+   ->  Gather Motion 1:1  (slice1; segments: 1)
+         ->  Seq Scan on t1_13532 x
+   ->  Hash
+         ->  Result
+               ->  Gather Motion 1:1  (slice2; segments: 1)
+                     ->  Index Scan using idx_t2_13532 on t2_13532 y
+                           Filter: ((a)::double precision < random())
+ Optimizer: Postgres query optimizer
+(10 rows)
+
 -- ORCA
 -- verify that JOIN derives the inner child distribution if the outer is tainted replicated (in this
 -- case, the inner child is the hash distributed table, but the distribution is random because the
@@ -1028,29 +1062,27 @@ set optimizer_enable_hashjoin=off;
 set enable_hashjoin=off;
 set enable_nestloop=on;
 explain select b from dist_tab where b in (select distinct c from rep_tab);
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000501.18..10000000503.40 rows=4 width=4)
-   ->  Nested Loop Semi Join  (cost=10000000501.18..10000000503.40 rows=2 width=4)
-         Join Filter: (dist_tab.b = rep_tab.c)
-         ->  Bitmap Heap Scan on dist_tab  (cost=500.15..502.19 rows=2 width=4)
-               ->  Bitmap Index Scan on idx  (cost=0.00..500.15 rows=2 width=0)
-         ->  Materialize  (cost=10000000001.03..10000000001.09 rows=1 width=4)
-               ->  GroupAggregate  (cost=10000000001.03..10000000001.06 rows=2 width=4)
-                     Group Key: rep_tab.c
-                     ->  Sort  (cost=10000000001.03..10000000001.03 rows=2 width=4)
-                           Sort Key: rep_tab.c
-                           ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000001.16..10000000601.46 rows=4 width=4)
+   ->  Nested Loop  (cost=10000000001.16..10000000601.46 rows=2 width=4)
+         ->  GroupAggregate  (cost=10000000001.03..10000000001.06 rows=2 width=4)
+               Group Key: rep_tab.c
+               ->  Sort  (cost=10000000001.03..10000000001.03 rows=2 width=4)
+                     Sort Key: rep_tab.c
+                     ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
+         ->  Index Only Scan using idx on dist_tab  (cost=0.13..300.17 rows=1 width=4)
+               Index Cond: (b = rep_tab.c)
  Optimizer: Postgres query optimizer
-(12 rows)
+(10 rows)
 
 select b from dist_tab where b in (select distinct c from rep_tab);
  b 
 ---
- 2
  1
  2
  1
+ 2
 (4 rows)
 
 reset optimizer_enable_hashjoin;
@@ -1125,10 +1157,10 @@ select a from dist_tab where a in (select distinct c from rep_tab);
 explain select d from rand_tab where d in (select distinct c from rep_tab);
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=20000000001.11..20000000002.17 rows=4 width=4)
-   ->  Hash Semi Join  (cost=20000000001.11..20000000002.17 rows=2 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=20000000001.11..20000000003.17 rows=4 width=4)
+   ->  Hash Semi Join  (cost=20000000001.11..20000000003.17 rows=2 width=4)
          Hash Cond: (rand_tab.d = rep_tab.c)
-         ->  Seq Scan on rand_tab  (cost=10000000000.00..10000000001.02 rows=1 width=4)
+         ->  Seq Scan on rand_tab  (cost=10000000000.00..10000000002.02 rows=1 width=4)
          ->  Hash  (cost=10000000001.08..10000000001.08 rows=1 width=4)
                ->  GroupAggregate  (cost=10000000001.03..10000000001.06 rows=2 width=4)
                      Group Key: rep_tab.c
@@ -1141,8 +1173,8 @@ explain select d from rand_tab where d in (select distinct c from rep_tab);
 select d from rand_tab where d in (select distinct c from rep_tab);
  d 
 ---
- 1
  2
+ 1
 (2 rows)
 
 -- Table	Side		Derives
@@ -1180,23 +1212,23 @@ select c from rep_tab where c in (select distinct a from dist_tab);
 explain select c from rep_tab where c in (select distinct d from rand_tab);
                                                              QUERY PLAN                                                             
 ------------------------------------------------------------------------------------------------------------------------------------
- Hash Semi Join  (cost=20000000002.27..20000000002.31 rows=4 width=4)
+ Hash Semi Join  (cost=20000000003.27..20000000003.31 rows=4 width=4)
    Hash Cond: (rep_tab.c = rand_tab.d)
    ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=10000000001.02..10000000001.02 rows=2 width=4)
          ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
-   ->  Hash  (cost=10000000001.22..10000000001.22 rows=1 width=4)
-         ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=10000000001.11..10000000001.22 rows=2 width=4)
-               ->  GroupAggregate  (cost=10000000001.11..10000000001.16 rows=1 width=4)
+   ->  Hash  (cost=10000000002.22..10000000002.22 rows=1 width=4)
+         ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=10000000002.11..10000000002.22 rows=2 width=4)
+               ->  GroupAggregate  (cost=10000000002.11..10000000002.16 rows=1 width=4)
                      Group Key: rand_tab.d
-                     ->  Sort  (cost=10000000001.11..10000000001.11 rows=1 width=4)
+                     ->  Sort  (cost=10000000002.11..10000000002.11 rows=1 width=4)
                            Sort Key: rand_tab.d
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=10000000001.03..10000000001.10 rows=1 width=4)
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=10000000002.03..10000000002.10 rows=1 width=4)
                                  Hash Key: rand_tab.d
-                                 ->  GroupAggregate  (cost=10000000001.03..10000000001.06 rows=1 width=4)
+                                 ->  GroupAggregate  (cost=10000000002.03..10000000002.06 rows=1 width=4)
                                        Group Key: rand_tab.d
-                                       ->  Sort  (cost=10000000001.03..10000000001.03 rows=1 width=4)
+                                       ->  Sort  (cost=10000000002.03..10000000002.03 rows=1 width=4)
                                              Sort Key: rand_tab.d
-                                             ->  Seq Scan on rand_tab  (cost=10000000000.00..10000000001.02 rows=1 width=4)
+                                             ->  Seq Scan on rand_tab  (cost=10000000000.00..10000000002.02 rows=1 width=4)
  Optimizer: Postgres query optimizer
 (18 rows)
 

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -123,10 +123,10 @@ insert into foo values (1,'aaa');
 insert into foo values (2,'bbb');
 -- fail
 insert into foo values (1,'ccc');
-ERROR:  duplicate key value violates unique constraint "foo_pkey"  (seg0 127.0.1.1:6002 pid=287620)
+ERROR:  duplicate key value violates unique constraint "foo_pkey"  (seg0 172.17.0.2:6002 pid=23394)
 DETAIL:  Key (id)=(1) already exists.
 insert into foo values (3,'aaa');
-ERROR:  duplicate key value violates unique constraint "foo_name_key"  (seg0 127.0.1.1:6002 pid=287620)
+ERROR:  duplicate key value violates unique constraint "foo_name_key"  (seg0 172.17.0.2:6002 pid=23394)
 DETAIL:  Key (name)=(aaa) already exists.
 drop table if exists foo;
 --
@@ -232,8 +232,8 @@ select * from bar;
  c1 | c2 
 ----+----
   1 |  1
-  3 |  3
   2 |  2
+  3 |  3
 (3 rows)
 
 drop table if exists foo;
@@ -245,9 +245,9 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entr
 select * from foo;
  c1 | c2 
 ----+----
-  1 |  1
-  2 |  2
   3 |  3
+  2 |  2
+  1 |  1
 (3 rows)
 
 create table bar as select * from foo order by c1 limit 1 distributed replicated;
@@ -357,15 +357,15 @@ select * from foo;
 select * from foo1;
  x  | y  
 ----+----
-  6 |  6
-  8 |  8
   9 |  9
  10 | 10
-  1 |  1
-  3 |  3
-  4 |  4
-  5 |  5
   2 |  2
+  3 |  3
+  5 |  5
+  8 |  8
+  1 |  1
+  4 |  4
+  6 |  6
   7 |  7
 (10 rows)
 
@@ -377,26 +377,26 @@ select * from bar;
   4 |  4
   7 |  7
   8 |  8
+  1 |  1
   5 |  5
   6 |  6
   9 |  9
  10 | 10
-  1 |  1
 (10 rows)
 
 select * from bar1;
  x  | y  
 ----+----
-  6 |  6
-  1 |  1
   4 |  4
-  7 |  7
   8 |  8
-  9 |  9
  10 | 10
+  1 |  1
+  5 |  5
+  6 |  6
+  7 |  7
+  9 |  9
   2 |  2
   3 |  3
-  5 |  5
 (10 rows)
 
 -- alter back
@@ -441,61 +441,61 @@ Distributed randomly
 select * from foo;
  x  | y  
 ----+----
-  1 |  1
-  5 |  5
-  6 |  6
-  9 |  9
- 10 | 10
   2 |  2
   3 |  3
   4 |  4
   7 |  7
   8 |  8
+  1 |  1
+  5 |  5
+  6 |  6
+  9 |  9
+ 10 | 10
 (10 rows)
 
 select * from foo1;
  x  | y  
 ----+----
-  2 |  2
-  7 |  7
+  1 |  1
+  4 |  4
   6 |  6
-  8 |  8
+  7 |  7
   9 |  9
  10 | 10
-  1 |  1
+  2 |  2
   3 |  3
-  4 |  4
   5 |  5
+  8 |  8
 (10 rows)
 
 select * from bar;
  x  | y  
 ----+----
-  1 |  1
-  5 |  5
-  6 |  6
-  9 |  9
- 10 | 10
   2 |  2
   3 |  3
   4 |  4
   7 |  7
   8 |  8
+  1 |  1
+  5 |  5
+  6 |  6
+  9 |  9
+ 10 | 10
 (10 rows)
 
 select * from bar1;
  x  | y  
 ----+----
+  4 |  4
+ 10 | 10
+  5 |  5
+  7 |  7
+  2 |  2
   6 |  6
-  8 |  8
   3 |  3
+  8 |  8
   1 |  1
   9 |  9
-  4 |  4
-  7 |  7
- 10 | 10
-  2 |  2
-  5 |  5
 (10 rows)
 
 drop table if exists foo;
@@ -702,71 +702,69 @@ DROP TABLE foopart;
 -- we correctly handle all these cases.
 -- FIXME: ORCA does not consider this, we need to fix the cases when ORCA
 -- consider this.
-set optimizer = off;
-set enable_bitmapscan = off;
 create table t_hashdist(a int, b int, c int) distributed by (a);
 create table t_replicate_volatile(a int, b int, c int) distributed replicated;
 ---- pushed down filter
 explain (costs off) select * from t_replicate_volatile, t_hashdist where t_replicate_volatile.a > random();
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
+         Join Filter: true
          ->  Seq Scan on t_hashdist
-         ->  Materialize
-               ->  Broadcast Motion 1:3  (slice1; segments: 1)
-                     ->  Result
-                           ->  Seq Scan on t_replicate_volatile
-                                 Filter: ((a)::double precision > random())
- Optimizer: Postgres query optimizer
-(9 rows)
+         ->  Seq Scan on t_replicate_volatile
+               Filter: ((a)::double precision > random())
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
 
 -- join qual
 explain (costs off) select * from t_hashdist, t_replicate_volatile x, t_replicate_volatile y where x.a + y.a > random();
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Nested Loop
-   ->  Result
-         ->  Gather Motion 1:1  (slice1; segments: 1)
-               ->  Nested Loop
-                     Join Filter: (((x.a + y.a))::double precision > random())
-                     ->  Seq Scan on t_replicate_volatile x
-                     ->  Materialize
-                           ->  Seq Scan on t_replicate_volatile y
-   ->  Materialize
-         ->  Gather Motion 3:1  (slice2; segments: 3)
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop
+         Join Filter: (((t_replicate_volatile_1.a + t_replicate_volatile.a))::double precision > random())
+         ->  Nested Loop
+               Join Filter: true
                ->  Seq Scan on t_hashdist
- Optimizer: Postgres query optimizer
-(12 rows)
+               ->  Seq Scan on t_replicate_volatile t_replicate_volatile_1
+         ->  Seq Scan on t_replicate_volatile
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
 
 -- sublink & subquery
 explain (costs off) select * from t_hashdist where a > All (select random() from t_replicate_volatile);
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)
-   ->  Nested Loop Left Anti Semi (Not-In) Join
-         Join Filter: ((t_hashdist.a)::double precision <= "NotIn_SUBQUERY".random)
-         ->  Seq Scan on t_hashdist
-         ->  Materialize
-               ->  Broadcast Motion 1:3  (slice1; segments: 1)
-                     ->  Subquery Scan on "NotIn_SUBQUERY"
-                           ->  Seq Scan on t_replicate_volatile
- Optimizer: Postgres query optimizer
-(9 rows)
+                                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on t_hashdist
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice1; segments: 3)
+           ->  Result
+                 ->  Result
+                       Filter: ((CASE WHEN ((sum((CASE WHEN ((t_hashdist.a)::double precision <= (random())) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN ((random()) IS NULL) THEN 1 ELSE 0 END))) > 0::bigint) THEN NULL::boolean WHEN ((t_hashdist.a)::double precision IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN ((t_hashdist.a)::double precision <= (random())) THEN 1 ELSE 0 END))) = 0::bigint) THEN true ELSE false END) = true)
+                       ->  Result
+                             ->  Aggregate
+                                   ->  Result
+                                         ->  Result
+                                               ->  Seq Scan on t_replicate_volatile
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
 
 explain (costs off) select * from t_hashdist where a in (select random()::int from t_replicate_volatile);
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Hash Semi Join
-         Hash Cond: (t_hashdist.a = ((random())::integer))
+         Hash Cond: (t_hashdist.a = (int4(random())))
          ->  Seq Scan on t_hashdist
          ->  Hash
                ->  Redistribute Motion 1:3  (slice1; segments: 1)
-                     Hash Key: ((random())::integer)
-                     ->  Seq Scan on t_replicate_volatile
- Optimizer: Postgres query optimizer
-(9 rows)
+                     Hash Key: (int4(random()))
+                     ->  Result
+                           ->  Seq Scan on t_replicate_volatile
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
 
 -- subplan
 explain (costs off, verbose) select * from t_hashdist left join t_replicate_volatile on t_hashdist.a > any (select random() from t_replicate_volatile);
@@ -791,150 +789,168 @@ explain (costs off, verbose) select * from t_hashdist left join t_replicate_vola
                        ->  Seq Scan on rpt.t_replicate_volatile t_replicate_volatile_1
                              Output: random()
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
+ Settings: enable_seqscan=off
 (20 rows)
 
 -- targetlist
 explain (costs off) select * from t_hashdist cross join (select random () from t_replicate_volatile)x;
-                          QUERY PLAN                           
----------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)
-   ->  Nested Loop
-         ->  Seq Scan on t_hashdist
-         ->  Materialize
-               ->  Broadcast Motion 1:3  (slice1; segments: 1)
-                     ->  Seq Scan on t_replicate_volatile
- Optimizer: Postgres query optimizer
-(7 rows)
-
-explain (costs off) select * from t_hashdist cross join (select a, sum(random()) from t_replicate_volatile group by a) x;
-                           QUERY PLAN                           
-----------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)
-   ->  Nested Loop
-         ->  Seq Scan on t_hashdist
-         ->  Materialize
-               ->  Broadcast Motion 1:3  (slice1; segments: 1)
-                     ->  HashAggregate
-                           Group Key: t_replicate_volatile.a
-                           ->  Seq Scan on t_replicate_volatile
- Optimizer: Postgres query optimizer
-(9 rows)
-
-explain (costs off) select * from t_hashdist cross join (select random() as k, sum(a) from t_replicate_volatile group by k) x;
                         QUERY PLAN                        
 ----------------------------------------------------------
- Nested Loop
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Seq Scan on t_hashdist
-   ->  Materialize
-         ->  Gather Motion 1:1  (slice2; segments: 1)
-               ->  HashAggregate
-                     Group Key: random()
-                     ->  Seq Scan on t_replicate_volatile
- Optimizer: Postgres query optimizer
-(9 rows)
-
-explain (costs off) select * from t_hashdist cross join (select a, sum(b) as s from t_replicate_volatile group by a having sum(b) > random() order by a) x ;
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)
+ Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
+         Join Filter: true
          ->  Seq Scan on t_hashdist
          ->  Materialize
-               ->  Broadcast Motion 1:3  (slice1; segments: 1)
+               ->  Result
+                     ->  Seq Scan on t_replicate_volatile
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+explain (costs off) select * from t_hashdist cross join (select a, sum(random()) from t_replicate_volatile group by a) x;
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Seq Scan on t_hashdist
+         ->  GroupAggregate
+               Group Key: t_replicate_volatile.a
+               ->  Sort
+                     Sort Key: t_replicate_volatile.a
+                     ->  Seq Scan on t_replicate_volatile
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+explain (costs off) select * from t_hashdist cross join (select random() as k, sum(a) from t_replicate_volatile group by k) x;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Broadcast Motion 3:3  (slice2; segments: 3)
+               ->  Seq Scan on t_hashdist
+         ->  GroupAggregate
+               Group Key: (random())
+               ->  Sort
+                     Sort Key: (random())
+                     ->  Redistribute Motion 1:3  (slice1; segments: 1)
+                           Hash Key: (random())
+                           ->  Result
+                                 ->  Result
+                                       ->  Seq Scan on t_replicate_volatile
+ Optimizer: Pivotal Optimizer (GPORCA)
+(15 rows)
+
+explain (costs off) select * from t_hashdist cross join (select a, sum(b) as s from t_replicate_volatile group by a having sum(b) > random() order by a) x ;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Seq Scan on t_hashdist
+         ->  Result
+               Filter: (((sum(t_replicate_volatile.b)))::double precision > random())
+               ->  GroupAggregate
+                     Group Key: t_replicate_volatile.a
                      ->  Sort
                            Sort Key: t_replicate_volatile.a
-                           ->  HashAggregate
-                                 Group Key: t_replicate_volatile.a
-                                 Filter: ((sum(t_replicate_volatile.b))::double precision > random())
-                                 ->  Seq Scan on t_replicate_volatile
- Optimizer: Postgres query optimizer
+                           ->  Seq Scan on t_replicate_volatile
+ Optimizer: Pivotal Optimizer (GPORCA)
 (12 rows)
 
 -- insert
 explain (costs off) insert into t_replicate_volatile select random() from t_replicate_volatile;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
- Insert on t_replicate_volatile
-   ->  Broadcast Motion 1:3  (slice1; segments: 1)
-         ->  Subquery Scan on "*SELECT*"
-               ->  Seq Scan on t_replicate_volatile t_replicate_volatile_1
- Optimizer: Postgres query optimizer
-(5 rows)
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Insert
+   ->  Result
+         ->  Broadcast Motion 1:3  (slice1; segments: 1)
+               ->  Result
+                     ->  Seq Scan on t_replicate_volatile
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
 
 explain (costs off) insert into t_replicate_volatile select random(), a, a from generate_series(1, 10) a;
-                      QUERY PLAN                      
-------------------------------------------------------
- Insert on t_replicate_volatile
-   ->  Broadcast Motion 1:3  (slice1; segments: 1)
-         ->  Subquery Scan on "*SELECT*"
-               ->  Function Scan on generate_series a
- Optimizer: Postgres query optimizer
-(5 rows)
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Insert
+   ->  Result
+         ->  Broadcast Motion 1:3  (slice1)
+               ->  Result
+                     ->  Result
+                           ->  Result
+                                 ->  Function Scan on generate_series
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
 
 create sequence seq_for_insert_replicated_table;
 explain (costs off) insert into t_replicate_volatile select nextval('seq_for_insert_replicated_table');
-                    QUERY PLAN                     
----------------------------------------------------
- Insert on t_replicate_volatile
-   ->  Broadcast Motion 1:3  (slice1; segments: 1)
-         ->  Subquery Scan on "*SELECT*"
+                 QUERY PLAN                 
+--------------------------------------------
+ Insert
+   ->  Result
+         ->  Broadcast Motion 1:3  (slice1)
                ->  Result
- Optimizer: Postgres query optimizer
-(5 rows)
+                     ->  Result
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
 
 explain (costs off) select a from t_replicate_volatile union all select * from nextval('seq_for_insert_replicated_table');
                      QUERY PLAN                     
 ----------------------------------------------------
- Append
-   ->  Gather Motion 1:1  (slice1; segments: 1)
-         ->  Subquery Scan on "*SELECT* 1"
+ Gather Motion 1:1  (slice2; segments: 1)
+   ->  Append
+         ->  Result
                ->  Seq Scan on t_replicate_volatile
-   ->  Function Scan on nextval
- Optimizer: Postgres query optimizer
-(6 rows)
+         ->  Broadcast Motion 1:1  (slice1)
+               ->  Function Scan on nextval
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
 
 -- update & delete
 explain (costs off) update t_replicate_volatile set a = 1 where b > random();
-ERROR:  could not devise a plan (cdbpath.c:2089)
+ERROR:  could not devise a plan (cdbpath.c:2082)
 explain (costs off) update t_replicate_volatile set a = 1 from t_replicate_volatile x where x.a + random() = t_replicate_volatile.b;
-ERROR:  could not devise a plan (cdbpath.c:2089)
+ERROR:  could not devise a plan (cdbpath.c:2082)
 explain (costs off) update t_replicate_volatile set a = 1 from t_hashdist x where x.a + random() = t_replicate_volatile.b;
-ERROR:  could not devise a plan (cdbpath.c:2089)
+ERROR:  could not devise a plan (cdbpath.c:2082)
 explain (costs off) delete from t_replicate_volatile where a < random();
-ERROR:  could not devise a plan (cdbpath.c:2089)
+ERROR:  could not devise a plan (cdbpath.c:2082)
 explain (costs off) delete from t_replicate_volatile using t_replicate_volatile x where t_replicate_volatile.a + x.b < random();
-ERROR:  could not devise a plan (cdbpath.c:2089)
+ERROR:  could not devise a plan (cdbpath.c:2082)
 explain (costs off) update t_replicate_volatile set a = random();
 ERROR:  could not devise a plan (createplan.c:6507)
 -- limit
 explain (costs off) insert into t_replicate_volatile select * from t_replicate_volatile limit 1;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
- Insert on t_replicate_volatile
-   ->  Broadcast Motion 1:3  (slice1; segments: 1)
-         ->  Limit
-               ->  Seq Scan on t_replicate_volatile t_replicate_volatile_1
- Optimizer: Postgres query optimizer
-(5 rows)
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Insert
+   ->  Result
+         ->  Broadcast Motion 1:3  (slice1; segments: 1)
+               ->  Limit
+                     ->  Seq Scan on t_replicate_volatile
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
 
 explain (costs off) select * from t_hashdist cross join (select * from t_replicate_volatile limit 1) x;
-                           QUERY PLAN                           
-----------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)
-   ->  Nested Loop
-         ->  Seq Scan on t_hashdist
-         ->  Materialize
-               ->  Broadcast Motion 1:3  (slice1; segments: 1)
-                     ->  Limit
-                           ->  Seq Scan on t_replicate_volatile
- Optimizer: Postgres query optimizer
-(8 rows)
+                      QUERY PLAN                      
+------------------------------------------------------
+ Nested Loop
+   Join Filter: true
+   ->  Limit
+         ->  Gather Motion 1:1  (slice2; segments: 1)
+               ->  Seq Scan on t_replicate_volatile
+   ->  Materialize
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               ->  Seq Scan on t_hashdist
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
 
 create table rtbl (a int, b int, c int, t text) distributed replicated;
 insert into t_hashdist values (1, 1, 1);
 insert into rtbl values (1, 1, 1, 'rtbl');
+analyze t_hashdist;
+analyze rtbl;
 -- The below tests used to do replicated table scan on entry db which contains empty data.
 -- So a motion node is needed to gather replicated table on entry db.
 -- See issue: https://github.com/greenplum-db/gpdb/issues/11945
@@ -964,6 +980,7 @@ select count(*) from tmp; -- should contain 1 row
      1
 (1 row)
 
+set enable_bitmapscan=off;
 -- 2. Join hashed table with (replicated table join catalog) should return 1 row
 explain (costs off) select relname from t_hashdist, (select * from pg_class c join rtbl on c.relname = rtbl.t) vtest where t_hashdist.a = vtest.a;
                                        QUERY PLAN                                       
@@ -1008,42 +1025,195 @@ explain (costs off) select a from t_hashdist, (select oid from pg_class union al
  Optimizer: Postgres query optimizer
 (12 rows)
 
-reset optimizer;
 reset enable_bitmapscan;
--- Github Issue 13532
-create table t1_13532(a int, b int) distributed replicated;
-create table t2_13532(a int, b int) distributed replicated;
-create index idx_t2_13532 on t2_13532(b);
-explain (costs off) select * from t1_13532 x, t2_13532 y where y.a < random() and x.b = y.b;
-                        QUERY PLAN                        
-----------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)
-   ->  Nested Loop
+-- ORCA
+-- verify that JOIN derives the inner child distribution if the outer is tainted replicated (in this
+-- case, the inner child is the hash distributed table, but the distribution is random because the
+-- hash distribution key is not the JOIN key. we want to return the inner distribution because the
+-- JOIN key determines the distribution of the JOIN output).
+create table dist_tab (a integer, b integer) distributed by (a);
+create table rep_tab (c integer) distributed replicated;
+create index idx on dist_tab (b);
+insert into dist_tab values (1, 2), (2, 2), (2, 1), (1, 1);
+insert into rep_tab values (1), (2);
+analyze dist_tab;
+analyze rep_tab;
+set optimizer_enable_hashjoin=off;
+set enable_hashjoin=off;
+set enable_nestloop=on;
+explain select b from dist_tab where b in (select distinct c from rep_tab);
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..443.00 rows=4 width=4)
+   ->  Nested Loop  (cost=0.00..443.00 rows=2 width=4)
          Join Filter: true
-         ->  Seq Scan on t1_13532
-         ->  Index Scan using idx_t2_13532 on t2_13532
-               Index Cond: (b = t1_13532.b)
-               Filter: ((a)::double precision < random())
+         ->  GroupAggregate  (cost=0.00..431.00 rows=2 width=4)
+               Group Key: rep_tab.c
+               ->  Sort  (cost=0.00..431.00 rows=2 width=4)
+                     Sort Key: rep_tab.c
+                     ->  Seq Scan on rep_tab  (cost=0.00..431.00 rows=2 width=4)
+         ->  Index Scan using idx on dist_tab  (cost=0.00..12.00 rows=1 width=4)
+               Index Cond: (b = rep_tab.c)
  Optimizer: Pivotal Optimizer (GPORCA)
-(8 rows)
+(11 rows)
 
-set enable_bitmapscan = off;
-explain (costs off) select * from t1_13532 x, t2_13532 y where y.a < random() and x.b = y.b;
-                        QUERY PLAN                        
-----------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)
-   ->  Nested Loop
-         Join Filter: true
-         ->  Seq Scan on t1_13532
-         ->  Index Scan using idx_t2_13532 on t2_13532
-               Index Cond: (b = t1_13532.b)
-               Filter: ((a)::double precision < random())
+select b from dist_tab where b in (select distinct c from rep_tab);
+ b 
+---
+ 1
+ 2
+ 1
+ 2
+(4 rows)
+
+reset optimizer_enable_hashjoin;
+reset enable_hashjoin;
+reset enable_nestloop;
+create table rand_tab (d integer) distributed randomly;
+insert into rand_tab values (1), (2);
+analyze rand_tab;
+-- Table	Side		Derives
+-- rep_tab	pdsOuter	EdtTaintedReplicated
+-- rep_tab	pdsInner	EdtHashed
+--
+-- join derives EdtHashed
+explain select c from rep_tab where c in (select distinct c from rep_tab);
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=2 width=4)
+   ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=4)
+         Hash Cond: (rep_tab.c = rep_tab_1.c)
+         ->  Result  (cost=0.00..431.00 rows=1 width=4)
+               ->  Seq Scan on rep_tab  (cost=0.00..431.00 rows=2 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+               ->  Redistribute Motion 1:3  (slice1; segments: 1)  (cost=0.00..431.00 rows=2 width=4)
+                     Hash Key: rep_tab_1.c
+                     ->  GroupAggregate  (cost=0.00..431.00 rows=2 width=4)
+                           Group Key: rep_tab_1.c
+                           ->  Sort  (cost=0.00..431.00 rows=2 width=4)
+                                 Sort Key: rep_tab_1.c
+                                 ->  Seq Scan on rep_tab rep_tab_1  (cost=0.00..431.00 rows=2 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(8 rows)
+(14 rows)
+
+select c from rep_tab where c in (select distinct c from rep_tab);
+ c 
+---
+ 2
+ 1
+(2 rows)
+
+-- Table	Side		Derives
+-- dist_tab	pdsOuter	EdtHashed
+-- rep_tab	pdsInner	EdtTaintedReplicated 
+--
+-- join derives EdtHashed
+explain select a from dist_tab where a in (select distinct c from rep_tab);
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=4 width=4)
+   ->  Hash Semi Join  (cost=0.00..862.00 rows=2 width=4)
+         Hash Cond: (dist_tab.a = rep_tab.c)
+         ->  Seq Scan on dist_tab  (cost=0.00..431.00 rows=2 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+               ->  Seq Scan on rep_tab  (cost=0.00..431.00 rows=2 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+select a from dist_tab where a in (select distinct c from rep_tab);
+ a 
+---
+ 2
+ 2
+ 1
+ 1
+(4 rows)
+
+-- Table	Side		Derives
+-- rand_tab	pdsOuter	EdtRandom
+-- rep_tab	pdsInner	EdtTaintedReplicated
+--
+-- join derives EdtRandom
+explain select d from rand_tab where d in (select distinct c from rep_tab);
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=4)
+   ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=4)
+         Hash Cond: (rand_tab.d = rep_tab.c)
+         ->  Seq Scan on rand_tab  (cost=0.00..431.00 rows=1 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+               ->  Seq Scan on rep_tab  (cost=0.00..431.00 rows=2 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+select d from rand_tab where d in (select distinct c from rep_tab);
+ d 
+---
+ 1
+ 2
+(2 rows)
+
+-- Table	Side		Derives
+-- rep_tab	pdsOuter	EdtTaintedReplicated
+-- dist_tab	pdsInner	EdtHashed
+--
+-- join derives EdtHashed
+explain select c from rep_tab where c in (select distinct a from dist_tab);
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=4)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+         Hash Cond: (dist_tab.a = rep_tab.c)
+         ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
+               Group Key: dist_tab.a
+               ->  Sort  (cost=0.00..431.00 rows=2 width=4)
+                     Sort Key: dist_tab.a
+                     ->  Seq Scan on dist_tab  (cost=0.00..431.00 rows=2 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+               ->  Seq Scan on rep_tab  (cost=0.00..431.00 rows=2 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+select c from rep_tab where c in (select distinct a from dist_tab);
+ c 
+---
+ 2
+ 1
+(2 rows)
+
+-- Table	Side		Derives
+-- rep_tab	pdsOuter	EdtTaintedReplicated
+-- rand_tab	pdsInner	EdtHashed
+--
+-- join derives EdtHashed
+explain select c from rep_tab where c in (select distinct d from rand_tab);
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=2 width=4)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+         Hash Cond: (rand_tab.d = rep_tab.c)
+         ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
+               Group Key: rand_tab.d
+               ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                     Sort Key: rand_tab.d
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                           Hash Key: rand_tab.d
+                           ->  Seq Scan on rand_tab  (cost=0.00..431.00 rows=1 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+               ->  Seq Scan on rep_tab  (cost=0.00..431.00 rows=2 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+
+select c from rep_tab where c in (select distinct d from rand_tab);
+ c 
+---
+ 1
+ 2
+(2 rows)
 
 -- start_ignore
 drop schema rpt cascade;
-NOTICE:  drop cascades to 13 other objects
+NOTICE:  drop cascades to 14 other objects
 DETAIL:  drop cascades to table foo
 drop cascades to table bar
 drop cascades to view v_foo
@@ -1055,6 +1225,7 @@ drop cascades to table t_hashdist
 drop cascades to table t_replicate_volatile
 drop cascades to sequence seq_for_insert_replicated_table
 drop cascades to table rtbl
-drop cascades to table t1_13532
-drop cascades to table t2_13532
+drop cascades to table dist_tab
+drop cascades to table rep_tab
+drop cascades to table rand_tab
 -- end_ignore

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -123,10 +123,10 @@ insert into foo values (1,'aaa');
 insert into foo values (2,'bbb');
 -- fail
 insert into foo values (1,'ccc');
-ERROR:  duplicate key value violates unique constraint "foo_pkey"  (seg0 172.17.0.2:6002 pid=23394)
+ERROR:  duplicate key value violates unique constraint "foo_pkey"  (seg0 127.0.1.1:6002 pid=287620)
 DETAIL:  Key (id)=(1) already exists.
 insert into foo values (3,'aaa');
-ERROR:  duplicate key value violates unique constraint "foo_name_key"  (seg0 172.17.0.2:6002 pid=23394)
+ERROR:  duplicate key value violates unique constraint "foo_name_key"  (seg0 127.0.1.1:6002 pid=287620)
 DETAIL:  Key (name)=(aaa) already exists.
 drop table if exists foo;
 --
@@ -232,8 +232,8 @@ select * from bar;
  c1 | c2 
 ----+----
   1 |  1
-  2 |  2
   3 |  3
+  2 |  2
 (3 rows)
 
 drop table if exists foo;
@@ -245,9 +245,9 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entr
 select * from foo;
  c1 | c2 
 ----+----
-  3 |  3
-  2 |  2
   1 |  1
+  2 |  2
+  3 |  3
 (3 rows)
 
 create table bar as select * from foo order by c1 limit 1 distributed replicated;
@@ -357,15 +357,15 @@ select * from foo;
 select * from foo1;
  x  | y  
 ----+----
+  6 |  6
+  8 |  8
   9 |  9
  10 | 10
-  2 |  2
-  3 |  3
-  5 |  5
-  8 |  8
   1 |  1
+  3 |  3
   4 |  4
-  6 |  6
+  5 |  5
+  2 |  2
   7 |  7
 (10 rows)
 
@@ -377,26 +377,26 @@ select * from bar;
   4 |  4
   7 |  7
   8 |  8
-  1 |  1
   5 |  5
   6 |  6
   9 |  9
  10 | 10
+  1 |  1
 (10 rows)
 
 select * from bar1;
  x  | y  
 ----+----
-  4 |  4
-  8 |  8
- 10 | 10
-  1 |  1
-  5 |  5
   6 |  6
+  1 |  1
+  4 |  4
   7 |  7
+  8 |  8
   9 |  9
+ 10 | 10
   2 |  2
   3 |  3
+  5 |  5
 (10 rows)
 
 -- alter back
@@ -441,61 +441,61 @@ Distributed randomly
 select * from foo;
  x  | y  
 ----+----
-  2 |  2
-  3 |  3
-  4 |  4
-  7 |  7
-  8 |  8
   1 |  1
   5 |  5
   6 |  6
   9 |  9
  10 | 10
+  2 |  2
+  3 |  3
+  4 |  4
+  7 |  7
+  8 |  8
 (10 rows)
 
 select * from foo1;
  x  | y  
 ----+----
-  1 |  1
-  4 |  4
-  6 |  6
+  2 |  2
   7 |  7
+  6 |  6
+  8 |  8
   9 |  9
  10 | 10
-  2 |  2
+  1 |  1
   3 |  3
+  4 |  4
   5 |  5
-  8 |  8
 (10 rows)
 
 select * from bar;
  x  | y  
 ----+----
-  2 |  2
-  3 |  3
-  4 |  4
-  7 |  7
-  8 |  8
   1 |  1
   5 |  5
   6 |  6
   9 |  9
  10 | 10
+  2 |  2
+  3 |  3
+  4 |  4
+  7 |  7
+  8 |  8
 (10 rows)
 
 select * from bar1;
  x  | y  
 ----+----
-  4 |  4
- 10 | 10
-  5 |  5
-  7 |  7
-  2 |  2
   6 |  6
-  3 |  3
   8 |  8
+  3 |  3
   1 |  1
   9 |  9
+  4 |  4
+  7 |  7
+ 10 | 10
+  2 |  2
+  5 |  5
 (10 rows)
 
 drop table if exists foo;
@@ -909,15 +909,15 @@ explain (costs off) select a from t_replicate_volatile union all select * from n
 
 -- update & delete
 explain (costs off) update t_replicate_volatile set a = 1 where b > random();
-ERROR:  could not devise a plan (cdbpath.c:2082)
+ERROR:  could not devise a plan (cdbpath.c:2089)
 explain (costs off) update t_replicate_volatile set a = 1 from t_replicate_volatile x where x.a + random() = t_replicate_volatile.b;
-ERROR:  could not devise a plan (cdbpath.c:2082)
+ERROR:  could not devise a plan (cdbpath.c:2089)
 explain (costs off) update t_replicate_volatile set a = 1 from t_hashdist x where x.a + random() = t_replicate_volatile.b;
-ERROR:  could not devise a plan (cdbpath.c:2082)
+ERROR:  could not devise a plan (cdbpath.c:2089)
 explain (costs off) delete from t_replicate_volatile where a < random();
-ERROR:  could not devise a plan (cdbpath.c:2082)
+ERROR:  could not devise a plan (cdbpath.c:2089)
 explain (costs off) delete from t_replicate_volatile using t_replicate_volatile x where t_replicate_volatile.a + x.b < random();
-ERROR:  could not devise a plan (cdbpath.c:2082)
+ERROR:  could not devise a plan (cdbpath.c:2089)
 explain (costs off) update t_replicate_volatile set a = random();
 ERROR:  could not devise a plan (createplan.c:6507)
 -- limit
@@ -949,8 +949,6 @@ explain (costs off) select * from t_hashdist cross join (select * from t_replica
 create table rtbl (a int, b int, c int, t text) distributed replicated;
 insert into t_hashdist values (1, 1, 1);
 insert into rtbl values (1, 1, 1, 'rtbl');
-analyze t_hashdist;
-analyze rtbl;
 -- The below tests used to do replicated table scan on entry db which contains empty data.
 -- So a motion node is needed to gather replicated table on entry db.
 -- See issue: https://github.com/greenplum-db/gpdb/issues/11945
@@ -1026,6 +1024,37 @@ explain (costs off) select a from t_hashdist, (select oid from pg_class union al
 (12 rows)
 
 reset enable_bitmapscan;
+-- Github Issue 13532
+create table t1_13532(a int, b int) distributed replicated;
+create table t2_13532(a int, b int) distributed replicated;
+create index idx_t2_13532 on t2_13532(b);
+explain (costs off) select * from t1_13532 x, t2_13532 y where y.a < random() and x.b = y.b;
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Seq Scan on t1_13532
+         ->  Index Scan using idx_t2_13532 on t2_13532
+               Index Cond: (b = t1_13532.b)
+               Filter: ((a)::double precision < random())
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+set enable_bitmapscan = off;
+explain (costs off) select * from t1_13532 x, t2_13532 y where y.a < random() and x.b = y.b;
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Seq Scan on t1_13532
+         ->  Index Scan using idx_t2_13532 on t2_13532
+               Index Cond: (b = t1_13532.b)
+               Filter: ((a)::double precision < random())
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
 -- ORCA
 -- verify that JOIN derives the inner child distribution if the outer is tainted replicated (in this
 -- case, the inner child is the hash distributed table, but the distribution is random because the
@@ -1213,7 +1242,7 @@ select c from rep_tab where c in (select distinct d from rand_tab);
 
 -- start_ignore
 drop schema rpt cascade;
-NOTICE:  drop cascades to 14 other objects
+NOTICE:  drop cascades to 13 other objects
 DETAIL:  drop cascades to table foo
 drop cascades to table bar
 drop cascades to view v_foo
@@ -1225,7 +1254,6 @@ drop cascades to table t_hashdist
 drop cascades to table t_replicate_volatile
 drop cascades to sequence seq_for_insert_replicated_table
 drop cascades to table rtbl
-drop cascades to table dist_tab
-drop cascades to table rep_tab
-drop cascades to table rand_tab
+drop cascades to table t1_13532
+drop cascades to table t2_13532
 -- end_ignore

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -702,69 +702,71 @@ DROP TABLE foopart;
 -- we correctly handle all these cases.
 -- FIXME: ORCA does not consider this, we need to fix the cases when ORCA
 -- consider this.
+set optimizer = off;
+set enable_bitmapscan = off;
 create table t_hashdist(a int, b int, c int) distributed by (a);
 create table t_replicate_volatile(a int, b int, c int) distributed replicated;
 ---- pushed down filter
 explain (costs off) select * from t_replicate_volatile, t_hashdist where t_replicate_volatile.a > random();
-                        QUERY PLAN                        
-----------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
    ->  Nested Loop
-         Join Filter: true
          ->  Seq Scan on t_hashdist
-         ->  Seq Scan on t_replicate_volatile
-               Filter: ((a)::double precision > random())
- Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+         ->  Materialize
+               ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                     ->  Result
+                           ->  Seq Scan on t_replicate_volatile
+                                 Filter: ((a)::double precision > random())
+ Optimizer: Postgres query optimizer
+(9 rows)
 
 -- join qual
 explain (costs off) select * from t_hashdist, t_replicate_volatile x, t_replicate_volatile y where x.a + y.a > random();
-                                                QUERY PLAN                                                 
------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Nested Loop
-         Join Filter: (((t_replicate_volatile_1.a + t_replicate_volatile.a))::double precision > random())
-         ->  Nested Loop
-               Join Filter: true
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Nested Loop
+   ->  Result
+         ->  Gather Motion 1:1  (slice1; segments: 1)
+               ->  Nested Loop
+                     Join Filter: (((x.a + y.a))::double precision > random())
+                     ->  Seq Scan on t_replicate_volatile x
+                     ->  Materialize
+                           ->  Seq Scan on t_replicate_volatile y
+   ->  Materialize
+         ->  Gather Motion 3:1  (slice2; segments: 3)
                ->  Seq Scan on t_hashdist
-               ->  Seq Scan on t_replicate_volatile t_replicate_volatile_1
-         ->  Seq Scan on t_replicate_volatile
- Optimizer: Pivotal Optimizer (GPORCA)
-(9 rows)
+ Optimizer: Postgres query optimizer
+(12 rows)
 
 -- sublink & subquery
 explain (costs off) select * from t_hashdist where a > All (select random() from t_replicate_volatile);
-                                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                                             
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on t_hashdist
-         Filter: (SubPlan 1)
-         SubPlan 1  (slice1; segments: 3)
-           ->  Result
-                 ->  Result
-                       Filter: ((CASE WHEN ((sum((CASE WHEN ((t_hashdist.a)::double precision <= (random())) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN ((random()) IS NULL) THEN 1 ELSE 0 END))) > 0::bigint) THEN NULL::boolean WHEN ((t_hashdist.a)::double precision IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN ((t_hashdist.a)::double precision <= (random())) THEN 1 ELSE 0 END))) = 0::bigint) THEN true ELSE false END) = true)
-                       ->  Result
-                             ->  Aggregate
-                                   ->  Result
-                                         ->  Result
-                                               ->  Seq Scan on t_replicate_volatile
- Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Nested Loop Left Anti Semi (Not-In) Join
+         Join Filter: ((t_hashdist.a)::double precision <= "NotIn_SUBQUERY".random)
+         ->  Seq Scan on t_hashdist
+         ->  Materialize
+               ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                     ->  Subquery Scan on "NotIn_SUBQUERY"
+                           ->  Seq Scan on t_replicate_volatile
+ Optimizer: Postgres query optimizer
+(9 rows)
 
 explain (costs off) select * from t_hashdist where a in (select random()::int from t_replicate_volatile);
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Hash Semi Join
-         Hash Cond: (t_hashdist.a = (int4(random())))
+         Hash Cond: (t_hashdist.a = ((random())::integer))
          ->  Seq Scan on t_hashdist
          ->  Hash
                ->  Redistribute Motion 1:3  (slice1; segments: 1)
-                     Hash Key: (int4(random()))
-                     ->  Result
-                           ->  Seq Scan on t_replicate_volatile
- Optimizer: Pivotal Optimizer (GPORCA)
-(10 rows)
+                     Hash Key: ((random())::integer)
+                     ->  Seq Scan on t_replicate_volatile
+ Optimizer: Postgres query optimizer
+(9 rows)
 
 -- subplan
 explain (costs off, verbose) select * from t_hashdist left join t_replicate_volatile on t_hashdist.a > any (select random() from t_replicate_volatile);
@@ -789,123 +791,109 @@ explain (costs off, verbose) select * from t_hashdist left join t_replicate_vola
                        ->  Seq Scan on rpt.t_replicate_volatile t_replicate_volatile_1
                              Output: random()
  Optimizer: Postgres query optimizer
- Settings: enable_seqscan=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (20 rows)
 
 -- targetlist
 explain (costs off) select * from t_hashdist cross join (select random () from t_replicate_volatile)x;
-                        QUERY PLAN                        
-----------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
    ->  Nested Loop
-         Join Filter: true
          ->  Seq Scan on t_hashdist
          ->  Materialize
-               ->  Result
+               ->  Broadcast Motion 1:3  (slice1; segments: 1)
                      ->  Seq Scan on t_replicate_volatile
- Optimizer: Pivotal Optimizer (GPORCA)
-(8 rows)
+ Optimizer: Postgres query optimizer
+(7 rows)
 
 explain (costs off) select * from t_hashdist cross join (select a, sum(random()) from t_replicate_volatile group by a) x;
-                        QUERY PLAN                        
-----------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
    ->  Nested Loop
-         Join Filter: true
          ->  Seq Scan on t_hashdist
-         ->  GroupAggregate
-               Group Key: t_replicate_volatile.a
-               ->  Sort
-                     Sort Key: t_replicate_volatile.a
-                     ->  Seq Scan on t_replicate_volatile
- Optimizer: Pivotal Optimizer (GPORCA)
-(10 rows)
+         ->  Materialize
+               ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                     ->  HashAggregate
+                           Group Key: t_replicate_volatile.a
+                           ->  Seq Scan on t_replicate_volatile
+ Optimizer: Postgres query optimizer
+(9 rows)
 
 explain (costs off) select * from t_hashdist cross join (select random() as k, sum(a) from t_replicate_volatile group by k) x;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)
-   ->  Nested Loop
-         Join Filter: true
-         ->  Broadcast Motion 3:3  (slice2; segments: 3)
-               ->  Seq Scan on t_hashdist
-         ->  GroupAggregate
-               Group Key: (random())
-               ->  Sort
-                     Sort Key: (random())
-                     ->  Redistribute Motion 1:3  (slice1; segments: 1)
-                           Hash Key: (random())
-                           ->  Result
-                                 ->  Result
-                                       ->  Seq Scan on t_replicate_volatile
- Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Nested Loop
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on t_hashdist
+   ->  Materialize
+         ->  Gather Motion 1:1  (slice2; segments: 1)
+               ->  HashAggregate
+                     Group Key: random()
+                     ->  Seq Scan on t_replicate_volatile
+ Optimizer: Postgres query optimizer
+(9 rows)
 
 explain (costs off) select * from t_hashdist cross join (select a, sum(b) as s from t_replicate_volatile group by a having sum(b) > random() order by a) x ;
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
    ->  Nested Loop
-         Join Filter: true
          ->  Seq Scan on t_hashdist
-         ->  Result
-               Filter: (((sum(t_replicate_volatile.b)))::double precision > random())
-               ->  GroupAggregate
-                     Group Key: t_replicate_volatile.a
+         ->  Materialize
+               ->  Broadcast Motion 1:3  (slice1; segments: 1)
                      ->  Sort
                            Sort Key: t_replicate_volatile.a
-                           ->  Seq Scan on t_replicate_volatile
- Optimizer: Pivotal Optimizer (GPORCA)
+                           ->  HashAggregate
+                                 Group Key: t_replicate_volatile.a
+                                 Filter: ((sum(t_replicate_volatile.b))::double precision > random())
+                                 ->  Seq Scan on t_replicate_volatile
+ Optimizer: Postgres query optimizer
 (12 rows)
 
 -- insert
 explain (costs off) insert into t_replicate_volatile select random() from t_replicate_volatile;
-                        QUERY PLAN                        
-----------------------------------------------------------
- Insert
-   ->  Result
-         ->  Broadcast Motion 1:3  (slice1; segments: 1)
-               ->  Result
-                     ->  Seq Scan on t_replicate_volatile
- Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Insert on t_replicate_volatile
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)
+         ->  Subquery Scan on "*SELECT*"
+               ->  Seq Scan on t_replicate_volatile t_replicate_volatile_1
+ Optimizer: Postgres query optimizer
+(5 rows)
 
 explain (costs off) insert into t_replicate_volatile select random(), a, a from generate_series(1, 10) a;
-                              QUERY PLAN                              
-----------------------------------------------------------------------
- Insert
-   ->  Result
-         ->  Broadcast Motion 1:3  (slice1)
-               ->  Result
-                     ->  Result
-                           ->  Result
-                                 ->  Function Scan on generate_series
- Optimizer: Pivotal Optimizer (GPORCA)
-(8 rows)
+                      QUERY PLAN                      
+------------------------------------------------------
+ Insert on t_replicate_volatile
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)
+         ->  Subquery Scan on "*SELECT*"
+               ->  Function Scan on generate_series a
+ Optimizer: Postgres query optimizer
+(5 rows)
 
 create sequence seq_for_insert_replicated_table;
 explain (costs off) insert into t_replicate_volatile select nextval('seq_for_insert_replicated_table');
-                 QUERY PLAN                 
---------------------------------------------
- Insert
-   ->  Result
-         ->  Broadcast Motion 1:3  (slice1)
+                    QUERY PLAN                     
+---------------------------------------------------
+ Insert on t_replicate_volatile
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)
+         ->  Subquery Scan on "*SELECT*"
                ->  Result
-                     ->  Result
- Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+ Optimizer: Postgres query optimizer
+(5 rows)
 
 explain (costs off) select a from t_replicate_volatile union all select * from nextval('seq_for_insert_replicated_table');
                      QUERY PLAN                     
 ----------------------------------------------------
- Gather Motion 1:1  (slice2; segments: 1)
-   ->  Append
-         ->  Result
+ Append
+   ->  Gather Motion 1:1  (slice1; segments: 1)
+         ->  Subquery Scan on "*SELECT* 1"
                ->  Seq Scan on t_replicate_volatile
-         ->  Broadcast Motion 1:1  (slice1)
-               ->  Function Scan on nextval
- Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+   ->  Function Scan on nextval
+ Optimizer: Postgres query optimizer
+(6 rows)
 
 -- update & delete
 explain (costs off) update t_replicate_volatile set a = 1 where b > random();
@@ -922,29 +910,27 @@ explain (costs off) update t_replicate_volatile set a = random();
 ERROR:  could not devise a plan (createplan.c:6507)
 -- limit
 explain (costs off) insert into t_replicate_volatile select * from t_replicate_volatile limit 1;
-                        QUERY PLAN                        
-----------------------------------------------------------
- Insert
-   ->  Result
-         ->  Broadcast Motion 1:3  (slice1; segments: 1)
-               ->  Limit
-                     ->  Seq Scan on t_replicate_volatile
- Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Insert on t_replicate_volatile
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)
+         ->  Limit
+               ->  Seq Scan on t_replicate_volatile t_replicate_volatile_1
+ Optimizer: Postgres query optimizer
+(5 rows)
 
 explain (costs off) select * from t_hashdist cross join (select * from t_replicate_volatile limit 1) x;
-                      QUERY PLAN                      
-------------------------------------------------------
- Nested Loop
-   Join Filter: true
-   ->  Limit
-         ->  Gather Motion 1:1  (slice2; segments: 1)
-               ->  Seq Scan on t_replicate_volatile
-   ->  Materialize
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               ->  Seq Scan on t_hashdist
- Optimizer: Pivotal Optimizer (GPORCA)
-(9 rows)
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Nested Loop
+         ->  Seq Scan on t_hashdist
+         ->  Materialize
+               ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                     ->  Limit
+                           ->  Seq Scan on t_replicate_volatile
+ Optimizer: Postgres query optimizer
+(8 rows)
 
 create table rtbl (a int, b int, c int, t text) distributed replicated;
 insert into t_hashdist values (1, 1, 1);
@@ -978,7 +964,6 @@ select count(*) from tmp; -- should contain 1 row
      1
 (1 row)
 
-set enable_bitmapscan=off;
 -- 2. Join hashed table with (replicated table join catalog) should return 1 row
 explain (costs off) select relname from t_hashdist, (select * from pg_class c join rtbl on c.relname = rtbl.t) vtest where t_hashdist.a = vtest.a;
                                        QUERY PLAN                                       
@@ -1023,6 +1008,7 @@ explain (costs off) select a from t_hashdist, (select oid from pg_class union al
  Optimizer: Postgres query optimizer
 (12 rows)
 
+reset optimizer;
 reset enable_bitmapscan;
 -- Github Issue 13532
 create table t1_13532(a int, b int) distributed replicated;

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -362,6 +362,8 @@ DROP TABLE foopart;
 
 -- FIXME: ORCA does not consider this, we need to fix the cases when ORCA
 -- consider this.
+set optimizer = off;
+set enable_bitmapscan = off;
 create table t_hashdist(a int, b int, c int) distributed by (a);
 create table t_replicate_volatile(a int, b int, c int) distributed replicated;
 
@@ -415,7 +417,6 @@ explain (costs off) create temp table tmp as select * from pg_class c join rtbl 
 create temp table tmp as select * from pg_class c join rtbl on c.relname = rtbl.t;
 select count(*) from tmp; -- should contain 1 row
 
-set enable_bitmapscan=off;
 -- 2. Join hashed table with (replicated table join catalog) should return 1 row
 explain (costs off) select relname from t_hashdist, (select * from pg_class c join rtbl on c.relname = rtbl.t) vtest where t_hashdist.a = vtest.a;
 select relname from t_hashdist, (select * from pg_class c join rtbl on c.relname = rtbl.t) vtest where t_hashdist.a = vtest.a;
@@ -423,6 +424,7 @@ select relname from t_hashdist, (select * from pg_class c join rtbl on c.relname
 -- 3. Join hashed table with (set operation on catalog and replicated table)
 explain (costs off) select a from t_hashdist, (select oid from pg_class union all select a from rtbl) vtest;
 
+reset optimizer;
 reset enable_bitmapscan;
 
 -- Github Issue 13532

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -362,8 +362,6 @@ DROP TABLE foopart;
 
 -- FIXME: ORCA does not consider this, we need to fix the cases when ORCA
 -- consider this.
-set optimizer = off;
-set enable_bitmapscan = off;
 create table t_hashdist(a int, b int, c int) distributed by (a);
 create table t_replicate_volatile(a int, b int, c int) distributed replicated;
 
@@ -408,6 +406,9 @@ create table rtbl (a int, b int, c int, t text) distributed replicated;
 insert into t_hashdist values (1, 1, 1);
 insert into rtbl values (1, 1, 1, 'rtbl');
 
+analyze t_hashdist;
+analyze rtbl;
+
 -- The below tests used to do replicated table scan on entry db which contains empty data.
 -- So a motion node is needed to gather replicated table on entry db.
 -- See issue: https://github.com/greenplum-db/gpdb/issues/11945
@@ -417,6 +418,7 @@ explain (costs off) create temp table tmp as select * from pg_class c join rtbl 
 create temp table tmp as select * from pg_class c join rtbl on c.relname = rtbl.t;
 select count(*) from tmp; -- should contain 1 row
 
+set enable_bitmapscan=off;
 -- 2. Join hashed table with (replicated table join catalog) should return 1 row
 explain (costs off) select relname from t_hashdist, (select * from pg_class c join rtbl on c.relname = rtbl.t) vtest where t_hashdist.a = vtest.a;
 select relname from t_hashdist, (select * from pg_class c join rtbl on c.relname = rtbl.t) vtest where t_hashdist.a = vtest.a;
@@ -424,16 +426,72 @@ select relname from t_hashdist, (select * from pg_class c join rtbl on c.relname
 -- 3. Join hashed table with (set operation on catalog and replicated table)
 explain (costs off) select a from t_hashdist, (select oid from pg_class union all select a from rtbl) vtest;
 
-reset optimizer;
 reset enable_bitmapscan;
 
--- Github Issue 13532
-create table t1_13532(a int, b int) distributed replicated;
-create table t2_13532(a int, b int) distributed replicated;
-create index idx_t2_13532 on t2_13532(b);
-explain (costs off) select * from t1_13532 x, t2_13532 y where y.a < random() and x.b = y.b;
-set enable_bitmapscan = off;
-explain (costs off) select * from t1_13532 x, t2_13532 y where y.a < random() and x.b = y.b;
+-- ORCA
+-- verify that JOIN derives the inner child distribution if the outer is tainted replicated (in this
+-- case, the inner child is the hash distributed table, but the distribution is random because the
+-- hash distribution key is not the JOIN key. we want to return the inner distribution because the
+-- JOIN key determines the distribution of the JOIN output).
+create table dist_tab (a integer, b integer) distributed by (a);
+create table rep_tab (c integer) distributed replicated;
+create index idx on dist_tab (b);
+insert into dist_tab values (1, 2), (2, 2), (2, 1), (1, 1);
+insert into rep_tab values (1), (2);
+analyze dist_tab;
+analyze rep_tab;
+set optimizer_enable_hashjoin=off;
+set enable_hashjoin=off;
+set enable_nestloop=on;
+explain select b from dist_tab where b in (select distinct c from rep_tab);
+select b from dist_tab where b in (select distinct c from rep_tab);
+reset optimizer_enable_hashjoin;
+reset enable_hashjoin;
+reset enable_nestloop;
+
+create table rand_tab (d integer) distributed randomly;
+insert into rand_tab values (1), (2);
+analyze rand_tab;
+
+-- Table	Side		Derives
+-- rep_tab	pdsOuter	EdtTaintedReplicated
+-- rep_tab	pdsInner	EdtHashed
+--
+-- join derives EdtHashed
+explain select c from rep_tab where c in (select distinct c from rep_tab);
+select c from rep_tab where c in (select distinct c from rep_tab);
+
+-- Table	Side		Derives
+-- dist_tab	pdsOuter	EdtHashed
+-- rep_tab	pdsInner	EdtTaintedReplicated 
+--
+-- join derives EdtHashed
+explain select a from dist_tab where a in (select distinct c from rep_tab);
+select a from dist_tab where a in (select distinct c from rep_tab);
+
+-- Table	Side		Derives
+-- rand_tab	pdsOuter	EdtRandom
+-- rep_tab	pdsInner	EdtTaintedReplicated
+--
+-- join derives EdtRandom
+explain select d from rand_tab where d in (select distinct c from rep_tab);
+select d from rand_tab where d in (select distinct c from rep_tab);
+
+-- Table	Side		Derives
+-- rep_tab	pdsOuter	EdtTaintedReplicated
+-- dist_tab	pdsInner	EdtHashed
+--
+-- join derives EdtHashed
+explain select c from rep_tab where c in (select distinct a from dist_tab);
+select c from rep_tab where c in (select distinct a from dist_tab);
+
+-- Table	Side		Derives
+-- rep_tab	pdsOuter	EdtTaintedReplicated
+-- rand_tab	pdsInner	EdtHashed
+--
+-- join derives EdtHashed
+explain select c from rep_tab where c in (select distinct d from rand_tab);
+select c from rep_tab where c in (select distinct d from rand_tab);
 
 -- start_ignore
 drop schema rpt cascade;


### PR DESCRIPTION
This addresses https://github.com/greenplum-db/gpdb/issues/13058

Previously, CPhysicalJoin derived the outer distribution when it was tainted
replicated. It checked only for strict replicated and universal replicated and
returned the inner distribution in these cases (in this case, it satisfies
random). Tainted replicated wasn't considered and was causing an undercount (the
JOIN derived tainted replicated instead of random, which was causing the number
of columns to be undercounted, because it wrongly assumed that one segment
contained all output columns).