### PR TITLE
Support both unicast and wildcard address binding

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -1032,8 +1032,26 @@ cdbcomponent_getComponentInfo(int contentId)
 static void
 ensureInterconnectAddress(void)
 {
+	/*
+	 * If the address type is wildcard, there is no need to populate an unicast
+	 * address in interconnect_address.
+	 */
+	if (Gp_interconnect_address_type == INTERCONNECT_ADDRESS_TYPE_WILDCARD)
+	{
+		interconnect_address = NULL;
+		return;
+	}
+
+	Assert(Gp_interconnect_address_type == INTERCONNECT_ADDRESS_TYPE_UNICAST);
+
+	/* If the unicast address has already been assigned, exit early. */
 	if (interconnect_address)
 		return;
+
+	/*
+	 * Retrieve the segment's gp_segment_configuration.address value, in order
+	 * to setup interconnect_address
+	 */
 
 	if (GpIdentity.segindex >= 0)
 	{

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -209,6 +209,7 @@ int			Gp_interconnect_debug_retry_interval = 10;
 int			interconnect_setup_timeout = 7200;
 
 int			Gp_interconnect_type = INTERCONNECT_TYPE_UDPIFC;
+int 		Gp_interconnect_address_type = INTERCONNECT_ADDRESS_TYPE_UNICAST;
 
 bool		gp_interconnect_aggressive_retry = true;	/* fast-track app-level
 														 * retry */

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -157,16 +157,21 @@ setupTCPListeningSocket(int backlog, int *listenerSocketFd, uint16 *listenerPort
 	hints.ai_socktype = SOCK_STREAM;	/* Two-way, out of band connection */
 	hints.ai_protocol = 0;		/* Any protocol - TCP implied for network use due to SOCK_STREAM */
 
-	/*
-	 * Restrict what IP address we will listen on to just the one that was
-	 * used to create this QE session.
-	 */
-	Assert(interconnect_address && strlen(interconnect_address) > 0);
-	hints.ai_flags |= AI_NUMERICHOST;
-	if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
-		ereport(DEBUG1,
-				(errmsg("getaddrinfo called with interconnect_address %s",
-						interconnect_address)));
+	if (Gp_interconnect_address_type == INTERCONNECT_ADDRESS_TYPE_UNICAST)
+	{
+		Assert(interconnect_address && strlen(interconnect_address) > 0);
+		hints.ai_flags |= AI_NUMERICHOST;
+		ereportif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+				  (errmsg("getaddrinfo called with unicast address: %s",
+						  interconnect_address)));
+	}
+	else
+	{
+		Assert(interconnect_address == NULL);
+		hints.ai_flags |= AI_PASSIVE;
+		ereportif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+				  (errmsg("getaddrinfo called with wildcard address")));
+	}
 
 	s = getaddrinfo(interconnect_address, service, &hints, &addrs);
 	if (s != 0)

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -1190,16 +1190,21 @@ setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort, int *txFami
 #endif
 
 	fun = "getaddrinfo";
-	/*
-	 * Restrict what IP address we will listen on to just the one that was
-	 * used to create this QE session.
-	 */
-	Assert(interconnect_address && strlen(interconnect_address) > 0);
-	hints.ai_flags |= AI_NUMERICHOST;
-	if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
-		ereport(DEBUG1,
-				(errmsg("getaddrinfo called with interconnect_address %s",
-								interconnect_address)));
+	if (Gp_interconnect_address_type == INTERCONNECT_ADDRESS_TYPE_UNICAST)
+	{
+		Assert(interconnect_address && strlen(interconnect_address) > 0);
+		hints.ai_flags |= AI_NUMERICHOST;
+		ereportif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+				  (errmsg("getaddrinfo called with unicast address: %s",
+						  interconnect_address)));
+	}
+	else
+	{
+		Assert(interconnect_address == NULL);
+		hints.ai_flags |= AI_PASSIVE;
+		ereportif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+				  (errmsg("getaddrinfo called with wildcard address")));
+	}
 
 	s = getaddrinfo(interconnect_address, service, &hints, &addrs);
 	if (s != 0)

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -517,6 +517,12 @@ static const struct config_enum_entry gp_interconnect_types[] = {
 	{NULL, 0}
 };
 
+static const struct config_enum_entry gp_interconnect_address_types[] = {
+	{"wildcard", INTERCONNECT_ADDRESS_TYPE_WILDCARD},
+	{"unicast", INTERCONNECT_ADDRESS_TYPE_UNICAST},
+	{NULL, 0}
+};
+
 static const struct config_enum_entry gp_log_verbosity[] = {
 	{"terse", GPVARS_VERBOSITY_TERSE},
 	{"off", GPVARS_VERBOSITY_OFF},
@@ -4600,6 +4606,16 @@ struct config_enum ConfigureNamesEnum_gp[] =
 		},
 		&Gp_interconnect_type,
 		INTERCONNECT_TYPE_UDPIFC, gp_interconnect_types,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"gp_interconnect_address_type", PGC_BACKEND, GP_ARRAY_TUNING,
+		 gettext_noop("Sets the interconnect address type used for inter-node communication."),
+		 gettext_noop("Valid values are \"unicast\" and \"wildcard\"")
+		},
+		&Gp_interconnect_address_type,
+		INTERCONNECT_ADDRESS_TYPE_UNICAST, gp_interconnect_address_types,
 		NULL, NULL, NULL
 	},
 

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -297,6 +297,33 @@ typedef enum GpVars_Interconnect_Type
 
 extern int Gp_interconnect_type;
 
+/*
+ * We support different strategies for address binding for sockets used for
+ * motion communication over the interconnect.
+ *
+ * One approach is to use an unicast address, specifically the segment's
+ * gp_segment_configuration.address field to perform the address binding. This
+ * has the benefits of reducing port usage on a segment host and ensures that
+ * the NIC backed by the address field is the only one used for communication
+ * (and not an externally facing slower NIC, like the ones that typically back
+ * the gp_segment_configuration.hostname field)
+ *
+ * In some cases, inter-segment communication using the unicast address
+ * mentioned above, may not be possible. One such example is if the source
+ * segment's address field and the destination segment's address field are on
+ * different subnets and/or existing routing rules don't allow for such
+ * communication. In these cases, using a wildcard address for address binding
+ * is the only available fallback, enabling the use of any network interface
+ * compliant with routing rules.
+ */
+typedef enum GpVars_Interconnect_Address_Type
+{
+	INTERCONNECT_ADDRESS_TYPE_UNICAST = 0,
+	INTERCONNECT_ADDRESS_TYPE_WILDCARD
+} GpVars_Interconnect_Address_Type;
+
+extern int Gp_interconnect_address_type;
+
 extern char *gp_interconnect_proxy_addresses;
 
 typedef enum GpVars_Interconnect_Method

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -42,6 +42,7 @@
 		"gp_interconnect_timer_period",
 		"gp_interconnect_transmit_timeout",
 		"gp_interconnect_type",
+		"gp_interconnect_address_type",
 		"gp_log_endpoints",
 		"gp_log_interconnect",
 		"gp_log_resgroup_memory",


### PR DESCRIPTION
790c7bac695 changed our address binding strategy to use a unicast
address (segment's gp_segment_configuration.address) instead of the
wildcard address, to reduce port usage on segment hosts and to ensure
that we don't inadvertently use a slower network interface for
interconnect traffic.

In some cases, inter-segment communication using the unicast address
mentioned above, may not be possible. One such example is if the source
segment's address field and the destination segment's address field are
on different subnets and/or existing routing rules don't allow for such
communication. In these cases, using a wildcard address for address
binding is the only available fallback, enabling the use of any
network interface compliant with routing rules.

Thus, this commit introduces the gp_interconnect_address_type GUC to
support both kinds of address binding.

We pick the default to be "unicast", as that is the only reasonable way
to ensure that the segment's address field is used for fast interconnect
communication and to keep port usage manageable on large clusters with
highly concurrent workloads.

Notes:

* Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/guc_unicast_wildcard
* We plan to use `wildcard` as the default for 6X, to minimize disruption for
specific existing customer setups.
* TODO: Test this out in a multi-node cluster, with each host having multiple NICs.
