### PR TITLE
Fix gpinitsystem fails with custom locale

### DIFF
--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -641,7 +641,8 @@ CHK_LOCALE_KNOWN () {
 
 	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
 	if [ $# -eq 0 ];then
-		if [ `$LOCALE -a |$GREP -ic $LOCALE_SETTING` -eq 0 ];then
+		if [ `$LOCALE -a |$GREP -ic $(NORMALIZE_CODESET_IN_LOCALE $LOCALE_SETTING)` -eq 0 ] \
+			&& [`$LOCALE -a |$GREP -ic $LOCALE_SETTING` -eq 0];then
 			LOG_MSG "[INFO]:-Coordinator host available locale values"
 			$LOCALE -a >> $LOG_FILE
 			LOG_MSG "[FATAL]:-Unable to locate locale value $LOCALE_SETTING on this host" 1
@@ -653,7 +654,8 @@ CHK_LOCALE_KNOWN () {
 		fi
 	else
 		# Hostname has been passed so check remote locale value
-		if [ $( REMOTE_EXECUTE_AND_GET_OUTPUT $1 "$LOCALE -a|$GREP -ic '$LOCALE_SETTING'" ) -eq 0 ];then
+		if [ $( REMOTE_EXECUTE_AND_GET_OUTPUT $1 "$LOCALE -a|$GREP -ic '$(NORMALIZE_CODESET_IN_LOCALE $LOCALE_SETTING)'" ) -eq 0 ] \
+			&& [$( REMOTE_EXECUTE_AND_GET_OUTPUT $1 "$LOCALE -a|$GREP -ic '$LOCALE_SETTING'" ) -eq 0] ;then
 			LOG_MSG "[INFO]:-Host $1 available locale values"
 			`$TRUSTED_SHELL $1 "$LOCALE -a"` >> $LOG_FILE
 			LOG_MSG "[FATAL]:-Unable to locate locale value $LOCALE_SETTING on $1" 1

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -477,7 +477,7 @@ CHK_PARAMS () {
 		# segment hosts.
 		LOCALE_SETTING=$(USE_FIRST_SET_ARG $REQ_LOCALE_SETTING $LC_ALL)
 		if [ x"" != x"$LOCALE_SETTING" ]; then
-			IN_ARRAY $LOCALE_SETTING "`locale -a`"
+			LOCALE_IS_AVAILABLE $LOCALE_SETTING
 			if [ $? -eq 0 ]; then
 				ERROR_EXIT "[FATAL]-Value $LOCALE_SETTING is not a valid value for --locale on this system."
 			fi
@@ -485,7 +485,7 @@ CHK_PARAMS () {
 
 		LCCOLLATE=$(USE_FIRST_SET_ARG $LCCOLLATE $LC_COLLATE $LOCALE_SETTING)
 		if [ x"" != x"$LCCOLLATE" ]; then
-			IN_ARRAY $LCCOLLATE "`locale -a`"
+			LOCALE_IS_AVAILABLE $LCCOLLATE
 			if [ $? -eq 0 ]; then
 				ERROR_EXIT "[FATAL]-Value $LCCOLLATE is not a valid value for --lc-collate on this system."
 			fi	
@@ -493,7 +493,7 @@ CHK_PARAMS () {
 
 		LCCTYPE=$(USE_FIRST_SET_ARG $LCCTYPE $LC_CTYPE $LOCALE_SETTING)
 		if [ x"" != x"$LCCTYPE" ]; then
-			IN_ARRAY $LCCTYPE "`locale -a`"
+			LOCALE_IS_AVAILABLE $LCCTYPE
 			if [ $? -eq 0 ]; then
 				ERROR_EXIT "[FATAL]-Value $LCCTYPE is not a valid value for --lc-ctype on this system."
 			fi
@@ -501,7 +501,7 @@ CHK_PARAMS () {
 
 		LCMESSAGES=$(USE_FIRST_SET_ARG $LCMESSAGES $LC_MESSAGES $LOCALE_SETTING)
 		if [ x"" != x"$LCMESSAGES" ]; then
-			IN_ARRAY $LCMESSAGES "`locale -a`"
+			LOCALE_IS_AVAILABLE $LCMESSAGES
 			if [ $? -eq 0 ]; then
 				ERROR_EXIT "[FATAL]-Value $LCMESSAGES is not a valid value for --lc-messages on this system."
 			fi
@@ -509,7 +509,7 @@ CHK_PARAMS () {
 		
 		LCMONETARY=$(USE_FIRST_SET_ARG $LCMONETARY $LC_MONETARY $LOCALE_SETTING)
 		if [ x"" != x"$LCMONETARY" ]; then
-			IN_ARRAY $LCMONETARY "`locale -a`"
+			LOCALE_IS_AVAILABLE $LCMONETARY
 			if [ $? -eq 0 ]; then
 				ERROR_EXIT "[FATAL]-Value $LCMONETARY is not a valid value for --lc-monetary on this system."
 			fi
@@ -517,7 +517,7 @@ CHK_PARAMS () {
 		
 		LCNUMERIC=$(USE_FIRST_SET_ARG $LCNUMERIC $LC_NUMERIC $LOCALE_SETTING)
 		if [ x"" != x"$LCNUMERIC" ]; then
-			IN_ARRAY $LCNUMERIC "`locale -a`"
+			LOCALE_IS_AVAILABLE $LCNUMERIC
 			if [ $? -eq 0 ]; then
 				ERROR_EXIT "[FATAL]-Value $LCNUMERIC is not a valid value for --lc-numeric on this system."
 			fi
@@ -525,7 +525,7 @@ CHK_PARAMS () {
 		
 		LCTIME=$(USE_FIRST_SET_ARG $LCTIME $LC_TIME $LOCALE_SETTING)
 		if [ x"" != x"$LCTIME" ]; then
-			IN_ARRAY $LCTIME "`locale -a`"
+			LOCALE_IS_AVAILABLE $LCTIME
 			if [ $? -eq 0 ]; then
 				ERROR_EXIT "[FATAL]-Value $LCTIME is not a valid value for --lc-time on this system."
 			fi

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -171,13 +171,35 @@ WARN_MARK="<<<<<"
 # Functions
 #******************************************************************************
 
+#
+# Simplified version of _nl_normalize_codeset from glibc
+# https://sourceware.org/git/?p=glibc.git;a=blob;f=intl/l10nflist.c;h=078a450dfec21faf2d26dc5d0cb02158c1f23229;hb=1305edd42c44fee6f8660734d2dfa4911ec755d6#l294
+# Input parameter - string with locale define as [language[_territory][.codeset][@modifier]]
+NORMALIZE_CODESET_IN_LOCALE () {
+	local language_and_territory=$(echo $1 | perl -ne 'print for /(^.+?(?=\.|@|$))/s')
+	local codeset=$(echo $1 | perl -ne 'print for /((?<=\.).+?(?=@|$))/s')
+	local modifier=$(echo -n $1 | perl -ne 'print for /((?<=@).+)/s' )
+
+	local digit_pattern='^[0-9]+$'
+	if [[ $codeset =~ $digit_pattern ]] ;
+	then
+		codeset="iso$codeset"
+	else
+		codeset=$(echo $codeset | perl -pe 's/([[:alpha:]])/\L\1/g; s/[^[:alnum:]]//g')
+	fi
+
+	echo "$language_and_territory$([ ! -z $codeset ] && echo ".$codeset")$([ ! -z $modifier ] && echo "@$modifier")"
+}
+
 IN_ARRAY () {
-    for v in $2; do
-        if [ x"$1" == x"$v" ]; then
-            return 1
-        fi
-    done
-    return 0
+	local locale=$(NORMALIZE_CODESET_IN_LOCALE $1)
+
+	for v in $2; do
+		if [ x"$locale" == x"$v" ] || [ x"$1" == x"$v" ]; then
+			return 1
+		fi
+	done
+	return 0
 }
 
 #

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -191,10 +191,11 @@ NORMALIZE_CODESET_IN_LOCALE () {
 	echo "$language_and_territory$([ ! -z $codeset ] && echo ".$codeset")$([ ! -z $modifier ] && echo "@$modifier")"
 }
 
-IN_ARRAY () {
+LOCALE_IS_AVAILABLE () {
 	local locale=$(NORMALIZE_CODESET_IN_LOCALE $1)
+	local all_available_locales=$(locale -a)
 
-	for v in $2; do
+	for v in $all_available_locales; do
 		if [ x"$locale" == x"$v" ] || [ x"$1" == x"$v" ]; then
 			return 1
 		fi

--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -17,6 +17,36 @@ Feature: gpinitsystem tests
         And gpconfig should print "Coordinator value: off" to stdout
         And gpconfig should print "Segment     value: off" to stdout
 
+    Scenario: gpinitsystem creates a cluster when the user set LC_ALL env variable
+        Given create demo cluster config
+        And the environment variable "LC_ALL" is set to "en_US.UTF-8"
+        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+        Then gpinitsystem should return a return code of 0
+        Given the user runs "gpstate"
+        Then gpstate should return a return code of 0
+
+    Scenario: gpinitsystem creates a cluster when the user set -n or --locale parameter
+        Given create demo cluster config
+        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -n en_US.UTF-8"
+        Then gpinitsystem should return a return code of 0
+        Given the user runs "gpstate"
+        Then gpstate should return a return code of 0
+
+	Scenario: gpinitsystem exits with status 0 when the user set locale variables
+        Given create demo cluster config
+        And the environment variable "LC_MONETARY" is set to "en_US.UTF-8"
+        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+        Then gpinitsystem should return a return code of 0
+        Given the user runs "gpstate"
+        Then gpstate should return a return code of 0
+
+    Scenario: gpinitsystem exits with status 0 when the user set locale parameters
+        Given create demo cluster config
+        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile --lc-monetary=en_US.UTF-8"
+        Then gpinitsystem should return a return code of 0
+        Given the user runs "gpstate"
+        Then gpstate should return a return code of 0
+
     Scenario: gpinitsystem exits with status 1 when the user enters nothing for the confirmation
         Given create demo cluster config
          When the user runs command "echo '' | gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile" eok


### PR DESCRIPTION
The gpinitsystem utility fails when incoming locale value doesn't
correspond character-by-character to the some line of locale -a output
[[1](https://github.com/greenplum-db/gpdb/blob/5cfd4791b3e327f733ba4a2832f627ef70f4aa91/gpMgmt/bin/gpinitsystem#L644-L653), [2](https://github.com/greenplum-db/gpdb/blob/5cfd4791b3e327f733ba4a2832f627ef70f4aa91/gpMgmt/bin/gpinitsystem#L656-L665), [3](https://github.com/greenplum-db/gpdb/blob/5cfd4791b3e327f733ba4a2832f627ef70f4aa91/gpMgmt/bin/lib/gp_bash_functions.sh#L179-L186)]

Because locale -a among other things [represents](https://github.com/bminor/glibc/blob/2d5ec6692f5746ccb11db60976a6481ef8e9d74f/locale/programs/locale.c#L440-L442) locales from the archive [with](https://github.com/bminor/glibc/blob/2d5ec6692f5746ccb11db60976a6481ef8e9d74f/locale/programs/locarchive.c#L1148-L1160 ) a normalized representation of encodings like en_US.UTF-8, then a locale with a
non-normalized encoding will not be found.

The current path adds locale normalization functionality and checks
to find matches between normalized locales and locale -a output
