### PR TITLE
Revert PG_TRY() / PG_CATCH() surrounding of CFI.

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -487,18 +487,9 @@ checkDispatchResult(CdbDispatcherState *ds, int timeout_sec)
 
 		/*
 		 * Current loop might last for the long time so check on interrupts.
-		 * If error will be thrown then ordinarily cancel all activities on
-		 * segments and re-throw this error at the end of current function.
 		 */
-		PG_TRY();
-		{
-			CHECK_FOR_INTERRUPTS();
-		}
-		PG_CATCH();
-		{
-			cancelRequested = true;
-		}
-		PG_END_TRY();
+
+		CHECK_FOR_INTERRUPTS();
 
 		/*
 		 * escalate waitMode to cancel if:
@@ -506,7 +497,7 @@ checkDispatchResult(CdbDispatcherState *ds, int timeout_sec)
 		 * - or an error has been reported by any QE,
 		 * - in case the caller wants cancelOnError
 		 */
-		if ((cancelRequested || meleeResults->errcode) && meleeResults->cancelOnError)
+		if ((CancelRequested() || meleeResults->errcode) && meleeResults->cancelOnError)
 			pParms->waitMode = DISPATCH_WAIT_CANCEL;
 
 		/*
@@ -660,8 +651,6 @@ checkDispatchResult(CdbDispatcherState *ds, int timeout_sec)
 	pfree(revents);
 	pfree(added);
 	FreeWaitEventSet(waitset);
-	if (cancelRequested)
-		PG_RE_THROW();
 }
 
 /*


### PR DESCRIPTION
A history commit ee255b55398818c6e6401668b540d2f45ff4c719 introduced a `PG_TRY()` / `PG_CATCH()` surrounding to `CHECK_FOR_INTERRUPTS`, which seems not necessary and may cause some trouble, according the discussions here:

- https://github.com/greenplum-db/gpdb/pull/13513#discussion_r883190234
- https://github.com/greenplum-db/gpdb/pull/13513#discussion_r883240823
- https://github.com/greenplum-db/gpdb/pull/13513#discussion_r883244949

So it's better to revert this change to avoid nested `TRY-CATCH` now.

What do you think? @maksm90 @soumyadeep2007 @interma 


,## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
