### PR TITLE
Fix epoll() fd leak in waiteventset

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -129,6 +129,10 @@ static void dispatchCommand(CdbDispatchResult *dispatchResult,
 
 static void checkDispatchResult(CdbDispatcherState *ds, int timeout_sec);
 
+static void checkDispatchResultLoop(CdbDispatcherState *ds, int timeout_sec, WaitEventSet *waitset);
+
+static void cdbdisp_waitDispatchFinishLoop_async(struct CdbDispatcherState *ds, WaitEventSet *waitset);
+
 static bool processResults(CdbDispatchResult *dispatchResult);
 
 static void
@@ -212,15 +216,35 @@ cdbdisp_getWaitSocketFds_async(struct CdbDispatcherState *ds, int *nsocks)
 static void
 cdbdisp_waitDispatchFinish_async(struct CdbDispatcherState *ds)
 {
+	CdbDispatchCmdAsync *pParms = (CdbDispatchCmdAsync *) ds->dispatchParams;
+	int				dispatchCount = pParms->dispatchCount;
+	WaitEventSet 	*volatile waitset = CreateWaitEventSet(CurrentMemoryContext, dispatchCount);
+
+	/* Use PG_TRY() - PG_CATCH() to make sure destory the waiteventset (close the epoll fd) */
+	PG_TRY();
+	{
+		cdbdisp_waitDispatchFinishLoop_async(ds, waitset);
+	}
+	PG_CATCH();
+	{
+		FreeWaitEventSet(waitset);
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+
+	FreeWaitEventSet(waitset);
+}
+
+static void
+cdbdisp_waitDispatchFinishLoop_async(struct CdbDispatcherState *ds, WaitEventSet *waitset)
+{
 	const static int DISPATCH_POLL_TIMEOUT = 500;
 	int			i;
 	CdbDispatchCmdAsync *pParms = (CdbDispatchCmdAsync *) ds->dispatchParams;
 	int			dispatchCount = pParms->dispatchCount;
 
-	WaitEventSet 	*waitset = CreateWaitEventSet(CurrentMemoryContext, dispatchCount);
 	WaitEvent 		*revents = palloc(sizeof(WaitEvent) * dispatchCount);
-	int 		*added = palloc0(sizeof(int) * dispatchCount);
-
+	int 			*added = palloc0(sizeof(int) * dispatchCount);
 	while (true)
 	{
 		int			pollRet;
@@ -266,7 +290,7 @@ cdbdisp_waitDispatchFinish_async(struct CdbDispatcherState *ds)
 				qeResult->stillRunning = false;
 				ereport(ERROR,
 						(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
-						 errmsg("Command could not be dispatch to segment %s: %s", qeResult->segdbDesc->whoami, msg ? msg : "unknown error")));
+						errmsg("Command could not be dispatch to segment %s: %s", qeResult->segdbDesc->whoami, msg ? msg : "unknown error")));
 			}
 		}
 
@@ -279,19 +303,14 @@ cdbdisp_waitDispatchFinish_async(struct CdbDispatcherState *ds)
 			CHECK_FOR_INTERRUPTS();
 
 			pollRet = WaitEventSetWait(waitset, DISPATCH_POLL_TIMEOUT, revents, dispatchCount, WAIT_EVENT_DISP_FINISH);
-
+			Assert(pollRet >= 0);
 			if (pollRet == 0)
 				ELOG_DISPATCHER_DEBUG("cdbdisp_waitDispatchFinish_async(): Dispatch poll timeout after %d ms", DISPATCH_POLL_TIMEOUT);
 		}
-		while (pollRet == 0 || (pollRet < 0 && (SOCK_ERRNO == EINTR || SOCK_ERRNO == EAGAIN)));
-
-		if (pollRet < 0)
-			elog(ERROR, "Poll failed during dispatch");
+		while (pollRet == 0);
 	}
-
 	pfree(revents);
 	pfree(added);
-	FreeWaitEventSet(waitset);
 }
 
 /*
@@ -442,30 +461,47 @@ cdbdisp_makeDispatchParams_async(int maxSlices, int largestGangSize, char *query
  * timeout_sec: the second that the dispatcher waits for the ack messages at most.
  *              DISPATCH_NO_WAIT(0): return immediate when there's no more data.
  *              DISPATCH_WAIT_UNTIL_FINISH(-1): wait until all dispatch works are completed.
- *
- * Don't throw out error, instead, append the error message to
- * CdbDispatchResult.error_message.
  */
 static void
 checkDispatchResult(CdbDispatcherState *ds, int timeout_sec)
 {
 	CdbDispatchCmdAsync *pParms = (CdbDispatchCmdAsync *) ds->dispatchParams;
-	CdbDispatchResults *meleeResults = ds->primaryResults;
-	SegmentDatabaseDescriptor *segdbDesc;
-	CdbDispatchResult *dispatchResult;
+	WaitEventSet *volatile waitset = CreateWaitEventSet(CurrentMemoryContext, pParms->dispatchCount);
+
+	/* Use PG_TRY() - PG_CATCH() to make sure destory the waiteventset (close the epoll fd) */
+	PG_TRY();
+	{
+		checkDispatchResultLoop(ds, timeout_sec, waitset);
+	}
+	PG_CATCH();
+	{
+		FreeWaitEventSet(waitset);
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+
+	FreeWaitEventSet(waitset);
+}
+
+static void
+checkDispatchResultLoop(CdbDispatcherState *ds, int timeout_sec, WaitEventSet *waitset)
+{
 	int			i;
 	int			timeout = 0;
 	bool		sentSignal = false;
 	uint8 ftsVersion = 0;
 	struct timeval start_ts, now;
 	int64		diff_us;
-	bool        cancelRequested = false;
+
+	CdbDispatchCmdAsync *pParms = (CdbDispatchCmdAsync *) ds->dispatchParams;
+	CdbDispatchResults *meleeResults = ds->primaryResults;
+	SegmentDatabaseDescriptor *segdbDesc;
+	CdbDispatchResult *dispatchResult;
 
 	int 	db_count = pParms->dispatchCount;
 	int 	*added = palloc0(db_count * sizeof(int));
-	WaitEventSet 	*waitset = CreateWaitEventSet(CurrentMemoryContext, db_count);
-	WaitEvent 		*revents = palloc(sizeof(WaitEvent) * db_count);
-	
+	WaitEvent *revents = palloc(sizeof(WaitEvent) * db_count);
+
 	/*
 	 * OK, we are finished submitting the command to the segdbs. Now, we have
 	 * to wait for them to finish.
@@ -488,7 +524,6 @@ checkDispatchResult(CdbDispatcherState *ds, int timeout_sec)
 		/*
 		 * Current loop might last for the long time so check on interrupts.
 		 */
-
 		CHECK_FOR_INTERRUPTS();
 
 		/*
@@ -537,7 +572,7 @@ checkDispatchResult(CdbDispatcherState *ds, int timeout_sec)
 				 */
 				if (pqFlush(conn) < 0)
 					elog(LOG, "Failed flushing outbound data to %s:%s",
-						 segdbDesc->whoami, PQerrorMessage(conn));
+						segdbDesc->whoami, PQerrorMessage(conn));
 			}
 
 			/* add segment sock to the waitset */
@@ -570,8 +605,8 @@ checkDispatchResult(CdbDispatcherState *ds, int timeout_sec)
 		if (timeout_sec == 0)
 			timeout = 0;
 		else if (pParms->waitMode == DISPATCH_WAIT_NONE ||
-				 pParms->waitMode == DISPATCH_WAIT_ACK_ROOT ||
-				 sentSignal)
+				pParms->waitMode == DISPATCH_WAIT_ACK_ROOT ||
+				sentSignal)
 			timeout = DISPATCH_WAIT_TIMEOUT_MSEC;
 		else
 			timeout = DISPATCH_WAIT_CANCEL_TIMEOUT_MSEC;
@@ -646,11 +681,10 @@ checkDispatchResult(CdbDispatcherState *ds, int timeout_sec)
 		/* We have data waiting on one or more of the connections. */
 		else
 			handlePollSuccess(pParms, revents, n);
-	}
+	} /* for (;;) */
 
 	pfree(revents);
 	pfree(added);
-	FreeWaitEventSet(waitset);
 }
 
 /*

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -220,7 +220,7 @@ cdbdisp_waitDispatchFinish_async(struct CdbDispatcherState *ds)
 	int				dispatchCount = pParms->dispatchCount;
 	WaitEventSet 	*volatile waitset = CreateWaitEventSet(CurrentMemoryContext, dispatchCount);
 
-	/* Use PG_TRY() - PG_CATCH() to make sure destory the waiteventset (close the epoll fd) */
+	/* Use PG_TRY() - PG_CATCH() to make sure destroy the waiteventset (close the epoll fd) */
 	PG_TRY();
 	{
 		cdbdisp_waitDispatchFinishLoop_async(ds, waitset);
@@ -468,7 +468,7 @@ checkDispatchResult(CdbDispatcherState *ds, int timeout_sec)
 	CdbDispatchCmdAsync *pParms = (CdbDispatchCmdAsync *) ds->dispatchParams;
 	WaitEventSet *volatile waitset = CreateWaitEventSet(CurrentMemoryContext, pParms->dispatchCount);
 
-	/* Use PG_TRY() - PG_CATCH() to make sure destory the waiteventset (close the epoll fd) */
+	/* Use PG_TRY() - PG_CATCH() to make sure destroy the waiteventset (close the epoll fd) */
 	PG_TRY();
 	{
 		checkDispatchResultLoop(ds, timeout_sec, waitset);
@@ -572,7 +572,7 @@ checkDispatchResultLoop(CdbDispatcherState *ds, int timeout_sec, WaitEventSet *w
 				 */
 				if (pqFlush(conn) < 0)
 					elog(LOG, "Failed flushing outbound data to %s:%s",
-						segdbDesc->whoami, PQerrorMessage(conn));
+						 segdbDesc->whoami, PQerrorMessage(conn));
 			}
 
 			/* add segment sock to the waitset */
@@ -605,8 +605,8 @@ checkDispatchResultLoop(CdbDispatcherState *ds, int timeout_sec, WaitEventSet *w
 		if (timeout_sec == 0)
 			timeout = 0;
 		else if (pParms->waitMode == DISPATCH_WAIT_NONE ||
-				pParms->waitMode == DISPATCH_WAIT_ACK_ROOT ||
-				sentSignal)
+				 pParms->waitMode == DISPATCH_WAIT_ACK_ROOT ||
+				 sentSignal)
 			timeout = DISPATCH_WAIT_TIMEOUT_MSEC;
 		else
 			timeout = DISPATCH_WAIT_CANCEL_TIMEOUT_MSEC;

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -56,8 +56,9 @@ cdbgang_createGang_async(List *segments, SegmentType segmentType)
 	int		poll_timeout = 0;
 	int		i = 0;
 	int		size = 0;
-	bool	retry = false;
 	int		totalSegs = 0;
+	bool	allStatusDone = true;
+	bool	retry = false;
 
 	WaitEventSet    *volatile gang_waitset = NULL;
 	/* the returned events of waiteventset */
@@ -194,7 +195,7 @@ create_gang_retry:
 								errdetail("timeout expired\n (%s)", segdbDesc->whoami)));
 
 			/*
-			 * GPDB_12_MERGE_FIXME: create and destory waiteventset in each loop
+			 * GPDB_12_MERGE_FIXME: create and destroy waiteventset in each loop
 			 * may impact the performance, please see:
 			 * https://github.com/greenplum-db/gpdb/pull/13494#discussion_r874243725
 			 * Let's verify it later.
@@ -272,7 +273,7 @@ create_gang_retry:
 				}
 			}
 
-			bool allStatusDone = true;
+			allStatusDone = true;
 			for (i = 0; i < size; i++)
 				allStatusDone &= connStatusDone[i];
 			if (allStatusDone)

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -3754,7 +3754,7 @@ receiveChunksUDPIFC(ChunkTransportState *pTransportStates, ChunkTransportStateEn
 	waitset = CreateWaitEventSet(CurrentMemoryContext, nevent);
 
 	/*
-	 * Use PG_TRY() - PG_CATCH() to make sure destory the waiteventset (close the epoll fd)
+	 * Use PG_TRY() - PG_CATCH() to make sure destroy the waiteventset (close the epoll fd)
 	 * The main receive logic is in receiveChunksUDPIFCLoop()
 	 */
 	PG_TRY();
@@ -3844,7 +3844,7 @@ receiveChunksUDPIFCLoop(ChunkTransportState *pTransportStates, ChunkTransportSta
 		if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
 		{
 			elog(DEBUG5, "waiting (timed) on route %d %s", rx_control_info.mainWaitingState.waitingRoute,
-				(rx_control_info.mainWaitingState.waitingRoute == ANY_ROUTE ? "(any route)" : ""));
+				 (rx_control_info.mainWaitingState.waitingRoute == ANY_ROUTE ? "(any route)" : ""));
 		}
 
 		/*
@@ -3889,8 +3889,8 @@ receiveChunksUDPIFCLoop(ChunkTransportState *pTransportStates, ChunkTransportSta
 			if (!PostmasterIsAlive())
 				ereport(FATAL,
 						(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
-						errmsg("interconnect failed to recv chunks"),
-						errdetail("Postmaster is not alive.")));
+						 errmsg("interconnect failed to recv chunks"),
+						 errdetail("Postmaster is not alive.")));
 		}
 
 		pthread_mutex_lock(&ic_control_info.lock);

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -719,6 +719,9 @@ static TupleChunkListItem RecvTupleChunkFromUDPIFC(ChunkTransportState *transpor
 static TupleChunkListItem receiveChunksUDPIFC(ChunkTransportState *pTransportStates, ChunkTransportStateEntry *pEntry,
 					int16 motNodeID, int16 *srcRoute, MotionConn *conn);
 
+static TupleChunkListItem receiveChunksUDPIFCLoop(ChunkTransportState *pTransportStates, ChunkTransportStateEntry *pEntry,
+						int16 *srcRoute, MotionConn *conn, WaitEventSet *waitset, int nevent);
+
 static void SendEosUDPIFC(ChunkTransportState *transportStates,
 			  int motNodeID, TupleChunkListItem tcItem);
 static bool SendChunkUDPIFC(ChunkTransportState *transportStates,
@@ -3712,14 +3715,10 @@ static TupleChunkListItem
 receiveChunksUDPIFC(ChunkTransportState *pTransportStates, ChunkTransportStateEntry *pEntry,
 					int16 motNodeID, int16 *srcRoute, MotionConn *conn)
 {
-	int			retries = 0;
-	bool		directed = false;
 	int 		nFds = 0;
 	int 		*waitFds = NULL;
 	int 		nevent = 0;
-	MotionConn 	*rxconn = NULL;
-	WaitEvent	*rEvents = NULL;
-	WaitEventSet		*waitset = NULL;
+	WaitEventSet	*waitset = NULL;
 	TupleChunkListItem	tcItem = NULL;
 
 #ifdef AMS_VERBOSE_LOGGING
@@ -3731,7 +3730,6 @@ receiveChunksUDPIFC(ChunkTransportState *pTransportStates, ChunkTransportStateEn
 
 	if (conn != NULL)
 	{
-		directed = true;
 		*srcRoute = conn->route;
 		setMainThreadWaiting(&rx_control_info.mainWaitingState, motNodeID, conn->route,
 							 pTransportStates->sliceTable->ic_instance_id);
@@ -3743,7 +3741,6 @@ receiveChunksUDPIFC(ChunkTransportState *pTransportStates, ChunkTransportStateEn
 							 pTransportStates->sliceTable->ic_instance_id);
 	}
 
-	nFds = 0;
 	nevent = 2; /* nevent = waited fds number + 2 (latch and postmaster) */
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
@@ -3751,20 +3748,57 @@ receiveChunksUDPIFC(ChunkTransportState *pTransportStates, ChunkTransportStateEn
 		waitFds = cdbdisp_getWaitSocketFds(pTransportStates->estate->dispatcherState, &nFds);
 		if (waitFds != NULL)
 			nevent += nFds;
-
 	}
 
 	/* init WaitEventSet */
 	waitset = CreateWaitEventSet(CurrentMemoryContext, nevent);
-	rEvents = palloc(nevent * sizeof(WaitEvent)); /* returned events */
-	AddWaitEventToSet(waitset, WL_LATCH_SET, PGINVALID_SOCKET, &ic_control_info.latch, NULL);
-	AddWaitEventToSet(waitset, WL_POSTMASTER_DEATH, PGINVALID_SOCKET, NULL, NULL);
 
-	for (int i = 0; i < nFds; i++)
+	/*
+	 * Use PG_TRY() - PG_CATCH() to make sure destory the waiteventset (close the epoll fd)
+	 * The main receive logic is in receiveChunksUDPIFCLoop()
+	 */
+	PG_TRY();
 	{
-		AddWaitEventToSet(waitset, WL_SOCKET_READABLE, waitFds[i], NULL, NULL);
-	}
+		AddWaitEventToSet(waitset, WL_LATCH_SET, PGINVALID_SOCKET, &ic_control_info.latch, NULL);
+		AddWaitEventToSet(waitset, WL_POSTMASTER_DEATH, PGINVALID_SOCKET, NULL, NULL);
+		for (int i = 0; i < nFds; i++)
+		{
+			AddWaitEventToSet(waitset, WL_SOCKET_READABLE, waitFds[i], NULL, NULL);
+		}
 
+		tcItem = receiveChunksUDPIFCLoop(pTransportStates, pEntry, srcRoute, conn, waitset, nevent);
+	}
+	PG_CATCH();
+	{
+		FreeWaitEventSet(waitset);
+		if (waitFds != NULL)
+			pfree(waitFds);
+
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+
+	FreeWaitEventSet(waitset);
+	if (waitFds != NULL)
+		pfree(waitFds);
+
+	return tcItem;
+}
+
+static TupleChunkListItem
+receiveChunksUDPIFCLoop(ChunkTransportState *pTransportStates, ChunkTransportStateEntry *pEntry,
+						int16 *srcRoute, MotionConn *conn, WaitEventSet *waitset, int nevent)
+{
+	TupleChunkListItem	tcItem = NULL;
+	MotionConn 	*rxconn = NULL;
+	int			retries = 0;
+	bool		directed = false;
+	WaitEvent	*rEvents = NULL;
+
+	if (conn != NULL)
+		directed = true;
+
+	rEvents = palloc(nevent * sizeof(WaitEvent)); /* returned events */
 	/* we didn't have any data, so we've got to read it from the network. */
 	for (;;)
 	{
@@ -3793,13 +3827,7 @@ receiveChunksUDPIFC(ChunkTransportState *pTransportStates, ChunkTransportStateEn
 
 			if (!directed)
 				*srcRoute = rxconn->route;
-
-			FreeWaitEventSet(waitset);
-			if (rEvents != NULL)
-				pfree(rEvents);
-			if (waitFds != NULL)
-				pfree(waitFds);
-
+			pfree(rEvents);
 			return tcItem;
 		}
 
@@ -3816,7 +3844,7 @@ receiveChunksUDPIFC(ChunkTransportState *pTransportStates, ChunkTransportStateEn
 		if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
 		{
 			elog(DEBUG5, "waiting (timed) on route %d %s", rx_control_info.mainWaitingState.waitingRoute,
-				 (rx_control_info.mainWaitingState.waitingRoute == ANY_ROUTE ? "(any route)" : ""));
+				(rx_control_info.mainWaitingState.waitingRoute == ANY_ROUTE ? "(any route)" : ""));
 		}
 
 		/*
@@ -3861,19 +3889,12 @@ receiveChunksUDPIFC(ChunkTransportState *pTransportStates, ChunkTransportStateEn
 			if (!PostmasterIsAlive())
 				ereport(FATAL,
 						(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
-						 errmsg("interconnect failed to recv chunks"),
-						 errdetail("Postmaster is not alive.")));
+						errmsg("interconnect failed to recv chunks"),
+						errdetail("Postmaster is not alive.")));
 		}
 
 		pthread_mutex_lock(&ic_control_info.lock);
-
-	}							/* for (;;) */
-
-	FreeWaitEventSet(waitset);
-	if (rEvents != NULL)
-		pfree(rEvents);
-	if (waitFds != NULL)
-		pfree(waitFds);
+	} /* for (;;) */
 
 	/* We either got data, or get cancelled. We never make it out to here. */
 	return NULL;				/* make GCC behave */

--- a/src/test/isolation2/init_file_isolation2
+++ b/src/test/isolation2/init_file_isolation2
@@ -56,7 +56,8 @@ s/^Process \d+ waits for ShareUpdateExclusiveLock on relation \d+ of database \d
 m/available \d+ MB/
 s/available \d+ MB//
 
-m/\(cdbdisp_async\.c\:\d+\)/
-s/\(cdbdisp_async\.c:\d+\)/\(cdbdisp_async\.c:LINE_NUM\)/
+# remove the cdbdisp_async suffix of some ERROR messages
+m/ \(cdbdisp_async\.c.*\)/
+s/ \(cdbdisp_async\.c.*\)//
 
 -- end_matchsubs

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -139,4 +139,8 @@ s/.//gs
 m/\(dbsize\.c\:\d+\)/
 s/\(dbsize\.c:\d+\)/\(dbsize\.c:XXX\)/
 
+# remove the cdbdisp_async suffix of some ERROR messages
+m/ \(cdbdisp_async\.c.*\)/
+s/ \(cdbdisp_async\.c.*\)//
+
 -- end_matchsubs


### PR DESCRIPTION
Introduced the waiteventset instead of poll() in my previous commits:
https://github.com/greenplum-db/gpdb/commit/e30909fccfef42a99070f080b7c06439d6d79b29
https://github.com/greenplum-db/gpdb/commit/683d5a4c724f4eee1dc98fded1e0b1e7b37371ef

But in some scenarios (most of them are exception related), the epoll fd leaks, this PR fix it.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
