### PR TITLE
Fix missing Redistribute on top of Split Update with Orca

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/UpdateDistKeyWithNestedJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateDistKeyWithNestedJoin.mdp
@@ -1,0 +1,924 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Objective: Test ORCA generates a plan that adds a Redistribute Motion on top of Split
+CREATE TABLE tab1 (id1 integer, id2 integer) DISTRIBUTED BY (id1);
+INSERT INTO tab1 SELECT i, -i FROM generate_series(-30000, 30000) i;
+EXPLAIN UPDATE tab1 t1 set id1 = t2.new_id1
+FROM
+  (SELECT a.id1, a.id2 AS new_id1 FROM tab1 a
+    INNER JOIN (SELECT id1 FROM tab1) b
+  on b.id1 = a.id1) t2
+WHERE t1.id1 = t2.id1;
+                                                 QUERY PLAN
+ Update on tab1  (cost=0.00..1293.07 rows=1 width=1)
+   ->  Result  (cost=0.00..1293.00 rows=2 width=26)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1293.00 rows=2 width=22)
+               Hash Key: tab1_1.id1
+               ->  Split  (cost=0.00..1293.00 rows=1 width=22)
+                     ->  Hash Join  (cost=0.00..1293.00 rows=1 width=22)
+                           Hash Cond: (tab1_1.id1 = tab1_2.id1)
+                           ->  Seq Scan on tab1 tab1_1  (cost=0.00..431.00 rows=1 width=18)
+                           ->  Hash  (cost=862.00..862.00 rows=1 width=8)
+                                 ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
+                                       Hash Cond: (tab1_2.id1 = tab1_3.id1)
+                                       ->  Seq Scan on tab1 tab1_2  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                             ->  Seq Scan on tab1 tab1_3  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.57388.1.0" Name="tab1" Rows="60001.000000" RelPages="67" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.57388.1.0" Name="tab1" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="id1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="id2" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:ColumnStatistics Mdid="1.57388.1.0.0" Name="id1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-29999"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-29416"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-29416"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-28807"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-28807"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-28226"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-28226"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-27659"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-27659"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-27070"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-27070"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-26478"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-26478"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-25901"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-25901"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-25318"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-25318"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-24666"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-24666"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-24100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-24100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-23458"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-23458"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-22851"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-22851"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-22253"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-22253"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-21668"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-21668"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-21073"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-21073"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-20495"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-20495"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-19900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-19900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-19280"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-19280"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-18718"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-18718"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-18103"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-18103"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-17512"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-17512"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-16936"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-16936"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-16343"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-16343"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-15769"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-15769"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-15162"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-15162"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-14569"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-14569"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-13984"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-13984"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-13363"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-13363"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-12806"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-12806"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-12191"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-12191"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-11550"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-11550"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-10960"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-10960"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-10368"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-10368"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-9757"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-9757"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-9161"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-9161"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-8540"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-8540"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-7946"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-7946"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-7353"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-7353"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-6755"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-6755"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-6112"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-6112"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-5527"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-5527"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-4892"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-4892"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-4305"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-4305"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-3710"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-3710"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-3118"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-3118"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-2544"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-2544"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-1979"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-1979"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-1360"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-1360"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-734"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-734"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-112"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-112"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="496"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="496"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1117"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1117"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1703"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1703"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2310"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2310"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2944"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2944"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3563"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3563"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4181"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4181"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4847"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4847"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5440"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5440"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6034"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6034"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6647"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6647"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7235"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7235"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7837"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7837"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8497"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8497"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9132"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9132"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9728"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9728"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10323"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10323"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10936"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10936"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11511"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11511"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12099"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12099"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12703"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12703"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13325"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13325"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13918"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13918"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14564"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14564"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15159"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15159"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15752"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15752"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16359"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16359"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16946"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16946"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17516"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17516"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18113"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18113"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18690"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18690"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19289"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19289"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19864"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19864"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20423"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20423"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21040"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21040"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21650"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21650"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22236"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22236"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22820"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22820"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23456"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23456"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24067"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24067"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24656"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24656"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25208"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25208"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25803"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25803"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26390"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26390"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26986"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26986"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27622"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27622"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28224"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28224"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28817"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28817"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29392"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="600.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29392"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="30000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="11" ColName="id1" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalUpdate DeleteColumns="1,2" InsertColumns="11,2" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+        <dxl:TableDescriptor Mdid="0.57388.1.0" TableName="tab1" LockMode="7">
+          <dxl:Columns>
+            <dxl:Column ColId="28" Attno="1" ColName="id1" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="29" Attno="2" ColName="id2" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="30" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="31" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="32" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="33" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="34" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="35" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="36" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+        <dxl:LogicalJoin JoinType="Inner">
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="0.57388.1.0" TableName="tab1" LockMode="7">
+              <dxl:Columns>
+                <dxl:Column ColId="1" Attno="1" ColName="id1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="2" ColName="id2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+          <dxl:LogicalJoin JoinType="Inner">
+            <dxl:LogicalGet>
+              <dxl:TableDescriptor Mdid="0.57388.1.0" TableName="tab1" LockMode="1">
+                <dxl:Columns>
+                  <dxl:Column ColId="10" Attno="1" ColName="id1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="11" Attno="2" ColName="id2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="13" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="14" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="15" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="16" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="17" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="18" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:LogicalGet>
+            <dxl:LogicalGet>
+              <dxl:TableDescriptor Mdid="0.57388.1.0" TableName="tab1" LockMode="1">
+                <dxl:Columns>
+                  <dxl:Column ColId="19" Attno="1" ColName="id1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="20" Attno="2" ColName="id2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="22" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="23" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="24" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="25" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="26" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="27" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:LogicalGet>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="19" ColName="id1" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="10" ColName="id1" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:LogicalJoin>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="1" ColName="id1" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="10" ColName="id1" TypeMdid="0.23.1.0"/>
+          </dxl:Comparison>
+        </dxl:LogicalJoin>
+      </dxl:LogicalUpdate>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="34">
+      <dxl:DMLUpdate Columns="0,1" ActionCol="27" OidCol="28" CtidCol="2" SegmentIdCol="8" InputSorted="false" PreserveOids="false">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="5381.429219" Rows="60001.000000" Width="1"/>
+        </dxl:Properties>
+        <dxl:DirectDispatchInfo/>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="id1">
+            <dxl:Ident ColId="0" ColName="id1" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="id2">
+            <dxl:Ident ColId="1" ColName="id2" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:TableDescriptor Mdid="0.57388.1.0" TableName="tab1" LockMode="7">
+          <dxl:Columns>
+            <dxl:Column ColId="29" Attno="1" ColName="id1" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="30" Attno="2" ColName="id2" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="31" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="32" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="33" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="34" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="35" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="36" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="37" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1318.861511" Rows="120002.000000" Width="26"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="id1">
+              <dxl:Ident ColId="0" ColName="id1" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="id2">
+              <dxl:Ident ColId="1" ColName="id2" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="ctid">
+              <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+              <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="27" Alias="ColRef_0027">
+              <dxl:Ident ColId="27" ColName="ColRef_0027" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="28" Alias="ColRef_0028">
+              <dxl:ConstValue TypeMdid="0.26.1.0" Value="57388"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1317.821494" Rows="120002.000000" Width="22"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="id1">
+                <dxl:Ident ColId="0" ColName="id1" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="id2">
+                <dxl:Ident ColId="1" ColName="id2" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="2" Alias="ctid">
+                <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="27" Alias="ColRef_0027">
+                <dxl:Ident ColId="27" ColName="ColRef_0027" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr Opfamily="0.1977.1.0">
+                <dxl:Ident ColId="0" ColName="id1" TypeMdid="0.23.1.0"/>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
+            <dxl:Split DeleteColumns="0,1" InsertColumns="10,1" ActionCol="27" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1315.067048" Rows="120002.000000" Width="22"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="id1">
+                  <dxl:Ident ColId="0" ColName="id1" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="id2">
+                  <dxl:Ident ColId="1" ColName="id2" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="2" Alias="ctid">
+                  <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                  <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="27" Alias="ColRef_0027">
+                  <dxl:DMLAction/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:HashJoin JoinType="Inner">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1314.187033" Rows="60001.000000" Width="22"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="id1">
+                    <dxl:Ident ColId="0" ColName="id1" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="id2">
+                    <dxl:Ident ColId="1" ColName="id2" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="10" Alias="id2">
+                    <dxl:Ident ColId="10" ColName="id2" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="2" Alias="ctid">
+                    <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                    <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:JoinFilter/>
+                <dxl:HashCondList>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="0" ColName="id1" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="9" ColName="id1" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:HashCondList>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.418007" Rows="60001.000000" Width="18"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="id1">
+                      <dxl:Ident ColId="0" ColName="id1" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="1" Alias="id2">
+                      <dxl:Ident ColId="1" ColName="id2" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="2" Alias="ctid">
+                      <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                      <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.57388.1.0" TableName="tab1" LockMode="7">
+                    <dxl:Columns>
+                      <dxl:Column ColId="0" Attno="1" ColName="id1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="1" Attno="2" ColName="id2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+                <dxl:HashJoin JoinType="Inner">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="871.231994" Rows="60001.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="9" Alias="id1">
+                      <dxl:Ident ColId="9" ColName="id1" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="10" Alias="id2">
+                      <dxl:Ident ColId="10" ColName="id2" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:JoinFilter/>
+                  <dxl:HashCondList>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="9" ColName="id1" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="18" ColName="id1" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:HashCondList>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.418007" Rows="60001.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="9" Alias="id1">
+                        <dxl:Ident ColId="9" ColName="id1" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="10" Alias="id2">
+                        <dxl:Ident ColId="10" ColName="id2" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.57388.1.0" TableName="tab1" LockMode="1">
+                      <dxl:Columns>
+                        <dxl:Column ColId="9" Attno="1" ColName="id1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="10" Attno="2" ColName="id2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                        <dxl:Column ColId="12" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="13" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="14" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="15" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="16" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="17" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.418007" Rows="60001.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="18" Alias="id1">
+                        <dxl:Ident ColId="18" ColName="id1" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.57388.1.0" TableName="tab1" LockMode="1">
+                      <dxl:Columns>
+                        <dxl:Column ColId="18" Attno="1" ColName="id1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                        <dxl:Column ColId="21" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="22" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="23" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="24" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="25" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="26" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:HashJoin>
+              </dxl:HashJoin>
+            </dxl:Split>
+          </dxl:RedistributeMotion>
+        </dxl:Result>
+      </dxl:DMLUpdate>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalSplit.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalSplit.cpp
@@ -352,8 +352,6 @@ CPhysicalSplit::PdsDerive(CMemoryPool *mp, CExpressionHandle &exprhdl) const
 
 	CDistributionSpecHashed *pdsHashed =
 		CDistributionSpecHashed::PdsConvert(pdsOuter);
-	CColRefSet *pcrsHashed =
-		CUtils::PcrsExtractColumns(mp, pdsHashed->Pdrgpexpr());
 
 	// Consider the below case for updating the same table.:
 	// create table s (a int, b int) distributed by (a);
@@ -376,34 +374,24 @@ CPhysicalSplit::PdsDerive(CMemoryPool *mp, CExpressionHandle &exprhdl) const
 	// this will satisfy the spec requested by CPhysicalDML
 	// (which should ask the child to be distributed by column a), and we will not see a redistribute motion.
 
-	if (!pcrsModified->IsDisjoint(pcrsHashed))
+	do
 	{
-		pcrsModified->Release();
-		pcrsHashed->Release();
-		pcrsDelete->Release();
-		return GPOS_NEW(mp) CDistributionSpecRandom();
-	}
-
-	if (NULL != pdsHashed->PdshashedEquiv())
-	{
-		CColRefSet *pcrsHashedEquiv = CUtils::PcrsExtractColumns(
-			mp, pdsHashed->PdshashedEquiv()->Pdrgpexpr());
-		if (!pcrsModified->IsDisjoint(pcrsHashedEquiv))
+		CColRefSet *pcrsHashed =
+			CUtils::PcrsExtractColumns(mp, pdsHashed->Pdrgpexpr());
+		if (!pcrsModified->IsDisjoint(pcrsHashed))
 		{
 			pcrsHashed->Release();
-			pcrsHashedEquiv->Release();
 			pcrsModified->Release();
 			pcrsDelete->Release();
 			return GPOS_NEW(mp) CDistributionSpecRandom();
 		}
-		pcrsHashedEquiv->Release();
-	}
+		pcrsHashed->Release();
+	} while (NULL != (pdsHashed = pdsHashed->PdshashedEquiv()));
 
 	pcrsModified->Release();
-	pcrsHashed->Release();
 	pcrsDelete->Release();
-	pdsHashed->AddRef();
-	return pdsHashed;
+	pdsOuter->AddRef();
+	return pdsOuter;
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/server/src/unittest/gpopt/minidump/CDMLTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/minidump/CDMLTest.cpp
@@ -99,6 +99,7 @@ const CHAR *rgszDMLFileNames[] = {
 	"../data/dxl/minidump/DML-With-CorrelatedNLJ-With-Universal-Child.mdp",
 	"../data/dxl/minidump/DML-Volatile-Function.mdp",
 	"../data/dxl/minidump/UpdateWindowGatherMerge.mdp",
+	"../data/dxl/minidump/UpdateDistKeyWithNestedJoin.mdp",
 };
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
When deriving distribution spec for `CPhysicalSplit`, ORCA checks if its
disjoint with the hashed colrefs aswell as the equivalent hashed colrefs
(PdshashedEquiv()). For certain nested queries with a JOIN on the same
column, it is possible that the equivalent hashed colrefs also have
other equivalent hashed colrefs. ORCA did not consider such cases and
would skip recursively checking for hashed-equivalent colrefs and
include it to check if its disjoint with the colrefs being modified.
Thus generating a plan without a Redistribute on top of a Split node
when updating the distribution column. This would lead to wrong results.
This commit fixes the issue.

Co-authored-by: gpopt <103469259+gpopt@users.noreply.github.com>

(cherry picked from commit f47b262779de1d940e47e109be0aa483f4494957)
