### PR TITLE
Resolve GPDB_12_MERGE_FIXME on index fetch tuple routines for Append-Optimized table.

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -615,10 +615,14 @@ static void
 aoco_index_fetch_reset(IndexFetchTableData *scan)
 {
 	/*
-	 * GPDB_12_MERGE_FIXME: Should we close the underlying AOCO fetch desc
-	 * here?  Remember to change the rescan case in aoco_rescan for bitmap
-	 * scan descriptor (AOCSBITMAPSCANDATA).
+	 * Unlike Heap, we don't release the resources (fetch descriptor and its
+	 * members) here because it is more like a global data structure shared
+	 * across scans, rather than an iterator to yield a granularity of data.
+	 * 
+	 * Additionally, should be aware of that no matter whether allocation or
+	 * release on fetch descriptor, it is considerably expensive.
 	 */
+	return;
 }
 
 static void

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -679,11 +679,13 @@ aoco_index_fetch_tuple(struct IndexFetchTableData *scan,
 											  appendOnlyMetaDataSnapshot,
 											  aocoscan->proj);
 	}
-	else
-	{
-		/* GPDB_12_MERGE_FIXME: Is it possible for the 'snapshot' to change
-		 * between calls? Add a sanity check for that here. */
-	}
+
+	/*
+	 * There is no reason to expect changes on snapshot between tuple
+	 * fetching calls after fech_init is called, treat it as a
+	 * programming error in case of occurrence.
+	 */
+	Assert(aocoscan->aocofetch->snapshot == snapshot);
 
 	ExecClearTuple(slot);
 

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -642,6 +642,8 @@ aoco_index_fetch_end(IndexFetchTableData *scan)
 		pfree(aocoscan->proj);
 		aocoscan->proj = NULL;
 	}
+
+	pfree(aocoscan);
 }
 
 static bool

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -473,11 +473,13 @@ appendonly_index_fetch_tuple(struct IndexFetchTableData *scan,
 								  snapshot,
 								  appendOnlyMetaDataSnapshot);
 	}
-	else
-	{
-		/* GPDB_12_MERGE_FIXME: Is it possible for the 'snapshot' to change
-		 * between calls? Add a sanity check for that here. */
-	}
+
+	/*
+	 * There is no reason to expect changes on snapshot between tuple
+	 * fetching calls after fech_init is called, treat it as a
+	 * programming error in case of occurrence.
+	 */
+	Assert(aoscan->aofetch->snapshot == snapshot);
 
 	appendonly_fetch(aoscan->aofetch, (AOTupleId *) tid, slot);
 

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -443,6 +443,8 @@ appendonly_index_fetch_end(IndexFetchTableData *scan)
 		pfree(aoscan->aofetch);
 		aoscan->aofetch = NULL;
 	}
+
+	pfree(aoscan);
 }
 
 static bool

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -421,7 +421,15 @@ appendonly_index_fetch_begin(Relation rel)
 static void
 appendonly_index_fetch_reset(IndexFetchTableData *scan)
 {
-	// GPDB_12_MERGE_FIXME: Should we close the underlying AO fetch desc here?
+	/*
+	 * Unlike Heap, we don't release the resources (fetch descriptor and its
+	 * members) here because it is more like a global data structure shared
+	 * across scans, rather than an iterator to yield a granularity of data.
+	 * 
+	 * Additionally, should be aware of that no matter whether allocation or
+	 * release on fetch descriptor, it is considerably expensive.
+	 */
+	return;
 }
 
 static void


### PR DESCRIPTION
The PR resolves the following items:
- Resolve GPDB_12_MERGE_FIXME: Should we close the underlying AO fetch desc here ?
    Unlike Heap, we don't release the fetch descriptor at index rescan
    because the featch descriptor for AO/CO is more like a global data
    structure shared across scans, rather than an iterator to yield a
    granularity of data.
- Resolve GPDB_12_MERGE_FIXME: Is it possible for the 'snapshot' to change.
    There should be identical snapshot between index fetching tuple
    calls after fetch_init is called. Otherwise tuple's visibility
    could be inconsistent in the same index scan.
- Fix a memory leak in index fetch tuple sub-routines on AO/CO.
    index_fetch_begin() allocates IndexFetchTableData scan at the beginning
    of the index fetching process, it should be freed in index_fetch_end().
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
