### PR TITLE
Add extension ip4r as contrib extension

### DIFF
--- a/gpcontrib/Makefile
+++ b/gpcontrib/Makefile
@@ -35,6 +35,8 @@ endif
 ifeq "$(with_quicklz)" "yes"
 	recurse_targets += quicklz
 endif
+recurse_targets += ip4r
+
 $(call recurse,all install clean distclean, $(recurse_targets))
 
 all: gpcloud pxf mapreduce orafce
@@ -98,3 +100,4 @@ installcheck:
 	if [ "$(with_zstd)" = "yes" ]; then $(MAKE) -C zstd installcheck; fi
 	if [ "$(with_quicklz)" = "yes" ]; then $(MAKE) -C quicklz installcheck; fi
 	$(MAKE) -C gp_sparse_vector installcheck
+	$(MAKE) -C ip4r installcheck

--- a/gpcontrib/ip4r/LICENSE
+++ b/gpcontrib/ip4r/LICENSE
@@ -1,0 +1,22 @@
+PostgreSQL License
+
+Copyright (c) 2004-2019, Andrew Gierth
+Copyright (c) 2003, Steve Atkins
+Copyright (c) 2000-2003, PostgreSQL Global Development Group
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose, without fee, and without a written agreement is
+hereby granted, provided that the above copyright notice and this paragraph
+and the following two paragraphs appear in all copies.
+
+IN NO EVENT SHALL THE AUTHORS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING
+OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF THE AUTHORS
+HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+THE AUTHORS SPECIFICALLY DISCLAIM ANY WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS" BASIS,
+AND THE AUTHORS HAVE NO OBLIGATIONS TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+

--- a/gpcontrib/ip4r/expected/ip4r-explain.out
+++ b/gpcontrib/ip4r/expected/ip4r-explain.out
@@ -1,6 +1,5 @@
 -- predicates and indexing
-\!gpconfig -c enable_seqscan -v "off" > /dev/null
-\!gpstop -u > /dev/null
+set enable_seqscan = "off";
 create table ipranges_exp (r iprange, r4 ip4r, r6 ip6r) distributed by (r);
 insert into ipranges_exp
 select r, null, r
@@ -678,14 +677,14 @@ explain select * from ipaddrs_exp where a4 between '8.0.0.0' and '15.0.0.0' orde
 explain select * from ipaddrs_exp a join ipranges_exp r on (r.r >>= a.a) order by a,r;
                                                        QUERY PLAN                                                       
 ------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=20000000910.35..20000001029.90 rows=8439 width=96)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=20000000914.35..20000001033.90 rows=8439 width=96)
    Merge Key: a.a, r.r
-   ->  Sort  (cost=20000000910.35..20000000917.38 rows=2813 width=96)
+   ->  Sort  (cost=20000000914.35..20000000921.38 rows=2813 width=96)
          Sort Key: a.a, r.r
-         ->  Nested Loop  (cost=20000000000.28..20000000749.19 rows=2813 width=96)
+         ->  Nested Loop  (cost=20000000000.28..20000000753.19 rows=2813 width=96)
                ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=10000000000.00..10000000005.53 rows=272 width=36)
                      ->  Seq Scan on ipaddrs_exp a  (cost=10000000000.00..10000000001.91 rows=91 width=36)
-               ->  Index Scan using ipranges_exp_r on ipranges_exp r  (cost=0.28..2.63 rows=10 width=60)
+               ->  Index Scan using ipranges_exp_r on ipranges_exp r  (cost=0.28..2.65 rows=10 width=60)
                      Index Cond: (r >>= (a.a)::iprange)
  Optimizer: Postgres query optimizer
 (10 rows)
@@ -708,14 +707,14 @@ explain select * from ipaddrs_exp a join ipranges_exp r on (r.r4 >>= a.a4) order
 explain select * from ipaddrs_exp a join ipranges_exp r on (r.r6 >>= a.a6) order by a6,r6;
                                                        QUERY PLAN                                                       
 ------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=20000000732.35..20000000851.90 rows=8439 width=96)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=20000000740.35..20000000859.90 rows=8439 width=96)
    Merge Key: a.a6, r.r6
-   ->  Sort  (cost=20000000732.35..20000000739.38 rows=2813 width=96)
+   ->  Sort  (cost=20000000740.35..20000000747.38 rows=2813 width=96)
          Sort Key: a.a6, r.r6
-         ->  Nested Loop  (cost=20000000000.15..20000000571.19 rows=2813 width=96)
+         ->  Nested Loop  (cost=20000000000.15..20000000579.19 rows=2813 width=96)
                ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=10000000000.00..10000000005.53 rows=272 width=36)
                      ->  Seq Scan on ipaddrs_exp a  (cost=10000000000.00..10000000001.91 rows=91 width=36)
-               ->  Index Scan using ipranges_exp_r6 on ipranges_exp r  (cost=0.15..1.98 rows=10 width=60)
+               ->  Index Scan using ipranges_exp_r6 on ipranges_exp r  (cost=0.15..2.01 rows=10 width=60)
                      Index Cond: (r6 >>= (a.a6)::ip6r)
  Optimizer: Postgres query optimizer
 (10 rows)
@@ -758,5 +757,3 @@ explain select r4 from ipranges_exp where r4 >>= '172.16.2.0' order by r4;
  Optimizer: Postgres query optimizer
 (7 rows)
 
-\!gpconfig -r enable_seqscan > /dev/null
-\!gpstop -u > /dev/null

--- a/gpcontrib/ip4r/expected/ip4r-explain_optimizer.out
+++ b/gpcontrib/ip4r/expected/ip4r-explain_optimizer.out
@@ -1,6 +1,5 @@
 -- predicates and indexing
-\!gpconfig -c enable_seqscan -v "off" > /dev/null
-\!gpstop -u > /dev/null
+set enable_seqscan = "off";
 create table ipranges_exp (r iprange, r4 ip4r, r6 ip6r) distributed by (r);
 insert into ipranges_exp
 select r, null, r
@@ -745,5 +744,3 @@ explain select r4 from ipranges_exp where r4 >>= '172.16.2.0' order by r4;
  Optimizer: Pivotal Optimizer (GPORCA)
 (8 rows)
 
-\!gpconfig -r enable_seqscan > /dev/null
-\!gpstop -u > /dev/null

--- a/gpcontrib/ip4r/sql/ip4r-explain.sql
+++ b/gpcontrib/ip4r/sql/ip4r-explain.sql
@@ -1,7 +1,6 @@
 -- predicates and indexing
 
-\!gpconfig -c enable_seqscan -v "off" > /dev/null
-\!gpstop -u > /dev/null
+set enable_seqscan = "off";
 
 create table ipranges_exp (r iprange, r4 ip4r, r6 ip6r) distributed by (r);
 
@@ -143,6 +142,3 @@ vacuum ipranges_exp;
 explain select r from ipranges_exp where r >>= '5555::' order by r;
 explain select r6 from ipranges_exp where r6 >>= '5555::' order by r6;
 explain select r4 from ipranges_exp where r4 >>= '172.16.2.0' order by r4;
-
-\!gpconfig -r enable_seqscan > /dev/null
-\!gpstop -u > /dev/null


### PR DESCRIPTION
This is a hotfix for the accident merge & push to master commit
17f17297c9. (#13418)

The following is the original commit message:

Add ip4r repository as a git subtree. Refer to gpcontrib/README on usage
of git subtree.

This extension add IPv4/v6 and IPv4/v6 range index type. Refer to
gpcontrib/ip4r/README.ip4r for more details.

Add testcase ip4r-explain.sql for index on these new types.

Co-authored-by: Chen Mulong <chenmulong@gmail.com>
Co-authored-by: Xuebin Su <sxuebin@vmware.com>
Co-authored-by: Sasasu <i@sasa.su>