### PR TITLE
gpstate -e: Remove progress for killed recoverseg (#13412)

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsSystemState.py
+++ b/gpMgmt/bin/gppylib/programs/clsSystemState.py
@@ -25,6 +25,7 @@ from gppylib.system import configurationInterface as configInterface
 from gppylib.system.environment import GpMasterEnvironment
 from gppylib.utils import TableLogger
 
+
 logger = gplog.get_default_logger()
 
 class FieldDefinition:
@@ -684,11 +685,12 @@ class GpSystemStateProgram:
         self.__addClusterDownWarning(gpArray, data)
 
         recovery_progress_file = get_recovery_progress_file(gplog)
-        recovery_progress_segs = self._parse_recovery_progress_data(data, recovery_progress_file, gpArray)
-        if recovery_progress_segs:
+        segments_under_recovery = self._parse_recovery_progress_data(data, recovery_progress_file, gpArray)
+        gprecoverseg_lock_dir = os.path.join(gpEnv.getMasterDataDir() + '/gprecoverseg.lock')
+        if segments_under_recovery and os.path.exists(gprecoverseg_lock_dir):
             logger.info("----------------------------------------------------")
             logger.info("Segments in recovery")
-            logSegments(recovery_progress_segs, False, [VALUE_RECOVERY_TYPE, VALUE_RECOVERY_COMPLETED_BYTES, VALUE_RECOVERY_TOTAL_BYTES,
+            logSegments(segments_under_recovery, False, [VALUE_RECOVERY_TYPE, VALUE_RECOVERY_COMPLETED_BYTES, VALUE_RECOVERY_TOTAL_BYTES,
                                                           VALUE_RECOVERY_PERCENTAGE])
             exitCode = 1
 
@@ -993,7 +995,6 @@ class GpSystemStateProgram:
                 data.addValue(VALUE_RECOVERY_PERCENTAGE, percentage)
 
         return recovery_progress_segs
-
 
     @staticmethod
     def _get_unsync_segs_add_wal_remaining_bytes(data, gpArray):

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -404,7 +404,7 @@ Feature: gprecoverseg tests
     And user can start transactions
     And all files in gpAdminLogs directory are deleted on all hosts in the cluster
     And a sample recovery_progress.file is created from saved lines
-    Then a sample gprecoverseg\.lock directory is created in master_data_directory
+    Then a sample gprecoverseg.lock directory is created in master_data_directory
     When the user runs "gpstate -e"
     Then gpstate should print "Segments in recovery" to stdout
 #    And gpstate output contains "incremental,incremental,incremental" entries for mirrors of content 0,1,2

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -404,6 +404,7 @@ Feature: gprecoverseg tests
     And user can start transactions
     And all files in gpAdminLogs directory are deleted on all hosts in the cluster
     And a sample recovery_progress.file is created from saved lines
+    Then a sample gprecoverseg\.lock directory is created in master_data_directory
     When the user runs "gpstate -e"
     Then gpstate should print "Segments in recovery" to stdout
 #    And gpstate output contains "incremental,incremental,incremental" entries for mirrors of content 0,1,2
@@ -413,6 +414,7 @@ Feature: gprecoverseg tests
 #      | \S+     | [0-9]+ | incremental    | [0-9]+                 | [0-9]+             | [0-9]+\%             |
 #      | \S+     | [0-9]+ | incremental    | [0-9]+                 | [0-9]+             | [0-9]+\%             |
     And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    Then the gprecoverseg lock directory is removed
 
     And user immediately stops all primary processes for content 0,1,2
     And user can start transactions
@@ -428,9 +430,11 @@ Feature: gprecoverseg tests
     And user can start transactions
 
     And a sample recovery_progress.file is created from saved lines
+    Then a sample gprecoverseg.lock directory is created in master_data_directory
     When the user runs "gpstate -e"
     Then gpstate should print "Segments in recovery" to stdout
     And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    Then the gprecoverseg lock directory is removed
 
   @demo_cluster
   @concourse_cluster
@@ -511,13 +515,39 @@ Feature: gprecoverseg tests
     And the user suspend the walsender on the primary on content 0
     When the user asynchronously runs "gprecoverseg -aF" and the process is saved
     Then the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
+    Then verify if the gprecoverseg.lock directory is present in master_data_directory
     When the user asynchronously sets up to end gprecoverseg process with SIGINT
     And the user waits until saved async process is completed
     Then recovery_progress.file should not exist in gpAdminLogs
     Then the user reset the walsender on the primary on content 0
-    And the gprecoverseg lock directory is removed
+    Then the gprecoverseg lock directory is removed
     And the user waits until mirror on content 0,1,2 is up
     And verify that lines from recovery_progress.file are present in segment progress files in gpAdminLogs
+    And the cluster is rebalanced
+
+  @demo_cluster
+  @concourse_cluster
+  Scenario:  SIGHUP on gprecoverseg should not display progress in gpstate -e
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user immediately stops all primary processes for content 0,1,2
+    And user can start transactions
+    And sql "DROP TABLE IF EXISTS test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,100000000) AS a;" is executed in "postgres" db
+    And the user suspend the walsender on the primary on content 0
+    When the user asynchronously runs "gprecoverseg -aF" and the process is saved
+    Then the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
+    Then verify if the gprecoverseg.lock directory is present in master_data_directory
+    When the user runs "gpstate -e"
+    Then gpstate should print "Segments in recovery" to stdout
+    When the user asynchronously sets up to end gprecoverseg process with SIGHUP
+    And the user waits until saved async process is completed
+    Then the gprecoverseg lock directory is removed
+    When the user runs "gpstate -e"
+    Then gpstate should not print "Segments in recovery" to stdout
+    Then the user reset the walsender on the primary on content 0
+    And the user waits until mirror on content 0,1,2 is up
     And the cluster is rebalanced
 
   @demo_cluster
@@ -852,7 +882,7 @@ Feature: gprecoverseg tests
           And the user asynchronously sets up to end gprecoverseg process when "Recovery type" is printed in the logs
           And the user runs "gprecoverseg -a"
          Then gprecoverseg should return a return code of -15
-          And the gprecoverseg lock directory is removed
+         Then the gprecoverseg lock directory is removed
 
          When the user runs "gprecoverseg -a"
          Then gprecoverseg should return a return code of 0

--- a/gpMgmt/test/behave/mgmt_utils/gpstate.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstate.feature
@@ -160,6 +160,7 @@ Feature: gpstate tests
         Given a standard local demo cluster is running
         Given all files in gpAdminLogs directory are deleted
         And a sample recovery_progress.file is created with ongoing recoveries in gpAdminLogs
+        And a sample gprecoverseg.lock directory is created in master_data_directory
         When the user runs "gpstate -e"
         Then gpstate should print "Segments in recovery" to stdout
         And gpstate output contains "full,incremental" entries for mirrors of content 0,1
@@ -168,11 +169,13 @@ Feature: gpstate tests
             | \S+     | [0-9]+ | full           | 1164848                | 1371715            | 84%                  |
             | \S+     | [0-9]+ | incremental    | 1                      | 1371875            | 1%                   |
         And all files in gpAdminLogs directory are deleted
+        And the gprecoverseg lock directory is removed
 
     Scenario: gpstate -e does not show information about segments with completed recovery
         Given a standard local demo cluster is running
         Given all files in gpAdminLogs directory are deleted
         And a sample recovery_progress.file is created with completed recoveries in gpAdminLogs
+        And a sample gprecoverseg.lock directory is created in master_data_directory
         When the user runs "gpstate -e"
         Then gpstate should print "Segments in recovery" to stdout
         And gpstate output contains "full" entries for mirrors of content 1
@@ -182,6 +185,7 @@ Feature: gpstate tests
         And gpstate should not print "incremental" to stdout
         And gpstate should not print "All segments are running normally" to stdout
         And all files in gpAdminLogs directory are deleted
+        Then the gprecoverseg lock directory is removed
 
     Scenario: gpstate -c logs cluster info for a mirrored cluster
         Given a standard local demo cluster is running

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
@@ -6,6 +6,10 @@ from gppylib.db import dbconn
 from gppylib.gparray import GpArray, ROLE_MIRROR
 from test.behave_utils.utils import check_stdout_msg, check_string_not_present_stdout
 
+master_data_dir = os.environ.get('MASTER_DATA_DIRECTORY')
+if master_data_dir is None:
+    raise Exception('Please set MASTER_DATA_DIRECTORY in environment')
+
 @then('a sample recovery_progress.file is created from saved lines')
 def impl(context):
     with open('{}/gpAdminLogs/recovery_progress.file'.format(os.path.expanduser("~")), 'w+') as fp:
@@ -16,6 +20,12 @@ def impl(context):
     with open('{}/gpAdminLogs/recovery_progress.file'.format(os.path.expanduser("~")), 'w+') as fp:
         fp.write("full:5: 1164848/1371715 kB (84%), 0/1 tablespace (...t1/demoDataDir0/base/16384/40962)\n")
         fp.write("incremental:6: 1/1371875 kB (1%)")
+
+@then('a sample gprecoverseg.lock directory is created in master_data_directory')
+@given('a sample gprecoverseg.lock directory is created in master_data_directory')
+def impl(context):
+    gprecoverseg_lock_dir = os.path.join(master_data_dir + '/gprecoverseg.lock')
+    os.mkdir(gprecoverseg_lock_dir)
 
 @given('a sample recovery_progress.file is created with completed recoveries in gpAdminLogs')
 def impl(context):

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -38,6 +38,7 @@ from test.behave_utils.cluster_expand import Gpexpand
 from test.behave_utils.gpexpand_dml import TestDML
 from gppylib.commands.base import Command, REMOTE
 from gppylib import pgconf
+from gppylib.operations.package import linux_distribution_id, linux_distribution_version
 
 
 master_data_dir = os.environ.get('MASTER_DATA_DIRECTORY')
@@ -449,6 +450,13 @@ def impl(context, logdir):
         if attempt == num_retries:
             raise Exception('Timed out after {} retries'.format(num_retries))
 
+@then( 'verify if the gprecoverseg.lock directory is present in master_data_directory')
+def impl(context):
+    gprecoverseg_lock_dir = "%s/gprecoverseg.lock" % master_data_dir
+    if not os.path.exists(gprecoverseg_lock_dir):
+        raise Exception('gprecoverseg.lock directory does not exist')
+    else:
+        return
 
 @then('verify that lines from recovery_progress.file are present in segment progress files in {logdir}')
 def impl(context, logdir):
@@ -615,6 +623,11 @@ def impl(context, kill_process_name, log_msg, logfile_name):
 @when('the user asynchronously sets up to end {process_name} process with SIGINT')
 def impl(context, process_name):
     command = "ps ux | grep bin/%s | awk '{print $2}' | xargs kill -2" % (process_name)
+    run_async_command(context, command)
+
+@when('the user asynchronously sets up to end {process_name} process with SIGHUP')
+def impl(context, process_name):
+    command = "ps ux | grep bin/%s | awk '{print $2}' | xargs kill -9" % (process_name)
     run_async_command(context, command)
 
 @when('the user asynchronously sets up to end gpcreateseg process when it starts')
@@ -2620,6 +2633,7 @@ def impl(context):
     files_found = glob.glob('%s/*' % (log_dir))
     for file in files_found:
         os.remove(file)
+
 
 @given('all files in gpAdminLogs directory are deleted on hosts {hosts}')
 def impl(context, hosts):

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -38,7 +38,6 @@ from test.behave_utils.cluster_expand import Gpexpand
 from test.behave_utils.gpexpand_dml import TestDML
 from gppylib.commands.base import Command, REMOTE
 from gppylib import pgconf
-from gppylib.operations.package import linux_distribution_id, linux_distribution_version
 
 
 master_data_dir = os.environ.get('MASTER_DATA_DIRECTORY')


### PR DESCRIPTION
* Problem Statement:
When gprecoverseg is running gpstate -e command displays status of the recovered segments. if the user kills the gprecoverseg process then gpstate -e continues to report the status of the old gprecoverseg.

Root Cause
gpstate -e command checks if the recovery_progress_file exists or not before displaying the gprecoverseg progress.
Since the recovery_progress_file is not removed when the gprecoverseg is forcefully killed, gpstate -e will continue to display the progress.

Fix:
To fix this issue, gpstate -e code is modified to verify if ~/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1/gprecoverseg.lock exists before reporting the gprecoverseg progress. Since the user is aware that the lock file should be removed if gprecoverseg process is killed, the double check ensures that gpstate -e does not report the progress of the old killed gprecoverseg.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
