### PR TITLE
Remove default partition for equality filters

### DIFF
--- a/src/backend/cdb/partitionselection.c
+++ b/src/backend/cdb/partitionselection.c
@@ -216,7 +216,14 @@ partition_rules_for_equality_predicate(PartitionSelectorState *node, int level,
 	Assert(level < ps->nLevels);
 
 	/* evaluate equalityPredicate to get partition identifier value */
-	List  *exprStateList = (List *) lfirst(list_nth_cell(node->levelEqExprStates, level));
+    List  *exprStateList = NIL;
+    ExprState *exprState = lfirst(list_nth_cell(node->levelEqExprStates, level));
+
+    if (IsA(exprState, List)) {
+        exprStateList = (List *) exprState;
+    } else {
+        exprStateList = list_append_unique(exprStateList, exprState);
+    }
 
 	ExprContext *econtext = node->ps.ps_ExprContext;
 
@@ -284,7 +291,7 @@ processLevel(PartitionSelectorState *node, int level, TupleTableSlot *inputTuple
 	Assert(level < ps->nLevels);
 
 	/* get equality and general predicate for the current level */
-	List	   *equalityPredicate = (List *) lfirst(list_nth_cell(ps->levelEqExpressions, level));
+	Expr       *equalityPredicate = (Expr*) lfirst(list_nth_cell(ps->levelEqExpressions, level));
 	Expr	   *generalPredicate = (Expr *) lfirst(list_nth_cell(ps->levelExpressions, level));
 
 	/* get parent PartitionNode if in level 0, it's the root PartitionNode */

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -3242,9 +3242,9 @@ CTranslatorDXLToPlStmt::TranslateDXLPartSelector(
 		output_context);
 
 	GPOS_ASSERT(filters_dxlnode->Arity() == num_of_levels);
-	partition_selector->levelExpressions = TranslateDXLFilterList(
-		filters_dxlnode, NULL /*base_table_context*/, child_contexts,
-		output_context);
+	partition_selector->levelExpressions =
+		TranslateDXLFilterList(filters_dxlnode, NULL /*base_table_context*/,
+							   child_contexts, output_context);
 
 	//translate residual filter
 	CMappingColIdVarPlStmt colid_var_mapping = CMappingColIdVarPlStmt(
@@ -3328,16 +3328,18 @@ CTranslatorDXLToPlStmt::TranslateDXLFilterList(
 	{
 		CDXLNode *child_filter_dxlnode = (*filter_list_dxlnode)[ul];
 
-		if (m_translator_dxl_to_scalar->HasConstTrue(
-									   child_filter_dxlnode, m_md_accessor))
+		if (m_translator_dxl_to_scalar->HasConstTrue(child_filter_dxlnode,
+													 m_md_accessor))
 		{
 			filters_list = gpdb::LAppend(filters_list, NULL /*datum*/);
-		} else {
-            Expr *filter_expr =
-                    m_translator_dxl_to_scalar->TranslateDXLToScalar(
-                            child_filter_dxlnode, &colid_var_mapping);
-            filters_list = gpdb::LAppend(filters_list, filter_expr);
-        }
+		}
+		else
+		{
+			Expr *filter_expr =
+				m_translator_dxl_to_scalar->TranslateDXLToScalar(
+					child_filter_dxlnode, &colid_var_mapping);
+			filters_list = gpdb::LAppend(filters_list, filter_expr);
+		}
 	}
 
 	return filters_list;

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -150,6 +150,8 @@ CTranslatorDXLToScalar::TranslateDXLToScalar(const CDXLNode *dxlnode,
 		 &CTranslatorDXLToScalar::TranslateDXLScalarValuesListToScalar},
 		{EdxlopScalarSortGroupClause,
 		 &CTranslatorDXLToScalar::TranslateDXLScalarSortGroupClauseToScalar},
+        {EdxlopScalarOpList,
+                &CTranslatorDXLToScalar::TranslateDXLScalarOpListToScalar},
 	};
 
 	const ULONG num_translators = GPOS_ARRAY_SIZE(translators);
@@ -176,6 +178,20 @@ CTranslatorDXLToScalar::TranslateDXLToScalar(const CDXLNode *dxlnode,
 	}
 
 	return (this->*translate_func)(dxlnode, colid_var);
+}
+
+//	@function:
+//		CTranslatorDXLToScalar::TranslateDXLScalarOpListToScalar
+//
+//	@doc:
+//		Translate children of scalar op list node, and add them to list
+//---------------------------------------------------------------------------
+Expr *
+CTranslatorDXLToScalar::TranslateDXLScalarOpListToScalar(
+        const CDXLNode *scalar_op_list_node, CMappingColIdVar *colid_var) {
+    List *exprs = NIL;
+    exprs = TranslateScalarChildren(exprs,scalar_op_list_node, colid_var);
+    return (Expr *) exprs;
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -152,6 +152,8 @@ CTranslatorDXLToScalar::TranslateDXLToScalar(const CDXLNode *dxlnode,
 		 &CTranslatorDXLToScalar::TranslateDXLScalarSortGroupClauseToScalar},
         {EdxlopScalarOpList,
                 &CTranslatorDXLToScalar::TranslateDXLScalarOpListToScalar},
+		{EdxlopScalarOpList,
+		 &CTranslatorDXLToScalar::TranslateDXLScalarOpListToScalar},
 	};
 
 	const ULONG num_translators = GPOS_ARRAY_SIZE(translators);
@@ -188,10 +190,11 @@ CTranslatorDXLToScalar::TranslateDXLToScalar(const CDXLNode *dxlnode,
 //---------------------------------------------------------------------------
 Expr *
 CTranslatorDXLToScalar::TranslateDXLScalarOpListToScalar(
-        const CDXLNode *scalar_op_list_node, CMappingColIdVar *colid_var) {
-    List *exprs = NIL;
-    exprs = TranslateScalarChildren(exprs,scalar_op_list_node, colid_var);
-    return (Expr *) exprs;
+	const CDXLNode *scalar_op_list_node, CMappingColIdVar *colid_var)
+{
+	List *exprs = NIL;
+	exprs = TranslateScalarChildren(exprs, scalar_op_list_node, colid_var);
+	return (Expr *) exprs;
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexProbeMergeFilters.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexProbeMergeFilters.mdp
@@ -728,9 +728,7 @@ EXPLAIN SELECT * FROM table_with_two_indices_ao WHERE b = 15 AND c BETWEEN 10000
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="15"/>
-              </dxl:PartEqFilterElems>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="15"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/CPhysicalParallelUnionAllTest/FallBackToSerialAppend.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CPhysicalParallelUnionAllTest/FallBackToSerialAppend.mdp
@@ -372,49 +372,10 @@ SELECT * FROM pp WHERE b=2 AND c=2;
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:PartEqFilters>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
-                <dxl:And>
-                  <dxl:Or>
-                    <dxl:And>
-                      <dxl:Or>
-                        <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
-                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                        </dxl:Comparison>
-                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                      </dxl:Or>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                    </dxl:And>
-                    <dxl:Or>
-                      <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                      </dxl:Comparison>
-                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                    </dxl:Or>
-                  </dxl:Or>
-                  <dxl:Or>
-                    <dxl:And>
-                      <dxl:Or>
-                        <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
-                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                        </dxl:Comparison>
-                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                      </dxl:Or>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                    </dxl:And>
-                    <dxl:Or>
-                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                      </dxl:Comparison>
-                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                    </dxl:Or>
-                  </dxl:Or>
-                </dxl:And>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartFilters>
               <dxl:ResidualFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DeleteMismatchedDistribution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeleteMismatchedDistribution.mdp
@@ -417,9 +417,7 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-Basic.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-Basic.mdp
@@ -305,9 +305,7 @@
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:PartEqFilters>
-                <dxl:PartEqFilterElems>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
-                </dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
@@ -1734,9 +1734,7 @@
                                                   </dxl:Properties>
                                                   <dxl:ProjList/>
                                                   <dxl:PartEqFilters>
-                                                    <dxl:PartEqFilterElems>
-                                                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="2002"/>
-                                                    </dxl:PartEqFilterElems>
+                                                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2002"/>
                                                   </dxl:PartEqFilters>
                                                   <dxl:PartFilters>
                                                     <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexGetDroppedCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexGetDroppedCols.mdp
@@ -2441,12 +2441,8 @@ EXPLAIN SELECT * FROM solo WHERE year_id=2017 AND month_id=6;
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2017"/>
-              </dxl:PartEqFilterElems>
-              <dxl:PartEqFilterElems>
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="6"/>
-              </dxl:PartEqFilterElems>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2017"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="6"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DefaultPartition.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DefaultPartition.mdp
@@ -375,52 +375,10 @@
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:PartEqFilters>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
-                <dxl:Or>
-                  <dxl:And>
-                    <dxl:Or>
-                      <dxl:And>
-                        <dxl:Or>
-                          <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
-                            <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                          </dxl:Comparison>
-                          <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                        </dxl:Or>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                      </dxl:And>
-                      <dxl:Or>
-                        <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                        </dxl:Comparison>
-                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                      </dxl:Or>
-                    </dxl:Or>
-                    <dxl:Or>
-                      <dxl:And>
-                        <dxl:Or>
-                          <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
-                            <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                          </dxl:Comparison>
-                          <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                        </dxl:Or>
-                        <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                      </dxl:And>
-                      <dxl:Or>
-                        <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                        </dxl:Comparison>
-                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                      </dxl:Or>
-                    </dxl:Or>
-                  </dxl:And>
-                  <dxl:DefaultPart Level="0"/>
-                </dxl:Or>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartFilters>
               <dxl:ResidualFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-EnabledDateConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-EnabledDateConstraint.mdp
@@ -366,49 +366,10 @@
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:PartEqFilters>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
-                <dxl:And>
-                  <dxl:Or>
-                    <dxl:And>
-                      <dxl:Or>
-                        <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.1096.1.0">
-                          <dxl:PartBound Level="0" Type="0.1082.1.0" LowerBound="true"/>
-                          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
-                        </dxl:Comparison>
-                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                      </dxl:Or>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                    </dxl:And>
-                    <dxl:Or>
-                      <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
-                        <dxl:PartBound Level="0" Type="0.1082.1.0" LowerBound="true"/>
-                        <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
-                      </dxl:Comparison>
-                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                    </dxl:Or>
-                  </dxl:Or>
-                  <dxl:Or>
-                    <dxl:And>
-                      <dxl:Or>
-                        <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
-                          <dxl:PartBound Level="0" Type="0.1082.1.0" LowerBound="false"/>
-                          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
-                        </dxl:Comparison>
-                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                      </dxl:Or>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                    </dxl:And>
-                    <dxl:Or>
-                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
-                        <dxl:PartBound Level="0" Type="0.1082.1.0" LowerBound="false"/>
-                        <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
-                      </dxl:Comparison>
-                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                    </dxl:Or>
-                  </dxl:Or>
-                </dxl:And>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartFilters>
               <dxl:ResidualFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-NoDTS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-NoDTS.mdp
@@ -339,49 +339,10 @@
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:PartEqFilters>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
-                <dxl:And>
-                  <dxl:Or>
-                    <dxl:And>
-                      <dxl:Or>
-                        <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
-                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                        </dxl:Comparison>
-                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                      </dxl:Or>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                    </dxl:And>
-                    <dxl:Or>
-                      <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                      </dxl:Comparison>
-                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                    </dxl:Or>
-                  </dxl:Or>
-                  <dxl:Or>
-                    <dxl:And>
-                      <dxl:Or>
-                        <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
-                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                        </dxl:Comparison>
-                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                      </dxl:Or>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                    </dxl:And>
-                    <dxl:Or>
-                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                      </dxl:Comparison>
-                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                    </dxl:Or>
-                  </dxl:Or>
-                </dxl:And>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartFilters>
               <dxl:ResidualFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-Overlapping.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-Overlapping.mdp
@@ -339,49 +339,10 @@
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:PartEqFilters>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
-                <dxl:And>
-                  <dxl:Or>
-                    <dxl:And>
-                      <dxl:Or>
-                        <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
-                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                        </dxl:Comparison>
-                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                      </dxl:Or>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                    </dxl:And>
-                    <dxl:Or>
-                      <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                      </dxl:Comparison>
-                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                    </dxl:Or>
-                  </dxl:Or>
-                  <dxl:Or>
-                    <dxl:And>
-                      <dxl:Or>
-                        <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
-                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                        </dxl:Comparison>
-                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                      </dxl:Or>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                    </dxl:And>
-                    <dxl:Or>
-                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                      </dxl:Comparison>
-                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                    </dxl:Or>
-                  </dxl:Or>
-                </dxl:And>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartFilters>
               <dxl:ResidualFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectEquality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectEquality.mdp
@@ -585,49 +585,10 @@
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:PartEqFilters>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
-                <dxl:And>
-                  <dxl:Or>
-                    <dxl:And>
-                      <dxl:Or>
-                        <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
-                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
-                        </dxl:Comparison>
-                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                      </dxl:Or>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                    </dxl:And>
-                    <dxl:Or>
-                      <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
-                      </dxl:Comparison>
-                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                    </dxl:Or>
-                  </dxl:Or>
-                  <dxl:Or>
-                    <dxl:And>
-                      <dxl:Or>
-                        <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
-                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
-                        </dxl:Comparison>
-                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                      </dxl:Or>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                    </dxl:And>
-                    <dxl:Or>
-                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
-                      </dxl:Comparison>
-                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                    </dxl:Or>
-                  </dxl:Or>
-                </dxl:And>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartFilters>
               <dxl:ResidualFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedConstraint.mdp
@@ -320,9 +320,7 @@
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
-              </dxl:PartEqFilterElems>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous.mdp
@@ -339,49 +339,10 @@
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:PartEqFilters>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
-                <dxl:And>
-                  <dxl:Or>
-                    <dxl:And>
-                      <dxl:Or>
-                        <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
-                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                        </dxl:Comparison>
-                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                      </dxl:Or>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                    </dxl:And>
-                    <dxl:Or>
-                      <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                      </dxl:Comparison>
-                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                    </dxl:Or>
-                  </dxl:Or>
-                  <dxl:Or>
-                    <dxl:And>
-                      <dxl:Or>
-                        <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
-                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                        </dxl:Comparison>
-                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                      </dxl:Or>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                    </dxl:And>
-                    <dxl:Or>
-                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                      </dxl:Comparison>
-                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                    </dxl:Or>
-                  </dxl:Or>
-                </dxl:And>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartFilters>
               <dxl:ResidualFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-EnabledDateConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-EnabledDateConstraint.mdp
@@ -387,9 +387,7 @@
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
-              </dxl:PartEqFilterElems>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-UnsupportedConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-UnsupportedConstraint.mdp
@@ -371,9 +371,7 @@
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
-              </dxl:PartEqFilterElems>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous.mdp
@@ -287,9 +287,7 @@
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-              </dxl:PartEqFilterElems>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-OpenEndedPartitions.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-OpenEndedPartitions.mdp
@@ -393,49 +393,10 @@
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:PartEqFilters>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
-                <dxl:And>
-                  <dxl:Or>
-                    <dxl:And>
-                      <dxl:Or>
-                        <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
-                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                        </dxl:Comparison>
-                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                      </dxl:Or>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                    </dxl:And>
-                    <dxl:Or>
-                      <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                      </dxl:Comparison>
-                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                    </dxl:Or>
-                  </dxl:Or>
-                  <dxl:Or>
-                    <dxl:And>
-                      <dxl:Or>
-                        <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
-                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                        </dxl:Comparison>
-                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                      </dxl:Or>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                    </dxl:And>
-                    <dxl:Or>
-                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                      </dxl:Comparison>
-                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                    </dxl:Or>
-                  </dxl:Or>
-                </dxl:And>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartFilters>
               <dxl:ResidualFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin2.mdp
@@ -10536,9 +10536,7 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="27" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="27" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -10598,9 +10596,7 @@
                     </dxl:Properties>
                     <dxl:ProjList/>
                     <dxl:PartEqFilters>
-                      <dxl:PartEqFilterElems>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2001"/>
-                      </dxl:PartEqFilterElems>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="2001"/>
                     </dxl:PartEqFilters>
                     <dxl:PartFilters>
                       <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/ExternalPartitionTableNoPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExternalPartitionTableNoPredicate.mdp
@@ -432,49 +432,10 @@
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:PartEqFilters>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2012"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
-                <dxl:And>
-                  <dxl:Or>
-                    <dxl:And>
-                      <dxl:Or>
-                        <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
-                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="2012"/>
-                        </dxl:Comparison>
-                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                      </dxl:Or>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                    </dxl:And>
-                    <dxl:Or>
-                      <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2012"/>
-                      </dxl:Comparison>
-                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                    </dxl:Or>
-                  </dxl:Or>
-                  <dxl:Or>
-                    <dxl:And>
-                      <dxl:Or>
-                        <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
-                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="2012"/>
-                        </dxl:Comparison>
-                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                      </dxl:Or>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                    </dxl:And>
-                    <dxl:Or>
-                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2012"/>
-                      </dxl:Comparison>
-                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                    </dxl:Or>
-                  </dxl:Or>
-                </dxl:And>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartFilters>
               <dxl:ResidualFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/ExternalPartitionTableSelectOnPartKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExternalPartitionTableSelectOnPartKey.mdp
@@ -433,49 +433,10 @@
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:PartEqFilters>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2010"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
-                <dxl:And>
-                  <dxl:Or>
-                    <dxl:And>
-                      <dxl:Or>
-                        <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
-                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="2010"/>
-                        </dxl:Comparison>
-                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                      </dxl:Or>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                    </dxl:And>
-                    <dxl:Or>
-                      <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2010"/>
-                      </dxl:Comparison>
-                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                    </dxl:Or>
-                  </dxl:Or>
-                  <dxl:Or>
-                    <dxl:And>
-                      <dxl:Or>
-                        <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
-                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="2010"/>
-                        </dxl:Comparison>
-                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                      </dxl:Or>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                    </dxl:And>
-                    <dxl:Or>
-                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2010"/>
-                      </dxl:Comparison>
-                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                    </dxl:Or>
-                  </dxl:Or>
-                </dxl:And>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartFilters>
               <dxl:ResidualFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisj.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisj.mdp
@@ -14953,9 +14953,7 @@ WHERE ((sale_type = 's'::text AND dyear = 2001 AND year_total &gt; 0::numeric) O
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:PartEqFilters>
-                        <dxl:PartEqFilterElems>
-                          <dxl:Ident ColId="55" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
-                        </dxl:PartEqFilterElems>
+                        <dxl:Ident ColId="55" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
                       </dxl:PartEqFilters>
                       <dxl:PartFilters>
                         <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/GroupingOnSameTblCol-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GroupingOnSameTblCol-2.mdp
@@ -4306,9 +4306,7 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:PartEqFilters>
-                    <dxl:PartEqFilterElems>
-                      <dxl:Ident ColId="27" ColName="date" TypeMdid="0.1114.1.0"/>
-                    </dxl:PartEqFilterElems>
+                    <dxl:Ident ColId="27" ColName="date" TypeMdid="0.1114.1.0"/>
                   </dxl:PartEqFilters>
                   <dxl:PartFilters>
                     <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/HJN-DPE-Bitmap-Outer-Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HJN-DPE-Bitmap-Outer-Child.mdp
@@ -955,9 +955,7 @@ select * from dbs_target, dbs_helper where dbs_target.c1 = dbs_helper.c1 and dbs
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="12" ColName="c3" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="12" ColName="c3" TypeMdid="0.23.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-ForPartialIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-ForPartialIndex.mdp
@@ -509,9 +509,7 @@ explain select t1.a from t1, foo_prt t2, t3 where (t1.b = t2.a) and t2.a = t3.b;
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:PartEqFilters>
-                <dxl:PartEqFilterElems>
-                  <dxl:Ident ColId="14" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:PartEqFilterElems>
+                <dxl:Ident ColId="14" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-PartKey-Is-IndexKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-PartKey-Is-IndexKey.mdp
@@ -637,9 +637,7 @@ select z_p.j from z_p,tt_p where  z_p.i=6 and z_p.i<tt_p.i;
                 </dxl:Properties>
                 <dxl:ProjList/>
                 <dxl:PartEqFilters>
-                  <dxl:PartEqFilterElems>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="6"/>
-                  </dxl:PartEqFilterElems>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="6"/>
                 </dxl:PartEqFilters>
                 <dxl:PartFilters>
                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicates.mdp
@@ -472,9 +472,7 @@ explain select 1+row_number() over(partition by foo.c) from foo, bar where foo.a
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:PartEqFilters>
-                      <dxl:PartEqFilterElems>
-                        <dxl:Ident ColId="10" ColName="d" TypeMdid="0.23.1.0"/>
-                      </dxl:PartEqFilterElems>
+                      <dxl:Ident ColId="10" ColName="d" TypeMdid="0.23.1.0"/>
                     </dxl:PartEqFilters>
                     <dxl:PartFilters>
                       <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -506,9 +504,7 @@ explain select 1+row_number() over(partition by foo.c) from foo, bar where foo.a
                         </dxl:Properties>
                         <dxl:ProjList/>
                         <dxl:PartEqFilters>
-                          <dxl:PartEqFilterElems>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
-                          </dxl:PartEqFilterElems>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
                         </dxl:PartEqFilters>
                         <dxl:PartFilters>
                           <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesBCC-vcpart-txt.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesBCC-vcpart-txt.mdp
@@ -827,11 +827,9 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
-                  <dxl:Ident ColId="9" ColName="a" TypeMdid="0.1043.1.0"/>
-                </dxl:Cast>
-              </dxl:PartEqFilterElems>
+              <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
+                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.1043.1.0"/>
+              </dxl:Cast>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesInnerOfLOJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesInnerOfLOJ.mdp
@@ -501,9 +501,7 @@
                 </dxl:Properties>
                 <dxl:ProjList/>
                 <dxl:PartEqFilters>
-                  <dxl:PartEqFilterElems>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
-                  </dxl:PartEqFilterElems>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
                 </dxl:PartEqFilters>
                 <dxl:PartFilters>
                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/Insert-AO-Partitioned-SortDisabled.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-AO-Partitioned-SortDisabled.mdp
@@ -446,9 +446,7 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/Insert-AO-Partitioned.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-AO-Partitioned.mdp
@@ -485,9 +485,7 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:PartEqFilters>
-                <dxl:PartEqFilterElems>
-                  <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
-                </dxl:PartEqFilterElems>
+                <dxl:Ident ColId="1" ColName="year" TypeMdid="0.23.1.0"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/Insert-Parquet-Partitioned-SortDisabled.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-Parquet-Partitioned-SortDisabled.mdp
@@ -281,9 +281,7 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/Insert-Parquet-Partitioned.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-Parquet-Partitioned.mdp
@@ -308,9 +308,7 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:PartEqFilters>
-                <dxl:PartEqFilterElems>
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:PartEqFilterElems>
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/InsertMismatchedDistrubution-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertMismatchedDistrubution-2.mdp
@@ -331,9 +331,7 @@ explain insert into pt2 select * from r;
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/InsertMismatchedDistrubution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertMismatchedDistrubution.mdp
@@ -331,9 +331,7 @@ explain insert into pt2 select * from r;
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
@@ -4162,9 +4162,7 @@
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:PartEqFilters>
-                        <dxl:PartEqFilterElems>
-                          <dxl:Ident ColId="26" ColName="ymd" TypeMdid="0.1082.1.0"/>
-                        </dxl:PartEqFilterElems>
+                        <dxl:Ident ColId="26" ColName="ymd" TypeMdid="0.1082.1.0"/>
                       </dxl:PartEqFilters>
                       <dxl:PartFilters>
                         <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinOrderDPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinOrderDPE.mdp
@@ -1806,9 +1806,7 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:PartEqFilters>
-                <dxl:PartEqFilterElems>
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:PartEqFilterElems>
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1857,9 +1855,7 @@
                     </dxl:Properties>
                     <dxl:ProjList/>
                     <dxl:PartEqFilters>
-                      <dxl:PartEqFilterElems>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
-                      </dxl:PartEqFilterElems>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
                     </dxl:PartEqFilters>
                     <dxl:PartFilters>
                       <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1946,9 +1942,7 @@
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:PartEqFilters>
-                <dxl:PartEqFilterElems>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
-                </dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndexWithSelect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndexWithSelect.mdp
@@ -481,9 +481,7 @@
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:PartEqFilters>
-                <dxl:PartEqFilterElems>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
-                </dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-DynBtreeIndexWithSelect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-DynBtreeIndexWithSelect.mdp
@@ -463,9 +463,7 @@
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:PartEqFilters>
-                <dxl:PartEqFilterElems>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
-                </dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/MS-UnionAll-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MS-UnionAll-1.mdp
@@ -3296,9 +3296,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3420,9 +3418,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3544,9 +3540,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3668,9 +3662,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3792,9 +3784,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3916,9 +3906,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4040,9 +4028,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4164,9 +4150,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4288,9 +4272,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4412,9 +4394,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4536,9 +4516,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4660,9 +4638,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4784,9 +4760,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/MS-UnionAll-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MS-UnionAll-2.mdp
@@ -3296,9 +3296,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3420,9 +3418,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3544,9 +3540,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3668,9 +3662,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3792,9 +3784,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3916,9 +3906,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4040,9 +4028,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4164,9 +4150,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4288,9 +4272,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4412,9 +4394,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4536,9 +4516,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4660,9 +4638,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4784,9 +4760,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/MS-UnionAll-4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MS-UnionAll-4.mdp
@@ -4,7 +4,7 @@
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
-      <dxl:CTEConfig CTEInliningCutoff="0"/> 
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
         <dxl:CostParams>
@@ -3089,9 +3089,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:PartEqFilterElems>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
-                            </dxl:PartEqFilterElems>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3322,9 +3320,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:PartEqFilterElems>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
-                            </dxl:PartEqFilterElems>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3555,9 +3551,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:PartEqFilterElems>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
-                            </dxl:PartEqFilterElems>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3788,9 +3782,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:PartEqFilterElems>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
-                            </dxl:PartEqFilterElems>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4021,9 +4013,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:PartEqFilterElems>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
-                            </dxl:PartEqFilterElems>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4254,9 +4244,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:PartEqFilterElems>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
-                            </dxl:PartEqFilterElems>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4487,9 +4475,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:PartEqFilterElems>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
-                            </dxl:PartEqFilterElems>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4720,9 +4706,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:PartEqFilterElems>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
-                            </dxl:PartEqFilterElems>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4953,9 +4937,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:PartEqFilterElems>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
-                            </dxl:PartEqFilterElems>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -5186,9 +5168,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:PartEqFilterElems>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
-                            </dxl:PartEqFilterElems>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -5419,9 +5399,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:PartEqFilterElems>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
-                            </dxl:PartEqFilterElems>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -5652,9 +5630,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:PartEqFilterElems>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
-                            </dxl:PartEqFilterElems>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -5885,9 +5861,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:PartEqFilterElems>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
-                            </dxl:PartEqFilterElems>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/MS-UnionAll-5.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MS-UnionAll-5.mdp
@@ -1071,9 +1071,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1213,9 +1211,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1355,9 +1351,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:PartEqFilterElems>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
-                              </dxl:PartEqFilterElems>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/MS-UnionAll-6.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MS-UnionAll-6.mdp
@@ -1049,9 +1049,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:PartEqFilterElems>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
-                            </dxl:PartEqFilterElems>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1304,9 +1302,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:PartEqFilterElems>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
-                            </dxl:PartEqFilterElems>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1559,9 +1555,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:PartEqFilterElems>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
-                            </dxl:PartEqFilterElems>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/MS-UnionAll-7.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MS-UnionAll-7.mdp
@@ -1049,9 +1049,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:PartEqFilterElems>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
-                            </dxl:PartEqFilterElems>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1304,9 +1302,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:PartEqFilterElems>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
-                            </dxl:PartEqFilterElems>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1559,9 +1555,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:PartEqFilterElems>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
-                            </dxl:PartEqFilterElems>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartSelectorOnJoinSide.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartSelectorOnJoinSide.mdp
@@ -1747,9 +1747,7 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartSelectorOnJoinSide2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartSelectorOnJoinSide2.mdp
@@ -1697,9 +1697,7 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-AvoidRangePred-DPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-AvoidRangePred-DPE.mdp
@@ -963,9 +963,7 @@ FROM abuela JOIN bar ON a = c AND b BETWEEN d - 1 AND d + 4
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="19" ColName="f" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="19" ColName="f" TypeMdid="0.23.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-Correlated-NLOuter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-Correlated-NLOuter.mdp
@@ -369,9 +369,7 @@ select (select h.i from t2) from h where h.j = 1;
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:PartEqFilters>
-                <dxl:PartEqFilterElems>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                </dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-GroupBy.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-GroupBy.mdp
@@ -635,9 +635,7 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="13" ColName="tid" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="13" ColName="tid" TypeMdid="0.23.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-Limit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-Limit.mdp
@@ -622,9 +622,7 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="13" ColName="tid" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="13" ColName="tid" TypeMdid="0.23.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-PartitionSelectorRewindability.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-PartitionSelectorRewindability.mdp
@@ -544,9 +544,7 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:PartEqFilters>
-                <dxl:PartEqFilterElems>
-                  <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:PartEqFilterElems>
+                <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-WindowFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-WindowFunction.mdp
@@ -773,9 +773,7 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1082.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1082.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-HJ4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-HJ4.mdp
@@ -338,9 +338,7 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-HJ5.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-HJ5.mdp
@@ -378,9 +378,7 @@ select * from s,t where s.b=t.a and t.b=35;
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -429,9 +427,7 @@ select * from s,t where s.b=t.a and t.b=35;
                   </dxl:Properties>
                   <dxl:ProjList/>
                   <dxl:PartEqFilters>
-                    <dxl:PartEqFilterElems>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="35"/>
-                    </dxl:PartEqFilterElems>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="35"/>
                   </dxl:PartEqFilters>
                   <dxl:PartFilters>
                     <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-IndexOnDefPartOnly.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-IndexOnDefPartOnly.mdp
@@ -1287,9 +1287,7 @@ SELECT * FROM pt_lt_tab WHERE col2 = 15 ORDER BY col2,col3 LIMIT 5;
                 </dxl:Properties>
                 <dxl:ProjList/>
                 <dxl:PartEqFilters>
-                  <dxl:PartEqFilterElems>
-                    <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAAAPAA==" DoubleValue="15.000000"/>
-                  </dxl:PartEqFilterElems>
+                  <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAAAPAA==" DoubleValue="15.000000"/>
                 </dxl:PartEqFilters>
                 <dxl:PartFilters>
                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverExcept.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverExcept.mdp
@@ -1445,9 +1445,7 @@ select * from (select * from p1 except select * from p2) as p, tt where p.b=tt.b
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1477,9 +1475,7 @@ select * from (select * from p1 except select * from p2) as p, tt where p.b=tt.b
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:PartEqFilters>
-                <dxl:PartEqFilterElems>
-                  <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:PartEqFilterElems>
+                <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverGbAgg-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverGbAgg-2.mdp
@@ -1331,9 +1331,7 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1437,9 +1435,7 @@
                         </dxl:Properties>
                         <dxl:ProjList/>
                         <dxl:PartEqFilters>
-                          <dxl:PartEqFilterElems>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
-                          </dxl:PartEqFilterElems>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
                         </dxl:PartEqFilters>
                         <dxl:PartFilters>
                           <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverGbAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverGbAgg.mdp
@@ -386,9 +386,7 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverIntersect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverIntersect.mdp
@@ -1463,9 +1463,7 @@ select * from (select * from p1 intersect select * from p2) as p, tt where p.b=t
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1495,9 +1493,7 @@ select * from (select * from p1 intersect select * from p2) as p, tt where p.b=t
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:PartEqFilters>
-                <dxl:PartEqFilterElems>
-                  <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:PartEqFilterElems>
+                <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-1.mdp
@@ -1412,9 +1412,7 @@ select * from (select * from p1 union all select * from p2) as p, tt where p.b=t
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1444,9 +1442,7 @@ select * from (select * from p1 union all select * from p2) as p, tt where p.b=t
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:PartEqFilters>
-                <dxl:PartEqFilterElems>
-                  <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:PartEqFilterElems>
+                <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-2.mdp
@@ -1013,9 +1013,7 @@ select * from (select * from tt union all select * from p2) as p, tt where p.b=t
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-List-DPE-Int-Predicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-List-DPE-Int-Predicates.mdp
@@ -356,9 +356,7 @@ select * from foo where b is not null;
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:PartEqFilters>
-                <dxl:PartEqFilterElems>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                </dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-List-DPE-Varchar-Predicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-List-DPE-Varchar-Predicates.mdp
@@ -399,9 +399,7 @@ select * from pt where gender is null;
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:PartEqFilters>
-                <dxl:PartEqFilterElems>
-                  <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABUY=" LintValue="160743980"/>
-                </dxl:PartEqFilterElems>
+                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABUY=" LintValue="160743980"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE-2.mdp
@@ -1880,9 +1880,7 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="30" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="30" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
@@ -4358,9 +4358,7 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:PartEqFilters>
-                <dxl:PartEqFilterElems>
-                  <dxl:Ident ColId="64" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
-                </dxl:PartEqFilterElems>
+                <dxl:Ident ColId="64" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4565,9 +4563,7 @@
                     </dxl:Properties>
                     <dxl:ProjList/>
                     <dxl:PartEqFilters>
-                      <dxl:PartEqFilterElems>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1999"/>
-                      </dxl:PartEqFilterElems>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1999"/>
                     </dxl:PartEqFilters>
                     <dxl:PartFilters>
                       <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-Relabel-Equality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-Relabel-Equality.mdp
@@ -294,9 +294,7 @@
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAACjIwMDgwMA==" LintValue="249955124"/>
-              </dxl:PartEqFilterElems>
+              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAACjIwMDgwMA==" LintValue="249955124"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncPredPushDown.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncPredPushDown.mdp
@@ -485,7 +485,7 @@
                   <dxl:ProjList/>
                   <dxl:PartEqFilters>
                     <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAB3VzYQ==" LintValue="2607030223"/>
                   </dxl:PartEqFilters>
                   <dxl:PartFilters>
                     <dxl:Or>
@@ -498,13 +498,7 @@
                       </dxl:Or>
                       <dxl:DefaultPart Level="0"/>
                     </dxl:Or>
-                    <dxl:Or>
-                      <dxl:ArrayComp OperatorName="=" OperatorMdid="0.98.1.0" OperatorType="Any">
-                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAB3VzYQ==" LintValue="2607030223"/>
-                        <dxl:PartListValues Level="1" ResultType="0.1009.1.0" ElementType="0.25.1.0"/>
-                      </dxl:ArrayComp>
-                      <dxl:DefaultPart Level="1"/>
-                    </dxl:Or>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                   </dxl:PartFilters>
                   <dxl:ResidualFilter>
                     <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncSinglePredPushDown.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncSinglePredPushDown.mdp
@@ -428,9 +428,7 @@
                   <dxl:ProjList/>
                   <dxl:PartEqFilters>
                     <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    <dxl:PartEqFilterElems>
-                      <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAB3VzYQ==" LintValue="2607030223"/>
-                    </dxl:PartEqFilterElems>
+                    <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAB3VzYQ==" LintValue="2607030223"/>
                   </dxl:PartEqFilters>
                   <dxl:PartFilters>
                     <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/QueryMismatchedDistribution-DynamicIndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/QueryMismatchedDistribution-DynamicIndexScan.mdp
@@ -519,9 +519,7 @@ explain select i, count(j) from pt2  where k=5 group by i;
                         </dxl:Properties>
                         <dxl:ProjList/>
                         <dxl:PartEqFilters>
-                          <dxl:PartEqFilterElems>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
-                          </dxl:PartEqFilterElems>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
                         </dxl:PartEqFilters>
                         <dxl:PartFilters>
                           <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedJoinPartitionedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedJoinPartitionedTable.mdp
@@ -741,9 +741,7 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/RightJoinDPS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RightJoinDPS.mdp
@@ -441,9 +441,7 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/UpdateDistKeyMismatchedDistribution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateDistKeyMismatchedDistribution.mdp
@@ -358,9 +358,7 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:PartEqFilters>
-            <dxl:PartEqFilterElems>
-              <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
-            </dxl:PartEqFilterElems>
+            <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
           </dxl:PartEqFilters>
           <dxl:PartFilters>
             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/UpdateDroppedCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateDroppedCols.mdp
@@ -295,9 +295,7 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:PartEqFilters>
-            <dxl:PartEqFilterElems>
-              <dxl:Ident ColId="1" ColName="c" TypeMdid="0.23.1.0"/>
-            </dxl:PartEqFilterElems>
+            <dxl:Ident ColId="1" ColName="c" TypeMdid="0.23.1.0"/>
           </dxl:PartEqFilters>
           <dxl:PartFilters>
             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/UpdateNoDistKeyMismatchedDistribution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateNoDistKeyMismatchedDistribution.mdp
@@ -359,9 +359,7 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:PartEqFilters>
-            <dxl:PartEqFilterElems>
-              <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
-            </dxl:PartEqFilterElems>
+            <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
           </dxl:PartEqFilters>
           <dxl:PartFilters>
             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/minidump/UpdatePartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdatePartTable.mdp
@@ -295,9 +295,7 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:PartEqFilters>
-            <dxl:PartEqFilterElems>
-              <dxl:Ident ColId="1" ColName="c" TypeMdid="0.23.1.0"/>
-            </dxl:PartEqFilterElems>
+            <dxl:Ident ColId="1" ColName="c" TypeMdid="0.23.1.0"/>
           </dxl:PartEqFilters>
           <dxl:PartFilters>
             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-cast_boundary_value_to_date.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-cast_boundary_value_to_date.mdp
@@ -362,9 +362,7 @@ explain select * from TestPartitionFilterCasting where p1 = 'a';
             <dxl:ProjList/>
             <dxl:PartEqFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              <dxl:PartEqFilterElems>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
-              </dxl:PartEqFilterElems>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-cast_partition_column_to_text.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-cast_partition_column_to_text.mdp
@@ -384,9 +384,7 @@ explain select * from TestPartitionFilterCasting where p2 = '2015-01-01';
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABWE=" LintValue="160440876"/>
-              </dxl:PartEqFilterElems>
+              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABWE=" LintValue="160440876"/>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PartEqFilters>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-no_casting.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-no_casting.mdp
@@ -363,9 +363,7 @@ explain select * from TestPartitionFilterCasting where p3 = 1.0;
             <dxl:PartEqFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              <dxl:PartEqFilterElems>
-                <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAQABAA==" DoubleValue="1.000000"/>
-              </dxl:PartEqFilterElems>
+              <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAQABAA==" DoubleValue="1.000000"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-predicate-on-all-levels.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-predicate-on-all-levels.mdp
@@ -368,15 +368,9 @@ explain select * from TestPartitionFilterCasting where p1 = 'a' and p2 = '2015-0
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABWE=" LintValue="160440876"/>
-              </dxl:PartEqFilterElems>
-              <dxl:PartEqFilterElems>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
-              </dxl:PartEqFilterElems>
-              <dxl:PartEqFilterElems>
-                <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAAABAA==" DoubleValue="1.000000"/>
-              </dxl:PartEqFilterElems>
+              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABWE=" LintValue="160440876"/>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
+              <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAAABAA==" DoubleValue="1.000000"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-predicate-on-non-leaf-levels.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-predicate-on-non-leaf-levels.mdp
@@ -464,12 +464,8 @@ explain select * from TestPartitionFilterCasting where p1 = 'a' and p2 = '2015-0
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABWE=" LintValue="160440876"/>
-              </dxl:PartEqFilterElems>
-              <dxl:PartEqFilterElems>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
-              </dxl:PartEqFilterElems>
+              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABWE=" LintValue="160440876"/>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-predicate-on-non-root-levels.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-predicate-on-non-root-levels.mdp
@@ -429,12 +429,8 @@ explain select * from TestPartitionFilterCasting where p2 = '2015-01-01' and p3 
             <dxl:ProjList/>
             <dxl:PartEqFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              <dxl:PartEqFilterElems>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
-              </dxl:PartEqFilterElems>
-              <dxl:PartEqFilterElems>
-                <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAAABAA==" DoubleValue="1.000000"/>
-              </dxl:PartEqFilterElems>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
+              <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAAABAA==" DoubleValue="1.000000"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-AllLevels-Default.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-AllLevels-Default.mdp
@@ -299,53 +299,11 @@ select * from PT where j < 5 and k = 4;
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
-              <dxl:Or>
-                <dxl:And>
-                  <dxl:Or>
-                    <dxl:And>
-                      <dxl:Or>
-                        <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
-                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
-                        </dxl:Comparison>
-                        <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                      </dxl:Or>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                    </dxl:And>
-                    <dxl:Or>
-                      <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
-                      </dxl:Comparison>
-                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                    </dxl:Or>
-                  </dxl:Or>
-                  <dxl:Or>
-                    <dxl:And>
-                      <dxl:Or>
-                        <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
-                          <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
-                        </dxl:Comparison>
-                        <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                      </dxl:Or>
-                      <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                    </dxl:And>
-                    <dxl:Or>
-                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
-                      </dxl:Comparison>
-                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                    </dxl:Or>
-                  </dxl:Or>
-                </dxl:And>
-                <dxl:DefaultPart Level="0"/>
-              </dxl:Or>
+              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               <dxl:Or>
                 <dxl:Or>
                   <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-AllLevels-NoDefault.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-AllLevels-NoDefault.mdp
@@ -297,50 +297,11 @@ explain select * from PT where j < 5 and k = 4;
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
-              <dxl:And>
-                <dxl:Or>
-                  <dxl:And>
-                    <dxl:Or>
-                      <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
-                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
-                      </dxl:Comparison>
-                      <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                    </dxl:Or>
-                    <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
-                  </dxl:And>
-                  <dxl:Or>
-                    <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                      <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="true"/>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
-                    </dxl:Comparison>
-                    <dxl:PartBoundOpen Level="0" LowerBound="true"/>
-                  </dxl:Or>
-                </dxl:Or>
-                <dxl:Or>
-                  <dxl:And>
-                    <dxl:Or>
-                      <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
-                        <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
-                      </dxl:Comparison>
-                      <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                    </dxl:Or>
-                    <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
-                  </dxl:And>
-                  <dxl:Or>
-                    <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                      <dxl:PartBound Level="0" Type="0.23.1.0" LowerBound="false"/>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
-                    </dxl:Comparison>
-                    <dxl:PartBoundOpen Level="0" LowerBound="false"/>
-                  </dxl:Or>
-                </dxl:Or>
-              </dxl:And>
+              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               <dxl:Or>
                 <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                   <dxl:PartBound Level="1" Type="0.23.1.0" LowerBound="true"/>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-Level2-Default.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-Level2-Default.mdp
@@ -294,9 +294,7 @@ select * from PT where j = 5;
             <dxl:ProjList/>
             <dxl:PartEqFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              <dxl:PartEqFilterElems>
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
-              </dxl:PartEqFilterElems>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-Level2-NoDefault.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-ConstPred-Level2-NoDefault.mdp
@@ -292,9 +292,7 @@ select * from PT where j = 5;
             <dxl:ProjList/>
             <dxl:PartEqFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              <dxl:PartEqFilterElems>
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
-              </dxl:PartEqFilterElems>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-JoinPred-AllLevels.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-JoinPred-AllLevels.mdp
@@ -434,12 +434,8 @@ select * from pt, t where pt.j = t.t1 and pt.k = t.t2;
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="7" ColName="t2" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="6" ColName="t1" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="7" ColName="t2" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="6" ColName="t1" TypeMdid="0.23.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-JoinPred-Level1.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-JoinPred-Level1.mdp
@@ -448,9 +448,7 @@ select * from pt, t where pt.k = t.t1;
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="6" ColName="t1" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="6" ColName="t1" TypeMdid="0.23.1.0"/>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-JoinPred-Level2.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-JoinPred-Level2.mdp
@@ -449,9 +449,7 @@ select * from pt, t where pt.j = t.t1;
             </dxl:ProjList>
             <dxl:PartEqFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="6" ColName="t1" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="6" ColName="t1" TypeMdid="0.23.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Nary-Join.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Nary-Join.mdp
@@ -1560,9 +1560,7 @@ select * from pt, foo, bar where pt.k=foo.a and pt.j = bar.a;
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:PartEqFilters>
-                <dxl:PartEqFilterElems>
-                  <dxl:Ident ColId="6" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:PartEqFilterElems>
+                <dxl:Ident ColId="6" ColName="a" TypeMdid="0.23.1.0"/>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
               </dxl:PartEqFilters>
               <dxl:PartFilters>
@@ -1635,9 +1633,7 @@ select * from pt, foo, bar where pt.k=foo.a and pt.j = bar.a;
             </dxl:ProjList>
             <dxl:PartEqFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
+              <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>

--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
@@ -456,7 +456,7 @@ private:
 
 	// construct a part eq filter elem list for the given partition level
 	CDXLNode *PdxlnPartEqFilterElemList(
-		CExpression *pexpr, bool fEqFilter, ULONG level,
+		CExpression *pexpr, ULONG level,
 		CPhysicalPartitionSelector *popSelector);
 
 	// check whether the given partition selector only has equality filters

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -4912,15 +4912,15 @@ CTranslatorExprToDXL::PdxlnPartEqFilterElemList(
 {
 	GPOS_ASSERT(NULL != pexpr);
 
-    if (fEqFilter)
+	if (fEqFilter)
 		return PdxlnScalar(pexpr);
 
-    CDXLNode *filter_elems_dxlnode = GPOS_NEW(m_mp)
-            CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarOpList(
-            m_mp, CDXLScalarOpList::EdxloplistEqFilterElemList));
+	CDXLNode *filter_elems_dxlnode = GPOS_NEW(m_mp)
+		CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarOpList(
+						   m_mp, CDXLScalarOpList::EdxloplistEqFilterElemList));
 
-    // extract the eq filter elems from the disjunction(s) of general filters
-    GPOS_ASSERT(CPredicateUtils::FOr(pexpr));
+	// extract the eq filter elems from the disjunction(s) of general filters
+	GPOS_ASSERT(CPredicateUtils::FOr(pexpr));
 
 	CColRef *colref =
 		CUtils::PcrExtractPartKey(popSelector->Pdrgpdrgpcr(), level);
@@ -4946,7 +4946,7 @@ CTranslatorExprToDXL::PdxlnPartEqFilterElemList(
 										   &pexprOther, &cmp_type);
 		GPOS_ASSERT(NULL != pexprOther);
 		filter_elems_dxlnode->AddChild(PdxlnScalar(pexprOther));
-    }
+	}
 	pdrgpexprEqCmps->Release();
 
 	return filter_elems_dxlnode;
@@ -5312,9 +5312,9 @@ CTranslatorExprToDXL::ConstructLevelFilters4PartitionSelector(
 		CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarOpList(
 						   m_mp, CDXLScalarOpList::EdxloplistEqFilterList));
 
-    for (ULONG ulLevel = 0; ulLevel < ulPartLevels; ulLevel++)
+	for (ULONG ulLevel = 0; ulLevel < ulPartLevels; ulLevel++)
 	{
-        CColRef *pcrPartKey =
+		CColRef *pcrPartKey =
 			CUtils::PcrExtractPartKey(pdrgpdrgpcrPartKeys, ulLevel);
 		IMDId *pmdidTypePartKey = pcrPartKey->RetrieveType()->MDId();
 		CHAR szPartType = pmdrel->PartTypeAtLevel(ulLevel);
@@ -5328,14 +5328,14 @@ CTranslatorExprToDXL::ConstructLevelFilters4PartitionSelector(
 		CExpression *pexprEqFilter = popSelector->PexprEqFilter(ulLevel);
 		if (NULL != pexprEqFilter)
 		{
-            (*ppdxlnEqFilters)->AddChild(PdxlnScalar(pexprEqFilter));
-            (*ppdxlnFilters)
-                    ->AddChild(CTranslatorExprToDXLUtils::PdxlnBoolConst(
-                            m_mp, m_pmda, true /*value*/));
-            continue;
+			(*ppdxlnEqFilters)->AddChild(PdxlnScalar(pexprEqFilter));
+			(*ppdxlnFilters)
+				->AddChild(CTranslatorExprToDXLUtils::PdxlnBoolConst(
+					m_mp, m_pmda, true /*value*/));
+			continue;
 		}
 
-            // check general filters on current level
+		// check general filters on current level
 		CExpression *pexprFilter = popSelector->PexprFilter(ulLevel);
 		if (NULL != pexprFilter)
 		{
@@ -5372,10 +5372,10 @@ CTranslatorExprToDXL::ConstructLevelFilters4PartitionSelector(
 				m_mp, m_pmda, true /*value*/);
 		}
 
-        (*ppdxlnFilters)->AddChild(filter_dxlnode);
-        (*ppdxlnEqFilters)
-                    ->AddChild(CTranslatorExprToDXLUtils::PdxlnBoolConst(
-                            m_mp, m_pmda, true /*value*/));
+		(*ppdxlnFilters)->AddChild(filter_dxlnode);
+		(*ppdxlnEqFilters)
+			->AddChild(CTranslatorExprToDXLUtils::PdxlnBoolConst(
+				m_mp, m_pmda, true /*value*/));
 	}
 
 	if (NULL != pbsDefaultParts)

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -4912,19 +4912,15 @@ CTranslatorExprToDXL::PdxlnPartEqFilterElemList(
 {
 	GPOS_ASSERT(NULL != pexpr);
 
-	CDXLNode *filter_elems_dxlnode = GPOS_NEW(m_mp)
-		CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarOpList(
-						   m_mp, CDXLScalarOpList::EdxloplistEqFilterElemList));
+    if (fEqFilter)
+		return PdxlnScalar(pexpr);
 
-	if (fEqFilter)
-	{
-		// just append the eq filter as-is
-		filter_elems_dxlnode->AddChild(PdxlnScalar(pexpr));
-		return filter_elems_dxlnode;
-	}
+    CDXLNode *filter_elems_dxlnode = GPOS_NEW(m_mp)
+            CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarOpList(
+            m_mp, CDXLScalarOpList::EdxloplistEqFilterElemList));
 
-	// extract the eq filter elems from the disjunction(s) of general filters
-	GPOS_ASSERT(CPredicateUtils::FOr(pexpr));
+    // extract the eq filter elems from the disjunction(s) of general filters
+    GPOS_ASSERT(CPredicateUtils::FOr(pexpr));
 
 	CColRef *colref =
 		CUtils::PcrExtractPartKey(popSelector->Pdrgpdrgpcr(), level);
@@ -4950,7 +4946,7 @@ CTranslatorExprToDXL::PdxlnPartEqFilterElemList(
 										   &pexprOther, &cmp_type);
 		GPOS_ASSERT(NULL != pexprOther);
 		filter_elems_dxlnode->AddChild(PdxlnScalar(pexprOther));
-	}
+    }
 	pdrgpexprEqCmps->Release();
 
 	return filter_elems_dxlnode;
@@ -5316,9 +5312,9 @@ CTranslatorExprToDXL::ConstructLevelFilters4PartitionSelector(
 		CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarOpList(
 						   m_mp, CDXLScalarOpList::EdxloplistEqFilterList));
 
-	for (ULONG ulLevel = 0; ulLevel < ulPartLevels; ulLevel++)
+    for (ULONG ulLevel = 0; ulLevel < ulPartLevels; ulLevel++)
 	{
-		CColRef *pcrPartKey =
+        CColRef *pcrPartKey =
 			CUtils::PcrExtractPartKey(pdrgpdrgpcrPartKeys, ulLevel);
 		IMDId *pmdidTypePartKey = pcrPartKey->RetrieveType()->MDId();
 		CHAR szPartType = pmdrel->PartTypeAtLevel(ulLevel);
@@ -5332,36 +5328,14 @@ CTranslatorExprToDXL::ConstructLevelFilters4PartitionSelector(
 		CExpression *pexprEqFilter = popSelector->PexprEqFilter(ulLevel);
 		if (NULL != pexprEqFilter)
 		{
-			CDXLNode *pdxlnEq = PdxlnScalar(pexprEqFilter);
-			IMDId *pmdidTypeOther =
-				CScalar::PopConvert(pexprEqFilter->Pop())->MdidType();
-
-			if (fRangePart)
-			{
-				filter_dxlnode =
-					CTranslatorExprToDXLUtils::PdxlnRangeFilterEqCmp(
-						m_mp, m_pmda, pdxlnEq, pmdidTypePartKey, pmdidTypeOther,
-						NULL /*pmdidTypeCastExpr*/, NULL /*mdid_cast_func*/,
-						ulLevel);
-			}
-			else  // list partition
-			{
-				CExpression *pexprIdent =
-					CUtils::PexprScalarIdent(m_mp, pcrPartKey);
-				// Create a ScalarIdent expression from the partition key
-				CDXLNode *pdxlnPartKey =
-					CTranslatorExprToDXLUtils::PdxlnListFilterPartKey(
-						m_mp, m_pmda, pexprIdent, pmdidTypePartKey, ulLevel);
-				pexprIdent->Release();
-				filter_dxlnode =
-					CTranslatorExprToDXLUtils::PdxlnListFilterScCmp(
-						m_mp, m_pmda, pdxlnPartKey, pdxlnEq, pmdidTypePartKey,
-						pmdidTypeOther, IMDType::EcmptEq, ulLevel,
-						fDefaultPartition);
-			}
+            (*ppdxlnEqFilters)->AddChild(PdxlnScalar(pexprEqFilter));
+            (*ppdxlnFilters)
+                    ->AddChild(CTranslatorExprToDXLUtils::PdxlnBoolConst(
+                            m_mp, m_pmda, true /*value*/));
+            continue;
 		}
 
-		// check general filters on current level
+            // check general filters on current level
 		CExpression *pexprFilter = popSelector->PexprFilter(ulLevel);
 		if (NULL != pexprFilter)
 		{
@@ -5398,10 +5372,10 @@ CTranslatorExprToDXL::ConstructLevelFilters4PartitionSelector(
 				m_mp, m_pmda, true /*value*/);
 		}
 
-		(*ppdxlnFilters)->AddChild(filter_dxlnode);
-		(*ppdxlnEqFilters)
-			->AddChild(CTranslatorExprToDXLUtils::PdxlnBoolConst(
-				m_mp, m_pmda, true /*value*/));
+        (*ppdxlnFilters)->AddChild(filter_dxlnode);
+        (*ppdxlnEqFilters)
+                    ->AddChild(CTranslatorExprToDXLUtils::PdxlnBoolConst(
+                            m_mp, m_pmda, true /*value*/));
 	}
 
 	if (NULL != pbsDefaultParts)

--- a/src/backend/gporca/scripts/fix_mdps.py
+++ b/src/backend/gporca/scripts/fix_mdps.py
@@ -61,7 +61,7 @@ def processLogFile(logFileLines):
     for line in logFileLines:
         fileNameMatch = re.match(r'.*../data/dxl/minidump/*.', line)
         if not fileNameMatch:
-		fileNameMatch = re.match(r'.*../data/dxl/multilevel-partitioning/*.', line)
+	    fileNameMatch = re.match(r'.*../data/dxl/multilevel-partitioning/*.', line)
         actualPlanMatch = re.match(r'Actual:', line)
         planBegin = re.match(r'.*<dxl:Plan*.', line)
         planEnd = re.match(r'.*</dxl:Plan>*.', line)

--- a/src/backend/gporca/scripts/fix_mdps.py
+++ b/src/backend/gporca/scripts/fix_mdps.py
@@ -60,6 +60,8 @@ def processLogFile(logFileLines):
 
     for line in logFileLines:
         fileNameMatch = re.match(r'.*../data/dxl/minidump/*.', line)
+        if not fileNameMatch:
+		fileNameMatch = re.match(r'.*../data/dxl/multilevel-partitioning/*.', line)
         actualPlanMatch = re.match(r'Actual:', line)
         planBegin = re.match(r'.*<dxl:Plan*.', line)
         planEnd = re.match(r'.*</dxl:Plan>*.', line)

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -449,8 +449,7 @@ private:
 		const CDXLNode *filter_list_dxlnode,
 		const CDXLTranslateContextBaseTable *base_table_context,
 		CDXLTranslationContextArray *child_contexts,
-		CDXLTranslateContext *output_context, bool is_eq_filters,
-		bool is_eq_filter_elems);
+		CDXLTranslateContext *output_context);
 
 	// create range table entry from a CDXLPhysicalTVF node
 	RangeTblEntry *TranslateDXLTvfToRangeTblEntry(

--- a/src/include/gpopt/translate/CTranslatorDXLToScalar.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToScalar.h
@@ -109,8 +109,8 @@ private:
 	ULONG m_num_of_segments;
 
 	// translate a CDXLScalarArrayComp into a GPDB ScalarArrayOpExpr
-    Expr *TranslateDXLScalarOpListToScalar(
-            const CDXLNode *scalar_op_list_node, CMappingColIdVar *colid_var);
+	Expr *TranslateDXLScalarOpListToScalar(const CDXLNode *scalar_op_list_node,
+										   CMappingColIdVar *colid_var);
 
 	Expr *TranslateDXLScalarArrayCompToScalar(
 		const CDXLNode *scalar_array_cmp_node, CMappingColIdVar *colid_var);

--- a/src/include/gpopt/translate/CTranslatorDXLToScalar.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToScalar.h
@@ -109,6 +109,9 @@ private:
 	ULONG m_num_of_segments;
 
 	// translate a CDXLScalarArrayComp into a GPDB ScalarArrayOpExpr
+    Expr *TranslateDXLScalarOpListToScalar(
+            const CDXLNode *scalar_op_list_node, CMappingColIdVar *colid_var);
+
 	Expr *TranslateDXLScalarArrayCompToScalar(
 		const CDXLNode *scalar_array_cmp_node, CMappingColIdVar *colid_var);
 

--- a/src/test/regress/expected/partition_pruning.out
+++ b/src/test/regress/expected/partition_pruning.out
@@ -2982,7 +2982,7 @@ select get_selected_parts('explain analyze select * from DATE_PARTS where month 
 (1 row)
 
 -- Expected total parts => 1 * 2 * 4 => 8: 
--- TODO #141973839: we selected extra parts because of disjunction: 24 parts: 2 * 3 * 4
+-- TODO #141973839: we selected extra parts because of disjunction: 12 parts: 1 * 3 * 4
 select get_selected_parts('explain analyze select * from DATE_PARTS where year = 2003 and month between 1 and 4;');
  get_selected_parts 
 --------------------

--- a/src/test/regress/expected/partition_pruning.out
+++ b/src/test/regress/expected/partition_pruning.out
@@ -3520,4 +3520,297 @@ where  trg.key1 = src.key1
 (17 rows)
 
 DROP TABLE t_part1;
+-- Test ORCA avoiding default partition scan for all levels with equality predicates
+-- Level 0: year 2 parts [2009, 2010), [2010, 2011)
+-- Level 1: quarter 5 parts
+-- Level 2: region 3 parts
+-- Level 3: sales 4 parts
+-- Total partitions: 2*5*3*4 = 120
+DROP TABLE sales;
+CREATE TABLE sales (id bigint, year int, quarter int, region text, sales int) DISTRIBUTED BY (id)
+PARTITION BY RANGE(year)
+ SUBPARTITION BY LIST (quarter)
+ SUBPARTITION TEMPLATE (DEFAULT subpartition other_quarter,
+				subpartition q1 VALUES (1),
+				subpartition q2 VALUES (2),
+				subpartition q3 VALUES (3),
+				subpartition q4 VALUES (4))
+ SUBPARTITION BY LIST (region)
+ SUBPARTITION TEMPLATE (DEFAULT subpartition other_region,
+                                subpartition eu VALUES ('eu'),
+                                subpartition usa VALUES ('usa'))
+ SUBPARTITION BY RANGE (sales)
+ SUBPARTITION TEMPLATE (DEFAULT SUBPARTITION other_sales,
+				SUBPARTITION below START (100) INCLUSIVE,
+       				SUBPARTITION meet START (5000) INCLUSIVE,
+       				SUBPARTITION beyond START (10000) INCLUSIVE END (50000) EXCLUSIVE)
+(START(2009) END(2011) EVERY(1));
+INSERT INTO sales
+SELECT generate_series(1,5), 2010, 0, 'asia', generate_series(50,36050,9000)
+UNION
+SELECT generate_series(6,15), 2009, 1, 'eu', generate_series(1000,4600,400)
+UNION
+SELECT generate_series(16,20), 2009, 2, 'usa', generate_series(8000,12000,1000)
+UNION
+SELECT generate_series(21,30), 2010, 3, 'usa', generate_series(4000,22000,2000)
+UNION
+SELECT generate_series(31,35), 2010, 4, 'usa', generate_series(7000,9000,500);
+SELECT * FROM sales ORDER BY id;
+ id | year | quarter | region | sales 
+----+------+---------+--------+-------
+  1 | 2010 |       0 | asia   |    50
+  2 | 2010 |       0 | asia   |  9050
+  3 | 2010 |       0 | asia   | 18050
+  4 | 2010 |       0 | asia   | 27050
+  5 | 2010 |       0 | asia   | 36050
+  6 | 2009 |       1 | eu     |  1000
+  7 | 2009 |       1 | eu     |  1400
+  8 | 2009 |       1 | eu     |  1800
+  9 | 2009 |       1 | eu     |  2200
+ 10 | 2009 |       1 | eu     |  2600
+ 11 | 2009 |       1 | eu     |  3000
+ 12 | 2009 |       1 | eu     |  3400
+ 13 | 2009 |       1 | eu     |  3800
+ 14 | 2009 |       1 | eu     |  4200
+ 15 | 2009 |       1 | eu     |  4600
+ 16 | 2009 |       2 | usa    |  8000
+ 17 | 2009 |       2 | usa    |  9000
+ 18 | 2009 |       2 | usa    | 10000
+ 19 | 2009 |       2 | usa    | 11000
+ 20 | 2009 |       2 | usa    | 12000
+ 21 | 2010 |       3 | usa    |  4000
+ 22 | 2010 |       3 | usa    |  6000
+ 23 | 2010 |       3 | usa    |  8000
+ 24 | 2010 |       3 | usa    | 10000
+ 25 | 2010 |       3 | usa    | 12000
+ 26 | 2010 |       3 | usa    | 14000
+ 27 | 2010 |       3 | usa    | 16000
+ 28 | 2010 |       3 | usa    | 18000
+ 29 | 2010 |       3 | usa    | 20000
+ 30 | 2010 |       3 | usa    | 22000
+ 31 | 2010 |       4 | usa    |  7000
+ 32 | 2010 |       4 | usa    |  7500
+ 33 | 2010 |       4 | usa    |  8000
+ 34 | 2010 |       4 | usa    |  8500
+ 35 | 2010 |       4 | usa    |  9000
+(35 rows)
+
+-- year 1, quarter 2, region 1, sales 1
+-- Expect to scan partitions 1*2*1*1 = 2
+EXPLAIN (COSTS OFF) SELECT * FROM sales WHERE year = 2009 AND
+quarter IN (2, 4) AND
+region = 'usa' AND
+sales = 8000;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on sales_1_prt_1_2_prt_other_quarter_3_prt_other_4_prt_other_sales
+               Filter: ((quarter = ANY ('{2,4}'::integer[])) AND (year = 2009) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_1_2_prt_other_quarter_3_prt_other_region_4_prt_meet
+               Filter: ((quarter = ANY ('{2,4}'::integer[])) AND (year = 2009) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_1_2_prt_other_quarter_3_prt_usa_4_prt_other_sales
+               Filter: ((quarter = ANY ('{2,4}'::integer[])) AND (year = 2009) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_1_2_prt_other_quarter_3_prt_usa_4_prt_meet
+               Filter: ((quarter = ANY ('{2,4}'::integer[])) AND (year = 2009) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q2_3_prt_other_region_4_prt_other_sales
+               Filter: ((quarter = ANY ('{2,4}'::integer[])) AND (year = 2009) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q2_3_prt_other_region_4_prt_meet
+               Filter: ((quarter = ANY ('{2,4}'::integer[])) AND (year = 2009) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q2_3_prt_usa_4_prt_other_sales
+               Filter: ((quarter = ANY ('{2,4}'::integer[])) AND (year = 2009) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q2_3_prt_usa_4_prt_meet
+               Filter: ((quarter = ANY ('{2,4}'::integer[])) AND (year = 2009) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q4_3_prt_other_region_4_prt_other_sales
+               Filter: ((quarter = ANY ('{2,4}'::integer[])) AND (year = 2009) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q4_3_prt_other_region_4_prt_meet
+               Filter: ((quarter = ANY ('{2,4}'::integer[])) AND (year = 2009) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q4_3_prt_usa_4_prt_other_sales
+               Filter: ((quarter = ANY ('{2,4}'::integer[])) AND (year = 2009) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q4_3_prt_usa_4_prt_meet
+               Filter: ((quarter = ANY ('{2,4}'::integer[])) AND (year = 2009) AND (region = 'usa'::text) AND (sales = 8000))
+ Optimizer: Postgres query optimizer
+(27 rows)
+
+-- year 2, quarter 2, region 1, sales 1
+-- Expect to scan partitions 2*2*1*1 = 4
+EXPLAIN (COSTS OFF) SELECT * FROM sales WHERE year > 2009 AND
+quarter IN (2, 4) AND
+region = 'usa' AND
+sales = 8000;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on sales_1_prt_1_2_prt_other_quarter_3_prt_other_4_prt_other_sales
+               Filter: ((year > 2009) AND (quarter = ANY ('{2,4}'::integer[])) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_1_2_prt_other_quarter_3_prt_other_region_4_prt_meet
+               Filter: ((year > 2009) AND (quarter = ANY ('{2,4}'::integer[])) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_1_2_prt_other_quarter_3_prt_usa_4_prt_other_sales
+               Filter: ((year > 2009) AND (quarter = ANY ('{2,4}'::integer[])) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_1_2_prt_other_quarter_3_prt_usa_4_prt_meet
+               Filter: ((year > 2009) AND (quarter = ANY ('{2,4}'::integer[])) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q2_3_prt_other_region_4_prt_other_sales
+               Filter: ((year > 2009) AND (quarter = ANY ('{2,4}'::integer[])) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q2_3_prt_other_region_4_prt_meet
+               Filter: ((year > 2009) AND (quarter = ANY ('{2,4}'::integer[])) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q2_3_prt_usa_4_prt_other_sales
+               Filter: ((year > 2009) AND (quarter = ANY ('{2,4}'::integer[])) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q2_3_prt_usa_4_prt_meet
+               Filter: ((year > 2009) AND (quarter = ANY ('{2,4}'::integer[])) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q4_3_prt_other_region_4_prt_other_sales
+               Filter: ((year > 2009) AND (quarter = ANY ('{2,4}'::integer[])) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q4_3_prt_other_region_4_prt_meet
+               Filter: ((year > 2009) AND (quarter = ANY ('{2,4}'::integer[])) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q4_3_prt_usa_4_prt_other_sales
+               Filter: ((year > 2009) AND (quarter = ANY ('{2,4}'::integer[])) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q4_3_prt_usa_4_prt_meet
+               Filter: ((year > 2009) AND (quarter = ANY ('{2,4}'::integer[])) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_2_2_prt_other_quarter_3_prt_other_4_prt_other_sales
+               Filter: ((year > 2009) AND (quarter = ANY ('{2,4}'::integer[])) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_2_2_prt_other_quarter_3_prt_other_region_4_prt_meet
+               Filter: ((year > 2009) AND (quarter = ANY ('{2,4}'::integer[])) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_2_2_prt_other_quarter_3_prt_usa_4_prt_other_sales
+               Filter: ((year > 2009) AND (quarter = ANY ('{2,4}'::integer[])) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_2_2_prt_other_quarter_3_prt_usa_4_prt_meet
+               Filter: ((year > 2009) AND (quarter = ANY ('{2,4}'::integer[])) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_2_2_prt_q2_3_prt_other_region_4_prt_other_sales
+               Filter: ((year > 2009) AND (quarter = ANY ('{2,4}'::integer[])) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_2_2_prt_q2_3_prt_other_region_4_prt_meet
+               Filter: ((year > 2009) AND (quarter = ANY ('{2,4}'::integer[])) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_2_2_prt_q2_3_prt_usa_4_prt_other_sales
+               Filter: ((year > 2009) AND (quarter = ANY ('{2,4}'::integer[])) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_2_2_prt_q2_3_prt_usa_4_prt_meet
+               Filter: ((year > 2009) AND (quarter = ANY ('{2,4}'::integer[])) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_2_2_prt_q4_3_prt_other_region_4_prt_other_sales
+               Filter: ((year > 2009) AND (quarter = ANY ('{2,4}'::integer[])) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_2_2_prt_q4_3_prt_other_region_4_prt_meet
+               Filter: ((year > 2009) AND (quarter = ANY ('{2,4}'::integer[])) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_2_2_prt_q4_3_prt_usa_4_prt_other_sales
+               Filter: ((year > 2009) AND (quarter = ANY ('{2,4}'::integer[])) AND (region = 'usa'::text) AND (sales = 8000))
+         ->  Seq Scan on sales_1_prt_2_2_prt_q4_3_prt_usa_4_prt_meet
+               Filter: ((year > 2009) AND (quarter = ANY ('{2,4}'::integer[])) AND (region = 'usa'::text) AND (sales = 8000))
+ Optimizer: Postgres query optimizer
+(51 rows)
+
+-- year 2, quarter 3 (including default), region 1, sales 3 (including default)
+-- Expect to scan partitions 2*3*1*3 = 18
+EXPLAIN (COSTS OFF) SELECT * FROM sales WHERE year > 2009 AND
+quarter >= 3 AND
+region = 'usa' AND
+sales > 8000;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on sales_1_prt_1_2_prt_other_quarter_3_prt_other_4_prt_other_sales
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_1_2_prt_other_quarter_3_prt_other_region_4_prt_meet
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_1_2_prt_other_quarter_3_prt_other_regi_4_prt_beyond
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_1_2_prt_other_quarter_3_prt_usa_4_prt_other_sales
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_1_2_prt_other_quarter_3_prt_usa_4_prt_meet
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_1_2_prt_other_quarter_3_prt_usa_4_prt_beyond
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q3_3_prt_other_region_4_prt_other_sales
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q3_3_prt_other_region_4_prt_meet
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q3_3_prt_other_region_4_prt_beyond
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q3_3_prt_usa_4_prt_other_sales
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q3_3_prt_usa_4_prt_meet
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q3_3_prt_usa_4_prt_beyond
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q4_3_prt_other_region_4_prt_other_sales
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q4_3_prt_other_region_4_prt_meet
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q4_3_prt_other_region_4_prt_beyond
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q4_3_prt_usa_4_prt_other_sales
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q4_3_prt_usa_4_prt_meet
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_1_2_prt_q4_3_prt_usa_4_prt_beyond
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_2_2_prt_other_quarter_3_prt_other_4_prt_other_sales
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_2_2_prt_other_quarter_3_prt_other_region_4_prt_meet
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_2_2_prt_other_quarter_3_prt_other_regi_4_prt_beyond
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_2_2_prt_other_quarter_3_prt_usa_4_prt_other_sales
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_2_2_prt_other_quarter_3_prt_usa_4_prt_meet
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_2_2_prt_other_quarter_3_prt_usa_4_prt_beyond
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_2_2_prt_q3_3_prt_other_region_4_prt_other_sales
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_2_2_prt_q3_3_prt_other_region_4_prt_meet
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_2_2_prt_q3_3_prt_other_region_4_prt_beyond
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_2_2_prt_q3_3_prt_usa_4_prt_other_sales
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_2_2_prt_q3_3_prt_usa_4_prt_meet
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_2_2_prt_q3_3_prt_usa_4_prt_beyond
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_2_2_prt_q4_3_prt_other_region_4_prt_other_sales
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_2_2_prt_q4_3_prt_other_region_4_prt_meet
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_2_2_prt_q4_3_prt_other_region_4_prt_beyond
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_2_2_prt_q4_3_prt_usa_4_prt_other_sales
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_2_2_prt_q4_3_prt_usa_4_prt_meet
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+         ->  Seq Scan on sales_1_prt_2_2_prt_q4_3_prt_usa_4_prt_beyond
+               Filter: ((year > 2009) AND (quarter >= 3) AND (sales > 8000) AND (region = 'usa'::text))
+ Optimizer: Postgres query optimizer
+(75 rows)
+
+SELECT * FROM sales WHERE year = 2009 AND
+quarter IN (2, 4) AND
+region = 'usa' AND
+sales = 8000;
+ id | year | quarter | region | sales 
+----+------+---------+--------+-------
+ 16 | 2009 |       2 | usa    |  8000
+(1 row)
+
+SELECT * FROM sales WHERE year > 2009 AND
+quarter IN (2, 4) AND
+region = 'usa' AND
+sales = 8000;
+ id | year | quarter | region | sales 
+----+------+---------+--------+-------
+ 33 | 2010 |       4 | usa    |  8000
+(1 row)
+
+SELECT * FROM sales WHERE year > 2009 AND
+quarter >= 3 AND
+region = 'usa' AND
+sales > 8000;
+ id | year | quarter | region | sales 
+----+------+---------+--------+-------
+ 28 | 2010 |       3 | usa    | 18000
+ 25 | 2010 |       3 | usa    | 12000
+ 30 | 2010 |       3 | usa    | 22000
+ 26 | 2010 |       3 | usa    | 14000
+ 35 | 2010 |       4 | usa    |  9000
+ 29 | 2010 |       3 | usa    | 20000
+ 24 | 2010 |       3 | usa    | 10000
+ 27 | 2010 |       3 | usa    | 16000
+ 34 | 2010 |       4 | usa    |  8500
+(9 rows)
+
 RESET ALL;

--- a/src/test/regress/expected/partition_pruning_optimizer.out
+++ b/src/test/regress/expected/partition_pruning_optimizer.out
@@ -3111,4 +3111,165 @@ where  trg.key1 = src.key1
 (22 rows)
 
 DROP TABLE t_part1;
+-- Test ORCA avoiding default partition scan for all levels with equality predicates
+-- Level 0: year 2 parts [2009, 2010), [2010, 2011)
+-- Level 1: quarter 5 parts
+-- Level 2: region 3 parts
+-- Level 3: sales 4 parts
+-- Total partitions: 2*5*3*4 = 120
+DROP TABLE sales;
+CREATE TABLE sales (id bigint, year int, quarter int, region text, sales int) DISTRIBUTED BY (id)
+PARTITION BY RANGE(year)
+ SUBPARTITION BY LIST (quarter)
+ SUBPARTITION TEMPLATE (DEFAULT subpartition other_quarter,
+				subpartition q1 VALUES (1),
+				subpartition q2 VALUES (2),
+				subpartition q3 VALUES (3),
+				subpartition q4 VALUES (4))
+ SUBPARTITION BY LIST (region)
+ SUBPARTITION TEMPLATE (DEFAULT subpartition other_region,
+                                subpartition eu VALUES ('eu'),
+                                subpartition usa VALUES ('usa'))
+ SUBPARTITION BY RANGE (sales)
+ SUBPARTITION TEMPLATE (DEFAULT SUBPARTITION other_sales,
+				SUBPARTITION below START (100) INCLUSIVE,
+       				SUBPARTITION meet START (5000) INCLUSIVE,
+       				SUBPARTITION beyond START (10000) INCLUSIVE END (50000) EXCLUSIVE)
+(START(2009) END(2011) EVERY(1));
+INSERT INTO sales
+SELECT generate_series(1,5), 2010, 0, 'asia', generate_series(50,36050,9000)
+UNION
+SELECT generate_series(6,15), 2009, 1, 'eu', generate_series(1000,4600,400)
+UNION
+SELECT generate_series(16,20), 2009, 2, 'usa', generate_series(8000,12000,1000)
+UNION
+SELECT generate_series(21,30), 2010, 3, 'usa', generate_series(4000,22000,2000)
+UNION
+SELECT generate_series(31,35), 2010, 4, 'usa', generate_series(7000,9000,500);
+SELECT * FROM sales ORDER BY id;
+ id | year | quarter | region | sales 
+----+------+---------+--------+-------
+  1 | 2010 |       0 | asia   |    50
+  2 | 2010 |       0 | asia   |  9050
+  3 | 2010 |       0 | asia   | 18050
+  4 | 2010 |       0 | asia   | 27050
+  5 | 2010 |       0 | asia   | 36050
+  6 | 2009 |       1 | eu     |  1000
+  7 | 2009 |       1 | eu     |  1400
+  8 | 2009 |       1 | eu     |  1800
+  9 | 2009 |       1 | eu     |  2200
+ 10 | 2009 |       1 | eu     |  2600
+ 11 | 2009 |       1 | eu     |  3000
+ 12 | 2009 |       1 | eu     |  3400
+ 13 | 2009 |       1 | eu     |  3800
+ 14 | 2009 |       1 | eu     |  4200
+ 15 | 2009 |       1 | eu     |  4600
+ 16 | 2009 |       2 | usa    |  8000
+ 17 | 2009 |       2 | usa    |  9000
+ 18 | 2009 |       2 | usa    | 10000
+ 19 | 2009 |       2 | usa    | 11000
+ 20 | 2009 |       2 | usa    | 12000
+ 21 | 2010 |       3 | usa    |  4000
+ 22 | 2010 |       3 | usa    |  6000
+ 23 | 2010 |       3 | usa    |  8000
+ 24 | 2010 |       3 | usa    | 10000
+ 25 | 2010 |       3 | usa    | 12000
+ 26 | 2010 |       3 | usa    | 14000
+ 27 | 2010 |       3 | usa    | 16000
+ 28 | 2010 |       3 | usa    | 18000
+ 29 | 2010 |       3 | usa    | 20000
+ 30 | 2010 |       3 | usa    | 22000
+ 31 | 2010 |       4 | usa    |  7000
+ 32 | 2010 |       4 | usa    |  7500
+ 33 | 2010 |       4 | usa    |  8000
+ 34 | 2010 |       4 | usa    |  8500
+ 35 | 2010 |       4 | usa    |  9000
+(35 rows)
+
+-- year 1, quarter 2, region 1, sales 1
+-- Expect to scan partitions 1*2*1*1 = 2
+EXPLAIN (COSTS OFF) SELECT * FROM sales WHERE year = 2009 AND
+quarter IN (2, 4) AND
+region = 'usa' AND
+sales = 8000;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Partition Selector for sales (dynamic scan id: 1)
+               Partitions selected: 2 (out of 120)
+         ->  Dynamic Seq Scan on sales (dynamic scan id: 1)
+               Filter: ((year = 2009) AND (quarter = ANY ('{2,4}'::integer[])) AND (region = 'usa'::text) AND (sales = 8000))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+-- year 2, quarter 2, region 1, sales 1
+-- Expect to scan partitions 2*2*1*1 = 4
+EXPLAIN (COSTS OFF) SELECT * FROM sales WHERE year > 2009 AND
+quarter IN (2, 4) AND
+region = 'usa' AND
+sales = 8000;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Partition Selector for sales (dynamic scan id: 1)
+               Partitions selected: 4 (out of 120)
+         ->  Dynamic Seq Scan on sales (dynamic scan id: 1)
+               Filter: ((year > 2009) AND (quarter = ANY ('{2,4}'::integer[])) AND (region = 'usa'::text) AND (sales = 8000))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+-- year 2, quarter 3 (including default), region 1, sales 3 (including default)
+-- Expect to scan partitions 2*3*1*3 = 18
+EXPLAIN (COSTS OFF) SELECT * FROM sales WHERE year > 2009 AND
+quarter >= 3 AND
+region = 'usa' AND
+sales > 8000;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Partition Selector for sales (dynamic scan id: 1)
+               Partitions selected: 18 (out of 120)
+         ->  Dynamic Seq Scan on sales (dynamic scan id: 1)
+               Filter: ((year > 2009) AND (quarter >= 3) AND (region = 'usa'::text) AND (sales > 8000))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+SELECT * FROM sales WHERE year = 2009 AND
+quarter IN (2, 4) AND
+region = 'usa' AND
+sales = 8000;
+ id | year | quarter | region | sales 
+----+------+---------+--------+-------
+ 16 | 2009 |       2 | usa    |  8000
+(1 row)
+
+SELECT * FROM sales WHERE year > 2009 AND
+quarter IN (2, 4) AND
+region = 'usa' AND
+sales = 8000;
+ id | year | quarter | region | sales 
+----+------+---------+--------+-------
+ 33 | 2010 |       4 | usa    |  8000
+(1 row)
+
+SELECT * FROM sales WHERE year > 2009 AND
+quarter >= 3 AND
+region = 'usa' AND
+sales > 8000;
+ id | year | quarter | region | sales 
+----+------+---------+--------+-------
+ 25 | 2010 |       3 | usa    | 12000
+ 28 | 2010 |       3 | usa    | 18000
+ 34 | 2010 |       4 | usa    |  8500
+ 27 | 2010 |       3 | usa    | 16000
+ 29 | 2010 |       3 | usa    | 20000
+ 24 | 2010 |       3 | usa    | 10000
+ 35 | 2010 |       4 | usa    |  9000
+ 26 | 2010 |       3 | usa    | 14000
+ 30 | 2010 |       3 | usa    | 22000
+(9 rows)
+
 RESET ALL;

--- a/src/test/regress/expected/partition_pruning_optimizer.out
+++ b/src/test/regress/expected/partition_pruning_optimizer.out
@@ -2591,11 +2591,11 @@ select get_selected_parts('explain analyze select * from DATE_PARTS where month 
 (1 row)
 
 -- Expected total parts => 1 * 2 * 4 => 8: 
--- TODO #141973839: we selected extra parts because of disjunction: 24 parts: 2 * 3 * 4
+-- TODO #141973839: we selected extra parts because of disjunction: 12 parts: 1 * 3 * 4
 select get_selected_parts('explain analyze select * from DATE_PARTS where year = 2003 and month between 1 and 4;');
  get_selected_parts 
 --------------------
- [24, 80]
+ [12, 80]
 (1 row)
 
 -- 1 :: 5 :: 4 => 20 // Only default for year

--- a/src/test/regress/sql/partition_pruning.sql
+++ b/src/test/regress/sql/partition_pruning.sql
@@ -722,7 +722,7 @@ select get_selected_parts('explain analyze select * from DATE_PARTS where month 
 select get_selected_parts('explain analyze select * from DATE_PARTS where month between 1 and 4;');
 
 -- Expected total parts => 1 * 2 * 4 => 8: 
--- TODO #141973839: we selected extra parts because of disjunction: 24 parts: 2 * 3 * 4
+-- TODO #141973839: we selected extra parts because of disjunction: 12 parts: 1 * 3 * 4
 select get_selected_parts('explain analyze select * from DATE_PARTS where year = 2003 and month between 1 and 4;');
 
 -- 1 :: 5 :: 4 => 20 // Only default for year


### PR DESCRIPTION
Background: In static partition selection, if the query has non-zero general filters, all the filters are treated as general filters. This triggers default partition scan for levels with default partition, even if the filter of that level is an equality filter. This potentially elongates the query runtime.

Solution: Add all equality filters to the equality filter list.

Implementation: 1. In non-passthrough filter translation (Expr -> DXL), add equality filter to the equality filter list. Add non-NULL general predicates containing disjunctions of ident equal comparisons to the equality filter list. 2. Rewrite filter list translation (DXL -> Plstmt) by handling equality filter elem list in DXL -> Scalar translation. This makes use of the recursive nature of DXL -> Scalar translation, and improves code readability. 3. Rewrite partition selection for equality prediçates. This allows the removal of the equality filter elem list wrapper when the list only has one child (const, cast, ident...) 4. Update filter lists in MDP tests. Relax file name matching in fix mdp script. 5. Add test for ORCA avoiding default partition scan for all levels with equality predicates.