### PR TITLE
Fix wrong results with JOINs and opfamilies

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/AntiSemiJoin2Select-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AntiSemiJoin2Select-1.mdp
@@ -296,7 +296,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="20">
+    <dxl:Plan Id="0" SpaceSize="22">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.087505" Rows="500.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/AntiSemiJoin2Select-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AntiSemiJoin2Select-2.mdp
@@ -296,7 +296,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="20">
+    <dxl:Plan Id="0" SpaceSize="22">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.065812" Rows="500.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/Coalesce-With-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Coalesce-With-Subquery.mdp
@@ -852,7 +852,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2856">
+    <dxl:Plan Id="0" SpaceSize="3768">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="38915.798285" Rows="4.000000" Width="269"/>

--- a/src/backend/gporca/data/dxl/minidump/CoerceToDomain.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CoerceToDomain.mdp
@@ -1931,7 +1931,7 @@ SELECT * FROM information_schema.tables;
         </dxl:LogicalJoin>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="24">
+    <dxl:Plan Id="0" SpaceSize="32">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.080500" Rows="2.800000" Width="96"/>

--- a/src/backend/gporca/data/dxl/minidump/Correlation-With-Casting-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Correlation-With-Casting-1.mdp
@@ -432,7 +432,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="17595">
+    <dxl:Plan Id="0" SpaceSize="17602">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2155.684179" Rows="70.000000" Width="10"/>

--- a/src/backend/gporca/data/dxl/minidump/Correlation-With-Casting-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Correlation-With-Casting-2.mdp
@@ -415,7 +415,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr <> c.u_v
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="8659.156042" Rows="400.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/DML-ComputeScalar-With-Outerref.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-ComputeScalar-With-Outerref.mdp
@@ -318,7 +318,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalInsert>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="96">
+    <dxl:Plan Id="0" SpaceSize="156">
       <dxl:DMLInsert Columns="0" ActionCol="29" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356691880.647039" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin2.mdp
@@ -11330,7 +11330,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="22">
+    <dxl:Plan Id="0" SpaceSize="33">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="865.875352" Rows="3866.533707" Width="116"/>

--- a/src/backend/gporca/data/dxl/minidump/ExpandFullOuterJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExpandFullOuterJoin.mdp
@@ -221,7 +221,7 @@ select * from t full join s on t1 = s1;
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="256">
+    <dxl:Plan Id="0" SpaceSize="436">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2586.001789" Rows="3.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/ExpandFullOuterJoin2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExpandFullOuterJoin2.mdp
@@ -203,7 +203,7 @@ select * from s full join s s1 on s.a = s1.a where s.a is null;
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="112">
+    <dxl:Plan Id="0" SpaceSize="180">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2586.001577" Rows="3.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-LeftOuter-NLJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-LeftOuter-NLJoin.mdp
@@ -500,7 +500,7 @@ explain select * from t0 left join t1 on t0.a=t1.a left join t2 on (t2.a=t0.a an
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="48">
+    <dxl:Plan Id="0" SpaceSize="216">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1231.893289" Rows="5.000000" Width="40"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-Redistribute-Const-Table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-Redistribute-Const-Table.mdp
@@ -388,7 +388,7 @@ Table X (int i, int j) is distributed by i, column i has index
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="22">
+    <dxl:Plan Id="0" SpaceSize="24">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="6.000265" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesForPartSQ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesForPartSQ.mdp
@@ -512,7 +512,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="173">
+    <dxl:Plan Id="0" SpaceSize="184">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000970" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesInnerOfLOJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesInnerOfLOJ.mdp
@@ -816,7 +816,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="238">
+    <dxl:Plan Id="0" SpaceSize="358">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.000804" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/Intersect-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Intersect-OuterRefs.mdp
@@ -1413,7 +1413,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4060">
+    <dxl:Plan Id="0" SpaceSize="5620">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.065290" Rows="77.229878" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-Disj-Subqs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-Disj-Subqs.mdp
@@ -985,7 +985,7 @@ OR
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="269692">
+    <dxl:Plan Id="0" SpaceSize="270380">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="9921.832259" Rows="521.833333" Width="246"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-With-Subq-Preds-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-With-Subq-Preds-1.mdp
@@ -783,7 +783,7 @@
         </dxl:Or>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="29572">
+    <dxl:Plan Id="0" SpaceSize="30720">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="10867.964640" Rows="10000000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-With-Subq-Preds-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-With-Subq-Preds-2.mdp
@@ -809,7 +809,7 @@
         </dxl:Or>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="234125728">
+    <dxl:Plan Id="0" SpaceSize="235263952">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="9312.745178" Rows="520834.333333" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndex.mdp
@@ -477,7 +477,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2">
+    <dxl:Plan Id="0" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="919.567476" Rows="10.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndexWithSelect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndexWithSelect.mdp
@@ -484,7 +484,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1">
+    <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="882688.974529" Rows="10.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-DynBtreeIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-DynBtreeIndex.mdp
@@ -449,7 +449,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6">
+    <dxl:Plan Id="0" SpaceSize="7">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="491.004667" Rows="10.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-CompsiteKey-Equiv.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-CompsiteKey-Equiv.mdp
@@ -393,7 +393,7 @@ explain select * from foo left join bar on foo.a = bar.a and foo.b = bar.b left 
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4">
+    <dxl:Plan Id="0" SpaceSize="9">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="868.122098" Rows="3.000000" Width="48"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-CompsiteKey-NoMotion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-CompsiteKey-NoMotion.mdp
@@ -462,7 +462,7 @@ explain select * from foo left join bar on foo.a = bar.a and foo.b = bar.b left 
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2">
+    <dxl:Plan Id="0" SpaceSize="9">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1330177.825157" Rows="3.000000" Width="48"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiIndexes.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiIndexes.mdp
@@ -405,7 +405,7 @@ set optimizer_enable_hashjoin = off;
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="868.122115" Rows="3.000000" Width="48"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-NonDistKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-NonDistKey.mdp
@@ -270,7 +270,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2">
+    <dxl:Plan Id="0" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="437.000572" Rows="2.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IsNullPred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IsNullPred.mdp
@@ -12159,7 +12159,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="8890.464428" Rows="2818278.671879" Width="251"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-With-Agg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-With-Agg.mdp
@@ -295,7 +295,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="42">
+    <dxl:Plan Id="0" SpaceSize="52">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000516" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Col-Const-Pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Col-Const-Pred.mdp
@@ -2110,7 +2110,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1028">
+    <dxl:Plan Id="0" SpaceSize="1470">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="69941.462832" Rows="896.720000" Width="238"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Pred-On-Inner.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Pred-On-Inner.mdp
@@ -254,7 +254,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="5">
+    <dxl:Plan Id="0" SpaceSize="6">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.001150" Rows="1.000000" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Pred-On-Inner2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Pred-On-Inner2.mdp
@@ -394,7 +394,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4">
+    <dxl:Plan Id="0" SpaceSize="5">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.008993" Rows="15.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin-Tpcds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin-Tpcds.mdp
@@ -11631,7 +11631,7 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
         </dxl:LogicalCTEAnchor>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="87522">
+    <dxl:Plan Id="0" SpaceSize="87534">
       <dxl:Limit>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="5904.512295" Rows="5.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/MotionHazard-NoMaterializeSortUnderResult.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MotionHazard-NoMaterializeSortUnderResult.mdp
@@ -433,7 +433,7 @@ explain select tab3.k, (select tab2.k from tab2 where tab2.i = tab1.i limit 1) a
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="20">
+    <dxl:Plan Id="0" SpaceSize="26">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="166193.741134" Rows="4994000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/MultiLevel-IN-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultiLevel-IN-Subquery.mdp
@@ -686,7 +686,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="950">
+    <dxl:Plan Id="0" SpaceSize="1054">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1294.489763" Rows="999.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/MultipleSubqueriesInSelectClause.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultipleSubqueriesInSelectClause.mdp
@@ -1178,7 +1178,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="324625">
+    <dxl:Plan Id="0" SpaceSize="326875">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="9309.074116" Rows="3000000.000000" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/NOT-IN-NotNullBoth.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NOT-IN-NotNullBoth.mdp
@@ -252,7 +252,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="11">
+    <dxl:Plan Id="0" SpaceSize="12">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000614" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/NestedSubqLimitBindings.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NestedSubqLimitBindings.mdp
@@ -485,7 +485,7 @@ select a from t as t1 where a in (
         </dxl:LogicalGet>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="7046592">
+    <dxl:Plan Id="0" SpaceSize="18801888">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="4165951483148.106445" Rows="1.000000" Width="1"/>

--- a/src/backend/gporca/data/dxl/minidump/NullIf-With-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NullIf-With-Subquery.mdp
@@ -427,7 +427,7 @@ FROM x
         </dxl:LogicalGet>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="55">
+    <dxl:Plan Id="0" SpaceSize="67">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.004152" Rows="10.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-GroupBy.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-GroupBy.mdp
@@ -828,7 +828,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="701">
+    <dxl:Plan Id="0" SpaceSize="1318">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.020922" Rows="100.000000" Width="14"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-LASJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-LASJ.mdp
@@ -935,7 +935,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18">
+    <dxl:Plan Id="0" SpaceSize="27">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.060573" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-LeftOuterHashJoin-DPE-IsNull.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-LeftOuterHashJoin-DPE-IsNull.mdp
@@ -368,7 +368,7 @@ select * from t2 left outer join t1 on t1.b = t2.d where t1.b is null;
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000687" Rows="2.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-LeftOuterNLJoin-DPE-IsNull.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-LeftOuterNLJoin-DPE-IsNull.mdp
@@ -368,7 +368,7 @@ select * from t2 left outer join t1 on t1.b = t2.d where t1.b is null;
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1">
+    <dxl:Plan Id="0" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.000446" Rows="2.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE-2.mdp
@@ -2566,7 +2566,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="261">
+    <dxl:Plan Id="0" SpaceSize="325">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="23515.903551" Rows="12277684.984863" Width="246"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SQExists.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SQExists.mdp
@@ -729,7 +729,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="41">
+    <dxl:Plan Id="0" SpaceSize="46">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000656" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SQNotExists.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SQNotExists.mdp
@@ -723,7 +723,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="25">
+    <dxl:Plan Id="0" SpaceSize="30">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000656" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SQScalar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SQScalar.mdp
@@ -739,7 +739,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="28">
+    <dxl:Plan Id="0" SpaceSize="29">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000898" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/PushSelectDownUnionAllOfCTG.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushSelectDownUnionAllOfCTG.mdp
@@ -214,7 +214,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="283008">
+    <dxl:Plan Id="0" SpaceSize="289440">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="0.001436" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/PushSelectWithOuterRefBelowUnion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushSelectWithOuterRefBelowUnion.mdp
@@ -5458,7 +5458,7 @@
         </dxl:Or>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="55602">
+    <dxl:Plan Id="0" SpaceSize="58426">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="25984.123228" Rows="60175000.000000" Width="14"/>

--- a/src/backend/gporca/data/dxl/minidump/RemoveImpliedPredOnBCCPredicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RemoveImpliedPredOnBCCPredicates.mdp
@@ -27,8 +27,7 @@
                          ->  Shared Scan (share slice:id 1:0)  (cost=0.00..559.53 rows=3333334 width=16)
      Optimizer: Pivotal Optimizer (GPORCA) version 3.39.0
 
-  ]]>
-  </dxl:Comment>
+  ]]></dxl:Comment>
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
@@ -275,7 +274,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="48">
+    <dxl:Plan Id="0" SpaceSize="34">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="12725.266667" Rows="10000000.000000" Width="48"/>
@@ -395,10 +394,10 @@
             <dxl:HashCondList>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
                 <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                  <dxl:Ident ColId="9" ColName="a" TypeMdid="0.1043.1.0"/>
+                  <dxl:Ident ColId="18" ColName="a" TypeMdid="0.1043.1.0"/>
                 </dxl:Cast>
                 <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                  <dxl:Ident ColId="18" ColName="a" TypeMdid="0.1043.1.0"/>
+                  <dxl:Ident ColId="9" ColName="a" TypeMdid="0.1043.1.0"/>
                 </dxl:Cast>
               </dxl:Comparison>
             </dxl:HashCondList>
@@ -407,11 +406,11 @@
                 <dxl:Cost StartupCost="0" TotalCost="5185.733333" Rows="10000000.000000" Width="32"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="9" Alias="a">
-                  <dxl:Ident ColId="9" ColName="a" TypeMdid="0.1043.1.0"/>
+                <dxl:ProjElem ColId="18" Alias="a">
+                  <dxl:Ident ColId="18" ColName="a" TypeMdid="0.1043.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="10" Alias="b">
-                  <dxl:Ident ColId="10" ColName="b" TypeMdid="0.1043.1.0"/>
+                <dxl:ProjElem ColId="19" Alias="b">
+                  <dxl:Ident ColId="19" ColName="b" TypeMdid="0.1043.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="27" Alias="a">
                   <dxl:Ident ColId="27" ColName="a" TypeMdid="0.1043.1.0"/>
@@ -425,23 +424,23 @@
               <dxl:HashCondList>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
                   <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                    <dxl:Ident ColId="9" ColName="a" TypeMdid="0.1043.1.0"/>
+                    <dxl:Ident ColId="18" ColName="a" TypeMdid="0.1043.1.0"/>
                   </dxl:Cast>
                   <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
                     <dxl:Ident ColId="27" ColName="a" TypeMdid="0.1043.1.0"/>
                   </dxl:Cast>
                 </dxl:Comparison>
               </dxl:HashCondList>
-              <dxl:CTEConsumer CTEId="0" Columns="9,10">
+              <dxl:CTEConsumer CTEId="0" Columns="18,19">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="559.533333" Rows="10000000.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="9" Alias="a">
-                    <dxl:Ident ColId="9" ColName="a" TypeMdid="0.1043.1.0"/>
+                  <dxl:ProjElem ColId="18" Alias="a">
+                    <dxl:Ident ColId="18" ColName="a" TypeMdid="0.1043.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="10" Alias="b">
-                    <dxl:Ident ColId="10" ColName="b" TypeMdid="0.1043.1.0"/>
+                  <dxl:ProjElem ColId="19" Alias="b">
+                    <dxl:Ident ColId="19" ColName="b" TypeMdid="0.1043.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
               </dxl:CTEConsumer>
@@ -459,16 +458,16 @@
                 </dxl:ProjList>
               </dxl:CTEConsumer>
             </dxl:HashJoin>
-            <dxl:CTEConsumer CTEId="0" Columns="18,19">
+            <dxl:CTEConsumer CTEId="0" Columns="9,10">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="559.533333" Rows="10000000.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="18" Alias="a">
-                  <dxl:Ident ColId="18" ColName="a" TypeMdid="0.1043.1.0"/>
+                <dxl:ProjElem ColId="9" Alias="a">
+                  <dxl:Ident ColId="9" ColName="a" TypeMdid="0.1043.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="19" Alias="b">
-                  <dxl:Ident ColId="19" ColName="b" TypeMdid="0.1043.1.0"/>
+                <dxl:ProjElem ColId="10" Alias="b">
+                  <dxl:Ident ColId="10" ColName="b" TypeMdid="0.1043.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
             </dxl:CTEConsumer>

--- a/src/backend/gporca/data/dxl/minidump/RightJoinNoDPSNonDistKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RightJoinNoDPSNonDistKey.mdp
@@ -1290,7 +1290,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="10">
+    <dxl:Plan Id="0" SpaceSize="11">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.159887" Rows="1009.000091" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/Select-Proj-OuterJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Select-Proj-OuterJoin.mdp
@@ -889,7 +889,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="16660">
+    <dxl:Plan Id="0" SpaceSize="28480">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="891.087839" Rows="3009.000000" Width="64"/>

--- a/src/backend/gporca/data/dxl/minidump/SemiJoinWithWindowsFuncInSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SemiJoinWithWindowsFuncInSubquery.mdp
@@ -338,191 +338,191 @@
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="0">
       <dxl:Result>
-	<dxl:Properties>
-	  <dxl:Cost StartupCost="0" TotalCost="1293.000491" Rows="1.000000" Width="4"/>
-	</dxl:Properties>
-	<dxl:ProjList>
-	  <dxl:ProjElem ColId="0" Alias="j">
-	    <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
-	  </dxl:ProjElem>
-	</dxl:ProjList>
-	<dxl:Filter>
-	  <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AnySubPlan">
-	    <dxl:TestExpr>
-	      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.15.1.0">
-		<dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
-		<dxl:Ident ColId="16" ColName="rank" TypeMdid="0.20.1.0"/>
-	      </dxl:Comparison>
-	    </dxl:TestExpr>
-	    <dxl:ParamList>
-	      <dxl:Param ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
-	    </dxl:ParamList>
-	    <dxl:Result>
-	      <dxl:Properties>
-		<dxl:Cost StartupCost="0" TotalCost="431.000145" Rows="1.000000" Width="8"/>
-	      </dxl:Properties>
-	      <dxl:ProjList>
-		<dxl:ProjElem ColId="16" Alias="rank">
-		  <dxl:Ident ColId="16" ColName="rank" TypeMdid="0.20.1.0"/>
-		</dxl:ProjElem>
-	      </dxl:ProjList>
-	      <dxl:Filter/>
-	      <dxl:OneTimeFilter/>
-	      <dxl:Window PartitionColumns="">
-		<dxl:Properties>
-		  <dxl:Cost StartupCost="0" TotalCost="431.000145" Rows="1.000000" Width="8"/>
-		</dxl:Properties>
-		<dxl:ProjList>
-		  <dxl:ProjElem ColId="16" Alias="rank">
-		    <dxl:WindowFunc Mdid="0.7001.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
-		  </dxl:ProjElem>
-		  <dxl:ProjElem ColId="8" Alias="i">
-		    <dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
-		  </dxl:ProjElem>
-		</dxl:ProjList>
-		<dxl:Filter/>
-		<dxl:Sort SortDiscardDuplicates="false">
-		  <dxl:Properties>
-		    <dxl:Cost StartupCost="0" TotalCost="431.000141" Rows="1.000000" Width="4"/>
-		  </dxl:Properties>
-		  <dxl:ProjList>
-		    <dxl:ProjElem ColId="8" Alias="i">
-		      <dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
-		    </dxl:ProjElem>
-		  </dxl:ProjList>
-		  <dxl:Filter/>
-		  <dxl:SortingColumnList>
-		    <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-		  </dxl:SortingColumnList>
-		  <dxl:LimitCount/>
-		  <dxl:LimitOffset/>
-		  <dxl:Result>
-		    <dxl:Properties>
-		      <dxl:Cost StartupCost="0" TotalCost="431.000141" Rows="1.000000" Width="4"/>
-		    </dxl:Properties>
-		    <dxl:ProjList>
-		      <dxl:ProjElem ColId="8" Alias="i">
-			<dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
-		      </dxl:ProjElem>
-		    </dxl:ProjList>
-		    <dxl:Filter>
-		      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-			<dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
-			<dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
-		      </dxl:Comparison>
-		    </dxl:Filter>
-		    <dxl:OneTimeFilter/>
-		    <dxl:Materialize Eager="false">
-		      <dxl:Properties>
-			<dxl:Cost StartupCost="0" TotalCost="431.000075" Rows="1.000000" Width="4"/>
-		      </dxl:Properties>
-		      <dxl:ProjList>
-			<dxl:ProjElem ColId="8" Alias="i">
-			  <dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
-			</dxl:ProjElem>
-		      </dxl:ProjList>
-		      <dxl:Filter/>
-		      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
-			<dxl:Properties>
-			  <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
-			</dxl:Properties>
-			<dxl:ProjList>
-			  <dxl:ProjElem ColId="8" Alias="i">
-			    <dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
-			  </dxl:ProjElem>
-			</dxl:ProjList>
-			<dxl:Filter/>
-			<dxl:SortingColumnList/>
-			<dxl:TableScan>
-			  <dxl:Properties>
-			    <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
-			  </dxl:Properties>
-			  <dxl:ProjList>
-			    <dxl:ProjElem ColId="8" Alias="i">
-			      <dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
-			    </dxl:ProjElem>
-			  </dxl:ProjList>
-			  <dxl:Filter/>
-			  <dxl:TableDescriptor Mdid="0.73978.1.0" TableName="a">
-			    <dxl:Columns>
-			      <dxl:Column ColId="8" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-			      <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-			      <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-			      <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-			      <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-			      <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-			      <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-			      <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-			    </dxl:Columns>
-			  </dxl:TableDescriptor>
-			</dxl:TableScan>
-		      </dxl:GatherMotion>
-		    </dxl:Materialize>
-		  </dxl:Result>
-		</dxl:Sort>
-		<dxl:WindowKeyList>
-		  <dxl:WindowKey>
-		    <dxl:SortingColumnList>
-		      <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-		    </dxl:SortingColumnList>
-		  </dxl:WindowKey>
-		</dxl:WindowKeyList>
-	      </dxl:Window>
-	    </dxl:Result>
-	  </dxl:SubPlan>
-	</dxl:Filter>
-	<dxl:OneTimeFilter/>
-	<dxl:Sort SortDiscardDuplicates="false">
-	  <dxl:Properties>
-	    <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
-	  </dxl:Properties>
-	  <dxl:ProjList>
-	    <dxl:ProjElem ColId="0" Alias="j">
-	      <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
-	    </dxl:ProjElem>
-	  </dxl:ProjList>
-	  <dxl:Filter/>
-	  <dxl:SortingColumnList>
-	    <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-	  </dxl:SortingColumnList>
-	  <dxl:LimitCount/>
-	  <dxl:LimitOffset/>
-	  <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
-	    <dxl:Properties>
-	      <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
-	    </dxl:Properties>
-	    <dxl:ProjList>
-	      <dxl:ProjElem ColId="0" Alias="j">
-		<dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
-	      </dxl:ProjElem>
-	    </dxl:ProjList>
-	    <dxl:Filter/>
-	    <dxl:SortingColumnList/>
-	    <dxl:TableScan>
-	      <dxl:Properties>
-		<dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
-	      </dxl:Properties>
-	      <dxl:ProjList>
-		<dxl:ProjElem ColId="0" Alias="j">
-		  <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
-		</dxl:ProjElem>
-	      </dxl:ProjList>
-	      <dxl:Filter/>
-	      <dxl:TableDescriptor Mdid="0.73981.1.0" TableName="b">
-		<dxl:Columns>
-		  <dxl:Column ColId="0" Attno="1" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
-		  <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-		  <dxl:Column ColId="2" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-		  <dxl:Column ColId="3" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-		  <dxl:Column ColId="4" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-		  <dxl:Column ColId="5" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-		  <dxl:Column ColId="6" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-		  <dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-		</dxl:Columns>
-	      </dxl:TableDescriptor>
-	    </dxl:TableScan>
-	  </dxl:GatherMotion>
-	</dxl:Sort>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1293.000491" Rows="1.000000" Width="4"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="j">
+            <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter>
+          <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AnySubPlan">
+            <dxl:TestExpr>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.15.1.0">
+                <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="16" ColName="rank" TypeMdid="0.20.1.0"/>
+              </dxl:Comparison>
+            </dxl:TestExpr>
+            <dxl:ParamList>
+              <dxl:Param ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+            </dxl:ParamList>
+            <dxl:Result>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000145" Rows="1.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="16" Alias="rank">
+                  <dxl:Ident ColId="16" ColName="rank" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+              <dxl:Window PartitionColumns="">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000145" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="16" Alias="rank">
+                    <dxl:WindowFunc Mdid="0.7001.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="8" Alias="i">
+                    <dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:Sort SortDiscardDuplicates="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000141" Rows="1.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="8" Alias="i">
+                      <dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  </dxl:SortingColumnList>
+                  <dxl:LimitCount/>
+                  <dxl:LimitOffset/>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000141" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="8" Alias="i">
+                        <dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                        <dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+                      </dxl:Comparison>
+                    </dxl:Filter>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Materialize Eager="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000075" Rows="1.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="8" Alias="i">
+                          <dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="8" Alias="i">
+                            <dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="8" Alias="i">
+                              <dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="0.73978.1.0" TableName="a">
+                            <dxl:Columns>
+                              <dxl:Column ColId="8" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                              <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:GatherMotion>
+                    </dxl:Materialize>
+                  </dxl:Result>
+                </dxl:Sort>
+                <dxl:WindowKeyList>
+                  <dxl:WindowKey>
+                    <dxl:SortingColumnList>
+                      <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                    </dxl:SortingColumnList>
+                  </dxl:WindowKey>
+                </dxl:WindowKeyList>
+              </dxl:Window>
+            </dxl:Result>
+          </dxl:SubPlan>
+        </dxl:Filter>
+        <dxl:OneTimeFilter/>
+        <dxl:Sort SortDiscardDuplicates="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="j">
+              <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
+          <dxl:LimitCount/>
+          <dxl:LimitOffset/>
+          <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="j">
+                <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="j">
+                  <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.73981.1.0" TableName="b">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="2" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="3" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:GatherMotion>
+        </dxl:Sort>
       </dxl:Result>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/Subq-JoinWithOuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq-JoinWithOuterRef.mdp
@@ -417,7 +417,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="53">
+    <dxl:Plan Id="0" SpaceSize="127">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.000818" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/Subq2CorrSQInLOJOn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq2CorrSQInLOJOn.mdp
@@ -2430,7 +2430,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="32">
+    <dxl:Plan Id="0" SpaceSize="62">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="568384082185.659546" Rows="1000.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Subq2OuterRef2InJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq2OuterRef2InJoin.mdp
@@ -457,7 +457,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="63">
+    <dxl:Plan Id="0" SpaceSize="84">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1423057834895712.000000" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Subq2OuterRefMultiLevelInOn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq2OuterRefMultiLevelInOn.mdp
@@ -492,7 +492,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="12">
+    <dxl:Plan Id="0" SpaceSize="16">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1896948689260387.750000" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Subq2PartialDecorrelate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq2PartialDecorrelate.mdp
@@ -434,7 +434,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="67">
+    <dxl:Plan Id="0" SpaceSize="90">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356692154.938896" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqAny-InsideScalarExpression.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqAny-InsideScalarExpression.mdp
@@ -381,7 +381,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="22">
+    <dxl:Plan Id="0" SpaceSize="29">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324032.643711" Rows="2.000000" Width="13"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqExists-With-External-Corrs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqExists-With-External-Corrs.mdp
@@ -456,7 +456,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="22026">
+    <dxl:Plan Id="0" SpaceSize="24458">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.001472" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqExists-Without-External-Corrs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqExists-Without-External-Corrs.mdp
@@ -431,7 +431,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="150026">
+    <dxl:Plan Id="0" SpaceSize="159750">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="12930.008073" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Subquery-AnyAllAggregates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subquery-AnyAllAggregates.mdp
@@ -524,7 +524,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="218">
+    <dxl:Plan Id="0" SpaceSize="294">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356698074.463431" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregates.mdp
@@ -598,7 +598,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="222">
+    <dxl:Plan Id="0" SpaceSize="306">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356695741.507501" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregatesWithDisjuncts.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregatesWithDisjuncts.mdp
@@ -665,7 +665,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1554">
+    <dxl:Plan Id="0" SpaceSize="2142">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2712065383.057338" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/Switch-With-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Switch-With-Subquery.mdp
@@ -406,7 +406,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="134">
+    <dxl:Plan Id="0" SpaceSize="257">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.002549" Rows="10.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/Union-OuterRefs-Casting-Output.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Union-OuterRefs-Casting-Output.mdp
@@ -396,7 +396,7 @@ select * from x2 where a in (select a from y union select 1::int8);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="36">
+    <dxl:Plan Id="0" SpaceSize="48">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.002070" Rows="10.000000" Width="2"/>

--- a/src/backend/gporca/data/dxl/minidump/Union-OuterRefs-InnerChild.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Union-OuterRefs-InnerChild.mdp
@@ -332,7 +332,7 @@ select * from y where m in (select 1 union select n from x);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="24">
+    <dxl:Plan Id="0" SpaceSize="36">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.000516" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/Union-OuterRefs-Output.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Union-OuterRefs-Output.mdp
@@ -377,7 +377,7 @@ select * from x where a in (select a from y union select 1);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="36">
+    <dxl:Plan Id="0" SpaceSize="48">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.002092" Rows="10.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/UnionWithOuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnionWithOuterRefs.mdp
@@ -729,7 +729,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1120">
+    <dxl:Plan Id="0" SpaceSize="1260">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="929.941015" Rows="14282.594514" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/UnnestSQJoins.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnnestSQJoins.mdp
@@ -1282,7 +1282,7 @@ WHERE
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="52727">
+    <dxl:Plan Id="0" SpaceSize="60392">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1306.824501" Rows="199.680000" Width="148"/>

--- a/src/backend/gporca/data/dxl/minidump/UnsupportedStatsPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnsupportedStatsPredicate.mdp
@@ -1016,7 +1016,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3">
+    <dxl:Plan Id="0" SpaceSize="4">
       <dxl:HashJoin JoinType="Left">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.173205" Rows="136.148000" Width="132"/>

--- a/src/backend/gporca/data/dxl/minidump/UpdateUniqueConstraint-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateUniqueConstraint-2.mdp
@@ -764,7 +764,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalUpdate>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="40">
+    <dxl:Plan Id="0" SpaceSize="44">
       <dxl:DMLUpdate Columns="0,1" ActionCol="23" OidCol="24" CtidCol="2" SegmentIdCol="8" InputSorted="false" PreserveOids="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="872.289027" Rows="100.000000" Width="1"/>

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalJoin.h
@@ -129,6 +129,8 @@ public:
 								   CDrvdPropArray *pdrgpdpCtxt,
 								   ULONG ulOptReq) const override;
 
+	CEnfdDistribution *PedOuterHashDistribute(CMemoryPool *mp,
+											  CExpressionHandle &exprhdl);
 	CEnfdDistribution *Ped(CMemoryPool *mp, CExpressionHandle &exprhdl,
 						   CReqdPropPlan *prppInput, ULONG child_index,
 						   CDrvdPropArray *pdrgpdpCtxt,

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPredicateUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPredicateUtils.h
@@ -487,6 +487,11 @@ public:
 	// NB: This does NOT recurse into Boolean AND/OR operations
 	static BOOL ExprsContainsOnlyStrictComparisons(CExpressionArray *conjuncts);
 
+	// recursively collect predicates included in equality within some larger set
+	static BOOL CollectEqualityWithinPcrs(CExpression *pexpr,
+										  CExpressionArray *pdrgpexpr,
+										  CColRefSet *pcrsSrc);
+
 };	// class CPredicateUtils
 }  // namespace gpopt
 

--- a/src/test/regress/expected/bfv_statistic_optimizer.out
+++ b/src/test/regress/expected/bfv_statistic_optimizer.out
@@ -396,25 +396,25 @@ ANALYZE test_join_card1;
 ANALYZE test_join_card2;
 ANALYZE test_join_card3;
 EXPLAIN SELECT * FROM test_join_card1 t1, test_join_card2 t2, test_join_card3 t3 WHERE t1.b = t2.b and t3.b = t2.b;
-                                                                QUERY PLAN                                                                
-------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1298.38 rows=5999 width=22)
-   ->  Hash Join  (cost=0.00..1297.89 rows=2000 width=22)
-         Hash Cond: (((test_join_card1.b)::text = (test_join_card2.b)::text) AND ((test_join_card3.b)::text = (test_join_card2.b)::text))
-         ->  Hash Join  (cost=0.00..865.03 rows=3334 width=18)
-               Hash Cond: ((test_join_card1.b)::text = (test_join_card3.b)::text)
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.48 rows=6667 width=10)
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1299.80 rows=5999 width=22)
+   ->  Hash Join  (cost=0.00..1299.31 rows=2000 width=22)
+         Hash Cond: ((test_join_card2.b)::text = (test_join_card1.b)::text)
+         ->  Hash Join  (cost=0.00..864.41 rows=2000 width=12)
+               Hash Cond: ((test_join_card3.b)::text = (test_join_card2.b)::text)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.20 rows=3334 width=8)
+                     Hash Key: test_join_card3.b
+                     ->  Seq Scan on test_join_card3  (cost=0.00..431.07 rows=3334 width=8)
+               ->  Hash  (cost=431.08..431.08 rows=2000 width=4)
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.08 rows=2000 width=4)
+                           Hash Key: test_join_card2.b
+                           ->  Seq Scan on test_join_card2  (cost=0.00..431.04 rows=2000 width=4)
+         ->  Hash  (cost=431.48..431.48 rows=6667 width=10)
+               ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.48 rows=6667 width=10)
                      Hash Key: test_join_card1.b
                      ->  Seq Scan on test_join_card1  (cost=0.00..431.15 rows=6667 width=10)
-               ->  Hash  (cost=431.20..431.20 rows=3334 width=8)
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.20 rows=3334 width=8)
-                           Hash Key: test_join_card3.b
-                           ->  Seq Scan on test_join_card3  (cost=0.00..431.07 rows=3334 width=8)
-         ->  Hash  (cost=431.08..431.08 rows=2000 width=4)
-               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.08 rows=2000 width=4)
-                     Hash Key: test_join_card2.b
-                     ->  Seq Scan on test_join_card2  (cost=0.00..431.04 rows=2000 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.41.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (17 rows)
 
 -- start_ignore

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14409,3 +14409,78 @@ select c from mix_func_cast();
  t
 (1 row)
 
+-- verify that a motion is introduced on the outer side
+-- verify that the varchar equality operator (which requires casts for both children)
+-- doesn't introduce additional predicates
+CREATE TABLE dist_tab_a (a varchar(15)) DISTRIBUTED BY(a);
+INSERT INTO dist_tab_a VALUES('1 '), ('2  '), ('3    ');
+CREATE TABLE dist_tab_b (a char(15), b bigint) DISTRIBUTED BY(a);
+INSERT INTO dist_tab_b VALUES('1 ', 1), ('2  ', 2), ('3    ', 3);
+explain SELECT a.a, b.b FROM dist_tab_a a JOIN dist_tab_b b ON a.a=b.a;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=274.75..41859.58 rows=1344990 width=56)
+   ->  Hash Join  (cost=274.75..23926.38 rows=448330 width=56)
+         Hash Cond: ((a.a)::bpchar = b.a)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..453.00 rows=13967 width=48)
+               Hash Key: a.a
+               ->  Seq Scan on dist_tab_a a  (cost=0.00..173.67 rows=13967 width=48)
+         ->  Hash  (cost=141.00..141.00 rows=10700 width=72)
+               ->  Seq Scan on dist_tab_b b  (cost=0.00..141.00 rows=10700 width=72)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+SELECT a.a, b.b FROM dist_tab_a a JOIN dist_tab_b b ON a.a=b.a;
+   a   | b 
+-------+---
+ 1     | 1
+ 3     | 3
+ 2     | 2
+(3 rows)
+
+set optimizer_enable_hashjoin=off;
+explain SELECT a.a, b.b FROM dist_tab_a a left JOIN dist_tab_b b ON a.a=b.a;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=274.75..41859.58 rows=1344990 width=56)
+   ->  Hash Left Join  (cost=274.75..23926.38 rows=448330 width=56)
+         Hash Cond: ((a.a)::bpchar = b.a)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..453.00 rows=13967 width=48)
+               Hash Key: a.a
+               ->  Seq Scan on dist_tab_a a  (cost=0.00..173.67 rows=13967 width=48)
+         ->  Hash  (cost=141.00..141.00 rows=10700 width=72)
+               ->  Seq Scan on dist_tab_b b  (cost=0.00..141.00 rows=10700 width=72)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+SELECT a.a, b.b FROM dist_tab_a a left JOIN dist_tab_b b ON a.a=b.a;
+   a   | b 
+-------+---
+ 1     | 1
+ 3     | 3
+ 2     | 2
+(3 rows)
+
+explain SELECT a.a, b.b FROM dist_tab_a a JOIN dist_tab_b b ON a.a=b.a;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=274.75..41859.58 rows=1344990 width=56)
+   ->  Hash Join  (cost=274.75..23926.38 rows=448330 width=56)
+         Hash Cond: ((a.a)::bpchar = b.a)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..453.00 rows=13967 width=48)
+               Hash Key: a.a
+               ->  Seq Scan on dist_tab_a a  (cost=0.00..173.67 rows=13967 width=48)
+         ->  Hash  (cost=141.00..141.00 rows=10700 width=72)
+               ->  Seq Scan on dist_tab_b b  (cost=0.00..141.00 rows=10700 width=72)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+SELECT a.a, b.b FROM dist_tab_a a JOIN dist_tab_b b ON a.a=b.a;
+   a   | b 
+-------+---
+ 3     | 3
+ 2     | 2
+ 1     | 1
+(3 rows)
+
+reset optimizer_enable_hashjoin;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14081,17 +14081,20 @@ set enable_nestloop=on;
 set enable_hashjoin=off;
 --- verify that the inner half of a left outer nested loop join is non-randomly distributed
 explain select r.a, r.b, r.c, l.c from left_outer_index_nl_foo r left outer join left_outer_index_nl_bar l on r.b=l.b;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324033.80 rows=7 width=16)
-   ->  Nested Loop Left Join  (cost=0.00..1324033.80 rows=3 width=16)
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.81 rows=7 width=16)
+   ->  Nested Loop Left Join  (cost=0.00..1324032.81 rows=3 width=16)
          Join Filter: (left_outer_index_nl_foo.b = left_outer_index_nl_bar.b)
-         ->  Seq Scan on left_outer_index_nl_foo  (cost=0.00..431.00 rows=2 width=12)
-         ->  Materialize  (cost=0.00..431.00 rows=5 width=8)
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=5 width=8)
+         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=2 width=12)
+               Hash Key: left_outer_index_nl_foo.b
+               ->  Seq Scan on left_outer_index_nl_foo  (cost=0.00..431.00 rows=2 width=12)
+         ->  Materialize  (cost=0.00..431.00 rows=2 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=8)
+                     Hash Key: left_outer_index_nl_bar.b
                      ->  Seq Scan on left_outer_index_nl_bar  (cost=0.00..431.00 rows=2 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(8 rows)
+(11 rows)
 
 select r.a, r.b, r.c, l.c from left_outer_index_nl_foo r left outer join left_outer_index_nl_bar l on r.b=l.b;
  a | b | c | c 
@@ -14115,17 +14118,20 @@ analyze left_outer_index_nl_foo_hash;
 analyze left_outer_index_nl_bar_hash;
 --- verify that the inner half of a left outer nested loop join is non-randomly distributed
 explain select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_hash r left outer join left_outer_index_nl_bar l on r.b=l.b;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324033.77 rows=7 width=14)
-   ->  Nested Loop Left Join  (cost=0.00..1324033.77 rows=3 width=14)
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.78 rows=7 width=14)
+   ->  Nested Loop Left Join  (cost=0.00..1324032.78 rows=3 width=14)
          Join Filter: (left_outer_index_nl_foo_hash.b = left_outer_index_nl_bar.b)
-         ->  Seq Scan on left_outer_index_nl_foo_hash  (cost=0.00..431.00 rows=2 width=10)
-         ->  Materialize  (cost=0.00..431.00 rows=5 width=8)
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=5 width=8)
+         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=2 width=10)
+               Hash Key: left_outer_index_nl_foo_hash.b
+               ->  Seq Scan on left_outer_index_nl_foo_hash  (cost=0.00..431.00 rows=2 width=10)
+         ->  Materialize  (cost=0.00..431.00 rows=2 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=8)
+                     Hash Key: left_outer_index_nl_bar.b
                      ->  Seq Scan on left_outer_index_nl_bar  (cost=0.00..431.00 rows=2 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(8 rows)
+(11 rows)
 
 select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_hash r left outer join left_outer_index_nl_bar l on r.b=l.b;
  a | b | c | c 
@@ -14140,15 +14146,18 @@ select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_hash r left outer join le
 explain select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_hash r left outer join left_outer_index_nl_bar_hash l on r.b=l.b;
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324033.54 rows=7 width=12)
-   ->  Nested Loop Left Join  (cost=0.00..1324033.54 rows=3 width=12)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.73 rows=7 width=12)
+   ->  Nested Loop Left Join  (cost=0.00..1324032.73 rows=3 width=12)
          Join Filter: (left_outer_index_nl_foo_hash.b = left_outer_index_nl_bar_hash.b)
-         ->  Seq Scan on left_outer_index_nl_foo_hash  (cost=0.00..431.00 rows=2 width=10)
-         ->  Materialize  (cost=0.00..431.00 rows=5 width=6)
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=5 width=6)
+         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=2 width=10)
+               Hash Key: left_outer_index_nl_foo_hash.b
+               ->  Seq Scan on left_outer_index_nl_foo_hash  (cost=0.00..431.00 rows=2 width=10)
+         ->  Materialize  (cost=0.00..431.00 rows=2 width=6)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=6)
+                     Hash Key: left_outer_index_nl_bar_hash.b
                      ->  Seq Scan on left_outer_index_nl_bar_hash  (cost=0.00..431.00 rows=2 width=6)
  Optimizer: Pivotal Optimizer (GPORCA)
-(8 rows)
+(11 rows)
 
 select r.a, r.b, r.c, l.c from left_outer_index_nl_foo_hash r left outer join left_outer_index_nl_bar_hash l on r.b=l.b;
  a | b | c | c 
@@ -14780,3 +14789,77 @@ select c from mix_func_cast();
  t
 (1 row)
 
+-- verify that a motion is introduced on the outer side
+-- verify that the varchar equality operator (which requires casts for both children)
+-- doesn't introduce additional predicates
+CREATE TABLE dist_tab_a (a varchar(15)) DISTRIBUTED BY(a);
+INSERT INTO dist_tab_a VALUES('1 '), ('2  '), ('3    ');
+CREATE TABLE dist_tab_b (a char(15), b bigint) DISTRIBUTED BY(a);
+INSERT INTO dist_tab_b VALUES('1 ', 1), ('2  ', 2), ('3    ', 3);
+explain SELECT a.a, b.b FROM dist_tab_a a JOIN dist_tab_b b ON a.a=b.a;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=16)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=16)
+         Hash Cond: (dist_tab_b.a = (dist_tab_a.a)::bpchar)
+         ->  Seq Scan on dist_tab_b  (cost=0.00..431.00 rows=1 width=16)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                     Hash Key: dist_tab_a.a
+                     ->  Seq Scan on dist_tab_a  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+SELECT a.a, b.b FROM dist_tab_a a JOIN dist_tab_b b ON a.a=b.a;
+   a   | b 
+-------+---
+ 1     | 1
+ 2     | 2
+ 3     | 3
+(3 rows)
+
+set optimizer_enable_hashjoin=off;
+explain SELECT a.a, b.b FROM dist_tab_a a left JOIN dist_tab_b b ON a.a=b.a;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.44 rows=2 width=16)
+   ->  Nested Loop Left Join  (cost=0.00..1324032.44 rows=1 width=16)
+         Join Filter: ((dist_tab_a.a)::bpchar = dist_tab_b.a)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+               Hash Key: (dist_tab_a.a)::bpchar
+               ->  Seq Scan on dist_tab_a  (cost=0.00..431.00 rows=1 width=8)
+         ->  Seq Scan on dist_tab_b  (cost=0.00..431.00 rows=1 width=16)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+SELECT a.a, b.b FROM dist_tab_a a left JOIN dist_tab_b b ON a.a=b.a;
+   a   | b 
+-------+---
+ 1     | 1
+ 3     | 3
+ 2     | 2
+(3 rows)
+
+explain SELECT a.a, b.b FROM dist_tab_a a JOIN dist_tab_b b ON a.a=b.a;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.42 rows=1 width=16)
+   ->  Nested Loop  (cost=0.00..1324032.42 rows=1 width=16)
+         Join Filter: ((dist_tab_a.a)::bpchar = dist_tab_b.a)
+         ->  Seq Scan on dist_tab_b  (cost=0.00..431.00 rows=1 width=16)
+         ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                     Hash Key: dist_tab_a.a
+                     ->  Seq Scan on dist_tab_a  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+SELECT a.a, b.b FROM dist_tab_a a JOIN dist_tab_b b ON a.a=b.a;
+   a   | b 
+-------+---
+ 1     | 1
+ 2     | 2
+ 3     | 3
+(3 rows)
+
+reset optimizer_enable_hashjoin;


### PR DESCRIPTION
This PR prevents equality predicates with two casts from being included in
equivalence classes (equality between `varchar` requires both sides be cast to
text, for example). This prevents redundant predicates from being introduced
which may produce incorrect results.

This PR allows redistribution motions on the outer child of various JOINs.

This PR also propagates opfamilies to children of hash joins to allow for
motions on the outer child.
