### PR TITLE
Support Const TVF returning composite type in ORCA

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -38,6 +38,7 @@ extern "C" {
 #include "gpopt/translate/CIndexQualInfo.h"
 #include "gpopt/translate/CTranslatorDXLToPlStmt.h"
 #include "gpopt/translate/CTranslatorUtils.h"
+#include "naucrates/dxl/operators/CDXLDatumGeneric.h"
 #include "naucrates/dxl/operators/CDXLDirectDispatchInfo.h"
 #include "naucrates/dxl/operators/CDXLNode.h"
 #include "naucrates/md/IMDAggregate.h"
@@ -1480,19 +1481,9 @@ CTranslatorDXLToPlStmt::TranslateDXLTvfToRangeTblEntry(
 	RangeTblEntry *rte = MakeNode(RangeTblEntry);
 	rte->rtekind = RTE_FUNCTION;
 
-	FuncExpr *func_expr = MakeNode(FuncExpr);
-
-	func_expr->funcid = CMDIdGPDB::CastMdid(dxlop->FuncMdId())->Oid();
-	func_expr->funcretset = true;
-	// this is a function call, as opposed to a cast
-	func_expr->funcformat = COERCE_EXPLICIT_CALL;
-	func_expr->funcresulttype =
-		CMDIdGPDB::CastMdid(dxlop->ReturnTypeMdId())->Oid();
-
+	// get function alias
 	Alias *alias = MakeNode(Alias);
 	alias->colnames = NIL;
-
-	// get function alias
 	alias->aliasname = CTranslatorUtils::CreateMultiByteCharStringFromWCString(
 		dxlop->Pstr()->GetBuffer());
 
@@ -1519,47 +1510,91 @@ CTranslatorDXLToPlStmt::TranslateDXLTvfToRangeTblEntry(
 												 ul + 1 /*attno*/);
 	}
 
-	// function arguments
-	const ULONG num_of_child = tvf_dxlnode->Arity();
-	for (ULONG ul = 1; ul < num_of_child; ++ul)
-	{
-		CDXLNode *func_arg_dxlnode = (*tvf_dxlnode)[ul];
-
-		CMappingColIdVarPlStmt colid_var_mapping(m_mp, base_table_context, NULL,
-												 output_context,
-												 m_dxl_to_plstmt_context);
-
-		Expr *pexprFuncArg = m_translator_dxl_to_scalar->TranslateDXLToScalar(
-			func_arg_dxlnode, &colid_var_mapping);
-		func_expr->args = gpdb::LAppend(func_expr->args, pexprFuncArg);
-	}
-
-	// GPDB_91_MERGE_FIXME: collation
-	func_expr->inputcollid = gpdb::ExprCollation((Node *) func_expr->args);
-	func_expr->funccollid = gpdb::TypeCollation(func_expr->funcresulttype);
-
-	// Populate RangeTblFunction::funcparams, by walking down the entire
-	// func_expr to capture ids of all the PARAMs
-	ListCell *lc = NULL;
-	List *param_exprs = gpdb::ExtractNodesExpression(
-		(Node *) func_expr, T_Param, false /*descend_into_subqueries */);
-	Bitmapset *funcparams = NULL;
-	ForEach(lc, param_exprs)
-	{
-		Param *param = (Param *) lfirst(lc);
-		funcparams = gpdb::BmsAddMember(funcparams, param->paramid);
-	}
-
 	RangeTblFunction *rtfunc = MakeNode(RangeTblFunction);
-	rtfunc->funcexpr = (Node *) func_expr;
+	Bitmapset *funcparams = NULL;
+
+	// invalid funcid indicates TVF evaluates to const
+	if (!dxlop->FuncMdId()->IsValid())
+	{
+		Const *const_expr = MakeNode(Const);
+
+		const_expr->consttype =
+			CMDIdGPDB::CastMdid(dxlop->ReturnTypeMdId())->Oid();
+		const_expr->consttypmod = -1;
+
+		CDXLNode *constVa = (*tvf_dxlnode)[1];
+		CDXLScalarConstValue *constValue =
+			CDXLScalarConstValue::Cast(constVa->GetOperator());
+		const CDXLDatum *datum_dxl = constValue->GetDatumVal();
+		CDXLDatumGeneric *datum_generic_dxl =
+			CDXLDatumGeneric::Cast(const_cast<gpdxl::CDXLDatum *>(datum_dxl));
+		const IMDType *type =
+			m_md_accessor->RetrieveType(datum_generic_dxl->MDId());
+		const_expr->constlen = type->Length();
+		Datum val = gpdb::DatumFromPointer(datum_generic_dxl->GetByteArray());
+		ULONG length =
+			(ULONG) gpdb::DatumSize(val, false, const_expr->constlen);
+		CHAR *str = (CHAR *) gpdb::GPDBAlloc(length + 1);
+		memcpy(str, datum_generic_dxl->GetByteArray(), length);
+		str[length] = '\0';
+		const_expr->constvalue = gpdb::DatumFromPointer(str);
+
+		rtfunc->funcexpr = (Node *) const_expr;
+		rtfunc->funccolcount = (int) num_of_cols;
+	}
+	else
+	{
+		FuncExpr *func_expr = MakeNode(FuncExpr);
+
+		func_expr->funcid = CMDIdGPDB::CastMdid(dxlop->FuncMdId())->Oid();
+		func_expr->funcretset = gpdb::GetFuncRetset(func_expr->funcid);
+		// this is a function call, as opposed to a cast
+		func_expr->funcformat = COERCE_EXPLICIT_CALL;
+		func_expr->funcresulttype =
+			CMDIdGPDB::CastMdid(dxlop->ReturnTypeMdId())->Oid();
+
+		// function arguments
+		const ULONG num_of_child = tvf_dxlnode->Arity();
+		for (ULONG ul = 1; ul < num_of_child; ++ul)
+		{
+			CDXLNode *func_arg_dxlnode = (*tvf_dxlnode)[ul];
+
+			CMappingColIdVarPlStmt colid_var_mapping(m_mp, base_table_context,
+													 NULL, output_context,
+													 m_dxl_to_plstmt_context);
+
+			Expr *pexprFuncArg =
+				m_translator_dxl_to_scalar->TranslateDXLToScalar(
+					func_arg_dxlnode, &colid_var_mapping);
+			func_expr->args = gpdb::LAppend(func_expr->args, pexprFuncArg);
+		}
+
+		// GPDB_91_MERGE_FIXME: collation
+		func_expr->inputcollid = gpdb::ExprCollation((Node *) func_expr->args);
+		func_expr->funccollid = gpdb::TypeCollation(func_expr->funcresulttype);
+
+		// Populate RangeTblFunction::funcparams, by walking down the entire
+		// func_expr to capture ids of all the PARAMs
+		ListCell *lc = NULL;
+		List *param_exprs = gpdb::ExtractNodesExpression(
+			(Node *) func_expr, T_Param, false /*descend_into_subqueries */);
+		ForEach(lc, param_exprs)
+		{
+			Param *param = (Param *) lfirst(lc);
+			funcparams = gpdb::BmsAddMember(funcparams, param->paramid);
+		}
+
+		rtfunc->funcexpr = (Node *) func_expr;
+	}
+
 	rtfunc->funcparams = funcparams;
 	// GPDB_91_MERGE_FIXME: collation
 	// set rtfunc->funccoltypemods & rtfunc->funccolcollations?
 	rte->functions = ListMake1(rtfunc);
 
 	rte->inFromCl = true;
-	rte->eref = alias;
 
+	rte->eref = alias;
 	return rte;
 }
 

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -3613,27 +3613,20 @@ CTranslatorQueryToDXL::TranslateTVFToDXL(const RangeTblEntry *rte,
 				   GPOS_WSZ_LIT("Multi-argument UNNEST() or TABLE()"));
 	}
 	RangeTblFunction *rtfunc = (RangeTblFunction *) linitial(rte->functions);
-	FuncExpr *funcexpr = (FuncExpr *) rtfunc->funcexpr;
-	GPOS_ASSERT(funcexpr);
+	BOOL is_composite_const =
+		CTranslatorUtils::IsCompositeConst(m_mp, m_md_accessor, rtfunc);
 
 	// if this is a folded function expression, generate a project over a CTG
-	if (!IsA(funcexpr, FuncExpr))
+	if (!IsA(rtfunc->funcexpr, FuncExpr) && !is_composite_const)
 	{
-		Oid funcTypeOid = gpdb::ExprType(rtfunc->funcexpr);
-		if (gpdb::IsCompositeType(funcTypeOid))
-		{
-			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
-					   GPOS_WSZ_LIT("Row-type variable"));
-		}
-
 		CDXLNode *const_tbl_get_dxlnode = DXLDummyConstTableGet();
 
 		CDXLNode *project_list_dxlnode = GPOS_NEW(m_mp)
 			CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarProjList(m_mp));
 
-		CDXLNode *project_elem_dxlnode =
-			TranslateExprToDXLProject((Expr *) funcexpr, rte->eref->aliasname,
-									  true /* insist_new_colids */);
+		CDXLNode *project_elem_dxlnode = TranslateExprToDXLProject(
+			(Expr *) rtfunc->funcexpr, rte->eref->aliasname,
+			true /* insist_new_colids */);
 		project_list_dxlnode->AddChild(project_elem_dxlnode);
 
 		CDXLNode *project_dxlnode = GPOS_NEW(m_mp)
@@ -3656,6 +3649,19 @@ CTranslatorQueryToDXL::TranslateTVFToDXL(const RangeTblEntry *rte,
 									tvf_dxlop->GetDXLColumnDescrArray());
 
 	BOOL is_subquery_in_args = false;
+
+	// funcexpr evaluates to const and returns composite type
+	if (IsA(rtfunc->funcexpr, Const))
+	{
+		CDXLNode *constValue = m_scalar_translator->TranslateScalarToDXL(
+			(Expr *) (rtfunc->funcexpr), m_var_to_colid_map);
+		tvf_dxlnode->AddChild(constValue);
+		return tvf_dxlnode;
+	}
+
+	GPOS_ASSERT(IsA(rtfunc->funcexpr, FuncExpr));
+
+	FuncExpr *funcexpr = (FuncExpr *) rtfunc->funcexpr;
 
 	// check if arguments contain SIRV functions
 	if (NIL != funcexpr->args && HasSirvFunctions((Node *) funcexpr->args))

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -266,10 +266,33 @@ CTranslatorUtils::ConvertToCDXLLogicalTVF(CMemoryPool *mp,
 	 */
 
 	RangeTblFunction *rtfunc = (RangeTblFunction *) linitial(rte->functions);
-	FuncExpr *funcexpr = (FuncExpr *) rtfunc->funcexpr;
-	GPOS_ASSERT(funcexpr);
-	GPOS_ASSERT(IsA(funcexpr, FuncExpr));
 
+
+	// TVF evaluates to const, return const DXL node
+	if (IsA(rtfunc->funcexpr, Const))
+	{
+		Const *constExpr = (Const *) rtfunc->funcexpr;
+
+		CMDIdGPDB *mdid_return_type =
+			GPOS_NEW(mp) CMDIdGPDB(constExpr->consttype);
+
+		const IMDType *type = md_accessor->RetrieveType(mdid_return_type);
+		CDXLColDescrArray *column_descrs = GetColumnDescriptorsFromComposite(
+			mp, md_accessor, id_generator, type);
+
+		CMDName *func_name =
+			CDXLUtils::CreateMDNameFromCharArray(mp, rte->eref->aliasname);
+		mdid_return_type->AddRef();
+
+		// if TVF evaluates to const, pass invalid key as funcid
+		CDXLLogicalTVF *tvf_dxl = GPOS_NEW(mp)
+			CDXLLogicalTVF(mp, GPOS_NEW(mp) CMDIdGPDB(0), mdid_return_type,
+						   func_name, column_descrs);
+
+		return tvf_dxl;
+	}
+
+	FuncExpr *funcexpr = (FuncExpr *) rtfunc->funcexpr;
 	// In the planner, scalar functions that are volatile (SIRV) or read or modify SQL
 	// data get patched into an InitPlan. This is not supported in the optimizer
 	if (IsSirvFunc(mp, md_accessor, funcexpr->funcid))
@@ -277,7 +300,6 @@ CTranslatorUtils::ConvertToCDXLLogicalTVF(CMemoryPool *mp,
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
 				   GPOS_WSZ_LIT("SIRV functions"));
 	}
-
 	// get function id
 	CMDIdGPDB *mdid_func = GPOS_NEW(mp) CMDIdGPDB(funcexpr->funcid);
 	CMDIdGPDB *mdid_return_type =
@@ -2566,6 +2588,26 @@ CTranslatorUtils::GetAggKind(EdxlAggrefKind aggkind)
 					   GPOS_WSZ_LIT("Unknown aggkind value"));
 		}
 	}
+}
+
+//---------------------------------------------------------------------------
+// CTranslatorUtils::IsCompositeConst
+// Check if const func returns composite type
+//---------------------------------------------------------------------------
+BOOL
+CTranslatorUtils::IsCompositeConst(CMemoryPool *mp, CMDAccessor *md_accessor,
+								   const RangeTblFunction *rtfunc)
+{
+	if (!IsA(rtfunc->funcexpr, Const))
+		return false;
+
+	Const *constExpr = (Const *) rtfunc->funcexpr;
+
+	CMDIdGPDB *mdid_return_type = GPOS_NEW(mp) CMDIdGPDB(constExpr->consttype);
+
+	const IMDType *type = md_accessor->RetrieveType(mdid_return_type);
+
+	return type->IsComposite();
 }
 
 // EOF

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalTVF.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalTVF.cpp
@@ -63,7 +63,6 @@ CLogicalTVF::CLogicalTVF(CMemoryPool *mp, IMDId *mdid_func,
 	  m_pdrgpcoldesc(pdrgpcoldesc),
 	  m_pdrgpcrOutput(NULL)
 {
-	GPOS_ASSERT(mdid_func->IsValid());
 	GPOS_ASSERT(mdid_return_type->IsValid());
 	GPOS_ASSERT(NULL != str);
 	GPOS_ASSERT(NULL != pdrgpcoldesc);
@@ -72,10 +71,18 @@ CLogicalTVF::CLogicalTVF(CMemoryPool *mp, IMDId *mdid_func,
 	m_pdrgpcrOutput = PdrgpcrCreateMapping(mp, pdrgpcoldesc, UlOpId());
 
 	CMDAccessor *md_accessor = COptCtxt::PoctxtFromTLS()->Pmda();
-	const IMDFunction *pmdfunc = md_accessor->RetrieveFunc(m_func_mdid);
+	if (mdid_func->IsValid())
+	{
+		const IMDFunction *pmdfunc = md_accessor->RetrieveFunc(m_func_mdid);
 
-	m_efs = pmdfunc->GetFuncStability();
-	m_returns_set = pmdfunc->ReturnsSet();
+		m_efs = pmdfunc->GetFuncStability();
+		m_returns_set = pmdfunc->ReturnsSet();
+	}
+	else
+	{
+		m_efs = gpmd::IMDFunction::EfsImmutable;
+		m_returns_set = false;
+	}
 }
 
 //---------------------------------------------------------------------------
@@ -145,6 +152,7 @@ CLogicalTVF::HashValue() const
 			gpos::CombineHashes(
 				m_return_type_mdid->HashValue(),
 				gpos::HashPtr<CColumnDescriptorArray>(m_pdrgpcoldesc))));
+
 	ulHash =
 		gpos::CombineHashes(ulHash, CUtils::UlHashColArray(m_pdrgpcrOutput));
 	return ulHash;

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalTVF.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalTVF.cpp
@@ -42,14 +42,16 @@ CPhysicalTVF::CPhysicalTVF(CMemoryPool *mp, IMDId *mdid_func,
 	  m_pdrgpcoldesc(pdrgpcoldesc),
 	  m_pcrsOutput(pcrsOutput)
 {
-	GPOS_ASSERT(m_func_mdid->IsValid());
 	GPOS_ASSERT(m_return_type_mdid->IsValid());
 	GPOS_ASSERT(NULL != m_pstr);
 	GPOS_ASSERT(NULL != m_pdrgpcoldesc);
 	GPOS_ASSERT(NULL != m_pcrsOutput);
 
 	CMDAccessor *md_accessor = COptCtxt::PoctxtFromTLS()->Pmda();
-	m_pmdfunc = md_accessor->RetrieveFunc(m_func_mdid);
+	if (m_func_mdid->IsValid())
+		m_pmdfunc = md_accessor->RetrieveFunc(m_func_mdid);
+	else
+		m_pmdfunc = NULL;
 }
 
 

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -538,6 +538,9 @@ CTranslatorDXLToExpr::PexprLogicalTVF(const CDXLNode *dxlnode)
 	ConstructDXLColId2ColRefMapping(dxl_op->GetDXLColumnDescrArray(),
 									popTVF->PdrgpcrOutput());
 
+	if (!popTVF->FuncMdId()->IsValid())
+		return pexpr;
+
 	const IMDFunction *pmdfunc = m_pmda->RetrieveFunc(mdid_func);
 
 	if (IMDFunction::EfsVolatile == pmdfunc->GetFuncStability())

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLLogicalTVF.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLLogicalTVF.cpp
@@ -36,7 +36,6 @@ CDXLLogicalTVF::CDXLLogicalTVF(CMemoryPool *mp, IMDId *mdid_func,
 	  m_mdname(mdname),
 	  m_dxl_col_descr_array(pdrgdxlcd)
 {
-	GPOS_ASSERT(m_func_mdid->IsValid());
 	GPOS_ASSERT(m_return_type_mdid->IsValid());
 }
 

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLPhysicalTVF.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLPhysicalTVF.cpp
@@ -35,7 +35,6 @@ CDXLPhysicalTVF::CDXLPhysicalTVF(CMemoryPool *mp, IMDId *mdid_func,
 	  func_name(str)
 {
 	GPOS_ASSERT(NULL != m_func_mdid);
-	GPOS_ASSERT(m_func_mdid->IsValid());
 	GPOS_ASSERT(NULL != m_return_type_mdid);
 	GPOS_ASSERT(m_return_type_mdid->IsValid());
 	GPOS_ASSERT(NULL != func_name);

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -365,6 +365,10 @@ public:
 
 	// return agg kind as a CHAR
 	static CHAR GetAggKind(EdxlAggrefKind aggkind);
+
+	// check if const func returns composite type
+	static BOOL IsCompositeConst(CMemoryPool *mp, CMDAccessor *md_accessor,
+								 const RangeTblFunction *rtfunc);
 };
 }  // namespace gpdxl
 

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14341,108 +14341,103 @@ where t.j = tt.j;
  Optimizer: Postgres query optimizer
 (19 rows)
 
--- start_ignore
-DROP SCHEMA orca CASCADE;
-NOTICE:  drop cascades to 167 other objects
-DETAIL:  drop cascades to table bar1
-drop cascades to table bar2
-drop cascades to table r
-drop cascades to table s
-drop cascades to table m
-drop cascades to table m1
-drop cascades to table orca_w1
-drop cascades to table orca_w2
-drop cascades to table orca_w3
-drop cascades to table rcte
-drop cascades to table onek
-drop cascades to table pp
-drop cascades to table multilevel_p
-drop cascades to table t
-drop cascades to table t_date
-drop cascades to table t_text
-drop cascades to type employee
-drop cascades to function emp_equal(employee,employee)
-drop cascades to operator =(employee,employee)
-drop cascades to operator family employee_op_class for access method btree
-drop cascades to table t_employee
-drop cascades to table t_ceeval_ints
-drop cascades to function csq_f(integer)
-drop cascades to table csq_r
-drop cascades to table fooh1
-drop cascades to table fooh2
-drop cascades to append only table t77
-drop cascades to table prod9
-drop cascades to table toanalyze
-drop cascades to table ur
-drop cascades to table us
-drop cascades to table ut
-drop cascades to table uu
-drop cascades to table twf1
-drop cascades to table twf2
-drop cascades to table tab1
-drop cascades to table tab2
-drop cascades to function sum_sfunc(anyelement,anyelement)
-drop cascades to function sum_combinefunc(anyelement,anyelement)
-drop cascades to function myagg1(anyelement)
-drop cascades to function sum_sfunc2(anyelement,anyelement,anyelement)
-drop cascades to function myagg2(anyelement,anyelement)
-drop cascades to function gptfp(anyarray,anyelement)
-drop cascades to function gpffp(anyarray)
-drop cascades to function myagg3(anyelement)
-drop cascades to table array_table
-drop cascades to table mpp22453
-drop cascades to table mpp22791
-drop cascades to table p1
-drop cascades to append only table tmp_verd_s_pp_provtabs_agt_0015_extract1
-drop cascades to table arrtest
-drop cascades to table foo_missing_stats
-drop cascades to table bar_missing_stats
-drop cascades to table cust
-drop cascades to table datedim
-drop cascades to function plusone(integer)
-drop cascades to table bm_test
-drop cascades to table bm_dyn_test
-drop cascades to table bm_dyn_test_onepart
-drop cascades to table bm_dyn_test_multilvl_part
-drop cascades to table my_tt_agg_opt
-drop cascades to table my_tq_agg_opt_part
-drop cascades to function plusone(numeric)
-drop cascades to table ggg
-drop cascades to table t3
-drop cascades to table index_test
-drop cascades to table btree_test
-drop cascades to table bitmap_test
-drop cascades to type rainbow
-drop cascades to table foo_ctas
-drop cascades to table input_tab1
-drop cascades to table input_tab2
-drop cascades to table tab_1
-drop cascades to table tab_2
-drop cascades to table tab_3
-drop cascades to table t_outer
-drop cascades to table t_inner
-drop cascades to table wst0
-drop cascades to table wst1
-drop cascades to table wst2
-drop cascades to table test1
-drop cascades to table t_new
-drop cascades to table x_tab
-drop cascades to table y_tab
-drop cascades to table z_tab
-drop cascades to function test_func_pg_stats()
-drop cascades to table bar
-drop cascades to type myint
-drop cascades to function myintout(myint)
-drop cascades to function myintin(cstring)
-drop cascades to function myint_int8(myint)
-drop cascades to table csq_cast_param_outer
-drop cascades to table csq_cast_param_inner
-drop cascades to function myint_numeric(myint)
-drop cascades to cast from myint to numeric
-drop cascades to table onetimefilter1
-drop cascades to table onetimefilter2
-drop cascades to table ffoo
-drop cascades to table fbar
-drop cascades to table touter
-and 67 other objects (see server log for list)
--- end_ignore
+----------------------------------
+-- Test ORCA support for const TVF
+----------------------------------
+create type complex_t as (r float8, i float8);
+-- Nested composite
+create type quad as (c1 complex_t, c2 complex_t);
+create function quad_func_cast() returns quad immutable as $$ select ((1.1,null),(2.2,null))::quad $$ language sql;
+explain select c1 from quad_func_cast();
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Function Scan on quad_func_cast  (cost=0.00..0.01 rows=1 width=32)
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+explain select c2 from quad_func_cast();
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Function Scan on quad_func_cast  (cost=0.00..0.01 rows=1 width=32)
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+explain select (c1).r from quad_func_cast();
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Function Scan on quad_func_cast  (cost=0.00..0.01 rows=1 width=32)
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+explain select (c2).i from quad_func_cast();
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Function Scan on quad_func_cast  (cost=0.00..0.01 rows=1 width=32)
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+select c1 from quad_func_cast();
+   c1   
+--------
+ (1.1,)
+(1 row)
+
+select c2 from quad_func_cast();
+   c2   
+--------
+ (2.2,)
+(1 row)
+
+select (c1).r from quad_func_cast();
+  r  
+-----
+ 1.1
+(1 row)
+
+select (c2).i from quad_func_cast();
+ i 
+---
+  
+(1 row)
+
+create type mix_type as (a text, b integer, c bool);
+create function mix_func_cast() returns mix_type immutable as $$ select ('column1', 1, true)::mix_type $$ language sql;
+explain select a from mix_func_cast();
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Function Scan on mix_func_cast  (cost=0.00..0.01 rows=1 width=32)
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+explain select b from mix_func_cast();
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Function Scan on mix_func_cast  (cost=0.00..0.01 rows=1 width=4)
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+explain select c from mix_func_cast();
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Function Scan on mix_func_cast  (cost=0.00..0.01 rows=1 width=1)
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+select a from mix_func_cast();
+    a    
+---------
+ column1
+(1 row)
+
+select b from mix_func_cast();
+ b 
+---
+ 1
+(1 row)
+
+select c from mix_func_cast();
+ c 
+---
+ t
+(1 row)
+

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14600,108 +14600,108 @@ where t.j = tt.j;
  Optimizer: Pivotal Optimizer (GPORCA)
 (17 rows)
 
--- start_ignore
-DROP SCHEMA orca CASCADE;
-NOTICE:  drop cascades to 167 other objects
-DETAIL:  drop cascades to table bar1
-drop cascades to table bar2
-drop cascades to table r
-drop cascades to table s
-drop cascades to table m
-drop cascades to table m1
-drop cascades to table orca_w1
-drop cascades to table orca_w2
-drop cascades to table orca_w3
-drop cascades to table rcte
-drop cascades to table onek
-drop cascades to table pp
-drop cascades to table multilevel_p
-drop cascades to table t
-drop cascades to table t_date
-drop cascades to table t_text
-drop cascades to type employee
-drop cascades to function emp_equal(employee,employee)
-drop cascades to operator =(employee,employee)
-drop cascades to operator family employee_op_class for access method btree
-drop cascades to table t_employee
-drop cascades to table t_ceeval_ints
-drop cascades to function csq_f(integer)
-drop cascades to table csq_r
-drop cascades to table fooh1
-drop cascades to table fooh2
-drop cascades to append only table t77
-drop cascades to table prod9
-drop cascades to table toanalyze
-drop cascades to table ur
-drop cascades to table us
-drop cascades to table ut
-drop cascades to table uu
-drop cascades to table twf1
-drop cascades to table twf2
-drop cascades to table tab1
-drop cascades to table tab2
-drop cascades to function sum_sfunc(anyelement,anyelement)
-drop cascades to function sum_combinefunc(anyelement,anyelement)
-drop cascades to function myagg1(anyelement)
-drop cascades to function sum_sfunc2(anyelement,anyelement,anyelement)
-drop cascades to function myagg2(anyelement,anyelement)
-drop cascades to function gptfp(anyarray,anyelement)
-drop cascades to function gpffp(anyarray)
-drop cascades to function myagg3(anyelement)
-drop cascades to table array_table
-drop cascades to table mpp22453
-drop cascades to table mpp22791
-drop cascades to table p1
-drop cascades to append only table tmp_verd_s_pp_provtabs_agt_0015_extract1
-drop cascades to table arrtest
-drop cascades to table foo_missing_stats
-drop cascades to table bar_missing_stats
-drop cascades to table cust
-drop cascades to table datedim
-drop cascades to function plusone(integer)
-drop cascades to table bm_test
-drop cascades to table bm_dyn_test
-drop cascades to table bm_dyn_test_onepart
-drop cascades to table bm_dyn_test_multilvl_part
-drop cascades to table my_tt_agg_opt
-drop cascades to table my_tq_agg_opt_part
-drop cascades to function plusone(numeric)
-drop cascades to table ggg
-drop cascades to table t3
-drop cascades to table index_test
-drop cascades to table btree_test
-drop cascades to table bitmap_test
-drop cascades to type rainbow
-drop cascades to table foo_ctas
-drop cascades to table input_tab1
-drop cascades to table input_tab2
-drop cascades to table tab_1
-drop cascades to table tab_2
-drop cascades to table tab_3
-drop cascades to table t_outer
-drop cascades to table t_inner
-drop cascades to table wst0
-drop cascades to table wst1
-drop cascades to table wst2
-drop cascades to table test1
-drop cascades to table t_new
-drop cascades to table x_tab
-drop cascades to table y_tab
-drop cascades to table z_tab
-drop cascades to function test_func_pg_stats()
-drop cascades to table bar
-drop cascades to type myint
-drop cascades to function myintout(myint)
-drop cascades to function myintin(cstring)
-drop cascades to function myint_int8(myint)
-drop cascades to table csq_cast_param_outer
-drop cascades to table csq_cast_param_inner
-drop cascades to function myint_numeric(myint)
-drop cascades to cast from myint to numeric
-drop cascades to table onetimefilter1
-drop cascades to table onetimefilter2
-drop cascades to table ffoo
-drop cascades to table fbar
-drop cascades to table touter
-and 67 other objects (see server log for list)
--- end_ignore
+----------------------------------
+-- Test ORCA support for const TVF
+----------------------------------
+create type complex_t as (r float8, i float8);
+-- Nested composite
+create type quad as (c1 complex_t, c2 complex_t);
+create function quad_func_cast() returns quad immutable as $$ select ((1.1,null),(2.2,null))::quad $$ language sql;
+explain select c1 from quad_func_cast();
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Result  (cost=0.00..0.00 rows=1 width=8)
+   ->  Function Scan on quad_func_cast  (cost=0.00..0.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(3 rows)
+
+explain select c2 from quad_func_cast();
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Result  (cost=0.00..0.00 rows=1 width=8)
+   ->  Function Scan on quad_func_cast  (cost=0.00..0.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(3 rows)
+
+explain select (c1).r from quad_func_cast();
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Function Scan on quad_func_cast  (cost=0.00..0.01 rows=1 width=32)
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+explain select (c2).i from quad_func_cast();
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Function Scan on quad_func_cast  (cost=0.00..0.01 rows=1 width=32)
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+select c1 from quad_func_cast();
+   c1   
+--------
+ (1.1,)
+(1 row)
+
+select c2 from quad_func_cast();
+   c2   
+--------
+ (2.2,)
+(1 row)
+
+select (c1).r from quad_func_cast();
+  r  
+-----
+ 1.1
+(1 row)
+
+select (c2).i from quad_func_cast();
+ i 
+---
+  
+(1 row)
+
+create type mix_type as (a text, b integer, c bool);
+create function mix_func_cast() returns mix_type immutable as $$ select ('column1', 1, true)::mix_type $$ language sql;
+explain select a from mix_func_cast();
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Result  (cost=0.00..0.00 rows=1 width=8)
+   ->  Function Scan on mix_func_cast  (cost=0.00..0.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(3 rows)
+
+explain select b from mix_func_cast();
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Result  (cost=0.00..0.00 rows=1 width=4)
+   ->  Function Scan on mix_func_cast  (cost=0.00..0.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(3 rows)
+
+explain select c from mix_func_cast();
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Result  (cost=0.00..0.00 rows=1 width=1)
+   ->  Function Scan on mix_func_cast  (cost=0.00..0.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(3 rows)
+
+select a from mix_func_cast();
+    a    
+---------
+ column1
+(1 row)
+
+select b from mix_func_cast();
+ b 
+---
+ 1
+(1 row)
+
+select c from mix_func_cast();
+ c 
+---
+ t
+(1 row)
+

--- a/src/test/regress/expected/qp_orca_fallback.out
+++ b/src/test/regress/expected/qp_orca_fallback.out
@@ -247,12 +247,3 @@ explain select count(*) from foo group by a;
  Optimizer: Postgres query optimizer
 (5 rows)
 
--- Orca should fallback for functions returning composite types
-create type compType as (a int, b int);
-create function myfunc5() returns compType IMMUTABLE as $$ select 2,3 $$ language sql;
-select a from myfunc5();
- a 
----
- 2
-(1 row)
-

--- a/src/test/regress/expected/qp_orca_fallback_optimizer.out
+++ b/src/test/regress/expected/qp_orca_fallback_optimizer.out
@@ -295,14 +295,3 @@ DETAIL:  No plan has been computed for required properties
  Optimizer: Postgres query optimizer
 (5 rows)
 
--- Orca should fallback for functions returning composite types
-create type compType as (a int, b int);
-create function myfunc5() returns compType IMMUTABLE as $$ select 2,3 $$ language sql;
-select a from myfunc5();
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Row-type variable
- a 
----
- 2
-(1 row)
-

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3259,6 +3259,31 @@ set i = tt.i
 from (select (min(i) over (order by j)) as i, j from window_agg_test) tt
 where t.j = tt.j;
 
+----------------------------------
+-- Test ORCA support for const TVF
+----------------------------------
+create type complex_t as (r float8, i float8);
+-- Nested composite
+create type quad as (c1 complex_t, c2 complex_t);
+create function quad_func_cast() returns quad immutable as $$ select ((1.1,null),(2.2,null))::quad $$ language sql;
+explain select c1 from quad_func_cast();
+explain select c2 from quad_func_cast();
+explain select (c1).r from quad_func_cast();
+explain select (c2).i from quad_func_cast();
+select c1 from quad_func_cast();
+select c2 from quad_func_cast();
+select (c1).r from quad_func_cast();
+select (c2).i from quad_func_cast();
+
+create type mix_type as (a text, b integer, c bool);
+create function mix_func_cast() returns mix_type immutable as $$ select ('column1', 1, true)::mix_type $$ language sql;
+explain select a from mix_func_cast();
+explain select b from mix_func_cast();
+explain select c from mix_func_cast();
+select a from mix_func_cast();
+select b from mix_func_cast();
+select c from mix_func_cast();
+
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 -- end_ignore

--- a/src/test/regress/sql/qp_orca_fallback.sql
+++ b/src/test/regress/sql/qp_orca_fallback.sql
@@ -101,8 +101,3 @@ explain select count(*) from foo group by a;
 set optimizer_enable_hashagg = off;
 set optimizer_enable_groupagg = off;
 explain select count(*) from foo group by a;
-
--- Orca should fallback for functions returning composite types
-create type compType as (a int, b int);
-create function myfunc5() returns compType IMMUTABLE as $$ select 2,3 $$ language sql;
-select a from myfunc5();


### PR DESCRIPTION
Background: Const TVF returning multi-column composite type returns incorrect result in 6X. TVF returning composite type falls back on planner in 7X.

Implementation:
1. Use invalid funcid to indicate TVF evaluates to const. Remove all valid funcid assertions.
2. Refactored code. Query -> DXL translation cases divided into three categories (i) non TVF && non const composite (eg. Var, Const returning simple type), (ii) const TVF returning composite type, (3) TVF.
3. Add relation storage type and token for composite type, similar to "virtual" storage type in 6X.
4. Remove tests for const TVF fall back. Add tests for const TVF

(cherry-picked from commit 6af81b4827bcaf8deefe2e196755104d52828f62)