### PR TITLE
optional reject parsing ambigous 5-digits date in non-standard YYYMMDD format

### DIFF
--- a/src/backend/utils/adt/datetime.c
+++ b/src/backend/utils/adt/datetime.c
@@ -2918,6 +2918,8 @@ DecodeNumberField(int len, char *str, int fmask,
 			tm->tm_year = atoi(str);
 			if ((len - 4) == 2)
 				*is2digits = TRUE;
+			else if (((len - 4 ) == 3) && !gp_allow_date_field_width_5digits)
+				return DTERR_BAD_FORMAT;
 
 			return DTK_DATE;
 		}

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -461,6 +461,9 @@ bool		gp_enable_global_deadlock_detector = false;
 
 bool		gp_log_endpoints = false;
 
+/* optional reject to  parse ambigous 5-digits date in YYYMMDD format */
+bool		gp_allow_date_field_width_5digits = false;
+
 static const struct config_enum_entry gp_log_format_options[] = {
 	{"text", 0},
 	{"csv", 1},
@@ -3090,6 +3093,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 		NULL, NULL, NULL
 	},
 
+	{
+		{"gp_allow_date_field_width_5digits", PGC_USERSET, COMPAT_OPTIONS_PREVIOUS,
+			gettext_noop("Allow parsing input date field with exactly continous 5 digits in non-standard YYYMMDD timeformat (follow pg12+ behave)"),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&gp_allow_date_field_width_5digits,
+		false,
+		NULL, NULL, NULL
+	},
 	{
 		{"optimizer_enable_eageragg", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Enable Eager Agg transform for pushing aggregate below an innerjoin."),

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -587,6 +587,8 @@ extern bool gp_enable_global_deadlock_detector;
 
 extern bool gp_log_endpoints;
 
+extern bool gp_allow_date_field_width_5digits;
+
 typedef enum
 {
 	INDEX_CHECK_NONE,

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -13,6 +13,7 @@
 		"execute_pruned_plan",
 		"explain_memory_verbosity",
 		"gin_fuzzy_search_limit",
+		"gp_allow_date_field_width_5digits",
 		"gp_blockdirectory_entry_min_range",
 		"gp_blockdirectory_minipage_size",
 		"gp_debug_linger",

--- a/src/test/regress/expected/date.out
+++ b/src/test/regress/expected/date.out
@@ -313,6 +313,21 @@ SELECT date '1999 08 01';
  1999-08-01
 (1 row)
 
+-- Test guc gp_allow_date_field_width_5digits
+-- should error out
+SELECT date '2020516';
+ERROR:  invalid input syntax for type date: "2020516"
+LINE 1: SELECT date '2020516';
+                    ^
+SET gp_allow_date_field_width_5digits=on;
+-- should parsed to 0202-05-16 ( non-standard YYYMMDD )
+SELECT date '2020516';
+    date    
+------------
+ 0202-05-16
+(1 row)
+
+RESET gp_allow_date_field_width_5digits;
 SET datestyle TO dmy;
 SELECT date 'January 8, 1999';
     date    
@@ -565,6 +580,21 @@ SELECT date '1999 08 01';
  1999-08-01
 (1 row)
 
+-- Test guc gp_allow_date_field_width_5digits
+-- should error out
+SELECT date '2020516';
+ERROR:  invalid input syntax for type date: "2020516"
+LINE 1: SELECT date '2020516';
+                    ^
+SET gp_allow_date_field_width_5digits=on;
+-- should parsed to 0202-05-16 ( non-standard YYYMMDD )
+SELECT date '2020516';
+    date    
+------------
+ 0202-05-16
+(1 row)
+
+RESET gp_allow_date_field_width_5digits;
 SET datestyle TO mdy;
 SELECT date 'January 8, 1999';
     date    
@@ -816,6 +846,21 @@ SELECT date '1999 08 01';
  1999-08-01
 (1 row)
 
+-- Test guc gp_allow_date_field_width_5digits
+-- should error out
+SELECT date '2020516';
+ERROR:  invalid input syntax for type date: "2020516"
+LINE 1: SELECT date '2020516';
+                    ^
+SET gp_allow_date_field_width_5digits=on;
+-- should parsed to 0202-05-16 ( non-standard YYYMMDD )
+SELECT date '2020516';
+    date    
+------------
+ 0202-05-16
+(1 row)
+
+RESET gp_allow_date_field_width_5digits;
 RESET datestyle;
 --
 -- Simple math

--- a/src/test/regress/sql/date.sql
+++ b/src/test/regress/sql/date.sql
@@ -84,6 +84,17 @@ SELECT date '01 08 1999';
 SELECT date '99 08 01';
 SELECT date '1999 08 01';
 
+-- Test guc gp_allow_date_field_width_5digits
+-- should error out
+SELECT date '2020516';
+
+SET gp_allow_date_field_width_5digits=on;
+
+-- should parsed to 0202-05-16 ( non-standard YYYMMDD )
+SELECT date '2020516';
+
+RESET gp_allow_date_field_width_5digits;
+
 SET datestyle TO dmy;
 
 SELECT date 'January 8, 1999';
@@ -135,6 +146,17 @@ SELECT date '01 08 1999';
 SELECT date '99 08 01';
 SELECT date '1999 08 01';
 
+-- Test guc gp_allow_date_field_width_5digits
+-- should error out
+SELECT date '2020516';
+
+SET gp_allow_date_field_width_5digits=on;
+
+-- should parsed to 0202-05-16 ( non-standard YYYMMDD )
+SELECT date '2020516';
+
+RESET gp_allow_date_field_width_5digits;
+
 SET datestyle TO mdy;
 
 SELECT date 'January 8, 1999';
@@ -185,6 +207,17 @@ SELECT date '01 08 99';
 SELECT date '01 08 1999';
 SELECT date '99 08 01';
 SELECT date '1999 08 01';
+
+-- Test guc gp_allow_date_field_width_5digits
+-- should error out
+SELECT date '2020516';
+
+SET gp_allow_date_field_width_5digits=on;
+
+-- should parsed to 0202-05-16 ( non-standard YYYMMDD )
+SELECT date '2020516';
+
+RESET gp_allow_date_field_width_5digits;
 
 RESET datestyle;
 


### PR DESCRIPTION
reject ambigous 5-digits date in non-standard YYYMMDD format

The 5-digits date string was invalid and would be rejected on GPDB5. But then
the upstream pg modified the date parsing logic, which would make it parsed
as YYYMMMDD. As it's not a standard timeformat and the change causes gp6+ to
behave differently from previous version. this commit lets gp reject it by
default. And if the pg-like date parsing required, we can set the value of
GUC gp_allow_date_field_width_5digits to true.

This is a backport of commit 52b3646a from gpdb master (v7)

The original PR for master is here ( https://github.com/greenplum-db/gpdb/pull/13500 )

