### PR TITLE
(6x only) Fix API broken introduced by cb120281a.

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -130,13 +130,13 @@ _copyPlannedStmt(const PlannedStmt *from)
 
 	COPY_SCALAR_FIELD(query_mem);
 
-	COPY_SCALAR_FIELD(total_memory_master);
-	COPY_SCALAR_FIELD(nsegments_master);
-
 	COPY_NODE_FIELD(intoClause);
 	COPY_NODE_FIELD(copyIntoClause);
 	COPY_NODE_FIELD(refreshClause);
 	COPY_SCALAR_FIELD(metricsQueryType);
+
+	COPY_SCALAR_FIELD(total_memory_master);
+	COPY_SCALAR_FIELD(nsegments_master);
 
 	return newnode;
 }

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -378,13 +378,13 @@ _outPlannedStmt(StringInfo str, PlannedStmt *node)
 	WRITE_NODE_FIELD(intoPolicy);
 	WRITE_UINT64_FIELD(query_mem);
 
-	WRITE_INT_FIELD(total_memory_master);
-	WRITE_INT_FIELD(nsegments_master);
-
 	WRITE_NODE_FIELD(intoClause);
 	WRITE_NODE_FIELD(copyIntoClause);
 	WRITE_NODE_FIELD(refreshClause);
 	WRITE_INT8_FIELD(metricsQueryType);
+
+	WRITE_INT_FIELD(total_memory_master);
+	WRITE_INT_FIELD(nsegments_master);
 }
 
 static void

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -323,13 +323,13 @@ _outPlannedStmt(StringInfo str, const PlannedStmt *node)
 
 	WRITE_UINT64_FIELD(query_mem);
 
-	WRITE_INT_FIELD(total_memory_master);
-	WRITE_INT_FIELD(nsegments_master);
-
 	WRITE_NODE_FIELD(intoClause);
 	WRITE_NODE_FIELD(copyIntoClause);
 	WRITE_NODE_FIELD(refreshClause);
 	WRITE_INT_FIELD(metricsQueryType);
+
+	WRITE_INT_FIELD(total_memory_master);
+	WRITE_INT_FIELD(nsegments_master);
 }
 #endif /* COMPILING_BINARY_FUNCS */
 

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -1380,13 +1380,14 @@ _readPlannedStmt(void)
 
 	READ_UINT64_FIELD(query_mem);
 
-	READ_INT_FIELD(total_memory_master);
-	READ_INT_FIELD(nsegments_master);
-
 	READ_NODE_FIELD(intoClause);
 	READ_NODE_FIELD(copyIntoClause);
 	READ_NODE_FIELD(refreshClause);
 	READ_INT8_FIELD(metricsQueryType);
+
+	READ_INT_FIELD(total_memory_master);
+	READ_INT_FIELD(nsegments_master);
+
 	READ_DONE();
 }
 

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -138,9 +138,6 @@ typedef struct PlannedStmt
 	/* What is the memory reserved for this query's execution? */
 	uint64		query_mem;
 
-	int			total_memory_master;	/* GPDB: The total usable virtual memory on master node in MB */
-	int			nsegments_master;		/* GPDB: The number of primary segments on master node  */
-
 	/*
 	 * GPDB: Used to keep target information for CTAS and it is needed
 	 * to be dispatched to QEs.
@@ -153,6 +150,9 @@ typedef struct PlannedStmt
  	 * GPDB: whether a query is a SPI inner query for extension usage 
  	 */
 	int8		metricsQueryType;
+
+	int			total_memory_master;	/* GPDB: The total usable virtual memory on master node in MB */
+	int			nsegments_master;		/* GPDB: The number of primary segments on master node  */
 } PlannedStmt;
 
 /*


### PR DESCRIPTION
Commit cb120281a introduces two fields of struct PlannedStmt and not
put them at the end of the struct. In Greenplum 6X, some extensions,
like metrics_collector will use fields of PlannedStmt, and the
extension is created in a previous version of Greenplum 6, when users
upgrade to later version of Greenplum 6, the extension's .so file is
not recompiled, however offset of fields changed.

This commit fixes the ABI broken by putting the new-added fields at
the end of the struct.

---------------------

WIP.

TODOS:

1. ~manually verify the fix~ (DONE, we manually test).
2. try to see if we can add a test case.