### PR TITLE
metadata tracking for GPDB specific ALTER PARTITION commands

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -1437,14 +1437,6 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId,
 	}
 
 	/* MPP-6929: metadata tracking */
-	/* GPDB_12_MERGE_FIXME: We reported new partitions with "ALTER INHERIT"
-	 * in previous versions, but I think it was mostly an implementation
-	 * artifact when PostgreSQL didn't have native partitioning support and
-	 * GPDB partitioning was a special case of table inheritance. Take a
-	 * holistic look on how all the partition commands are reported in
-	 * pg_stat_last_operation. Including new upstream commands
-	 * CREATE TABLE PARTITITION OF, ATTACH PARTITION etc.
-	 */
 	if (stmt->partbound && Gp_role == GP_ROLE_DISPATCH)
 	{
 		MetaTrackUpdObject(RelationRelationId,

--- a/src/include/commands/tablecmds.h
+++ b/src/include/commands/tablecmds.h
@@ -115,6 +115,7 @@ extern bool PartConstraintImpliedByRelConstraint(Relation scanrel,
 
 /* GPDB specific functions */
 extern void ATExecGPPartCmds(Relation origrel, AlterTableCmd *cmd);
+extern void GpAlterPartMetaTrackUpdObject(Oid relid, AlterTableType subcmdtype);
 extern void GpRenameChildPartitions(Relation targetrelation,
 									const char *oldparentrelname,
 									const char *newparentrelname);

--- a/src/test/regress/expected/pg_stat_last_operation.out
+++ b/src/test/regress/expected/pg_stat_last_operation.out
@@ -110,6 +110,8 @@ ALTER TABLE mdt_test_part1 ATTACH PARTITION mdt_test_newpart2 FOR VALUES IN ('Y'
 CREATE TABLE mdt_test_detach PARTITION OF mdt_test_part1 FOR VALUES IN ('Z');
 NOTICE:  table has parent, setting distribution columns to match parent table
 ALTER TABLE mdt_test_part1 DETACH PARTITION mdt_test_detach;
+-- DROP PARTITION
+ALTER TABLE mdt_test_part1 DROP PARTITION FOR ('Y');
 -- GRANT
 GRANT ALL ON mdt_all_types TO public;
 SELECT * FROM pg_stat_last_operation_testview WHERE actionname = 'PRIVILEGE';
@@ -164,6 +166,7 @@ SELECT * FROM pg_stat_last_operation_testview WHERE objname like ('mdt_%');
                   objname                  | actionname | subtype  
 -------------------------------------------+------------+----------
  mdt_test_part1                            | CREATE     | TABLE
+ mdt_test_part1                            | PARTITION  | DROP
  mdt_test_part1_1_prt_1                    | CREATE     | TABLE
  mdt_test_part1_1_prt_1                    | PARTITION  | ATTACH
  mdt_test_part1_1_prt_2                    | CREATE     | TABLE
@@ -183,20 +186,19 @@ SELECT * FROM pg_stat_last_operation_testview WHERE objname like ('mdt_%');
  mdt_all_types_col023_seq                  | ALTER      | OWNED BY
  mdt_test_newpart                          | CREATE     | TABLE
  mdt_test_newpart                          | PARTITION  | ATTACH
- mdt_test_newpart2                         | CREATE     | TABLE
- mdt_test_newpart2                         | PARTITION  | ATTACH
  mdt_test_detach                           | CREATE     | TABLE
  mdt_test_detach                           | PARTITION  | DETACH
  mdt_all_types                             | PRIVILEGE  | GRANT
  mdt_all_types                             | VACUUM     | 
  mdt_all_types                             | ANALYZE    | 
-(27 rows)
+(26 rows)
 
 DROP TABLE mdt_all_types;
 SELECT * FROM pg_stat_last_operation_testview WHERE objname like ('mdt_%');
                   objname                  | actionname | subtype 
 -------------------------------------------+------------+---------
  mdt_test_part1                            | CREATE     | TABLE
+ mdt_test_part1                            | PARTITION  | DROP
  mdt_test_part1_1_prt_1                    | CREATE     | TABLE
  mdt_test_part1_1_prt_1                    | PARTITION  | ATTACH
  mdt_test_part1_1_prt_2                    | CREATE     | TABLE
@@ -211,11 +213,9 @@ SELECT * FROM pg_stat_last_operation_testview WHERE objname like ('mdt_%');
  mdt_test_part1_1_prt_default_part_2_prt_1 | PARTITION  | ATTACH
  mdt_test_newpart                          | CREATE     | TABLE
  mdt_test_newpart                          | PARTITION  | ATTACH
- mdt_test_newpart2                         | CREATE     | TABLE
- mdt_test_newpart2                         | PARTITION  | ATTACH
  mdt_test_detach                           | CREATE     | TABLE
  mdt_test_detach                           | PARTITION  | DETACH
-(19 rows)
+(18 rows)
 
 DROP TABLE mdt_test_part1;
 SELECT * FROM pg_stat_last_operation_testview WHERE objname like ('mdt_%');

--- a/src/test/regress/sql/pg_stat_last_operation.sql
+++ b/src/test/regress/sql/pg_stat_last_operation.sql
@@ -94,6 +94,9 @@ ALTER TABLE mdt_test_part1 ATTACH PARTITION mdt_test_newpart2 FOR VALUES IN ('Y'
 CREATE TABLE mdt_test_detach PARTITION OF mdt_test_part1 FOR VALUES IN ('Z');
 ALTER TABLE mdt_test_part1 DETACH PARTITION mdt_test_detach;
 
+-- DROP PARTITION
+ALTER TABLE mdt_test_part1 DROP PARTITION FOR ('Y');
+
 -- GRANT
 GRANT ALL ON mdt_all_types TO public;
 SELECT * FROM pg_stat_last_operation_testview WHERE actionname = 'PRIVILEGE';


### PR DESCRIPTION
> GPDB_12_MERGE_FIXME: We reported new partitions with "ALTER INHERIT"
> in previous versions, but I think it was mostly an implementation
> artifact when PostgreSQL didn't have native partitioning support and
> GPDB partitioning was a special case of table inheritance. Take a
> holistic look on how all the partition commands are reported in
> pg_stat_last_operation. Including new upstream commands
> CREATE TABLE PARTITITION OF, ATTACH PARTITION etc.

This commit tracked GPDB specific alter partition commands in pg_stat_last_operation.

New upstream commands:
```
postgres=# alter table sales detach partition sales_1_prt_sep16;
postgres=# select * from pg_stat_last_operation;
 classid | objid | staactionname | stasysid | stausename | stasubtype |            statime
---------+-------+---------------+----------+------------+------------+-------------------------------
    1259 | 16411 | PARTITION     |       10 | gpadmin    | DETACH     | 2022-05-24 14:12:18.615458+08

postgres=# alter table sales attach partition sales_1_prt_sep16 for values from (date '2016-09-01') TO (date '2016-09-30');
postgres=# select * from pg_stat_last_operation ;
 classid | objid | staactionname | stasysid | stausename | stasubtype |            statime
---------+-------+---------------+----------+------------+------------+-------------------------------
    1259 | 16411 | PARTITION     |       10 | gpadmin    | ATTACH     | 2022-05-24 14:14:30.286769+08
```

GPDB specific commands(portion):
```
postgres=# ALTER TABLE sales ADD PARTITION START (date '2017-02-01') INCLUSIVE END (date '2017-03-01') EXCLUSIVE;
postgres=# select * from pg_stat_last_operation;
 classid | objid | staactionname | stasysid | stausename | stasubtype |            statime
---------+-------+---------------+----------+------------+------------+-------------------------------
    1259 | 16384 | PARTITION     |       10 | gpadmin    | ADD        | 2022-05-24 15:48:47.365979+08

postgres=# alter table sales drop partition for  (date '2017-02-01');
postgres=# select * from pg_stat_last_operation;
 classid | objid | staactionname | stasysid | stausename | stasubtype |            statime
---------+-------+---------------+----------+------------+------------+-------------------------------
    1259 | 16384 | PARTITION     |       10 | gpadmin    | DROP       | 2022-05-24 15:50:12.307402+08

postgres=# alter table sales truncate partition for  (date '2017-02-01');
postgres=# select * from pg_stat_last_operation;
 classid | objid | staactionname | stasysid | stausename | stasubtype |            statime
---------+-------+---------------+----------+------------+------------+-------------------------------
    1259 | 16384 | PARTITION     |       10 | gpadmin    | TRUNCATE   | 2022-05-24 15:54:30.205289+08
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
