### PR TITLE
Resolve GPDB_12_MERGE_FIXME in PartitionSelector to support walking prune info

### DIFF
--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -2329,12 +2329,23 @@ expression_tree_walker(Node *node,
 			}
 			break;
 
-		case T_PartitionSelector:
+		case T_PartitionedRelPruneInfo:
 			{
-				//PartitionSelector *pselector = (PartitionSelector *) node;
+				PartitionedRelPruneInfo *prpinfo= (PartitionedRelPruneInfo *) node;
 
-				/* GPDB_12_MERGE_FIXME: need to walk prune info? We don't do that
-				 * in Append either.. */
+				if (walker((Node *)prpinfo->initial_pruning_steps, context))
+					return true;
+				if (walker((Node *)prpinfo->exec_pruning_steps, context))
+					return true;
+			}
+			break;
+
+		case T_PartitionPruneInfo:
+			{
+				PartitionPruneInfo *ppinfo = (PartitionPruneInfo *)node;
+
+				if (walker((Node *) ppinfo->prune_infos, context))
+					return true;
 			}
 			break;
 

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -3013,7 +3013,7 @@ finalize_plan(PlannerInfo *root, Plan *plan,
 			break;
 
 		case T_PartitionSelector:
-			/* GPDB_12_MERGE_FIXME: need to do something with the paramid here? */
+
 			break;
 			
 		case T_RecursiveUnion:

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -3013,6 +3013,22 @@ finalize_plan(PlannerInfo *root, Plan *plan,
 			break;
 
 		case T_PartitionSelector:
+			/* the paramid in PartitionSelector struct is a special executor param
+			 * which is used to do partition pruning in an Append node on the other
+			 * side of the join. It can also contain normal executor params in
+			 * part_prune_info field.
+			 * But all of the params above are only used to compute which partitions
+			 * on other side of a join can contain rows that match the join quals.
+			 * The tuple from the child plan will pass to the outerplan node directly
+			 * after the computation. So the params above won't affect the output of
+			 * this plan node.
+			 * The params in part_prune_info field still can affect the result of the
+			 * outer join, but the params in part_prune_info are also in join qual or
+			 * join filter of outer join node, so that these params will be added to
+			 * outer join plan's extParam and allParam whatever.
+			 * And PartitionSelector node don't support rescan for now, as the above,
+			 * don't add the paramids here won't affect the execute result.
+			 */
 
 			break;
 			


### PR DESCRIPTION
1.remove fixme in subselect.c: the paramid in PartitionSelector and the
params in part_prune_info is used to do partition pruning on the other
side of the join, they won't affect the output of this plan node. And
the params in part_prune_info are also in join qual or join filter,
so they won't affect the join plan's extParam/allParam either.
2.add the support to walk prune infos.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
