### PR TITLE
Resolve GPDB_12_MERGE_FIXME: exclude PROC_IN_VACUUM flag in procarray.c

### DIFF
--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -1461,11 +1461,7 @@ GetLocalOldestXmin(Relation rel, int flags)
 		PGPROC	   *proc = &allProcs[pgprocno];
 		PGXACT	   *pgxact = &allPgXact[pgprocno];
 
-		/* GPDB_12_MERGE_FIXME: We used to ignore PROC_IN_VACUUM flag in GPDB.
-		 * Do we still need to? If so, refactor the ignorance to use the
-		 * new 'flags' bitmask.
-		 * See comment in vacuumStatement_Relation()
-		 */
+		/* Upstream code which ignores lazy vacuum is not applicable to GPDB, see comment in vacuum_rel() */
 		if (pgxact->vacuumFlags & (flags & PROCARRAY_PROC_FLAGS_MASK))
 			continue;
 
@@ -2296,15 +2292,11 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 
 			/*
 			 * Skip over backends doing logical decoding which manages xmin
-			 * separately (check below) and ones running LAZY VACUUM.
+			 * separately (check below).
+			 * Upstream code which skips ones running LAZY VACUUM is not applicable
+			 * to GPDB, see comment in vacuum_rel().
 			 */
-			/* GPDB_12_MERGE_FIXME: We used to ignore PROC_IN_VACUUM flag in GPDB.
-			 * Do we still need to? If so, refactor the ignorance to use the
-			 * new 'flags' bitmask.
-			 * See comment in vacuumStatement_Relation()
-			 */
-			if (pgxact->vacuumFlags &
-				(PROC_IN_LOGICAL_DECODING | PROC_IN_VACUUM))
+			if (pgxact->vacuumFlags & PROC_IN_LOGICAL_DECODING)
 				continue;
 
 			/* Update globalxmin to be the smallest valid xmin */

--- a/src/include/storage/procarray.h
+++ b/src/include/storage/procarray.h
@@ -44,10 +44,9 @@ struct DtxContextInfo;         /* cdb/cdbdtxcontextinfo.h */
  * Only flags in PROCARRAY_PROC_FLAGS_MASK are considered when matching
  * PGXACT->vacuumFlags. Other flags are used for different purposes and
  * have no corresponding PROC flag equivalent.
+ * GPDB doesn't use PROC_IN_VACUUM for now, see comment in vacuum_rel().
  */
-#define		PROCARRAY_PROC_FLAGS_MASK	(PROCARRAY_VACUUM_FLAG | \
-										 PROCARRAY_ANALYZE_FLAG | \
-										 PROCARRAY_LOGICAL_DECODING_FLAG)
+#define		PROCARRAY_PROC_FLAGS_MASK	(PROCARRAY_ANALYZE_FLAG | PROCARRAY_LOGICAL_DECODING_FLAG)
 
 /* Use the following flags as an input "flags" to GetOldestXmin function */
 /* Consider all backends except for logical decoding ones which manage xmin separately */


### PR DESCRIPTION
As commit 7383c2b said, lazy vacuum for bitmap indexed tables performs
reindex causing updates to pg_class for index entries, ignoring lazy
vacuum will cause incorrect result. GPDB doesn't set PROC_IN_VACUUM flag
in lazy vacuum, exclude PROC_IN_VACUUM flag in procarray.c too.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
