### PR TITLE
Feat: Find the pids of overflowd subtransaction

### DIFF
--- a/src/backend/catalog/system_views.sql
+++ b/src/backend/catalog/system_views.sql
@@ -1776,3 +1776,12 @@ CREATE VIEW pg_catalog.gp_segment_endpoints AS
 
 CREATE VIEW pg_catalog.gp_session_endpoints AS
     SELECT * FROM pg_catalog.gp_get_session_endpoints();
+
+-- Dispatch and Aggregate the pids of subtransactions overflowed
+CREATE OR REPLACE function gp_find_subtx_overflowed(OUT segid int4, OUT pids text) returns setof record as
+$$
+  select -1, gp_find_subtx_overflowed_pids()
+  UNION ALL
+  select gp_segment_id, gp_find_subtx_overflowed_pids() from gp_dist_random('gp_id');
+$$
+LANGUAGE SQL EXECUTE ON COORDINATOR;

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -10881,6 +10881,9 @@
    proargmodes => '{o,o,o,o,o,o,o,o,o,o}',
    proargnames => '{segid,waiter_dxid,holder_dxid,holdTillEndXact,waiter_lpid,holder_lpid,waiter_lockmode,waiter_locktype,waiter_sessionid,holder_sessionid}',
    prosrc => 'gp_dist_wait_status' },
+{ oid => 6464, descr => 'get current PIDs of overflowed subtransaction',
+   proname => 'gp_find_subtx_overflowed_pids', provolatile => 'v', prorettype => 'text', proargtypes => '', prosrc => 'gp_find_subtx_overflowed_pids' },
+
 
 { oid => 6030, descr => 'Return resource queue information',
    proname => 'pg_resqueue_status', prorows => '1000', proretset => 't', provolatile => 'v', proparallel => 'r', prorettype => 'record', proargtypes => '', prosrc => 'pg_resqueue_status' },

--- a/src/test/regress/expected/subtrx_overflow.out
+++ b/src/test/regress/expected/subtrx_overflow.out
@@ -1,0 +1,115 @@
+-- The case is created using plpgsql. We execute the insert_data() funcion on
+-- all segments. It insert data into the different segments.
+-- We can see the `begin...exception...end` clause where the exception is
+-- not exectued. So, it has 1000 active subtransaction for a transaction.
+-- It need back and force from disk and shared memory when we need inspect
+-- the snapshot visibility, which may occur stall for the systems.
+-- We call the function using the following the SQL statement:
+-- begin;
+-- select insert_data();
+-- end;
+-- NOTE: It occur the all segments when subtransactions overflow.
+DROP TABLE IF EXISTS t_13524_1;
+NOTICE:  table "t_13524_1" does not exist, skipping
+CREATE TABLE t_13524_1(c1 int) distributed by (c1);
+CREATE OR REPLACE FUNCTION insert_data()
+returns void AS $$
+DECLARE
+    i int;
+BEGIN
+	FOR i in 0..1000
+	LOOP
+		BEGIN
+			INSERT INTO t_13524_1 VALUES(i);
+		EXCEPTION
+		WHEN UNIQUE_VIOLATION THEN
+			NULL;
+		END;
+	END LOOP;
+END;
+$$
+LANGUAGE plpgsql;
+-- This function use the plpgsql also. And it create temp table, which lead to
+-- modify the catalog. The coordinator may occur subtransactions overflow if
+-- we modify the system catalog. And then, we also insert data into all segments.
+-- It leads to overflow of coordinator and segments.
+CREATE PROCEDURE transaction_test1()
+AS $$
+DECLARE
+    i int;
+begin
+	for i in 0..1000
+	loop
+		begin
+			create temp table tmptab(c int) distributed by (c);
+			drop table tmptab;
+			insert into t_13524_1 values(i);
+		exception
+			WHEN others THEN
+				NULL;
+		end;
+	end loop;
+end;
+$$
+LANGUAGE plpgsql;
+-- This is corner case when the number of active subtransactions has not exceed
+-- 64. The `exception` clause is going to be executed When we call function.
+-- It leads to the subtransactions abort. According to the postgres rules, it
+-- has not subtransactions overflow problem.
+DROP TABLE IF EXISTS t_13524_2;
+NOTICE:  table "t_13524_2" does not exist, skipping
+create table t_13524_2(c int PRIMARY KEY);
+CREATE PROCEDURE transaction_test2()
+AS $$
+DECLARE i int;
+begin
+	for i in 0..1000
+	loop
+		begin
+			insert into t_13524_2 values(1);
+		exception
+			WHEN UNIQUE_VIOLATION THEN
+				NULL;
+		end;
+	end loop;
+end;
+$$
+LANGUAGE plpgsql;
+begin;
+select insert_data();
+ insert_data 
+-------------
+ 
+(1 row)
+
+select count(*) from (select (i).segid, (i).pids
+    from (select gp_find_subtx_overflowed())a(i) where length((i).pids) > 2)
+        as test;
+ count 
+-------
+     3
+(1 row)
+
+commit;
+begin;
+call transaction_test1();
+select count(*) from (select (i).segid, (i).pids
+    from (select gp_find_subtx_overflowed())a(i) where length((i).pids) > 2)
+        as test;
+ count 
+-------
+     4
+(1 row)
+
+commit;
+begin;
+call transaction_test2();
+select count(*) from (select (i).segid, (i).pids
+    from (select gp_find_subtx_overflowed())a(i) where length((i).pids) > 2)
+        as test;
+ count 
+-------
+     0
+(1 row)
+
+commit;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -297,4 +297,6 @@ test: create_extension_fail
 # test if motion sockets are created with the gp_segment_configuration.address
 test: motion_socket
 
+# subtransaction overflow test
+test: subtrx_overflow
 # end of tests

--- a/src/test/regress/sql/subtrx_overflow.sql
+++ b/src/test/regress/sql/subtrx_overflow.sql
@@ -1,0 +1,100 @@
+-- The case is created using plpgsql. We execute the insert_data() funcion on
+-- all segments. It insert data into the different segments.
+-- We can see the `begin...exception...end` clause where the exception is
+-- not exectued. So, it has 1000 active subtransaction for a transaction.
+-- It need back and force from disk and shared memory when we need inspect
+-- the snapshot visibility, which may occur stall for the systems.
+-- We call the function using the following the SQL statement:
+-- begin;
+-- select insert_data();
+-- end;
+-- NOTE: It occur the all segments when subtransactions overflow.
+DROP TABLE IF EXISTS t_13524_1;
+CREATE TABLE t_13524_1(c1 int) distributed by (c1);
+CREATE OR REPLACE FUNCTION insert_data()
+returns void AS $$
+DECLARE
+    i int;
+BEGIN
+	FOR i in 0..1000
+	LOOP
+		BEGIN
+			INSERT INTO t_13524_1 VALUES(i);
+		EXCEPTION
+		WHEN UNIQUE_VIOLATION THEN
+			NULL;
+		END;
+	END LOOP;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- This function use the plpgsql also. And it create temp table, which lead to
+-- modify the catalog. The coordinator may occur subtransactions overflow if
+-- we modify the system catalog. And then, we also insert data into all segments.
+-- It leads to overflow of coordinator and segments.
+CREATE PROCEDURE transaction_test1()
+AS $$
+DECLARE
+    i int;
+begin
+	for i in 0..1000
+	loop
+		begin
+			create temp table tmptab(c int) distributed by (c);
+			drop table tmptab;
+			insert into t_13524_1 values(i);
+		exception
+			WHEN others THEN
+				NULL;
+		end;
+	end loop;
+end;
+$$
+LANGUAGE plpgsql;
+
+
+-- This is corner case when the number of active subtransactions has not exceed
+-- 64. The `exception` clause is going to be executed When we call function.
+-- It leads to the subtransactions abort. According to the postgres rules, it
+-- has not subtransactions overflow problem.
+DROP TABLE IF EXISTS t_13524_2;
+create table t_13524_2(c int PRIMARY KEY);
+CREATE PROCEDURE transaction_test2()
+AS $$
+DECLARE i int;
+begin
+	for i in 0..1000
+	loop
+		begin
+			insert into t_13524_2 values(1);
+		exception
+			WHEN UNIQUE_VIOLATION THEN
+				NULL;
+		end;
+	end loop;
+end;
+$$
+LANGUAGE plpgsql;
+
+
+begin;
+select insert_data();
+select count(*) from (select (i).segid, (i).pids
+    from (select gp_find_subtx_overflowed())a(i) where length((i).pids) > 2)
+        as test;
+commit;
+
+begin;
+call transaction_test1();
+select count(*) from (select (i).segid, (i).pids
+    from (select gp_find_subtx_overflowed())a(i) where length((i).pids) > 2)
+        as test;
+commit;
+
+begin;
+call transaction_test2();
+select count(*) from (select (i).segid, (i).pids
+    from (select gp_find_subtx_overflowed())a(i) where length((i).pids) > 2)
+        as test;
+commit;


### PR DESCRIPTION
In gpdb, it support using `savepoint`, `begin...exception...`, and `plpython`
to issue the subtransactions. Especially, it may be much serious for the
application error handling. It may issue many more subtransaction for
error handling.

For the postgres and gpdb, the number of active subtransactions has maximum
value. The subtransaction state move back and force when the number of
active subtransactions exceed the maximum value (64) for inspect the
snapshot visiblity. It may cause shake in system performance.

The DBA need to inspect the cause. So, we add the helper function for
finding the pids of overflowed subtransaction for coordinator and segments.

The alternative implementation #13539 

