### PR TITLE
fix gpfdist crash

### DIFF
--- a/src/backend/utils/misc/fstream/gfile.c
+++ b/src/backend/utils/misc/fstream/gfile.c
@@ -372,6 +372,10 @@ gz_file_write_one_chunk(gfile_t *fd, int do_flush)
 		
 		z->s.avail_out = COMPRESSION_BUFFER_SIZE;
 		z->s.next_out = z->out;
+		if (z->s.state == 0x0)
+		{
+			return -1;
+		}
 		ret1 = deflate(&(z->s), do_flush);    /* no bad return value */
 		assert(ret1 != Z_STREAM_ERROR);  /* state not clobbered */
 		have = COMPRESSION_BUFFER_SIZE - z->s.avail_out;


### PR DESCRIPTION
_Long log:_
The bug is strongly related to special data and it will be triggered only if there is no extra space on the disk.
We failed to reproduce this bug and can only analyze it by gdb debugging. After analyzing the core dump, we found fd->u.z->s.state=0x0 in gz_file_write_one_chunk(). This may be the reason.
The solution is to return -1 as long as s.state=0x0.

Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>


**The gdb log of bug is shown as followed:**
```
$ gdb gpfdist
(gdb) b gz_file_write_one_chunk
Breakpoint 1 at 0xc8b0: gz_file_write_one_chunk. (2 locations)
(gdb) r -d /home/gpadmin/gpfdist_test/ -p 8080 
// ......
Breakpoint 1, gz_file_write_one_chunk (fd=0x55555556ec90, do_flush=0) at gfile.c:362
// ......
(gdb) p *z
$3 = {s = {next_in = 0x7ffff7c9b028 "str\ndemo\nhello\nbug\ngp\ngpdb\ngpss\nbye\n", avail_in = 36, total_in = 0, next_out = 0x55555557b98c "", avail_out = 16384, total_out = 0, msg = 0x0, 
    state = 0x55555557f9a0, zalloc = 0x5555555604a0 <z_alloc>, zfree = 0x5555555608a0 <z_free>, opaque = 0x0, data_type = 2, adler = 0, reserved = 0}, in_size = 0, out_size = 0, eof = 0, 
  in = '\000' <repeats 16383 times>, out = '\000' <repeats 16383 times>}
(gdb) print z->s.state=0x0
$4 = (struct internal_state *) 0x0
(gdb) p *z
$5 = {s = {next_in = 0x7ffff7c9b028 "str\ndemo\nhello\nbug\ngp\ngpdb\ngpss\nbye\n", avail_in = 36, total_in = 0, next_out = 0x55555557b98c "", avail_out = 16384, total_out = 0, msg = 0x0, state = 0x0, 
    zalloc = 0x5555555604a0 <z_alloc>, zfree = 0x5555555608a0 <z_free>, opaque = 0x0, data_type = 2, adler = 0, reserved = 0}, in_size = 0, out_size = 0, eof = 0, in = '\000' <repeats 16383 times>, 
  out = '\000' <repeats 16383 times>}
(gdb) s
375			ret1 = deflate(&(z->s), do_flush);    /* no bad return value */
(gdb) s
376			assert(ret1 != Z_STREAM_ERROR);  /* state not clobbered */
(gdb) s
// ......
Breakpoint 1, gz_file_write_one_chunk (fd=0x55555556ec90, do_flush=0) at gfile.c:376
376			assert(ret1 != Z_STREAM_ERROR);  /* state not clobbered */
(gdb) s
__GI___assert_fail (assertion=0x5555555673dd "ret1 != Z_STREAM_ERROR", file=0x5555555673c5 "gfile.c", line=376, function=0x555555567510 <__PRETTY_FUNCTION__.8849> "gz_file_write_one_chunk")
    at assert.c:100
100	assert.c: No such file or directory.
(gdb) s
101	in assert.c
(gdb) s
__GI___dcgettext (domainname=0x7ffff7e69418 <_libc_intl_domainname> "libc", msgid=msgid@entry=0x7ffff7e6d588 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", category=category@entry=5) at dcgettext.c:46
46	dcgettext.c: No such file or directory.
(gdb) s
47	in dcgettext.c
(gdb) s
__dcigettext (domainname=0x7ffff7e69418 <_libc_intl_domainname> "libc", msgid1=msgid1@entry=0x7ffff7e6d588 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", msgid2=msgid2@entry=0x0, plural=plural@entry=0, 
    n=n@entry=0, category=category@entry=5) at dcigettext.c:485
485	dcigettext.c: No such file or directory.
```

**The gdb log with patch is shown as followed:**
```
$ gdb gpfdist
(gdb) b gz_file_write_one_chunk
Breakpoint 1 at 0x40b480: gz_file_write_one_chunk. (2 locations)
(gdb)  r -d /home/gpadmin/core_analysis/load_files/ -p 8080
// ......
Breakpoint 1, gz_file_write (fd=0x61dd30, ptr=0x67c898, size=16) at gfile.c:423
423                     ret = gz_file_write_one_chunk(fd, Z_NO_FLUSH);
Missing separate debuginfos, use: debuginfo-install apr-1.4.8-7.el7.x86_64 bzip2-libs-1.0.6-13.el7.x86_64 libevent-2.0.21-4.el7.x86_64 libuuid-2.23.2-65.el7_9.1.x86_64 libyaml-0.1.4-11.el7_0.x86_64 nss-softokn-freebl-3.53.1-6.el7_9.x86_64 zlib-1.2.7-19.el7_9.x86_64
(gdb) s
gz_file_write_one_chunk (do_flush=0, fd=0x61dd30) at gfile.c:367
367             struct zlib_stuff* z = fd->u.z;
(gdb) s
375                     if (z->s.state == 0x0)
(gdb) p *z
$1 = {s = {next_in = 0x67c898 "1\n2\n3\n4\n5\n6\n7\n8\n", avail_in = 16, total_in = 0, next_out = 0x6370dc "", avail_out = 0,
    total_out = 0, msg = 0x0, state = 0x63b0f0, zalloc = 0x40b330 <z_alloc>, zfree = 0x40b420 <z_free>, opaque = 0x0, data_type = 2,
    adler = 0, reserved = 0}, in_size = 0, out_size = 0, eof = 0, in = '\000' <repeats 16383 times>, out = '\000' <repeats 16383 times>}
(gdb) print  z->s.state=0x0
$2 = (struct internal_state *) 0x0
(gdb) p *z
$3 = {s = {next_in = 0x67c898 "1\n2\n3\n4\n5\n6\n7\n8\n", avail_in = 16, total_in = 0, next_out = 0x6370dc "", avail_out = 0,
    total_out = 0, msg = 0x0, state = 0x0, zalloc = 0x40b330 <z_alloc>, zfree = 0x40b420 <z_free>, opaque = 0x0, data_type = 2,
    adler = 0, reserved = 0}, in_size = 0, out_size = 0, eof = 0, in = '\000' <repeats 16383 times>, out = '\000' <repeats 16383 times>}
// ......
(gdb) s 10
2022-05-23 10:55:52 27926 WARN [1:2:0:8] HTTP ERROR: 127.0.0.1 - 500 cannot write into file
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
