### PR TITLE
[6x backport] Handling exception to call mppExecutorCleanup in standard_ExecutorStart

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -384,20 +384,29 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 
 		if (!should_skip_operator_memory_assign)
 		{
-			switch(*gp_resmanager_memory_policy)
+			PG_TRY();
 			{
-				case RESMANAGER_MEMORY_POLICY_AUTO:
-					PolicyAutoAssignOperatorMemoryKB(queryDesc->plannedstmt,
+				switch(*gp_resmanager_memory_policy)
+				{
+					case RESMANAGER_MEMORY_POLICY_AUTO:
+						PolicyAutoAssignOperatorMemoryKB(queryDesc->plannedstmt,
 													 queryDesc->plannedstmt->query_mem);
-					break;
-				case RESMANAGER_MEMORY_POLICY_EAGER_FREE:
-					PolicyEagerFreeAssignOperatorMemoryKB(queryDesc->plannedstmt,
+						break;
+					case RESMANAGER_MEMORY_POLICY_EAGER_FREE:
+						PolicyEagerFreeAssignOperatorMemoryKB(queryDesc->plannedstmt,
 														  queryDesc->plannedstmt->query_mem);
-					break;
-				default:
-					Assert(IsResManagerMemoryPolicyNone());
-					break;
+						break;
+					default:
+						Assert(IsResManagerMemoryPolicyNone());
+						break;
+				}
 			}
+			PG_CATCH();
+			{
+				mppExecutorCleanup(queryDesc);
+				PG_RE_THROW();
+			}
+			PG_END_TRY();
 		}
 	}
 


### PR DESCRIPTION
According to a reported error in PolicyEagerFreeAssignOperatorMemoryKB makes query end without calling mppExecutorCleanup https://github.com/greenplum-db/gpdb/issues/12690 , the code path in standard_ExecutorStart didn't handle exception in PolicyAutoAssignOperatorMemoryKB and PolicyEagerFreeAssignOperatorMemoryKB calling, which may cause the OOM exception not handled in standard_ExecutorStart but throw to upper PortalStart methods, while there is also exception handling machanism in PortalStart but mppExecutorCleanup will not call because of portal->queryDesc will be NULL in certain transation states. This PR fixed this issue.

This is a backport of PR #12694 to 6x branch.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
