### PR TITLE
resolve GPDB_12_MERGE_FIXME in planner to revert 1 phase limit path to 2 phase limit path

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -2855,35 +2855,28 @@ grouping_planner(PlannerInfo *root, bool inheritance_update,
 			{
 
 				/*
-				 * There is a corner case we can not generate gpdb private
-				 * two phase limit path.
-				 * if a subpath is sorted under a subqueryscan path, but the
-				 * subqueryscan is not.
-				 *
+				 * if a subpath is sorted under a subqueryscan path, but the subqueryscan
+				 * is not. the order of subqueryscan is implementation-dependent.
+				 * which is specified by SQL standard.
 				 * e.g.
 				 * create table foo (a int, b int, c int);
-				 *
 				 * select *
 				 * from (select b, c from foo order by 1,2) as x
 				 * limit 3;
 				 *
-				 * If a gather motion is directly upon a subquery scan,
-				 * the motion node will push down under the subqueryscan to promise
-				 * data ordered.
+				 * when we generate one phase limit path for it.
+				 * the results are sorted but may have a poor performance.
 				 *
-				 * GPDB_12_MERGE_FIXME:
-				 * A better approach is that our motion have LIMIT node ability.
-				 * All two phases limit is translated to `limit->gather motion->subpath...`
-				 * In executor, upper slice's gather motion sort tuples, under
-				 * slice's gather motion directly limit the number of tuples send out.
+				 * when we generate two phase limit path for it.
+				 * the results are not sorted but that also is up to SQL standard.
+				 *
+				 * we just generate gpdb private two phase limit path to
+				 * be consistent with gpdb6.
 				 */
-				if (!(IsA(path, SubqueryScanPath)
-					&& !path->pathkeys
-					&& ((SubqueryScanPath *)path)->subpath->pathkeys))
-					path = (Path *) create_preliminary_limit_path(root, final_rel, path,
-					                                              parse->limitOffset,
-					                                              parse->limitCount,
-					                                              offset_est, count_est);
+				path = (Path *) create_preliminary_limit_path(root, final_rel, path,
+															  parse->limitOffset,
+															  parse->limitCount,
+															  offset_est, count_est);
 			}
 
 			/*

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -1189,27 +1189,33 @@ begin
 end;
 $$;
 select * from explain_sq_limit();
-                               explain_sq_limit                               
-------------------------------------------------------------------------------
+                              explain_sq_limit                              
+----------------------------------------------------------------------------
  Limit (actual rows=3 loops=1)
-   ->  Subquery Scan on x (actual rows=3 loops=1)
-         ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
-               Merge Key: sq_limit.c1, sq_limit.pk
-               ->  Sort (actual rows=5 loops=1)
-                     Sort Key: sq_limit.c1, sq_limit.pk
-                     Sort Method:  quicksort  Memory: xxx
-                     ->  Seq Scan on sq_limit (actual rows=5 loops=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
+         ->  Limit (actual rows=3 loops=1)
+               ->  Subquery Scan on x (actual rows=3 loops=1)
+                     ->  Sort (actual rows=3 loops=1)
+                           Sort Key: sq_limit.c1, sq_limit.pk
+                           Sort Method:  quicksort  Memory: xxx
+                           ->  Seq Scan on sq_limit (actual rows=5 loops=1)
  Optimizer: Postgres query optimizer
 (9 rows)
 
+-- a subpath is sorted under a subqueryscan. however, the subqueryscan is not.
+-- whether the order of subpath can applied to the subqueryscan is up-to-implement.
+-- now we do not guarantee the order of subpath can apply to the subqueryscan.
+-- so the results of bellow is not stable, so we ignore the results
+--start_ignore
 select * from (select pk,c2 from sq_limit order by c1,pk) as x limit 3;
  pk | c2 
 ----+----
   1 |  1
   5 |  1
-  2 |  2
+  6 |  2
 (3 rows)
 
+--end_ignore
 reset optimizer;
 drop function explain_sq_limit();
 drop table sq_limit;

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -1225,19 +1225,24 @@ begin
 end;
 $$;
 select * from explain_sq_limit();
-                               explain_sq_limit                               
-------------------------------------------------------------------------------
+                              explain_sq_limit                              
+----------------------------------------------------------------------------
  Limit (actual rows=3 loops=1)
-   ->  Subquery Scan on x (actual rows=3 loops=1)
-         ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
-               Merge Key: sq_limit.c1, sq_limit.pk
-               ->  Sort (actual rows=5 loops=1)
-                     Sort Key: sq_limit.c1, sq_limit.pk
-                     Sort Method:  quicksort  Memory: xxx
-                     ->  Seq Scan on sq_limit (actual rows=5 loops=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
+         ->  Limit (actual rows=3 loops=1)
+               ->  Subquery Scan on x (actual rows=3 loops=1)
+                     ->  Sort (actual rows=3 loops=1)
+                           Sort Key: sq_limit.c1, sq_limit.pk
+                           Sort Method:  quicksort  Memory: xxx
+                           ->  Seq Scan on sq_limit (actual rows=5 loops=1)
  Optimizer: Postgres query optimizer
 (9 rows)
 
+-- a subpath is sorted under a subqueryscan. however, the subqueryscan is not.
+-- whether the order of subpath can applied to the subqueryscan is up-to-implement.
+-- now we do not guarantee the order of subpath can apply to the subqueryscan.
+-- so the results of bellow is not stable, so we ignore the results
+--start_ignore
 select * from (select pk,c2 from sq_limit order by c1,pk) as x limit 3;
  pk | c2 
 ----+----
@@ -1246,6 +1251,7 @@ select * from (select pk,c2 from sq_limit order by c1,pk) as x limit 3;
   2 |  2
 (3 rows)
 
+--end_ignore
 reset optimizer;
 drop function explain_sq_limit();
 drop table sq_limit;

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -650,7 +650,13 @@ $$;
 
 select * from explain_sq_limit();
 
+-- a subpath is sorted under a subqueryscan. however, the subqueryscan is not.
+-- whether the order of subpath can applied to the subqueryscan is up-to-implement.
+-- now we do not guarantee the order of subpath can apply to the subqueryscan.
+-- so the results of bellow is not stable, so we ignore the results
+--start_ignore
 select * from (select pk,c2 from sq_limit order by c1,pk) as x limit 3;
+--end_ignore
 reset optimizer;
 
 drop function explain_sq_limit();


### PR DESCRIPTION
1.   create table foo (a int, b int, c int);
    explain select * from (select b, c from foo order by 1,2) as x limit 3;
    above case in 6X_STABLE generate 2 phase limit path, the results are not sorted. 
    in master, the case generates 1 phase limit path, but the results are sorted.
    if a subpath is sorted, but the subqueryscan is not. the order of subqueryscan is 
    implementation-dependent which is specified by SQL standard.
    revert the modification to be consistent with gpdb6 to enhance performance.

2.   define a ParseState as the param of make_op instead of NULL to avoid hitting null pointer exception.
   when calculating limitoffset we should use "+" of schema pg_catalog to avoid misuse user-defined operator "+".
