### PR TITLE
fixme: delete toast values of invisible AppendOptimized tuple during vacuum.

### DIFF
--- a/src/backend/access/aocs/aocs_compaction.c
+++ b/src/backend/access/aocs/aocs_compaction.c
@@ -286,7 +286,7 @@ AOCSSegmentFileFullCompaction(Relation aorel,
 		else
 		{
 			/* Tuple is invisible and needs to be dropped */
-			AppendOnlyThrowAwayTuple(aorel, slot);
+			AppendOnlyThrowAwayTuple(aorel, slot, mt_bind);
 		}
 
 		/*

--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -278,7 +278,6 @@ AppendOnlyMoveTuple(TupleTableSlot *slot,
 					EState *estate)
 {
 	MemTuple	tuple;
-	bool		shouldFree;
 	AOTupleId  *oldAoTupleId;
 	AOTupleId	newAoTupleId;
 
@@ -291,7 +290,7 @@ AppendOnlyMoveTuple(TupleTableSlot *slot,
 	/* Extract all the values of the tuple */
 	slot_getallattrs(slot);
 
-	tuple = ExecFetchSlotMemTuple(slot, &shouldFree, mt_bind);
+	tuple = appendonly_form_memtuple(slot, mt_bind);
 	appendonly_insert(insertDesc,
 					  tuple,
 					  &newAoTupleId);
@@ -308,8 +307,7 @@ AppendOnlyMoveTuple(TupleTableSlot *slot,
 		ResetPerTupleExprContext(estate);
 	}
 
-	if (shouldFree)
-		pfree(tuple);
+	appendonly_free_memtuple(tuple);
 
 	if (Debug_appendonly_print_compaction)
 		ereport(DEBUG5,
@@ -324,7 +322,6 @@ AppendOnlyThrowAwayTuple(Relation rel, TupleTableSlot *slot, MemTupleBinding *mt
 	int			i;
 	int			numAttrs;
 	MemTuple	tuple;
-	bool		shouldFree;
 	TupleDesc	tupleDesc;
 	AOTupleId  *aoTupleId;
 	Datum		toast_values[MaxHeapAttributeNumber];
@@ -336,7 +333,7 @@ AppendOnlyThrowAwayTuple(Relation rel, TupleTableSlot *slot, MemTupleBinding *mt
 	/* Extract all the values of the tuple */
 	slot_getallattrs(slot);
 
-	tuple = ExecFetchSlotMemTuple(slot, &shouldFree, mt_bind);
+	tuple = appendonly_form_memtuple(slot, mt_bind);
 	tupleDesc = rel->rd_att;
 	numAttrs = tupleDesc->natts;
 
@@ -358,8 +355,7 @@ AppendOnlyThrowAwayTuple(Relation rel, TupleTableSlot *slot, MemTupleBinding *mt
 		}
 	}
 
-	if (shouldFree)
-		pfree(tuple);
+	appendonly_free_memtuple(tuple);
 	
 	if (Debug_appendonly_print_compaction)
 		ereport(DEBUG5,

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -348,12 +348,10 @@ appendonly_slot_callbacks(Relation relation)
 }
 
 MemTuple
-ExecFetchSlotMemTuple(TupleTableSlot *slot, bool *shouldFree, MemTupleBinding *mt_bind)
+appendonly_form_memtuple(TupleTableSlot *slot, MemTupleBinding *mt_bind)
 {
 	MemTuple		result;
 	MemoryContext	oldContext;
-
-	*shouldFree = true;
 
 	/*
 	 * In case of a non virtal tuple, make certain that the slot's values are
@@ -369,6 +367,15 @@ ExecFetchSlotMemTuple(TupleTableSlot *slot, bool *shouldFree, MemTupleBinding *m
 	MemoryContextSwitchTo(oldContext);
 
 	return result;
+}
+
+/*
+ * appendonly_free_memtuple
+ */
+void
+appendonly_free_memtuple(MemTuple tuple)
+{
+	pfree(tuple);
 }
 
 /* ------------------------------------------------------------------------
@@ -569,10 +576,9 @@ appendonly_tuple_insert(Relation relation, TupleTableSlot *slot, CommandId cid,
 {
 	AppendOnlyInsertDesc    insertDesc;
 	MemTuple				mtuple;
-	bool					shouldFree = true;
 
 	insertDesc = get_insert_descriptor(relation);
-	mtuple = ExecFetchSlotMemTuple(slot, &shouldFree, insertDesc->mt_bind);
+	mtuple = appendonly_form_memtuple(slot, insertDesc->mt_bind);
 
 	/* Update the tuple with table oid */
 	slot->tts_tableOid = RelationGetRelid(relation);
@@ -582,8 +588,7 @@ appendonly_tuple_insert(Relation relation, TupleTableSlot *slot, CommandId cid,
 
 	pgstat_count_heap_insert(relation, 1);
 
-	if (shouldFree)
-		pfree(mtuple);
+	appendonly_free_memtuple(mtuple);
 }
 
 static void
@@ -659,7 +664,6 @@ appendonly_tuple_update(Relation relation, ItemPointer otid, TupleTableSlot *slo
 	AppendOnlyDeleteDesc	deleteDesc;
 	MemTuple				mtuple;
 	TM_Result				result;
-	bool					shouldFree = true;
 
 	insertDesc = get_insert_descriptor(relation);
 	deleteDesc = get_delete_descriptor(relation, true);
@@ -667,8 +671,7 @@ appendonly_tuple_update(Relation relation, ItemPointer otid, TupleTableSlot *slo
 	/* Update the tuple with table oid */
 	slot->tts_tableOid = RelationGetRelid(relation);
 
-	mtuple = ExecFetchSlotMemTuple(slot, &shouldFree,
-								   insertDesc->mt_bind);
+	mtuple = appendonly_form_memtuple(slot, insertDesc->mt_bind);
 
 #ifdef FAULT_INJECTOR
 	FaultInjector_InjectFaultIfSet(
@@ -689,8 +692,7 @@ appendonly_tuple_update(Relation relation, ItemPointer otid, TupleTableSlot *slo
 	/* No HOT updates with AO tables. */
 	*update_indexes = true;
 
-	if (shouldFree)
-		pfree(mtuple);
+	appendonly_free_memtuple(mtuple);
 
 	return result;
 }

--- a/src/backend/access/heap/tuptoaster.c
+++ b/src/backend/access/heap/tuptoaster.c
@@ -68,7 +68,6 @@ typedef struct toast_compress_header
 #define TOAST_COMPRESS_SET_RAWSIZE(ptr, len) \
 	(((toast_compress_header *) (ptr))->rawsize = (len))
 
-static void toast_delete_datum(Relation rel, Datum value, bool is_speculative);
 static Datum toast_save_datum(Relation rel, Datum value,
 							  struct varlena *oldexternal, bool isFrozen, int options);
 static bool toastrel_valueid_exists(Relation toastrel, Oid valueid);
@@ -1960,7 +1959,7 @@ toast_save_datum(Relation rel, Datum value,
  *	Delete a single external stored value.
  * ----------
  */
-static void
+void
 toast_delete_datum(Relation rel, Datum value, bool is_speculative)
 {
 	struct varlena *attr = (struct varlena *) DatumGetPointer(value);

--- a/src/include/access/appendonly_compaction.h
+++ b/src/include/access/appendonly_compaction.h
@@ -33,7 +33,7 @@ extern bool AppendOnlyCompaction_ShouldCompact(
 								   int64 segmentTotalTupcount,
 								   bool isFull,
 								   Snapshot appendOnlyMetaDataSnapshot);
-extern void AppendOnlyThrowAwayTuple(Relation rel, TupleTableSlot *slot);
+extern void AppendOnlyThrowAwayTuple(Relation rel, TupleTableSlot *slot, MemTupleBinding *mt_bind);
 extern void AppendOptimizedTruncateToEOF(Relation aorel);
 
 #endif

--- a/src/include/access/tuptoaster.h
+++ b/src/include/access/tuptoaster.h
@@ -165,6 +165,14 @@ extern MemTuple toast_insert_or_update_memtup(Relation rel,
 extern void toast_delete(Relation rel, HeapTuple oldtup, bool is_speculative);
 
 /* ----------
+ * toast_delete_datum -
+ *
+ *	Delete a single external stored value.
+ * ----------
+ */
+extern void toast_delete_datum(Relation rel, Datum value, bool is_speculative);
+
+/* ----------
  * heap_tuple_fetch_attr() -
  *
  *		Fetches an external stored attribute from the toast

--- a/src/include/executor/tuptable.h
+++ b/src/include/executor/tuptable.h
@@ -330,7 +330,8 @@ extern void slot_getmissingattrs(TupleTableSlot *slot, int startAttNum,
 								 int lastAttNum);
 extern void slot_getsomeattrs_int(TupleTableSlot *slot, int attnum);
 
-extern MemTuple ExecFetchSlotMemTuple(TupleTableSlot *slot, bool *shouldFree, MemTupleBinding *mt_bind);
+extern MemTuple appendonly_form_memtuple(TupleTableSlot *slot, MemTupleBinding *mt_bind);
+extern void appendonly_free_memtuple(MemTuple tuple);
 
 #ifndef FRONTEND
 

--- a/src/test/regress/expected/toast.out
+++ b/src/test/regress/expected/toast.out
@@ -7,6 +7,11 @@ ALTER TABLE toastable_ao ALTER COLUMN a SET STORAGE EXTERNAL;
 CREATE FUNCTION randomtext(len int) returns text as $$
   select string_agg(md5(random()::text),'') from generate_series(1, $1 / 32)
 $$ language sql;
+create function get_rel_toast_count(relname text) returns int as $$
+reltoastoid = plpy.execute("select \'"+ relname +"\'::regclass::oid;")[0]['oid']
+count = plpy.execute("select count(*) from pg_toast.pg_toast_"+str(reltoastoid)+";")[0]['count']
+return count
+$$ language plpython3u;
 -- INSERT 
 -- uses the toast call to store the large tuples
 INSERT INTO toastable_heap VALUES(repeat('a',100000), repeat('b',100001), 1);
@@ -71,6 +76,22 @@ SELECT char_length(a), char_length(b), c, d FROM toastable_ao ORDER BY c;
 -- remove reference to toast table and create a new one with different values
 TRUNCATE toastable_heap;
 TRUNCATE toastable_ao;
+select gp_segment_id, get_rel_toast_count('toastable_heap') from gp_dist_random('gp_id') order by gp_segment_id;
+ gp_segment_id | get_rel_toast_count 
+---------------+---------------------
+             0 |                   0
+             1 |                   0
+             2 |                   0
+(3 rows)
+
+select gp_segment_id, get_rel_toast_count('toastable_ao') from gp_dist_random('gp_id') order by gp_segment_id;
+ gp_segment_id | get_rel_toast_count 
+---------------+---------------------
+             0 |                   0
+             1 |                   0
+             2 |                   0
+(3 rows)
+
 INSERT INTO toastable_heap VALUES(repeat('a',100002), repeat('b',100003), 2, 20);
 INSERT INTO toastable_ao VALUES(repeat('a',100002), repeat('b',100003), 2, 20);
 SELECT char_length(a), char_length(b), c, d FROM toastable_heap;
@@ -85,7 +106,41 @@ SELECT char_length(a), char_length(b), c, d FROM toastable_ao;
       100002 |      100003 | 2 | 20
 (1 row)
 
--- TODO: figure out a way to verify that toasted data is removed after the truncate.
+select gp_segment_id, get_rel_toast_count('toastable_heap') from gp_dist_random('gp_id') order by gp_segment_id;
+ gp_segment_id | get_rel_toast_count 
+---------------+---------------------
+             0 |                   0
+             1 |                   0
+             2 |                   0
+(3 rows)
+
+select gp_segment_id, get_rel_toast_count('toastable_ao') from gp_dist_random('gp_id') order by gp_segment_id;
+ gp_segment_id | get_rel_toast_count 
+---------------+---------------------
+             0 |                  13
+             1 |                   0
+             2 |                   0
+(3 rows)
+
+delete from toastable_heap;
+delete from toastable_ao;
+vacuum toastable_heap, toastable_ao;
+select gp_segment_id, get_rel_toast_count('toastable_heap') from gp_dist_random('gp_id') order by gp_segment_id;
+ gp_segment_id | get_rel_toast_count 
+---------------+---------------------
+             0 |                   0
+             1 |                   0
+             2 |                   0
+(3 rows)
+
+select gp_segment_id, get_rel_toast_count('toastable_ao') from gp_dist_random('gp_id') order by gp_segment_id;
+ gp_segment_id | get_rel_toast_count 
+---------------+---------------------
+             0 |                   0
+             1 |                   0
+             2 |                   0
+(3 rows)
+
 DROP TABLE toastable_heap;
 DROP TABLE toastable_ao;
 -- TODO: figure out a way to verify that the toast tables are dropped


### PR DESCRIPTION
This PR contains the following changes:  
1. Resolves GPDB_12_MERGE_FIXME in  appendonly_compaction.c:

    > GPDB_12_MERGE_FIXME: loop through all attributes, call `toast_delete_datum()`
    > on any toasted datums, like `toast_delete` does for heap tuples.

2. Refactor `ExecFetchSlotMemTuple()`：
     - Rename `ExecFetchSlotMemTuple()` to `appendonly_form_memtuple()` like `heap_from_tuple()`.
     - Remove `shouldFree` parameter since it's always set as true.
     - Add function `appendonly_free_memtuple()` to replace `free(memtuple)`.


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
