### PR TITLE
[ORCA] Update compute scalar func cost model

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/AggTopOfMultipleSetRetFuncs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/AggTopOfMultipleSetRetFuncs.mdp
@@ -137,14 +137,14 @@ select count(*) from ( select unnest(arr) i, unnest(arr) j  from (    select str
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.000011" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.000111" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="4" Alias="count">
             <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
               <dxl:ValuesList ParamType="aggargs">
-              <dxl:Ident ColId="5" ColName="ColRef_0005" TypeMdid="0.20.1.0"/>
+                <dxl:Ident ColId="5" ColName="ColRef_0005" TypeMdid="0.20.1.0"/>
               </dxl:ValuesList>
               <dxl:ValuesList ParamType="aggdirectargs"/>
               <dxl:ValuesList ParamType="aggorder"/>
@@ -155,7 +155,7 @@ select count(*) from ( select unnest(arr) i, unnest(arr) j  from (    select str
         <dxl:Filter/>
         <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.000010" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000110" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:GroupingColumns/>
           <dxl:ProjList>
@@ -171,7 +171,7 @@ select count(*) from ( select unnest(arr) i, unnest(arr) j  from (    select str
           <dxl:Filter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.000010" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000110" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="2" Alias="i">
@@ -193,7 +193,7 @@ select count(*) from ( select unnest(arr) i, unnest(arr) j  from (    select str
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="arr">
-                  <dxl:ConstValue TypeMdid="0.1009.1.0" Value="AAAAOAEAAAAAAAAAGQAAAAQAAAABAAAAAAAABmFhAAAAAAAGYmIAAAAAAAZj&#10;YwAAAAAABmRkAAA="/>
+                  <dxl:ConstValue TypeMdid="0.1009.1.0" Value="AAAAOAEAAAAAAAAAGQAAAAQAAAABAAAAAAAABmFhAAAAAAAGYmIAAAAAAAZj&#xA;YwAAAAAABmRkAAA="/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>

--- a/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/AggTopOfMultipleSetRetFuncsAndUnusedScalar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/AggTopOfMultipleSetRetFuncsAndUnusedScalar.mdp
@@ -150,14 +150,14 @@ select count(*) from (select unnest(arr) i, 1 j from (select string_to_array('aa
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.000011" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.000111" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="4" Alias="count">
             <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
               <dxl:ValuesList ParamType="aggargs">
-              <dxl:Ident ColId="5" ColName="ColRef_0005" TypeMdid="0.20.1.0"/>
+                <dxl:Ident ColId="5" ColName="ColRef_0005" TypeMdid="0.20.1.0"/>
               </dxl:ValuesList>
               <dxl:ValuesList ParamType="aggdirectargs"/>
               <dxl:ValuesList ParamType="aggorder"/>
@@ -168,7 +168,7 @@ select count(*) from (select unnest(arr) i, 1 j from (select string_to_array('aa
         <dxl:Filter/>
         <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.000010" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000110" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:GroupingColumns/>
           <dxl:ProjList>
@@ -184,7 +184,7 @@ select count(*) from (select unnest(arr) i, 1 j from (select string_to_array('aa
           <dxl:Filter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.000010" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000110" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="2" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/AggTopOfSetRefFuncsOnTopTbl.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/AggTopOfSetRefFuncsOnTopTbl.mdp
@@ -282,14 +282,14 @@ select count(*) from (select unnest(string_to_array(c, '|')) i, d from foo) t;
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000046" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000079" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="count">
             <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
               <dxl:ValuesList ParamType="aggargs">
-              <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.20.1.0"/>
+                <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.20.1.0"/>
               </dxl:ValuesList>
               <dxl:ValuesList ParamType="aggdirectargs"/>
               <dxl:ValuesList ParamType="aggorder"/>
@@ -300,7 +300,7 @@ select count(*) from (select unnest(string_to_array(c, '|')) i, d from foo) t;
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000078" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="11" Alias="ColRef_0011">
@@ -311,7 +311,7 @@ select count(*) from (select unnest(string_to_array(c, '|')) i, d from foo) t;
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000049" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -327,7 +327,7 @@ select count(*) from (select unnest(string_to_array(c, '|')) i, d from foo) t;
             <dxl:Filter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000049" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/AggTopOfSetRetFuncsAndUnusedScalar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/AggTopOfSetRetFuncsAndUnusedScalar.mdp
@@ -129,14 +129,14 @@ explain select count(*) from (select generate_series(1, 10) i) t1, (select 1 j) 
     <dxl:Plan Id="0" SpaceSize="3">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000110" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="4" Alias="count">
             <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
               <dxl:ValuesList ParamType="aggargs">
-              <dxl:Ident ColId="5" ColName="ColRef_0005" TypeMdid="0.20.1.0"/>
+                <dxl:Ident ColId="5" ColName="ColRef_0005" TypeMdid="0.20.1.0"/>
               </dxl:ValuesList>
               <dxl:ValuesList ParamType="aggdirectargs"/>
               <dxl:ValuesList ParamType="aggorder"/>
@@ -147,7 +147,7 @@ explain select count(*) from (select generate_series(1, 10) i) t1, (select 1 j) 
         <dxl:Filter/>
         <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000110" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:GroupingColumns/>
           <dxl:ProjList>
@@ -161,9 +161,9 @@ explain select count(*) from (select generate_series(1, 10) i) t1, (select 1 j) 
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false">
+          <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000110" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter/>
@@ -172,7 +172,7 @@ explain select count(*) from (select generate_series(1, 10) i) t1, (select 1 j) 
             </dxl:JoinFilter>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000002" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000102" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/AggTopOfSingleSetRetFuncs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/AggTopOfSingleSetRetFuncs.mdp
@@ -132,14 +132,14 @@ select count(*) from (select generate_series(1, 10) i) t1, (select generate_seri
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000212" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="4" Alias="count">
             <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
               <dxl:ValuesList ParamType="aggargs">
-              <dxl:Ident ColId="5" ColName="ColRef_0005" TypeMdid="0.20.1.0"/>
+                <dxl:Ident ColId="5" ColName="ColRef_0005" TypeMdid="0.20.1.0"/>
               </dxl:ValuesList>
               <dxl:ValuesList ParamType="aggdirectargs"/>
               <dxl:ValuesList ParamType="aggorder"/>
@@ -150,7 +150,7 @@ select count(*) from (select generate_series(1, 10) i) t1, (select generate_seri
         <dxl:Filter/>
         <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000212" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:GroupingColumns/>
           <dxl:ProjList>
@@ -166,7 +166,7 @@ select count(*) from (select generate_series(1, 10) i) t1, (select generate_seri
           <dxl:Filter/>
           <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000212" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter/>
@@ -175,7 +175,7 @@ select count(*) from (select generate_series(1, 10) i) t1, (select generate_seri
             </dxl:JoinFilter>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000002" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000102" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="i">
@@ -202,7 +202,7 @@ select count(*) from (select generate_series(1, 10) i) t1, (select generate_seri
             </dxl:Result>
             <dxl:Materialize Eager="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000003" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000103" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="3" Alias="j">
@@ -212,7 +212,7 @@ select count(*) from (select generate_series(1, 10) i) t1, (select generate_seri
               <dxl:Filter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.000002" Rows="1.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000102" Rows="1.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="3" Alias="j">

--- a/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/AllColsUsed.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/AllColsUsed.mdp
@@ -260,7 +260,7 @@ select i, j from (select unnest(string_to_array(c, '|')) i, abs(d) j from foo) t
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000101" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000134" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="9" Alias="i">
@@ -274,7 +274,7 @@ select i, j from (select unnest(string_to_array(c, '|')) i, abs(d) j from foo) t
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000056" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000089" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/MultiLevelSubqueryWithSetRetFuncs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/MultiLevelSubqueryWithSetRetFuncs.mdp
@@ -318,14 +318,14 @@ select count(*) from (select (select unnest(string_to_array(c, '|')) ii from foo
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000046" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000079" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="21" Alias="count">
             <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
               <dxl:ValuesList ParamType="aggargs">
-              <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
+                <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
               </dxl:ValuesList>
               <dxl:ValuesList ParamType="aggdirectargs"/>
               <dxl:ValuesList ParamType="aggorder"/>
@@ -336,7 +336,7 @@ select count(*) from (select (select unnest(string_to_array(c, '|')) ii from foo
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000078" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="22" Alias="ColRef_0022">
@@ -347,7 +347,7 @@ select count(*) from (select (select unnest(string_to_array(c, '|')) ii from foo
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000049" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -363,7 +363,7 @@ select count(*) from (select (select unnest(string_to_array(c, '|')) ii from foo
             <dxl:Filter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000049" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="20" Alias="j">

--- a/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/MultiLevelSubqueryWithSetRetFuncsAndScalarFuncs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/MultiLevelSubqueryWithSetRetFuncsAndScalarFuncs.mdp
@@ -301,14 +301,14 @@ select count(*) from (select (select 1 as p) i, unnest(string_to_array(c, '|')) 
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000046" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000079" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="13" Alias="count">
             <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
               <dxl:ValuesList ParamType="aggargs">
-              <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
+                <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
               </dxl:ValuesList>
               <dxl:ValuesList ParamType="aggdirectargs"/>
               <dxl:ValuesList ParamType="aggorder"/>
@@ -319,7 +319,7 @@ select count(*) from (select (select 1 as p) i, unnest(string_to_array(c, '|')) 
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000078" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="14" Alias="ColRef_0014">
@@ -330,7 +330,7 @@ select count(*) from (select (select 1 as p) i, unnest(string_to_array(c, '|')) 
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000049" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -346,7 +346,7 @@ select count(*) from (select (select 1 as p) i, unnest(string_to_array(c, '|')) 
             <dxl:Filter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000049" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="12" Alias="j">

--- a/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/UnusedSetRetFuncAndUsedScalarFunc.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/UnusedSetRetFuncAndUsedScalarFunc.mdp
@@ -259,7 +259,7 @@ select j from (select unnest(string_to_array(c, '|')) i, abs(d) j from foo) t;
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000068" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000102" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="j">
@@ -270,7 +270,7 @@ select j from (select unnest(string_to_array(c, '|')) i, abs(d) j from foo) t;
         <dxl:OneTimeFilter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000068" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000102" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="j">
@@ -284,7 +284,7 @@ select j from (select unnest(string_to_array(c, '|')) i, abs(d) j from foo) t;
           <dxl:SortingColumnList/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000053" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000087" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="10" Alias="j">

--- a/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/UsedSetRetFuncAndUnusedScalarFunc.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CPruneColumnsTest/UsedSetRetFuncAndUnusedScalarFunc.mdp
@@ -259,7 +259,7 @@ select i from (select unnest(string_to_array(c, '|')) i, abs(d) j from foo) t;
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000081" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="9" Alias="i">
@@ -270,7 +270,7 @@ select i from (select unnest(string_to_array(c, '|')) i, abs(d) j from foo) t;
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000051" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/CTE-volatile.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-volatile.mdp
@@ -413,7 +413,7 @@
     <dxl:Plan Id="0" SpaceSize="32">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.050688" Rows="100.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.055688" Rows="100.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="a">
@@ -433,7 +433,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.039912" Rows="100.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.044912" Rows="100.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="a">
@@ -451,7 +451,7 @@
           </dxl:ProjList>
           <dxl:CTEProducer CTEId="0" Columns="9,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.003945" Rows="100.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.008945" Rows="100.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="a">
@@ -463,7 +463,7 @@
             </dxl:ProjList>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.003895" Rows="100.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.008895" Rows="100.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="a">
@@ -482,7 +482,7 @@
               </dxl:HashExprList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.002017" Rows="100.000000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.007017" Rows="100.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/CTEWithVolatileFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTEWithVolatileFunction.mdp
@@ -163,7 +163,7 @@
     <dxl:Plan Id="0" SpaceSize="60">
       <dxl:Sequence>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.000209" Rows="2.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000309" Rows="2.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="4" Alias="sum">
@@ -172,7 +172,7 @@
         </dxl:ProjList>
         <dxl:CTEProducer CTEId="0" Columns="1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.000010" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000110" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="nextval">
@@ -181,7 +181,7 @@
           </dxl:ProjList>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000109" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="nextval">
@@ -249,7 +249,7 @@
                   <dxl:ProjElem ColId="4" Alias="sum">
                     <dxl:AggFunc AggMdid="0.2107.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" >
                       <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="2" ColName="nextval" TypeMdid="0.20.1.0"/>
+                        <dxl:Ident ColId="2" ColName="nextval" TypeMdid="0.20.1.0"/>
                       </dxl:ValuesList>
                       <dxl:ValuesList ParamType="aggdirectargs"/>
                       <dxl:ValuesList ParamType="aggorder"/>
@@ -337,7 +337,7 @@
                     <dxl:ProjElem ColId="7" Alias="sum">
                       <dxl:AggFunc AggMdid="0.2107.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" >
                         <dxl:ValuesList ParamType="aggargs">
-                        <dxl:Ident ColId="5" ColName="nextval" TypeMdid="0.20.1.0"/>
+                          <dxl:Ident ColId="5" ColName="nextval" TypeMdid="0.20.1.0"/>
                         </dxl:ValuesList>
                         <dxl:ValuesList ParamType="aggdirectargs"/>
                         <dxl:ValuesList ParamType="aggorder"/>

--- a/src/backend/gporca/data/dxl/minidump/Coalesce-With-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Coalesce-With-Subquery.mdp
@@ -855,7 +855,7 @@
     <dxl:Plan Id="0" SpaceSize="2856">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="38915.797885" Rows="4.000000" Width="269"/>
+          <dxl:Cost StartupCost="0" TotalCost="38915.798285" Rows="4.000000" Width="269"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="datname">

--- a/src/backend/gporca/data/dxl/minidump/CollapseProject-SetReturning-CTE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CollapseProject-SetReturning-CTE.mdp
@@ -238,7 +238,7 @@ select * from t2;
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000135" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000202" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="21" Alias="c">
@@ -252,7 +252,7 @@ select * from t2;
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000075" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000142" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="21" Alias="c">
@@ -269,7 +269,7 @@ select * from t2;
           <dxl:OneTimeFilter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000070" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000103" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="21" Alias="c">

--- a/src/backend/gporca/data/dxl/minidump/CollapseProject-SetReturning.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CollapseProject-SetReturning.mdp
@@ -220,7 +220,7 @@ from (select regexp_split_to_table(a, ',') as c, b from t) dumb(c, b);
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000135" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000202" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="9" Alias="c">
@@ -234,7 +234,7 @@ from (select regexp_split_to_table(a, ',') as c, b from t) dumb(c, b);
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000075" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000142" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="c">
@@ -251,7 +251,7 @@ from (select regexp_split_to_table(a, ',') as c, b from t) dumb(c, b);
           <dxl:OneTimeFilter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000070" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000103" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="c">

--- a/src/backend/gporca/data/dxl/minidump/ConstScalarFuncNotPushedBelowGather.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ConstScalarFuncNotPushedBelowGather.mdp
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Objective: Ensure that an immutable function in a query projection with
+    constant arguements is "executed" on the corrdinator. Unlike similar
+    testcase ScalarFuncPushedBelowGather, in this case there is no
+    parallelization benefit of running on segments.
+
+    test=# CREATE TABLE r (i) AS SELECT generate_series(1, 10000000) DISTRIBUTED RANDOMLY;
+    test=# ANALYZE r;
+    test=# CREATE EXTENSION IF NOT EXISTS plpython3u;
+    test=# CREATE OR REPLACE FUNCTION add_one (i int) RETURNS int LANGUAGE plpython3u IMMUTABLE AS $$ return i + 1 $$;
+
+    test=# EXPLAIN VERBOSE SELECT i, add_one(42) FROM r;
+                                            QUERY PLAN
+    -------------------------------------------------------------------------------------------
+     Result  (cost=0.00..747.20 rows=10000000 width=8)
+       Output: i, 43
+       ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..667.20 rows=10000000 width=4)
+             Output: i
+             ->  Seq Scan on public.t  (cost=0.00..493.33 rows=3333334 width=4)
+                   Output: i
+     Optimizer: Pivotal Optimizer (GPORCA)
+    (7 rows)
+
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.49173.1.0" Name="t" Rows="10000000.000000" RelPages="11003" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.49173.1.0" Name="t" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Random" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="i" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="9" ColName="add_one" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalProject>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="9" Alias="add_one">
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="43"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.49173.1.0" TableName="t" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalProject>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:Result>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="747.200000" Rows="10000000.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="i">
+            <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="8" Alias="add_one">
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="43"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:OneTimeFilter/>
+        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="667.200000" Rows="10000000.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="i">
+              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="493.333333" Rows="10000000.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="i">
+                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="0.49173.1.0" TableName="t" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="2" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:GatherMotion>
+      </dxl:Result>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/Correlation-With-Casting-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Correlation-With-Casting-1.mdp
@@ -435,7 +435,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
     <dxl:Plan Id="0" SpaceSize="18507">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2155.680679" Rows="70.000000" Width="10"/>
+          <dxl:Cost StartupCost="0" TotalCost="2155.684179" Rows="70.000000" Width="10"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -452,7 +452,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2155.677536" Rows="70.000000" Width="10"/>
+            <dxl:Cost StartupCost="0" TotalCost="2155.681036" Rows="70.000000" Width="10"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -476,7 +476,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2155.675233" Rows="70.000000" Width="18"/>
+              <dxl:Cost StartupCost="0" TotalCost="2155.678733" Rows="70.000000" Width="18"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="0"/>
@@ -491,7 +491,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
               <dxl:ProjElem ColId="32" Alias="max">
                 <dxl:AggFunc AggMdid="0.2129.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
                   <dxl:ValuesList ParamType="aggargs">
-                  <dxl:Ident ColId="34" ColName="ColRef_0034" TypeMdid="0.25.1.0"/>
+                    <dxl:Ident ColId="34" ColName="ColRef_0034" TypeMdid="0.25.1.0"/>
                   </dxl:ValuesList>
                   <dxl:ValuesList ParamType="aggdirectargs"/>
                   <dxl:ValuesList ParamType="aggorder"/>
@@ -523,7 +523,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2155.673340" Rows="70.000000" Width="44"/>
+                <dxl:Cost StartupCost="0" TotalCost="2155.676840" Rows="70.000000" Width="44"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -565,7 +565,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
               <dxl:LimitOffset/>
               <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2155.628552" Rows="70.000000" Width="44"/>
+                  <dxl:Cost StartupCost="0" TotalCost="2155.632052" Rows="70.000000" Width="44"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -620,7 +620,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
                 </dxl:HashExprList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2155.623732" Rows="70.000000" Width="44"/>
+                    <dxl:Cost StartupCost="0" TotalCost="2155.627232" Rows="70.000000" Width="44"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -652,7 +652,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="2155.623732" Rows="70.000000" Width="44"/>
+                      <dxl:Cost StartupCost="0" TotalCost="2155.627232" Rows="70.000000" Width="44"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="0"/>
@@ -667,9 +667,9 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
                       <dxl:ProjElem ColId="34" Alias="ColRef_0034">
                         <dxl:AggFunc AggMdid="0.2129.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
                           <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                            <dxl:Ident ColId="24" ColName="u_folio" TypeMdid="0.1043.1.0"/>
-                          </dxl:Cast>
+                            <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                              <dxl:Ident ColId="24" ColName="u_folio" TypeMdid="0.1043.1.0"/>
+                            </dxl:Cast>
                           </dxl:ValuesList>
                           <dxl:ValuesList ParamType="aggdirectargs"/>
                           <dxl:ValuesList ParamType="aggorder"/>
@@ -701,7 +701,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
                     <dxl:Filter/>
                     <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="2155.621503" Rows="70.000000" Width="39"/>
+                        <dxl:Cost StartupCost="0" TotalCost="2155.625003" Rows="70.000000" Width="39"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -752,7 +752,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
                       </dxl:JoinFilter>
                       <dxl:Sort SortDiscardDuplicates="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1293.246803" Rows="70.000000" Width="36"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1293.250303" Rows="70.000000" Width="36"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -791,7 +791,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
                         <dxl:LimitOffset/>
                         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1293.210158" Rows="70.000000" Width="36"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1293.213658" Rows="70.000000" Width="36"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -837,7 +837,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
                           </dxl:JoinFilter>
                           <dxl:Result>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.012206" Rows="70.000000" Width="20"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.015706" Rows="70.000000" Width="20"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="21" Alias="substr">
@@ -867,7 +867,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
                                 <dxl:ProjElem ColId="20" Alias="max">
                                   <dxl:AggFunc AggMdid="0.2129.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
                                     <dxl:ValuesList ParamType="aggargs">
-                                    <dxl:Ident ColId="33" ColName="ColRef_0033" TypeMdid="0.25.1.0"/>
+                                      <dxl:Ident ColId="33" ColName="ColRef_0033" TypeMdid="0.25.1.0"/>
                                     </dxl:ValuesList>
                                     <dxl:ValuesList ParamType="aggdirectargs"/>
                                     <dxl:ValuesList ParamType="aggorder"/>
@@ -923,26 +923,26 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
                                       <dxl:ProjElem ColId="33" Alias="ColRef_0033">
                                         <dxl:AggFunc AggMdid="0.2129.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
                                           <dxl:ValuesList ParamType="aggargs">
-                                          <dxl:If TypeMdid="0.25.1.0">
-                                            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                                              <dxl:FuncExpr FuncId="0.819.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                                                <dxl:Ident ColId="11" ColName="u_zj" TypeMdid="0.1043.1.0"/>
-                                              </dxl:FuncExpr>
-                                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="50"/>
-                                            </dxl:Comparison>
-                                            <dxl:OpExpr OperatorName="||" OperatorMdid="0.654.1.0" OperatorType="0.25.1.0">
-                                              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABjIw" LintValue="873595684"/>
-                                              <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                                                <dxl:Ident ColId="11" ColName="u_zj" TypeMdid="0.1043.1.0"/>
-                                              </dxl:Cast>
-                                            </dxl:OpExpr>
-                                            <dxl:OpExpr OperatorName="||" OperatorMdid="0.654.1.0" OperatorType="0.25.1.0">
-                                              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABjE5" LintValue="882058028"/>
-                                              <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                                                <dxl:Ident ColId="11" ColName="u_zj" TypeMdid="0.1043.1.0"/>
-                                              </dxl:Cast>
-                                            </dxl:OpExpr>
-                                          </dxl:If>
+                                            <dxl:If TypeMdid="0.25.1.0">
+                                              <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                                                <dxl:FuncExpr FuncId="0.819.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                                                  <dxl:Ident ColId="11" ColName="u_zj" TypeMdid="0.1043.1.0"/>
+                                                </dxl:FuncExpr>
+                                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="50"/>
+                                              </dxl:Comparison>
+                                              <dxl:OpExpr OperatorName="||" OperatorMdid="0.654.1.0" OperatorType="0.25.1.0">
+                                                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABjIw" LintValue="873595684"/>
+                                                <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                                                  <dxl:Ident ColId="11" ColName="u_zj" TypeMdid="0.1043.1.0"/>
+                                                </dxl:Cast>
+                                              </dxl:OpExpr>
+                                              <dxl:OpExpr OperatorName="||" OperatorMdid="0.654.1.0" OperatorType="0.25.1.0">
+                                                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABjE5" LintValue="882058028"/>
+                                                <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                                                  <dxl:Ident ColId="11" ColName="u_zj" TypeMdid="0.1043.1.0"/>
+                                                </dxl:Cast>
+                                              </dxl:OpExpr>
+                                            </dxl:If>
                                           </dxl:ValuesList>
                                           <dxl:ValuesList ParamType="aggdirectargs"/>
                                           <dxl:ValuesList ParamType="aggorder"/>

--- a/src/backend/gporca/data/dxl/minidump/Correlation-With-Casting-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Correlation-With-Casting-2.mdp
@@ -418,7 +418,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr <> c.u_v
     <dxl:Plan Id="0" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="8659.155642" Rows="400.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="8659.156042" Rows="400.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -435,7 +435,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr <> c.u_v
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="8659.112538" Rows="400.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="8659.112938" Rows="400.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -468,9 +468,9 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr <> c.u_v
                     <dxl:ProjElem ColId="32" Alias="max">
                       <dxl:AggFunc AggMdid="0.2129.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" >
                         <dxl:ValuesList ParamType="aggargs">
-                        <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                          <dxl:Ident ColId="24" ColName="u_folio" TypeMdid="0.1043.1.0"/>
-                        </dxl:Cast>
+                          <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                            <dxl:Ident ColId="24" ColName="u_folio" TypeMdid="0.1043.1.0"/>
+                          </dxl:Cast>
                         </dxl:ValuesList>
                         <dxl:ValuesList ParamType="aggdirectargs"/>
                         <dxl:ValuesList ParamType="aggorder"/>
@@ -583,7 +583,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr <> c.u_v
           <dxl:OneTimeFilter/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.396607" Rows="1000.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.396707" Rows="1000.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="u_vtgnr">
@@ -608,7 +608,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr <> c.u_v
                   </dxl:ParamList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.336993" Rows="2.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.337093" Rows="2.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="21" Alias="substr">
@@ -630,26 +630,26 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr <> c.u_v
                         <dxl:ProjElem ColId="20" Alias="max">
                           <dxl:AggFunc AggMdid="0.2129.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" >
                             <dxl:ValuesList ParamType="aggargs">
-                            <dxl:If TypeMdid="0.25.1.0">
-                              <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                                <dxl:FuncExpr FuncId="0.819.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                                  <dxl:Ident ColId="11" ColName="u_zj" TypeMdid="0.1043.1.0"/>
-                                </dxl:FuncExpr>
-                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="50"/>
-                              </dxl:Comparison>
-                              <dxl:OpExpr OperatorName="||" OperatorMdid="0.654.1.0" OperatorType="0.25.1.0">
-                                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABjIw" LintValue="873595684"/>
-                                <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                                  <dxl:Ident ColId="11" ColName="u_zj" TypeMdid="0.1043.1.0"/>
-                                </dxl:Cast>
-                              </dxl:OpExpr>
-                              <dxl:OpExpr OperatorName="||" OperatorMdid="0.654.1.0" OperatorType="0.25.1.0">
-                                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABjE5" LintValue="882058028"/>
-                                <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                                  <dxl:Ident ColId="11" ColName="u_zj" TypeMdid="0.1043.1.0"/>
-                                </dxl:Cast>
-                              </dxl:OpExpr>
-                            </dxl:If>
+                              <dxl:If TypeMdid="0.25.1.0">
+                                <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                                  <dxl:FuncExpr FuncId="0.819.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                                    <dxl:Ident ColId="11" ColName="u_zj" TypeMdid="0.1043.1.0"/>
+                                  </dxl:FuncExpr>
+                                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="50"/>
+                                </dxl:Comparison>
+                                <dxl:OpExpr OperatorName="||" OperatorMdid="0.654.1.0" OperatorType="0.25.1.0">
+                                  <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABjIw" LintValue="873595684"/>
+                                  <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                                    <dxl:Ident ColId="11" ColName="u_zj" TypeMdid="0.1043.1.0"/>
+                                  </dxl:Cast>
+                                </dxl:OpExpr>
+                                <dxl:OpExpr OperatorName="||" OperatorMdid="0.654.1.0" OperatorType="0.25.1.0">
+                                  <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABjE5" LintValue="882058028"/>
+                                  <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                                    <dxl:Ident ColId="11" ColName="u_zj" TypeMdid="0.1043.1.0"/>
+                                  </dxl:Cast>
+                                </dxl:OpExpr>
+                              </dxl:If>
                             </dxl:ValuesList>
                             <dxl:ValuesList ParamType="aggdirectargs"/>
                             <dxl:ValuesList ParamType="aggorder"/>

--- a/src/backend/gporca/data/dxl/minidump/DML-Replicated-Input.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-Replicated-Input.mdp
@@ -341,7 +341,7 @@ WHERE  sach_vsnr = 465132477;
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLInsert Columns="0,1,10" ActionCol="11" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.001126" Rows="1.000000" Width="10"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.001226" Rows="1.000000" Width="10"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo>
           <dxl:KeyValue>
@@ -375,7 +375,7 @@ WHERE  sach_vsnr = 465132477;
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000113" Rows="1.000000" Width="14"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000213" Rows="1.000000" Width="14"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="ag">
@@ -400,7 +400,7 @@ WHERE  sach_vsnr = 465132477;
           </dxl:HashExprList>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000081" Rows="1.000000" Width="14"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000181" Rows="1.000000" Width="14"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="ag">

--- a/src/backend/gporca/data/dxl/minidump/DML-Volatile-Function.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-Volatile-Function.mdp
@@ -251,7 +251,7 @@
     <dxl:Plan Id="0" SpaceSize="3">
       <dxl:DMLInsert Columns="8" ActionCol="9" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.010464" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.010506" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -273,7 +273,7 @@
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1,2">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000089" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="8" Alias="test_func_pg_stats">
@@ -292,7 +292,7 @@
           </dxl:HashExprList>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000027" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000068" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="8" Alias="test_func_pg_stats">
@@ -306,31 +306,35 @@
             <dxl:OneTimeFilter/>
             <dxl:Limit>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000060" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="8" Alias="test_func_pg_stats">
                   <dxl:Ident ColId="8" ColName="test_func_pg_stats" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Result>
+              <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000056" Rows="1.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="8" Alias="test_func_pg_stats">
-                    <dxl:FuncExpr FuncId="0.147456.1.0" FuncRetSet="false" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="8" ColName="test_func_pg_stats" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                <dxl:SortingColumnList/>
+                <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000011" Rows="1.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
-                  <dxl:ProjList/>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="8" Alias="test_func_pg_stats">
+                      <dxl:FuncExpr FuncId="0.147456.1.0" FuncRetSet="false" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:SortingColumnList/>
+                  <dxl:OneTimeFilter/>
                   <dxl:TableScan>
                     <dxl:Properties>
                       <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="1"/>
@@ -350,8 +354,8 @@
                       </dxl:Columns>
                     </dxl:TableDescriptor>
                   </dxl:TableScan>
-                </dxl:GatherMotion>
-              </dxl:Result>
+                </dxl:Result>
+              </dxl:GatherMotion>
               <dxl:LimitCount>
                 <dxl:ConstValue TypeMdid="0.20.1.0" Value="2"/>
               </dxl:LimitCount>

--- a/src/backend/gporca/data/dxl/minidump/Except-Volatile-Func.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Except-Volatile-Func.mdp
@@ -112,7 +112,7 @@
     <dxl:Plan Id="0" SpaceSize="25">
       <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.000397" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.000497" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:GroupingColumns>
           <dxl:GroupingColumn ColId="1"/>
@@ -125,7 +125,7 @@
         <dxl:Filter/>
         <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.000391" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000491" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="?column?">
@@ -140,7 +140,7 @@
           <dxl:LimitOffset/>
           <dxl:HashJoin JoinType="LeftAntiSemiJoin">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.000391" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000491" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="?column?">
@@ -183,7 +183,7 @@
             </dxl:Result>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000105" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="3" Alias="generate_series">

--- a/src/backend/gporca/data/dxl/minidump/ExpandJoinOrder.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExpandJoinOrder.mdp
@@ -868,7 +868,7 @@
     <dxl:Plan Id="0" SpaceSize="2316">
       <dxl:Limit>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="31120.116045" Rows="100.000000" Width="128"/>
+          <dxl:Cost StartupCost="0" TotalCost="31120.423435" Rows="100.000000" Width="128"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="73" Alias="char_length">
@@ -970,7 +970,7 @@
         </dxl:ProjList>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="31120.103245" Rows="100.000000" Width="128"/>
+            <dxl:Cost StartupCost="0" TotalCost="31120.410635" Rows="100.000000" Width="128"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="73" Alias="char_length">
@@ -1107,7 +1107,7 @@
           </dxl:SortingColumnList>
           <dxl:Limit>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="31120.045773" Rows="100.000000" Width="128"/>
+              <dxl:Cost StartupCost="0" TotalCost="31120.353163" Rows="100.000000" Width="128"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="73" Alias="char_length">
@@ -1209,7 +1209,7 @@
             </dxl:ProjList>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="31120.039373" Rows="6147.800000" Width="128"/>
+                <dxl:Cost StartupCost="0" TotalCost="31120.346763" Rows="6147.800000" Width="128"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="73" Alias="char_length">
@@ -1348,7 +1348,7 @@
               <dxl:LimitOffset/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="31094.192332" Rows="6147.800000" Width="128"/>
+                  <dxl:Cost StartupCost="0" TotalCost="31094.499722" Rows="6147.800000" Width="128"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="73" Alias="char_length">

--- a/src/backend/gporca/data/dxl/minidump/Insert-With-HJ-CTE-Agg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-With-HJ-CTE-Agg.mdp
@@ -511,9 +511,9 @@
     <dxl:Plan Id="0" SpaceSize="1180">
       <dxl:DMLInsert Columns="38,39,42,43,44" ActionCol="48" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="867.119333" Rows="96.000000" Width="36"/>
+          <dxl:Cost StartupCost="0" TotalCost="867.122533" Rows="96.000000" Width="36"/>
         </dxl:Properties>
-	<dxl:DirectDispatchInfo/>
+        <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="38" Alias="?column?">
             <dxl:Ident ColId="38" ColName="?column?" TypeMdid="0.25.1.0"/>
@@ -549,7 +549,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.119333" Rows="96.000000" Width="40"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.122533" Rows="96.000000" Width="40"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="38" Alias="?column?">

--- a/src/backend/gporca/data/dxl/minidump/InsertConstTupleVolatileFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertConstTupleVolatileFunction.mdp
@@ -233,7 +233,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLInsert Columns="1,2" ActionCol="3" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.023495" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.023595" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -259,7 +259,7 @@
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.000058" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000158" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="id">
@@ -281,7 +281,7 @@
           </dxl:HashExprList>
           <dxl:Assert ErrorCode="23502">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.000025" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000125" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="id">
@@ -305,7 +305,7 @@
             </dxl:AssertConstraintList>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000013" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000113" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="3" Alias="ColRef_0003">

--- a/src/backend/gporca/data/dxl/minidump/InsertConstTupleVolatileFunctionMOTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertConstTupleVolatileFunctionMOTable.mdp
@@ -223,7 +223,7 @@
     <dxl:Plan Id="0" SpaceSize="5">
       <dxl:DMLInsert Columns="1,2" ActionCol="3" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.046900" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.047000" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -249,7 +249,7 @@
         </dxl:TableDescriptor>
         <dxl:Assert ErrorCode="23502">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.000025" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000125" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="a">
@@ -273,7 +273,7 @@
           </dxl:AssertConstraintList>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.000013" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000113" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="3" Alias="ColRef_0003">

--- a/src/backend/gporca/data/dxl/minidump/InsertReplicatedIntoSerialHashDistributedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertReplicatedIntoSerialHashDistributedTable.mdp
@@ -322,7 +322,7 @@ EXPLAIN (COSTS OFF) INSERT INTO distributed_table (val1, val2) SELECT val1, val2
     <dxl:Plan Id="0" SpaceSize="3">
       <dxl:DMLInsert Columns="9,0,1" ActionCol="10" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="434.666207" Rows="100.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="434.676207" Rows="100.000000" Width="24"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -352,7 +352,7 @@ EXPLAIN (COSTS OFF) INSERT INTO distributed_table (val1, val2) SELECT val1, val2
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.020373" Rows="100.000000" Width="28"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.030373" Rows="100.000000" Width="28"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="_etl_id">
@@ -372,7 +372,7 @@ EXPLAIN (COSTS OFF) INSERT INTO distributed_table (val1, val2) SELECT val1, val2
           <dxl:OneTimeFilter/>
           <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.019440" Rows="100.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.029440" Rows="100.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="val1">
@@ -394,7 +394,7 @@ EXPLAIN (COSTS OFF) INSERT INTO distributed_table (val1, val2) SELECT val1, val2
             </dxl:HashExprList>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.013208" Rows="300.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.023208" Rows="300.000000" Width="24"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="val1">
@@ -411,7 +411,7 @@ EXPLAIN (COSTS OFF) INSERT INTO distributed_table (val1, val2) SELECT val1, val2
               <dxl:OneTimeFilter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.013208" Rows="300.000000" Width="24"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.023208" Rows="300.000000" Width="24"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="_etl_id">

--- a/src/backend/gporca/data/dxl/minidump/Intersect-Volatile-Func.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Intersect-Volatile-Func.mdp
@@ -112,7 +112,7 @@
     <dxl:Plan Id="0" SpaceSize="476">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.000404" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.000504" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="?column?">
@@ -185,7 +185,7 @@
         </dxl:Aggregate>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.000011" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000111" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="3"/>
@@ -198,7 +198,7 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000105" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="3" Alias="generate_series">
@@ -213,7 +213,7 @@
             <dxl:LimitOffset/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000105" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="3" Alias="generate_series">

--- a/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Col-Const-Pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Col-Const-Pred.mdp
@@ -2113,7 +2113,7 @@
     <dxl:Plan Id="0" SpaceSize="1028">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="69941.373160" Rows="896.720000" Width="238"/>
+          <dxl:Cost StartupCost="0" TotalCost="69941.462832" Rows="896.720000" Width="238"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="36" Alias="tableoid">

--- a/src/backend/gporca/data/dxl/minidump/MultipleSetReturningFunction-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultipleSetReturningFunction-1.mdp
@@ -129,7 +129,7 @@ select generate_series(0,2) rn, unnest(arr) cnt_div from (select ARRAY['0','1','
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.000021" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.000121" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="2" Alias="rn">

--- a/src/backend/gporca/data/dxl/minidump/MultipleSetReturningFunction-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultipleSetReturningFunction-2.mdp
@@ -128,7 +128,7 @@ EXPLAIN select generate_series(0,2) x, generate_series(0,3) y, arr cnt_div from 
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.000017" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.000117" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="2" Alias="x">

--- a/src/backend/gporca/data/dxl/minidump/MultipleSetReturningFunction-3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultipleSetReturningFunction-3.mdp
@@ -96,7 +96,7 @@ explain select generate_series(0,2) x, generate_series(0,3) y from (select gener
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.000010" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.000210" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="2" Alias="x">
@@ -116,7 +116,7 @@ explain select generate_series(0,2) x, generate_series(0,3) y from (select gener
         <dxl:OneTimeFilter/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.000002" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000102" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="generate_series">

--- a/src/backend/gporca/data/dxl/minidump/MultipleSubqueriesInSelectClause.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultipleSubqueriesInSelectClause.mdp
@@ -1181,7 +1181,7 @@
     <dxl:Plan Id="0" SpaceSize="324625">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="9309.072916" Rows="3000000.000000" Width="32"/>
+          <dxl:Cost StartupCost="0" TotalCost="9309.074116" Rows="3000000.000000" Width="32"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="field1">
@@ -1222,7 +1222,7 @@
         <dxl:OneTimeFilter/>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="9213.072916" Rows="1000.000000" Width="23"/>
+            <dxl:Cost StartupCost="0" TotalCost="9213.074116" Rows="1000.000000" Width="23"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="field1">
@@ -1251,7 +1251,7 @@
           <dxl:SortingColumnList/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="9212.969646" Rows="1000.000000" Width="23"/>
+              <dxl:Cost StartupCost="0" TotalCost="9212.970846" Rows="1000.000000" Width="23"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="field1">
@@ -1277,7 +1277,7 @@
                   <dxl:ParamList/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000006" Rows="1.000000" Width="5"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000106" Rows="1.000000" Width="5"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="8" Alias="a">
@@ -1288,7 +1288,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.000006" Rows="1.000000" Width="5"/>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000106" Rows="1.000000" Width="5"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="28" Alias="ColRef_0028">
@@ -1327,7 +1327,7 @@
                   <dxl:ParamList/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000006" Rows="1.000000" Width="5"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000106" Rows="1.000000" Width="5"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="11" Alias="b">
@@ -1338,7 +1338,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.000006" Rows="1.000000" Width="5"/>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000106" Rows="1.000000" Width="5"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="29" Alias="ColRef_0029">
@@ -1377,7 +1377,7 @@
                   <dxl:ParamList/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000006" Rows="1.000000" Width="5"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000106" Rows="1.000000" Width="5"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="14" Alias="c">
@@ -1388,7 +1388,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.000006" Rows="1.000000" Width="5"/>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000106" Rows="1.000000" Width="5"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="30" Alias="ColRef_0030">
@@ -1421,7 +1421,7 @@
             <dxl:OneTimeFilter/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1440.898906" Rows="1000.000000" Width="21"/>
+                <dxl:Cost StartupCost="0" TotalCost="1440.899006" Rows="1000.000000" Width="21"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="field1">

--- a/src/backend/gporca/data/dxl/minidump/NLJ-Rewindability-CTAS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NLJ-Rewindability-CTAS.mdp
@@ -447,7 +447,7 @@
     <dxl:Plan Id="0" SpaceSize="84">
       <dxl:PhysicalCTAS Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" DistributionPolicy="Random" InsertColumns="20" VarTypeModList="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324033.167977" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324033.270477" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:DistrOpclasses/>
         <dxl:Columns>
@@ -461,7 +461,7 @@
         </dxl:ProjList>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324033.152352" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324033.254852" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="20" Alias="coalesce">
@@ -475,7 +475,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324033.152348" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324033.254848" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="20" Alias="coalesce">
@@ -484,7 +484,7 @@
             </dxl:ProjList>
             <dxl:CTEProducer CTEId="0" Columns="1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000018" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000118" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="val">
@@ -496,7 +496,7 @@
               </dxl:ProjList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.000017" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000117" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="val">
@@ -528,7 +528,7 @@
             </dxl:CTEProducer>
             <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324033.152328" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324033.254728" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="20" Alias="coalesce">
@@ -539,7 +539,7 @@
               <dxl:SortingColumnList/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324033.152307" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324033.254707" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="20" Alias="coalesce">
@@ -559,7 +559,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324033.152299" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324033.254699" Rows="1.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns/>
                   <dxl:ProjList>
@@ -616,7 +616,7 @@
                   <dxl:Filter/>
                   <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324033.152213" Rows="3.000000" Width="32"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1324033.254613" Rows="3.000000" Width="32"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="9" Alias="val">
@@ -638,7 +638,7 @@
                     </dxl:JoinFilter>
                     <dxl:MergeJoin JoinType="Full" UniqueOuter="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000659" Rows="3.000000" Width="24"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000759" Rows="3.000000" Width="24"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="9" Alias="val">
@@ -693,7 +693,7 @@
                       </dxl:Sort>
                       <dxl:Sort SortDiscardDuplicates="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="0.000109" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="12" Alias="val">
@@ -708,7 +708,7 @@
                         <dxl:LimitOffset/>
                         <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
+                            <dxl:Cost StartupCost="0" TotalCost="0.000109" Rows="1.000000" Width="8"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="12" Alias="val">

--- a/src/backend/gporca/data/dxl/minidump/NLJ-Rewindability.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NLJ-Rewindability.mdp
@@ -424,7 +424,7 @@
     <dxl:Plan Id="0" SpaceSize="432">
       <dxl:Sequence>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324033.152333" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324033.254833" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="20" Alias="coalesce">
@@ -433,7 +433,7 @@
         </dxl:ProjList>
         <dxl:CTEProducer CTEId="0" Columns="1,2">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.000018" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000118" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="val">
@@ -445,7 +445,7 @@
           </dxl:ProjList>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.000017" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000117" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="val">
@@ -477,7 +477,7 @@
         </dxl:CTEProducer>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324033.152307" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324033.254707" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="20" Alias="coalesce">
@@ -497,7 +497,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324033.152299" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324033.254699" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -554,7 +554,7 @@
             <dxl:Filter/>
             <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324033.152213" Rows="3.000000" Width="32"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324033.254613" Rows="3.000000" Width="32"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="val">
@@ -576,7 +576,7 @@
               </dxl:JoinFilter>
               <dxl:MergeJoin JoinType="Full" UniqueOuter="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000659" Rows="3.000000" Width="24"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000759" Rows="3.000000" Width="24"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="val">
@@ -631,7 +631,7 @@
                 </dxl:Sort>
                 <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000109" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="12" Alias="val">
@@ -646,7 +646,7 @@
                   <dxl:LimitOffset/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000109" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="12" Alias="val">

--- a/src/backend/gporca/data/dxl/minidump/Project-With-NonScalar-Func.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Project-With-NonScalar-Func.mdp
@@ -195,7 +195,7 @@
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="441344.177904" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="441344.280304" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="3" Alias="?column?">
@@ -209,7 +209,7 @@
         <dxl:OneTimeFilter/>
         <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="441344.177903" Rows="2.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="441344.280303" Rows="2.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="ColRef_0009">
@@ -234,7 +234,7 @@
           </dxl:Result>
           <dxl:Assert ErrorCode="P0003">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.000082" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000182" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="ColRef_0009">
@@ -251,7 +251,7 @@
             </dxl:AssertConstraintList>
             <dxl:Window PartitionColumns="">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000074" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000174" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="12" Alias="row_number">
@@ -264,7 +264,7 @@
               <dxl:Filter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.000074" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000174" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="ColRef_0009">
@@ -289,7 +289,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Materialize Eager="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000066" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000166" Rows="1.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="7" Alias="ColRef_0007">
@@ -302,7 +302,7 @@
                   <dxl:Filter/>
                   <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000050" Rows="1.000000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000150" Rows="1.000000" Width="16"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns/>
                     <dxl:ProjList>
@@ -330,7 +330,7 @@
                     <dxl:Filter/>
                     <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.000043" Rows="1.000000" Width="16"/>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000143" Rows="1.000000" Width="16"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns/>
                       <dxl:ProjList>
@@ -356,7 +356,7 @@
                       <dxl:Filter/>
                       <dxl:Result>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="0.000042" Rows="1.000000" Width="4"/>
+                          <dxl:Cost StartupCost="0" TotalCost="0.000142" Rows="1.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="6" Alias="ColRef_0006">
@@ -373,7 +373,7 @@
                         <dxl:OneTimeFilter/>
                         <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="0.000038" Rows="1.000000" Width="4"/>
+                            <dxl:Cost StartupCost="0" TotalCost="0.000138" Rows="1.000000" Width="4"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="2" Alias="generate_series">
@@ -394,7 +394,7 @@
                           <dxl:OneTimeFilter/>
                           <dxl:Result>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                              <dxl:Cost StartupCost="0" TotalCost="0.000105" Rows="1.000000" Width="4"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="2" Alias="generate_series">

--- a/src/backend/gporca/data/dxl/minidump/ProjectSetFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ProjectSetFunction.mdp
@@ -232,7 +232,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:DMLInsert Columns="1,2" ActionCol="3" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.015671" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.015771" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -258,7 +258,7 @@
         </dxl:TableDescriptor>
         <dxl:RandomMotion InputSegments="0,1,2" OutputSegments="0,1,2">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.000046" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000146" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="a">
@@ -275,7 +275,7 @@
           <dxl:SortingColumnList/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.000034" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000134" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="a">
@@ -292,7 +292,7 @@
             <dxl:OneTimeFilter/>
             <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000030" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000130" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="a">
@@ -306,7 +306,7 @@
               <dxl:SortingColumnList/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000109" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/ReplicatedTableSequenceInsert.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ReplicatedTableSequenceInsert.mdp
@@ -302,7 +302,7 @@
     <dxl:Plan Id="0" SpaceSize="3">
       <dxl:DMLInsert Columns="8,0" ActionCol="9" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.047042" Rows="3.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.047075" Rows="3.000000" Width="8"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -328,7 +328,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000167" Rows="3.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000200" Rows="3.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="8" Alias="a">
@@ -345,7 +345,7 @@
           <dxl:OneTimeFilter/>
           <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000155" Rows="3.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000188" Rows="3.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="b">
@@ -359,7 +359,7 @@
             <dxl:SortingColumnList/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000011" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="b">
@@ -373,7 +373,7 @@
               <dxl:OneTimeFilter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000011" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="8" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/ScalarFuncPushedBelowGather.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ScalarFuncPushedBelowGather.mdp
@@ -1,0 +1,670 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Objective: Generally we want to ensure that the execution of a scalar
+    function in the project of a table scan is done on the segments to utilize
+    parallelization. Note that there are cases when executing on coordinator
+    is better. This would be when network cost is high (e.g. function returns
+    large text string) and compute cost is low (i.e. less win from
+    parallelization).
+
+    test=# CREATE TABLE r (i) AS SELECT generate_series(1, 10000000) DISTRIBUTED RANDOMLY;
+    test=# ANALYZE r;
+    test=# CREATE EXTENSION IF NOT EXISTS plpython3u;
+    test=# CREATE OR REPLACE FUNCTION add_one (i int) RETURNS int LANGUAGE plpython3u IMMUTABLE AS $$ return i + 1 $$;
+
+    test=# EXPLAIN VERBOSE SELECT i, add_one(i) FROM r;
+                                          QUERY PLAN
+    --------------------------------------------------------------------------------------
+     Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1176.27 rows=10000000 width=8)
+       Output: i, (add_one(i))
+       ->  Seq Scan on public.r  (cost=0.00..493.33 rows=3333334 width=4)
+             Output: i, add_one(i)
+     Optimizer: Pivotal Optimizer (GPORCA)
+    (5 rows)
+
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.73735.1.0" Name="r" Rows="10000000.000000" RelPages="11002" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.73735.1.0" Name="r" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Random" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="i" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:GPDBFunc Mdid="0.73743.1.0" Name="add_one" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="false" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.23.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.73735.1.0.0" Name="i" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="746"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95599"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95599"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="193266"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="193266"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="300335"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="300335"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="391877"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="391877"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="494287"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="494287"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="592464"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="592464"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="688570"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="688570"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="788504"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="788504"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="884367"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="884367"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="973395"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="973395"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1074592"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1074592"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1169394"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1169394"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1265213"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1265213"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1376400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1376400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1477709"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1477709"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1571135"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1571135"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1677846"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1677846"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1783290"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1783290"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1876156"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1876156"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1972781"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1972781"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2067561"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2067561"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2163317"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2163317"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2256333"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2256333"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2349512"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2349512"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2449968"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2449968"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2556132"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2556132"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2665193"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2665193"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2768648"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2768648"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2871793"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2871793"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2966332"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2966332"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3068433"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3068433"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3170119"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3170119"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3268944"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3268944"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3371259"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3371259"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3476169"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3476169"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3571378"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3571378"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3674057"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3674057"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3771187"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3771187"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3875583"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3875583"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3975278"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3975278"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4076436"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4076436"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4165785"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4165785"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4276118"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4276118"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4377415"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4377415"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4487939"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4487939"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4598269"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4598269"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4698651"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4698651"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4798457"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4798457"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4895102"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4895102"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5003675"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5003675"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5108898"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5108898"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5209107"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5209107"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5309712"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5309712"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5404722"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5404722"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5506023"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5506023"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5614008"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5614008"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5715369"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5715369"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5810430"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5810430"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5906531"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5906531"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5992369"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5992369"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6094143"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6094143"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6188478"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6188478"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6285300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6285300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6384773"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6384773"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6483192"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6483192"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6579491"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6579491"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6676338"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6676338"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6773399"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6773399"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6872481"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6872481"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6970756"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6970756"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7068393"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7068393"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7163005"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7163005"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7273316"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7273316"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7372821"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7372821"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7464000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7464000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7559439"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7559439"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7658687"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7658687"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7757804"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7757804"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7860598"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7860598"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7967269"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7967269"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8076858"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8076858"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8178583"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8178583"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8282035"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8282035"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8378916"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8378916"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8490257"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8490257"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8591733"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8591733"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8691858"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8691858"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8792676"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8792676"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8888432"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8888432"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8989922"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8989922"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9092977"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9092977"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9195577"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9195577"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9295937"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9295937"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9394109"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9394109"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9486333"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9486333"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9591952"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9591952"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9699762"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9699762"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9802791"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9802791"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9898745"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9898745"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="9999326"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="9" ColName="add_one" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalProject>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="9" Alias="add_one">
+            <dxl:FuncExpr FuncId="0.73743.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+              <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+            </dxl:FuncExpr>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.73735.1.0" TableName="r" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalProject>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="2">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1176.266667" Rows="10000000.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="i">
+            <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="8" Alias="add_one">
+            <dxl:Ident ColId="8" ColName="add_one" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="878.133333" Rows="10000000.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="i">
+              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="8" Alias="add_one">
+              <dxl:FuncExpr FuncId="0.73743.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:FuncExpr>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="493.333333" Rows="10000000.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="i">
+                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="0.73735.1.0" TableName="r" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="2" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:Result>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/ScalarSubq-Eq-SubqAll-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ScalarSubq-Eq-SubqAll-1.mdp
@@ -210,7 +210,7 @@
     <dxl:Plan Id="0" SpaceSize="0">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="452414879.449778" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="452414984.307378" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="5" Alias="?column?">
@@ -224,7 +224,7 @@
               <dxl:ParamList/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="441380.314547" Rows="1000.000000" Width="9"/>
+                  <dxl:Cost StartupCost="0" TotalCost="441380.416947" Rows="1000.000000" Width="9"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="2" Alias="generate_series">
@@ -238,7 +238,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="441380.314547" Rows="1000.000000" Width="9"/>
+                    <dxl:Cost StartupCost="0" TotalCost="441380.416947" Rows="1000.000000" Width="9"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="6" Alias="ColRef_0006">
@@ -282,7 +282,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000105" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="2" Alias="generate_series">

--- a/src/backend/gporca/data/dxl/minidump/ScalarSubq-Eq-SubqAll-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ScalarSubq-Eq-SubqAll-2.mdp
@@ -224,7 +224,7 @@
     <dxl:Plan Id="0" SpaceSize="0">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="452414966.423292" Rows="2.000000" Width="5"/>
+          <dxl:Cost StartupCost="0" TotalCost="452415071.280892" Rows="2.000000" Width="5"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="5" Alias="?column?">
@@ -240,7 +240,7 @@
               </dxl:ParamList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="441380.314547" Rows="1000.000000" Width="9"/>
+                  <dxl:Cost StartupCost="0" TotalCost="441380.416947" Rows="1000.000000" Width="9"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="2" Alias="generate_series">
@@ -254,7 +254,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="441380.314547" Rows="1000.000000" Width="9"/>
+                    <dxl:Cost StartupCost="0" TotalCost="441380.416947" Rows="1000.000000" Width="9"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="6" Alias="ColRef_0006">
@@ -303,7 +303,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000105" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="2" Alias="generate_series">

--- a/src/backend/gporca/data/dxl/minidump/SqlFuncDmlScalar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SqlFuncDmlScalar.mdp
@@ -297,7 +297,7 @@ LIMIT 999
     <dxl:Plan Id="0" SpaceSize="3">
       <dxl:DMLInsert Columns="8" ActionCol="9" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.010492" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.010525" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -319,7 +319,7 @@ LIMIT 999
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000075" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000108" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="8" Alias="yolo">
@@ -338,7 +338,7 @@ LIMIT 999
           </dxl:HashExprList>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000088" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="8" Alias="yolo">
@@ -352,7 +352,7 @@ LIMIT 999
             <dxl:OneTimeFilter/>
             <dxl:Limit>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000046" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000080" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="8" Alias="yolo">
@@ -361,7 +361,7 @@ LIMIT 999
               </dxl:ProjList>
               <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="1.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000076" Rows="1.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="8" Alias="yolo">
@@ -372,7 +372,7 @@ LIMIT 999
                 <dxl:SortingColumnList/>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000027" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000061" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="8" Alias="yolo">

--- a/src/backend/gporca/data/dxl/minidump/Stats-For-Select-With-Outer-Refs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Stats-For-Select-With-Outer-Refs.mdp
@@ -731,7 +731,7 @@
     <dxl:Plan Id="0" SpaceSize="3">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5177.936329" Rows="2585.000000" Width="83"/>
+          <dxl:Cost StartupCost="0" TotalCost="5178.194829" Rows="2585.000000" Width="83"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="attname">

--- a/src/backend/gporca/data/dxl/minidump/StatsFilter-AnyWithNewColStats.mdp
+++ b/src/backend/gporca/data/dxl/minidump/StatsFilter-AnyWithNewColStats.mdp
@@ -291,7 +291,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="442.218450" Rows="40113.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="445.561117" Rows="40113.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="a">
@@ -305,7 +305,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="439.826646" Rows="40113.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="443.169312" Rows="40113.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="a">
@@ -329,7 +329,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="438.726908" Rows="100280.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="442.069575" Rows="100280.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="10" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/Subq2NotInWhereLOJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq2NotInWhereLOJ.mdp
@@ -679,7 +679,7 @@
     <dxl:Plan Id="0" SpaceSize="1680">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1724.003881" Rows="1.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="1724.004114" Rows="1.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="30" Alias="s1">
@@ -696,7 +696,7 @@
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1724.003792" Rows="1.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="1724.004025" Rows="1.000000" Width="24"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="30"/>
@@ -717,7 +717,7 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1724.003763" Rows="1.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="1724.003996" Rows="1.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="30" Alias="s1">
@@ -740,7 +740,7 @@
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1724.003763" Rows="1.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="1724.003996" Rows="1.000000" Width="24"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="30" Alias="s1">
@@ -768,7 +768,7 @@
               </dxl:HashExprList>
               <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1724.003725" Rows="1.000000" Width="24"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1724.003959" Rows="1.000000" Width="24"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="30"/>
@@ -789,7 +789,7 @@
                 <dxl:Filter/>
                 <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1724.003705" Rows="2.000000" Width="24"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1724.003938" Rows="2.000000" Width="24"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="43" Alias="coalesce">
@@ -812,7 +812,7 @@
                   <dxl:LimitOffset/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1724.003705" Rows="2.000000" Width="24"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1724.003938" Rows="2.000000" Width="24"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="43" Alias="coalesce">
@@ -832,7 +832,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:HashJoin JoinType="Left">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1724.003689" Rows="2.000000" Width="24"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1724.003922" Rows="2.000000" Width="24"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="30" Alias="s1">
@@ -859,7 +859,7 @@
                       </dxl:HashCondList>
                       <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1293.002612" Rows="2.000000" Width="24"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1293.002846" Rows="2.000000" Width="24"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="30" Alias="s1">
@@ -881,7 +881,7 @@
                         </dxl:HashExprList>
                         <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1293.002462" Rows="2.000000" Width="24"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1293.002695" Rows="2.000000" Width="24"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="30" Alias="s1">
@@ -929,7 +929,7 @@
                           <dxl:OneTimeFilter/>
                           <dxl:HashJoin JoinType="LeftAntiSemiJoinNotIn">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1293.002414" Rows="2.000000" Width="24"/>
+                              <dxl:Cost StartupCost="0" TotalCost="1293.002447" Rows="2.000000" Width="24"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="0" Alias="id">
@@ -1137,7 +1137,7 @@
                             </dxl:HashJoin>
                             <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000262" Rows="3.000000" Width="8"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000296" Rows="3.000000" Width="8"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="29" Alias="btrim">
@@ -1148,7 +1148,7 @@
                               <dxl:SortingColumnList/>
                               <dxl:Result>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000119" Rows="1.000000" Width="8"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000152" Rows="1.000000" Width="8"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="29" Alias="btrim">

--- a/src/backend/gporca/data/dxl/minidump/SubqueryNoPullUpTableValueFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqueryNoPullUpTableValueFunction.mdp
@@ -144,10 +144,10 @@ SELECT 0 IS DISTINCT FROM (SELECT COUNT(*) FROM (SELECT UNNEST(ARRAY[1,2,3,4])) 
         </dxl:LogicalConstTable>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="12">
+    <dxl:Plan Id="0" SpaceSize="18">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000120" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000220" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="4" Alias="?column?">
@@ -164,7 +164,7 @@ SELECT 0 IS DISTINCT FROM (SELECT COUNT(*) FROM (SELECT UNNEST(ARRAY[1,2,3,4])) 
         <dxl:OneTimeFilter/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000119" Rows="2.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000219" Rows="2.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="5" Alias="ColRef_0005">
@@ -175,7 +175,7 @@ SELECT 0 IS DISTINCT FROM (SELECT COUNT(*) FROM (SELECT UNNEST(ARRAY[1,2,3,4])) 
           <dxl:OneTimeFilter/>
           <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000103" Rows="2.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000203" Rows="2.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="3" Alias="count">
@@ -200,7 +200,7 @@ SELECT 0 IS DISTINCT FROM (SELECT COUNT(*) FROM (SELECT UNNEST(ARRAY[1,2,3,4])) 
             </dxl:Result>
             <dxl:Materialize Eager="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000011" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000111" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="3" Alias="count">
@@ -210,7 +210,7 @@ SELECT 0 IS DISTINCT FROM (SELECT COUNT(*) FROM (SELECT UNNEST(ARRAY[1,2,3,4])) 
               <dxl:Filter/>
               <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.000003" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000103" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns/>
                 <dxl:ProjList>
@@ -228,7 +228,7 @@ SELECT 0 IS DISTINCT FROM (SELECT COUNT(*) FROM (SELECT UNNEST(ARRAY[1,2,3,4])) 
                 <dxl:Filter/>
                 <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000002" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000102" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns/>
                   <dxl:ProjList>
@@ -244,7 +244,7 @@ SELECT 0 IS DISTINCT FROM (SELECT COUNT(*) FROM (SELECT UNNEST(ARRAY[1,2,3,4])) 
                   <dxl:Filter/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000002" Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000102" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="2" Alias="unnest">

--- a/src/backend/gporca/data/dxl/minidump/TypeModifierCast.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TypeModifierCast.mdp
@@ -201,7 +201,7 @@ EXPLAIN SELECT b::varchar(40) FROM tab1;
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000046" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000079" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="9" Alias="b">
@@ -212,7 +212,7 @@ EXPLAIN SELECT b::varchar(40) FROM tab1;
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000016" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000049" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="b">

--- a/src/backend/gporca/data/dxl/minidump/Union-Volatile-Func.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Union-Volatile-Func.mdp
@@ -111,7 +111,7 @@
     <dxl:Plan Id="0" SpaceSize="840">
       <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.000074" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.000174" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:GroupingColumns>
           <dxl:GroupingColumn ColId="1"/>
@@ -124,7 +124,7 @@
         <dxl:Filter/>
         <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.000063" Rows="2.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000163" Rows="2.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="?column?">
@@ -139,7 +139,7 @@
           <dxl:LimitOffset/>
           <dxl:Append IsTarget="false" IsZapped="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.000018" Rows="2.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000118" Rows="2.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="?column?">
@@ -173,7 +173,7 @@
             </dxl:Result>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000105" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="3" Alias="generate_series">

--- a/src/backend/gporca/data/dxl/minidump/UpdateVolatileFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateVolatileFunction.mdp
@@ -413,7 +413,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLUpdate Columns="0,1" ActionCol="10" OidCol="11" CtidCol="2" SegmentIdCol="8" InputSorted="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="532.717550" Rows="1000.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="532.767550" Rows="1000.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -439,7 +439,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.155050" Rows="2000.000000" Width="26"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.205050" Rows="2000.000000" Width="26"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -465,7 +465,7 @@
           <dxl:OneTimeFilter/>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.129050" Rows="2000.000000" Width="22"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.179050" Rows="2000.000000" Width="22"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -493,7 +493,7 @@
             </dxl:HashExprList>
             <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.060190" Rows="2000.000000" Width="22"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.110190" Rows="2000.000000" Width="22"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -514,7 +514,7 @@
               </dxl:ProjList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.038190" Rows="1000.000000" Width="22"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.088190" Rows="1000.000000" Width="22"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/UseDistributionSatisfactionForUniversalInnerChild.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UseDistributionSatisfactionForUniversalInnerChild.mdp
@@ -107,7 +107,7 @@
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.000397" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.000497" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:GroupingColumns>
           <dxl:GroupingColumn ColId="1"/>
@@ -120,7 +120,7 @@
         <dxl:Filter/>
         <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.000391" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000491" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="generate_series">
@@ -135,7 +135,7 @@
           <dxl:LimitOffset/>
           <dxl:HashJoin JoinType="LeftAntiSemiJoin">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.000391" Rows="1.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000491" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="generate_series">
@@ -154,7 +154,7 @@
             </dxl:HashCondList>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000105" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="generate_series">

--- a/src/backend/gporca/data/dxl/minidump/retail_28.mdp
+++ b/src/backend/gporca/data/dxl/minidump/retail_28.mdp
@@ -4280,7 +4280,7 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
     <dxl:Plan Id="0" SpaceSize="144">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="989438.980909" Rows="58129406.108810" Width="25"/>
+          <dxl:Cost StartupCost="0" TotalCost="1001749.283506" Rows="58129406.108810" Width="25"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="35" Alias="ship_month">
@@ -4300,7 +4300,7 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
         </dxl:SortingColumnList>
         <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="982913.955073" Rows="58129406.108810" Width="25"/>
+            <dxl:Cost StartupCost="0" TotalCost="995224.257670" Rows="58129406.108810" Width="25"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="35" Alias="ship_month">
@@ -4322,7 +4322,7 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
           <dxl:LimitOffset/>
           <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="880769.706276" Rows="58129406.108810" Width="25"/>
+              <dxl:Cost StartupCost="0" TotalCost="893080.008873" Rows="58129406.108810" Width="25"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="35"/>
@@ -4349,7 +4349,7 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
             <dxl:Filter/>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="850127.970637" Rows="246206051.943378" Width="27"/>
+                <dxl:Cost StartupCost="0" TotalCost="862438.273234" Rows="246206051.943378" Width="27"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="order_id">
@@ -4374,7 +4374,7 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
               </dxl:HashExprList>
               <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="839724.533912" Rows="246206051.943378" Width="27"/>
+                  <dxl:Cost StartupCost="0" TotalCost="852034.836509" Rows="246206051.943378" Width="27"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="35"/>
@@ -4395,7 +4395,7 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
                 <dxl:Filter/>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="792426.012376" Rows="246206051.943378" Width="27"/>
+                    <dxl:Cost StartupCost="0" TotalCost="804736.314973" Rows="246206051.943378" Width="27"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="35" Alias="ship_month">

--- a/src/backend/gporca/libgpdbcost/include/gpdbcost/CCostModelGPDB.h
+++ b/src/backend/gporca/libgpdbcost/include/gpdbcost/CCostModelGPDB.h
@@ -220,6 +220,12 @@ private:
 	static CCost CostBitmapLargeNDV(const CCostModelGPDB *pcmgpdb,
 									const SCostingInfo *pci, CDouble dNDV);
 
+	// cost of compute scalar
+	static CCost CostComputeScalar(CMemoryPool *mp, CExpressionHandle &exprhdl,
+								   const SCostingInfo *pci,
+								   ICostModelParams *pcp,
+								   const CCostModelGPDB *pcmgpdb);
+
 public:
 	// ctor
 	CCostModelGPDB(CMemoryPool *mp, ULONG ulSegments,

--- a/src/backend/gporca/libgpdbcost/include/gpdbcost/CCostModelParamsGPDB.h
+++ b/src/backend/gporca/libgpdbcost/include/gpdbcost/CCostModelParamsGPDB.h
@@ -104,6 +104,8 @@ public:
 		EcpBitmapScanRebindCost,	// cost of rebind operation in a bitmap scan
 		EcpPenalizeHJSkewUpperLimit,  // upper limit for penalizing a skewed hashjoin operator
 
+		EcpScalarFuncCost,	// cost of scalar func
+
 		EcpSentinel
 	};
 
@@ -273,6 +275,9 @@ private:
 
 	// upper limit for penalizing a skewed hash operator
 	static const CDouble DPenalizeHJSkewUpperLimit;
+
+	// default value of compute scalar func cost
+	static const CDouble DScalarFuncCost;
 
 	// private copy ctor
 	CCostModelParamsGPDB(CCostModelParamsGPDB &);

--- a/src/backend/gporca/libgpdbcost/src/CCostModelGPDB.cpp
+++ b/src/backend/gporca/libgpdbcost/src/CCostModelGPDB.cpp
@@ -211,6 +211,52 @@ CCostModelGPDB::CostScanOutput(CMemoryPool *,  // mp
 
 //---------------------------------------------------------------------------
 //	@function:
+//		CCostModelGPDB::CostComputeScalar
+//
+//	@doc:
+//		Helper function to return cost of a plan containing compute scalar
+//		operator
+//
+//---------------------------------------------------------------------------
+CCost
+CCostModelGPDB::CostComputeScalar(CMemoryPool *mp, CExpressionHandle &exprhdl,
+								  const SCostingInfo *pci,
+								  ICostModelParams *pcp,
+								  const CCostModelGPDB *pcmgpdb)
+{
+	GPOS_ASSERT(NULL != pci);
+	GPOS_ASSERT(NULL != pcp);
+	GPOS_ASSERT(NULL != pcmgpdb);
+
+	DOUBLE rows = pci->Rows();
+	DOUBLE width = pci->Width();
+	DOUBLE num_rebinds = pci->NumRebinds();
+
+	CCost costLocal =
+		CCost(num_rebinds * CostTupleProcessing(rows, width, pcp).Get());
+	CCost costChild = CostChildren(mp, exprhdl, pci, pcp);
+
+	CCost costCompute(0);
+
+	if (exprhdl.DeriveHasScalarFuncProject(1))
+	{
+		// If the compute scalar operator has a scalar func operator in the
+		// project list then aggregate that cost of the scalar func. The number
+		// of times the scalar func is run is proportional to the number of
+		// rows.
+		costCompute =
+			CCost(pcmgpdb->GetCostModelParams()
+					  ->PcpLookup(CCostModelParamsGPDB::EcpScalarFuncCost)
+					  ->Get() *
+				  rows);
+	}
+
+	return costLocal + costChild + costCompute;
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
 //		CCostModelGPDB::CostUnary
 //
 //	@doc:
@@ -2010,6 +2056,10 @@ CCostModelGPDB::Cost(
 	GPOS_ASSERT(NULL != pci);
 
 	COperator::EOperatorId op_id = exprhdl.Pop()->Eopid();
+	if (op_id == COperator::EopPhysicalComputeScalar)
+	{
+		return CostComputeScalar(m_mp, exprhdl, pci, m_cost_model_params, this);
+	}
 	if (FUnary(op_id))
 	{
 		return CostUnary(m_mp, exprhdl, pci, m_cost_model_params);

--- a/src/backend/gporca/libgpdbcost/src/CCostModelParamsGPDB.cpp
+++ b/src/backend/gporca/libgpdbcost/src/CCostModelParamsGPDB.cpp
@@ -183,6 +183,9 @@ const CDouble CCostModelParamsGPDB::DBitmapScanRebindCost(0.06);
 // see CCostModelGPDB::CostHashJoin() for why this is needed
 const CDouble CCostModelParamsGPDB::DPenalizeHJSkewUpperLimit(10.0);
 
+// default scalar func cost
+const CDouble CCostModelParamsGPDB::DScalarFuncCost(1.0e-04);
+
 #define GPOPT_COSTPARAM_NAME_MAX_LENGTH 80
 
 // parameter names in the same order of param enumeration
@@ -238,6 +241,7 @@ const CHAR rgszCostParamNames[CCostModelParamsGPDB::EcpSentinel]
 								 "BitmapPageCostLargerNDV",
 								 "BitmapPageCostSmallerNDV",
 								 "BitmapNDVThreshold",
+								 "ScalarFuncCostUnit",
 };
 
 //---------------------------------------------------------------------------
@@ -428,6 +432,10 @@ CCostModelParamsGPDB::CCostModelParamsGPDB(CMemoryPool *mp) : m_mp(mp)
 	m_rgpcp[EcpPenalizeHJSkewUpperLimit] = GPOS_NEW(mp) SCostParam(
 		EcpPenalizeHJSkewUpperLimit, DPenalizeHJSkewUpperLimit,
 		DPenalizeHJSkewUpperLimit - 1.0, DPenalizeHJSkewUpperLimit + 1.0);
+
+	m_rgpcp[EcpScalarFuncCost] =
+		GPOS_NEW(mp) SCostParam(EcpScalarFuncCost, DScalarFuncCost,
+								DScalarFuncCost - 0.0, DScalarFuncCost + 0.0);
 }
 
 

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdPropScalar.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdPropScalar.h
@@ -53,6 +53,7 @@ class CDrvdPropScalar : public CDrvdProp
 		EdptUlDistinctAggs,
 		EdptFHasMultipleDistinctAggs,
 		EdptFHasScalarArrayCmp,
+		EdptFHasScalarFuncProject,
 		EdptSentinel
 	};
 
@@ -85,6 +86,9 @@ private:
 	// total number of Distinct Aggs (e.g., {count(distinct a), sum(distinct a), count(distinct b)}, the value is 3),
 	// only applicable to project lists
 	ULONG m_ulDistinctAggs;
+
+	// only applicable to project lists
+	BOOL m_fHasScalarFunc;
 
 	// does operator define Distinct Aggs on different arguments (e.g., count(distinct a), sum(distinct b)),
 	// only applicable to project lists
@@ -125,6 +129,8 @@ protected:
 	BOOL DeriveHasNonScalarFunction(CExpressionHandle &);
 
 	ULONG DeriveTotalDistinctAggs(CExpressionHandle &);
+
+	BOOL DeriveHasScalarFuncProject(CExpressionHandle &);
 
 	BOOL DeriveHasMultipleDistinctAggs(CExpressionHandle &);
 
@@ -180,6 +186,8 @@ public:
 
 	// return total number of Distinct Aggs, only applicable to project list
 	ULONG GetTotalDistinctAggs() const;
+
+	BOOL HasScalarFuncProject() const;
 
 	// does operator define Distinct Aggs on different arguments, only applicable to project lists
 	BOOL HasMultipleDistinctAggs() const;

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CExpression.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CExpression.h
@@ -316,6 +316,7 @@ public:
 	ULONG DeriveTotalDistinctAggs();
 	BOOL DeriveHasMultipleDistinctAggs();
 	BOOL DeriveHasScalarArrayCmp();
+	BOOL DeriveHasScalarFuncProject();
 
 };	// class CExpression
 

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionHandle.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionHandle.h
@@ -337,6 +337,7 @@ public:
 	ULONG DeriveTotalDistinctAggs(ULONG child_index);
 	BOOL DeriveHasMultipleDistinctAggs(ULONG child_index);
 	BOOL DeriveHasScalarArrayCmp(ULONG child_index);
+	BOOL DeriveHasScalarFuncProject(ULONG child_index);
 
 };	// class CExpressionHandle
 

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarProjectList.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarProjectList.h
@@ -96,6 +96,9 @@ public:
 	// check if a project list has multiple distinct aggregates
 	static BOOL FHasMultipleDistinctAggs(CExpressionHandle &exprhdl);
 
+	// check if a project list has a scalar func
+	static BOOL FHasScalarFunc(CExpressionHandle &exprhdl);
+
 };	// class CScalarProjectList
 
 }  // namespace gpopt

--- a/src/backend/gporca/libgpopt/src/base/CDrvdPropScalar.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDrvdPropScalar.cpp
@@ -98,6 +98,8 @@ CDrvdPropScalar::Derive(CMemoryPool *, CExpressionHandle &exprhdl,
 
 	DeriveTotalDistinctAggs(exprhdl);
 
+	DeriveHasScalarFuncProject(exprhdl);
+
 	DeriveHasMultipleDistinctAggs(exprhdl);
 
 	DeriveHasScalarArrayCmp(exprhdl);
@@ -353,6 +355,26 @@ CDrvdPropScalar::DeriveTotalDistinctAggs(CExpressionHandle &exprhdl)
 		}
 	}
 	return m_ulDistinctAggs;
+}
+
+BOOL
+CDrvdPropScalar::HasScalarFuncProject() const
+{
+	GPOS_RTL_ASSERT(IsComplete());
+	return m_fHasScalarFunc;
+}
+
+BOOL
+CDrvdPropScalar::DeriveHasScalarFuncProject(CExpressionHandle &exprhdl)
+{
+	if (!m_is_prop_derived->ExchangeSet(EdptFHasScalarFuncProject))
+	{
+		if (COperator::EopScalarProjectList == exprhdl.Pop()->Eopid())
+		{
+			m_fHasScalarFunc = CScalarProjectList::FHasScalarFunc(exprhdl);
+		}
+	}
+	return m_fHasScalarFunc;
 }
 
 // does operator define Distinct Aggs on different arguments, only applicable to project lists

--- a/src/backend/gporca/libgpopt/src/operators/CExpression.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpression.cpp
@@ -1617,4 +1617,11 @@ CExpression::DeriveHasScalarArrayCmp()
 	exprhdl.Attach(this);
 	return m_pdpscalar->DeriveHasScalarArrayCmp(exprhdl);
 }
+BOOL
+CExpression::DeriveHasScalarFuncProject()
+{
+	CExpressionHandle exprhdl(m_mp);
+	exprhdl.Attach(this);
+	return m_pdpscalar->DeriveHasScalarFuncProject(exprhdl);
+}
 // EOF

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionHandle.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionHandle.cpp
@@ -2127,4 +2127,15 @@ CExpressionHandle::DeriveHasScalarArrayCmp(ULONG child_index)
 
 	return GetDrvdScalarProps(child_index)->HasScalarArrayCmp();
 }
+
+BOOL
+CExpressionHandle::DeriveHasScalarFuncProject(ULONG child_index)
+{
+	if (NULL != Pexpr())
+	{
+		return (*Pexpr())[child_index]->DeriveHasScalarFuncProject();
+	}
+
+	return GetDrvdScalarProps(child_index)->HasScalarFuncProject();
+}
 // EOF

--- a/src/backend/gporca/libgpopt/src/operators/CScalarProjectList.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CScalarProjectList.cpp
@@ -156,4 +156,42 @@ CScalarProjectList::FHasMultipleDistinctAggs(CExpressionHandle &exprhdl)
 }
 
 
+//---------------------------------------------------------------------------
+//	@function:
+//		CScalarProjectList::FHasScalarFunc
+//
+//	@doc:
+//		Check if given project list has a scalar func, for example:
+//			select random() from T;
+//
+//---------------------------------------------------------------------------
+BOOL
+CScalarProjectList::FHasScalarFunc(CExpressionHandle &exprhdl)
+{
+	// We make do with an inexact representative expression returned by exprhdl.PexprScalarRep(),
+	// knowing that at this time, aggregate functions are accurately contained in it. What's not
+	// exact are subqueries. This is better than just returning 0 for project lists with subqueries.
+	CExpression *pexprPrjList = exprhdl.PexprScalarRep();
+
+	GPOS_ASSERT(NULL != pexprPrjList);
+	GPOS_ASSERT(COperator::EopScalarProjectList ==
+				pexprPrjList->Pop()->Eopid());
+
+	const ULONG arity = pexprPrjList->Arity();
+	for (ULONG ul = 0; ul < arity; ul++)
+	{
+		CExpression *pexprPrjEl = (*pexprPrjList)[ul];
+		CExpression *pexprChild = (*pexprPrjEl)[0];
+		COperator::EOperatorId eopidChild = pexprChild->Pop()->Eopid();
+
+		if (COperator::EopScalarFunc == eopidChild)
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+
 // EOF

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -353,7 +353,10 @@ CRightJoinTest:
 RightJoinHashed RightJoinRedistribute RightJoinReplicated RightJoinBothReplicated RightJoinDPS RightJoinNoDPSNonDistKey RightJoinTVF;
 
 CSqlFunctionTest:
-SqlFuncNullReject SqlFuncPredFactorize SqlFuncDmlScalar SqlFuncDmlTvf
+SqlFuncNullReject SqlFuncPredFactorize SqlFuncDmlScalar SqlFuncDmlTvf;
+
+CScalarFuncPushDownTest:
+ScalarFuncPushedBelowGather ConstScalarFuncNotPushedBelowGather
 ")
 
 set(mdp_dir "../data/dxl/minidump/")

--- a/src/test/regress/expected/create_index_optimizer.out
+++ b/src/test/regress/expected/create_index_optimizer.out
@@ -462,18 +462,19 @@ SELECT * FROM polygon_tbl WHERE f1 ~ '((1,1),(2,2),(2,1))'::polygon
 EXPLAIN (COSTS OFF)
 SELECT * FROM circle_tbl WHERE f1 && circle(point(1,-2), 1)
     ORDER BY area(f1);
-                             QUERY PLAN                              
----------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Result
-   ->  Sort
-         Sort Key: (area(f1))
-         ->  Result
-               ->  Gather Motion 3:1  (slice1; segments: 3)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: (area(f1))
+         ->  Sort
+               Sort Key: (area(f1))
+               ->  Result
                      ->  Index Scan using gcircleind on circle_tbl
                            Index Cond: (f1 && '<(1,-2),1>'::circle)
                            Filter: (f1 && '<(1,-2),1>'::circle)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.68.0
-(9 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
 
 SELECT * FROM circle_tbl WHERE f1 && circle(point(1,-2), 1)
     ORDER BY area(f1);


### PR DESCRIPTION
Issue is that following SQL:
```sql
CREATE TABLE t(i) AS SELECT generate_series(1, 10000000) DISTRIBUTED RANDOMLY;
CREATE OR REPLACE FUNCTION add_one (i int) RETURNS int LANGUAGE plpython3u IMMUTABLE AS $$ return i + 1 $$;
EXPLAIN VERBOSE SELECT i, add_one(i) FROM t;
```

Produced following plan:
```
test=# EXPLAIN (COSTS OFF, VERBOSE) SELECT i, add_one(i) FROM t;
                   QUERY PLAN
------------------------------------------------
 Result
   Output: i, add_one(i)
   ->  Gather Motion 3:1  (slice1; segments: 3)
         Output: i
         ->  Seq Scan on public.t
               Output: i
 Optimizer: Pivotal Optimizer (GPORCA)
(7 rows)
```

Here add_one() function is run serially on coordinator rather than in parallel
on the segments because ORCA did not properly account for the cost of scalar
func.

Following plan was a pruned alternative:
```
                QUERY PLAN
------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   Output: i, (add_one(i))
   ->  Seq Scan on public.t
         Output: i, add_one(i)
 Optimizer: Pivotal Optimizer (GPORCA)
(5 rows)
```

However, due to the extra column projected under the gather, ORCA decided
against picking it.

This commit fixes this by adding a cost model param for compute scalar func and
using it to produce better cost comparisons between plans executing scalar func
on coordinator versus executing scalar func on the segments.

Fixes #13384

(cherry picked from commit 4506e0d84aafcdf7ef8ca12971cff8ca4c0c530b)

---

Cherry-pick conflicts (mostly clean):
- some C++11 nullptr
- const functions (I opted to keep same as other 6X code)