### PR TITLE
Resolve GPDB_12_MERGE_FIXMEs on index creation for Append-Optimized t…

### DIFF
--- a/src/backend/catalog/aoblkdir.c
+++ b/src/backend/catalog/aoblkdir.c
@@ -50,17 +50,15 @@ AlterTableCreateAoBlkdirTable(Oid relOid)
 		return;
 
 	/*
-	 * GPDB_12_MERGE_FIXME: Block directory creation must block any
-	 * transactions that may create or update indexes such as insert, vacuum
-	 * and create-index.  Concurrent sequential scans (select) transactions
-	 * need not be blocked.  Index scans cannot happen because the fact that
-	 * we are creating block directory implies no index is yet defined on this
-	 * appendoptimized table.  ShareRowExclusiveLock seems appropriate for
-	 * this purpose.  See if using that instead of the sledgehammer of
-	 * AccessExclusiveLock.  New tests will be needed to validate concurrent
-	 * select with index creation.
+	 * Block directory creation must block any transactions that may create
+	 * or update indexes such as insert, vacuum and create-index. Concurrent
+	 * sequential scans (select) transactions need not be blocked. Index scans
+	 * cannot happen because the fact that we are creating block directory
+	 * implies no index is yet defined on this appendoptimized table.
+	 * Using ExclusiveLock for this purpose as we allow read-only transactions
+	 * being running concurrently.
 	 */
-	rel = table_open(relOid, AccessExclusiveLock);
+	rel = table_open(relOid, ExclusiveLock);
 
 	/* Create a tuple descriptor */
 	tupdesc = CreateTemplateTupleDesc(4);

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -291,7 +291,6 @@ static void RelationParseRelOptions(Relation relation, HeapTuple tuple);
 static void RelationBuildTupleDesc(Relation relation);
 static Relation RelationBuildDesc(Oid targetRelId, bool insertIt);
 static void RelationInitPhysicalAddr(Relation relation);
-//static void RelationInitAppendOnlyInfo(Relation relation);
 static void load_critical_index(Oid indexoid, Oid heapoid);
 static TupleDesc GetPgClassDescriptor(void);
 static TupleDesc GetPgIndexDescriptor(void);

--- a/src/test/isolation2/input/uao/visibility_check_in_snapshotany.source
+++ b/src/test/isolation2/input/uao/visibility_check_in_snapshotany.source
@@ -19,5 +19,34 @@ insert into @amname@_snapshotany_tbl select a,a from generate_series(1,10) a;
 1: end;
 2: end;
 
+-- Case 2, verify index creation is able to update table's pg_class->reltuples correctly
+-- when pre-existing readonly transaction is not finished.
+
+1: set enable_seqscan = off;
+1: begin;
+-- start_ignore
+1: explain select * from @amname@_snapshotany_tbl where a = 2;
+-- end_ignore
+1: select * from @amname@_snapshotany_tbl where a = 2;
+
+0U: select reltuples from pg_class where relname='@amname@_snapshotany_tbl'; -- expect reltuples = 5;
+0U: select reltuples from pg_class where relname='@amname@_snapshotany_tbl_a_idx'; -- expect reltuples = 5;
+
+2: delete from @amname@_snapshotany_tbl where a = 2;
+
+0U: analyze @amname@_snapshotany_tbl;
+
+0U: select reltuples from pg_class where relname='@amname@_snapshotany_tbl'; -- expect reltuples = 4;
+0U: select reltuples from pg_class where relname='@amname@_snapshotany_tbl_a_idx'; -- expect reltuples = 4;
+
+2: create index on @amname@_snapshotany_tbl(a);
+
+0U: select reltuples from pg_class where relname='@amname@_snapshotany_tbl'; -- expect reltuples = 4;
+0U: select reltuples from pg_class where relname='@amname@_snapshotany_tbl_a_idx'; -- expect reltuples = 4;
+0U: select reltuples from pg_class where relname='@amname@_snapshotany_tbl_a_idx1'; -- expect reltuples = 5;
+0Uq:
+
+1: end;
+
 drop table @amname@_snapshotany_tbl;
 reset default_table_access_method;

--- a/src/test/isolation2/input/uao/visibility_check_in_snapshotany.source
+++ b/src/test/isolation2/input/uao/visibility_check_in_snapshotany.source
@@ -1,0 +1,23 @@
+-- This is intended to verify read-only transactions is able to run
+-- concurently with index creation.
+
+set default_table_access_method=@amname@;
+
+create table @amname@_snapshotany_tbl(a int, b int);
+insert into @amname@_snapshotany_tbl select a,a from generate_series(1,10) a;
+
+-- Case 1, verify readonly transaction is able to run concurrently with index creation.
+
+1: begin;
+1: select * from @amname@_snapshotany_tbl where a = 2;
+
+2: begin;
+2: create index on @amname@_snapshotany_tbl(a); -- expect no hang;
+
+1: select * from @amname@_snapshotany_tbl where a = 2; -- expect no hang;
+
+1: end;
+2: end;
+
+drop table @amname@_snapshotany_tbl;
+reset default_table_access_method;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -156,6 +156,7 @@ test: uao/vacuum_cleanup_row
 test: uao/vacuum_index_stats_row
 test: uao/bitmapindex_rescan_row
 test: uao/limit_indexscan_inits_row
+test: uao/visibility_check_in_snapshotany_row
 test: reorganize_after_ao_vacuum_skip_drop truncate_after_ao_vacuum_skip_drop mark_all_aoseg_await_drop
 # below test(s) inject faults so each of them need to be in a separate group
 test: segwalrep/master_wal_switch
@@ -209,6 +210,7 @@ test: uao/vacuum_cleanup_column
 test: uao/vacuum_index_stats_column
 test: uao/bitmapindex_rescan_column
 test: uao/limit_indexscan_inits_column
+test: uao/visibility_check_in_snapshotany_column
 
 # this case contains fault injection, must be put in a separate test group
 test: terminate_in_gang_creation

--- a/src/test/isolation2/output/uao/visibility_check_in_snapshotany.source
+++ b/src/test/isolation2/output/uao/visibility_check_in_snapshotany.source
@@ -1,0 +1,41 @@
+-- This is intended to verify read-only transactions is able to run
+-- concurently with index creation.
+
+set default_table_access_method=@amname@;
+SET
+
+create table @amname@_snapshotany_tbl(a int, b int);
+CREATE
+insert into @amname@_snapshotany_tbl select a,a from generate_series(1,10) a;
+INSERT 10
+
+-- Case 1, verify readonly transaction is able to run concurrently with index creation.
+
+1: begin;
+BEGIN
+1: select * from @amname@_snapshotany_tbl where a = 2;
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+
+2: begin;
+BEGIN
+2: create index on @amname@_snapshotany_tbl(a); -- expect no hang;
+CREATE
+
+1: select * from @amname@_snapshotany_tbl where a = 2; -- expect no hang;
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+
+1: end;
+END
+2: end;
+END
+
+drop table @amname@_snapshotany_tbl;
+DROP
+reset default_table_access_method;
+RESET

--- a/src/test/isolation2/output/uao/visibility_check_in_snapshotany.source
+++ b/src/test/isolation2/output/uao/visibility_check_in_snapshotany.source
@@ -35,6 +35,82 @@ END
 2: end;
 END
 
+-- Case 2, verify index creation is able to update table's pg_class->reltuples correctly
+-- when pre-existing readonly transaction is not finished.
+
+1: set enable_seqscan = off;
+SET
+1: begin;
+BEGIN
+-- start_ignore
+1: explain select * from @amname@_snapshotany_tbl where a = 2;
+ QUERY PLAN                                                                                       
+--------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=4.82..40.81 rows=86 width=8)                     
+   ->  Bitmap Heap Scan on @amname@_snapshotany_tbl  (cost=4.82..39.67 rows=29 width=8)             
+         Recheck Cond: (a = 2)                                                                    
+         ->  Bitmap Index Scan on @amname@_snapshotany_tbl_a_idx  (cost=0.00..4.81 rows=29 width=0) 
+               Index Cond: (a = 2)                                                                
+ Optimizer: Postgres query optimizer                                                              
+(6 rows)
+-- end_ignore
+1: select * from @amname@_snapshotany_tbl where a = 2;
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+
+0U: select reltuples from pg_class where relname='@amname@_snapshotany_tbl'; -- expect reltuples = 5;
+ reltuples 
+-----------
+ 5         
+(1 row)
+0U: select reltuples from pg_class where relname='@amname@_snapshotany_tbl_a_idx'; -- expect reltuples = 5;
+ reltuples 
+-----------
+ 5         
+(1 row)
+
+2: delete from @amname@_snapshotany_tbl where a = 2;
+DELETE 1
+
+0U: analyze @amname@_snapshotany_tbl;
+ANALYZE
+
+0U: select reltuples from pg_class where relname='@amname@_snapshotany_tbl'; -- expect reltuples = 4;
+ reltuples 
+-----------
+ 4         
+(1 row)
+0U: select reltuples from pg_class where relname='@amname@_snapshotany_tbl_a_idx'; -- expect reltuples = 4;
+ reltuples 
+-----------
+ 4         
+(1 row)
+
+2: create index on @amname@_snapshotany_tbl(a);
+CREATE
+
+0U: select reltuples from pg_class where relname='@amname@_snapshotany_tbl'; -- expect reltuples = 4;
+ reltuples 
+-----------
+ 4         
+(1 row)
+0U: select reltuples from pg_class where relname='@amname@_snapshotany_tbl_a_idx'; -- expect reltuples = 4;
+ reltuples 
+-----------
+ 4         
+(1 row)
+0U: select reltuples from pg_class where relname='@amname@_snapshotany_tbl_a_idx1'; -- expect reltuples = 5;
+ reltuples 
+-----------
+ 5         
+(1 row)
+0Uq: ... <quitting>
+
+1: end;
+END
+
 drop table @amname@_snapshotany_tbl;
 DROP
 reset default_table_access_method;


### PR DESCRIPTION
…ables.

This PR contains the following items:
- Resolve GPDB_12_MERGE_FIXME "visibility checks in SnapshotAny" on
  Append-Optimized tables, in appendonly/aoco_index_build_range_scan();
- Resolve GPDB_12_MERGE_FIXME replace AccessExclusiveLock with
  ShareRowExclusiveLock in AlterTableCreateAoBlkdirTable() to relief table
  level exclusive lock contention.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
