### PR TITLE
resolve GPDB_12_MERGE_FIXME in createplan.c

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -256,9 +256,9 @@ static NestLoop *make_nestloop(List *tlist,
 							   JoinType jointype, bool inner_unique);
 static HashJoin *make_hashjoin(List *tlist,
 							   List *joinclauses, List *otherclauses,
-							   List *hashclauses, List *hashqualclauses,
-							   Plan *lefttree, Plan *righttree,
-							   JoinType jointype, bool inner_unique);
+							   List *hashclauses, Plan *lefttree,
+							   Plan *righttree, JoinType jointype,
+							   bool inner_unique);
 static Hash *make_hash(Plan *lefttree,
 					   Oid skewTable,
 					   AttrNumber skewColumn,
@@ -1103,9 +1103,6 @@ create_join_plan(PlannerInfo *root, JoinPath *best_path)
 	/* CDB: if the join's locus is bottleneck which means the
 	 * join gang only contains one process, so there is no
 	 * risk for motion deadlock.
-	 *
-	 * GPDB_12_MERGE_FIXME: this overwrites the prefetch_inner flag that may
-	 * have been set for Partition Selectors. That's not cool, right?
 	 */
 	if (CdbPathLocus_IsBottleneck(best_path->path.locus))
 	{
@@ -5534,7 +5531,6 @@ create_hashjoin_plan(PlannerInfo *root,
 							  joinclauses,
 							  otherclauses,
 							  hashclauses,
-							  NIL, /* hashqualclauses */
 							  outer_plan,
 							  (Plan *) hash_plan,
 							  best_path->jpath.jointype,
@@ -6655,7 +6651,6 @@ make_hashjoin(List *tlist,
 			  List *joinclauses,
 			  List *otherclauses,
 			  List *hashclauses,
-			  List *hashqualclauses, /* GPDB_12_MERGE_FIXME: Does it need to rid of ? */
 			  Plan *lefttree,
 			  Plan *righttree,
 			  JoinType jointype,
@@ -6669,7 +6664,7 @@ make_hashjoin(List *tlist,
 	plan->lefttree = lefttree;
 	plan->righttree = righttree;
 	node->hashclauses = hashclauses;
-	node->hashqualclauses = hashqualclauses;
+	node->hashqualclauses = NIL;
 	node->join.jointype = jointype;
 	node->join.inner_unique = inner_unique;
 	node->join.joinqual = joinclauses;

--- a/src/test/regress/expected/select_distinct.out
+++ b/src/test/regress/expected/select_distinct.out
@@ -323,6 +323,64 @@ SELECT null IS NOT DISTINCT FROM null as "yes";
  t
 (1 row)
 
+-- join cases
+-- test IS DISTINCT FROM and IS NOT DISTINCT FROM join qual. the postgres planner doesn't support hash join
+-- on IS NOT DISTINCT FROM for now, ORCA support "IS NOT DISTINCT FROM" Hash Join but generates wrong result,
+-- DISABLE ORCA. Please fix me later if ORCA resolve the problem.
+SET optimizer TO off;
+CREATE TABLE distinct_1(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE distinct_2(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO distinct_1 VALUES(1),(2),(NULL);
+INSERT INTO distinct_2 VALUES(1),(NULL);
+EXPLAIN SELECT * FROM distinct_1, distinct_2 WHERE distinct_1.a IS DISTINCT FROM distinct_2.a;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10214778180.80 rows=9264416310 width=8)
+   ->  Nested Loop  (cost=10000000000.00..10091252630.00 rows=3088138770 width=8)
+         Join Filter: (distinct_1.a IS DISTINCT FROM distinct_2.a)
+         ->  Seq Scan on distinct_1  (cost=0.00..355.00 rows=32100 width=4)
+         ->  Materialize  (cost=0.00..2120.50 rows=96300 width=4)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1639.00 rows=96300 width=4)
+                     ->  Seq Scan on distinct_2  (cost=0.00..355.00 rows=32100 width=4)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+EXPLAIN SELECT * FROM distinct_1, distinct_2 WHERE distinct_1.a IS NOT DISTINCT FROM distinct_2.a;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10091376279.20 rows=9273690 width=8)
+   ->  Nested Loop  (cost=10000000000.00..10091252630.00 rows=3091230 width=8)
+         Join Filter: (NOT (distinct_1.a IS DISTINCT FROM distinct_2.a))
+         ->  Seq Scan on distinct_1  (cost=0.00..355.00 rows=32100 width=4)
+         ->  Materialize  (cost=0.00..2120.50 rows=96300 width=4)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1639.00 rows=96300 width=4)
+                     ->  Seq Scan on distinct_2  (cost=0.00..355.00 rows=32100 width=4)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+SELECT * FROM distinct_1, distinct_2 WHERE distinct_1.a IS DISTINCT FROM distinct_2.a;
+ a | a 
+---+---
+ 1 |  
+ 2 | 1
+ 2 |  
+   | 1
+(4 rows)
+
+SELECT * FROM distinct_1, distinct_2 WHERE distinct_1.a IS NOT DISTINCT FROM distinct_2.a;
+ a | a 
+---+---
+   |  
+ 1 | 1
+(2 rows)
+
+DROP TABLE distinct_1;
+DROP TABLE distinct_2;
+RESET optimizer;
 -- gpdb start: test inherit/partition table distinct when gp_statistics_pullup_from_child_partition is on
 set gp_statistics_pullup_from_child_partition to on;
 CREATE TABLE sales (id int, date date, amt decimal(10,2))

--- a/src/test/regress/expected/select_distinct_optimizer.out
+++ b/src/test/regress/expected/select_distinct_optimizer.out
@@ -330,6 +330,64 @@ SELECT null IS NOT DISTINCT FROM null as "yes";
  t
 (1 row)
 
+-- join cases
+-- test IS DISTINCT FROM and IS NOT DISTINCT FROM join qual. the postgres planner doesn't support hash join
+-- on IS NOT DISTINCT FROM for now, ORCA support "IS NOT DISTINCT FROM" Hash Join but generates wrong result,
+-- DISABLE ORCA. Please fix me later if ORCA resolve the problem.
+SET optimizer TO off;
+CREATE TABLE distinct_1(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE distinct_2(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO distinct_1 VALUES(1),(2),(NULL);
+INSERT INTO distinct_2 VALUES(1),(NULL);
+EXPLAIN SELECT * FROM distinct_1, distinct_2 WHERE distinct_1.a IS DISTINCT FROM distinct_2.a;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10214778180.80 rows=9264416310 width=8)
+   ->  Nested Loop  (cost=10000000000.00..10091252630.00 rows=3088138770 width=8)
+         Join Filter: (distinct_1.a IS DISTINCT FROM distinct_2.a)
+         ->  Seq Scan on distinct_1  (cost=0.00..355.00 rows=32100 width=4)
+         ->  Materialize  (cost=0.00..2120.50 rows=96300 width=4)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1639.00 rows=96300 width=4)
+                     ->  Seq Scan on distinct_2  (cost=0.00..355.00 rows=32100 width=4)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+EXPLAIN SELECT * FROM distinct_1, distinct_2 WHERE distinct_1.a IS NOT DISTINCT FROM distinct_2.a;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10091376279.20 rows=9273690 width=8)
+   ->  Nested Loop  (cost=10000000000.00..10091252630.00 rows=3091230 width=8)
+         Join Filter: (NOT (distinct_1.a IS DISTINCT FROM distinct_2.a))
+         ->  Seq Scan on distinct_1  (cost=0.00..355.00 rows=32100 width=4)
+         ->  Materialize  (cost=0.00..2120.50 rows=96300 width=4)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1639.00 rows=96300 width=4)
+                     ->  Seq Scan on distinct_2  (cost=0.00..355.00 rows=32100 width=4)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+SELECT * FROM distinct_1, distinct_2 WHERE distinct_1.a IS DISTINCT FROM distinct_2.a;
+ a | a 
+---+---
+ 2 |  
+ 2 | 1
+   | 1
+ 1 |  
+(4 rows)
+
+SELECT * FROM distinct_1, distinct_2 WHERE distinct_1.a IS NOT DISTINCT FROM distinct_2.a;
+ a | a 
+---+---
+   |  
+ 1 | 1
+(2 rows)
+
+DROP TABLE distinct_1;
+DROP TABLE distinct_2;
+RESET optimizer;
 -- gpdb start: test inherit/partition table distinct when gp_statistics_pullup_from_child_partition is on
 set gp_statistics_pullup_from_child_partition to on;
 CREATE TABLE sales (id int, date date, amt decimal(10,2))

--- a/src/test/regress/sql/select_distinct.sql
+++ b/src/test/regress/sql/select_distinct.sql
@@ -138,6 +138,23 @@ SELECT 2 IS NOT DISTINCT FROM 2 as "yes";
 SELECT 2 IS NOT DISTINCT FROM null as "no";
 SELECT null IS NOT DISTINCT FROM null as "yes";
 
+-- join cases
+-- test IS DISTINCT FROM and IS NOT DISTINCT FROM join qual. the postgres planner doesn't support hash join
+-- on IS NOT DISTINCT FROM for now, ORCA support "IS NOT DISTINCT FROM" Hash Join but generates wrong result,
+-- DISABLE ORCA. Please fix me later if ORCA resolve the problem.
+SET optimizer TO off;
+CREATE TABLE distinct_1(a int);
+CREATE TABLE distinct_2(a int);
+INSERT INTO distinct_1 VALUES(1),(2),(NULL);
+INSERT INTO distinct_2 VALUES(1),(NULL);
+EXPLAIN SELECT * FROM distinct_1, distinct_2 WHERE distinct_1.a IS DISTINCT FROM distinct_2.a;
+EXPLAIN SELECT * FROM distinct_1, distinct_2 WHERE distinct_1.a IS NOT DISTINCT FROM distinct_2.a;
+SELECT * FROM distinct_1, distinct_2 WHERE distinct_1.a IS DISTINCT FROM distinct_2.a;
+SELECT * FROM distinct_1, distinct_2 WHERE distinct_1.a IS NOT DISTINCT FROM distinct_2.a;
+DROP TABLE distinct_1;
+DROP TABLE distinct_2;
+RESET optimizer;
+
 -- gpdb start: test inherit/partition table distinct when gp_statistics_pullup_from_child_partition is on
 set gp_statistics_pullup_from_child_partition to on;
 CREATE TABLE sales (id int, date date, amt decimal(10,2))


### PR DESCRIPTION
1. due to function push_partition_selector_candidate_for_join: for hashjoin,
or for nestloop or mergejoin with a Material or Sort node on the inner side,
they will process all the inner rows before scanning the outer side. Only in
these cases, a Partition Selector could be placed at this join. Even if the
prefetch_inner flag maybe reset to false, it doesn't affect the resullt.
2. the postgres planner doesn't support hash join on IS NOT DISTINCT FROM
for now, get rid of the hashqualclauses parameter from the make_hashjoin().

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
