### PR TITLE
Fix assertion failure when concurrent update for AO tables

### DIFF
--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -898,7 +898,7 @@ ldelete:;
 					ereport(ERROR,
 							(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
 							 errmsg("could not serialize access due to concurrent update")));
-				if (ItemPointerIndicatesMovedPartitions(&hufd.ctid))
+				if (!isAORowsTable && !isAOColsTable && ItemPointerIndicatesMovedPartitions(&hufd.ctid))
 					ereport(ERROR,
 							(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
 							 errmsg("tuple to be %s was already moved to another segment due to concurrent update",
@@ -922,7 +922,7 @@ ldelete:;
 							 errmsg("concurrent updates distribution keys on the same row is not allowed")));
 				}
 
-				if (!ItemPointerEquals(tupleid, &hufd.ctid))
+				if (!isAORowsTable && !isAOColsTable && !ItemPointerEquals(tupleid, &hufd.ctid))
 				{
 					TupleTableSlot *epqslot;
 
@@ -1525,11 +1525,11 @@ lreplace:;
 					ereport(ERROR,
 							(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
 							 errmsg("could not serialize access due to concurrent update")));
-				if (ItemPointerIndicatesMovedPartitions(&hufd.ctid))
+				if (!rel_is_aorows && !rel_is_aocols && ItemPointerIndicatesMovedPartitions(&hufd.ctid))
 					ereport(ERROR,
 							(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
 							 errmsg("tuple to be updated was already moved to another segment due to concurrent update")));
-		if (!ItemPointerEquals(tupleid, &hufd.ctid))
+				if (!rel_is_aorows && !rel_is_aocols && !ItemPointerEquals(tupleid, &hufd.ctid))
 				{
 					TupleTableSlot *epqslot;
 


### PR DESCRIPTION
Inside ExecDelete()/ExecUpdate(), local variable `HeapUpdateFailureData hufd` is
only initialized for heap tables. But at switch case HeapTupleUpdated, hufd is
used unconditionally even if it is AO row/col table. Uninitialized hufd could
cause unexpected behaviors, e.g. trigger ItemPointerIsValid(&hufd.ctid).

Fix it by bypassing hufd use for AO tables.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
