### PR TITLE
Speed up planning times by marking some partition constraints as dummy constraints

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CLogicalDynamicGetBase.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalDynamicGetBase.cpp
@@ -259,6 +259,9 @@ CLogicalDynamicGetBase::SetPartConstraint(CPartConstraint *ppartcnstr)
 {
 	GPOS_ASSERT(NULL != ppartcnstr);
 	GPOS_ASSERT(NULL != m_part_constraint);
+	GPOS_ASSERT_IMP(m_is_partial,
+					NULL != ppartcnstr->PcnstrCombined() &&
+						"Partial scan with unsupported constraint type");
 
 	m_part_constraint->Release();
 	m_part_constraint = ppartcnstr;

--- a/src/backend/gporca/libgpopt/src/xforms/CXformJoin2IndexApply.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformJoin2IndexApply.cpp
@@ -175,10 +175,13 @@ CXformJoin2IndexApply::CreateHomogeneousBtreeIndexApplyAlternatives(
 		CPartConstraint *ppartcnstrIndex = NULL;
 		if (NULL != popDynamicGet)
 		{
+			// Partition constraints are expensive to compute and needed only for
+			// partial scans. For all other cases, pass along dummy constraints
+			const BOOL fDummyConstraint = !popDynamicGet->IsPartial();
 			ppartcnstrIndex = CUtils::PpartcnstrFromMDPartCnstr(
 				mp, COptCtxt::PoctxtFromTLS()->Pmda(),
 				popDynamicGet->PdrgpdrgpcrPart(), pmdindex->MDPartConstraint(),
-				popDynamicGet->PdrgpcrOutput());
+				popDynamicGet->PdrgpcrOutput(), fDummyConstraint);
 		}
 		CreateAlternativesForBtreeIndex(
 			mp, joinOp, pexprOuter, pexprInner, origJoinPred,


### PR DESCRIPTION
Prior to this commit, ORCA would calculate partition constraints
everytime (for DynamicGet) and use it only for partial scans later. As
the number of partitions grow, calculating these constraints would slow
down the query plan time. This commit speeds it up by computing
constraints only for partial scans and passing dummy constraints
otherwise.

This also adds an assertion which verifies that partition constraints (when
added after the partial index flag has been set) are valid. A similar assertion
exists inside of SetPartial, but running SetPartial before SetPartCnstr would
only check against the old partition constraints and not the new partition
constraints. This reverse-pattern exists in the codebase currently.

(cherry picked from commit 1849a2c8b2806a317e588bdf42aafe68763985ce)