### PR TITLE
FIXME in nodeSort.c: re-implement explain analyze related code in tuplesort

### DIFF
--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -816,8 +816,15 @@ cdbexplain_collectStatsFromNode(PlanState *planstate, CdbExplain_SendStatCtx *ct
 	if (si->bnotes < si->enotes)
 		appendStringInfoChar(ctx->notebuf, '\0');
 
-	if (planstate->node_context)
+	/* Use the instrument's memory record if exists, or query the memory context. */
+	if (instr->execmemused)
+	{
+		si->execmemused = instr->execmemused;
+	}
+	else if (planstate->node_context)
+	{
 		si->execmemused = (double) MemoryContextGetPeakSpace(planstate->node_context);
+	}
 
 	/* Transfer this node's statistics from Instrumentation into StatInst. */
 	si->starttime = instr->starttime;

--- a/src/backend/utils/sort/tuplesort.c
+++ b/src/backend/utils/sort/tuplesort.c
@@ -113,6 +113,7 @@
 #include "utils/rel.h"
 #include "utils/sortsupport.h"
 #include "utils/tuplesort.h"
+#include "utils/dynahash.h"
 
 #include "utils/faultinjector.h"
 
@@ -298,6 +299,7 @@ struct Tuplesortstate
 	int			memtupcount;	/* number of tuples currently present */
 	int			memtupsize;		/* allocated length of memtuples array */
 	bool		growmemtuples;	/* memtuples' growth still underway? */
+	int64		totalNumTuples; /* count of all input tuples */ /*CDB*/
 
 	/*
 	 * Memory for tuples is sometimes allocated using a simple slab allocator,
@@ -459,6 +461,13 @@ struct Tuplesortstate
 	Oid			datumType;
 	/* we need typelen in order to know how to copy the Datums. */
 	int			datumTypeLen;
+
+	/*
+	 * CDB: EXPLAIN ANALYZE reporting interface and statistics.
+	 */
+	struct Instrumentation *instrument;
+	struct StringInfoData  *explainbuf;
+	uint64 spilledBytes;
 
 	/*
 	 * Resource snapshot for time of sort start.
@@ -755,6 +764,7 @@ tuplesort_begin_common(int workMem, SortCoordinate coordinate,
 							ALLOCSET_SEPARATE_THRESHOLD / sizeof(SortTuple) + 1);
 
 	state->growmemtuples = true;
+	state->totalNumTuples  = 0; /*CDB*/
 	state->slabAllocatorUsed = false;
 	state->memtuples = (SortTuple *) palloc(state->memtupsize * sizeof(SortTuple));
 
@@ -1641,6 +1651,8 @@ puttuple_common(Tuplesortstate *state, SortTuple *tuple)
 {
 	Assert(!LEADER(state));
 
+	state->totalNumTuples++;
+
 	switch (state->status)
 	{
 		case TSS_INITIAL:
@@ -1865,6 +1877,24 @@ tuplesort_performsort(Tuplesortstate *state)
 			 * Note that mergeruns sets the correct state->status.
 			 */
 			dumptuples(state, true);
+
+			/* CDB: How much work_mem would be enough for in-memory sort? */
+			if (state->instrument && state->instrument->need_cdb)
+			{
+				/*
+				 * The workmemwanted is summed up of the following:
+				 * (1) metadata: Tuplesortstate, tuple array
+				 * (2) the total bytes for all tuples.
+				 */
+				int64   workmemwanted =
+					sizeof(Tuplesortstate) +
+					((uint64)(1 << my_log2(state->totalNumTuples))) * sizeof(SortTuple) +
+					state->spilledBytes;
+
+				state->instrument->workmemwanted =
+					Max(state->instrument->workmemwanted, workmemwanted);
+			}
+
 			mergeruns(state);
 			state->eof_reached = false;
 			state->markpos_block = 0L;
@@ -2971,6 +3001,7 @@ dumptuples(Tuplesortstate *state, bool alltuples)
 {
 	int			memtupwrite;
 	int			i;
+	long		prevAvailMem = state->availMem;
 
 	/*
 	 * Nothing to do if we still fit in available memory and have array slots,
@@ -3079,6 +3110,12 @@ dumptuples(Tuplesortstate *state, bool alltuples)
 			 state->worker, state->currentRun, state->destTape,
 			 pg_rusage_show(&state->ru_start));
 #endif
+
+	/* CDB: Accumulate total size of spilled tuples. */
+	if (state->availMem > prevAvailMem)
+	{
+		state->spilledBytes += state->availMem - prevAvailMem;
+	}
 
 	if (!alltuples)
 		selectnewtape(state);
@@ -3214,7 +3251,11 @@ tuplesort_get_stats(Tuplesortstate *state,
 		stats->spaceType = SORT_SPACE_TYPE_MEMORY;
 		stats->spaceUsed = (state->allowedMem - state->availMem + 1023) / 1024;
 	}
-	stats->workmemused = MemoryContextGetPeakSpace(state->sortcontext);
+	if (state->instrument)
+	{
+		stats->workmemused = state->instrument->workmemused;
+		stats->execmemused = state->instrument->execmemused;
+	}
 
 	switch (state->status)
 	{
@@ -4673,4 +4714,46 @@ free_sort_tuple(Tuplesortstate *state, SortTuple *stup)
 {
 	FREEMEM(state, GetMemoryChunkSpace(stup->tuple));
 	pfree(stup->tuple);
+}
+
+/*
+ * tuplesort_set_instrument
+ *
+ * May be called after tuplesort_begin_xxx() to enable reporting of
+ * statistics and events for EXPLAIN ANALYZE.
+ *
+ * The 'instr' and 'explainbuf' ptrs are retained in the 'state' object for
+ * possible use anytime during the sort, up to and including tuplesort_end().
+ * The caller must ensure that the referenced objects remain allocated and
+ * valid for the life of the Tuplesortstate object; or if they are to be
+ * freed early, disconnect them by calling again with NULL pointers.
+ */
+void
+tuplesort_set_instrument(Tuplesortstate            *state,
+						 struct Instrumentation    *instrument,
+						 struct StringInfoData     *explainbuf)
+{
+	state->instrument = instrument;
+	state->explainbuf = explainbuf;
+}
+
+/*
+ * tuplesort_finalize_stats
+ *
+ * Finalize the EXPLAIN ANALYZE stats.
+ */
+void
+tuplesort_finalize_stats(Tuplesortstate *state,
+					TuplesortInstrumentation *stats)
+{
+	if (state->instrument)
+	{
+		double  workmemused;
+
+		workmemused = MemoryContextGetPeakSpace(state->sortcontext);
+		if (state->instrument->workmemused < workmemused)
+			state->instrument->workmemused = workmemused;
+		state->instrument->execmemused += MemoryContextGetPeakSpace(state->sortcontext);
+	}
+	tuplesort_get_stats(state, stats);
 }

--- a/src/include/utils/tuplesort.h
+++ b/src/include/utils/tuplesort.h
@@ -89,6 +89,7 @@ typedef struct TuplesortInstrumentation
 	long		spaceUsed;		/* space consumption, in kB */
 
 	Size		workmemused;
+	Size		execmemused;
 } TuplesortInstrumentation;
 
 
@@ -248,6 +249,8 @@ extern void tuplesort_end(Tuplesortstate *state);
 
 extern void tuplesort_get_stats(Tuplesortstate *state,
 								TuplesortInstrumentation *stats);
+extern void tuplesort_finalize_stats(Tuplesortstate *state,
+								TuplesortInstrumentation *stats);
 extern const char *tuplesort_method_name(TuplesortMethod m);
 extern const char *tuplesort_space_type_name(TuplesortSpaceType t);
 
@@ -257,6 +260,10 @@ extern Size tuplesort_estimate_shared(int nworkers);
 extern void tuplesort_initialize_shared(Sharedsort *shared, int nWorkers,
 										dsm_segment *seg);
 extern void tuplesort_attach_shared(Sharedsort *shared, dsm_segment *seg);
+
+extern void tuplesort_set_instrument(Tuplesortstate            *state,
+									 struct Instrumentation    *instrument,
+									 struct StringInfoData     *explainbuf);
 
 /*
  * These routines may only be called if randomAccess was specified 'true'.

--- a/src/test/regress/expected/dpe.out
+++ b/src/test/regress/expected/dpe.out
@@ -11,6 +11,12 @@
 -- s/Batches: \d+/Batches: ###/
 -- m/Extra Text: \(seg\d+\)/
 -- s/Extra Text: \(seg\d+\)/Extra Text: ###/
+-- m/Segments: \d+/
+-- s/Segments: \d+/Segments: ###/ 
+-- m/Max: \d+kB/
+-- s/Max: \d+kB/Max: ###kB/
+-- m/segment: \d+/ 
+-- s/segment: \d+/segment: ###/
 -- m/Hash chain length \d+\.\d+ avg, \d+ max/
 -- s/Hash chain length \d+\.\d+ avg, \d+ max/Hash chain length ###/
 -- m/using \d+ of \d+ buckets/
@@ -391,6 +397,7 @@ explain (costs off, timing off, summary off, analyze) select *, rank() over (ord
          ->  Sort (actual rows=8 loops=1)
                Sort Key: pt_1_prt_2.ptid, pt_1_prt_2.pt1
                Sort Method:  quicksort  Memory: 152kB
+               Executor Memory: 85kB  Segments: 3  Max: 29kB (segment 1)
                ->  Hash Join (actual rows=8 loops=1)
                      Hash Cond: (pt_1_prt_2.ptid = t.tid)
                      Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 2 of 262144 buckets.
@@ -1057,6 +1064,7 @@ explain (costs off, timing off, summary off, analyze) select * from pt, pt1 wher
    ->  Sort (actual rows=5 loops=1)
          Sort Key: pt1_1_prt_2.dist
          Sort Method:  quicksort  Memory: 150kB
+         Executor Memory: 77kB  Segments: 3  Max: 26kB (segment 1)
          ->  Hash Join (actual rows=5 loops=1)
                Hash Cond: (pt1_1_prt_2.ptid = pt_1_prt_2.ptid)
                Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 1 of 131072 buckets.
@@ -1289,6 +1297,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
    ->  Sort (actual rows=50 loops=1)
          Sort Key: fact1_1_prt_1_2_prt_ca.u
          Sort Method:  quicksort  Memory: 158kB
+         Executor Memory: 79kB  Segments: 3  Max: 29kB (segment 1)
          ->  Hash Join (actual rows=50 loops=1)
                Hash Cond: ((fact1_1_prt_1_2_prt_ca.pid = dim1.pid) AND (fact1_1_prt_1_2_prt_ca.code = dim1.code))
                Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 262144 buckets.
@@ -1376,6 +1385,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
    ->  Sort (actual rows=50 loops=1)
          Sort Key: fact1_1_prt_1_2_prt_ca.u
          Sort Method:  quicksort  Memory: 158kB
+         Executor Memory: 79kB  Segments: 3  Max: 29kB (segment 1)
          ->  Hash Join (actual rows=50 loops=1)
                Hash Cond: ((fact1_1_prt_1_2_prt_ca.pid = dim1.pid) AND (fact1_1_prt_1_2_prt_ca.code = dim1.code))
                Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 262144 buckets.
@@ -1468,6 +1478,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
    ->  Sort (actual rows=100 loops=1)
          Sort Key: fact1_1_prt_1_2_prt_ca.u
          Sort Method:  quicksort  Memory: 166kB
+         Executor Memory: 82kB  Segments: 3  Max: 32kB (segment 1)
          ->  Hash Join (actual rows=100 loops=1)
                Hash Cond: (fact1_1_prt_1_2_prt_ca.pid = dim1.pid)
                Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 262144 buckets.
@@ -1605,6 +1616,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
    ->  Sort (actual rows=100 loops=1)
          Sort Key: fact1_1_prt_1_2_prt_ca.u
          Sort Method:  quicksort  Memory: 166kB
+         Executor Memory: 82kB  Segments: 3  Max: 32kB (segment 1)
          ->  Hash Join (actual rows=100 loops=1)
                Hash Cond: (fact1_1_prt_1_2_prt_ca.pid = dim1.pid)
                Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 262144 buckets.
@@ -2218,6 +2230,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
    ->  Sort (actual rows=50 loops=1)
          Sort Key: fact1_1_prt_1_2_prt_oh.u
          Sort Method:  quicksort  Memory: 158kB
+         Executor Memory: 79kB  Segments: 3  Max: 29kB (segment 1)
          ->  Hash Join (actual rows=50 loops=1)
                Hash Cond: (fact1_1_prt_1_2_prt_oh.pid = dim1.pid)
                Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 262144 buckets.
@@ -2301,6 +2314,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
    ->  Sort (actual rows=50 loops=1)
          Sort Key: fact1_1_prt_1_2_prt_oh.u
          Sort Method:  quicksort  Memory: 158kB
+         Executor Memory: 79kB  Segments: 3  Max: 29kB (segment 1)
          ->  Hash Join (actual rows=50 loops=1)
                Hash Cond: (fact1_1_prt_1_2_prt_oh.pid = dim1.pid)
                Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 262144 buckets.
@@ -2391,6 +2405,7 @@ explain (costs off, timing off, summary off, analyze) select fact1.code, count(*
          ->  Sort (actual rows=100 loops=1)
                Sort Key: fact1_1_prt_1_2_prt_ca.code
                Sort Method:  quicksort  Memory: 160kB
+               Executor Memory: 86kB  Segments: 3  Max: 31kB (segment 1)
                ->  Redistribute Motion 3:3  (slice2; segments: 3) (actual rows=100 loops=1)
                      Hash Key: fact1_1_prt_1_2_prt_ca.code
                      ->  Hash Join (actual rows=100 loops=1)
@@ -2434,6 +2449,7 @@ explain (costs off, timing off, summary off, analyze) select fact1.code, count(*
          ->  Sort (actual rows=100 loops=1)
                Sort Key: fact1_1_prt_1_2_prt_ca.code
                Sort Method:  quicksort  Memory: 160kB
+               Executor Memory: 86kB  Segments: 3  Max: 31kB (segment 1)
                ->  Redistribute Motion 3:3  (slice2; segments: 3) (actual rows=100 loops=1)
                      Hash Key: fact1_1_prt_1_2_prt_ca.code
                      ->  Hash Join (actual rows=100 loops=1)
@@ -2695,6 +2711,7 @@ explain (costs off, timing off, summary off, analyze) select * from (select coun
                                              ->  Sort (actual rows=1 loops=1)
                                                    Sort Key: jpat_1.a
                                                    Sort Method:  quicksort  Memory: 150kB
+                                                   Executor Memory: 178kB  Segments: 3  Max: 60kB (segment 0)
                                                    ->  Seq Scan on jpat jpat_1 (actual rows=1 loops=1)
  Optimizer: Postgres query optimizer
 (24 rows)
@@ -2920,6 +2937,7 @@ select * from pt, t where t.dist = pt.dist and t.tid = pt.ptid order by t.tid, t
    ->  Sort  (cost=14.20..14.21 rows=3 width=24) (actual rows=2 loops=1)
          Sort Key: pt1.ptid, t.sk
          Sort Method:  quicksort  Memory: 150kB
+         Executor Memory: 76kB  Segments: 3  Max: 26kB (segment 0)
          ->  Merge Join  (cost=8.08..14.10 rows=3 width=24) (actual rows=2 loops=1)
                Merge Cond: (pt1.ptid = t.tid)
                Join Filter: (pt1.dist = t.dist)

--- a/src/test/regress/expected/dpe.out
+++ b/src/test/regress/expected/dpe.out
@@ -15,8 +15,8 @@
 -- s/Segments: \d+/Segments: ###/ 
 -- m/Max: \d+kB/
 -- s/Max: \d+kB/Max: ###kB/
--- m/segment: \d+/ 
--- s/segment: \d+/segment: ###/
+-- m/segment \d+/ 
+-- s/segment \d+/segment ###/
 -- m/Hash chain length \d+\.\d+ avg, \d+ max/
 -- s/Hash chain length \d+\.\d+ avg, \d+ max/Hash chain length ###/
 -- m/using \d+ of \d+ buckets/

--- a/src/test/regress/expected/dpe_optimizer.out
+++ b/src/test/regress/expected/dpe_optimizer.out
@@ -11,6 +11,12 @@
 -- s/Batches: \d+/Batches: ###/
 -- m/Extra Text: \(seg\d+\)/
 -- s/Extra Text: \(seg\d+\)/Extra Text: ###/
+-- m/Segments: \d+/
+-- s/Segments: \d+/Segments: ###/ 
+-- m/Max: \d+kB/
+-- s/Max: \d+kB/Max: ###kB/
+-- m/segment: \d+/ 
+-- s/segment: \d+/segment: ###/
 -- m/Hash chain length \d+\.\d+ avg, \d+ max/
 -- s/Hash chain length \d+\.\d+ avg, \d+ max/Hash chain length ###/
 -- m/using \d+ of \d+ buckets/
@@ -281,6 +287,7 @@ explain (costs off, timing off, summary off, analyze) select * from pt where pti
                                  ->  Sort (actual rows=2 loops=1)
                                        Sort Key: t.tid
                                        Sort Method:  quicksort  Memory: 150kB
+                                       Executor Memory: 178kB  Segments: 3  Max: 60kB (segment 0)
                                        ->  Redistribute Motion 3:3  (slice3; segments: 3) (actual rows=2 loops=1)
                                              Hash Key: t.tid
                                              ->  Seq Scan on t (actual rows=2 loops=1)
@@ -338,6 +345,7 @@ explain (costs off, timing off, summary off, analyze) select * from pt where exi
                                  ->  Sort (actual rows=2 loops=1)
                                        Sort Key: t.tid
                                        Sort Method:  quicksort  Memory: 150kB
+                                       Executor Memory: 76kB  Segments: 3  Max: 26kB (segment 1)
                                        ->  Redistribute Motion 3:3  (slice3; segments: 3) (actual rows=2 loops=1)
                                              Hash Key: t.tid
                                              ->  Seq Scan on t (actual rows=2 loops=1)
@@ -416,6 +424,7 @@ explain (costs off, timing off, summary off, analyze) select *, rank() over (ord
          ->  Sort (actual rows=8 loops=1)
                Sort Key: pt_1_prt_2.ptid, pt_1_prt_2.pt1
                Sort Method:  quicksort  Memory: 152kB
+               Executor Memory: 85kB  Segments: 3  Max: 29kB (segment 1)
                ->  Nested Loop (actual rows=8 loops=1)
                      Join Filter: true
                      ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=2 loops=1)
@@ -1120,6 +1129,7 @@ explain (costs off, timing off, summary off, analyze) select * from pt, pt1 wher
    ->  Sort (actual rows=5 loops=1)
          Sort Key: pt1_1_prt_2.dist
          Sort Method:  quicksort  Memory: 150kB
+         Executor Memory: 77kB  Segments: 3  Max: 26kB (segment 1)
          ->  Hash Join (actual rows=5 loops=1)
                Hash Cond: (pt1_1_prt_2.ptid = pt_1_prt_2.ptid)
                Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 1 of 131072 buckets.
@@ -1356,6 +1366,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
    ->  Sort (actual rows=50 loops=1)
          Sort Key: fact1_1_prt_1_2_prt_ca.u
          Sort Method:  quicksort  Memory: 158kB
+         Executor Memory: 79kB  Segments: 3  Max: 29kB (segment 1)
          ->  Hash Join (actual rows=50 loops=1)
                Hash Cond: ((fact1_1_prt_1_2_prt_ca.pid = dim1.pid) AND (fact1_1_prt_1_2_prt_ca.code = dim1.code))
                Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 131072 buckets.
@@ -1443,6 +1454,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
    ->  Sort (actual rows=50 loops=1)
          Sort Key: fact1_1_prt_1_2_prt_ca.u
          Sort Method:  quicksort  Memory: 158kB
+         Executor Memory: 79kB  Segments: 3  Max: 29kB (segment 1)
          ->  Hash Join (actual rows=50 loops=1)
                Hash Cond: ((fact1_1_prt_1_2_prt_ca.pid = dim1.pid) AND (fact1_1_prt_1_2_prt_ca.code = dim1.code))
                Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 131072 buckets.
@@ -1535,6 +1547,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
    ->  Sort (actual rows=100 loops=1)
          Sort Key: fact1_1_prt_1_2_prt_ca.u
          Sort Method:  quicksort  Memory: 166kB
+         Executor Memory: 82kB  Segments: 3  Max: 32kB (segment 1)
          ->  Hash Join (actual rows=100 loops=1)
                Hash Cond: (fact1_1_prt_1_2_prt_ca.pid = dim1.pid)
                Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 131072 buckets.
@@ -1672,6 +1685,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
    ->  Sort (actual rows=100 loops=1)
          Sort Key: fact1_1_prt_1_2_prt_ca.u
          Sort Method:  quicksort  Memory: 166kB
+         Executor Memory: 82kB  Segments: 3  Max: 32kB (segment 1)
          ->  Hash Join (actual rows=100 loops=1)
                Hash Cond: (fact1_1_prt_1_2_prt_ca.pid = dim1.pid)
                Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 131072 buckets.
@@ -2285,6 +2299,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
    ->  Sort (actual rows=50 loops=1)
          Sort Key: fact1_1_prt_1_2_prt_oh.u
          Sort Method:  quicksort  Memory: 158kB
+         Executor Memory: 79kB  Segments: 3  Max: 29kB (segment 1)
          ->  Hash Join (actual rows=50 loops=1)
                Hash Cond: (fact1_1_prt_1_2_prt_oh.pid = dim1.pid)
                Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 131072 buckets.
@@ -2368,6 +2383,7 @@ explain (costs off, timing off, summary off, analyze) select * from dim1 inner j
    ->  Sort (actual rows=50 loops=1)
          Sort Key: fact1_1_prt_1_2_prt_oh.u
          Sort Method:  quicksort  Memory: 158kB
+         Executor Memory: 79kB  Segments: 3  Max: 29kB (segment 1)
          ->  Hash Join (actual rows=50 loops=1)
                Hash Cond: (fact1_1_prt_1_2_prt_oh.pid = dim1.pid)
                Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 3 of 131072 buckets.
@@ -2458,6 +2474,7 @@ explain (costs off, timing off, summary off, analyze) select fact1.code, count(*
          ->  Sort (actual rows=100 loops=1)
                Sort Key: fact1_1_prt_1_2_prt_ca.code
                Sort Method:  quicksort  Memory: 160kB
+               Executor Memory: 86kB  Segments: 3  Max: 31kB (segment 1)
                ->  Redistribute Motion 3:3  (slice2; segments: 3) (actual rows=100 loops=1)
                      Hash Key: fact1_1_prt_1_2_prt_ca.code
                      ->  Hash Join (actual rows=100 loops=1)
@@ -2501,6 +2518,7 @@ explain (costs off, timing off, summary off, analyze) select fact1.code, count(*
          ->  Sort (actual rows=100 loops=1)
                Sort Key: fact1_1_prt_1_2_prt_ca.code
                Sort Method:  quicksort  Memory: 160kB
+               Executor Memory: 86kB  Segments: 3  Max: 31kB (segment 1)
                ->  Redistribute Motion 3:3  (slice2; segments: 3) (actual rows=100 loops=1)
                      Hash Key: fact1_1_prt_1_2_prt_ca.code
                      ->  Hash Join (actual rows=100 loops=1)
@@ -2751,6 +2769,7 @@ explain (costs off, timing off, summary off, analyze) select * from (select coun
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: jpat.a
                      Sort Method:  quicksort  Memory: 150kB
+                     Executor Memory: 76kB  Segments: 3  Max: 26kB (segment 1)
                      ->  Seq Scan on jpat (actual rows=1 loops=1)
    ->  Hash (actual rows=10 loops=1)
          Buckets: 131072  Batches: 1  Memory Usage: 1025kB
@@ -2985,6 +3004,7 @@ select * from pt, t where t.dist = pt.dist and t.tid = pt.ptid order by t.tid, t
    ->  Sort  (cost=0.00..862.09 rows=33 width=24) (actual rows=2 loops=1)
          Sort Key: t.tid, t.sk
          Sort Method:  quicksort  Memory: 150kB
+         Executor Memory: 76kB  Segments: 3  Max: 26kB (segment 0)
          ->  Hash Join  (cost=0.00..862.05 rows=33 width=24) (actual rows=2 loops=1)
                Hash Cond: ((pt1.dist = t.dist) AND (pt1.ptid = t.tid))
                Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 36 of 262144 buckets.

--- a/src/test/regress/expected/dpe_optimizer.out
+++ b/src/test/regress/expected/dpe_optimizer.out
@@ -15,8 +15,8 @@
 -- s/Segments: \d+/Segments: ###/ 
 -- m/Max: \d+kB/
 -- s/Max: \d+kB/Max: ###kB/
--- m/segment: \d+/ 
--- s/segment: \d+/segment: ###/
+-- m/segment \d+/ 
+-- s/segment \d+/segment ###/
 -- m/Hash chain length \d+\.\d+ avg, \d+ max/
 -- s/Hash chain length \d+\.\d+ avg, \d+ max/Hash chain length ###/
 -- m/using \d+ of \d+ buckets/

--- a/src/test/regress/expected/eagerfree.out
+++ b/src/test/regress/expected/eagerfree.out
@@ -62,6 +62,19 @@ explain analyze select d, count(*) from smallt group by d;
  Execution Time: 2.695 ms
 (17 rows)
 
+select * from
+  test_util.extract_plan_stats($$
+select d, count(*) from smallt group by d;
+  $$, false)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
+      stats_name      | stats_value 
+----------------------+-------------
+ executor_mem_lines   |           0
+ workmem_wanted_lines |           0
+(2 rows)
+
 set statement_mem=2560;
 select count(*) from (select i, t, d, count(*) from bigt group by i, t, d) tmp;
  count  
@@ -207,6 +220,21 @@ where t1.d = t2.d;
  Execution Time: 3.142 ms
 (31 rows)
 
+select * from
+  test_util.extract_plan_stats($$
+select t1.*, t2.* from
+(select d, count(*) from smallt group by d) as t1, (select d, sum(i) from smallt group by d) as t2
+where t1.d = t2.d;
+  $$, false)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
+      stats_name      | stats_value 
+----------------------+-------------
+ executor_mem_lines   |           0
+ workmem_wanted_lines |           0
+(2 rows)
+
 set enable_nestloop=off;
 set enable_hashjoin=on;
 -- Rescan on Agg (with Material in the inner side of nestloop)
@@ -258,6 +286,21 @@ where t1.i = t2.i;
  Execution Time: 1.119 ms
 (19 rows)
 
+select * from
+  test_util.extract_plan_stats($$
+select t1.*, t2.* from
+(select i, count(*) from smallt group by i) as t1, (select i, sum(i) from smallt group by i) as t2
+where t1.i = t2.i;
+  $$, false)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
+      stats_name      | stats_value 
+----------------------+-------------
+ executor_mem_lines   |           0
+ workmem_wanted_lines |           0
+(2 rows)
+
 set enable_nestloop=off;
 set enable_hashjoin=on;
 -- Limit on Agg
@@ -293,6 +336,19 @@ explain analyze select d, count(*) from smallt group by d limit 5;
  Optimizer: Postgres query optimizer
  Execution time: 1.363 ms
 (18 rows)
+
+select * from
+  test_util.extract_plan_stats($$
+select d, count(*) from smallt group by d limit 5;
+  $$, false)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
+      stats_name      | stats_value 
+----------------------+-------------
+ executor_mem_lines   |           1
+ workmem_wanted_lines |           0
+(2 rows)
 
 -- HashJoin
 select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i order by 1,2,3;

--- a/src/test/regress/expected/eagerfree_optimizer.out
+++ b/src/test/regress/expected/eagerfree_optimizer.out
@@ -49,6 +49,7 @@ explain analyze select d, count(*) from smallt group by d;
          ->  Sort  (cost=0.00..431.01 rows=34 width=4) (actual time=1.510..1.513 rows=35 loops=1)
                Sort Key: d
                Sort Method:  quicksort  Memory: 99kB
+               Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 1)
                ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.342..1.481 rows=35 loops=1)
                      Hash Key: d
                      ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.002..0.004 rows=50 loops=1)
@@ -59,7 +60,20 @@ explain analyze select d, count(*) from smallt group by d;
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
  Execution time: 2.061 ms
-(16 rows)
+(17 rows)
+
+select * from
+  test_util.extract_plan_stats($$
+select d, count(*) from smallt group by d;
+  $$, false)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
+      stats_name      | stats_value 
+----------------------+-------------
+ executor_mem_lines   |           1
+ workmem_wanted_lines |           0
+(2 rows)
 
 set statement_mem=2560;
 select count(*) from (select i, t, d, count(*) from bigt group by i, t, d) tmp;
@@ -192,6 +206,7 @@ where t1.d = t2.d;
                ->  Sort  (cost=0.00..431.01 rows=34 width=4) (actual time=0.029..0.032 rows=35 loops=1)
                      Sort Key: smallt.d
                      Sort Method:  quicksort  Memory: 99kB
+                     Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 1)
                      ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.004..0.011 rows=35 loops=1)
                            Hash Key: smallt.d
                            ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.003..0.018 rows=50 loops=1)
@@ -212,6 +227,21 @@ where t1.d = t2.d;
  Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
  Execution time: 2.226 ms
 (29 rows)
+
+select * from
+  test_util.extract_plan_stats($$
+select t1.*, t2.* from
+(select d, count(*) from smallt group by d) as t1, (select d, sum(i) from smallt group by d) as t2
+where t1.d = t2.d;
+  $$, false)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
+      stats_name      | stats_value 
+----------------------+-------------
+ executor_mem_lines   |           1
+ workmem_wanted_lines |           0
+(2 rows)
 
 set enable_nestloop=off;
 set enable_hashjoin=on;
@@ -247,12 +277,12 @@ where t1.i = t2.i;
    ->  Hash Join  (cost=0.00..862.01 rows=4 width=24) (actual time=0.166..0.460 rows=2 loops=2)
          Hash Cond: smallt.i = smallt_1.i
          Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 4 of 131072 buckets.
- 
          ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12) (actual time=0.041..0.055 rows=2 loops=2)
                Group Key: smallt.i
                ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.036..0.042 rows=20 loops=2)
                      Sort Key: smallt.i
                      Sort Method:  quicksort  Memory: 99kB
+                     Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 0)
                      ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.004..0.013 rows=20 loops=2)
          ->  Hash  (cost=431.01..431.01 rows=4 width=12) (actual time=0.072..0.072 rows=2 loops=2)
                ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12) (actual time=0.053..0.069 rows=2 loops=2)
@@ -260,13 +290,29 @@ where t1.i = t2.i;
                      ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.048..0.053 rows=20 loops=2)
                            Sort Key: smallt_1.i
                            Sort Method:  quicksort  Memory: 99kB
+                           Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 0)
                            ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=4) (actual time=0.012..0.022 rows=20 loops=2)
    (slice0)    Executor memory: 386K bytes.
    (slice1)    Executor memory: 1238K bytes avg x 3 workers, 1238K bytes max (seg0).  Work_mem: 33K bytes max.
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
  Total runtime: 2.471 ms
-(23 rows)
+(26 rows)
+
+select * from
+  test_util.extract_plan_stats($$
+select t1.*, t2.* from
+(select i, count(*) from smallt group by i) as t1, (select i, sum(i) from smallt group by i) as t2
+where t1.i = t2.i;
+  $$, false)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
+      stats_name      | stats_value 
+----------------------+-------------
+ executor_mem_lines   |           2
+ workmem_wanted_lines |           0
+(2 rows)
 
 set enable_nestloop=off;
 set enable_hashjoin=on;
@@ -292,6 +338,7 @@ explain analyze select d, count(*) from smallt group by d limit 5;
                      ->  Sort  (cost=0.00..431.01 rows=34 width=4) (actual time=1.449..1.453 rows=26 loops=1)
                            Sort Key: d
                            Sort Method:  quicksort  Memory: 99kB
+                           Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 1)
                            ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.413..1.428 rows=35 loops=1)
                                  Hash Key: d
                                  ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.003..0.006 rows=50 loops=1)
@@ -302,7 +349,20 @@ explain analyze select d, count(*) from smallt group by d limit 5;
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
  Execution time: 2.024 ms
-(18 rows)
+(19 rows)
+
+select * from
+  test_util.extract_plan_stats($$
+select d, count(*) from smallt group by d limit 5;
+  $$, false)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
+      stats_name      | stats_value 
+----------------------+-------------
+ executor_mem_lines   |           1
+ workmem_wanted_lines |           0
+(2 rows)
 
 -- HashJoin
 select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i order by 1,2,3;

--- a/src/test/regress/expected/gp_array_agg.out
+++ b/src/test/regress/expected/gp_array_agg.out
@@ -145,6 +145,7 @@ order by 1,2;
  Sort  (cost=9.02..9.11 rows=37 width=40) (actual time=0.826..0.839 rows=7 loops=1)
    Sort Key: r.a, r.b
    Sort Method:  quicksort  Memory: 50kB
+   Executor Memory: 26kB  Segments: 1  Max: 26kB (segment -1)
    ->  Append  (cost=3.92..8.06 rows=37 width=40) (actual time=0.539..0.806 rows=7 loops=1)
          ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=3.92..4.70 rows=36 width=40) (actual time=0.538..0.744 rows=6 loops=1)
                ->  HashAggregate  (cost=3.92..4.10 rows=12 width=40) (actual time=0.356..0.364 rows=4 loops=1)
@@ -162,8 +163,26 @@ order by 1,2;
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Execution Time: 1.461 ms
-(20 rows)
+(21 rows)
 
+set optimizer_trace_fallback = off;
+select * from
+  test_util.extract_plan_stats($$
+select a, b, array_dims(gp_array_agg(x)) from mergeappend_test r group by a, b
+union all
+select null, null, array_dims(gp_array_agg(x)) from mergeappend_test r
+order by 1,2;
+  $$, false)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
+      stats_name      | stats_value 
+----------------------+-------------
+ executor_mem_lines   |           1
+ workmem_wanted_lines |           0
+(2 rows)
+
+set optimizer_trace_fallback = on;
 -- create a view as we otherwise have to repeat this query a few times.
 create view v_pagg_test as
 select

--- a/src/test/regress/expected/gp_array_agg_optimizer.out
+++ b/src/test/regress/expected/gp_array_agg_optimizer.out
@@ -151,6 +151,7 @@ order by 1,2;
    ->  Sort  (cost=0.00..862.06 rows=8 width=16) (actual time=1.839..1.855 rows=5 loops=1)
          Sort Key: mergeappend_test.a, mergeappend_test.b
          Sort Method:  quicksort  Memory: 150kB
+         Executor Memory: 76kB  Segments: 3  Max: 26kB (segment 0)
          ->  Append  (cost=0.00..862.06 rows=8 width=16) (actual time=0.333..1.826 rows=5 loops=1)
                ->  HashAggregate  (cost=0.00..431.05 rows=7 width=16) (actual time=0.332..0.341 rows=4 loops=1)
                      Group Key: mergeappend_test.a, mergeappend_test.b
@@ -169,8 +170,26 @@ order by 1,2;
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA)
  Execution Time: 2.943 ms
-(23 rows)
+(24 rows)
 
+set optimizer_trace_fallback = off;
+select * from
+  test_util.extract_plan_stats($$
+select a, b, array_dims(gp_array_agg(x)) from mergeappend_test r group by a, b
+union all
+select null, null, array_dims(gp_array_agg(x)) from mergeappend_test r
+order by 1,2;
+  $$, false)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
+      stats_name      | stats_value 
+----------------------+-------------
+ workmem_wanted_lines |           0
+ executor_mem_lines   |           1
+(2 rows)
+
+set optimizer_trace_fallback = on;
 -- create a view as we otherwise have to repeat this query a few times.
 create view v_pagg_test as
 select

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -106,8 +106,10 @@ LIMIT 1;
                ->  Sort  (cost=3.17..3.17 rows=2 width=4) (actual time=0.594..0.594 rows=1 loops=1)
                      Sort Key: explaintest.id
                      Sort Method:  top-N heapsort  Memory: 51kB
+                     Executor Memory: 76kB  Segments: 3  Max: 26kB (segment 2)
                      ->  Seq Scan on explaintest  (cost=0.00..3.15 rows=2 width=4) (actual time=0.035..0.040 rows=3 loops=1)
                            Filter: ((id)::numeric > $0)
+                           Rows Removed by Filter: 1
  Planning time: 1.607 ms
    (slice0)    Executor memory: 156K bytes.
  * (slice1)    Executor memory: 94K bytes avg x 3 workers, 100K bytes max (seg1).  Work_mem: 65K bytes max, 1K bytes wanted.
@@ -118,7 +120,29 @@ LIMIT 1;
  Memory wanted:  800kB
  Optimizer: Postgres query optimizer
  Execution time: 25.040 ms
-(24 rows)
+(26 rows)
+
+select * from
+  test_util.extract_plan_stats($$
+SELECT id FROM 
+( SELECT id  
+    FROM explaintest
+    WHERE id > ( 
+        SELECT avg(id)
+        FROM explaintest
+    )   
+) as foo 
+ORDER BY id
+LIMIT 1;
+  $$, false)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
+      stats_name      | stats_value 
+----------------------+-------------
+ executor_mem_lines   |           1
+ workmem_wanted_lines |           0
+(2 rows)
 
 -- Verify that the column references are OK. This tests for an old ORCA bug,
 -- where the Filter clause in the IndexScan of this query was incorrectly

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -100,8 +100,10 @@ LIMIT 1;
                ->  Sort  (cost=0.00..1324033.14 rows=4 width=4) (actual time=1.620..1.620 rows=1 loops=1)
                      Sort Key: explaintest.id
                      Sort Method:  top-N heapsort  Memory: 51kB
+                     Sort Method:  quicksort  Memory: 100kB
                      ->  Nested Loop  (cost=0.00..1324033.14 rows=4 width=4) (actual time=1.038..1.046 rows=3 loops=1)
                            Join Filter: ((explaintest.id)::numeric > (avg(explaintest_1.id)))
+                           Rows Removed by Join Filter: 1
                            ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8) (actual time=0.767..0.767 rows=1 loops=1)
                                  ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=0.168..0.168 rows=1 loops=1)
                                        ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=0.008..0.137 rows=3 loops=1)
@@ -117,7 +119,29 @@ LIMIT 1;
  Memory wanted:  1000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
  Execution time: 15.429 ms
-(24 rows)
+(26 rows)
+
+select * from
+  test_util.extract_plan_stats($$
+SELECT id FROM 
+( SELECT id  
+    FROM explaintest
+    WHERE id > ( 
+        SELECT avg(id)
+        FROM explaintest
+    )   
+) as foo 
+ORDER BY id
+LIMIT 1;
+  $$, false)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
+      stats_name      | stats_value 
+----------------------+-------------
+ executor_mem_lines   |           1
+ workmem_wanted_lines |           0
+(2 rows)
 
 -- Verify that the column references are OK. This tests for an old ORCA bug,
 -- where the Filter clause in the IndexScan of this query was incorrectly

--- a/src/test/regress/expected/partition_prune.out
+++ b/src/test/regress/expected/partition_prune.out
@@ -23,6 +23,14 @@
 -- s/((0[1-9]|1[0-2])-(0[1-9]|1[0-9]|2[0-9])|(0[13-9]|1[0-2])-30|(0[13578]|1[02])-31)-(?!0000)[0-9]{4}/xx-xx-xxxx/
 -- m/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/
 -- s/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/xxx xx xx xx:xx:xx xxxx"/
+-- m/Memory: \d+kB/
+-- s/Memory: \d+kB/Memory: ###kB/
+-- m/Segments: \d+/
+-- s/Segments: \d+/Segments: ###/
+-- m/Max: \d+kB/
+-- s/Max: \d+kB/Max: ###kB/
+-- m/segment \d+/
+-- s/segment \d+/segment ###/
 -- end_matchsubs
 -- Force generic plans to be used for all prepared statements in this file.
 set plan_cache_mode = force_generic_plan;

--- a/src/test/regress/expected/partition_prune_optimizer.out
+++ b/src/test/regress/expected/partition_prune_optimizer.out
@@ -23,6 +23,14 @@
 -- s/((0[1-9]|1[0-2])-(0[1-9]|1[0-9]|2[0-9])|(0[13-9]|1[0-2])-30|(0[13578]|1[02])-31)-(?!0000)[0-9]{4}/xx-xx-xxxx/
 -- m/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/
 -- s/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/xxx xx xx xx:xx:xx xxxx"/
+-- m/Memory: \d+kB/
+-- s/Memory: \d+kB/Memory: ###kB/
+-- m/Segments: \d+/
+-- s/Segments: \d+/Segments: ###/
+-- m/Max: \d+kB/
+-- s/Max: \d+kB/Max: ###kB/
+-- m/segment \d+/
+-- s/segment \d+/segment ###/
 -- end_matchsubs
 -- Force generic plans to be used for all prepared statements in this file.
 set plan_cache_mode = force_generic_plan;
@@ -3476,7 +3484,8 @@ explain (analyze, costs off, summary off, timing off) select * from ma_test wher
    Merge Key: ma_test_p1.b
    ->  Sort (actual rows=8 loops=1)
          Sort Key: ma_test_p1.b
-         Sort Method:  quicksort  Memory: 150kB
+         Sort Method:  quicksort  Memory: ###kB
+         Executor Memory: ###kB  Segments: ###  Max: ###kB (segment ###)
          ->  Nested Loop (actual rows=8 loops=1)
                Join Filter: (ma_test_p1.a >= (min(ma_test_p2_1.b)))
                Rows Removed by Join Filter: 3

--- a/src/test/regress/expected/qp_union_intersect.out
+++ b/src/test/regress/expected/qp_union_intersect.out
@@ -2039,10 +2039,12 @@ order by 1,2;
                ->  Sort  (cost=8.82..9.23 rows=167 width=12) (actual time=0.221..0.265 rows=301 loops=1)
                      Sort Key: r.a, r.b
                      Sort Method:  quicksort  Memory: 202kB
+                     Executor Memory: 76kB  Segments: 3  Max: 26kB (segment 0)
                      ->  Seq Scan on mergeappend_test r  (cost=0.00..2.67 rows=167 width=12) (actual time=0.102..0.147 rows=301 loops=1)
    ->  Sort  (cost=3.19..3.19 rows=1 width=40) (actual time=1.142..1.145 rows=1 loops=1)
          Sort Key: (NULL::integer), (NULL::integer)
          Sort Method:  quicksort  Memory: 50kB
+         Executor Memory: 26kB  Segments: 1  Max: 26kB (segment -1)
          ->  Finalize Aggregate  (cost=3.15..3.17 rows=1 width=40) (actual time=1.135..1.135 rows=1 loops=1)
                ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=3.09..3.14 rows=3 width=32) (actual time=0.014..1.105 rows=3 loops=1)
                      ->  Partial Aggregate  (cost=3.09..3.10 rows=1 width=32) (actual time=0.261..0.261 rows=1 loops=1)
@@ -2054,7 +2056,23 @@ order by 1,2;
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Execution Time: 2.406 ms
-(24 rows)
+(26 rows)
+
+select * from
+  test_util.extract_plan_stats($$
+select a, b, array_dims(array_agg(x)) from mergeappend_test r group by a, b
+union all
+select null, null, array_dims(array_agg(x)) FROM mergeappend_test r
+order by 1,2;
+  $$, false)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
+      stats_name      | stats_value 
+----------------------+-------------
+ executor_mem_lines   |           2
+ workmem_wanted_lines |           0
+(2 rows)
 
 CREATE TABLE t1(c1 int, c2 int, c3 int);
 CREATE TABLE t2(c1 int, c2 int, c3 int);

--- a/src/test/regress/expected/qp_union_intersect_optimizer.out
+++ b/src/test/regress/expected/qp_union_intersect_optimizer.out
@@ -2032,6 +2032,7 @@ order by 1,2;
    ->  Sort  (cost=0.00..862.06 rows=8 width=16) (actual time=1.633..1.637 rows=5 loops=1)
          Sort Key: mergeappend_test.a, mergeappend_test.b
          Sort Method:  quicksort  Memory: 150kB
+         Executor Memory: 76kB  Segments: 3  Max: 26kB (segment 0)
          ->  Append  (cost=0.00..862.06 rows=8 width=16) (actual time=0.482..1.625 rows=5 loops=1)
                ->  HashAggregate  (cost=0.00..431.05 rows=7 width=16) (actual time=0.482..0.489 rows=4 loops=1)
                      Group Key: mergeappend_test.a, mergeappend_test.b
@@ -2050,7 +2051,23 @@ order by 1,2;
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA)
  Execution Time: 2.977 ms
-(23 rows)
+(24 rows)
+
+select * from
+  test_util.extract_plan_stats($$
+select a, b, array_dims(array_agg(x)) from mergeappend_test r group by a, b
+union all
+select null, null, array_dims(array_agg(x)) FROM mergeappend_test r
+order by 1,2;
+  $$, false)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
+      stats_name      | stats_value 
+----------------------+-------------
+ executor_mem_lines   |           1
+ workmem_wanted_lines |           0
+(2 rows)
 
 CREATE TABLE t1(c1 int, c2 int, c3 int);
 CREATE TABLE t2(c1 int, c2 int, c3 int);

--- a/src/test/regress/expected/select_parallel.out
+++ b/src/test/regress/expected/select_parallel.out
@@ -607,6 +607,7 @@ select * from explain_parallel_sort_stats();
                ->  Sort (actual rows=3386 loops=1)
                      Sort Key: tenk1.ten
                      Sort Method:  quicksort  Memory: xxx
+                     Executor Memory: xxx  Segments: 3  Max: 203kB (segment 1)
                      ->  Seq Scan on tenk1 (actual rows=3386 loops=1)
                            Filter: (ten < 100)
  Optimizer: Postgres query optimizer

--- a/src/test/regress/expected/statement_mem_for_windowagg.out
+++ b/src/test/regress/expected/statement_mem_for_windowagg.out
@@ -27,6 +27,7 @@ NOTICE:  winagg: tuplestore fitted in memory  (seg2 slice1 127.0.0.1:7004 pid=43
          ->  Sort  (cost=0.00..431.00 rows=1 width=8) (actual time=5.298..6.324 rows=10001 loops=1)
                Sort Key: y
                Sort Method:  quicksort  Memory: 5040kB
+               Executor Memory: 3677kB  Segments: 3  Max: 1226kB (segment 0)
                ->  Seq Scan on dummy_table  (cost=0.00..431.00 rows=1 width=8) (actual time=0.036..3.299 rows=10001 loops=1)
  Planning Time: 5.241 ms
    (slice0)    Executor memory: 48K bytes.
@@ -34,7 +35,20 @@ NOTICE:  winagg: tuplestore fitted in memory  (seg2 slice1 127.0.0.1:7004 pid=43
  Memory used:  2048kB
  Optimizer: Pivotal Optimizer (GPORCA)
  Execution Time: 17.225 ms
-(13 rows)
+(14 rows)
+
+select * from
+  test_util.extract_plan_stats($$
+SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
+  $$, false)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
+      stats_name      | stats_value 
+----------------------+-------------
+ executor_mem_lines   |           1
+ workmem_wanted_lines |           0
+(2 rows)
 
 SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
@@ -69,14 +83,29 @@ NOTICE:  winagg: tuplestore spilled to disk  (seg2 slice1 127.0.0.1:7004 pid=434
          ->  Sort  (cost=0.00..431.00 rows=1 width=8) (actual time=3.125..4.135 rows=10001 loops=1)
                Sort Key: y
                Sort Method:  external merge  Disk: 6144kB
+               Executor Memory: 1268kB  Segments: 3  Max: 423kB (segment 0)
                ->  Seq Scan on dummy_table  (cost=0.00..431.00 rows=1 width=8) (actual time=0.032..1.589 rows=10001 loops=1)
  Planning Time: 3.174 ms
    (slice0)    Executor memory: 42K bytes.
    (slice1)    Executor memory: 391K bytes avg x 3 workers, 391K bytes max (seg0).  Work_mem: 391K bytes max.
  Memory used:  1024kB
+ Memory wanted:  3924kB
  Optimizer: Pivotal Optimizer (GPORCA)
  Execution Time: 15.235 ms
-(13 rows)
+(15 rows)
+
+select * from
+  test_util.extract_plan_stats($$
+SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
+  $$, true)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
+      stats_name      | stats_value 
+----------------------+-------------
+ executor_mem_lines   |           1
+ workmem_wanted_lines |           1
+(2 rows)
 
 SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
@@ -111,6 +140,7 @@ NOTICE:  distinct winagg sortstats: sort operation fitted in memory  (seg2 slice
          ->  Sort  (cost=2446.06..2517.81 rows=28700 width=8) (actual time=3.678..4.683 rows=10001 loops=1)
                Sort Key: y
                Sort Method:  external merge  Disk: 6144kB
+               Executor Memory: 3677kB  Segments: 3  Max: 1226kB (segment 0)
                ->  Seq Scan on dummy_table  (cost=0.00..321.00 rows=28700 width=8) (actual time=0.030..1.919 rows=10001 loops=1)
  Planning Time: 1.695 ms
    (slice0)    Executor memory: 50K bytes.
@@ -118,7 +148,21 @@ NOTICE:  distinct winagg sortstats: sort operation fitted in memory  (seg2 slice
  Memory used:  1024kB
  Optimizer: Postgres query optimizer
  Execution Time: 18.747 ms
-(13 rows)
+(14 rows)
+
+select * from
+  test_util.extract_plan_stats($$
+SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
+  $$, true)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
+NOTICE:  distinct winagg sortstats: sort operation fitted in memory
+      stats_name      | stats_value 
+----------------------+-------------
+ executor_mem_lines   |           1
+ workmem_wanted_lines |           0
+(2 rows)
 
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
@@ -153,14 +197,30 @@ NOTICE:  distinct winagg sortstats: sort operation spilled to disk  (seg2 slice1
          ->  Sort  (cost=2446.06..2517.81 rows=28700 width=8) (actual time=4.278..5.449 rows=10001 loops=1)
                Sort Key: y
                Sort Method:  external merge  Disk: 9216kB
+               Executor Memory: 1268kB  Segments: 3  Max: 423kB (segment 0)
                ->  Seq Scan on dummy_table  (cost=0.00..321.00 rows=28700 width=8) (actual time=0.029..1.746 rows=10001 loops=1)
  Planning Time: 1.509 ms
    (slice0)    Executor memory: 39K bytes.
    (slice1)    Executor memory: 275K bytes avg x 3 workers, 275K bytes max (seg0).  Work_mem: 275K bytes max.
  Memory used:  128kB
+ Memory wanted:  3924kB
  Optimizer: Postgres query optimizer
  Execution Time: 22.056 ms
-(13 rows)
+(15 rows)
+
+select * from
+  test_util.extract_plan_stats($$
+SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
+  $$, true)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
+NOTICE:  distinct winagg sortstats: sort operation spilled to disk
+      stats_name      | stats_value 
+----------------------+-------------
+ executor_mem_lines   |           1
+ workmem_wanted_lines |           1
+(2 rows)
 
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -1178,22 +1178,24 @@ begin
         ln := regexp_replace(ln, 'Memory: \S*',  'Memory: xxx');
         -- this case might occur if force_parallel_mode is on:
         ln := regexp_replace(ln, 'Worker 0:  Sort Method',  'Sort Method');
+        ln := regexp_replace(ln, 'Segments: \S*  Max: \S*kB \(segment \S*\)',  'Segments: x  Max: xxkB (segment x)');
         return next ln;
     end loop;
 end;
 $$;
 select * from explain_sq_limit();
-                           explain_sq_limit                           
-----------------------------------------------------------------------
+                               explain_sq_limit                               
+------------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1) (actual rows=3 loops=1)
    ->  Limit (actual rows=3 loops=1)
          ->  Subquery Scan on x (actual rows=3 loops=1)
                ->  Sort (actual rows=3 loops=1)
                      Sort Key: sq_limit.c1, sq_limit.pk
                      Sort Method:  top-N heapsort  Memory: xxx
+                     Executor Memory: xxx  Segments: x  Max: xxkB (segment x)
                      ->  Seq Scan on sq_limit (actual rows=8 loops=1)
  Optimizer: Postgres query optimizer
-(8 rows)
+(10 rows)
 
 -- a subpath is sorted under a subqueryscan. however, the subqueryscan is not.
 -- whether the order of subpath can applied to the subqueryscan is up-to-implement.

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -1214,22 +1214,24 @@ begin
         ln := regexp_replace(ln, 'Memory: \S*',  'Memory: xxx');
         -- this case might occur if force_parallel_mode is on:
         ln := regexp_replace(ln, 'Worker 0:  Sort Method',  'Sort Method');
+        ln := regexp_replace(ln, 'Segments: \S*  Max: \S*kB \(segment \S*\)',  'Segments: x  Max: xxkB (segment x)');
         return next ln;
     end loop;
 end;
 $$;
 select * from explain_sq_limit();
-                           explain_sq_limit                           
-----------------------------------------------------------------------
+                               explain_sq_limit                               
+------------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1) (actual rows=3 loops=1)
    ->  Limit (actual rows=3 loops=1)
          ->  Subquery Scan on x (actual rows=3 loops=1)
                ->  Sort (actual rows=3 loops=1)
                      Sort Key: sq_limit.c1, sq_limit.pk
                      Sort Method:  top-N heapsort  Memory: xxx
+                     Executor Memory: xxx  Segments: x  Max: xxkB (segment x)
                      ->  Seq Scan on sq_limit (actual rows=8 loops=1)
  Optimizer: Postgres query optimizer
-(8 rows)
+(9 rows)
 
 -- a subpath is sorted under a subqueryscan. however, the subqueryscan is not.
 -- whether the order of subpath can applied to the subqueryscan is up-to-implement.

--- a/src/test/regress/expected/test_setup.out
+++ b/src/test/regress/expected/test_setup.out
@@ -1,0 +1,41 @@
+-- Suppress NOTICE messages when schema doesn't exist
+SET client_min_messages TO 'warning';
+DROP SCHEMA IF EXISTS test_util CASCADE;
+SET client_min_messages TO 'notice';
+CREATE SCHEMA test_util;
+-- Helper function, to return the EXPLAIN output of a query as a normal
+-- result set, so that you can manipulate it further.
+create or replace function test_util.get_explain_output(explain_query text, is_verbose boolean)
+returns setof text as
+$$
+declare
+  explainrow text;
+  sqltext text;
+begin
+  sqltext = 'EXPLAIN analyze ';
+  if is_verbose then sqltext = sqltext || ' verbose ';
+  end if;
+  sqltext = sqltext || explain_query;
+  for explainrow in execute sqltext
+  loop
+    return next explainrow;
+  end loop;
+end;
+$$ language plpgsql;
+create or replace function test_util.extract_plan_stats(explain_query text, is_verbose boolean)
+  returns table (stats_name  text,
+                 stats_value bigint) as
+$$
+begin
+return query
+  WITH query_plan (et) AS
+(
+  SELECT test_util.get_explain_output(explain_query, is_verbose)
+)
+SELECT
+  'executor_mem_lines', (SELECT COUNT(*) FROM query_plan WHERE et like '%Executor Memory: %')
+UNION
+SELECT
+  'workmem_wanted_lines', (SELECT COUNT(*) FROM query_plan WHERE et like '%Work_mem wanted: %');
+end;
+$$ language plpgsql;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -15,6 +15,9 @@
 #   hitting max_connections limit on segments.
 #
 
+# required setup steps
+test: test_setup
+
 test: gp_dispatch_keepalives
 
 # copy command

--- a/src/test/regress/icudp_schedule
+++ b/src/test/regress/icudp_schedule
@@ -2,6 +2,9 @@
 # Interconnect tests.
 #
 
+# required setup steps
+test: test_setup
+
 # Below cases are also in greenplum_schedule, but as they are fast enough
 # we duplicate them here to make this pipeline cover more on icudp.
 test: icudp/gp_interconnect_queue_depth icudp/gp_interconnect_queue_depth_longtime icudp/gp_interconnect_snd_queue_depth icudp/gp_interconnect_snd_queue_depth_longtime icudp/gp_interconnect_min_retries_before_timeout icudp/gp_interconnect_transmit_timeout icudp/gp_interconnect_cache_future_packets icudp/gp_interconnect_default_rtt icudp/gp_interconnect_fc_method icudp/gp_interconnect_min_rto icudp/gp_interconnect_timer_checking_period icudp/gp_interconnect_timer_period icudp/queue_depth_combination_loss icudp/queue_depth_combination_capacity icudp/icudp_regression

--- a/src/test/regress/minimal_schedule
+++ b/src/test/regress/minimal_schedule
@@ -1,3 +1,6 @@
+# required setup steps
+test: test_setup
+
 # do not include any partition table tests in this group
 # test 'partition' checks on pg_partition, pg_partition_templates without
 # any filters.

--- a/src/test/regress/mirrorless_schedule
+++ b/src/test/regress/mirrorless_schedule
@@ -1,3 +1,6 @@
+# required setup steps
+test: test_setup
+
 # Test relevant to gp_dispatch_keepalives_* GUCs 
 test: gp_dispatch_keepalives
 

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -5,6 +5,9 @@
 # this limits the number of connections needed to run the tests.
 # ----------
 
+# required setup steps
+test: test_setup
+
 # run tablespace by itself, and first, because it forces a checkpoint;
 # we'd prefer not to have checkpoints later in the tests because that
 # interferes with crash-recovery testing.

--- a/src/test/regress/serial_schedule
+++ b/src/test/regress/serial_schedule
@@ -1,3 +1,6 @@
+# required setup steps
+test: test_setup
+
 # src/test/regress/serial_schedule
 # This should probably be in an order similar to parallel_schedule.
 test: tablespace

--- a/src/test/regress/sql/dpe.sql
+++ b/src/test/regress/sql/dpe.sql
@@ -12,6 +12,12 @@
 -- s/Batches: \d+/Batches: ###/
 -- m/Extra Text: \(seg\d+\)/
 -- s/Extra Text: \(seg\d+\)/Extra Text: ###/
+-- m/Segments: \d+/
+-- s/Segments: \d+/Segments: ###/ 
+-- m/Max: \d+kB/
+-- s/Max: \d+kB/Max: ###kB/
+-- m/segment: \d+/ 
+-- s/segment: \d+/segment: ###/
 -- m/Hash chain length \d+\.\d+ avg, \d+ max/
 -- s/Hash chain length \d+\.\d+ avg, \d+ max/Hash chain length ###/
 -- m/using \d+ of \d+ buckets/

--- a/src/test/regress/sql/dpe.sql
+++ b/src/test/regress/sql/dpe.sql
@@ -16,8 +16,8 @@
 -- s/Segments: \d+/Segments: ###/ 
 -- m/Max: \d+kB/
 -- s/Max: \d+kB/Max: ###kB/
--- m/segment: \d+/ 
--- s/segment: \d+/segment: ###/
+-- m/segment \d+/ 
+-- s/segment \d+/segment ###/
 -- m/Hash chain length \d+\.\d+ avg, \d+ max/
 -- s/Hash chain length \d+\.\d+ avg, \d+ max/Hash chain length ###/
 -- m/using \d+ of \d+ buckets/

--- a/src/test/regress/sql/eagerfree.sql
+++ b/src/test/regress/sql/eagerfree.sql
@@ -23,6 +23,14 @@ set gp_motion_cost_per_row = 0.1;
 select d, count(*) from smallt group by d;
 explain analyze select d, count(*) from smallt group by d;
 
+select * from
+  test_util.extract_plan_stats($$
+select d, count(*) from smallt group by d;
+  $$, false)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
+
 set statement_mem=2560;
 select count(*) from (select i, t, d, count(*) from bigt group by i, t, d) tmp;
 explain analyze select count(*) from (select i, t, d, count(*) from bigt group by i, t, d) tmp;
@@ -54,6 +62,17 @@ where t1.d = t2.d;
 explain analyze select t1.*, t2.* from
 (select d, count(*) from smallt group by d) as t1, (select d, sum(i) from smallt group by d) as t2
 where t1.d = t2.d;
+
+select * from
+  test_util.extract_plan_stats($$
+select t1.*, t2.* from
+(select d, count(*) from smallt group by d) as t1, (select d, sum(i) from smallt group by d) as t2
+where t1.d = t2.d;
+  $$, false)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
+
 set enable_nestloop=off;
 set enable_hashjoin=on;
 
@@ -69,12 +88,31 @@ where t1.i = t2.i;
 explain analyze select t1.*, t2.* from
 (select i, count(*) from smallt group by i) as t1, (select i, sum(i) from smallt group by i) as t2
 where t1.i = t2.i;
+
+select * from
+  test_util.extract_plan_stats($$
+select t1.*, t2.* from
+(select i, count(*) from smallt group by i) as t1, (select i, sum(i) from smallt group by i) as t2
+where t1.i = t2.i;
+  $$, false)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
+
 set enable_nestloop=off;
 set enable_hashjoin=on;
 
 -- Limit on Agg
 select d, count(*) from smallt group by d limit 5; --ignore
 explain analyze select d, count(*) from smallt group by d limit 5;
+
+select * from
+  test_util.extract_plan_stats($$
+select d, count(*) from smallt group by d limit 5;
+  $$, false)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
 
 -- HashJoin
 select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i order by 1,2,3;

--- a/src/test/regress/sql/gp_array_agg.sql
+++ b/src/test/regress/sql/gp_array_agg.sql
@@ -56,6 +56,21 @@ union all
 select null, null, array_dims(gp_array_agg(x)) from mergeappend_test r
 order by 1,2;
 
+set optimizer_trace_fallback = off;
+
+select * from
+  test_util.extract_plan_stats($$
+select a, b, array_dims(gp_array_agg(x)) from mergeappend_test r group by a, b
+union all
+select null, null, array_dims(gp_array_agg(x)) from mergeappend_test r
+order by 1,2;
+  $$, false)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
+
+set optimizer_trace_fallback = on;
+
 -- create a view as we otherwise have to repeat this query a few times.
 create view v_pagg_test as
 select

--- a/src/test/regress/sql/gp_explain.sql
+++ b/src/test/regress/sql/gp_explain.sql
@@ -79,6 +79,22 @@ EXPLAIN ANALYZE SELECT id FROM
 ORDER BY id
 LIMIT 1;
 
+select * from
+  test_util.extract_plan_stats($$
+SELECT id FROM 
+( SELECT id  
+    FROM explaintest
+    WHERE id > ( 
+        SELECT avg(id)
+        FROM explaintest
+    )   
+) as foo 
+ORDER BY id
+LIMIT 1;
+  $$, false)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
 
 -- Verify that the column references are OK. This tests for an old ORCA bug,
 -- where the Filter clause in the IndexScan of this query was incorrectly

--- a/src/test/regress/sql/partition_prune.sql
+++ b/src/test/regress/sql/partition_prune.sql
@@ -24,6 +24,14 @@
 -- s/((0[1-9]|1[0-2])-(0[1-9]|1[0-9]|2[0-9])|(0[13-9]|1[0-2])-30|(0[13578]|1[02])-31)-(?!0000)[0-9]{4}/xx-xx-xxxx/
 -- m/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/
 -- s/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/xxx xx xx xx:xx:xx xxxx"/
+-- m/Memory: \d+kB/
+-- s/Memory: \d+kB/Memory: ###kB/
+-- m/Segments: \d+/
+-- s/Segments: \d+/Segments: ###/
+-- m/Max: \d+kB/
+-- s/Max: \d+kB/Max: ###kB/
+-- m/segment \d+/
+-- s/segment \d+/segment ###/
 -- end_matchsubs
 
 -- Force generic plans to be used for all prepared statements in this file.

--- a/src/test/regress/sql/qp_union_intersect.sql
+++ b/src/test/regress/sql/qp_union_intersect.sql
@@ -784,6 +784,17 @@ union all
 select null, null, array_dims(array_agg(x)) FROM mergeappend_test r
 order by 1,2;
 
+select * from
+  test_util.extract_plan_stats($$
+select a, b, array_dims(array_agg(x)) from mergeappend_test r group by a, b
+union all
+select null, null, array_dims(array_agg(x)) FROM mergeappend_test r
+order by 1,2;
+  $$, false)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
+
 CREATE TABLE t1(c1 int, c2 int, c3 int);
 CREATE TABLE t2(c1 int, c2 int, c3 int);
 INSERT INTO t1 SELECT i, i ,i + 1 FROM generate_series(1,10) i;

--- a/src/test/regress/sql/statement_mem_for_windowagg.sql
+++ b/src/test/regress/sql/statement_mem_for_windowagg.sql
@@ -13,6 +13,14 @@ SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
 
 EXPLAIN ANALYZE SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
 
+select * from
+  test_util.extract_plan_stats($$
+SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
+  $$, false)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
+
 SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
 
@@ -24,6 +32,14 @@ SELECT gp_inject_fault('winagg_after_spool_tuples', 'skip', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
 
 EXPLAIN ANALYZE SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
+
+select * from
+  test_util.extract_plan_stats($$
+SELECT AVG(x) OVER (PARTITION BY y) FROM dummy_table;
+  $$, true)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
 
 SELECT gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
@@ -37,6 +53,14 @@ SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
 
 EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
 
+select * from
+  test_util.extract_plan_stats($$
+SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
+  $$, true)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
+
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
 
@@ -48,6 +72,14 @@ SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'skip', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;
 
 EXPLAIN ANALYZE SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
+
+select * from
+  test_util.extract_plan_stats($$
+SELECT AVG(DISTINCT x) OVER (PARTITION BY y) FROM dummy_table;
+  $$, true)
+where stats_name = 'executor_mem_lines'
+or stats_name = 'workmem_wanted_lines'
+order by stats_name;
 
 SELECT gp_inject_fault_infinite('distinct_winagg_perform_sort', 'reset', dbid)
   FROM gp_segment_configuration WHERE role='p' AND content>=0;

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -637,6 +637,7 @@ begin
         ln := regexp_replace(ln, 'Memory: \S*',  'Memory: xxx');
         -- this case might occur if force_parallel_mode is on:
         ln := regexp_replace(ln, 'Worker 0:  Sort Method',  'Sort Method');
+        ln := regexp_replace(ln, 'Segments: \S*  Max: \S*kB \(segment \S*\)',  'Segments: x  Max: xxkB (segment x)');
         return next ln;
     end loop;
 end;

--- a/src/test/regress/sql/test_setup.sql
+++ b/src/test/regress/sql/test_setup.sql
@@ -1,0 +1,43 @@
+-- Suppress NOTICE messages when schema doesn't exist
+SET client_min_messages TO 'warning';
+DROP SCHEMA IF EXISTS test_util CASCADE;
+SET client_min_messages TO 'notice';
+CREATE SCHEMA test_util;
+
+-- Helper function, to return the EXPLAIN output of a query as a normal
+-- result set, so that you can manipulate it further.
+create or replace function test_util.get_explain_output(explain_query text, is_verbose boolean)
+returns setof text as
+$$
+declare
+  explainrow text;
+  sqltext text;
+begin
+  sqltext = 'EXPLAIN analyze ';
+  if is_verbose then sqltext = sqltext || ' verbose ';
+  end if;
+  sqltext = sqltext || explain_query;
+  for explainrow in execute sqltext
+  loop
+    return next explainrow;
+  end loop;
+end;
+$$ language plpgsql;
+
+create or replace function test_util.extract_plan_stats(explain_query text, is_verbose boolean)
+  returns table (stats_name  text,
+                 stats_value bigint) as
+$$
+begin
+return query
+  WITH query_plan (et) AS
+(
+  SELECT test_util.get_explain_output(explain_query, is_verbose)
+)
+SELECT
+  'executor_mem_lines', (SELECT COUNT(*) FROM query_plan WHERE et like '%Executor Memory: %')
+UNION
+SELECT
+  'workmem_wanted_lines', (SELECT COUNT(*) FROM query_plan WHERE et like '%Work_mem wanted: %');
+end;
+$$ language plpgsql;

--- a/src/test/regress/standby_schedule
+++ b/src/test/regress/standby_schedule
@@ -9,6 +9,10 @@
 #
 # psql -f src/test/regress/sql/hs_primary_setup.sql regression
 #
+
+# required setup steps
+test: test_setup
+
 test: hs_standby_check
 #
 # These tests will pass on both primary and standby servers


### PR DESCRIPTION
### Brief

The FIXME is about re-implementing explain analyze related codes in tuplesort. In tuplesort.c on GPDB6, there are some codes to collect statistic info for "explain analyze" output. On GPDB7, most of codes were rewritten and the explain analyze related codes were gone. The task is to re-implement them.

### Code

The major logic is straightforward and follows similar logic on GPDB6 to collect info and calculate statistic numbers in tuplesort. An exception is, since the code path is pretty different between GPDB6 and 7, I have to add a function `tuplesort_finalize_stats()` (different from GPDB6 version) to handle the stuffs when statistic info can be finalized.

### Test

The code change impacts a lot of test cases. In addition, in some (not all) cases we compare some extracted info from PLAN as "explain analyze" output, but not the PLAN itself. It means, the extra info added by this code change may be ignored by the cases. To check the extra info, we need:

1. Use UDF to detect particular info in PLAN: I added two UDFs to 
src/test/regress/sql/setup.sql: `get_explain_output()` to run SQL query with "explain ..." and return result as text rows, and `extract_plan_stats()` to detect particular keywords and return statistic info as a table. Both are placed on schema `test_util` for further reuse in future. 
2. Share common codes among mutilple test cases: as said, common codes were added into setup.sql. Similar to isolation2, I added "setup" to `setup_tests` in pg_regress_main.c, so `setup.sql` will be called automatically before running any test case. In addition, `pg_regress` might be called outside of the source tree by other test cases, and there might not be test case "setup" on the dir. I updated code `in run_single_test()` to detect whether there is `setup.sql`, and ignore the calling if not.

Please note:

1. Some tests implemented similar UDFs to detect particular info but not for common use. Theoretically they can be replaced by the common version. I prefer to keep them as-is and use the common version in future code. 
2. Some tests adapts `setup.sql` as prerequisite by hard-coding in script (e.g. `contrib/extprotocol`). Since we have an automatically running version, I have to update the cases by removing the hard-coding or something.