### PR TITLE
Feat: Find the pids of overflowd subtransaction

### DIFF
--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -10882,6 +10882,15 @@
    proargnames => '{segid,waiter_dxid,holder_dxid,holdTillEndXact,waiter_lpid,holder_lpid,waiter_lockmode,waiter_locktype,waiter_sessionid,holder_sessionid}',
    prosrc => 'gp_dist_wait_status' },
 
+{ oid => 6485, descr => 'get pids of overflowed subtransactions',
+   proname => 'gp_subtrx_overflow_pids', prorows => '1000', proisstrict => 'f',
+   proretset => 't', provolatile => 'v', proparallel => 'r',
+   prorettype => 'record', proargtypes => '',
+   proallargtypes => '{int4,text}',
+   proargmodes => '{o,o}',
+   proargnames => '{segid,pids}',
+   prosrc => 'gp_subtrx_overflow_pids' },
+
 { oid => 6030, descr => 'Return resource queue information',
    proname => 'pg_resqueue_status', prorows => '1000', proretset => 't', provolatile => 'v', proparallel => 'r', prorettype => 'record', proargtypes => '', prosrc => 'pg_resqueue_status' },
 

--- a/src/test/regress/expected/subtrx_overflow.out
+++ b/src/test/regress/expected/subtrx_overflow.out
@@ -1,0 +1,93 @@
+drop table if exists t_135244_1;
+NOTICE:  table "t_135244_1" does not exist, skipping
+CREATE TABLE t_135244_1(c1 int) distributed by (c1);
+CREATE OR REPLACE FUNCTION insert_data()
+returns void AS $$
+DECLARE
+    i int;
+BEGIN
+	FOR i in 0..1000
+	LOOP
+		BEGIN
+			INSERT INTO t_135244_1 VALUES(i);
+		EXCEPTION
+		WHEN UNIQUE_VIOLATION THEN
+			NULL;
+		END;
+	END LOOP;
+END;
+$$
+LANGUAGE plpgsql;
+CREATE PROCEDURE transaction_test1()
+AS $$
+DECLARE
+    i int;
+begin
+	for i in 0..1000
+	loop
+		begin
+			create temp table tmptab(c int) distributed by (c);
+			drop table tmptab;
+			insert into t_135244_1 values(i);
+		exception
+			WHEN others THEN
+				NULL;
+		end;
+	end loop;
+end;
+$$
+LANGUAGE plpgsql;
+drop table if exists t_135244_2;
+NOTICE:  table "t_135244_2" does not exist, skipping
+create table t_135244_2(c int PRIMARY KEY);
+CREATE PROCEDURE transaction_test2()
+AS $$
+DECLARE i int;
+begin
+	for i in 0..1000
+	loop
+		begin
+			insert into t_135244_2 values(1);
+		exception
+			WHEN UNIQUE_VIOLATION THEN
+				NULL;
+		end;
+	end loop;
+end;
+$$
+LANGUAGE plpgsql;
+begin;
+select insert_data();
+ insert_data 
+-------------
+ 
+(1 row)
+
+select count(*) from (select * from gp_subtrx_overflow_pids())
+        as a where length(pids) > 0;
+ count 
+-------
+     3
+(1 row)
+
+commit;
+begin;
+call transaction_test1();
+select count(*) from (select * from gp_subtrx_overflow_pids())
+        as a where length(pids) > 0;
+ count 
+-------
+     4
+(1 row)
+
+commit;
+begin;
+call transaction_test2();
+select count(*) from (select * from gp_subtrx_overflow_pids())
+        as a where length(pids) > 0;
+ count 
+-------
+     0
+(1 row)
+
+commit;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -297,4 +297,6 @@ test: create_extension_fail
 # test if motion sockets are created with the gp_segment_configuration.address
 test: motion_socket
 
+# find the pids tests for subtransacton overflow
+test: subtrx_overflow
 # end of tests

--- a/src/test/regress/sql/subtrx_overflow.sql
+++ b/src/test/regress/sql/subtrx_overflow.sql
@@ -1,0 +1,78 @@
+drop table if exists t_135244_1;
+CREATE TABLE t_135244_1(c1 int) distributed by (c1);
+CREATE OR REPLACE FUNCTION insert_data()
+returns void AS $$
+DECLARE
+    i int;
+BEGIN
+	FOR i in 0..1000
+	LOOP
+		BEGIN
+			INSERT INTO t_135244_1 VALUES(i);
+		EXCEPTION
+		WHEN UNIQUE_VIOLATION THEN
+			NULL;
+		END;
+	END LOOP;
+END;
+$$
+LANGUAGE plpgsql;
+
+
+CREATE PROCEDURE transaction_test1()
+AS $$
+DECLARE
+    i int;
+begin
+	for i in 0..1000
+	loop
+		begin
+			create temp table tmptab(c int) distributed by (c);
+			drop table tmptab;
+			insert into t_135244_1 values(i);
+		exception
+			WHEN others THEN
+				NULL;
+		end;
+	end loop;
+end;
+$$
+LANGUAGE plpgsql;
+
+
+drop table if exists t_135244_2;
+create table t_135244_2(c int PRIMARY KEY);
+CREATE PROCEDURE transaction_test2()
+AS $$
+DECLARE i int;
+begin
+	for i in 0..1000
+	loop
+		begin
+			insert into t_135244_2 values(1);
+		exception
+			WHEN UNIQUE_VIOLATION THEN
+				NULL;
+		end;
+	end loop;
+end;
+$$
+LANGUAGE plpgsql;
+
+begin;
+select insert_data();
+select count(*) from (select * from gp_subtrx_overflow_pids())
+        as a where length(pids) > 0;
+commit;
+
+begin;
+call transaction_test1();
+select count(*) from (select * from gp_subtrx_overflow_pids())
+        as a where length(pids) > 0;
+commit;
+
+begin;
+call transaction_test2();
+select count(*) from (select * from gp_subtrx_overflow_pids())
+        as a where length(pids) > 0;
+commit;


### PR DESCRIPTION
In gpdb, it supports using savepoint, begin...exception..., and plpython
to issue the subtransactions. Especially, it may be much more serious for the
application error handling. It may issue many more subtransactions for
error handling.

For the postgres and gpdb, the number of active subtransactions has a maximum
value. The subtransaction state moves back and force when the number of
active subtransactions exceeds the maximum value (64) to inspect the
snapshot visibility. It may cause a shake in system performance.

The DBA needs to inspect the cause. So, we add the helper function for
finding the pids of overflowed subtransaction for coordinator and segments.

The alternative implementation #13554