### PR TITLE
docs - updates for greenplum SCRAM-SHA-256 support

### DIFF
--- a/gpdb-doc/markdown/admin_guide/access_db/topics/pgbouncer.html.md
+++ b/gpdb-doc/markdown/admin_guide/access_db/topics/pgbouncer.html.md
@@ -120,8 +120,6 @@ The passwords or secrets stored in the authentication file serve two purposes. F
 
 SCRAM secrets can only be used for logging into a server if the client authentication also uses SCRAM, the PgBouncer database definition does not specify a user name, and the SCRAM secrets are identical in PgBouncer and the PostgreSQL server \(same salt and iterations, not merely the same password\). This is due to an inherent security property of SCRAM: The stored SCRAM secret cannot by itself be used for deriving login credentials.
 
-**Note:** While the `pgbouncer` installed with Greenplum 6.x supports the `SCRAM-SHA-256` authentication method, the Greenplum 6.x `psql` client is too old to support this type of client authentication. You can not use `SCRAM-SHA-256` authentication with the Greenplum 6.x `psql` client program.
-
 The authentication file can be written by hand, but it’s also useful to generate it from some other list of users and passwords. See `./etc/mkauth.py` for a sample script to generate the authentication file from the `pg_shadow` system table. Alternatively, use
 
 ```

--- a/gpdb-doc/markdown/admin_guide/roles_privs.html.md
+++ b/gpdb-doc/markdown/admin_guide/roles_privs.html.md
@@ -367,7 +367,7 @@ Greenplum Database supports SHA-256 and SCRAM-SHA-256 password hash algorithms a
 | password_hash_algorithm Parameter Value | pg_hba.conf Authentication Method | Comments |
 |-----------|-------|-------------------|
 | MD5 | md5 | The default Greenplum Database password hash algorithm. |
-| SCRAM-SHA-256 | scram-sha-256 | The most secure method, but may not be supported by older clients. |
+| SCRAM-SHA-256 | scram-sha-256 | The most secure method, **but is not supported by Greenplum Database version 6.20.x and older clients**. |
 | SHA-256 | password | Clear text passwords are sent over the network, SSL-secured client connections are recommended. |
 
 The password hash function runs when the password is set by using any of the following commands:

--- a/gpdb-doc/markdown/admin_guide/roles_privs.html.md
+++ b/gpdb-doc/markdown/admin_guide/roles_privs.html.md
@@ -360,9 +360,17 @@ See [pgcrypto](https://www.postgresql.org/docs/9.4/pgcrypto.html) in the Postgre
 
 ## <a id="topic9"></a>Protecting Passwords in Greenplum Database 
 
-In its default configuration, Greenplum Database saves MD5 hashes of login users' passwords in the `pg_authid` system catalog rather than saving clear text passwords. Anyone who is able to view the `pg_authid` table can see hash strings, but no passwords. This also ensures that passwords are obscured when the database is dumped to backup files.
+In its default configuration, Greenplum Database saves MD5 hashes of login users' passwords in the [pg_authid](../ref_guide/system_catalogs/pg_authid.html) system catalog rather than saving clear text passwords. Anyone who is able to view the `pg_authid` table can see hash strings, but no passwords. This also ensures that passwords are obscured when the database is dumped to backup files.
 
-The hash function runs when the password is set by using any of the following commands:
+Greenplum Database supports SHA-256 and SCRAM-SHA-256 password hash algorithms as well. The [password_hash_algorithm](../ref_guide/config_params/guc-list.html#password_hash_algorithm) server configuration parameter value and pg_hba.conf settings determine how passwords are hashed and what authentication method is in effect.
+
+| password_hash_algorithm Parameter Value | pg_hba.conf Authentication Method | Comments |
+|-----------|-------|-------------------|
+| MD5 | md5 | The default Greenplum Database password hash algorithm. |
+| SCRAM-SHA-256 | scram-sha-256 | The most secure method, but may not be supported by older clients. |
+| SHA-256 | password | Clear text passwords are sent over the network, SSL-secured client connections are recommended. |
+
+The password hash function runs when the password is set by using any of the following commands:
 
 -   `CREATE USER name WITH ENCRYPTED PASSWORD 'password'`
 -   `CREATE ROLE name WITH LOGIN ENCRYPTED PASSWORD 'password'`
@@ -373,9 +381,7 @@ The `ENCRYPTED` keyword may be omitted when the `password_encryption` system con
 
 **Note:** The SQL command syntax and `password_encryption` configuration variable include the term *encrypt*, but the passwords are not technically encrypted. They are *hashed* and therefore cannot be decrypted.
 
-The hash is calculated on the concatenated clear text password and role name. The MD5 hash produces a 32-byte hexadecimal string prefixed with the characters `md5`. The hashed password is saved in the `rolpassword` column of the `pg_authid` system table.
-
-Although it is not recommended, passwords may be saved in clear text in the database by including the `UNENCRYPTED` keyword in the command or by setting the `password_encryption` configuration variable to `off`. Note that changing the configuration value has no effect on existing passwords, only newly created or updated passwords.
+Although it is not recommended, passwords may be saved in clear text in the database by including the `UNENCRYPTED` keyword in the command or by setting the `password_encryption` configuration variable to `off`. Note that changing the configuration value has no effect on existing passwords, only newly-created or updated passwords.
 
 To set `password_encryption` globally, run these commands in a shell as the `gpadmin` user:
 
@@ -390,23 +396,54 @@ To set `password_encryption` in a session, use the SQL `SET` command:
 =# SET password_encryption = 'on';
 ```
 
-Passwords may be hashed using the SHA-256 hash algorithm instead of the default MD5 hash algorithm. The algorithm produces a 64-byte hexadecimal string prefixed with the characters `sha256`.
+### <a id="topic9_default"></a> About MD5 Password Hashing
 
-**Note:**
+In its default configuration, Greenplum Database saves MD5 hashes of login users' passwords.
 
-Although SHA-256 uses a stronger cryptographic algorithm and produces a longer hash string, it cannot be used with the MD5 authentication method. To use SHA-256 password hashing the authentication method must be set to `password` in the `pg_hba.conf` configuration file so that clear text passwords are sent to Greenplum Database. Because clear text passwords are sent over the network, it is very important to use SSL for client connections when you use SHA-256. The default `md5` authentication method, on the other hand, hashes the password twice before sending it to Greenplum Database, once on the password and role name and then again with a salt value shared between the client and server, so the clear text password is never sent on the network.
+The hash is calculated on the concatenated clear text password and role name. The MD5 hash produces a 32-byte hexadecimal string prefixed with the characters `md5`. The hashed password is saved in the `rolpassword` column of the `pg_authid` system table.
 
-To enable SHA-256 hashing, change the `password_hash_algorithm` configuration parameter from its default value, `md5`, to `sha-256`. The parameter can be set either globally or at the session level. To set `password_hash_algorithm` globally, execute these commands in a shell as the `gpadmin` user:
+The default `md5` authentication method hashes the password twice before sending it to Greenplum Database, once on the password and role name and then again with a salt value shared between the client and server, so the clear text password is never sent on the network.
+
+### <a id="topic9_scram-sha-256"></a> About SCRAM-SHA-256 Password Hashing
+
+Passwords may be hashed using the SCRAM-SHA-256 hash algorithm instead of the default MD5 hash algorithm. When a password is encrypted with SCRAM-SHA-256, it has the format:
 
 ```
-$ gpconfig -c password_hash_algorithm -v 'sha-256'
+SCRAM-SHA-256$<iteration count>:<salt>$<StoredKey>:<ServerKey>
+```
+
+where `<salt>`, `<StoredKey>`, and `<ServerKey>` are in base64-encoded format. This format is the same as that specified by RFC 5803.
+
+To enable SCRAM-SHA-256 hashing, change the `password_hash_algorithm` configuration parameter from its default value, `MD5`, to `SCRAM-SHA-256`. The parameter can be set either globally or at the session level. To set `password_hash_algorithm` globally, execute these commands in a shell as the `gpadmin` user:
+
+```
+$ gpconfig -c password_hash_algorithm -v 'SCRAM-SHA-256'
 $ gpstop -u
 ```
 
 To set `password_hash_algorithm` in a session, use the SQL `SET` command:
 
 ```
-=# SET password_hash_algorithm = 'sha-256';
+=# SET password_hash_algorithm = 'SCRAM-SHA-256';
+```
+
+### <a id="topic9_sha-256"></a> About SHA-256 Password Hashing
+
+Passwords may be hashed using the SHA-256 hash algorithm instead of the default MD5 hash algorithm. The algorithm produces a 64-byte hexadecimal string prefixed with the characters `sha256`.
+
+**Note:** Although SHA-256 uses a stronger cryptographic algorithm and produces a longer hash string, it cannot be used with the `md5` authentication method. To use SHA-256 password hashing the authentication method must be set to `password` in the `pg_hba.conf` configuration file so that clear text passwords are sent to Greenplum Database. **Because clear text passwords are sent over the network, it is very important to use SSL-secured client connections when you use SHA-256.**
+
+To enable SHA-256 hashing, change the `password_hash_algorithm` configuration parameter from its default value, `MD5`, to `SHA-256`. The parameter can be set either globally or at the session level. To set `password_hash_algorithm` globally, execute these commands in a shell as the `gpadmin` user:
+
+```
+$ gpconfig -c password_hash_algorithm -v 'SHA-256'
+$ gpstop -u
+```
+
+To set `password_hash_algorithm` in a session, use the SQL `SET` command:
+
+```
+=# SET password_hash_algorithm = 'SHA-256';
 ```
 
 ## <a id="topic13"></a>Time-based Authentication 

--- a/gpdb-doc/markdown/admin_guide/roles_privs.html.md
+++ b/gpdb-doc/markdown/admin_guide/roles_privs.html.md
@@ -431,7 +431,7 @@ To set `password_hash_algorithm` in a session, use the SQL `SET` command:
 
 Passwords may be hashed using the SHA-256 hash algorithm instead of the default MD5 hash algorithm. The algorithm produces a 64-byte hexadecimal string prefixed with the characters `sha256`.
 
-**Note:** Although SHA-256 uses a stronger cryptographic algorithm and produces a longer hash string, it cannot be used with the `md5` authentication method. To use SHA-256 password hashing the authentication method must be set to `password` in the `pg_hba.conf` configuration file so that clear text passwords are sent to Greenplum Database. **Because clear text passwords are sent over the network, it is very important to use SSL-secured client connections when you use SHA-256.**
+**Note:** Although SHA-256 uses a stronger cryptographic algorithm and produces a longer hash string for password hashing, it does not include SHA-256 password hashing over the network during client authentication. To use SHA-256 password hashing, the authentication method must be set to `password` in the `pg_hba.conf` configuration file so that clear text passwords are sent to Greenplum Database. SHA-256 password hashing cannot be used with the `md5` authentication method. **Because clear text passwords are sent over the network, it is very important to use SSL-secured client connections when you use SHA-256.**
 
 To enable SHA-256 hashing, change the `password_hash_algorithm` configuration parameter from its default value, `MD5`, to `SHA-256`. The parameter can be set either globally or at the session level. To set `password_hash_algorithm` globally, execute these commands in a shell as the `gpadmin` user:
 

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -2469,11 +2469,11 @@ When a password is specified in CREATE USER or ALTER USER without writing either
 
 Specifies the cryptographic hash algorithm that is used when storing an encrypted Greenplum Database user password. The default algorithm is MD5.
 
-For information about setting the password hash algorithm to protect user passwords, see "Protecting Passwords in Greenplum Database" in the *Greenplum Database Administrator Guide*.
+For information about setting the password hash algorithm to protect user passwords, see [Protecting Passwords in Greenplum Database](../../admin_guide/roles_privs.html#topic9).
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|MD5<br/><br/>SHA-256|MD5|master, session, reload, superuser|
+|MD5<br/><br/>SHA-256<br/><br/>SCRAM-SHA-256|MD5|master, session, reload, superuser|
 
 ## <a id="plan_cache_mode"></a>plan\_cache\_mode 
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_ROLE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_ROLE.html.md
@@ -87,10 +87,9 @@ CONNECTION LIMIT connlimit
 
 PASSWORD password
 :   Sets the user password for roles with the `LOGIN` attribute. If you do not plan to use password authentication you can omit this option. If no password is specified, the password will be set to null and password authentication will always fail for that user. A null password can optionally be written explicitly as `PASSWORD NULL`.
-
-ENCRYPTED
-UNENCRYPTED
-:   These key words control whether the password is stored encrypted in the system catalogs. \(If neither is specified, the default behavior is determined by the configuration parameter password\_encryption.\) If the presented password string is already in MD5-encrypted format, then it is stored encrypted as-is, regardless of whether `ENCRYPTED` or `UNENCRYPTED` is specified \(since the system cannot decrypt the specified encrypted password string\). This allows reloading of encrypted passwords during dump/restore.
+: Specifying an empty string will also set the password to null, but that was not the case before Greenplum Database version 6.21. In earlier versions, an empty string could be used, or not, depending on the authentication method and the exact version, and libpq would refuse to use it in any case.  To avoid the ambiguity, specifying an empty string should be avoided.
+:   The `ENCRYPTED` and `UNENCRYPTED` key words control whether the password is stored encrypted in the system catalogs. \(If neither is specified, the default behavior is determined by the configuration parameter `password_encryption`.\) If the presented password string is already in MD5-encrypted or SCRAM-encrypted format, then it is stored encrypted as-is, regardless of whether `ENCRYPTED` or `UNENCRYPTED` is specified \(since the system cannot decrypt the specified encrypted password string\). This allows reloading of encrypted passwords during dump/restore.
+: Note that older clients might lack support for the SCRAM authentication mechanism.
 
 VALID UNTIL 'timestamp'
 :   The VALID UNTIL clause sets a date and time after which the role's password is no longer valid. If this clause is omitted the password will never expire.

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/pg_authid.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/pg_authid.html.md
@@ -20,13 +20,29 @@ Because user identities are system-wide, `pg_authid` is shared across all databa
 |`rolcanlogin`|boolean| |Role may log in. That is, this role can be given as the initial session authorization identifier|
 |`rolreplication`|boolean| |Role is a replication role. That is, this role can initiate streaming replication and set/unset the system backup mode using `pg_start_backup` and `pg_stop_backup`.|
 |`rolconnlimit`|int4| |For roles that can log in, this sets maximum number of concurrent connections this role can make. `-1` means no limit|
-|`rolpassword`|text| |Password \(possibly encrypted\); NULL if none. If the password is encrypted, this column will begin with the string `md5` followed by a 32-character hexadecimal MD5 hash. The MD5 hash will be the user's password concatenated to their user name. For example, if user `joe` has password `xyzzy`, Greenplum Database will store the md5 hash of `xyzzyjoe`. Greenplum assumes that a password that does not follow that format is unencrypted.|
+|`rolpassword`|text| |Password \(possibly encrypted\); NULL if none. The format depends on the form of encryption used.<sup>1</sup>|
 |`rolvaliduntil`|timestamptz| |Password expiry time \(only used for password authentication\); NULL if no expiration|
 |`rolresqueue`|oid| |Object ID of the associated resource queue ID in *pg\_resqueue*|
 |`rolcreaterextgpfd`|boolean| |Privilege to create read external tables with the `gpfdist` or `gpfdists` protocol|
 |`rolcreaterexhttp`|boolean| |Privilege to create read external tables with the `http` protocol|
 |`rolcreatewextgpfd`|boolean| |Privilege to create write external tables with the `gpfdist` or `gpfdists` protocol|
 |`rolresgroup`|oid| |Object ID of the associated resource group ID in *pg\_resgroup*|
+
+Notes<sup>1</sup>:
+
+- For an MD5-encrypted password, `rolpassword` column will begin with the string `md5` followed by a 32-character hexadecimal MD5 hash. The MD5 hash will be of the user's password concatenated to their user name. For example, if user `joe` has password `xyzzy` Greenplum Database will store the md5 hash of `xyzzyjoe`.
+
+- If the password is encrypted with SCRAM-SHA-256, the `rolpassword` column has the format:
+
+    ```
+    SCRAM-SHA-256$<iteration count>:<salt>$<StoredKey>:<ServerKey>
+    ```
+
+    where `<salt>`, `<StoredKey>` and `<ServerKey>` are in Base64-encoded format. This format is the same as that specified by RFC 5803.
+
+- If the password is encrypted with SHA-256, the `rolpassword` column is a 64-byte hexadecimal string prefixed with the characters `sha256`.
+
+A password that does not follow any of these formats is assumed to be unencrypted.
 
 **Parent topic:** [System Catalogs Definitions](../system_catalogs/catalog_ref-html.html)
 

--- a/gpdb-doc/markdown/security-guide/topics/Authorization.html.md
+++ b/gpdb-doc/markdown/security-guide/topics/Authorization.html.md
@@ -50,17 +50,27 @@ You can also use the `DROP OWNED` and `REASSIGN OWNED` commands for managing obj
  =# DROP OWNED BY visitor; 
 ```
 
-## <a id="using-ssh-256"></a>Using SSH-256 Encryption 
+## <a id="obj-access"></a>About Object Access Privileges
 
 Greenplum Database access control corresponds roughly to the Orange Book 'C2' level of security, not the 'B1' level. Greenplum Database currently supports access privileges at the object level. Greenplum Database does not support row-level access or row-level, labeled security.
 
 You can simulate row-level access by using views to restrict the rows that are selected. You can simulate row-level labels by adding an extra column to the table to store sensitivity information, and then using views to control row-level access based on this column. You can then grant roles access to the views rather than the base table. While these workarounds do not provide the same as "B1" level security, they may still be a viable alternative for many organizations.
 
-To use SHA-256 encryption, you must set a parameter either at the system or the session level. This section outlines how to use a server parameter to implement SHA-256 encrypted password storage. Note that in order to use SHA-256 encryption for storage, the client authentication method must be set to password rather than the default, MD5. \(See [Configuring the SSL Client Connection](Authenticate.md#config_ssl_client_conn) for more details.\) This means that the password is transmitted in clear text over the network, so we highly recommend that you set up SSL to encrypt the client server communication channel.
 
-You can set your chosen encryption method system-wide or on a per-session basis. The available encryption methods are SHA-256 and MD5 \(for backward compatibility\).
+## <a id="password-encryption"></a>About Password Encryption in Greenplum Database
 
-### <a id="system-wide"></a>Setting Encryption Method System-wide 
+The available password encryption methods in Greenplum Database are SCRAM-SHA-256, SHA-256, and MD5 \(the default\).
+
+You can set your chosen encryption method system-wide or on a per-session basis.
+
+### <a id="using-ssh-256"></a>Using SHA-256 Password Encryption
+
+To use SHA-256 password encryption, you must set a server configuration parameter either at the system or the session level. This section outlines how to use a server parameter to implement SHA-256 encrypted password storage.
+
+Note that in order to use SHA-256 encryption for password storage, the `pg_hba.conf` client authentication method must be set to `password` rather than the default, `md5`. \(See [Configuring the SSL Client Connection](Authenticate.md#config_ssl_client_conn) for more details.\) **With this authentication setting, the password is transmitted in clear text over the network; it is highly recommend that you set up SSL to encrypt the client server communication channel.**
+
+
+#### <a id="system-wide"></a>Setting the SHA-256 Password Hash Algorithm System-wide
 
 To set the `password_hash_algorithm` server parameter on a complete Greenplum system \(master and its segments\):
 
@@ -85,7 +95,7 @@ To set the `password_hash_algorithm` server parameter on a complete Greenplum sy
     ```
 
 
-### <a id="individual_session"></a>Setting Encryption Method for an Individual Session 
+#### <a id="individual_session"></a>Setting the SHA-256 Password Hash Algorithm for an Individual Session
 
 To set the `password_hash_algorithm` server parameter for an individual session:
 
@@ -110,12 +120,14 @@ To set the `password_hash_algorithm` server parameter for an individual session:
     ```
 
 
-Following is an example of how the new setting works:
+#### <a id="sha256-example"></a>Example
+
+An example of how to use and verify the `SHA-256` `password_hash_algorithm` follows:
 
 1.  Log in as a super user and verify the password hash algorithm setting:
 
     ```
-    # show password_hash_algorithm 
+    SHOW password_hash_algorithm 
      password_hash_algorithm 
      ------------------------------- 
      SHA-256
@@ -124,7 +136,7 @@ Following is an example of how the new setting works:
 2.  Create a new role with password that has login privileges.
 
     ```
-    create role testdb with password 'testdb12345#' LOGIN; 
+    CREATE ROLE testdb WITH PASSWORD 'testdb12345#' LOGIN; 
     ```
 
 3.  Change the client authentication method to allow for storage of SHA-256 encrypted passwords:
@@ -133,7 +145,6 @@ Following is an example of how the new setting works:
 
     ```
     host all testdb 0.0.0.0/0 password
-      
     ```
 
 4.  Restart the cluster.
@@ -152,12 +163,65 @@ Following is an example of how the new setting works:
 9.  Execute the following query:
 
     ```
-    
-        # SELECT rolpassword FROM pg_authid WHERE rolname = 'testdb';
-        Rolpassword
-        -----------
-        sha256<64 hexadecimal characters>
+    # SELECT rolpassword FROM pg_authid WHERE rolname = 'testdb';
+    Rolpassword
+    -----------
+    sha256<64 hexadecimal characters>
+    ```
+
+### <a id="using-scram-256"></a>Using SCRAM-SHA-256 Password Encryption
+
+To use SCRAM-SHA-256 password encryption, you must set a server configuration parameter either at the system or the session level. This section outlines how to use a server parameter to implement SCRAM-SHA-256 encrypted password storage.
+
+Note that in order to use SCRAM-SHA-256 encryption for password storage, the `pg_hba.conf` client authentication method must be set to `scram-sha-256` rather than the default, `md5`.
+
+### <a id="scram-system-wide"></a>Setting the SCRAM-SHA-256 Password Hash Algorithm System-wide
+
+To set the `password_hash_algorithm` server parameter on a complete Greenplum system \(master and its segments\):
+
+1.  Log in to your Greenplum Database instance as a superuser.
+2.  Execute `gpconfig` with the `password_hash_algorithm` set to SCRAM-SHA-256:
+
+    ```
+    $ gpconfig -c password_hash_algorithm -v 'SCRAM-SHA-256' 
+    ```
+
+3.  Verify the setting:
+
+    ```
+    $ gpconfig -s
+    ```
+
+    You will see:
+
+    ```
+    Master value: SCRAM-SHA-256
+    Segment value: SCRAM-SHA-256 
+    ```
+
+
+### <a id="scram-individual_session"></a>Setting the SCRAM-SHA-256 Password Hash Algorithm for an Individual Session
+
+To set the `password_hash_algorithm` server parameter for an individual session:
+
+1.  Log in to your Greenplum Database instance as a superuser.
+2.  Set the `password_hash_algorithm` to SCRAM-SHA-256:
+
+    ```
+    # set password_hash_algorithm = 'SCRAM-SHA-256'
       
+    ```
+
+3.  Verify the setting:
+
+    ```
+    # show password_hash_algorithm;
+    ```
+
+    You will see:
+
+    ```
+    SCRAM-SHA-256 
     ```
 
 ## <a id="time-based-restriction"></a>Restricting Access by Time 

--- a/gpdb-doc/markdown/security-guide/topics/Authorization.html.md
+++ b/gpdb-doc/markdown/security-guide/topics/Authorization.html.md
@@ -63,6 +63,61 @@ The available password encryption methods in Greenplum Database are SCRAM-SHA-25
 
 You can set your chosen encryption method system-wide or on a per-session basis.
 
+### <a id="using-scram-256"></a>Using SCRAM-SHA-256 Password Encryption
+
+To use SCRAM-SHA-256 password encryption, you must set a server configuration parameter either at the system or the session level. This section outlines how to use a server parameter to implement SCRAM-SHA-256 encrypted password storage.
+
+Note that in order to use SCRAM-SHA-256 encryption for password storage, the `pg_hba.conf` client authentication method must be set to `scram-sha-256` rather than the default, `md5`.
+
+### <a id="scram-system-wide"></a>Setting the SCRAM-SHA-256 Password Hash Algorithm System-wide
+
+To set the `password_hash_algorithm` server parameter on a complete Greenplum system \(master and its segments\):
+
+1.  Log in to your Greenplum Database instance as a superuser.
+2.  Execute `gpconfig` with the `password_hash_algorithm` set to SCRAM-SHA-256:
+
+    ```
+    $ gpconfig -c password_hash_algorithm -v 'SCRAM-SHA-256' 
+    ```
+
+3.  Verify the setting:
+
+    ```
+    $ gpconfig -s
+    ```
+
+    You will see:
+
+    ```
+    Master value: SCRAM-SHA-256
+    Segment value: SCRAM-SHA-256 
+    ```
+
+
+### <a id="scram-individual_session"></a>Setting the SCRAM-SHA-256 Password Hash Algorithm for an Individual Session
+
+To set the `password_hash_algorithm` server parameter for an individual session:
+
+1.  Log in to your Greenplum Database instance as a superuser.
+2.  Set the `password_hash_algorithm` to SCRAM-SHA-256:
+
+    ```
+    # set password_hash_algorithm = 'SCRAM-SHA-256'
+      
+    ```
+
+3.  Verify the setting:
+
+    ```
+    # show password_hash_algorithm;
+    ```
+
+    You will see:
+
+    ```
+    SCRAM-SHA-256 
+    ```
+
 ### <a id="using-ssh-256"></a>Using SHA-256 Password Encryption
 
 To use SHA-256 password encryption, you must set a server configuration parameter either at the system or the session level. This section outlines how to use a server parameter to implement SHA-256 encrypted password storage.
@@ -167,61 +222,6 @@ An example of how to use and verify the `SHA-256` `password_hash_algorithm` foll
     Rolpassword
     -----------
     sha256<64 hexadecimal characters>
-    ```
-
-### <a id="using-scram-256"></a>Using SCRAM-SHA-256 Password Encryption
-
-To use SCRAM-SHA-256 password encryption, you must set a server configuration parameter either at the system or the session level. This section outlines how to use a server parameter to implement SCRAM-SHA-256 encrypted password storage.
-
-Note that in order to use SCRAM-SHA-256 encryption for password storage, the `pg_hba.conf` client authentication method must be set to `scram-sha-256` rather than the default, `md5`.
-
-### <a id="scram-system-wide"></a>Setting the SCRAM-SHA-256 Password Hash Algorithm System-wide
-
-To set the `password_hash_algorithm` server parameter on a complete Greenplum system \(master and its segments\):
-
-1.  Log in to your Greenplum Database instance as a superuser.
-2.  Execute `gpconfig` with the `password_hash_algorithm` set to SCRAM-SHA-256:
-
-    ```
-    $ gpconfig -c password_hash_algorithm -v 'SCRAM-SHA-256' 
-    ```
-
-3.  Verify the setting:
-
-    ```
-    $ gpconfig -s
-    ```
-
-    You will see:
-
-    ```
-    Master value: SCRAM-SHA-256
-    Segment value: SCRAM-SHA-256 
-    ```
-
-
-### <a id="scram-individual_session"></a>Setting the SCRAM-SHA-256 Password Hash Algorithm for an Individual Session
-
-To set the `password_hash_algorithm` server parameter for an individual session:
-
-1.  Log in to your Greenplum Database instance as a superuser.
-2.  Set the `password_hash_algorithm` to SCRAM-SHA-256:
-
-    ```
-    # set password_hash_algorithm = 'SCRAM-SHA-256'
-      
-    ```
-
-3.  Verify the setting:
-
-    ```
-    # show password_hash_algorithm;
-    ```
-
-    You will see:
-
-    ```
-    SCRAM-SHA-256 
     ```
 
 ## <a id="time-based-restriction"></a>Restricting Access by Time 


### PR DESCRIPTION
doc changes for https://github.com/greenplum-db/gpdb/pull/13286.  6X_STABLE.

in this PR (review site is behind the vpn):
- remove pgbouncer note about greenplum client not supporting scram-sha-256
- update the "managing roles and privileges" topic in the admin guide - rearrange topic, add scram-sha-256 info; doc review site link:  https://docs-staging.vmware.com/en/VMware-Tanzu-Greenplum/lisa-review/greenplum-database/GUID-admin_guide-roles_privs.html#protecting-passwords-in-greenplum-database
- add SCRAM-SHA-256 password_hash_algorithm guc value; doc review site link:  https://docs-staging.vmware.com/en/VMware-Tanzu-Greenplum/lisa-review/greenplum-database/GUID-ref_guide-config_params-guc-list.html#password_hash_algorithm
- update the CREATE ROLE topic; doc review site link:  https://docs-staging.vmware.com/en/VMware-Tanzu-Greenplum/lisa-review/greenplum-database/GUID-ref_guide-sql_commands-CREATE_ROLE.html
- update the pg_authid system catalog table docs rolpassword and add notes; doc review site link:  https://docs-staging.vmware.com/en/VMware-Tanzu-Greenplum/lisa-review/greenplum-database/GUID-ref_guide-system_catalogs-pg_authid.html
- update the authentication topic in the security guide - add scram-sha-256 authentication method, examples; doc review site link:  https://docs-staging.vmware.com/en/VMware-Tanzu-Greenplum/lisa-review/greenplum-database/GUID-security-guide-topics-Authenticate.html#basic_auth
- update the authorization topic in the security guide - added a parallel topic to "using sha-256 passwrod encrpytion"; doc review site link:  https://docs-staging.vmware.com/en/VMware-Tanzu-Greenplum/lisa-review/greenplum-database/GUID-security-guide-topics-Authorization.html#about-password-encryption-in-greenplum-database

notes:
- the existings docs have information in various places and use different terminology.  i tried to work within the framework of the existing doc content.
- pgbouncer doc updates will be in a separate PR.
