### PR TITLE
Fix txns_using_rel leak in AppendOnlyHash entry

### DIFF
--- a/src/test/isolation2/input/uao/max_concurrency2.source
+++ b/src/test/isolation2/input/uao/max_concurrency2.source
@@ -399,4 +399,8 @@ ALTER RESOURCE GROUP admin_group SET CONCURRENCY 130;
 SELECT * FROM ao;
 SELECT * FROM gp_ao_or_aocs_seg('ao') ORDER BY segno;
 
+-- Since all transactions have completed, we should be able to evict the AO cache entry.
+SELECT state, count(state) FROM gp_toolkit.__gp_get_ao_entry_from_cache('ao'::regclass) GROUP BY state;
+SELECT gp_toolkit.__gp_remove_ao_entry_from_cache('ao'::regclass);
+
 ALTER RESOURCE GROUP admin_group SET CONCURRENCY 20;

--- a/src/test/isolation2/output/uao/max_concurrency2.source
+++ b/src/test/isolation2/output/uao/max_concurrency2.source
@@ -1047,5 +1047,17 @@ SELECT * FROM gp_ao_or_aocs_seg('ao') ORDER BY segno;
  127   | 1        | 1        | 3             | 1     
 (127 rows)
 
+-- Since all transactions have completed, we should be able to evict the AO cache entry.
+SELECT state, count(state) FROM gp_toolkit.__gp_get_ao_entry_from_cache('ao'::regclass) GROUP BY state;
+ state | count 
+-------+-------
+ 1     | 128   
+(1 row)
+SELECT gp_toolkit.__gp_remove_ao_entry_from_cache('ao'::regclass);
+ __gp_remove_ao_entry_from_cache 
+---------------------------------
+                                 
+(1 row)
+
 ALTER RESOURCE GROUP admin_group SET CONCURRENCY 20;
 ALTER


### PR DESCRIPTION
When finding an available AO segment file to start writes, the
AppendOnlyHash entry's txns_using_rel is always incremented
immediately at the beginning. There were two ERROR locations during
this selection process where the transaction could exit but the
entry's txns_using_rel would not decrement back down. To fix the
issue, simply increment the AppendOnlyHash entry's txns_using_rel
after the two ERROR locations when the AO segment file has actually
been chosen instead of before.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
