### PR TITLE
Add support for changing ACCESS METHOD from heap to AO

### DIFF
--- a/doc/src/sgml/ref/alter_table.sgml
+++ b/doc/src/sgml/ref/alter_table.sgml
@@ -81,6 +81,7 @@ ALTER TABLE name
     CLUSTER ON <replaceable class="parameter">index_name</replaceable>
     SET WITHOUT CLUSTER
     SET WITHOUT OIDS
+    SET ACCESS METHOD <replaceable class="parameter">new_access_method</replaceable>
     SET TABLESPACE <replaceable class="parameter">new_tablespace</replaceable>
     SET { LOGGED | UNLOGGED }
     SET ( <replaceable class="parameter">storage_parameter</replaceable> = <replaceable class="parameter">value</replaceable> [, ... ] )
@@ -700,6 +701,16 @@ Where column_reference_storage_directive is:
    </varlistentry>
 
    <varlistentry>
+    <term><literal>SET ACCESS METHOD</literal></term>
+    <listitem>
+     <para>
+      This form changes the access method of the table by rewriting it. See
+      <xref linkend="tableam"/> for more information.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
     <term><literal>SET TABLESPACE</literal></term>
     <listitem>
      <para>
@@ -1204,6 +1215,15 @@ Where column_reference_storage_directive is:
       <listitem>
        <para>
         The user name of the new owner of the table.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry>
+      <term><replaceable class="parameter">new_access_method</replaceable></term>
+      <listitem>
+       <para>
+        The name of the access method to which the table will be converted.
        </para>
       </listitem>
      </varlistentry>

--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -632,6 +632,7 @@ static void
 rebuild_relation(Relation OldHeap, Oid indexOid, bool verbose)
 {
 	Oid			tableOid = RelationGetRelid(OldHeap);
+	Oid			accessMethod = OldHeap->rd_rel->relam;
 	Oid			tableSpace = OldHeap->rd_rel->reltablespace;
 	Oid			OIDNewHeap;
 	char		relpersistence;
@@ -659,6 +660,7 @@ rebuild_relation(Relation OldHeap, Oid indexOid, bool verbose)
 
 	/* Create the transient table that will receive the re-ordered data */
 	OIDNewHeap = make_new_heap(tableOid, tableSpace,
+							   accessMethod,
 							   relpersistence,
 							   AccessExclusiveLock,
 							   true /* createAoBlockDirectory */,
@@ -684,15 +686,16 @@ rebuild_relation(Relation OldHeap, Oid indexOid, bool verbose)
 /*
  * Create the transient table that will be filled with new data during
  * CLUSTER, ALTER TABLE, and similar operations.  The transient table
- * duplicates the logical structure of the OldHeap, but is placed in
- * NewTableSpace which might be different from OldHeap's.  Also, it's built
- * with the specified persistence, which might differ from the original's.
+ * duplicates the logical structure of the OldHeap; but will have the
+ * specified physical storage properties NewTableSpace, NewAccessMethod, and
+ * relpersistence.
  *
  * After this, the caller should load the new heap with transferred/modified
  * data, then call finish_heap_swap to complete the operation.
  */
 Oid
-make_new_heap(Oid OIDOldHeap, Oid NewTableSpace, char relpersistence,
+make_new_heap(Oid OIDOldHeap, Oid NewTableSpace, Oid NewAccessMethod,
+			  char relpersistence,
 			  LOCKMODE lockmode,
 			  bool createAoBlockDirectory,
 			  bool makeCdbPolicy)
@@ -754,7 +757,7 @@ make_new_heap(Oid OIDOldHeap, Oid NewTableSpace, char relpersistence,
 										  InvalidOid,
 										  InvalidOid,
 										  OldHeap->rd_rel->relowner,
-										  OldHeap->rd_rel->relam,
+										  NewAccessMethod,
 										  OldHeapDesc,
 										  NIL,
 										  RELKIND_RELATION,
@@ -1170,6 +1173,10 @@ swap_relation_files(Oid r1, Oid r2, bool target_is_pg_class,
 		relform1->reltablespace = relform2->reltablespace;
 		relform2->reltablespace = swaptemp;
 
+		swaptemp = relform1->relam;
+		relform1->relam = relform2->relam;
+		relform2->relam = swaptemp;
+
 		swptmpchr = relform1->relpersistence;
 		relform1->relpersistence = relform2->relpersistence;
 		relform2->relpersistence = swptmpchr;
@@ -1204,6 +1211,9 @@ swap_relation_files(Oid r1, Oid r2, bool target_is_pg_class,
 				 NameStr(relform1->relname));
 		if (relform1->relpersistence != relform2->relpersistence)
 			elog(ERROR, "cannot change persistence of mapped relation \"%s\"",
+				 NameStr(relform1->relname));
+		if (relform1->relam != relform2->relam)
+			elog(ERROR, "cannot change access method of mapped relation \"%s\"",
 				 NameStr(relform1->relname));
 		if (!swap_toast_by_content &&
 			(relform1->reltoastrelid || relform2->reltoastrelid))

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -334,7 +334,7 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 	 * it against access by any other process until commit (by which time it
 	 * will be gone).
 	 */
-	OIDNewHeap = make_new_heap(matviewOid, tableSpace, relpersistence,
+	OIDNewHeap = make_new_heap(matviewOid, tableSpace, matviewRel->rd_rel->relam, relpersistence,
 							   ExclusiveLock, false, true);
 	LockRelationOid(OIDNewHeap, AccessExclusiveLock);
 	dest = CreateTransientRelDestReceiver(OIDNewHeap, matviewOid, concurrent, relpersistence,
@@ -575,7 +575,8 @@ transientrel_init(QueryDesc *queryDesc)
 	 * it against access by any other process until commit (by which time it
 	 * will be gone).
 	 */
-	OIDNewHeap = make_new_heap(matviewOid, tableSpace, relpersistence,
+	OIDNewHeap = make_new_heap(matviewOid, tableSpace, matviewRel->rd_rel->relam,
+							   relpersistence,
 							   ExclusiveLock, false, false);
 	LockRelationOid(OIDNewHeap, AccessExclusiveLock);
 

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -448,6 +448,7 @@ static void change_owner_recurse_to_sequences(Oid relationOid,
 static ObjectAddress ATExecClusterOn(Relation rel, const char *indexName,
 									 LOCKMODE lockmode);
 static void ATExecDropCluster(Relation rel, LOCKMODE lockmode);
+static void ATPrepSetAccessMethod(AlteredTableInfo *tab, Relation rel, const char *amname);
 static bool ATPrepChangePersistence(Relation rel, bool toLogged);
 static void ATPrepSetTableSpace(AlteredTableInfo *tab, Relation rel,
 								const char *tablespacename, LOCKMODE lockmode);
@@ -4246,6 +4247,7 @@ AlterTableGetLockLevel(List *cmds)
 				 */
 			case AT_AddColumn:	/* may rewrite heap, in some cases and visible
 								 * to SELECT */
+			case AT_SetAccessMethod:	/* must rewrite heap */
 			case AT_SetTableSpace:	/* must rewrite heap */
 			case AT_AlterColumnType:	/* must rewrite heap */
 				cmd_lockmode = AccessExclusiveLock;
@@ -4780,6 +4782,24 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 			ATSimplePermissions(rel, ATT_TABLE | ATT_FOREIGN_TABLE);
 			pass = AT_PASS_DROP;
 			break;
+		case AT_SetAccessMethod:	/* SET ACCESS METHOD */
+			ATSimplePermissions(rel, ATT_TABLE | ATT_MATVIEW);
+
+			/* partitioned tables don't have an access method */
+			if (rel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE)
+				ereport(ERROR,
+						(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+						 errmsg("cannot change access method of a partitioned table")));
+
+			/* check if another access method change was already requested */
+			if (OidIsValid(tab->newAccessMethod))
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("cannot have multiple SET ACCESS METHOD subcommands")));
+
+			ATPrepSetAccessMethod(tab, rel, cmd->name);
+			pass = AT_PASS_MISC;	/* does not matter; no work in Phase 2 */
+			break;
 		case AT_SetTableSpace:	/* SET TABLESPACE */
 			ATSimplePermissions(rel, ATT_TABLE | ATT_MATVIEW | ATT_INDEX |
 								ATT_PARTITIONED_INDEX);
@@ -5265,6 +5285,9 @@ ATExecCmd(List **wqueue, AlteredTableInfo *tab, Relation rel,
 		case AT_DropOids:		/* SET WITHOUT OIDS */
 			/* nothing to do here, oid columns don't exist anymore */
 			break;
+		case AT_SetAccessMethod:	/* SET ACCESS METHOD */
+			/* handled specially in Phase 3 */
+			break;
 		case AT_SetTableSpace:	/* SET TABLESPACE */
 
 			/*
@@ -5572,7 +5595,7 @@ ATRewriteTables(AlterTableStmt *parsetree, List **wqueue, LOCKMODE lockmode)
 		/*
 		 * We only need to rewrite the table if at least one column needs to
 		 * be recomputed, we are adding/removing the OID column, or we are
-		 * changing its persistence.
+		 * changing its persistence or access method.
 		 *
 		 * There are two reasons for requiring a rewrite when changing
 		 * persistence: on one hand, we need to ensure that the buffers
@@ -5585,8 +5608,10 @@ ATRewriteTables(AlterTableStmt *parsetree, List **wqueue, LOCKMODE lockmode)
 		{
 			/* Build a temporary relation and copy data */
 			Oid			OIDNewHeap;
+			Oid			NewAccessMethod;
 			Oid			NewTableSpace;
 			char		persistence;
+			TransactionId relfrozenxid;
 
 			OldHeap = table_open(tab->relid, NoLock);
 
@@ -5624,6 +5649,15 @@ ATRewriteTables(AlterTableStmt *parsetree, List **wqueue, LOCKMODE lockmode)
 				NewTableSpace = tab->newTableSpace;
 			else
 				NewTableSpace = oldTableSpace;
+
+			/*
+			 * Select destination access method (same as original unless user
+			 * requested a change)
+			 */
+			if (OidIsValid(tab->newAccessMethod))
+				NewAccessMethod = tab->newAccessMethod;
+			else
+				NewAccessMethod = OldHeap->rd_rel->relam;
 
 			/*
 			 * Select persistence of transient table (same as original unless
@@ -5664,8 +5698,8 @@ ATRewriteTables(AlterTableStmt *parsetree, List **wqueue, LOCKMODE lockmode)
 			 * persistence. That wouldn't work for pg_class, but that can't be
 			 * unlogged anyway.
 			 */
-			OIDNewHeap = make_new_heap(tab->relid, NewTableSpace, persistence,
-									   lockmode, hasIndexes, false);
+			OIDNewHeap = make_new_heap(tab->relid, NewTableSpace, NewAccessMethod,
+									   persistence, lockmode, hasIndexes, false);
 
 			/*
 			 * Copy the heap data into the new table with the desired
@@ -5687,13 +5721,21 @@ ATRewriteTables(AlterTableStmt *parsetree, List **wqueue, LOCKMODE lockmode)
 			 * over to our original pg_class tuple. We do not want to do this
 			 * in the case of ALTER TABLE rewrites as the temp relfile will
 			 * not have correct stats.
+			 *
+			 * GPDB: Since pg_class.relfrozenxid doesn't mean anything for
+			 * AO/AOCO tables, and should not be set, pass in
+			 * InvalidTransactionId instead of RecentXmin.
 			 */
+			if (NewAccessMethod == AO_ROW_TABLE_AM_OID || NewAccessMethod == AO_COLUMN_TABLE_AM_OID)
+				relfrozenxid = InvalidTransactionId;
+			else
+				relfrozenxid = RecentXmin;
 			finish_heap_swap(tab->relid, OIDNewHeap,
 							 false, false,
 							 false /* swap_stats */,
 							 true,
 							 !OidIsValid(tab->newTableSpace),
-							 RecentXmin,
+							 relfrozenxid,
 							 ReadNextMultiXactId(),
 							 persistence);
 		}
@@ -6273,16 +6315,9 @@ ATRewriteTable(AlteredTableInfo *tab, Oid OIDNewHeap, LOCKMODE lockmode)
 		scan = table_beginscan(oldrel, snapshot, 0, NULL);
 
 		if (newrel && RelationIsAoRows(newrel))
-		{
-			/* Table access method is not permitted to change */
-			Assert(RelationIsAoRows(oldrel));
 			appendonly_dml_init(newrel, CMD_INSERT);
-		}
 		else if (newrel && RelationIsAoCols(newrel))
-		{
-			Assert(RelationIsAoCols(oldrel));
 			aoco_dml_init(newrel, CMD_INSERT);
-		}
 
 		/*
 		 * Switch to per-tuple memory context and reset it for each tuple
@@ -6481,6 +6516,8 @@ ATGetQueueEntry(List **wqueue, Relation rel)
 	tab->relid = relid;
 	tab->relkind = rel->rd_rel->relkind;
 	tab->oldDesc = CreateTupleDescCopyConstr(RelationGetDescr(rel));
+	tab->newAccessMethod = InvalidOid;
+	tab->newTableSpace = InvalidOid;
 	tab->newrelpersistence = RELPERSISTENCE_PERMANENT;
 	tab->chgPersistence = false;
 
@@ -14023,6 +14060,41 @@ ATExecDropCluster(Relation rel, LOCKMODE lockmode)
 						   GetUserId(),
 						   "ALTER", "SET WITHOUT CLUSTER"
 				);
+}
+
+/*
+ * Preparation phase for SET ACCESS METHOD
+ *
+ * Check that access method exists.  If it is the same as the table's current
+ * access method, it is a no-op.  Otherwise, a table rewrite is necessary.
+ */
+static void
+ATPrepSetAccessMethod(AlteredTableInfo *tab, Relation rel, const char *amname)
+{
+	Oid			amoid;
+
+	/* Check that the table access method exists */
+	amoid = get_table_am_oid(amname, false);
+
+	if (rel->rd_rel->relam == amoid)
+		return;
+
+	/*
+	 * Since we don't support unique indexes for AO/AOCO tables, ban
+	 * heap->AO/AOCO in case the heap table has a unique index.
+	 */
+	if (rel->rd_rel->relam == HEAP_TABLE_AM_OID &&
+		(amoid == AO_ROW_TABLE_AM_OID || amoid == AO_COLUMN_TABLE_AM_OID))
+	{
+		if (relationHasUniqueIndex(rel))
+				ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					errmsg("append-only tables do not support unique indexes"),
+					errdetail("heap table \"%s\" being altered contains unique index", RelationGetRelationName(rel))));
+	}
+
+	/* Save info for Phase 3 to do the real work */
+	tab->rewrite |= AT_REWRITE_ACCESS_METHOD;
+	tab->newAccessMethod = amoid;
 }
 
 /*

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3426,6 +3426,7 @@ _outAlteredTableInfo(StringInfo str, const AlteredTableInfo *node)
 	WRITE_NODE_FIELD(newvals);
 	WRITE_BOOL_FIELD(verify_new_notnull);
 	WRITE_INT_FIELD(rewrite);
+	WRITE_OID_FIELD(newAccessMethod);
 	WRITE_BOOL_FIELD(dist_opfamily_changed);
 	WRITE_OID_FIELD(new_opclass);
 	WRITE_OID_FIELD(newTableSpace);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -954,6 +954,7 @@ _readAlteredTableInfo(void)
 	READ_NODE_FIELD(newvals);
 	READ_BOOL_FIELD(verify_new_notnull);
 	READ_INT_FIELD(rewrite);
+	READ_OID_FIELD(newAccessMethod);
 	READ_BOOL_FIELD(dist_opfamily_changed);
 	READ_OID_FIELD(new_opclass);
 	READ_OID_FIELD(newTableSpace);

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -198,6 +198,7 @@ static Node *makeRecursiveViewSelect(char *relname, List *aliases, Node *query);
 
 static Node *makeIsNotDistinctFromNode(Node *expr, int position);
 
+static bool isSetWithReorganize(List **options);
 static char *greenplumLegacyAOoptions(const char *accessMethod, List **options);
 static void check_expressions_in_partition_key(PartitionSpec *spec, core_yyscan_t yyscanner);
 
@@ -3241,12 +3242,25 @@ alter_table_cmd:
 					n->def = (Node *) list_make2($3, $4);
 					$$ = (Node *)n;
 				}
-			/* storage only */
+			/* table storage type  or reorganize only */
 			| SET WITH definition
 				{
 					AlterTableCmd *n = makeNode(AlterTableCmd);
-					n->subtype = AT_SetDistributedBy;
-					n->def = (Node *) list_make2($3, NULL);
+					if (isSetWithReorganize(&$3))
+					{
+						n->subtype = AT_SetDistributedBy;
+						n->def = (Node *) list_make2($3, NULL);
+					}
+					else
+					{
+						n->subtype = AT_SetAccessMethod;
+						n->name = greenplumLegacyAOoptions(n->name, &$3);
+						if (!n->name)
+							ereport(ERROR,
+								(errcode(ERRCODE_SYNTAX_ERROR),
+								 errmsg("invalid storage type"),
+								 parser_errposition(@3)));
+					}
 					$$ = (Node *)n;
 				}
 			| alter_table_partition_cmd
@@ -19620,6 +19634,28 @@ makeRecursiveViewSelect(char *relname, List *aliases, Node *query)
 
 	return (Node *) s;
 }
+
+static bool
+isSetWithReorganize(List **options)
+{
+	ListCell *lc;
+	foreach (lc, *options)
+	{
+		DefElem *elem = lfirst(lc);
+
+		if (strcmp(elem->defname, "reorganize") == 0)
+		{
+			if (list_length(*options) == 1)
+				return true;
+			else
+				ereport(ERROR,
+					(errcode(ERRCODE_SYNTAX_ERROR),
+					errmsg("reorganize isn't supported with other options in SET WITH")));
+		}
+	}
+	return false;
+}
+
 
 /*
  * Greenplum: a thin wax off layer to keep compatibility with the legacy syntax

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -3292,6 +3292,14 @@ alter_table_cmd:
 					n->newowner = $3;
 					$$ = (Node *)n;
 				}
+			/* ALTER TABLE <name> SET ACCESS METHOD <amname> */
+			| SET ACCESS METHOD name
+				{
+					AlterTableCmd *n = makeNode(AlterTableCmd);
+					n->subtype = AT_SetAccessMethod;
+					n->name = $4;
+					$$ = (Node *)n;
+				}
 			/* ALTER TABLE <name> SET TABLESPACE <tablespacename> */
 			| SET TABLESPACE name
 				{

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1991,8 +1991,15 @@ psql_completion(const char *text, int start, int end)
 	}
 	/* If we have ALTER TABLE <sth> SET, provide list of attributes and '(' */
 	else if (Matches("ALTER", "TABLE", MatchAny, "SET"))
-		COMPLETE_WITH("(", "LOGGED", "SCHEMA", "TABLESPACE", "UNLOGGED",
-					  "WITH", "WITHOUT");
+		COMPLETE_WITH("(", "ACCESS METHOD", "LOGGED", "SCHEMA",
+					  "TABLESPACE", "UNLOGGED", "WITH", "WITHOUT");
+
+	/*
+	 * If we have ALTER TABLE <smt> SET ACCESS METHOD provide a list of table
+	 * AMs.
+	 */
+	else if (Matches("ALTER", "TABLE", MatchAny, "SET", "ACCESS", "METHOD"))
+		COMPLETE_WITH_QUERY(Query_for_list_of_table_access_methods);
 
 	/*
 	 * If we have ALTER TABLE <sth> SET TABLESPACE provide a list of

--- a/src/include/catalog/pg_appendonly.h
+++ b/src/include/catalog/pg_appendonly.h
@@ -17,6 +17,7 @@
 
 #include "catalog/genbki.h"
 #include "catalog/pg_appendonly_d.h"
+#include "catalog/pg_class.h"
 #include "utils/relcache.h"
 #include "utils/snapshot.h"
 
@@ -164,7 +165,6 @@ UpdateAppendOnlyEntryAuxOids(Oid relid,
 extern void
 RemoveAppendonlyEntry(Oid relid);
 
-extern void
-SwapAppendonlyEntries(Oid entryRelId1, Oid entryRelId2);
+extern void ATAOEntries(Form_pg_class relform1, Form_pg_class relform2);
 
 #endif   /* PG_APPENDONLY_H */

--- a/src/include/commands/cluster.h
+++ b/src/include/commands/cluster.h
@@ -25,7 +25,8 @@ extern void check_index_is_clusterable(Relation OldHeap, Oid indexOid,
 									   bool recheck, LOCKMODE lockmode);
 extern void mark_index_clustered(Relation rel, Oid indexOid, bool is_internal);
 
-extern Oid make_new_heap(Oid OIDOldHeap, Oid NewTableSpace, char relpersistence,
+extern Oid make_new_heap(Oid OIDOldHeap, Oid NewTableSpace, Oid NewAccessMethod,
+						 char relpersistence,
 						 LOCKMODE lockmode,
 						 bool createAoBlockDirectory,
 						 bool makeCdbPolicy);

--- a/src/include/commands/event_trigger.h
+++ b/src/include/commands/event_trigger.h
@@ -31,8 +31,9 @@ typedef struct EventTriggerData
 #define AT_REWRITE_ALTER_PERSISTENCE	0x01
 #define AT_REWRITE_DEFAULT_VAL			0x02
 #define AT_REWRITE_COLUMN_REWRITE		0x04
+#define AT_REWRITE_ACCESS_METHOD		0x08
 /* set if AOCS and only the AT_PASS_ADD_COL subcmd is populated */
-#define AT_REWRITE_NEW_COLUMNS_ONLY_AOCS	0x08
+#define AT_REWRITE_NEW_COLUMNS_ONLY_AOCS	0x10
 
 /*
  * EventTriggerData is the node type that is passed as fmgr "context" info

--- a/src/include/nodes/altertablenodes.h
+++ b/src/include/nodes/altertablenodes.h
@@ -66,6 +66,7 @@ typedef struct AlteredTableInfo
 	List	   *newvals;		/* List of NewColumnValue */
 	bool		verify_new_notnull; /* T if we should recheck NOT NULL */
 	int			rewrite;		/* Reason for forced rewrite, if any */
+	Oid 		newAccessMethod; /* new access method; 0 means no change */
 	bool		dist_opfamily_changed; /* T if changing datatype of distribution key column and new opclass is in different opfamily than old one */
 	Oid			new_opclass;		/* new opclass, if changing a distribution key column */
 	Oid			newTableSpace;	/* new tablespace; 0 means no change */

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1959,6 +1959,7 @@ typedef enum AlterTableType
 	AT_SetLogged,				/* SET LOGGED */
 	AT_SetUnLogged,				/* SET UNLOGGED */
 	AT_DropOids,				/* SET WITHOUT OIDS */
+	AT_SetAccessMethod,			/* SET ACCESS METHOD */
 	AT_SetTableSpace,			/* SET TABLESPACE */
 	AT_SetRelOptions,			/* SET (...) -- AM specific parameters */
 	AT_ResetRelOptions,			/* RESET (...) -- AM specific parameters */

--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -171,12 +171,12 @@ ERROR:  permission denied: "pg_class" is a system catalog
 create table atsdb (i int, j text) distributed by (j);
 insert into atsdb select i, i::text from generate_series(1, 10) i;
 alter table atsdb set with(appendonly = true);
-ERROR:  option "appendonly" not supported
 select relname, segrelid != 0, reloptions from pg_class, pg_appendonly where pg_class.oid =
 'atsdb'::regclass and relid = pg_class.oid;
  relname | ?column? | reloptions 
 ---------+----------+------------
-(0 rows)
+ atsdb   | t        | 
+(1 row)
 
 select * from atsdb;
  i  | j  
@@ -316,12 +316,12 @@ select * from distcheck where rel = 'atsdb';
 
 alter table atsdb drop column n;
 alter table atsdb set with(appendonly = true, compresslevel = 3);
-ERROR:  cannot specify more than one option in WITH clause
 select relname, segrelid != 0, reloptions from pg_class, pg_appendonly where pg_class.oid =
 'atsdb'::regclass and relid = pg_class.oid;
  relname | ?column? | reloptions 
 ---------+----------+------------
-(0 rows)
+ atsdb   | t        | 
+(1 row)
 
 select * from distcheck where rel = 'atsdb';
   rel  | attname 
@@ -445,7 +445,8 @@ select relname, segrelid != 0, reloptions from pg_class, pg_appendonly where pg_
 'atsdb'::regclass and relid = pg_class.oid;
  relname | ?column? | reloptions 
 ---------+----------+------------
-(0 rows)
+ atsdb   | t        | 
+(1 row)
 
 select * from atsdb;
   j  |  t  
@@ -554,10 +555,12 @@ select * from atsdb;
 
 -- validate parameters
 alter table atsdb set with (appendonly = ff);
-ERROR:  option "appendonly" not supported
+ERROR:  appendonly requires a Boolean value
 alter table atsdb set with (reorganize = true);
 alter table atsdb set with (fgdfgef = asds);
-ERROR:  option "fgdfgef" not supported
+ERROR:  invalid storage type
+LINE 1: alter table atsdb set with (fgdfgef = asds);
+                                   ^
 alter table atsdb set with(reorganize = true, reorganize = false) distributed
 randomly;
 ERROR:  cannot specify more than one option in WITH clause
@@ -648,7 +651,7 @@ select * from atsdb order by 1, 2, 3;
 (9 rows)
 
 alter table atsdb set with(appendonly = true);
-ERROR:  option "appendonly" not supported
+ERROR:  cannot change access method of a partitioned table
 select relname, a.blocksize, compresslevel, compresstype, checksum from pg_class c, pg_appendonly a where
 relname  like 'atsdb%' and c.oid = a.relid order by 1;
  relname | blocksize | compresslevel | compresstype | checksum 
@@ -762,7 +765,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into mpp5746 select array[i], i from generate_series(1, 100) i;
 alter table mpp5746 set with (reorganize=true, appendonly = true);
-ERROR:  cannot specify more than one option in WITH clause
+ERROR:  reorganize isn't supported with other options in SET WITH
 select * from mpp5746 order by 1;
    c   |  t  
 -------+-----
@@ -975,7 +978,7 @@ select * from mpp5746 order by 1;
 (100 rows)
 
 alter table mpp5746 set with (reorganize=true, appendonly = false);
-ERROR:  cannot specify more than one option in WITH clause
+ERROR:  reorganize isn't supported with other options in SET WITH
 select * from mpp5746 order by 1;
    c   
 -------
@@ -1104,7 +1107,7 @@ select * from mpp5738;
 (10 rows)
 
 alter table mpp5738 alter partition for (1) set with (appendonly=true);
-ERROR:  option "appendonly" not supported
+ERROR:  table "mpp5738_1_prt_1" is not partitioned
 select * from mpp5738;
  a  | b  | c  | d  
 ----+----+----+----
@@ -1233,15 +1236,11 @@ Alter table abc set with (reorganize=false) distributed randomly;
 WARNING:  distribution policy of relation "abc" already set to DISTRIBUTED RANDOMLY
 HINT:  Use ALTER TABLE "abc" SET WITH (REORGANIZE=TRUE) DISTRIBUTED RANDOMLY to force a random redistribution.
 drop table abc;
--- disallow, so fails
-create table atsdb (i int, j text) distributed by (j);
-alter table atsdb set with(appendonly = true);
-ERROR:  option "appendonly" not supported
-drop table atsdb;
 -- MPP-18660: duplicate entry in gp_distribution_policy
 set enable_indexscan=on;
 set enable_seqscan=off;
 drop table if exists distrib_index_test;
+NOTICE:  table "distrib_index_test" does not exist, skipping
 create table distrib_index_test (a int, b text) distributed by (a);
 select count(*) from gp_distribution_policy
 	where localoid in (select oid from pg_class where relname='distrib_index_test');

--- a/src/test/regress/expected/alter_table_set_am.out
+++ b/src/test/regress/expected/alter_table_set_am.out
@@ -1,31 +1,34 @@
 -- Check changing table access method
 -- Scenario 1: Heap to Heap
 CREATE TABLE heap2heap(a int, b int) DISTRIBUTED BY (a);
+CREATE TABLE heap2heap2(a int, b int) DISTRIBUTED BY (a);
 INSERT INTO heap2heap SELECT i,i FROM generate_series(1,5) i;
+INSERT INTO heap2heap2 SELECT i,i FROM generate_series(1,5) i;
 CREATE TEMP TABLE relfilebeforeheap AS
-    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heap2heap')
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heap2heap', 'heap2heap2')
     UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
-    WHERE relname in ('heap2heap') ORDER BY segid;
+    WHERE relname in ('heap2heap', 'heap2heap2') ORDER BY segid;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- changing to the same access method shouldn't rewrite the table
 -- (i.e. the relfilenodes shouldn't change)
 ALTER TABLE heap2heap SET ACCESS METHOD heap;
+ALTER TABLE heap2heap2 SET WITH (appendoptimized=false);
 CREATE TEMP TABLE relfileafterheap AS
-    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heap2heap')
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heap2heap', 'heap2heap2')
     UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
-    WHERE relname in ('heap2heap') ORDER BY segid;
+    WHERE relname in ('heap2heap', 'heap2heap2') ORDER BY segid;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- relfilenodes shouldn't change
 SELECT count(*) FROM (SELECT * FROM relfilebeforeheap UNION SELECT * FROM relfileafterheap)a;
  count 
 -------
-     4
+     8
 (1 row)
 
 -- Scenario 2: Heap to AO
-CREATE TABLE heap2ao(a int, b int) DISTRIBUTED BY (a);
+CREATE TABLE heap2ao(a int, b int) WITH (fillfactor=70) DISTRIBUTED BY (a);
 CREATE TABLE heap2ao2(a int, b int) DISTRIBUTED BY (a);
 CREATE INDEX heapi ON heap2ao(b);
 ALTER TABLE heap2ao2 ADD CONSTRAINT unique_constraint UNIQUE (a);
@@ -47,53 +50,42 @@ ALTER TABLE heap2ao2 DROP CONSTRAINT unique_constraint;
 SET gp_default_storage_options = 'blocksize=65536, compresstype=zlib, compresslevel=5, checksum=true';
 -- Alter table heap to AO should work
 ALTER TABLE heap2ao SET ACCESS METHOD ao_row;
-ALTER TABLE heap2ao2 SET ACCESS METHOD ao_row;
+ALTER TABLE heap2ao2 SET WITH (appendoptimized=true);
 -- The altered table should inherit storage options from gp_default_storage_options
 SELECT blocksize,compresslevel,checksum,compresstype,columnstore
-FROM pg_appendonly WHERE relid='heap2ao'::regclass::oid;
+FROM pg_appendonly WHERE relid in ('heap2ao'::regclass::oid, 'heap2ao2'::regclass::oid);
  blocksize | compresslevel | checksum | compresstype | columnstore 
 -----------+---------------+----------+--------------+-------------
      65536 |             5 | t        | zlib         | f
-(1 row)
-
-SELECT reloptions from pg_class where relname='heap2ao';
-            reloptions             
------------------------------------
- {blocksize=65536,compresslevel=5}
-(1 row)
-
-SELECT blocksize,compresslevel,checksum,compresstype,columnstore
-FROM pg_appendonly WHERE relid='heap2ao2'::regclass::oid;
- blocksize | compresslevel | checksum | compresstype | columnstore 
------------+---------------+----------+--------------+-------------
      65536 |             5 | t        | zlib         | f
-(1 row)
+(2 rows)
 
-SELECT reloptions from pg_class where relname='heap2ao2';
+SELECT reloptions from pg_class where relname in ('heap2ao', 'heap2ao2');
             reloptions             
 -----------------------------------
  {blocksize=65536,compresslevel=5}
-(1 row)
+ {blocksize=65536,compresslevel=5}
+(2 rows)
 
 -- Check data is intact
 SELECT * FROM heap2ao;
  a | b 
 ---+---
+ 1 | 1
  2 | 2
  3 | 3
  4 | 4
- 1 | 1
  5 | 5
 (5 rows)
 
 SELECT * FROM heap2ao2;
  a | b 
 ---+---
- 5 | 5
+ 1 | 1
  2 | 2
  3 | 3
  4 | 4
- 1 | 1
+ 5 | 5
 (5 rows)
 
 -- The tables and indexes should have been rewritten (should have different relfilenodes)
@@ -113,9 +105,9 @@ SELECT * FROM relfilebeforeao INTERSECT SELECT * FROM relfileafterao;
 SELECT * FROM gp_toolkit.__gp_aoseg('heap2ao');
  segment_id | segno | eof | tupcount | varblockcount | eof_uncompressed | modcount | formatversion | state 
 ------------+-------+-----+----------+---------------+------------------+----------+---------------+-------
+          2 |     0 |  40 |        1 |             1 |               40 |        1 |             3 |     1
           0 |     0 |  72 |        3 |             1 |               88 |        1 |             3 |     1
           1 |     0 |  40 |        1 |             1 |               40 |        1 |             3 |     1
-          2 |     0 |  40 |        1 |             1 |               40 |        1 |             3 |     1
 (3 rows)
 
 SELECT * FROM gp_toolkit.__gp_aovisimap('heap2ao');
@@ -136,29 +128,35 @@ SELECT * FROM gp_toolkit.__gp_aovisimap('heap2ao2');
 -----+-------+---------
 (0 rows)
 
-DROP TABLE heap2ao;
-DROP TABLE heap2ao2;
 -- check inherited tables
 CREATE TABLE heapbase (a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TABLE child (c int) INHERITS (heapbase);
 NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE heapbase2 (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE child2 (c int) INHERITS (heapbase2);
+NOTICE:  table has parent, setting distribution columns to match parent table
 INSERT INTO heapbase SELECT i,i FROM generate_series(1,5) i;
 INSERT INTO child SELECT i,i,i FROM generate_series(1,5) i;
+INSERT INTO heapbase2 SELECT i,i FROM generate_series(1,5) i;
+INSERT INTO child2 SELECT i,i,i FROM generate_series(1,5) i;
 CREATE TEMP TABLE inheritrelfilebefore AS
-    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heapbase')
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heapbase', 'heapbase2')
     UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
-    WHERE relname in ('heapbase') ORDER BY segid;
+    WHERE relname in ('heapbase', 'heapbase2') ORDER BY segid;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TEMP TABLE inheritchildrelfilebefore AS
-    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('child')
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('child', 'child2')
     UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
-    WHERE relname in ('child') ORDER BY segid;
+    WHERE relname in ('child', 'child2') ORDER BY segid;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ALTER TABLE heapbase SET ACCESS METHOD ao_row;
+ALTER TABLE heapbase2 SET WITH (appendoptimized=true);
 -- The altered table should inherit storage options from gp_default_storage_options
 show gp_default_storage_options;
                    gp_default_storage_options                    
@@ -167,38 +165,41 @@ show gp_default_storage_options;
 (1 row)
 
 SELECT blocksize,compresslevel,checksum,compresstype,columnstore
-FROM pg_appendonly WHERE relid='heapbase'::regclass::oid;
+FROM pg_appendonly WHERE relid in ('heapbase'::regclass::oid, 'heapbase2'::regclass::oid);
  blocksize | compresslevel | checksum | compresstype | columnstore 
 -----------+---------------+----------+--------------+-------------
      65536 |             5 | t        | zlib         | f
-(1 row)
+     65536 |             5 | t        | zlib         | f
+(2 rows)
 
-SELECT reloptions from pg_class where relname='heapbase';
+SELECT reloptions from pg_class where relname in ('heapbase','heapbase2');
             reloptions             
 -----------------------------------
  {blocksize=65536,compresslevel=5}
-(1 row)
+ {blocksize=65536,compresslevel=5}
+(2 rows)
 
 SELECT blocksize,compresslevel,checksum,compresstype,columnstore
-FROM pg_appendonly WHERE relid='child'::regclass::oid;
+FROM pg_appendonly WHERE relid in ('child'::regclass::oid, 'child2'::regclass::oid);
  blocksize | compresslevel | checksum | compresstype | columnstore 
 -----------+---------------+----------+--------------+-------------
 (0 rows)
 
-SELECT reloptions from pg_class where relname='child';
+SELECT reloptions from pg_class where relname in ('child','child2');
  reloptions 
 ------------
  
-(1 row)
+ 
+(2 rows)
 
 -- Check data is intact
 SELECT * FROM heapbase;
  a | b 
 ---+---
- 1 | 1
- 1 | 1
  5 | 5
  5 | 5
+ 1 | 1
+ 1 | 1
  2 | 2
  3 | 3
  4 | 4
@@ -207,11 +208,26 @@ SELECT * FROM heapbase;
  4 | 4
 (10 rows)
 
+SELECT * FROM heapbase2;
+ a | b 
+---+---
+ 2 | 2
+ 3 | 3
+ 4 | 4
+ 2 | 2
+ 3 | 3
+ 4 | 4
+ 5 | 5
+ 5 | 5
+ 1 | 1
+ 1 | 1
+(10 rows)
+
 -- relfile node should change for base table set to AO
 CREATE TEMP TABLE inheritrelfileafter AS
-    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heapbase')
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heapbase', 'heapbase2')
     UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
-    WHERE relname in ('heapbase') ORDER BY segid;
+    WHERE relname in ('heapbase', 'heapbase2') ORDER BY segid;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 SELECT * FROM inheritrelfilebefore INTERSECT SELECT * FROM inheritrelfileafter;
@@ -221,15 +237,15 @@ SELECT * FROM inheritrelfilebefore INTERSECT SELECT * FROM inheritrelfileafter;
 
 -- relfile node should not change for child table
 CREATE TEMP TABLE inheritchildrelfileafter AS
-    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('child')
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('child', 'child2')
     UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
-    WHERE relname in ('child') ORDER BY segid;
+    WHERE relname in ('child', 'child2') ORDER BY segid;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 SELECT count(*) FROM (SELECT * FROM inheritchildrelfilebefore UNION SELECT * FROM inheritchildrelfileafter)a;
  count 
 -------
-     4
+     8
 (1 row)
 
 -- aux tables are created, pg_appendonly row is created
@@ -246,10 +262,25 @@ SELECT * FROM gp_toolkit.__gp_aovisimap('heapbase');
 -----+-------+---------
 (0 rows)
 
+SELECT * FROM gp_toolkit.__gp_aoseg('heapbase2');
+ segment_id | segno | eof | tupcount | varblockcount | eof_uncompressed | modcount | formatversion | state 
+------------+-------+-----+----------+---------------+------------------+----------+---------------+-------
+          1 |     0 |  40 |        1 |             1 |               40 |        1 |             3 |     1
+          2 |     0 |  40 |        1 |             1 |               40 |        1 |             3 |     1
+          0 |     0 |  72 |        3 |             1 |               88 |        1 |             3 |     1
+(3 rows)
+
+SELECT * FROM gp_toolkit.__gp_aovisimap('heapbase2');
+ tid | segno | row_num 
+-----+-------+---------
+(0 rows)
+
 -- aux tables are not created for child table
 SELECT * FROM gp_toolkit.__gp_aoseg('child');
-ERROR:  'child' is not an append-only row relation  (seg0 slice1 127.0.0.1:7002 pid=19419)
+ERROR:  'child' is not an append-only row relation  (seg0 slice1 127.0.0.1:7002 pid=29947)
 SELECT * FROM gp_toolkit.__gp_aovisimap('child');
 ERROR:  function not supported on relation
-DROP TABLE heapbase CASCADE;
-NOTICE:  drop cascades to table child
+SELECT * FROM gp_toolkit.__gp_aoseg('child2');
+ERROR:  'child2' is not an append-only row relation  (seg0 slice1 127.0.0.1:7002 pid=29947)
+SELECT * FROM gp_toolkit.__gp_aovisimap('child2');
+ERROR:  function not supported on relation

--- a/src/test/regress/expected/alter_table_set_am.out
+++ b/src/test/regress/expected/alter_table_set_am.out
@@ -1,0 +1,255 @@
+-- Check changing table access method
+-- Scenario 1: Heap to Heap
+CREATE TABLE heap2heap(a int, b int) DISTRIBUTED BY (a);
+INSERT INTO heap2heap SELECT i,i FROM generate_series(1,5) i;
+CREATE TEMP TABLE relfilebeforeheap AS
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heap2heap')
+    UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname in ('heap2heap') ORDER BY segid;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- changing to the same access method shouldn't rewrite the table
+-- (i.e. the relfilenodes shouldn't change)
+ALTER TABLE heap2heap SET ACCESS METHOD heap;
+CREATE TEMP TABLE relfileafterheap AS
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heap2heap')
+    UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname in ('heap2heap') ORDER BY segid;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- relfilenodes shouldn't change
+SELECT count(*) FROM (SELECT * FROM relfilebeforeheap UNION SELECT * FROM relfileafterheap)a;
+ count 
+-------
+     4
+(1 row)
+
+-- Scenario 2: Heap to AO
+CREATE TABLE heap2ao(a int, b int) DISTRIBUTED BY (a);
+CREATE TABLE heap2ao2(a int, b int) DISTRIBUTED BY (a);
+CREATE INDEX heapi ON heap2ao(b);
+ALTER TABLE heap2ao2 ADD CONSTRAINT unique_constraint UNIQUE (a);
+INSERT INTO heap2ao SELECT i,i FROM generate_series(1,5) i;
+INSERT INTO heap2ao2 SELECT i,i FROM generate_series(1,5) i;
+CREATE TEMP TABLE relfilebeforeao AS
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heap2ao', 'heap2ao2', 'heapi')
+    UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname in ('heap2ao', 'heap2ao2', 'heapi') ORDER BY segid;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Altering a heap table with a unique index to AO should error out
+-- as unique indexes aren't supported on AO tables
+ALTER TABLE heap2ao2 SET ACCESS METHOD ao_row;
+ERROR:  append-only tables do not support unique indexes
+DETAIL:  heap table "heap2ao2" being altered contains unique index
+ALTER TABLE heap2ao2 DROP CONSTRAINT unique_constraint;
+-- Set default storage options for the table to inherit from
+SET gp_default_storage_options = 'blocksize=65536, compresstype=zlib, compresslevel=5, checksum=true';
+-- Alter table heap to AO should work
+ALTER TABLE heap2ao SET ACCESS METHOD ao_row;
+ALTER TABLE heap2ao2 SET ACCESS METHOD ao_row;
+-- The altered table should inherit storage options from gp_default_storage_options
+SELECT blocksize,compresslevel,checksum,compresstype,columnstore
+FROM pg_appendonly WHERE relid='heap2ao'::regclass::oid;
+ blocksize | compresslevel | checksum | compresstype | columnstore 
+-----------+---------------+----------+--------------+-------------
+     65536 |             5 | t        | zlib         | f
+(1 row)
+
+SELECT reloptions from pg_class where relname='heap2ao';
+            reloptions             
+-----------------------------------
+ {blocksize=65536,compresslevel=5}
+(1 row)
+
+SELECT blocksize,compresslevel,checksum,compresstype,columnstore
+FROM pg_appendonly WHERE relid='heap2ao2'::regclass::oid;
+ blocksize | compresslevel | checksum | compresstype | columnstore 
+-----------+---------------+----------+--------------+-------------
+     65536 |             5 | t        | zlib         | f
+(1 row)
+
+SELECT reloptions from pg_class where relname='heap2ao2';
+            reloptions             
+-----------------------------------
+ {blocksize=65536,compresslevel=5}
+(1 row)
+
+-- Check data is intact
+SELECT * FROM heap2ao;
+ a | b 
+---+---
+ 2 | 2
+ 3 | 3
+ 4 | 4
+ 1 | 1
+ 5 | 5
+(5 rows)
+
+SELECT * FROM heap2ao2;
+ a | b 
+---+---
+ 5 | 5
+ 2 | 2
+ 3 | 3
+ 4 | 4
+ 1 | 1
+(5 rows)
+
+-- The tables and indexes should have been rewritten (should have different relfilenodes)
+CREATE TEMP TABLE relfileafterao AS
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heap2ao', 'heap2ao2', 'heapi')
+    UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname in ('heap2ao', 'heap2ao2', 'heapi') ORDER BY segid;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT * FROM relfilebeforeao INTERSECT SELECT * FROM relfileafterao;
+ segid | relfilenode 
+-------+-------------
+(0 rows)
+
+-- aux tables are created, pg_appendonly row is created
+-- FIXME: add check for gp_aoblkdir
+SELECT * FROM gp_toolkit.__gp_aoseg('heap2ao');
+ segment_id | segno | eof | tupcount | varblockcount | eof_uncompressed | modcount | formatversion | state 
+------------+-------+-----+----------+---------------+------------------+----------+---------------+-------
+          0 |     0 |  72 |        3 |             1 |               88 |        1 |             3 |     1
+          1 |     0 |  40 |        1 |             1 |               40 |        1 |             3 |     1
+          2 |     0 |  40 |        1 |             1 |               40 |        1 |             3 |     1
+(3 rows)
+
+SELECT * FROM gp_toolkit.__gp_aovisimap('heap2ao');
+ tid | segno | row_num 
+-----+-------+---------
+(0 rows)
+
+SELECT * FROM gp_toolkit.__gp_aoseg('heap2ao2');
+ segment_id | segno | eof | tupcount | varblockcount | eof_uncompressed | modcount | formatversion | state 
+------------+-------+-----+----------+---------------+------------------+----------+---------------+-------
+          1 |     0 |  40 |        1 |             1 |               40 |        1 |             3 |     1
+          2 |     0 |  40 |        1 |             1 |               40 |        1 |             3 |     1
+          0 |     0 |  72 |        3 |             1 |               88 |        1 |             3 |     1
+(3 rows)
+
+SELECT * FROM gp_toolkit.__gp_aovisimap('heap2ao2');
+ tid | segno | row_num 
+-----+-------+---------
+(0 rows)
+
+DROP TABLE heap2ao;
+DROP TABLE heap2ao2;
+-- check inherited tables
+CREATE TABLE heapbase (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE child (c int) INHERITS (heapbase);
+NOTICE:  table has parent, setting distribution columns to match parent table
+INSERT INTO heapbase SELECT i,i FROM generate_series(1,5) i;
+INSERT INTO child SELECT i,i,i FROM generate_series(1,5) i;
+CREATE TEMP TABLE inheritrelfilebefore AS
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heapbase')
+    UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname in ('heapbase') ORDER BY segid;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TEMP TABLE inheritchildrelfilebefore AS
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('child')
+    UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname in ('child') ORDER BY segid;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ALTER TABLE heapbase SET ACCESS METHOD ao_row;
+-- The altered table should inherit storage options from gp_default_storage_options
+show gp_default_storage_options;
+                   gp_default_storage_options                    
+-----------------------------------------------------------------
+ blocksize=65536,compresstype=zlib,compresslevel=5,checksum=true
+(1 row)
+
+SELECT blocksize,compresslevel,checksum,compresstype,columnstore
+FROM pg_appendonly WHERE relid='heapbase'::regclass::oid;
+ blocksize | compresslevel | checksum | compresstype | columnstore 
+-----------+---------------+----------+--------------+-------------
+     65536 |             5 | t        | zlib         | f
+(1 row)
+
+SELECT reloptions from pg_class where relname='heapbase';
+            reloptions             
+-----------------------------------
+ {blocksize=65536,compresslevel=5}
+(1 row)
+
+SELECT blocksize,compresslevel,checksum,compresstype,columnstore
+FROM pg_appendonly WHERE relid='child'::regclass::oid;
+ blocksize | compresslevel | checksum | compresstype | columnstore 
+-----------+---------------+----------+--------------+-------------
+(0 rows)
+
+SELECT reloptions from pg_class where relname='child';
+ reloptions 
+------------
+ 
+(1 row)
+
+-- Check data is intact
+SELECT * FROM heapbase;
+ a | b 
+---+---
+ 1 | 1
+ 1 | 1
+ 5 | 5
+ 5 | 5
+ 2 | 2
+ 3 | 3
+ 4 | 4
+ 2 | 2
+ 3 | 3
+ 4 | 4
+(10 rows)
+
+-- relfile node should change for base table set to AO
+CREATE TEMP TABLE inheritrelfileafter AS
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heapbase')
+    UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname in ('heapbase') ORDER BY segid;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT * FROM inheritrelfilebefore INTERSECT SELECT * FROM inheritrelfileafter;
+ segid | relfilenode 
+-------+-------------
+(0 rows)
+
+-- relfile node should not change for child table
+CREATE TEMP TABLE inheritchildrelfileafter AS
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('child')
+    UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname in ('child') ORDER BY segid;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT count(*) FROM (SELECT * FROM inheritchildrelfilebefore UNION SELECT * FROM inheritchildrelfileafter)a;
+ count 
+-------
+     4
+(1 row)
+
+-- aux tables are created, pg_appendonly row is created
+SELECT * FROM gp_toolkit.__gp_aoseg('heapbase');
+ segment_id | segno | eof | tupcount | varblockcount | eof_uncompressed | modcount | formatversion | state 
+------------+-------+-----+----------+---------------+------------------+----------+---------------+-------
+          0 |     0 |  72 |        3 |             1 |               88 |        1 |             3 |     1
+          1 |     0 |  40 |        1 |             1 |               40 |        1 |             3 |     1
+          2 |     0 |  40 |        1 |             1 |               40 |        1 |             3 |     1
+(3 rows)
+
+SELECT * FROM gp_toolkit.__gp_aovisimap('heapbase');
+ tid | segno | row_num 
+-----+-------+---------
+(0 rows)
+
+-- aux tables are not created for child table
+SELECT * FROM gp_toolkit.__gp_aoseg('child');
+ERROR:  'child' is not an append-only row relation  (seg0 slice1 127.0.0.1:7002 pid=19419)
+SELECT * FROM gp_toolkit.__gp_aovisimap('child');
+ERROR:  function not supported on relation
+DROP TABLE heapbase CASCADE;
+NOTICE:  drop cascades to table child

--- a/src/test/regress/expected/create_am.out
+++ b/src/test/regress/expected/create_am.out
@@ -238,6 +238,40 @@ ORDER BY classid, objid, objsubid;
  table tableam_parted_d_heap2
 (5 rows)
 
+-- ALTER TABLE SET ACCESS METHOD
+CREATE TABLE heaptable USING heap AS
+  SELECT a, repeat(a::text, 100) FROM generate_series(1,9) AS a;
+SELECT amname FROM pg_class c, pg_am am
+  WHERE c.relam = am.oid AND c.oid = 'heaptable'::regclass;
+ amname 
+--------
+ heap
+(1 row)
+
+ALTER TABLE heaptable SET ACCESS METHOD heap2;
+SELECT amname FROM pg_class c, pg_am am
+  WHERE c.relam = am.oid AND c.oid = 'heaptable'::regclass;
+ amname 
+--------
+ heap2
+(1 row)
+
+SELECT COUNT(a), COUNT(1) FILTER(WHERE a=1) FROM heaptable;
+ count | count 
+-------+-------
+     9 |     1
+(1 row)
+
+-- No support for multiple subcommands
+ALTER TABLE heaptable SET ACCESS METHOD heap, SET ACCESS METHOD heap2;
+ERROR:  cannot have multiple SET ACCESS METHOD subcommands
+DROP TABLE heaptable;
+-- No support for partitioned tables.
+CREATE TABLE am_partitioned(x INT, y INT)
+  PARTITION BY hash (x);
+ALTER TABLE am_partitioned SET ACCESS METHOD heap2;
+ERROR:  cannot change access method of a partitioned table
+DROP TABLE am_partitioned;
 -- Second, create objects in the new AM by changing the default AM
 BEGIN;
 SET LOCAL default_table_access_method = 'heap2';

--- a/src/test/regress/expected/create_am_optimizer.out
+++ b/src/test/regress/expected/create_am_optimizer.out
@@ -237,6 +237,43 @@ ORDER BY classid, objid, objsubid;
  table tableam_parted_d_heap2
 (5 rows)
 
+-- ALTER TABLE SET ACCESS METHOD
+CREATE TABLE heaptable USING heap AS
+  SELECT a, repeat(a::text, 100) FROM generate_series(1,9) AS a;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+SELECT amname FROM pg_class c, pg_am am
+  WHERE c.relam = am.oid AND c.oid = 'heaptable'::regclass;
+ amname 
+--------
+ heap
+(1 row)
+
+ALTER TABLE heaptable SET ACCESS METHOD heap2;
+SELECT amname FROM pg_class c, pg_am am
+  WHERE c.relam = am.oid AND c.oid = 'heaptable'::regclass;
+ amname 
+--------
+ heap2
+(1 row)
+
+SELECT COUNT(a), COUNT(1) FILTER(WHERE a=1) FROM heaptable;
+ count | count 
+-------+-------
+     9 |     1
+(1 row)
+
+-- No support for multiple subcommands
+ALTER TABLE heaptable SET ACCESS METHOD heap, SET ACCESS METHOD heap2;
+ERROR:  cannot have multiple SET ACCESS METHOD subcommands
+DROP TABLE heaptable;
+-- No support for partitioned tables.
+CREATE TABLE am_partitioned(x INT, y INT)
+  PARTITION BY hash (x);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ALTER TABLE am_partitioned SET ACCESS METHOD heap2;
+ERROR:  cannot change access method of a partitioned table
+DROP TABLE am_partitioned;
 -- Second, create objects in the new AM by changing the default AM
 BEGIN;
 SET LOCAL default_table_access_method = 'heap2';

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -130,7 +130,7 @@ test: db_size_functions
 
 ignore: gp_portal_error
 test: external_table external_table_union_all external_table_create_privs external_table_persistent_error_log column_compression eagerfree alter_table_aocs alter_table_aocs2 alter_distribution_policy aoco_privileges
-test: alter_table_set alter_table_gp alter_table_ao subtransaction_visibility oid_consistency udf_exception_blocks
+test: alter_table_set alter_table_gp alter_table_ao alter_table_set_am subtransaction_visibility oid_consistency udf_exception_blocks
 # below test(s) inject faults so each of them need to be in a separate group
 test: aocs
 test: ic

--- a/src/test/regress/sql/alter_distribution_policy.sql
+++ b/src/test/regress/sql/alter_distribution_policy.sql
@@ -308,11 +308,6 @@ Alter table abc set distributed randomly;
 Alter table abc set with (reorganize=false) distributed randomly;
 drop table abc;
 
--- disallow, so fails
-create table atsdb (i int, j text) distributed by (j);
-alter table atsdb set with(appendonly = true);
-drop table atsdb;
-
 -- MPP-18660: duplicate entry in gp_distribution_policy
 set enable_indexscan=on;
 set enable_seqscan=off;

--- a/src/test/regress/sql/alter_table_set_am.sql
+++ b/src/test/regress/sql/alter_table_set_am.sql
@@ -1,0 +1,139 @@
+-- Check changing table access method
+
+-- Scenario 1: Heap to Heap
+CREATE TABLE heap2heap(a int, b int) DISTRIBUTED BY (a);
+
+INSERT INTO heap2heap SELECT i,i FROM generate_series(1,5) i;
+
+CREATE TEMP TABLE relfilebeforeheap AS
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heap2heap')
+    UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname in ('heap2heap') ORDER BY segid;
+
+-- changing to the same access method shouldn't rewrite the table
+-- (i.e. the relfilenodes shouldn't change)
+ALTER TABLE heap2heap SET ACCESS METHOD heap;
+
+CREATE TEMP TABLE relfileafterheap AS
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heap2heap')
+    UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname in ('heap2heap') ORDER BY segid;
+
+-- relfilenodes shouldn't change
+SELECT count(*) FROM (SELECT * FROM relfilebeforeheap UNION SELECT * FROM relfileafterheap)a;
+
+
+-- Scenario 2: Heap to AO
+CREATE TABLE heap2ao(a int, b int) DISTRIBUTED BY (a);
+CREATE TABLE heap2ao2(a int, b int) DISTRIBUTED BY (a);
+
+CREATE INDEX heapi ON heap2ao(b);
+ALTER TABLE heap2ao2 ADD CONSTRAINT unique_constraint UNIQUE (a);
+
+INSERT INTO heap2ao SELECT i,i FROM generate_series(1,5) i;
+INSERT INTO heap2ao2 SELECT i,i FROM generate_series(1,5) i;
+
+CREATE TEMP TABLE relfilebeforeao AS
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heap2ao', 'heap2ao2', 'heapi')
+    UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname in ('heap2ao', 'heap2ao2', 'heapi') ORDER BY segid;
+
+-- Altering a heap table with a unique index to AO should error out
+-- as unique indexes aren't supported on AO tables
+ALTER TABLE heap2ao2 SET ACCESS METHOD ao_row;
+ALTER TABLE heap2ao2 DROP CONSTRAINT unique_constraint;
+
+-- Set default storage options for the table to inherit from
+SET gp_default_storage_options = 'blocksize=65536, compresstype=zlib, compresslevel=5, checksum=true';
+
+-- Alter table heap to AO should work
+ALTER TABLE heap2ao SET ACCESS METHOD ao_row;
+ALTER TABLE heap2ao2 SET ACCESS METHOD ao_row;
+
+-- The altered table should inherit storage options from gp_default_storage_options
+SELECT blocksize,compresslevel,checksum,compresstype,columnstore
+FROM pg_appendonly WHERE relid='heap2ao'::regclass::oid;
+SELECT reloptions from pg_class where relname='heap2ao';
+SELECT blocksize,compresslevel,checksum,compresstype,columnstore
+FROM pg_appendonly WHERE relid='heap2ao2'::regclass::oid;
+SELECT reloptions from pg_class where relname='heap2ao2';
+
+-- Check data is intact
+SELECT * FROM heap2ao;
+SELECT * FROM heap2ao2;
+
+-- The tables and indexes should have been rewritten (should have different relfilenodes)
+CREATE TEMP TABLE relfileafterao AS
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heap2ao', 'heap2ao2', 'heapi')
+    UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname in ('heap2ao', 'heap2ao2', 'heapi') ORDER BY segid;
+
+SELECT * FROM relfilebeforeao INTERSECT SELECT * FROM relfileafterao;
+
+-- aux tables are created, pg_appendonly row is created
+-- FIXME: add check for gp_aoblkdir
+SELECT * FROM gp_toolkit.__gp_aoseg('heap2ao');
+SELECT * FROM gp_toolkit.__gp_aovisimap('heap2ao');
+SELECT * FROM gp_toolkit.__gp_aoseg('heap2ao2');
+SELECT * FROM gp_toolkit.__gp_aovisimap('heap2ao2');
+
+DROP TABLE heap2ao;
+DROP TABLE heap2ao2;
+
+
+-- check inherited tables
+CREATE TABLE heapbase (a int, b int);
+CREATE TABLE child (c int) INHERITS (heapbase);
+
+INSERT INTO heapbase SELECT i,i FROM generate_series(1,5) i;
+INSERT INTO child SELECT i,i,i FROM generate_series(1,5) i;
+
+CREATE TEMP TABLE inheritrelfilebefore AS
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heapbase')
+    UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname in ('heapbase') ORDER BY segid;
+
+CREATE TEMP TABLE inheritchildrelfilebefore AS
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('child')
+    UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname in ('child') ORDER BY segid;
+
+ALTER TABLE heapbase SET ACCESS METHOD ao_row;
+
+-- The altered table should inherit storage options from gp_default_storage_options
+show gp_default_storage_options;
+SELECT blocksize,compresslevel,checksum,compresstype,columnstore
+FROM pg_appendonly WHERE relid='heapbase'::regclass::oid;
+SELECT reloptions from pg_class where relname='heapbase';
+SELECT blocksize,compresslevel,checksum,compresstype,columnstore
+FROM pg_appendonly WHERE relid='child'::regclass::oid;
+SELECT reloptions from pg_class where relname='child';
+
+-- Check data is intact
+SELECT * FROM heapbase;
+
+-- relfile node should change for base table set to AO
+CREATE TEMP TABLE inheritrelfileafter AS
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heapbase')
+    UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname in ('heapbase') ORDER BY segid;
+
+SELECT * FROM inheritrelfilebefore INTERSECT SELECT * FROM inheritrelfileafter;
+
+-- relfile node should not change for child table
+CREATE TEMP TABLE inheritchildrelfileafter AS
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('child')
+    UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname in ('child') ORDER BY segid;
+
+SELECT count(*) FROM (SELECT * FROM inheritchildrelfilebefore UNION SELECT * FROM inheritchildrelfileafter)a;
+
+-- aux tables are created, pg_appendonly row is created
+SELECT * FROM gp_toolkit.__gp_aoseg('heapbase');
+SELECT * FROM gp_toolkit.__gp_aovisimap('heapbase');
+
+-- aux tables are not created for child table
+SELECT * FROM gp_toolkit.__gp_aoseg('child');
+SELECT * FROM gp_toolkit.__gp_aovisimap('child');
+
+DROP TABLE heapbase CASCADE;

--- a/src/test/regress/sql/alter_table_set_am.sql
+++ b/src/test/regress/sql/alter_table_set_am.sql
@@ -2,29 +2,32 @@
 
 -- Scenario 1: Heap to Heap
 CREATE TABLE heap2heap(a int, b int) DISTRIBUTED BY (a);
+CREATE TABLE heap2heap2(a int, b int) DISTRIBUTED BY (a);
 
 INSERT INTO heap2heap SELECT i,i FROM generate_series(1,5) i;
+INSERT INTO heap2heap2 SELECT i,i FROM generate_series(1,5) i;
 
 CREATE TEMP TABLE relfilebeforeheap AS
-    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heap2heap')
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heap2heap', 'heap2heap2')
     UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
-    WHERE relname in ('heap2heap') ORDER BY segid;
+    WHERE relname in ('heap2heap', 'heap2heap2') ORDER BY segid;
 
 -- changing to the same access method shouldn't rewrite the table
 -- (i.e. the relfilenodes shouldn't change)
 ALTER TABLE heap2heap SET ACCESS METHOD heap;
+ALTER TABLE heap2heap2 SET WITH (appendoptimized=false);
 
 CREATE TEMP TABLE relfileafterheap AS
-    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heap2heap')
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heap2heap', 'heap2heap2')
     UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
-    WHERE relname in ('heap2heap') ORDER BY segid;
+    WHERE relname in ('heap2heap', 'heap2heap2') ORDER BY segid;
 
 -- relfilenodes shouldn't change
 SELECT count(*) FROM (SELECT * FROM relfilebeforeheap UNION SELECT * FROM relfileafterheap)a;
 
 
 -- Scenario 2: Heap to AO
-CREATE TABLE heap2ao(a int, b int) DISTRIBUTED BY (a);
+CREATE TABLE heap2ao(a int, b int) WITH (fillfactor=70) DISTRIBUTED BY (a);
 CREATE TABLE heap2ao2(a int, b int) DISTRIBUTED BY (a);
 
 CREATE INDEX heapi ON heap2ao(b);
@@ -48,15 +51,12 @@ SET gp_default_storage_options = 'blocksize=65536, compresstype=zlib, compressle
 
 -- Alter table heap to AO should work
 ALTER TABLE heap2ao SET ACCESS METHOD ao_row;
-ALTER TABLE heap2ao2 SET ACCESS METHOD ao_row;
+ALTER TABLE heap2ao2 SET WITH (appendoptimized=true);
 
 -- The altered table should inherit storage options from gp_default_storage_options
 SELECT blocksize,compresslevel,checksum,compresstype,columnstore
-FROM pg_appendonly WHERE relid='heap2ao'::regclass::oid;
-SELECT reloptions from pg_class where relname='heap2ao';
-SELECT blocksize,compresslevel,checksum,compresstype,columnstore
-FROM pg_appendonly WHERE relid='heap2ao2'::regclass::oid;
-SELECT reloptions from pg_class where relname='heap2ao2';
+FROM pg_appendonly WHERE relid in ('heap2ao'::regclass::oid, 'heap2ao2'::regclass::oid);
+SELECT reloptions from pg_class where relname in ('heap2ao', 'heap2ao2');
 
 -- Check data is intact
 SELECT * FROM heap2ao;
@@ -77,63 +77,69 @@ SELECT * FROM gp_toolkit.__gp_aovisimap('heap2ao');
 SELECT * FROM gp_toolkit.__gp_aoseg('heap2ao2');
 SELECT * FROM gp_toolkit.__gp_aovisimap('heap2ao2');
 
-DROP TABLE heap2ao;
-DROP TABLE heap2ao2;
-
 
 -- check inherited tables
 CREATE TABLE heapbase (a int, b int);
 CREATE TABLE child (c int) INHERITS (heapbase);
+CREATE TABLE heapbase2 (a int, b int);
+CREATE TABLE child2 (c int) INHERITS (heapbase2);
 
 INSERT INTO heapbase SELECT i,i FROM generate_series(1,5) i;
 INSERT INTO child SELECT i,i,i FROM generate_series(1,5) i;
+INSERT INTO heapbase2 SELECT i,i FROM generate_series(1,5) i;
+INSERT INTO child2 SELECT i,i,i FROM generate_series(1,5) i;
 
 CREATE TEMP TABLE inheritrelfilebefore AS
-    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heapbase')
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heapbase', 'heapbase2')
     UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
-    WHERE relname in ('heapbase') ORDER BY segid;
+    WHERE relname in ('heapbase', 'heapbase2') ORDER BY segid;
 
 CREATE TEMP TABLE inheritchildrelfilebefore AS
-    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('child')
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('child', 'child2')
     UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
-    WHERE relname in ('child') ORDER BY segid;
+    WHERE relname in ('child', 'child2') ORDER BY segid;
 
 ALTER TABLE heapbase SET ACCESS METHOD ao_row;
+ALTER TABLE heapbase2 SET WITH (appendoptimized=true);
 
 -- The altered table should inherit storage options from gp_default_storage_options
 show gp_default_storage_options;
 SELECT blocksize,compresslevel,checksum,compresstype,columnstore
-FROM pg_appendonly WHERE relid='heapbase'::regclass::oid;
-SELECT reloptions from pg_class where relname='heapbase';
+FROM pg_appendonly WHERE relid in ('heapbase'::regclass::oid, 'heapbase2'::regclass::oid);
+SELECT reloptions from pg_class where relname in ('heapbase','heapbase2');
+
 SELECT blocksize,compresslevel,checksum,compresstype,columnstore
-FROM pg_appendonly WHERE relid='child'::regclass::oid;
-SELECT reloptions from pg_class where relname='child';
+FROM pg_appendonly WHERE relid in ('child'::regclass::oid, 'child2'::regclass::oid);
+SELECT reloptions from pg_class where relname in ('child','child2');
 
 -- Check data is intact
 SELECT * FROM heapbase;
+SELECT * FROM heapbase2;
 
 -- relfile node should change for base table set to AO
 CREATE TEMP TABLE inheritrelfileafter AS
-    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heapbase')
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heapbase', 'heapbase2')
     UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
-    WHERE relname in ('heapbase') ORDER BY segid;
+    WHERE relname in ('heapbase', 'heapbase2') ORDER BY segid;
 
 SELECT * FROM inheritrelfilebefore INTERSECT SELECT * FROM inheritrelfileafter;
 
 -- relfile node should not change for child table
 CREATE TEMP TABLE inheritchildrelfileafter AS
-    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('child')
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('child', 'child2')
     UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
-    WHERE relname in ('child') ORDER BY segid;
+    WHERE relname in ('child', 'child2') ORDER BY segid;
 
 SELECT count(*) FROM (SELECT * FROM inheritchildrelfilebefore UNION SELECT * FROM inheritchildrelfileafter)a;
 
 -- aux tables are created, pg_appendonly row is created
 SELECT * FROM gp_toolkit.__gp_aoseg('heapbase');
 SELECT * FROM gp_toolkit.__gp_aovisimap('heapbase');
+SELECT * FROM gp_toolkit.__gp_aoseg('heapbase2');
+SELECT * FROM gp_toolkit.__gp_aovisimap('heapbase2');
 
 -- aux tables are not created for child table
 SELECT * FROM gp_toolkit.__gp_aoseg('child');
 SELECT * FROM gp_toolkit.__gp_aovisimap('child');
-
-DROP TABLE heapbase CASCADE;
+SELECT * FROM gp_toolkit.__gp_aoseg('child2');
+SELECT * FROM gp_toolkit.__gp_aovisimap('child2');

--- a/src/test/regress/sql/create_am.sql
+++ b/src/test/regress/sql/create_am.sql
@@ -158,6 +158,23 @@ WHERE pg_depend.refclassid = 'pg_am'::regclass
     AND pg_am.amname = 'heap2'
 ORDER BY classid, objid, objsubid;
 
+-- ALTER TABLE SET ACCESS METHOD
+CREATE TABLE heaptable USING heap AS
+  SELECT a, repeat(a::text, 100) FROM generate_series(1,9) AS a;
+SELECT amname FROM pg_class c, pg_am am
+  WHERE c.relam = am.oid AND c.oid = 'heaptable'::regclass;
+ALTER TABLE heaptable SET ACCESS METHOD heap2;
+SELECT amname FROM pg_class c, pg_am am
+  WHERE c.relam = am.oid AND c.oid = 'heaptable'::regclass;
+SELECT COUNT(a), COUNT(1) FILTER(WHERE a=1) FROM heaptable;
+-- No support for multiple subcommands
+ALTER TABLE heaptable SET ACCESS METHOD heap, SET ACCESS METHOD heap2;
+DROP TABLE heaptable;
+-- No support for partitioned tables.
+CREATE TABLE am_partitioned(x INT, y INT)
+  PARTITION BY hash (x);
+ALTER TABLE am_partitioned SET ACCESS METHOD heap2;
+DROP TABLE am_partitioned;
 
 -- Second, create objects in the new AM by changing the default AM
 BEGIN;


### PR DESCRIPTION
This PR is a combination of following changes:

Add support for SET ACCESS METHOD in ALTER TABLE - This is a backport of a PG15 commit, motivating the feature to swap in between heap, AO and AOCS tables.

Add support for changing access method from heap to AO.
This change includes creating the catalog entries for AO tables, and AO auxiliary tables, and supporting the `AT SET ACCESS METHOD ao_row;` for heap tables.

Add support for AT SET WITH() syntax to change access method
