### PR TITLE
[6X_STABLE] Add support in ORCA to generate efficient plans for ordered-set aggs

### DIFF
--- a/gpcontrib/Makefile
+++ b/gpcontrib/Makefile
@@ -22,6 +22,7 @@ ifeq "$(enable_debug_extensions)" "yes"
                gp_replica_check \
                gp_legacy_string_agg \
                gp_array_agg \
+               gp_percentile_agg \
                gp_error_handling
 else
 	recurse_targets = gp_sparse_vector \
@@ -31,6 +32,7 @@ else
                gp_pitr \
                gp_legacy_string_agg \
                gp_array_agg \
+               gp_percentile_agg \
                gp_error_handling
 endif
 
@@ -93,3 +95,4 @@ installcheck:
 	if [ "$(with_zstd)" = "yes" ]; then $(MAKE) -C zstd installcheck; fi
 	if [ "$(with_quicklz)" = "yes" ]; then $(MAKE) -C quicklz installcheck; fi
 	$(MAKE) -C gp_sparse_vector installcheck
+	$(MAKE) -C gp_percentile_agg installcheck

--- a/gpcontrib/gp_percentile_agg/Makefile
+++ b/gpcontrib/gp_percentile_agg/Makefile
@@ -1,0 +1,19 @@
+MODULES = gp_percentile_agg
+OBJS = gp_percentile_agg.o
+EXTENSION = gp_percentile_agg
+DATA = gp_percentile_agg--1.0.0.sql
+
+REGRESS = gp_percentile_agg
+REGRESS_OPTS = --load-extension gp_percentile_agg --init-file=$(top_builddir)/src/test/regress/init_file
+CFLAGS=`pg_config --includedir-server`
+
+ifdef USE_PGXS
+	PG_CONFIG = pg_config
+	PGXS := $(shell $(PG_CONFIG) --pgxs)
+	include $(PGXS)
+else
+  subdir = gpcontrib/gp_percentile_agg
+  top_builddir = ../..
+  include $(top_builddir)/src/Makefile.global
+  include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/gpcontrib/gp_percentile_agg/README.md
+++ b/gpcontrib/gp_percentile_agg/README.md
@@ -1,0 +1,16 @@
+gp_percentile_agg aggregate
+========================
+This extension provides an alternative to in-built percentile_cont and
+percentile_disc ordered aggregates. gp_percentile_cont and gp_percentile_disc
+supports percentile calculation based on the total count assuming data is
+passed in sorted.
+
+Installation
+------------
+Installing this is very simple, especially if you're using pgxn client.
+All you need to do is this:
+
+
+
+    $ make USE_PGXS=1 install
+    $ psql dbname -c "CREATE EXTENSION gp_percentile_agg"

--- a/gpcontrib/gp_percentile_agg/expected/gp_percentile_agg.out
+++ b/gpcontrib/gp_percentile_agg/expected/gp_percentile_agg.out
@@ -1,0 +1,1464 @@
+create table perct as select a, a / 10 as b from generate_series(1, 100)a distributed by (a);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table perct2 as select a, a / 10 as b from generate_series(1, 100)a, generate_series(1, 2);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table perct3 as select a, b from perct, generate_series(1, 10)i where a % 7 < i;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table perct4 as select case when a % 10 = 5 then null else a end as a,
+	b, null::float as c from perct;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table percts as select '2012-01-01 00:00:00'::timestamp + interval '1day' * i as a,
+	i / 10 as b, i as c from generate_series(1, 100)i;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table perctsz as select '2012-01-01 00:00:00 UTC'::timestamptz + interval '1day' * i as a,
+	i / 10 as b, i as c from generate_series(1, 100)i;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table perctnum as select a, (a / 13)::float8  as b, (a * 1.9999 )::numeric as c  from generate_series(1, 100)a;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create view percv as select percentile_cont(0.4) within group (order by a / 10),
+	median(a), percentile_disc(0.51) within group (order by a desc) from perct group by b order by b;
+create view percv2 as select median(a) as m1, median(a::float) as m2 from perct;
+create table mpp_22219(col_a character(2) NOT NULL, dkey_a character varying(8) NOT NULL, value double precision)
+WITH (APPENDONLY=true, COMPRESSLEVEL=5, ORIENTATION=column, COMPRESSTYPE=zlib, OIDS=FALSE)
+DISTRIBUTED BY (dkey_a);
+insert into mpp_22219 select i, i, i from  (select * from generate_series(1, 20) i ) a ;
+create table mpp_21026 ( t1 varchar(10), t2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 't1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into mpp_21026 select i, i from  (select * from generate_series(1, 20) i ) a ;
+create table mpp_20076 (col1 timestamp, col2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into mpp_20076 select to_timestamp(i),i from generate_series(1,20) i;
+CREATE TABLE mpp_22413
+(
+  col_a character(2) NOT NULL,
+  d1 character varying(8) NOT NULL,
+  d2 character varying(8) NOT NULL,
+  d3 character varying(8) NOT NULL,
+  value1 double precision,
+  value2 double precision
+)
+WITH (OIDS=FALSE)
+DISTRIBUTED BY (d1,d2,d3);
+insert into mpp_22413
+select i, i, i, i, i,i
+from  (select * from generate_series(1, 99) i ) a ;
+set optimizer_enable_orderedagg=on;
+explain select percentile_cont(0.5) within group (order by a),
+	median(a), percentile_disc(0.5) within group(order by a) from perct;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Aggregate  (cost=9.26..9.27 rows=1 width=20)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8.00 rows=100 width=4)
+         ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=4)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select percentile_cont(0.5) within group (order by a),
+	median(a), percentile_disc(0.5) within group(order by a) from perct;
+ percentile_cont | median | percentile_disc 
+-----------------+--------+-----------------
+            50.5 |   50.5 |              50
+(1 row)
+
+explain select b, percentile_cont(0.5) within group (order by a),
+	median(a), percentile_disc(0.5) within group(order by a) from perct group by b order by b;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=9.32..11.26 rows=11 width=24)
+   Merge Key: b
+   ->  GroupAggregate  (cost=9.32..11.26 rows=4 width=24)
+         Group Key: b
+         ->  Sort  (cost=9.32..9.57 rows=34 width=8)
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..6.00 rows=34 width=8)
+                     Hash Key: b
+                     ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=8)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select b, percentile_cont(0.5) within group (order by a),
+	median(a), percentile_disc(0.5) within group(order by a) from perct group by b order by b;
+ b  | percentile_cont | median | percentile_disc 
+----+-----------------+--------+-----------------
+  0 |               5 |      5 |               5
+  1 |            14.5 |   14.5 |              14
+  2 |            24.5 |   24.5 |              24
+  3 |            34.5 |   34.5 |              34
+  4 |            44.5 |   44.5 |              44
+  5 |            54.5 |   54.5 |              54
+  6 |            64.5 |   64.5 |              64
+  7 |            74.5 |   74.5 |              74
+  8 |            84.5 |   84.5 |              84
+  9 |            94.5 |   94.5 |              94
+ 10 |             100 |    100 |             100
+(11 rows)
+
+explain select percentile_cont(0.2) within group (order by a) from generate_series(1, 100)a;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Aggregate  (cost=15.00..15.01 rows=1 width=8)
+   ->  Function Scan on generate_series a  (cost=0.00..10.00 rows=334 width=4)
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select percentile_cont(0.2) within group (order by a) from generate_series(1, 100)a;
+ percentile_cont 
+-----------------
+            20.8
+(1 row)
+
+explain select a / 10, percentile_cont(0.2) within group (order by a) from generate_series(1, 100)a
+	group by a / 10 order by a / 10;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ GroupAggregate  (cost=62.33..87.33 rows=334 width=12)
+   Group Key: ((a / 10))
+   ->  Sort  (cost=62.33..64.83 rows=334 width=4)
+         Sort Key: ((a / 10))
+         ->  Function Scan on generate_series a  (cost=0.00..12.50 rows=334 width=4)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+select a / 10, percentile_cont(0.2) within group (order by a) from generate_series(1, 100)a
+	group by a / 10 order by a / 10;
+ ?column? | percentile_cont 
+----------+-----------------
+        0 |             2.6
+        1 |            11.8
+        2 |            21.8
+        3 |            31.8
+        4 |            41.8
+        5 |            51.8
+        6 |            61.8
+        7 |            71.8
+        8 |            81.8
+        9 |            91.8
+       10 |             100
+(11 rows)
+
+explain select percentile_cont(0.2) within group (order by a),
+	percentile_cont(0.8) within group (order by a desc) from perct group by b order by b;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=9.32..10.99 rows=11 width=20)
+   Merge Key: b
+   ->  GroupAggregate  (cost=9.32..10.99 rows=4 width=20)
+         Group Key: b
+         ->  Sort  (cost=9.32..9.57 rows=34 width=8)
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..6.00 rows=34 width=8)
+                     Hash Key: b
+                     ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=8)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select percentile_cont(0.2) within group (order by a),
+	percentile_cont(0.8) within group (order by a desc) from perct group by b order by b;
+ percentile_cont | percentile_cont 
+-----------------+-----------------
+             2.6 |             2.6
+            11.8 |            11.8
+            21.8 |            21.8
+            31.8 |            31.8
+            41.8 |            41.8
+            51.8 |            51.8
+            61.8 |            61.8
+            71.8 |            71.8
+            81.8 |            81.8
+            91.8 |            91.8
+             100 |             100
+(11 rows)
+
+explain select percentile_cont(0.1) within group (order by a), count(*), sum(a) from perct
+	group by b order by b;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=9.32..10.96 rows=11 width=28)
+   Merge Key: b
+   ->  GroupAggregate  (cost=9.32..10.96 rows=4 width=28)
+         Group Key: b
+         ->  Sort  (cost=9.32..9.57 rows=34 width=8)
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..6.00 rows=34 width=8)
+                     Hash Key: b
+                     ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=8)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select percentile_cont(0.1) within group (order by a), count(*), sum(a) from perct
+	group by b order by b;
+ percentile_cont | count | sum 
+-----------------+-------+-----
+             1.8 |     9 |  45
+            10.9 |    10 | 145
+            20.9 |    10 | 245
+            30.9 |    10 | 345
+            40.9 |    10 | 445
+            50.9 |    10 | 545
+            60.9 |    10 | 645
+            70.9 |    10 | 745
+            80.9 |    10 | 845
+            90.9 |    10 | 945
+             100 |     1 | 100
+(11 rows)
+
+explain select percentile_cont(0.6) within group (order by a), count(*), sum(a) from perct;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Aggregate  (cost=9.00..9.01 rows=1 width=24)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8.00 rows=100 width=4)
+         ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=4)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select percentile_cont(0.6) within group (order by a), count(*), sum(a) from perct;
+ percentile_cont | count | sum  
+-----------------+-------+------
+            60.4 |   100 | 5050
+(1 row)
+
+explain select percentile_cont(0.3) within group (order by a) + count(*) from perct group by b order by b;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=9.32..10.76 rows=11 width=12)
+   Merge Key: b
+   ->  GroupAggregate  (cost=9.32..10.76 rows=4 width=12)
+         Group Key: b
+         ->  Sort  (cost=9.32..9.57 rows=34 width=8)
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..6.00 rows=34 width=8)
+                     Hash Key: b
+                     ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=8)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select percentile_cont(0.3) within group (order by a) + count(*) from perct group by b order by b;
+ ?column? 
+----------
+     12.4
+     22.7
+     32.7
+     42.7
+     52.7
+     62.7
+     72.7
+     82.7
+     92.7
+    102.7
+      101
+(11 rows)
+
+explain select median(a) from perct group by b having median(a) = 5;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=9.32..11.01 rows=11 width=12)
+   ->  GroupAggregate  (cost=9.32..11.01 rows=4 width=12)
+         Group Key: b
+         Filter: (MEDIAN(a) = 5::double precision)
+         ->  Sort  (cost=9.32..9.57 rows=34 width=8)
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..6.00 rows=34 width=8)
+                     Hash Key: b
+                     ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=8)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select median(a) from perct group by b having median(a) = 5;
+ median 
+--------
+      5
+(1 row)
+
+explain select median(a), percentile_cont(0.6) within group (order by a desc) from perct group by b having count(*) > 1 order by 1;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=11.45..11.48 rows=11 width=20)
+   Merge Key: (MEDIAN(a))
+   ->  Sort  (cost=11.45..11.48 rows=4 width=20)
+         Sort Key: (MEDIAN(a))
+         ->  GroupAggregate  (cost=9.32..11.26 rows=4 width=20)
+               Group Key: b
+               Filter: (count(*) > 1)
+               ->  Sort  (cost=9.32..9.57 rows=34 width=8)
+                     Sort Key: b
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..6.00 rows=34 width=8)
+                           Hash Key: b
+                           ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=8)
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+select median(a), percentile_cont(0.6) within group (order by a desc) from perct group by b having count(*) > 1 order by 1;
+ median | percentile_cont 
+--------+-----------------
+      5 |             4.2
+   14.5 |            13.6
+   24.5 |            23.6
+   34.5 |            33.6
+   44.5 |            43.6
+   54.5 |            53.6
+   64.5 |            63.6
+   74.5 |            73.6
+   84.5 |            83.6
+   94.5 |            93.6
+(10 rows)
+
+explain select median(10);
+                   QUERY PLAN                   
+------------------------------------------------
+ Aggregate  (cost=0.02..0.03 rows=1 width=8)
+   ->  Result  (cost=0.00..0.01 rows=1 width=0)
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select median(10);
+ median 
+--------
+     10
+(1 row)
+
+explain select count(*), median(b+1) from perct group by b+2
+	having median(b+1) in (select avg(b+1) from perct group by b+2);
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=15.18..17.67 rows=11 width=20)
+   ->  GroupAggregate  (cost=15.18..17.67 rows=4 width=20)
+         Group Key: ((perct.b + 2))
+         Filter: (hashed SubPlan 1)
+         ->  Sort  (cost=9.57..9.82 rows=34 width=4)
+               Sort Key: ((perct.b + 2))
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..6.25 rows=34 width=4)
+                     Hash Key: ((perct.b + 2))
+                     ->  Seq Scan on perct  (cost=0.00..4.25 rows=34 width=4)
+         SubPlan 1  (slice4; segments: 3)
+           ->  Materialize  (cost=5.44..5.63 rows=4 width=36)
+                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=5.44..5.58 rows=4 width=36)
+                       ->  HashAggregate  (cost=5.44..5.58 rows=4 width=36)
+                             Group Key: ((perct_1.b + 2))
+                             ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=5.00..5.25 rows=4 width=36)
+                                   Hash Key: ((perct_1.b + 2))
+                                   ->  HashAggregate  (cost=5.00..5.03 rows=4 width=36)
+                                         Group Key: (perct_1.b + 2)
+                                         ->  Seq Scan on perct perct_1  (cost=0.00..4.25 rows=34 width=4)
+ Optimizer: Postgres query optimizer
+(20 rows)
+
+select count(*), median(b+1) from perct group by b+2
+	having median(b+1) in (select avg(b+1) from perct group by b+2);
+ count | median 
+-------+--------
+     1 |     11
+     9 |      1
+    10 |      2
+    10 |      3
+    10 |      4
+    10 |      5
+    10 |      6
+    10 |      7
+    10 |      8
+    10 |      9
+    10 |     10
+(11 rows)
+
+explain select median(a) from perct2;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Aggregate  (cost=14.00..14.01 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..13.00 rows=200 width=4)
+         ->  Seq Scan on perct2  (cost=0.00..5.00 rows=67 width=4)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select median(a) from perct2;
+ median 
+--------
+   50.5
+(1 row)
+
+explain select median(a) from perct2 group by b order by b;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=16.64..18.78 rows=11 width=12)
+   Merge Key: b
+   ->  GroupAggregate  (cost=16.64..18.78 rows=4 width=12)
+         Group Key: b
+         ->  Sort  (cost=16.64..17.14 rows=67 width=8)
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..9.00 rows=67 width=8)
+                     Hash Key: b
+                     ->  Seq Scan on perct2  (cost=0.00..5.00 rows=67 width=8)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select median(a) from perct2 group by b order by b;
+ median 
+--------
+      5
+   14.5
+   24.5
+   34.5
+   44.5
+   54.5
+   64.5
+   74.5
+   84.5
+   94.5
+    100
+(11 rows)
+
+explain select b, count(*), count(distinct a), median(a) from perct3 group by b order by b;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=57.33..68.02 rows=11 width=28)
+   Merge Key: b
+   ->  GroupAggregate  (cost=57.33..68.02 rows=4 width=28)
+         Group Key: b
+         ->  Sort  (cost=57.33..59.09 rows=235 width=8)
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..24.09 rows=235 width=8)
+                     Hash Key: b
+                     ->  Seq Scan on perct3  (cost=0.00..10.03 rows=235 width=8)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select b, count(*), count(distinct a), median(a) from perct3 group by b order by b;
+ b  | count | count | median 
+----+-------+-------+--------
+  0 |    66 |     9 |      5
+  1 |    67 |    10 |     15
+  2 |    72 |    10 |     24
+  3 |    70 |    10 |     35
+  4 |    68 |    10 |     44
+  5 |    73 |    10 |     55
+  6 |    64 |    10 |     64
+  7 |    76 |    10 |     74
+  8 |    67 |    10 |     85
+  9 |    72 |    10 |     94
+ 10 |     8 |     1 |    100
+(11 rows)
+
+explain select b+1, count(*), count(distinct a),
+       median(a), percentile_cont(0.3) within group (order by a desc)
+from perct group by b+1 order by b+1;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=9.57..11.76 rows=11 width=36)
+   Merge Key: ((b + 1))
+   ->  GroupAggregate  (cost=9.57..11.76 rows=4 width=36)
+         Group Key: ((b + 1))
+         ->  Sort  (cost=9.57..9.82 rows=34 width=8)
+               Sort Key: ((b + 1))
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..6.25 rows=34 width=8)
+                     Hash Key: ((b + 1))
+                     ->  Seq Scan on perct  (cost=0.00..4.25 rows=34 width=8)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select b+1, count(*), count(distinct a),
+       median(a), percentile_cont(0.3) within group (order by a desc)
+from perct group by b+1 order by b+1;
+ ?column? | count | count | median | percentile_cont 
+----------+-------+-------+--------+-----------------
+        1 |     9 |     9 |      5 |             6.6
+        2 |    10 |    10 |   14.5 |            16.3
+        3 |    10 |    10 |   24.5 |            26.3
+        4 |    10 |    10 |   34.5 |            36.3
+        5 |    10 |    10 |   44.5 |            46.3
+        6 |    10 |    10 |   54.5 |            56.3
+        7 |    10 |    10 |   64.5 |            66.3
+        8 |    10 |    10 |   74.5 |            76.3
+        9 |    10 |    10 |   84.5 |            86.3
+       10 |    10 |    10 |   94.5 |            96.3
+       11 |     1 |     1 |    100 |             100
+(11 rows)
+
+explain select median(a), median(c) from perct4;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Aggregate  (cost=8.76..8.77 rows=1 width=16)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8.00 rows=100 width=12)
+         ->  Seq Scan on perct4  (cost=0.00..4.00 rows=34 width=12)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select median(a), median(c) from perct4;
+ median | median 
+--------+--------
+   50.5 |       
+(1 row)
+
+explain select median(a), median(c) from perct4 group by b;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=9.32..10.74 rows=11 width=20)
+   ->  GroupAggregate  (cost=9.32..10.74 rows=4 width=20)
+         Group Key: b
+         ->  Sort  (cost=9.32..9.57 rows=34 width=16)
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..6.00 rows=34 width=16)
+                     Hash Key: b
+                     ->  Seq Scan on perct4  (cost=0.00..4.00 rows=34 width=16)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+select median(a), median(c) from perct4 group by b;
+ median | median 
+--------+--------
+      5 |       
+     14 |       
+     24 |       
+     34 |       
+     44 |       
+     54 |       
+     64 |       
+     74 |       
+     84 |       
+     94 |       
+    100 |       
+(11 rows)
+
+explain select count(*) over (partition by b), median(a) from perct group by b order by b;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=9.32..10.73 rows=11 width=12)
+   Merge Key: perct.b
+   ->  WindowAgg  (cost=9.32..10.73 rows=4 width=12)
+         Partition By: perct.b
+         ->  GroupAggregate  (cost=9.32..10.46 rows=4 width=12)
+               Group Key: perct.b
+               ->  Sort  (cost=9.32..9.57 rows=34 width=8)
+                     Sort Key: perct.b
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..6.00 rows=34 width=8)
+                           Hash Key: perct.b
+                           ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=8)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+select count(*) over (partition by b), median(a) from perct group by b order by b;
+ count | median 
+-------+--------
+     1 |      5
+     1 |   14.5
+     1 |   24.5
+     1 |   34.5
+     1 |   44.5
+     1 |   54.5
+     1 |   64.5
+     1 |   74.5
+     1 |   84.5
+     1 |   94.5
+     1 |    100
+(11 rows)
+
+explain select sum(median(a)) over (partition by b) from perct group by b order by b;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=9.32..10.73 rows=11 width=12)
+   Merge Key: perct.b
+   ->  WindowAgg  (cost=9.32..10.73 rows=4 width=12)
+         Partition By: perct.b
+         ->  GroupAggregate  (cost=9.32..10.46 rows=4 width=12)
+               Group Key: perct.b
+               ->  Sort  (cost=9.32..9.57 rows=34 width=8)
+                     Sort Key: perct.b
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..6.00 rows=34 width=8)
+                           Hash Key: perct.b
+                           ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=8)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+select sum(median(a)) over (partition by b) from perct group by b order by b;
+ sum  
+------
+    5
+ 14.5
+ 24.5
+ 34.5
+ 44.5
+ 54.5
+ 64.5
+ 74.5
+ 84.5
+ 94.5
+  100
+(11 rows)
+
+explain select percentile_disc(0) within group (order by a) from perct;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Aggregate  (cost=8.25..8.26 rows=1 width=4)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8.00 rows=100 width=4)
+         ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=4)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select percentile_disc(0) within group (order by a) from perct;
+ percentile_disc 
+-----------------
+               1
+(1 row)
+
+prepare p (float) as select percentile_cont($1) within group (order by a)
+  from perct group by b order by b;
+execute p(0.1);
+ percentile_cont 
+-----------------
+             1.8
+            10.9
+            20.9
+            30.9
+            40.9
+            50.9
+            60.9
+            70.9
+            80.9
+            90.9
+             100
+(11 rows)
+
+execute p(0.8);
+ percentile_cont 
+-----------------
+             100
+             7.4
+            17.2
+            27.2
+            37.2
+            47.2
+            57.2
+            67.2
+            77.2
+            87.2
+            97.2
+(11 rows)
+
+deallocate p;
+explain select sum((select median(a) from perct)) from perct;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Aggregate  (cost=12.82..12.83 rows=1 width=8)
+   InitPlan 1 (returns $0)  (slice3)
+     ->  Aggregate  (cost=8.50..8.51 rows=1 width=8)
+           ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..8.00 rows=100 width=4)
+                 ->  Seq Scan on perct perct_1  (cost=0.00..4.00 rows=34 width=4)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=4.25..4.30 rows=1 width=8)
+         ->  Aggregate  (cost=4.25..4.26 rows=1 width=8)
+               ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=0)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+select sum((select median(a) from perct)) from perct;
+ sum  
+------
+ 5050
+(1 row)
+
+explain select percentile_cont(null) within group (order by a) from perct;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Aggregate  (cost=8.50..8.51 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8.00 rows=100 width=4)
+         ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=4)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select percentile_cont(null) within group (order by a) from perct;
+ percentile_cont 
+-----------------
+                
+(1 row)
+
+explain select percentile_cont(null) within group (order by a),
+       percentile_disc(null) within group (order by a desc) from perct group by b;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=9.32..10.74 rows=11 width=16)
+   ->  GroupAggregate  (cost=9.32..10.74 rows=4 width=16)
+         Group Key: b
+         ->  Sort  (cost=9.32..9.57 rows=34 width=8)
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..6.00 rows=34 width=8)
+                     Hash Key: b
+                     ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=8)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+select percentile_cont(null) within group (order by a),
+       percentile_disc(null) within group (order by a desc) from perct group by b;
+ percentile_cont | percentile_disc 
+-----------------+-----------------
+                 |                
+                 |                
+                 |                
+                 |                
+                 |                
+                 |                
+                 |                
+                 |                
+                 |                
+                 |                
+                 |                
+(11 rows)
+
+explain select median(a), percentile_cont(0.5) within group (order by a),
+       percentile_disc(0.5) within group(order by a),
+       (select min(a) from percts) - interval '1day' + interval '1day' * median(c),
+       (select min(a) from percts) - interval '1day' + interval '1day' *
+         percentile_disc(0.5) within group (order by c)
+from percts group by b order by b;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=9.32..11.76 rows=11 width=44)
+   Merge Key: percts.b
+   ->  GroupAggregate  (cost=17.97..20.41 rows=4 width=44)
+         Group Key: percts.b
+         InitPlan 1 (returns $0)  (slice5)
+           ->  Aggregate  (cost=4.31..4.32 rows=1 width=8)
+                 ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=4.25..4.30 rows=1 width=8)
+                       ->  Aggregate  (cost=4.25..4.26 rows=1 width=8)
+                             ->  Seq Scan on percts percts_1  (cost=0.00..4.00 rows=34 width=8)
+         InitPlan 2 (returns $1)  (slice6)
+           ->  Aggregate  (cost=4.31..4.32 rows=1 width=8)
+                 ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=4.25..4.30 rows=1 width=8)
+                       ->  Aggregate  (cost=4.25..4.26 rows=1 width=8)
+                             ->  Seq Scan on percts percts_2  (cost=0.00..4.00 rows=34 width=8)
+         ->  Sort  (cost=9.32..9.57 rows=34 width=16)
+               Sort Key: percts.b
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..6.00 rows=34 width=16)
+                     Hash Key: percts.b
+                     ->  Seq Scan on percts  (cost=0.00..4.00 rows=34 width=16)
+ Optimizer: Postgres query optimizer
+(20 rows)
+
+select median(a), percentile_cont(0.5) within group (order by a),
+       percentile_disc(0.5) within group(order by a),
+       (select min(a) from percts) - interval '1day' + interval '1day' * median(c),
+       (select min(a) from percts) - interval '1day' + interval '1day' *
+         percentile_disc(0.5) within group (order by c)
+from percts group by b order by b;
+          median          |     percentile_cont      |     percentile_disc      |         ?column?         |         ?column?         
+--------------------------+--------------------------+--------------------------+--------------------------+--------------------------
+ Fri Jan 06 00:00:00 2012 | Fri Jan 06 00:00:00 2012 | Fri Jan 06 00:00:00 2012 | Fri Jan 06 00:00:00 2012 | Fri Jan 06 00:00:00 2012
+ Sun Jan 15 12:00:00 2012 | Sun Jan 15 12:00:00 2012 | Sun Jan 15 00:00:00 2012 | Sun Jan 15 12:00:00 2012 | Sun Jan 15 00:00:00 2012
+ Wed Jan 25 12:00:00 2012 | Wed Jan 25 12:00:00 2012 | Wed Jan 25 00:00:00 2012 | Wed Jan 25 12:00:00 2012 | Wed Jan 25 00:00:00 2012
+ Sat Feb 04 12:00:00 2012 | Sat Feb 04 12:00:00 2012 | Sat Feb 04 00:00:00 2012 | Sat Feb 04 12:00:00 2012 | Sat Feb 04 00:00:00 2012
+ Tue Feb 14 12:00:00 2012 | Tue Feb 14 12:00:00 2012 | Tue Feb 14 00:00:00 2012 | Tue Feb 14 12:00:00 2012 | Tue Feb 14 00:00:00 2012
+ Fri Feb 24 12:00:00 2012 | Fri Feb 24 12:00:00 2012 | Fri Feb 24 00:00:00 2012 | Fri Feb 24 12:00:00 2012 | Fri Feb 24 00:00:00 2012
+ Mon Mar 05 12:00:00 2012 | Mon Mar 05 12:00:00 2012 | Mon Mar 05 00:00:00 2012 | Mon Mar 05 12:00:00 2012 | Mon Mar 05 00:00:00 2012
+ Thu Mar 15 12:00:00 2012 | Thu Mar 15 12:00:00 2012 | Thu Mar 15 00:00:00 2012 | Thu Mar 15 12:00:00 2012 | Thu Mar 15 00:00:00 2012
+ Sun Mar 25 12:00:00 2012 | Sun Mar 25 12:00:00 2012 | Sun Mar 25 00:00:00 2012 | Sun Mar 25 12:00:00 2012 | Sun Mar 25 00:00:00 2012
+ Wed Apr 04 12:00:00 2012 | Wed Apr 04 12:00:00 2012 | Wed Apr 04 00:00:00 2012 | Wed Apr 04 12:00:00 2012 | Wed Apr 04 00:00:00 2012
+ Tue Apr 10 00:00:00 2012 | Tue Apr 10 00:00:00 2012 | Tue Apr 10 00:00:00 2012 | Tue Apr 10 00:00:00 2012 | Tue Apr 10 00:00:00 2012
+(11 rows)
+
+explain select percentile_cont(1.0/86400) within group (order by a) from percts
+	where c between 1 and 2;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Aggregate  (cost=4.55..4.56 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4.54 rows=2 width=8)
+         ->  Seq Scan on percts  (cost=0.00..4.50 rows=1 width=8)
+               Filter: ((c >= 1) AND (c <= 2))
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+select percentile_cont(1.0/86400) within group (order by a) from percts
+	where c between 1 and 2;
+     percentile_cont      
+--------------------------
+ Mon Jan 02 00:00:01 2012
+(1 row)
+
+explain select percentile_cont(0.1) within group (order by a),
+       percentile_cont(0.9) within group (order by a desc) from percts;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Aggregate  (cost=8.51..8.52 rows=1 width=16)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8.00 rows=100 width=8)
+         ->  Seq Scan on percts  (cost=0.00..4.00 rows=34 width=8)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select percentile_cont(0.1) within group (order by a),
+       percentile_cont(0.9) within group (order by a desc) from percts;
+     percentile_cont      |     percentile_cont      
+--------------------------+--------------------------
+ Wed Jan 11 21:36:00 2012 | Wed Jan 11 21:36:00 2012
+(1 row)
+
+explain select percentile_cont(0.1) within group (order by a),
+       percentile_cont(0.2) within group (order by a) from perctsz;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Aggregate  (cost=8.51..8.52 rows=1 width=16)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8.00 rows=100 width=8)
+         ->  Seq Scan on perctsz  (cost=0.00..4.00 rows=34 width=8)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select percentile_cont(0.1) within group (order by a),
+       percentile_cont(0.2) within group (order by a) from perctsz;
+       percentile_cont        |       percentile_cont        
+------------------------------+------------------------------
+ Wed Jan 11 13:36:00 2012 PST | Sat Jan 21 11:12:00 2012 PST
+(1 row)
+
+explain select median(a - (select min(a) from percts)) from percts;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Aggregate  (cost=12.82..12.83 rows=1 width=16)
+   InitPlan 1 (returns $0)  (slice3)
+     ->  Aggregate  (cost=4.31..4.32 rows=1 width=8)
+           ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=4.25..4.30 rows=1 width=8)
+                 ->  Aggregate  (cost=4.25..4.26 rows=1 width=8)
+                       ->  Seq Scan on percts percts_1  (cost=0.00..4.00 rows=34 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8.00 rows=100 width=8)
+         ->  Seq Scan on percts  (cost=0.00..4.00 rows=34 width=8)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+select median(a - (select min(a) from percts)) from percts;
+       median       
+--------------------
+ @ 49 days 12 hours
+(1 row)
+
+explain select median(a), b from perct group by b order by b desc;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=9.32..10.46 rows=11 width=12)
+   Merge Key: b
+   ->  GroupAggregate  (cost=9.32..10.46 rows=4 width=12)
+         Group Key: b
+         ->  Sort  (cost=9.32..9.57 rows=34 width=8)
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..6.00 rows=34 width=8)
+                     Hash Key: b
+                     ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=8)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select median(a), b from perct group by b order by b desc;
+ median | b  
+--------+----
+    100 | 10
+   94.5 |  9
+   84.5 |  8
+   74.5 |  7
+   64.5 |  6
+   54.5 |  5
+   44.5 |  4
+   34.5 |  3
+   24.5 |  2
+   14.5 |  1
+      5 |  0
+(11 rows)
+
+explain select count(*) from(select median(a) from perct group by ())s;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Aggregate  (cost=8.52..8.53 rows=1 width=8)
+   ->  Aggregate  (cost=8.50..8.51 rows=1 width=8)
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8.00 rows=100 width=4)
+               ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=4)
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+select count(*) from(select median(a) from perct group by ())s;
+ count 
+-------
+     1
+(1 row)
+
+explain select median(a) from perct group by grouping sets((b)) order by b;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=9.32..10.46 rows=11 width=12)
+   Merge Key: b
+   ->  GroupAggregate  (cost=9.32..10.46 rows=4 width=12)
+         Group Key: b
+         ->  Sort  (cost=9.32..9.57 rows=34 width=8)
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..6.00 rows=34 width=8)
+                     Hash Key: b
+                     ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=8)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select median(a) from perct group by grouping sets((b)) order by b;
+ median 
+--------
+      5
+   14.5
+   24.5
+   34.5
+   44.5
+   54.5
+   64.5
+   74.5
+   84.5
+   94.5
+    100
+(11 rows)
+
+explain select distinct median(a), count(*) from perct;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ HashAggregate  (cost=8.77..8.78 rows=1 width=16)
+   Group Key: MEDIAN(a), count(*)
+   ->  Aggregate  (cost=8.75..8.76 rows=1 width=16)
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8.00 rows=100 width=4)
+               ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=4)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+select distinct median(a), count(*) from perct;
+ median | count 
+--------+-------
+   50.5 |   100
+(1 row)
+
+explain select perct.a, 0.2*avg(perct2.a) as avga,
+	percentile_cont(0.34)within group(order by perct2.b)
+	from
+		(select a, a / 10 b from generate_series(1, 100)a)perct,
+		(select a, a / 10 b from generate_series(1, 100)a)perct2
+	where perct.a=perct2.a group by perct.a having median(perct.b) > 10;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ GroupAggregate  (cost=219.83..264.83 rows=334 width=44)
+   Group Key: a.a
+   Filter: (MEDIAN((a.a / 10)) > 10::double precision)
+   ->  Sort  (cost=219.83..222.33 rows=334 width=8)
+         Sort Key: a.a
+         ->  Hash Join  (cost=22.50..170.00 rows=334 width=8)
+               Hash Cond: (a.a = a_1.a)
+               ->  Function Scan on generate_series a  (cost=0.00..10.00 rows=334 width=4)
+               ->  Hash  (cost=10.00..10.00 rows=334 width=4)
+                     ->  Function Scan on generate_series a_1  (cost=0.00..10.00 rows=334 width=4)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select perct.a, 0.2*avg(perct2.a) as avga,
+	percentile_cont(0.34)within group(order by perct2.b)
+	from
+		(select a, a / 10 b from generate_series(1, 100)a)perct,
+		(select a, a / 10 b from generate_series(1, 100)a)perct2
+	where perct.a=perct2.a group by perct.a having median(perct.b) > 10;
+ a | avga | percentile_cont 
+---+------+-----------------
+(0 rows)
+
+explain select median(a - '2011-12-31 00:00:00 UTC'::timestamptz) from perctsz group by b order by median;
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10.65..10.68 rows=11 width=20)
+   Merge Key: (MEDIAN((a - 'Fri Dec 30 16:00:00 2011 PST'::timestamp with time zone)))
+   ->  Sort  (cost=10.65..10.68 rows=4 width=20)
+         Sort Key: (MEDIAN((a - 'Fri Dec 30 16:00:00 2011 PST'::timestamp with time zone)))
+         ->  GroupAggregate  (cost=9.32..10.46 rows=4 width=20)
+               Group Key: b
+               ->  Sort  (cost=9.32..9.57 rows=34 width=12)
+                     Sort Key: b
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..6.00 rows=34 width=12)
+                           Hash Key: b
+                           ->  Seq Scan on perctsz  (cost=0.00..4.00 rows=34 width=12)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+select median(a - '2011-12-31 00:00:00 UTC'::timestamptz) from perctsz group by b order by median;
+       median        
+---------------------
+ @ 6 days
+ @ 15 days 12 hours
+ @ 25 days 12 hours
+ @ 35 days 12 hours
+ @ 45 days 12 hours
+ @ 55 days 12 hours
+ @ 65 days 12 hours
+ @ 74 days 35 hours
+ @ 84 days 35 hours
+ @ 94 days 35 hours
+ @ 100 days 23 hours
+(11 rows)
+
+--numeric types
+explain select percentile_cont(0.95) within group( order by c) from perctnum;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Aggregate  (cost=8.50..8.51 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8.00 rows=100 width=7)
+         ->  Seq Scan on perctnum  (cost=0.00..4.00 rows=34 width=7)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select percentile_cont(0.95) within group( order by c) from perctnum;
+ percentile_cont 
+-----------------
+      190.090495
+(1 row)
+
+-- view
+select * from percv;
+ percentile_cont | median | percentile_disc 
+-----------------+--------+-----------------
+               0 |      5 |               5
+               1 |   14.5 |              14
+               2 |   24.5 |              24
+               3 |   34.5 |              34
+               4 |   44.5 |              44
+               5 |   54.5 |              54
+               6 |   64.5 |              64
+               7 |   74.5 |              74
+               8 |   84.5 |              84
+               9 |   94.5 |              94
+              10 |    100 |             100
+(11 rows)
+
+select pg_get_viewdef('percv');
+                                                         pg_get_viewdef                                                          
+---------------------------------------------------------------------------------------------------------------------------------
+  SELECT percentile_cont((0.4)::double precision) WITHIN GROUP (ORDER BY ((perct.a / 10))::double precision) AS percentile_cont,+
+     MEDIAN(perct.a) AS "median",                                                                                               +
+     percentile_disc((0.51)::double precision) WITHIN GROUP (ORDER BY perct.a DESC) AS percentile_disc                          +
+    FROM perct                                                                                                                  +
+   GROUP BY perct.b                                                                                                             +
+   ORDER BY perct.b;
+(1 row)
+
+select pg_get_viewdef('percv2');
+                pg_get_viewdef                 
+-----------------------------------------------
+  SELECT MEDIAN(perct.a) AS m1,               +
+     MEDIAN((perct.a)::double precision) AS m2+
+    FROM perct;
+(1 row)
+
+-- errors
+-- no WITHIN GROUP clause
+select percentile_cont(a) from perct;
+ERROR:  function percentile_cont(integer) does not exist
+LINE 1: select percentile_cont(a) from perct;
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+-- the argument must not contain variable
+select percentile_cont(a) within group (order by a) from perct;
+ERROR:  column "perct.a" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: select percentile_cont(a) within group (order by a) from per...
+                               ^
+DETAIL:  Direct arguments of an ordered-set aggregate must use only grouped columns.
+-- ungrouped column
+select b, percentile_disc(0.1) within group (order by a) from perct;
+ERROR:  column "perct.b" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: select b, percentile_disc(0.1) within group (order by a) fro...
+               ^
+-- nested aggregate
+select percentile_cont(count(*)) within group (order by a) from perct;
+ERROR:  aggregate function calls cannot be nested
+LINE 1: select percentile_cont(count(*)) within group (order by a) f...
+                               ^
+select sum(percentile_cont(0.22) within group (order by a)) from perct;
+ERROR:  aggregate function calls cannot be nested
+LINE 1: select sum(percentile_cont(0.22) within group (order by a)) ...
+                   ^
+-- OVER clause
+select percentile_cont(0.3333) within group (order by a) over (partition by a%2) from perct;
+ERROR:  OVER is not supported for ordered-set aggregate percentile_cont
+LINE 1: select percentile_cont(0.3333) within group (order by a) ove...
+               ^
+select median(a) over (partition by b) from perct group by b;
+ERROR:  syntax error at or near "over"
+LINE 1: select median(a) over (partition by b) from perct group by b...
+                         ^
+-- function scan
+select * from median(10);
+ERROR:  aggregate functions are not allowed in functions in FROM
+LINE 1: select * from median(10);
+                      ^
+-- wrong type argument
+select percentile_disc('a') within group (order by a) from perct;
+ERROR:  invalid input syntax for type double precision: "a"
+LINE 1: select percentile_disc('a') within group (order by a) from p...
+                               ^
+-- nested case
+select count(median(a)) from perct;
+ERROR:  aggregate function calls cannot be nested
+LINE 1: select count(median(a)) from perct;
+                     ^
+select median(count(*)) from perct;
+ERROR:  aggregate function calls cannot be nested
+LINE 1: select median(count(*)) from perct;
+                      ^
+select percentile_cont(0.2) within group (order by count(*) over()) from perct;
+ERROR:  aggregate function calls cannot contain window function calls
+LINE 1: ...elect percentile_cont(0.2) within group (order by count(*) o...
+                                                             ^
+select percentile_disc(0.1) within group (order by group_id()) from perct;
+ERROR:  aggregate function calls cannot be nested
+-- subquery in argument
+select percentile_cont((select 0.1 from gp_id)) within group (order by a) from perct;
+ percentile_cont 
+-----------------
+            10.9
+(1 row)
+
+-- volatile argument
+explain select percentile_cont(floor(random()*0.1)+0.5) within group (order by a) from perct;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Aggregate  (cost=8.51..8.52 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8.00 rows=100 width=4)
+         ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=4)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select percentile_cont(floor(random()*0.1)+0.5) within group (order by a) from perct;
+ percentile_cont 
+-----------------
+            50.5
+(1 row)
+
+-- out of range
+explain select percentile_cont(-0.1) within group (order by a) from perct;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Aggregate  (cost=8.50..8.51 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8.00 rows=100 width=4)
+         ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=4)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select percentile_cont(-0.1) within group (order by a) from perct;
+ERROR:  percentile value -0.1 is not between 0 and 1
+explain select percentile_cont(1.00000001) within group (order by a) from perct;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Aggregate  (cost=8.50..8.51 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8.00 rows=100 width=4)
+         ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=4)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select percentile_cont(1.00000001) within group (order by a) from perct;
+ERROR:  percentile value 1 is not between 0 and 1
+-- correlated subquery
+explain select sum((select median(a) from perct where b = t.b)) from perct t;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=476.14..476.15 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=471.41..471.46 rows=1 width=8)
+         ->  Aggregate  (cost=471.41..471.42 rows=1 width=8)
+               ->  Seq Scan on perct t  (cost=0.00..4.00 rows=34 width=4)
+               SubPlan 1  (slice2; segments: 3)
+                 ->  Aggregate  (cost=4.66..4.67 rows=1 width=8)
+                       ->  Result  (cost=0.00..4.30 rows=4 width=4)
+                             Filter: (perct.b = t.b)
+                             ->  Materialize  (cost=0.00..4.30 rows=4 width=4)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..4.25 rows=4 width=4)
+                                         ->  Seq Scan on perct  (cost=0.00..4.25 rows=4 width=4)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+select sum((select median(a) from perct where b = t.b)) from perct t;
+ sum  
+------
+ 5050
+(1 row)
+
+-- used in LIMIT
+select * from perct limit median(a);
+ERROR:  aggregate functions are not allowed in LIMIT
+LINE 1: select * from perct limit median(a);
+                                  ^
+-- multiple sort key
+select percentile_cont(0.8) within group (order by a, a + 1, a + 2) from perct;
+ERROR:  function percentile_cont(numeric, integer, integer, integer) does not exist
+LINE 1: select percentile_cont(0.8) within group (order by a, a + 1,...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+-- set-returning
+explain select generate_series(1, 2), median(a) from perct;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Aggregate  (cost=8.50..13.51 rows=1000 width=12)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..8.00 rows=100 width=4)
+         ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=4)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select generate_series(1, 2), median(a) from perct;
+ generate_series | median 
+-----------------+--------
+               1 |   50.5
+               2 |   50.5
+(2 rows)
+
+-- GROUPING SETS
+explain select median(a) from perct group by grouping sets((), (b));
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Append  (cost=13.69..29.54 rows=12 width=24)
+   ->  GroupAggregate  (cost=13.69..14.83 rows=11 width=24)
+         Group Key: share0_ref1.b
+         ->  Sort  (cost=13.69..13.94 rows=100 width=8)
+               Sort Key: share0_ref1.b
+               ->  Shared Scan (share slice:id 0:0)  (cost=10.07..10.37 rows=100 width=8)
+                     ->  Materialize  (cost=7.32..10.07 rows=100 width=8)
+                           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=7.32..9.57 rows=100 width=8)
+                                 Merge Key: perct.b
+                                 ->  Sort  (cost=7.32..7.57 rows=34 width=8)
+                                       Sort Key: perct.b
+                                       ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=8)
+   ->  GroupAggregate  (cost=13.69..14.71 rows=1 width=24)
+         Group Key: share0_ref2.b
+         ->  Sort  (cost=13.69..13.94 rows=100 width=8)
+               Sort Key: share0_ref2.b
+               ->  Shared Scan (share slice:id 0:0)  (cost=10.07..10.37 rows=100 width=8)
+ Optimizer: Postgres query optimizer
+(18 rows)
+
+select median(a) from perct group by grouping sets((), (b));
+ median 
+--------
+      5
+    100
+   14.5
+   24.5
+   34.5
+   44.5
+   50.5
+   54.5
+   64.5
+   74.5
+   84.5
+   94.5
+(12 rows)
+
+-- wrong type in ORDER BY
+select median('text') from perct;
+ERROR:  invalid input syntax for type double precision: "text"
+LINE 1: select median('text') from perct;
+                      ^
+select percentile_cont(now()) within group (order by a) from percts;
+ERROR:  function percentile_cont(timestamp with time zone, timestamp without time zone) does not exist
+LINE 1: select percentile_cont(now()) within group (order by a) from...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+select percentile_cont(0.5) within group (order by point(0,0)) from perct;
+ERROR:  function percentile_cont(numeric, point) does not exist
+LINE 1: select percentile_cont(0.5) within group (order by point(0,0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+-- outer references
+explain select (select a from perct where median(t.a) = 5) from perct t;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=8.50..12.52 rows=1 width=4)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..8.00 rows=100 width=4)
+         ->  Seq Scan on perct t  (cost=0.00..4.00 rows=34 width=4)
+   SubPlan 1  (slice0)
+     ->  Result  (cost=0.00..4.00 rows=34 width=4)
+           One-Time Filter: (MEDIAN(t.a) = 5::double precision)
+           ->  Result  (cost=0.00..4.50 rows=34 width=4)
+                 ->  Materialize  (cost=0.00..4.50 rows=34 width=4)
+                       ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4.00 rows=100 width=4)
+                             ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=4)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select (select a from perct where median(t.a) = 5) from perct t;
+ a 
+---
+  
+(1 row)
+
+explain select (select array_agg(a ORDER BY a) from perct where median(t.a) = 50.5) from (select * from perct t order by a offset 0) as t;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=13.07..21.35 rows=1 width=32)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=7.32..12.57 rows=100 width=4)
+         ->  Subquery Scan on t  (cost=7.32..8.57 rows=34 width=4)
+               ->  Sort  (cost=7.32..7.57 rows=34 width=8)
+                     Sort Key: t_1.a
+                     ->  Seq Scan on perct t_1  (cost=0.00..4.00 rows=34 width=8)
+   SubPlan 1  (slice0)
+     ->  Aggregate  (cost=8.26..8.27 rows=1 width=32)
+           ->  Result  (cost=0.00..4.00 rows=34 width=4)
+                 One-Time Filter: (MEDIAN(t.a) = 50.5::double precision)
+                 ->  Result  (cost=0.00..4.50 rows=34 width=4)
+                       ->  Materialize  (cost=0.00..4.50 rows=34 width=4)
+                             ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..4.00 rows=100 width=4)
+                                   ->  Seq Scan on perct  (cost=0.00..4.00 rows=34 width=4)
+ Optimizer: Postgres query optimizer
+(15 rows)
+
+select (select array_agg(a ORDER BY a) from perct where median(t.a) = 50.5) from (select * from perct t order by a offset 0) as t;
+                                                                                                                                               array_agg                                                                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100}
+(1 row)
+
+-- MPP-22219
+select count(*) from
+(SELECT b.dkey_a, MEDIAN(B.VALUE)
+FROM     mpp_22219 B
+GROUP BY b.dkey_a) s;
+ count 
+-------
+    20
+(1 row)
+
+select count(*) from
+(SELECT b.dkey_a, percentile_cont(0.5) within  group (order by b.VALUE)
+FROM     mpp_22219 B
+GROUP BY b.dkey_a) s;
+ count 
+-------
+    20
+(1 row)
+
+-- MPP-21026
+select median(t2) from mpp_21026 group by t1;
+ median 
+--------
+      1
+      2
+      3
+      4
+      5
+      6
+      7
+      8
+      9
+     10
+     11
+     12
+     13
+     14
+     15
+     16
+     17
+     18
+     19
+     20
+(20 rows)
+
+-- MPP-20076
+select 1, to_char(col1, 'YYYY'), median(col2) from mpp_20076 group by 1, 2;
+ ?column? | to_char | median 
+----------+---------+--------
+        1 | 1969    |   10.5
+(1 row)
+
+select 1, col1, median(col2) from mpp_20076 group by 1, 2;
+ ?column? |           col1           | median 
+----------+--------------------------+--------
+        1 | Wed Dec 31 16:00:01 1969 |      1
+        1 | Wed Dec 31 16:00:02 1969 |      2
+        1 | Wed Dec 31 16:00:03 1969 |      3
+        1 | Wed Dec 31 16:00:04 1969 |      4
+        1 | Wed Dec 31 16:00:05 1969 |      5
+        1 | Wed Dec 31 16:00:06 1969 |      6
+        1 | Wed Dec 31 16:00:07 1969 |      7
+        1 | Wed Dec 31 16:00:08 1969 |      8
+        1 | Wed Dec 31 16:00:09 1969 |      9
+        1 | Wed Dec 31 16:00:10 1969 |     10
+        1 | Wed Dec 31 16:00:11 1969 |     11
+        1 | Wed Dec 31 16:00:12 1969 |     12
+        1 | Wed Dec 31 16:00:13 1969 |     13
+        1 | Wed Dec 31 16:00:14 1969 |     14
+        1 | Wed Dec 31 16:00:15 1969 |     15
+        1 | Wed Dec 31 16:00:16 1969 |     16
+        1 | Wed Dec 31 16:00:17 1969 |     17
+        1 | Wed Dec 31 16:00:18 1969 |     18
+        1 | Wed Dec 31 16:00:19 1969 |     19
+        1 | Wed Dec 31 16:00:20 1969 |     20
+(20 rows)
+
+select to_char(col1, 'YYYY') AS tstmp_column, median(col2) from mpp_20076 group by 1;
+ tstmp_column | median 
+--------------+--------
+ 1969         |   10.5
+(1 row)
+
+select 1, median(col2) from mpp_20076 group by 1;
+ ?column? | median 
+----------+--------
+        1 |   10.5
+(1 row)
+
+-- MPP-22413
+select median(value1), count(*)
+from  mpp_22413
+where d2 ='55'
+group by d1, d2, d3, value2;
+ median | count 
+--------+-------
+     55 |     1
+(1 row)
+
+select median(value1), count(*)
+from  mpp_22413
+where d2 ='55'
+group by d1, d2, d3, value2::int;
+ median | count 
+--------+-------
+     55 |     1
+(1 row)
+
+select median(value1), count(*)
+from  mpp_22413
+where d2 ='55'
+group by d1, d2, d3, value2::varchar;
+ median | count 
+--------+-------
+     55 |     1
+(1 row)
+
+select median(value1), count(*)
+from  mpp_22413
+where d2 ='55'
+group by d1, d2, value2;
+ median | count 
+--------+-------
+     55 |     1
+(1 row)
+
+select median(value1), count(*)
+from  mpp_22413
+where d2 ='55'
+group by d1, d2, value2, d3;
+ median | count 
+--------+-------
+     55 |     1
+(1 row)
+
+select median(value1), count(*)
+from  mpp_22413
+where d2 ='55'
+group by d1, d2;
+ median | count 
+--------+-------
+     55 |     1
+(1 row)
+
+drop view percv2;
+drop view percv;
+drop table perct;
+drop table perct2;
+drop table perct3;
+drop table perct4;
+drop table percts;
+drop table perctsz;
+drop table mpp_22219;
+drop table mpp_21026;
+drop table mpp_20076;
+drop table mpp_22413;

--- a/gpcontrib/gp_percentile_agg/expected/gp_percentile_agg_optimizer.out
+++ b/gpcontrib/gp_percentile_agg/expected/gp_percentile_agg_optimizer.out
@@ -1,0 +1,1912 @@
+create table perct as select a, a / 10 as b from generate_series(1, 100)a distributed by (a);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table perct2 as select a, a / 10 as b from generate_series(1, 100)a, generate_series(1, 2);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table perct3 as select a, b from perct, generate_series(1, 10)i where a % 7 < i;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table perct4 as select case when a % 10 = 5 then null else a end as a,
+	b, null::float as c from perct;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table percts as select '2012-01-01 00:00:00'::timestamp + interval '1day' * i as a,
+	i / 10 as b, i as c from generate_series(1, 100)i;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table perctsz as select '2012-01-01 00:00:00 UTC'::timestamptz + interval '1day' * i as a,
+	i / 10 as b, i as c from generate_series(1, 100)i;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+create table perctnum as select a, (a / 13)::float8  as b, (a * 1.9999 )::numeric as c  from generate_series(1, 100)a;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+create view percv as select percentile_cont(0.4) within group (order by a / 10),
+	median(a), percentile_disc(0.51) within group (order by a desc) from perct group by b order by b;
+create view percv2 as select median(a) as m1, median(a::float) as m2 from perct;
+create table mpp_22219(col_a character(2) NOT NULL, dkey_a character varying(8) NOT NULL, value double precision)
+WITH (APPENDONLY=true, COMPRESSLEVEL=5, ORIENTATION=column, COMPRESSTYPE=zlib, OIDS=FALSE)
+DISTRIBUTED BY (dkey_a);
+insert into mpp_22219 select i, i, i from  (select * from generate_series(1, 20) i ) a ;
+create table mpp_21026 ( t1 varchar(10), t2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 't1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into mpp_21026 select i, i from  (select * from generate_series(1, 20) i ) a ;
+create table mpp_20076 (col1 timestamp, col2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into mpp_20076 select to_timestamp(i),i from generate_series(1,20) i;
+CREATE TABLE mpp_22413
+(
+  col_a character(2) NOT NULL,
+  d1 character varying(8) NOT NULL,
+  d2 character varying(8) NOT NULL,
+  d3 character varying(8) NOT NULL,
+  value1 double precision,
+  value2 double precision
+)
+WITH (OIDS=FALSE)
+DISTRIBUTED BY (d1,d2,d3);
+insert into mpp_22413
+select i, i, i, i, i,i
+from  (select * from generate_series(1, 99) i ) a ;
+set optimizer_enable_orderedagg=on;
+explain select percentile_cont(0.5) within group (order by a),
+	median(a), percentile_disc(0.5) within group(order by a) from perct;
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice8; segments: 3)  (cost=0.00..2712065311.58 rows=1 width=20)
+   ->  Sequence  (cost=0.00..2712065311.58 rows=1 width=20)
+         ->  Shared Scan (share slice:id 8:0)  (cost=0.00..431.00 rows=34 width=1)
+               ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
+                     ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=34)
+         ->  Redistribute Motion 1:3  (slice7)  (cost=0.00..2712064880.58 rows=1 width=20)
+               ->  Nested Loop  (cost=0.00..2712064880.58 rows=1 width=20)
+                     Join Filter: true
+                     ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=16)
+                           ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
+                                 ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
+                                       Merge Key: share0_ref4.a
+                                       ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
+                                             Sort Key: share0_ref4.a
+                                             ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
+                                                   Join Filter: true
+                                                   ->  Broadcast Motion 1:3  (slice5)  (cost=0.00..431.00 rows=3 width=8)
+                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Shared Scan (share slice:id 4:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                   ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=34 width=4)
+                     ->  Materialize  (cost=0.00..1324034.93 rows=1 width=4)
+                           ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=4)
+                                 ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
+                                       ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
+                                             Merge Key: share0_ref2.a
+                                             ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
+                                                   Sort Key: share0_ref2.a
+                                                   ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
+                                                         Join Filter: true
+                                                         ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                 ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                         ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(38 rows)
+
+select percentile_cont(0.5) within group (order by a),
+	median(a), percentile_disc(0.5) within group(order by a) from perct;
+ percentile_cont | median | percentile_disc 
+-----------------+--------+-----------------
+            50.5 |   50.5 |              50
+(1 row)
+
+explain select b, percentile_cont(0.5) within group (order by a),
+	median(a), percentile_disc(0.5) within group(order by a) from perct group by b order by b;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=11 width=24)
+   Merge Key: b
+   ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=24)
+         Group Key: b
+         ->  Sort  (cost=0.00..431.01 rows=34 width=8)
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=8)
+                     Hash Key: b
+                     ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+select b, percentile_cont(0.5) within group (order by a),
+	median(a), percentile_disc(0.5) within group(order by a) from perct group by b order by b;
+ b  | percentile_cont | median | percentile_disc 
+----+-----------------+--------+-----------------
+  0 |               5 |      5 |               5
+  1 |            14.5 |   14.5 |              14
+  2 |            24.5 |   24.5 |              24
+  3 |            34.5 |   34.5 |              34
+  4 |            44.5 |   44.5 |              44
+  5 |            54.5 |   54.5 |              54
+  6 |            64.5 |   64.5 |              64
+  7 |            74.5 |   74.5 |              74
+  8 |            84.5 |   84.5 |              84
+  9 |            94.5 |   94.5 |              94
+ 10 |             100 |    100 |             100
+(11 rows)
+
+explain select percentile_cont(0.2) within group (order by a) from generate_series(1, 100)a;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Sequence  (cost=0.00..1324105.78 rows=1 width=8)
+   ->  Shared Scan (share slice:id -1:0)  (cost=0.00..0.01 rows=334 width=1)
+         ->  Materialize  (cost=0.00..0.01 rows=334 width=1)
+               ->  Function Scan on generate_series  (cost=0.00..0.00 rows=334 width=4)
+   ->  Aggregate  (cost=0.00..1324105.78 rows=1 width=8)
+         ->  Limit  (cost=0.00..1324105.78 rows=334 width=12)
+               ->  Sort  (cost=0.00..1324105.76 rows=334 width=12)
+                     Sort Key: share0_ref2.generate_series
+                     ->  Nested Loop  (cost=0.00..1324105.09 rows=334 width=12)
+                           Join Filter: true
+                           ->  Aggregate  (cost=0.00..431.01 rows=1 width=8)
+                                 ->  Shared Scan (share slice:id -1:0)  (cost=0.00..431.01 rows=334 width=4)
+                           ->  Shared Scan (share slice:id -1:0)  (cost=0.00..431.01 rows=334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(14 rows)
+
+select percentile_cont(0.2) within group (order by a) from generate_series(1, 100)a;
+ percentile_cont 
+-----------------
+            20.8
+(1 row)
+
+explain select a / 10, percentile_cont(0.2) within group (order by a) from generate_series(1, 100)a
+	group by a / 10 order by a / 10;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ GroupAggregate  (cost=0.00..0.48 rows=334 width=12)
+   Group Key: ((generate_series / 10))
+   ->  Sort  (cost=0.00..0.46 rows=334 width=8)
+         Sort Key: ((generate_series / 10))
+         ->  Result  (cost=0.00..0.01 rows=334 width=8)
+               ->  Function Scan on generate_series  (cost=0.00..0.00 rows=334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+select a / 10, percentile_cont(0.2) within group (order by a) from generate_series(1, 100)a
+	group by a / 10 order by a / 10;
+ ?column? | percentile_cont 
+----------+-----------------
+        0 |             2.6
+        1 |            11.8
+        2 |            21.8
+        3 |            31.8
+        4 |            41.8
+        5 |            51.8
+        6 |            61.8
+        7 |            71.8
+        8 |            81.8
+        9 |            91.8
+       10 |             100
+(11 rows)
+
+explain select percentile_cont(0.2) within group (order by a),
+	percentile_cont(0.8) within group (order by a desc) from perct group by b order by b;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..431.01 rows=4 width=16)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=11 width=16)
+         Merge Key: b
+         ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=20)
+               Group Key: b
+               ->  Sort  (cost=0.00..431.01 rows=34 width=8)
+                     Sort Key: b
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=8)
+                           Hash Key: b
+                           ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+select percentile_cont(0.2) within group (order by a),
+	percentile_cont(0.8) within group (order by a desc) from perct group by b order by b;
+ percentile_cont | percentile_cont 
+-----------------+-----------------
+             2.6 |             2.6
+            11.8 |            11.8
+            21.8 |            21.8
+            31.8 |            31.8
+            41.8 |            41.8
+            51.8 |            51.8
+            61.8 |            61.8
+            71.8 |            71.8
+            81.8 |            81.8
+            91.8 |            91.8
+             100 |             100
+(11 rows)
+
+explain select percentile_cont(0.1) within group (order by a), count(*), sum(a) from perct
+	group by b order by b;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..431.01 rows=4 width=24)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=11 width=24)
+         Merge Key: b
+         ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=28)
+               Group Key: b
+               ->  Sort  (cost=0.00..431.01 rows=34 width=8)
+                     Sort Key: b
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=8)
+                           Hash Key: b
+                           ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+select percentile_cont(0.1) within group (order by a), count(*), sum(a) from perct
+	group by b order by b;
+ percentile_cont | count | sum 
+-----------------+-------+-----
+             1.8 |     9 |  45
+            10.9 |    10 | 145
+            20.9 |    10 | 245
+            30.9 |    10 | 345
+            40.9 |    10 | 445
+            50.9 |    10 | 545
+            60.9 |    10 | 645
+            70.9 |    10 | 745
+            80.9 |    10 | 845
+            90.9 |    10 | 945
+             100 |     1 | 100
+(11 rows)
+
+explain select percentile_cont(0.6) within group (order by a), count(*), sum(a) from perct;
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1356694888.30 rows=1 width=24)
+   ->  Sequence  (cost=0.00..1356694888.30 rows=1 width=24)
+         ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=34 width=1)
+               ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
+                     ->  Seq Scan on perct perct_1  (cost=0.00..431.00 rows=34 width=34)
+         ->  Redistribute Motion 1:3  (slice5)  (cost=0.00..1356694457.29 rows=1 width=24)
+               ->  Nested Loop  (cost=0.00..1356694457.29 rows=1 width=24)
+                     Join Filter: true
+                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                           ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+                                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                                       ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=4)
+                     ->  Materialize  (cost=0.00..1324034.93 rows=1 width=8)
+                           ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=8)
+                                 ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
+                                       ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
+                                             Merge Key: share0_ref2.a
+                                             ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
+                                                   Sort Key: share0_ref2.a
+                                                   ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
+                                                         Join Filter: true
+                                                         ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                 ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                         ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(28 rows)
+
+select percentile_cont(0.6) within group (order by a), count(*), sum(a) from perct;
+ percentile_cont | count | sum  
+-----------------+-------+------
+            60.4 |   100 | 5050
+(1 row)
+
+explain select percentile_cont(0.3) within group (order by a) + count(*) from perct group by b order by b;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..431.01 rows=4 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=11 width=8)
+         Merge Key: b
+         ->  Result  (cost=0.00..431.01 rows=4 width=12)
+               ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=20)
+                     Group Key: b
+                     ->  Sort  (cost=0.00..431.01 rows=34 width=8)
+                           Sort Key: b
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=8)
+                                 Hash Key: b
+                                 ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
+select percentile_cont(0.3) within group (order by a) + count(*) from perct group by b order by b;
+ ?column? 
+----------
+     12.4
+     22.7
+     32.7
+     42.7
+     52.7
+     62.7
+     72.7
+     82.7
+     92.7
+    102.7
+      101
+(11 rows)
+
+explain select median(a) from perct group by b having median(a) = 5;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=5 width=8)
+   ->  Result  (cost=0.00..431.01 rows=2 width=8)
+         Filter: ((MEDIAN(a)) = 5::double precision)
+         ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=16)
+               Group Key: b
+               ->  Sort  (cost=0.00..431.01 rows=34 width=8)
+                     Sort Key: b
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=8)
+                           Hash Key: b
+                           ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+select median(a) from perct group by b having median(a) = 5;
+ median 
+--------
+      5
+(1 row)
+
+explain select median(a), percentile_cont(0.6) within group (order by a desc) from perct group by b having count(*) > 1 order by 1;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=5 width=16)
+   Merge Key: (MEDIAN(a))
+   ->  Sort  (cost=0.00..431.01 rows=2 width=16)
+         Sort Key: (MEDIAN(a))
+         ->  Result  (cost=0.00..431.01 rows=2 width=16)
+               Filter: ((count()) > 1)
+               ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=24)
+                     Group Key: b
+                     ->  Sort  (cost=0.00..431.01 rows=34 width=8)
+                           Sort Key: b
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=8)
+                                 Hash Key: b
+                                 ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(14 rows)
+
+select median(a), percentile_cont(0.6) within group (order by a desc) from perct group by b having count(*) > 1 order by 1;
+ median | percentile_cont 
+--------+-----------------
+      5 |             4.2
+   14.5 |            13.6
+   24.5 |            23.6
+   34.5 |            33.6
+   44.5 |            43.6
+   54.5 |            53.6
+   64.5 |            63.6
+   74.5 |            73.6
+   84.5 |            83.6
+   94.5 |            93.6
+(10 rows)
+
+explain select median(10);
+                   QUERY PLAN                   
+------------------------------------------------
+ Aggregate  (cost=0.00..0.00 rows=1 width=8)
+   ->  Result  (cost=0.00..0.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(3 rows)
+
+select median(10);
+ median 
+--------
+     10
+(1 row)
+
+explain select count(*), median(b+1) from perct group by b+2
+	having median(b+1) in (select avg(b+1) from perct group by b+2);
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..862.02 rows=1 width=16)
+   ->  Hash Semi Join  (cost=0.00..862.02 rows=1 width=16)
+         Hash Cond: ((MEDIAN((perct.b + 1))) = ((pg_catalog.avg((avg((perct_1.b + 1))))))::double precision)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.01 rows=4 width=24)
+               Hash Key: (MEDIAN((perct.b + 1)))
+               ->  Result  (cost=0.00..431.01 rows=4 width=24)
+                     ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=24)
+                           Group Key: ((perct.b + 2))
+                           ->  Sort  (cost=0.00..431.01 rows=34 width=8)
+                                 Sort Key: ((perct.b + 2))
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=8)
+                                       Hash Key: ((perct.b + 2))
+                                       ->  Result  (cost=0.00..431.00 rows=34 width=8)
+                                             ->  Result  (cost=0.00..431.00 rows=34 width=8)
+                                                   ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=4)
+         ->  Hash  (cost=431.01..431.01 rows=4 width=8)
+               ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.01 rows=4 width=8)
+                     Hash Key: ((pg_catalog.avg((avg((perct_1.b + 1))))))::double precision
+                     ->  Result  (cost=0.00..431.01 rows=4 width=8)
+                           ->  HashAggregate  (cost=0.00..431.01 rows=4 width=8)
+                                 Group Key: ((perct_1.b + 2))
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.01 rows=4 width=12)
+                                       Hash Key: ((perct_1.b + 2))
+                                       ->  Result  (cost=0.00..431.01 rows=4 width=12)
+                                             ->  HashAggregate  (cost=0.00..431.01 rows=4 width=12)
+                                                   Group Key: (perct_1.b + 2)
+                                                   ->  Result  (cost=0.00..431.00 rows=34 width=8)
+                                                         ->  Seq Scan on perct perct_1  (cost=0.00..431.00 rows=34 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(29 rows)
+
+select count(*), median(b+1) from perct group by b+2
+	having median(b+1) in (select avg(b+1) from perct group by b+2);
+ count | median 
+-------+--------
+     1 |     11
+     9 |      1
+    10 |      2
+    10 |      3
+    10 |      4
+    10 |      5
+    10 |      6
+    10 |      7
+    10 |      8
+    10 |      9
+    10 |     10
+(11 rows)
+
+explain select median(a) from perct2;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324468.39 rows=1 width=8)
+   ->  Sequence  (cost=0.00..1324468.39 rows=1 width=8)
+         ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.01 rows=67 width=1)
+               ->  Materialize  (cost=0.00..431.01 rows=67 width=1)
+                     ->  Seq Scan on perct2  (cost=0.00..431.00 rows=67 width=34)
+         ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324037.39 rows=1 width=8)
+               ->  Aggregate  (cost=0.00..1324037.39 rows=1 width=8)
+                     ->  Limit  (cost=0.00..1324037.39 rows=67 width=12)
+                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324037.38 rows=200 width=12)
+                                 Merge Key: share0_ref2.a
+                                 ->  Sort  (cost=0.00..1324037.38 rows=67 width=12)
+                                       Sort Key: share0_ref2.a
+                                       ->  Nested Loop  (cost=0.00..1324037.35 rows=67 width=12)
+                                             Join Filter: true
+                                             ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=67 width=4)
+                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=67 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(21 rows)
+
+select median(a) from perct2;
+ median 
+--------
+   50.5
+(1 row)
+
+explain select median(a) from perct2 group by b order by b;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..431.02 rows=4 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.02 rows=11 width=8)
+         Merge Key: b
+         ->  GroupAggregate  (cost=0.00..431.02 rows=4 width=12)
+               Group Key: b
+               ->  Sort  (cost=0.00..431.02 rows=67 width=8)
+                     Sort Key: b
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=67 width=8)
+                           Hash Key: b
+                           ->  Seq Scan on perct2  (cost=0.00..431.00 rows=67 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+select median(a) from perct2 group by b order by b;
+ median 
+--------
+      5
+   14.5
+   24.5
+   34.5
+   44.5
+   54.5
+   64.5
+   74.5
+   84.5
+   94.5
+    100
+(11 rows)
+
+explain select b, count(*), count(distinct a), median(a) from perct3 group by b order by b;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.10 rows=11 width=28)
+   Merge Key: b
+   ->  GroupAggregate  (cost=0.00..431.10 rows=4 width=28)
+         Group Key: b
+         ->  Sort  (cost=0.00..431.10 rows=235 width=8)
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.01 rows=235 width=8)
+                     Hash Key: b
+                     ->  Seq Scan on perct3  (cost=0.00..431.00 rows=235 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+select b, count(*), count(distinct a), median(a) from perct3 group by b order by b;
+ b  | count | count | median 
+----+-------+-------+--------
+  0 |    66 |     9 |      5
+  1 |    67 |    10 |     15
+  2 |    72 |    10 |     24
+  3 |    70 |    10 |     35
+  4 |    68 |    10 |     44
+  5 |    73 |    10 |     55
+  6 |    64 |    10 |     64
+  7 |    76 |    10 |     74
+  8 |    67 |    10 |     85
+  9 |    72 |    10 |     94
+ 10 |     8 |     1 |    100
+(11 rows)
+
+explain select b+1, count(*), count(distinct a),
+       median(a), percentile_cont(0.3) within group (order by a desc)
+from perct group by b+1 order by b+1;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=11 width=36)
+   Merge Key: ((b + 1))
+   ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=36)
+         Group Key: ((b + 1))
+         ->  Sort  (cost=0.00..431.01 rows=34 width=8)
+               Sort Key: ((b + 1))
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=8)
+                     Hash Key: ((b + 1))
+                     ->  Result  (cost=0.00..431.00 rows=34 width=8)
+                           ->  Result  (cost=0.00..431.00 rows=34 width=8)
+                                 ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
+select b+1, count(*), count(distinct a),
+       median(a), percentile_cont(0.3) within group (order by a desc)
+from perct group by b+1 order by b+1;
+ ?column? | count | count | median | percentile_cont 
+----------+-------+-------+--------+-----------------
+        1 |     9 |     9 |      5 |             6.6
+        2 |    10 |    10 |   14.5 |            16.3
+        3 |    10 |    10 |   24.5 |            26.3
+        4 |    10 |    10 |   34.5 |            36.3
+        5 |    10 |    10 |   44.5 |            46.3
+        6 |    10 |    10 |   54.5 |            56.3
+        7 |    10 |    10 |   64.5 |            66.3
+        8 |    10 |    10 |   74.5 |            76.3
+        9 |    10 |    10 |   84.5 |            86.3
+       10 |    10 |    10 |   94.5 |            96.3
+       11 |     1 |     1 |    100 |             100
+(11 rows)
+
+explain select median(a), median(c) from perct4;
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice8; segments: 3)  (cost=0.00..2712066833.06 rows=1 width=16)
+   ->  Sequence  (cost=0.00..2712066833.06 rows=1 width=16)
+         ->  Shared Scan (share slice:id 8:0)  (cost=0.00..431.00 rows=34 width=1)
+               ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
+                     ->  Seq Scan on perct4  (cost=0.00..431.00 rows=34 width=42)
+         ->  Redistribute Motion 1:3  (slice7)  (cost=0.00..2712066402.06 rows=1 width=16)
+               ->  Nested Loop  (cost=0.00..2712066402.06 rows=1 width=16)
+                     Join Filter: true
+                     ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=8)
+                           ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
+                                 ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
+                                       Merge Key: share0_ref4.a
+                                       ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
+                                             Sort Key: share0_ref4.a
+                                             ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
+                                                   Join Filter: true
+                                                   ->  Broadcast Motion 1:3  (slice5)  (cost=0.00..431.00 rows=3 width=8)
+                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Shared Scan (share slice:id 4:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                   ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=34 width=4)
+                     ->  Materialize  (cost=0.00..1324036.42 rows=1 width=8)
+                           ->  Aggregate  (cost=0.00..1324036.42 rows=1 width=8)
+                                 ->  Limit  (cost=0.00..1324036.42 rows=34 width=16)
+                                       ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324036.41 rows=100 width=16)
+                                             Merge Key: share0_ref2.c
+                                             ->  Sort  (cost=0.00..1324036.41 rows=34 width=16)
+                                                   Sort Key: share0_ref2.c
+                                                   ->  Nested Loop  (cost=0.00..1324036.39 rows=34 width=16)
+                                                         Join Filter: true
+                                                         ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                 ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=8)
+                                                         ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(38 rows)
+
+select median(a), median(c) from perct4;
+ median | median 
+--------+--------
+   50.5 |       
+(1 row)
+
+explain select median(a), median(c) from perct4 group by b;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.02 rows=11 width=16)
+   ->  Result  (cost=0.00..431.02 rows=4 width=16)
+         ->  GroupAggregate  (cost=0.00..431.02 rows=4 width=16)
+               Group Key: b
+               ->  Sort  (cost=0.00..431.02 rows=34 width=16)
+                     Sort Key: b
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=16)
+                           Hash Key: b
+                           ->  Seq Scan on perct4  (cost=0.00..431.00 rows=34 width=16)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+select median(a), median(c) from perct4 group by b;
+ median | median 
+--------+--------
+      5 |       
+     14 |       
+     24 |       
+     34 |       
+     44 |       
+     54 |       
+     64 |       
+     74 |       
+     84 |       
+     94 |       
+    100 |       
+(11 rows)
+
+explain select count(*) over (partition by b), median(a) from perct group by b order by b;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..431.01 rows=4 width=16)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=11 width=16)
+         Merge Key: b
+         ->  WindowAgg  (cost=0.00..431.01 rows=4 width=20)
+               Partition By: b
+               ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12)
+                     Group Key: b
+                     ->  Sort  (cost=0.00..431.01 rows=34 width=8)
+                           Sort Key: b
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=8)
+                                 Hash Key: b
+                                 ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+
+select count(*) over (partition by b), median(a) from perct group by b order by b;
+ count | median 
+-------+--------
+     1 |      5
+     1 |   14.5
+     1 |   24.5
+     1 |   34.5
+     1 |   44.5
+     1 |   54.5
+     1 |   64.5
+     1 |   74.5
+     1 |   84.5
+     1 |   94.5
+     1 |    100
+(11 rows)
+
+explain select sum(median(a)) over (partition by b) from perct group by b order by b;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..431.01 rows=4 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=11 width=8)
+         Merge Key: b
+         ->  WindowAgg  (cost=0.00..431.01 rows=4 width=12)
+               Partition By: b
+               ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12)
+                     Group Key: b
+                     ->  Sort  (cost=0.00..431.01 rows=34 width=8)
+                           Sort Key: b
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=8)
+                                 Hash Key: b
+                                 ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+
+select sum(median(a)) over (partition by b) from perct group by b order by b;
+ sum  
+------
+    5
+ 14.5
+ 24.5
+ 34.5
+ 44.5
+ 54.5
+ 64.5
+ 74.5
+ 84.5
+ 94.5
+  100
+(11 rows)
+
+explain select percentile_disc(0) within group (order by a) from perct;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324465.93 rows=1 width=4)
+   ->  Sequence  (cost=0.00..1324465.93 rows=1 width=4)
+         ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=34 width=1)
+               ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
+                     ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=34)
+         ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324034.93 rows=1 width=4)
+               ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=4)
+                     ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
+                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
+                                 Merge Key: share0_ref2.a
+                                 ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
+                                       Sort Key: share0_ref2.a
+                                       ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
+                                             Join Filter: true
+                                             ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=4)
+                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(21 rows)
+
+select percentile_disc(0) within group (order by a) from perct;
+ percentile_disc 
+-----------------
+               1
+(1 row)
+
+prepare p (float) as select percentile_cont($1) within group (order by a)
+  from perct group by b order by b;
+execute p(0.1);
+ percentile_cont 
+-----------------
+             1.8
+            10.9
+            20.9
+            30.9
+            40.9
+            50.9
+            60.9
+            70.9
+            80.9
+            90.9
+             100
+(11 rows)
+
+execute p(0.8);
+ percentile_cont 
+-----------------
+             100
+             7.4
+            17.2
+            27.2
+            37.2
+            47.2
+            57.2
+            67.2
+            77.2
+            87.2
+            97.2
+(11 rows)
+
+deallocate p;
+explain select sum((select median(a) from perct)) from perct;
+                                                                                 QUERY PLAN                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..1357135807.06 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1357135807.06 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..1357135807.06 rows=1 width=8)
+               ->  Nested Loop Left Join  (cost=0.00..1357135807.06 rows=67 width=8)
+                     Join Filter: true
+                     ->  Seq Scan on perct perct_1  (cost=0.00..431.00 rows=34 width=1)
+                     ->  Materialize  (cost=0.00..1324465.93 rows=1 width=8)
+                           ->  Broadcast Motion 3:3  (slice5; segments: 3)  (cost=0.00..1324465.93 rows=1 width=8)
+                                 ->  Sequence  (cost=0.00..1324465.93 rows=1 width=8)
+                                       ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=34 width=1)
+                                             ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
+                                                   ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=34)
+                                       ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324034.93 rows=1 width=8)
+                                             ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=8)
+                                                   ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
+                                                         ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
+                                                               Merge Key: share0_ref2.a
+                                                               ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
+                                                                     Sort Key: share0_ref2.a
+                                                                     ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
+                                                                           Join Filter: true
+                                                                           ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                                                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                       ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                                             ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                                   ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                                           ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(28 rows)
+
+select sum((select median(a) from perct)) from perct;
+ sum  
+------
+ 5050
+(1 row)
+
+explain select percentile_cont(null) within group (order by a) from perct;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324465.93 rows=1 width=8)
+   ->  Sequence  (cost=0.00..1324465.93 rows=1 width=8)
+         ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=34 width=1)
+               ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
+                     ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=34)
+         ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324034.93 rows=1 width=8)
+               ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=8)
+                     ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
+                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
+                                 Merge Key: share0_ref2.a
+                                 ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
+                                       Sort Key: share0_ref2.a
+                                       ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
+                                             Join Filter: true
+                                             ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=4)
+                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(21 rows)
+
+select percentile_cont(null) within group (order by a) from perct;
+ percentile_cont 
+-----------------
+                
+(1 row)
+
+explain select percentile_cont(null) within group (order by a),
+       percentile_disc(null) within group (order by a desc) from perct group by b;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=11 width=12)
+   ->  Result  (cost=0.00..431.01 rows=4 width=12)
+         ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12)
+               Group Key: b
+               ->  Sort  (cost=0.00..431.01 rows=34 width=8)
+                     Sort Key: b
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=8)
+                           Hash Key: b
+                           ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+select percentile_cont(null) within group (order by a),
+       percentile_disc(null) within group (order by a desc) from perct group by b;
+ percentile_cont | percentile_disc 
+-----------------+-----------------
+                 |                
+                 |                
+                 |                
+                 |                
+                 |                
+                 |                
+                 |                
+                 |                
+                 |                
+                 |                
+                 |                
+(11 rows)
+
+explain select median(a), percentile_cont(0.5) within group (order by a),
+       percentile_disc(0.5) within group(order by a),
+       (select min(a) from percts) - interval '1day' + interval '1day' * median(c),
+       (select min(a) from percts) - interval '1day' + interval '1day' *
+         percentile_disc(0.5) within group (order by c)
+from percts group by b order by b;
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1356715266.56 rows=4 width=40)
+   ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1356715266.56 rows=11 width=40)
+         Merge Key: percts_2.b
+         ->  Result  (cost=0.00..1356715266.55 rows=4 width=44)
+               ->  Nested Loop Left Join  (cost=0.00..1356715266.55 rows=15 width=56)
+                     Join Filter: true
+                     ->  Nested Loop Left Join  (cost=0.00..1324055.25 rows=8 width=48)
+                           Join Filter: true
+                           ->  GroupAggregate  (cost=0.00..431.02 rows=4 width=40)
+                                 Group Key: percts_2.b
+                                 ->  Sort  (cost=0.00..431.02 rows=34 width=16)
+                                       Sort Key: percts_2.b
+                                       ->  Redistribute Motion 3:3  (slice5; segments: 3)  (cost=0.00..431.00 rows=34 width=16)
+                                             Hash Key: percts_2.b
+                                             ->  Seq Scan on percts percts_2  (cost=0.00..431.00 rows=34 width=16)
+                           ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Broadcast Motion 1:3  (slice4)  (cost=0.00..431.00 rows=3 width=8)
+                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Seq Scan on percts percts_1  (cost=0.00..431.00 rows=34 width=8)
+                     ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Seq Scan on percts  (cost=0.00..431.00 rows=34 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(28 rows)
+
+select median(a), percentile_cont(0.5) within group (order by a),
+       percentile_disc(0.5) within group(order by a),
+       (select min(a) from percts) - interval '1day' + interval '1day' * median(c),
+       (select min(a) from percts) - interval '1day' + interval '1day' *
+         percentile_disc(0.5) within group (order by c)
+from percts group by b order by b;
+          median          |     percentile_cont      |     percentile_disc      |         ?column?         |         ?column?         
+--------------------------+--------------------------+--------------------------+--------------------------+--------------------------
+ Fri Jan 06 00:00:00 2012 | Fri Jan 06 00:00:00 2012 | Fri Jan 06 00:00:00 2012 | Fri Jan 06 00:00:00 2012 | Fri Jan 06 00:00:00 2012
+ Sun Jan 15 12:00:00 2012 | Sun Jan 15 12:00:00 2012 | Sun Jan 15 00:00:00 2012 | Sun Jan 15 12:00:00 2012 | Sun Jan 15 00:00:00 2012
+ Wed Jan 25 12:00:00 2012 | Wed Jan 25 12:00:00 2012 | Wed Jan 25 00:00:00 2012 | Wed Jan 25 12:00:00 2012 | Wed Jan 25 00:00:00 2012
+ Sat Feb 04 12:00:00 2012 | Sat Feb 04 12:00:00 2012 | Sat Feb 04 00:00:00 2012 | Sat Feb 04 12:00:00 2012 | Sat Feb 04 00:00:00 2012
+ Tue Feb 14 12:00:00 2012 | Tue Feb 14 12:00:00 2012 | Tue Feb 14 00:00:00 2012 | Tue Feb 14 12:00:00 2012 | Tue Feb 14 00:00:00 2012
+ Fri Feb 24 12:00:00 2012 | Fri Feb 24 12:00:00 2012 | Fri Feb 24 00:00:00 2012 | Fri Feb 24 12:00:00 2012 | Fri Feb 24 00:00:00 2012
+ Mon Mar 05 12:00:00 2012 | Mon Mar 05 12:00:00 2012 | Mon Mar 05 00:00:00 2012 | Mon Mar 05 12:00:00 2012 | Mon Mar 05 00:00:00 2012
+ Thu Mar 15 12:00:00 2012 | Thu Mar 15 12:00:00 2012 | Thu Mar 15 00:00:00 2012 | Thu Mar 15 12:00:00 2012 | Thu Mar 15 00:00:00 2012
+ Sun Mar 25 12:00:00 2012 | Sun Mar 25 12:00:00 2012 | Sun Mar 25 00:00:00 2012 | Sun Mar 25 12:00:00 2012 | Sun Mar 25 00:00:00 2012
+ Wed Apr 04 12:00:00 2012 | Wed Apr 04 12:00:00 2012 | Wed Apr 04 00:00:00 2012 | Wed Apr 04 12:00:00 2012 | Wed Apr 04 00:00:00 2012
+ Tue Apr 10 00:00:00 2012 | Tue Apr 10 00:00:00 2012 | Tue Apr 10 00:00:00 2012 | Tue Apr 10 00:00:00 2012 | Tue Apr 10 00:00:00 2012
+(11 rows)
+
+explain select percentile_cont(1.0/86400) within group (order by a) from percts
+	where c between 1 and 2;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Sequence  (cost=0.00..1324463.26 rows=1 width=8)
+   ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=1)
+         ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=42)
+                     ->  Seq Scan on percts  (cost=0.00..431.00 rows=1 width=42)
+                           Filter: ((c >= 1) AND (c <= 2))
+   ->  Aggregate  (cost=0.00..1324032.25 rows=1 width=8)
+         ->  Limit  (cost=0.00..1324032.25 rows=1 width=16)
+               ->  Sort  (cost=0.00..1324032.25 rows=1 width=16)
+                     Sort Key: share0_ref3.a
+                     ->  Nested Loop  (cost=0.00..1324032.25 rows=1 width=16)
+                           Join Filter: true
+                           ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(17 rows)
+
+select percentile_cont(1.0/86400) within group (order by a) from percts
+	where c between 1 and 2;
+     percentile_cont      
+--------------------------
+ Mon Jan 02 00:00:01 2012
+(1 row)
+
+explain select percentile_cont(0.1) within group (order by a),
+       percentile_cont(0.9) within group (order by a desc) from percts;
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice8; segments: 3)  (cost=0.00..2712068354.83 rows=1 width=16)
+   ->  Sequence  (cost=0.00..2712068354.83 rows=1 width=16)
+         ->  Shared Scan (share slice:id 8:0)  (cost=0.00..431.00 rows=34 width=1)
+               ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
+                     ->  Seq Scan on percts  (cost=0.00..431.00 rows=34 width=38)
+         ->  Redistribute Motion 1:3  (slice7)  (cost=0.00..2712067923.83 rows=1 width=16)
+               ->  Nested Loop  (cost=0.00..2712067923.83 rows=1 width=16)
+                     Join Filter: true
+                     ->  Aggregate  (cost=0.00..1324036.42 rows=1 width=8)
+                           ->  Limit  (cost=0.00..1324036.42 rows=34 width=16)
+                                 ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1324036.41 rows=100 width=16)
+                                       Merge Key: share0_ref4.a
+                                       ->  Sort  (cost=0.00..1324036.41 rows=34 width=16)
+                                             Sort Key: share0_ref4.a
+                                             ->  Nested Loop  (cost=0.00..1324036.39 rows=34 width=16)
+                                                   Join Filter: true
+                                                   ->  Broadcast Motion 1:3  (slice5)  (cost=0.00..431.00 rows=3 width=8)
+                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Shared Scan (share slice:id 4:0)  (cost=0.00..431.00 rows=34 width=8)
+                                                   ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=34 width=8)
+                     ->  Materialize  (cost=0.00..1324036.42 rows=1 width=8)
+                           ->  Aggregate  (cost=0.00..1324036.42 rows=1 width=8)
+                                 ->  Limit  (cost=0.00..1324036.42 rows=34 width=16)
+                                       ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324036.41 rows=100 width=16)
+                                             Merge Key: share0_ref2.a
+                                             ->  Sort  (cost=0.00..1324036.41 rows=34 width=16)
+                                                   Sort Key: share0_ref2.a
+                                                   ->  Nested Loop  (cost=0.00..1324036.39 rows=34 width=16)
+                                                         Join Filter: true
+                                                         ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                 ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=8)
+                                                         ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(38 rows)
+
+select percentile_cont(0.1) within group (order by a),
+       percentile_cont(0.9) within group (order by a desc) from percts;
+     percentile_cont      |     percentile_cont      
+--------------------------+--------------------------
+ Wed Jan 11 21:36:00 2012 | Wed Jan 11 21:36:00 2012
+(1 row)
+
+explain select percentile_cont(0.1) within group (order by a),
+       percentile_cont(0.2) within group (order by a) from perctsz;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324467.42 rows=1 width=16)
+   ->  Sequence  (cost=0.00..1324467.42 rows=1 width=16)
+         ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=34 width=1)
+               ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
+                     ->  Seq Scan on perctsz  (cost=0.00..431.00 rows=34 width=38)
+         ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324036.42 rows=1 width=16)
+               ->  Aggregate  (cost=0.00..1324036.42 rows=1 width=16)
+                     ->  Limit  (cost=0.00..1324036.42 rows=34 width=16)
+                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324036.41 rows=100 width=16)
+                                 Merge Key: share0_ref2.a
+                                 ->  Sort  (cost=0.00..1324036.41 rows=34 width=16)
+                                       Sort Key: share0_ref2.a
+                                       ->  Nested Loop  (cost=0.00..1324036.39 rows=34 width=16)
+                                             Join Filter: true
+                                             ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=8)
+                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(21 rows)
+
+select percentile_cont(0.1) within group (order by a),
+       percentile_cont(0.2) within group (order by a) from perctsz;
+       percentile_cont        |       percentile_cont        
+------------------------------+------------------------------
+ Wed Jan 11 13:36:00 2012 PST | Sat Jan 21 11:12:00 2012 PST
+(1 row)
+
+explain select median(a - (select min(a) from percts)) from percts;
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..1324040.42 rows=1 width=16)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324040.42 rows=200 width=16)
+         ->  Nested Loop Left Join  (cost=0.00..1324040.41 rows=67 width=16)
+               Join Filter: true
+               ->  Seq Scan on percts percts_1  (cost=0.00..431.00 rows=34 width=8)
+               ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Seq Scan on percts  (cost=0.00..431.00 rows=34 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
+select median(a - (select min(a) from percts)) from percts;
+       median       
+--------------------
+ @ 49 days 12 hours
+(1 row)
+
+explain select median(a), b from perct group by b order by b desc;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=11 width=12)
+   Merge Key: b
+   ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12)
+         Group Key: b
+         ->  Sort  (cost=0.00..431.01 rows=34 width=8)
+               Sort Key: b
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=8)
+                     Hash Key: b
+                     ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+select median(a), b from perct group by b order by b desc;
+ median | b  
+--------+----
+    100 | 10
+   94.5 |  9
+   84.5 |  8
+   74.5 |  7
+   64.5 |  6
+   54.5 |  5
+   44.5 |  4
+   34.5 |  3
+   24.5 |  2
+   14.5 |  1
+      5 |  0
+(11 rows)
+
+explain select count(*) from(select median(a) from perct group by ())s;
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..1324465.93 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324465.93 rows=1 width=1)
+         ->  Sequence  (cost=0.00..1324465.93 rows=1 width=1)
+               ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=34 width=1)
+                     ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
+                           ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=34)
+               ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324034.93 rows=1 width=1)
+                     ->  Result  (cost=0.00..1324034.93 rows=1 width=1)
+                           ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=1)
+                                 ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
+                                       ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
+                                             Merge Key: share0_ref2.a
+                                             ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
+                                                   Sort Key: share0_ref2.a
+                                                   ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
+                                                         Join Filter: true
+                                                         ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                 ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                         ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(23 rows)
+
+select count(*) from(select median(a) from perct group by ())s;
+ count 
+-------
+     1
+(1 row)
+
+explain select median(a) from perct group by grouping sets((b)) order by b;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..431.01 rows=4 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=11 width=8)
+         Merge Key: b
+         ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12)
+               Group Key: b
+               ->  Sort  (cost=0.00..431.01 rows=34 width=8)
+                     Sort Key: b
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=8)
+                           Hash Key: b
+                           ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+select median(a) from perct group by grouping sets((b)) order by b;
+ median 
+--------
+      5
+   14.5
+   24.5
+   34.5
+   44.5
+   54.5
+   64.5
+   74.5
+   84.5
+   94.5
+    100
+(11 rows)
+
+explain select distinct median(a), count(*) from perct;
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1356694888.00 rows=1 width=16)
+   ->  Sequence  (cost=0.00..1356694888.00 rows=1 width=16)
+         ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=34 width=1)
+               ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
+                     ->  Seq Scan on perct perct_1  (cost=0.00..431.00 rows=34 width=34)
+         ->  Redistribute Motion 1:3  (slice5)  (cost=0.00..1356694457.00 rows=1 width=16)
+               ->  Nested Loop  (cost=0.00..1356694457.00 rows=1 width=16)
+                     Join Filter: true
+                     ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=8)
+                           ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
+                                 ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
+                                       Merge Key: share0_ref2.a
+                                       ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
+                                             Sort Key: share0_ref2.a
+                                             ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
+                                                   Join Filter: true
+                                                   ->  Broadcast Motion 1:3  (slice3)  (cost=0.00..431.00 rows=3 width=8)
+                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                   ->  Shared Scan (share slice:id 4:0)  (cost=0.00..431.00 rows=34 width=4)
+                     ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(28 rows)
+
+select distinct median(a), count(*) from perct;
+ median | count 
+--------+-------
+   50.5 |   100
+(1 row)
+
+explain select perct.a, 0.2*avg(perct2.a) as avga,
+	percentile_cont(0.34)within group(order by perct2.b)
+	from
+		(select a, a / 10 b from generate_series(1, 100)a)perct,
+		(select a, a / 10 b from generate_series(1, 100)a)perct2
+	where perct.a=perct2.a group by perct.a having median(perct.b) > 10;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1.52 rows=134 width=20)
+   ->  Result  (cost=0.00..1.51 rows=134 width=20)
+         Filter: ((MEDIAN(((generate_series.generate_series / 10)))) > 10::double precision)
+         ->  GroupAggregate  (cost=0.00..1.48 rows=334 width=28)
+               Group Key: generate_series.generate_series
+               ->  Sort  (cost=0.00..1.44 rows=334 width=16)
+                     Sort Key: generate_series.generate_series
+                     ->  Hash Join  (cost=0.00..0.54 rows=334 width=16)
+                           Hash Cond: (generate_series.generate_series = generate_series_1.generate_series)
+                           ->  Result  (cost=0.00..0.01 rows=334 width=8)
+                                 ->  Function Scan on generate_series  (cost=0.00..0.00 rows=334 width=4)
+                           ->  Hash  (cost=0.01..0.01 rows=334 width=8)
+                                 ->  Result  (cost=0.00..0.01 rows=334 width=8)
+                                       ->  Function Scan on generate_series generate_series_1  (cost=0.00..0.00 rows=334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(15 rows)
+
+select perct.a, 0.2*avg(perct2.a) as avga,
+	percentile_cont(0.34)within group(order by perct2.b)
+	from
+		(select a, a / 10 b from generate_series(1, 100)a)perct,
+		(select a, a / 10 b from generate_series(1, 100)a)perct2
+	where perct.a=perct2.a group by perct.a having median(perct.b) > 10;
+ a | avga | percentile_cont 
+---+------+-----------------
+(0 rows)
+
+explain select median(a - '2011-12-31 00:00:00 UTC'::timestamptz) from perctsz group by b order by median;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.02 rows=11 width=16)
+   Merge Key: (MEDIAN((a - 'Fri Dec 30 16:00:00 2011 PST'::timestamp with time zone)))
+   ->  Result  (cost=0.00..431.02 rows=4 width=16)
+         ->  Sort  (cost=0.00..431.02 rows=4 width=16)
+               Sort Key: (MEDIAN((a - 'Fri Dec 30 16:00:00 2011 PST'::timestamp with time zone)))
+               ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=16)
+                     Group Key: b
+                     ->  Sort  (cost=0.00..431.01 rows=34 width=12)
+                           Sort Key: b
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=12)
+                                 Hash Key: b
+                                 ->  Seq Scan on perctsz  (cost=0.00..431.00 rows=34 width=12)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+
+select median(a - '2011-12-31 00:00:00 UTC'::timestamptz) from perctsz group by b order by median;
+       median        
+---------------------
+ @ 6 days
+ @ 15 days 12 hours
+ @ 25 days 12 hours
+ @ 35 days 12 hours
+ @ 45 days 12 hours
+ @ 55 days 12 hours
+ @ 65 days 12 hours
+ @ 74 days 35 hours
+ @ 84 days 35 hours
+ @ 94 days 35 hours
+ @ 100 days 23 hours
+(11 rows)
+
+--numeric types
+explain select percentile_cont(0.95) within group( order by c) from perctnum;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324467.05 rows=1 width=8)
+   ->  Sequence  (cost=0.00..1324467.05 rows=1 width=8)
+         ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=34 width=1)
+               ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
+                     ->  Seq Scan on perctnum  (cost=0.00..431.00 rows=34 width=37)
+         ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324036.04 rows=1 width=8)
+               ->  Aggregate  (cost=0.00..1324036.04 rows=1 width=8)
+                     ->  Limit  (cost=0.00..1324036.04 rows=34 width=15)
+                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324036.04 rows=100 width=15)
+                                 Merge Key: share0_ref2.c
+                                 ->  Sort  (cost=0.00..1324036.04 rows=34 width=15)
+                                       Sort Key: share0_ref2.c
+                                       ->  Nested Loop  (cost=0.00..1324036.02 rows=34 width=15)
+                                             Join Filter: true
+                                             ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=7)
+                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=7)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(21 rows)
+
+select percentile_cont(0.95) within group( order by c) from perctnum;
+ percentile_cont 
+-----------------
+      190.090495
+(1 row)
+
+-- view
+select * from percv;
+ percentile_cont | median | percentile_disc 
+-----------------+--------+-----------------
+               0 |      5 |               5
+               1 |   14.5 |              14
+               2 |   24.5 |              24
+               3 |   34.5 |              34
+               4 |   44.5 |              44
+               5 |   54.5 |              54
+               6 |   64.5 |              64
+               7 |   74.5 |              74
+               8 |   84.5 |              84
+               9 |   94.5 |              94
+              10 |    100 |             100
+(11 rows)
+
+select pg_get_viewdef('percv');
+                                                         pg_get_viewdef                                                          
+---------------------------------------------------------------------------------------------------------------------------------
+  SELECT percentile_cont((0.4)::double precision) WITHIN GROUP (ORDER BY ((perct.a / 10))::double precision) AS percentile_cont,+
+     MEDIAN(perct.a) AS "median",                                                                                               +
+     percentile_disc((0.51)::double precision) WITHIN GROUP (ORDER BY perct.a DESC) AS percentile_disc                          +
+    FROM perct                                                                                                                  +
+   GROUP BY perct.b                                                                                                             +
+   ORDER BY perct.b;
+(1 row)
+
+select pg_get_viewdef('percv2');
+                pg_get_viewdef                 
+-----------------------------------------------
+  SELECT MEDIAN(perct.a) AS m1,               +
+     MEDIAN((perct.a)::double precision) AS m2+
+    FROM perct;
+(1 row)
+
+-- errors
+-- no WITHIN GROUP clause
+select percentile_cont(a) from perct;
+ERROR:  function percentile_cont(integer) does not exist
+LINE 1: select percentile_cont(a) from perct;
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+-- the argument must not contain variable
+select percentile_cont(a) within group (order by a) from perct;
+ERROR:  column "perct.a" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: select percentile_cont(a) within group (order by a) from per...
+                               ^
+DETAIL:  Direct arguments of an ordered-set aggregate must use only grouped columns.
+-- ungrouped column
+select b, percentile_disc(0.1) within group (order by a) from perct;
+ERROR:  column "perct.b" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: select b, percentile_disc(0.1) within group (order by a) fro...
+               ^
+-- nested aggregate
+select percentile_cont(count(*)) within group (order by a) from perct;
+ERROR:  aggregate function calls cannot be nested
+LINE 1: select percentile_cont(count(*)) within group (order by a) f...
+                               ^
+select sum(percentile_cont(0.22) within group (order by a)) from perct;
+ERROR:  aggregate function calls cannot be nested
+LINE 1: select sum(percentile_cont(0.22) within group (order by a)) ...
+                   ^
+-- OVER clause
+select percentile_cont(0.3333) within group (order by a) over (partition by a%2) from perct;
+ERROR:  OVER is not supported for ordered-set aggregate percentile_cont
+LINE 1: select percentile_cont(0.3333) within group (order by a) ove...
+               ^
+select median(a) over (partition by b) from perct group by b;
+ERROR:  syntax error at or near "over"
+LINE 1: select median(a) over (partition by b) from perct group by b...
+                         ^
+-- function scan
+select * from median(10);
+ERROR:  aggregate functions are not allowed in functions in FROM
+LINE 1: select * from median(10);
+                      ^
+-- wrong type argument
+select percentile_disc('a') within group (order by a) from perct;
+ERROR:  invalid input syntax for type double precision: "a"
+LINE 1: select percentile_disc('a') within group (order by a) from p...
+                               ^
+-- nested case
+select count(median(a)) from perct;
+ERROR:  aggregate function calls cannot be nested
+LINE 1: select count(median(a)) from perct;
+                     ^
+select median(count(*)) from perct;
+ERROR:  aggregate function calls cannot be nested
+LINE 1: select median(count(*)) from perct;
+                      ^
+select percentile_cont(0.2) within group (order by count(*) over()) from perct;
+ERROR:  aggregate function calls cannot contain window function calls
+LINE 1: ...elect percentile_cont(0.2) within group (order by count(*) o...
+                                                             ^
+select percentile_disc(0.1) within group (order by group_id()) from perct;
+ERROR:  aggregate function calls cannot be nested
+-- subquery in argument
+select percentile_cont((select 0.1 from gp_id)) within group (order by a) from perct;
+ percentile_cont 
+-----------------
+            10.9
+(1 row)
+
+-- volatile argument
+explain select percentile_cont(floor(random()*0.1)+0.5) within group (order by a) from perct;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324465.93 rows=1 width=8)
+   ->  Sequence  (cost=0.00..1324465.93 rows=1 width=8)
+         ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=34 width=1)
+               ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
+                     ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=34)
+         ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324034.93 rows=1 width=8)
+               ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=8)
+                     ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
+                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
+                                 Merge Key: share0_ref2.a
+                                 ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
+                                       Sort Key: share0_ref2.a
+                                       ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
+                                             Join Filter: true
+                                             ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=4)
+                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(21 rows)
+
+select percentile_cont(floor(random()*0.1)+0.5) within group (order by a) from perct;
+ percentile_cont 
+-----------------
+            50.5
+(1 row)
+
+-- out of range
+explain select percentile_cont(-0.1) within group (order by a) from perct;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324465.93 rows=1 width=8)
+   ->  Sequence  (cost=0.00..1324465.93 rows=1 width=8)
+         ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=34 width=1)
+               ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
+                     ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=34)
+         ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324034.93 rows=1 width=8)
+               ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=8)
+                     ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
+                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
+                                 Merge Key: share0_ref2.a
+                                 ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
+                                       Sort Key: share0_ref2.a
+                                       ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
+                                             Join Filter: true
+                                             ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=4)
+                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(21 rows)
+
+select percentile_cont(-0.1) within group (order by a) from perct;
+ERROR:  percentile value -0.1 is not between 0 and 1
+explain select percentile_cont(1.00000001) within group (order by a) from perct;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324465.93 rows=1 width=8)
+   ->  Sequence  (cost=0.00..1324465.93 rows=1 width=8)
+         ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=34 width=1)
+               ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
+                     ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=34)
+         ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324034.93 rows=1 width=8)
+               ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=8)
+                     ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
+                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
+                                 Merge Key: share0_ref2.a
+                                 ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
+                                       Sort Key: share0_ref2.a
+                                       ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
+                                             Join Filter: true
+                                             ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=4)
+                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(21 rows)
+
+select percentile_cont(1.00000001) within group (order by a) from perct;
+ERROR:  percentile value 1 is not between 0 and 1
+-- correlated subquery
+explain select sum((select median(a) from perct where b = t.b)) from perct t;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=476.14..476.15 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=471.41..471.46 rows=1 width=8)
+         ->  Aggregate  (cost=471.41..471.42 rows=1 width=8)
+               ->  Seq Scan on perct t  (cost=0.00..4.00 rows=34 width=4)
+               SubPlan 1  (slice2; segments: 3)
+                 ->  Aggregate  (cost=4.66..4.67 rows=1 width=8)
+                       ->  Result  (cost=0.00..4.30 rows=4 width=4)
+                             Filter: (perct.b = t.b)
+                             ->  Materialize  (cost=0.00..4.30 rows=4 width=4)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..4.25 rows=4 width=4)
+                                         ->  Seq Scan on perct  (cost=0.00..4.25 rows=4 width=4)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+select sum((select median(a) from perct where b = t.b)) from perct t;
+ sum  
+------
+ 5050
+(1 row)
+
+-- used in LIMIT
+select * from perct limit median(a);
+ERROR:  aggregate functions are not allowed in LIMIT
+LINE 1: select * from perct limit median(a);
+                                  ^
+-- multiple sort key
+select percentile_cont(0.8) within group (order by a, a + 1, a + 2) from perct;
+ERROR:  function percentile_cont(numeric, integer, integer, integer) does not exist
+LINE 1: select percentile_cont(0.8) within group (order by a, a + 1,...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+-- set-returning
+explain select generate_series(1, 2), median(a) from perct;
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324465.93 rows=1 width=12)
+   ->  Result  (cost=0.00..1324465.93 rows=1 width=12)
+         ->  Sequence  (cost=0.00..1324465.93 rows=1 width=8)
+               ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=34 width=1)
+                     ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
+                           ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=34)
+               ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324034.93 rows=1 width=8)
+                     ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=8)
+                           ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
+                                 ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
+                                       Merge Key: share0_ref2.a
+                                       ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
+                                             Sort Key: share0_ref2.a
+                                             ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
+                                                   Join Filter: true
+                                                   ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                   ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(22 rows)
+
+select generate_series(1, 2), median(a) from perct;
+ generate_series | median 
+-----------------+--------
+               1 |   50.5
+               2 |   50.5
+(2 rows)
+
+-- GROUPING SETS
+explain select median(a) from perct group by grouping sets((), (b));
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1325327.94 rows=12 width=8)
+   ->  Sequence  (cost=0.00..1325327.94 rows=4 width=8)
+         ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=34 width=1)
+               ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
+                     ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=8)
+         ->  Append  (cost=0.00..1324896.94 rows=4 width=8)
+               ->  Result  (cost=0.00..431.01 rows=4 width=8)
+                     ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=8)
+                           Group Key: share0_ref2.b
+                           ->  Sort  (cost=0.00..431.01 rows=34 width=8)
+                                 Sort Key: share0_ref2.b
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=8)
+                                       Hash Key: share0_ref2.b
+                                       ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=8)
+               ->  Result  (cost=0.00..1324465.93 rows=1 width=8)
+                     ->  Sequence  (cost=0.00..1324465.93 rows=1 width=8)
+                           ->  Shared Scan (share slice:id 6:1)  (cost=0.00..431.00 rows=34 width=1)
+                                 ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
+                                       ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=34 width=8)
+                           ->  Redistribute Motion 1:3  (slice5)  (cost=0.00..1324034.93 rows=1 width=8)
+                                 ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=8)
+                                       ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
+                                             ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
+                                                   Merge Key: share1_ref2.a
+                                                   ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
+                                                         Sort Key: share1_ref2.a
+                                                         ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
+                                                               Join Filter: true
+                                                               ->  Broadcast Motion 1:3  (slice3)  (cost=0.00..431.00 rows=3 width=8)
+                                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                       ->  Shared Scan (share slice:id 2:1)  (cost=0.00..431.00 rows=34 width=4)
+                                                               ->  Shared Scan (share slice:id 4:1)  (cost=0.00..431.00 rows=34 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(35 rows)
+
+select median(a) from perct group by grouping sets((), (b));
+ median 
+--------
+      5
+    100
+   14.5
+   24.5
+   34.5
+   44.5
+   50.5
+   54.5
+   64.5
+   74.5
+   84.5
+   94.5
+(12 rows)
+
+-- wrong type in ORDER BY
+select median('text') from perct;
+ERROR:  invalid input syntax for type double precision: "text"
+LINE 1: select median('text') from perct;
+                      ^
+select percentile_cont(now()) within group (order by a) from percts;
+ERROR:  function percentile_cont(timestamp with time zone, timestamp without time zone) does not exist
+LINE 1: select percentile_cont(now()) within group (order by a) from...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+select percentile_cont(0.5) within group (order by point(0,0)) from perct;
+ERROR:  function percentile_cont(numeric, point) does not exist
+LINE 1: select percentile_cont(0.5) within group (order by point(0,0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+-- outer references
+explain select (select a from perct where median(t.a) = 5) from perct t;
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1357135822.46 rows=1 width=4)
+   ->  Result  (cost=0.00..1357135822.46 rows=1 width=4)
+         ->  Sequence  (cost=0.00..1324465.93 rows=1 width=8)
+               ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=34 width=1)
+                     ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
+                           ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=34)
+               ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324034.93 rows=1 width=8)
+                     ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=8)
+                           ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
+                                 ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
+                                       Merge Key: share0_ref2.a
+                                       ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
+                                             Sort Key: share0_ref2.a
+                                             ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
+                                                   Join Filter: true
+                                                   ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                   ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=4)
+         SubPlan 1  (slice6; segments: 3)
+           ->  Result  (cost=0.00..431.01 rows=40 width=4)
+                 One-Time Filter: ((gp_percentile_cont((share0_ref2.a)::double precision, 0.5::double precision, (count((count(share0_ref3.a)))), 1::bigint)) = 5::double precision)
+                 ->  Materialize  (cost=0.00..431.01 rows=100 width=4)
+                       ->  Broadcast Motion 3:3  (slice5; segments: 3)  (cost=0.00..431.01 rows=100 width=4)
+                             ->  Seq Scan on perct perct_1  (cost=0.00..431.00 rows=34 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(28 rows)
+
+select (select a from perct where median(t.a) = 5) from perct t;
+ a 
+---
+  
+(1 row)
+
+explain select (select array_agg(a ORDER BY a) from perct where median(t.a) = 50.5) from (select * from perct t order by a offset 0) as t;
+                                                                                          QUERY PLAN                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1357135829.77 rows=1 width=8)
+   ->  Result  (cost=0.00..1357135829.77 rows=1 width=8)
+         ->  Sequence  (cost=0.00..1324465.93 rows=1 width=8)
+               ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=34 width=1)
+                     ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
+                           ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=34)
+               ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324034.93 rows=1 width=8)
+                     ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=8)
+                           ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
+                                 ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
+                                       Merge Key: share0_ref2.a
+                                       ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
+                                             Sort Key: share0_ref2.a
+                                             ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
+                                                   Join Filter: true
+                                                   ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                   ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=4)
+         SubPlan 1  (slice6; segments: 3)
+           ->  Aggregate  (cost=0.00..431.01 rows=1 width=8)
+                 ->  Result  (cost=0.00..431.01 rows=40 width=4)
+                       One-Time Filter: ((gp_percentile_cont((share0_ref2.a)::double precision, 0.5::double precision, (count((count(share0_ref3.a)))), 1::bigint)) = 50.5::double precision)
+                       ->  Materialize  (cost=0.00..431.01 rows=100 width=4)
+                             ->  Broadcast Motion 3:3  (slice5; segments: 3)  (cost=0.00..431.01 rows=100 width=4)
+                                   ->  Seq Scan on perct perct_1  (cost=0.00..431.00 rows=34 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(29 rows)
+
+select (select array_agg(a ORDER BY a) from perct where median(t.a) = 50.5) from (select * from perct t order by a offset 0) as t;
+                                                                                                                                               array_agg                                                                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100}
+(1 row)
+
+-- MPP-22219
+select count(*) from
+(SELECT b.dkey_a, MEDIAN(B.VALUE)
+FROM     mpp_22219 B
+GROUP BY b.dkey_a) s;
+ count 
+-------
+    20
+(1 row)
+
+select count(*) from
+(SELECT b.dkey_a, percentile_cont(0.5) within  group (order by b.VALUE)
+FROM     mpp_22219 B
+GROUP BY b.dkey_a) s;
+ count 
+-------
+    20
+(1 row)
+
+-- MPP-21026
+select median(t2) from mpp_21026 group by t1;
+ median 
+--------
+      1
+      2
+      3
+      4
+      5
+      6
+      7
+      8
+      9
+     10
+     11
+     12
+     13
+     14
+     15
+     16
+     17
+     18
+     19
+     20
+(20 rows)
+
+-- MPP-20076
+select 1, to_char(col1, 'YYYY'), median(col2) from mpp_20076 group by 1, 2;
+ ?column? | to_char | median 
+----------+---------+--------
+        1 | 1969    |   10.5
+(1 row)
+
+select 1, col1, median(col2) from mpp_20076 group by 1, 2;
+ ?column? |           col1           | median 
+----------+--------------------------+--------
+        1 | Wed Dec 31 16:00:01 1969 |      1
+        1 | Wed Dec 31 16:00:02 1969 |      2
+        1 | Wed Dec 31 16:00:03 1969 |      3
+        1 | Wed Dec 31 16:00:04 1969 |      4
+        1 | Wed Dec 31 16:00:05 1969 |      5
+        1 | Wed Dec 31 16:00:06 1969 |      6
+        1 | Wed Dec 31 16:00:07 1969 |      7
+        1 | Wed Dec 31 16:00:08 1969 |      8
+        1 | Wed Dec 31 16:00:09 1969 |      9
+        1 | Wed Dec 31 16:00:10 1969 |     10
+        1 | Wed Dec 31 16:00:11 1969 |     11
+        1 | Wed Dec 31 16:00:12 1969 |     12
+        1 | Wed Dec 31 16:00:13 1969 |     13
+        1 | Wed Dec 31 16:00:14 1969 |     14
+        1 | Wed Dec 31 16:00:15 1969 |     15
+        1 | Wed Dec 31 16:00:16 1969 |     16
+        1 | Wed Dec 31 16:00:17 1969 |     17
+        1 | Wed Dec 31 16:00:18 1969 |     18
+        1 | Wed Dec 31 16:00:19 1969 |     19
+        1 | Wed Dec 31 16:00:20 1969 |     20
+(20 rows)
+
+select to_char(col1, 'YYYY') AS tstmp_column, median(col2) from mpp_20076 group by 1;
+ tstmp_column | median 
+--------------+--------
+ 1969         |   10.5
+(1 row)
+
+select 1, median(col2) from mpp_20076 group by 1;
+ ?column? | median 
+----------+--------
+        1 |   10.5
+(1 row)
+
+-- MPP-22413
+select median(value1), count(*)
+from  mpp_22413
+where d2 ='55'
+group by d1, d2, d3, value2;
+ median | count 
+--------+-------
+     55 |     1
+(1 row)
+
+select median(value1), count(*)
+from  mpp_22413
+where d2 ='55'
+group by d1, d2, d3, value2::int;
+ median | count 
+--------+-------
+     55 |     1
+(1 row)
+
+select median(value1), count(*)
+from  mpp_22413
+where d2 ='55'
+group by d1, d2, d3, value2::varchar;
+ median | count 
+--------+-------
+     55 |     1
+(1 row)
+
+select median(value1), count(*)
+from  mpp_22413
+where d2 ='55'
+group by d1, d2, value2;
+ median | count 
+--------+-------
+     55 |     1
+(1 row)
+
+select median(value1), count(*)
+from  mpp_22413
+where d2 ='55'
+group by d1, d2, value2, d3;
+ median | count 
+--------+-------
+     55 |     1
+(1 row)
+
+select median(value1), count(*)
+from  mpp_22413
+where d2 ='55'
+group by d1, d2;
+ median | count 
+--------+-------
+     55 |     1
+(1 row)
+
+drop view percv2;
+drop view percv;
+drop table perct;
+drop table perct2;
+drop table perct3;
+drop table perct4;
+drop table percts;
+drop table perctsz;
+drop table mpp_22219;
+drop table mpp_21026;
+drop table mpp_20076;
+drop table mpp_22413;

--- a/gpcontrib/gp_percentile_agg/gp_percentile_agg--1.0.0.sql
+++ b/gpcontrib/gp_percentile_agg/gp_percentile_agg--1.0.0.sql
@@ -1,0 +1,80 @@
+---------------------------------------------------------------------------
+--
+-- gp_percentile_agg.sql-
+--    This file creates gp_percentila_cont() and gp_percentile_disc() for
+--    percentile calculation but assumes data is passed in sorted.
+--
+--
+-- Copyright (c) 2022-Present VMware, Inc. or its affiliates.
+--
+--
+---------------------------------------------------------------------------
+
+-- Look at gp_percentile_agg.c for the source.  Note we mark them IMMUTABLE,
+-- since they always return the same outputs given the same inputs.
+
+CREATE FUNCTION gp_percentile_cont_float8_transition(float8, float8, float8, int8, int8)
+    RETURNS float8
+AS '$libdir/gp_percentile_agg'
+   LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION gp_percentile_cont_interval_transition(interval, interval, float8, int8, int8)
+    RETURNS interval
+AS '$libdir/gp_percentile_agg'
+   LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION gp_percentile_cont_timestamp_transition(timestamp, timestamp, float8, int8, int8)
+    RETURNS timestamp
+AS '$libdir/gp_percentile_agg'
+   LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION gp_percentile_cont_timestamptz_transition(timestamptz, timestamptz, float8, int8, int8)
+    RETURNS timestamptz
+AS '$libdir/gp_percentile_agg'
+   LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION gp_percentile_disc_transition(anyelement, anyelement, float8, int8, int8)
+    RETURNS anyelement
+AS '$libdir/gp_percentile_agg'
+   LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION gp_percentile_final(anyelement)
+    RETURNS anyelement
+AS '$libdir/gp_percentile_agg'
+   LANGUAGE C IMMUTABLE STRICT;
+
+-- Creating aggregate functions
+CREATE AGGREGATE gp_percentile_cont(float8, float8, int8, int8)
+(
+     SFUNC = gp_percentile_cont_float8_transition,
+     STYPE = float8,
+     FINALFUNC = gp_percentile_final
+);
+
+CREATE AGGREGATE gp_percentile_cont(interval, float8, int8, int8)
+(
+     SFUNC = gp_percentile_cont_interval_transition,
+     STYPE = interval,
+     FINALFUNC = gp_percentile_final
+);
+
+CREATE AGGREGATE gp_percentile_cont(timestamp, float8, int8, int8)
+(
+     SFUNC = gp_percentile_cont_timestamp_transition,
+     STYPE = timestamp,
+     FINALFUNC = gp_percentile_final
+);
+
+CREATE AGGREGATE gp_percentile_cont(timestamptz, float8, int8, int8)
+(
+     SFUNC = gp_percentile_cont_timestamptz_transition,
+     STYPE = timestamptz,
+     FINALFUNC = gp_percentile_final
+);
+
+CREATE AGGREGATE gp_percentile_disc(anyelement, float8, int8, int8)
+(
+     SFUNC = gp_percentile_disc_transition,
+     STYPE = anyelement,
+     FINALFUNC = gp_percentile_final
+);

--- a/gpcontrib/gp_percentile_agg/gp_percentile_agg.c
+++ b/gpcontrib/gp_percentile_agg/gp_percentile_agg.c
@@ -1,0 +1,219 @@
+/*
+ * gpcontrib/gp_percentile_agg/gp_percentile_agg.c
+ *
+ * Copyright (c) 2022-Present VMware, Inc. or its affiliates.
+ *
+ ******************************************************************************
+  This file contains routines that can be bound to a Postgres backend and
+  called by the backend in the process of processing queries.  The calling
+  format for these routines is dictated by Postgres architecture.
+******************************************************************************/
+
+#include "postgres.h"
+
+#include <math.h>
+
+#include "catalog/pg_aggregate.h"
+#include "catalog/pg_operator.h"
+#include "catalog/pg_type.h"
+#include "executor/executor.h"
+#include "miscadmin.h"
+#include "nodes/nodeFuncs.h"
+#include "optimizer/tlist.h"
+#include "utils/array.h"
+#include "utils/builtins.h"
+#include "utils/lsyscache.h"
+#include "utils/timestamp.h"
+#include "utils/tuplesort.h"
+#include "../backend/utils/adt/orderedsetaggs.c"
+
+PG_MODULE_MAGIC;
+
+/*
+ * Since we use V1 function calling convention, all these functions have
+ * the same signature as far as C is concerned.  We provide these prototypes
+ * just to forestall warnings when compiled with gcc -Wmissing-prototypes.
+ */
+PG_FUNCTION_INFO_V1(gp_percentile_cont_float8_transition);
+PG_FUNCTION_INFO_V1(gp_percentile_cont_interval_transition);
+PG_FUNCTION_INFO_V1(gp_percentile_cont_timestamp_transition);
+PG_FUNCTION_INFO_V1(gp_percentile_cont_timestamptz_transition);
+PG_FUNCTION_INFO_V1(gp_percentile_disc_transition);
+PG_FUNCTION_INFO_V1(gp_percentile_final);
+
+Datum gp_percentile_cont_float8_transition(PG_FUNCTION_ARGS);
+Datum gp_percentile_cont_interval_transition(PG_FUNCTION_ARGS);
+Datum gp_percentile_cont_timestamp_transition(PG_FUNCTION_ARGS);
+Datum gp_percentile_cont_timestamptz_transition(PG_FUNCTION_ARGS);
+Datum gp_percentile_disc_transition(PG_FUNCTION_ARGS);
+Datum gp_percentile_final(PG_FUNCTION_ARGS);
+
+/*
+ * Generic transition function for gp_percentile_cont
+ * with a single input column in which we want to suppress nulls
+ * This assumes the input tuples are already sorted
+ */
+static Datum
+gp_percentile_cont_transition(FunctionCallInfo fcinfo,
+		       LerpFunc lerpfunc)
+{
+	int64        first_row;
+	int64        second_row;
+
+	/* Ignore NULL inputs for val, percent and total_count*/
+	if (PG_ARGISNULL(1) || PG_ARGISNULL(2) || PG_ARGISNULL(3))
+		PG_RETURN_NULL();
+
+	double percentile = PG_GETARG_FLOAT8(2);
+	if (percentile < 0 || percentile > 1 || isnan(percentile))
+		ereport(ERROR,
+				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
+				 errmsg("percentile value %g is not between 0 and 1",
+						percentile)));
+
+	Datum prev_state = PG_GETARG_DATUM(0);
+	Datum val = PG_GETARG_DATUM(1);
+	Datum return_state = prev_state;
+	int64 total_rows = PG_GETARG_INT64(3);
+	first_row = (int64) floor(percentile * (total_rows - 1));
+	second_row = (int64) ceil(percentile * (total_rows - 1));
+	double proportion = (percentile * (total_rows - 1)) - floor(percentile * (total_rows - 1));
+	int64 *cnt;
+
+	if(first_row == second_row)
+		proportion = 0;
+
+	if (!fcinfo->flinfo->fn_extra)
+	{
+		cnt = (int64 *) MemoryContextAllocZero(fcinfo->flinfo->fn_mcxt, sizeof(int64));
+		*cnt = 1;
+		fcinfo->flinfo->fn_extra = cnt;
+	}
+	else
+	{
+		cnt = (int64 *) fcinfo->flinfo->fn_extra;
+	}
+
+	if(*cnt == first_row)
+	{
+		return_state = val;
+	}
+	else if(*cnt == second_row)
+	{
+		return_state = lerpfunc(prev_state, val, proportion);
+	}
+	*cnt = *cnt + 1;
+
+	if(*cnt >= total_rows)
+	{
+		/* Clean up, so the next group can see NULL for fn_extra */
+		pfree(cnt);
+		fcinfo->flinfo->fn_extra = NULL;
+	}
+
+	PG_RETURN_DATUM(return_state);
+}
+
+/*
+ * gp_percentile_cont(float8, float8, bigint)    - continuous percentile
+ */
+Datum
+gp_percentile_cont_float8_transition(PG_FUNCTION_ARGS)
+{
+	return gp_percentile_cont_transition(fcinfo, float8_lerp);
+}
+
+/*
+ * gp_percentile_cont(interval, float8, bigint)    - continuous percentile
+ */
+Datum
+gp_percentile_cont_interval_transition(PG_FUNCTION_ARGS)
+{
+	return gp_percentile_cont_transition(fcinfo, interval_lerp);
+}
+
+/*
+ * gp_percentile_cont(timestamp, float8, bigint)    - continuous percentile
+ */
+Datum
+gp_percentile_cont_timestamp_transition(PG_FUNCTION_ARGS)
+{
+	return gp_percentile_cont_transition(fcinfo, timestamp_lerp);
+}
+
+/*
+ * gp_percentile_cont(timestamptz, float8, bigint)    - continuous percentile
+ */
+Datum
+gp_percentile_cont_timestamptz_transition(PG_FUNCTION_ARGS)
+{
+	return gp_percentile_cont_transition(fcinfo, timestamptz_lerp);
+}
+
+/*
+ * Transition function for gp_percentile_disc  - discrete percentile
+ * This assumes the input tuples are already sorted
+ */
+Datum
+gp_percentile_disc_transition(PG_FUNCTION_ARGS)
+{
+	int64        rownum;
+
+	/* Ignore NULL inputs for val, percent and total_count*/
+	if (PG_ARGISNULL(1) || PG_ARGISNULL(2) || PG_ARGISNULL(3))
+			PG_RETURN_NULL();
+
+	double percentile = PG_GETARG_FLOAT8(2);
+	if (percentile < 0 || percentile > 1 || isnan(percentile))
+		ereport(ERROR,
+				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
+				 errmsg("percentile value %g is not between 0 and 1",
+						percentile)));
+	Datum prev_state = PG_GETARG_DATUM(0);
+	Datum val = PG_GETARG_DATUM(1);
+	Datum return_state = prev_state;
+	int64 total_rows = PG_GETARG_INT64(3);
+	rownum = (int64) ceil(percentile * (total_rows));
+	int64 *cnt;
+
+	if (!fcinfo->flinfo->fn_extra)
+	{
+		cnt = (int64 *) MemoryContextAllocZero(fcinfo->flinfo->fn_mcxt, sizeof(int64));
+		*cnt = 1;
+		fcinfo->flinfo->fn_extra = cnt;
+	}
+	else
+	{
+		cnt = (int64 *) fcinfo->flinfo->fn_extra;
+	}
+
+	if(*cnt == rownum - 1)
+	{
+		return_state = val;
+	}
+
+	*cnt = *cnt + 1;
+
+	if(*cnt >= total_rows)
+	{
+		/* Clean up, so the next group can see NULL for fn_extra */
+		pfree(cnt);
+		fcinfo->flinfo->fn_extra = NULL;
+	}
+
+	PG_RETURN_DATUM(return_state);
+}
+
+/*
+ * Final function for gp_percentile
+ */
+Datum
+gp_percentile_final(PG_FUNCTION_ARGS)
+{
+	/* Get and check the percentile argument */
+	if (PG_ARGISNULL(0))
+		PG_RETURN_NULL();
+
+	PG_RETURN_DATUM(PG_GETARG_DATUM(0));
+}
+

--- a/gpcontrib/gp_percentile_agg/gp_percentile_agg.control
+++ b/gpcontrib/gp_percentile_agg/gp_percentile_agg.control
@@ -1,0 +1,3 @@
+comment = 'Greenplum percentile aggregate implementation'
+default_version = '1.0.0'
+relocatable = true

--- a/gpcontrib/gp_percentile_agg/sql/gp_percentile_agg.sql
+++ b/gpcontrib/gp_percentile_agg/sql/gp_percentile_agg.sql
@@ -1,0 +1,288 @@
+create table perct as select a, a / 10 as b from generate_series(1, 100)a distributed by (a);
+create table perct2 as select a, a / 10 as b from generate_series(1, 100)a, generate_series(1, 2);
+create table perct3 as select a, b from perct, generate_series(1, 10)i where a % 7 < i;
+create table perct4 as select case when a % 10 = 5 then null else a end as a,
+	b, null::float as c from perct;
+create table percts as select '2012-01-01 00:00:00'::timestamp + interval '1day' * i as a,
+	i / 10 as b, i as c from generate_series(1, 100)i;
+create table perctsz as select '2012-01-01 00:00:00 UTC'::timestamptz + interval '1day' * i as a,
+	i / 10 as b, i as c from generate_series(1, 100)i;
+create table perctnum as select a, (a / 13)::float8  as b, (a * 1.9999 )::numeric as c  from generate_series(1, 100)a;
+create view percv as select percentile_cont(0.4) within group (order by a / 10),
+	median(a), percentile_disc(0.51) within group (order by a desc) from perct group by b order by b;
+create view percv2 as select median(a) as m1, median(a::float) as m2 from perct;
+
+create table mpp_22219(col_a character(2) NOT NULL, dkey_a character varying(8) NOT NULL, value double precision)
+WITH (APPENDONLY=true, COMPRESSLEVEL=5, ORIENTATION=column, COMPRESSTYPE=zlib, OIDS=FALSE)
+DISTRIBUTED BY (dkey_a);
+insert into mpp_22219 select i, i, i from  (select * from generate_series(1, 20) i ) a ;
+
+create table mpp_21026 ( t1 varchar(10), t2 int);
+insert into mpp_21026 select i, i from  (select * from generate_series(1, 20) i ) a ;
+
+create table mpp_20076 (col1 timestamp, col2 int);
+insert into mpp_20076 select to_timestamp(i),i from generate_series(1,20) i;
+
+CREATE TABLE mpp_22413
+(
+  col_a character(2) NOT NULL,
+  d1 character varying(8) NOT NULL,
+  d2 character varying(8) NOT NULL,
+  d3 character varying(8) NOT NULL,
+  value1 double precision,
+  value2 double precision
+)
+WITH (OIDS=FALSE)
+DISTRIBUTED BY (d1,d2,d3);
+
+insert into mpp_22413
+select i, i, i, i, i,i
+from  (select * from generate_series(1, 99) i ) a ;
+
+set optimizer_enable_orderedagg=on;
+explain select percentile_cont(0.5) within group (order by a),
+	median(a), percentile_disc(0.5) within group(order by a) from perct;
+select percentile_cont(0.5) within group (order by a),
+	median(a), percentile_disc(0.5) within group(order by a) from perct;
+explain select b, percentile_cont(0.5) within group (order by a),
+	median(a), percentile_disc(0.5) within group(order by a) from perct group by b order by b;
+select b, percentile_cont(0.5) within group (order by a),
+	median(a), percentile_disc(0.5) within group(order by a) from perct group by b order by b;
+explain select percentile_cont(0.2) within group (order by a) from generate_series(1, 100)a;
+select percentile_cont(0.2) within group (order by a) from generate_series(1, 100)a;
+explain select a / 10, percentile_cont(0.2) within group (order by a) from generate_series(1, 100)a
+	group by a / 10 order by a / 10;
+select a / 10, percentile_cont(0.2) within group (order by a) from generate_series(1, 100)a
+	group by a / 10 order by a / 10;
+explain select percentile_cont(0.2) within group (order by a),
+	percentile_cont(0.8) within group (order by a desc) from perct group by b order by b;
+select percentile_cont(0.2) within group (order by a),
+	percentile_cont(0.8) within group (order by a desc) from perct group by b order by b;
+explain select percentile_cont(0.1) within group (order by a), count(*), sum(a) from perct
+	group by b order by b;
+select percentile_cont(0.1) within group (order by a), count(*), sum(a) from perct
+	group by b order by b;
+explain select percentile_cont(0.6) within group (order by a), count(*), sum(a) from perct;
+select percentile_cont(0.6) within group (order by a), count(*), sum(a) from perct;
+explain select percentile_cont(0.3) within group (order by a) + count(*) from perct group by b order by b;
+select percentile_cont(0.3) within group (order by a) + count(*) from perct group by b order by b;
+explain select median(a) from perct group by b having median(a) = 5;
+select median(a) from perct group by b having median(a) = 5;
+explain select median(a), percentile_cont(0.6) within group (order by a desc) from perct group by b having count(*) > 1 order by 1;
+select median(a), percentile_cont(0.6) within group (order by a desc) from perct group by b having count(*) > 1 order by 1;
+explain select median(10);
+select median(10);
+explain select count(*), median(b+1) from perct group by b+2
+	having median(b+1) in (select avg(b+1) from perct group by b+2);
+select count(*), median(b+1) from perct group by b+2
+	having median(b+1) in (select avg(b+1) from perct group by b+2);
+explain select median(a) from perct2;
+select median(a) from perct2;
+explain select median(a) from perct2 group by b order by b;
+select median(a) from perct2 group by b order by b;
+explain select b, count(*), count(distinct a), median(a) from perct3 group by b order by b;
+select b, count(*), count(distinct a), median(a) from perct3 group by b order by b;
+explain select b+1, count(*), count(distinct a),
+       median(a), percentile_cont(0.3) within group (order by a desc)
+from perct group by b+1 order by b+1;
+select b+1, count(*), count(distinct a),
+       median(a), percentile_cont(0.3) within group (order by a desc)
+from perct group by b+1 order by b+1;
+explain select median(a), median(c) from perct4;
+select median(a), median(c) from perct4;
+explain select median(a), median(c) from perct4 group by b;
+select median(a), median(c) from perct4 group by b;
+explain select count(*) over (partition by b), median(a) from perct group by b order by b;
+select count(*) over (partition by b), median(a) from perct group by b order by b;
+explain select sum(median(a)) over (partition by b) from perct group by b order by b;
+select sum(median(a)) over (partition by b) from perct group by b order by b;
+explain select percentile_disc(0) within group (order by a) from perct;
+select percentile_disc(0) within group (order by a) from perct;
+prepare p (float) as select percentile_cont($1) within group (order by a)
+  from perct group by b order by b;
+execute p(0.1);
+execute p(0.8);
+deallocate p;
+explain select sum((select median(a) from perct)) from perct;
+select sum((select median(a) from perct)) from perct;
+explain select percentile_cont(null) within group (order by a) from perct;
+select percentile_cont(null) within group (order by a) from perct;
+explain select percentile_cont(null) within group (order by a),
+       percentile_disc(null) within group (order by a desc) from perct group by b;
+select percentile_cont(null) within group (order by a),
+       percentile_disc(null) within group (order by a desc) from perct group by b;
+explain select median(a), percentile_cont(0.5) within group (order by a),
+       percentile_disc(0.5) within group(order by a),
+       (select min(a) from percts) - interval '1day' + interval '1day' * median(c),
+       (select min(a) from percts) - interval '1day' + interval '1day' *
+         percentile_disc(0.5) within group (order by c)
+from percts group by b order by b;
+select median(a), percentile_cont(0.5) within group (order by a),
+       percentile_disc(0.5) within group(order by a),
+       (select min(a) from percts) - interval '1day' + interval '1day' * median(c),
+       (select min(a) from percts) - interval '1day' + interval '1day' *
+         percentile_disc(0.5) within group (order by c)
+from percts group by b order by b;
+explain select percentile_cont(1.0/86400) within group (order by a) from percts
+	where c between 1 and 2;
+select percentile_cont(1.0/86400) within group (order by a) from percts
+	where c between 1 and 2;
+explain select percentile_cont(0.1) within group (order by a),
+       percentile_cont(0.9) within group (order by a desc) from percts;
+select percentile_cont(0.1) within group (order by a),
+       percentile_cont(0.9) within group (order by a desc) from percts;
+explain select percentile_cont(0.1) within group (order by a),
+       percentile_cont(0.2) within group (order by a) from perctsz;
+select percentile_cont(0.1) within group (order by a),
+       percentile_cont(0.2) within group (order by a) from perctsz;
+explain select median(a - (select min(a) from percts)) from percts;
+select median(a - (select min(a) from percts)) from percts;
+explain select median(a), b from perct group by b order by b desc;
+select median(a), b from perct group by b order by b desc;
+explain select count(*) from(select median(a) from perct group by ())s;
+select count(*) from(select median(a) from perct group by ())s;
+explain select median(a) from perct group by grouping sets((b)) order by b;
+select median(a) from perct group by grouping sets((b)) order by b;
+explain select distinct median(a), count(*) from perct;
+select distinct median(a), count(*) from perct;
+explain select perct.a, 0.2*avg(perct2.a) as avga,
+	percentile_cont(0.34)within group(order by perct2.b)
+	from
+		(select a, a / 10 b from generate_series(1, 100)a)perct,
+		(select a, a / 10 b from generate_series(1, 100)a)perct2
+	where perct.a=perct2.a group by perct.a having median(perct.b) > 10;
+select perct.a, 0.2*avg(perct2.a) as avga,
+	percentile_cont(0.34)within group(order by perct2.b)
+	from
+		(select a, a / 10 b from generate_series(1, 100)a)perct,
+		(select a, a / 10 b from generate_series(1, 100)a)perct2
+	where perct.a=perct2.a group by perct.a having median(perct.b) > 10;
+explain select median(a - '2011-12-31 00:00:00 UTC'::timestamptz) from perctsz group by b order by median;
+select median(a - '2011-12-31 00:00:00 UTC'::timestamptz) from perctsz group by b order by median;
+--numeric types
+explain select percentile_cont(0.95) within group( order by c) from perctnum;
+select percentile_cont(0.95) within group( order by c) from perctnum;
+-- view
+select * from percv;
+
+select pg_get_viewdef('percv');
+select pg_get_viewdef('percv2');
+
+-- errors
+-- no WITHIN GROUP clause
+select percentile_cont(a) from perct;
+-- the argument must not contain variable
+select percentile_cont(a) within group (order by a) from perct;
+-- ungrouped column
+select b, percentile_disc(0.1) within group (order by a) from perct;
+-- nested aggregate
+select percentile_cont(count(*)) within group (order by a) from perct;
+select sum(percentile_cont(0.22) within group (order by a)) from perct;
+-- OVER clause
+select percentile_cont(0.3333) within group (order by a) over (partition by a%2) from perct;
+select median(a) over (partition by b) from perct group by b;
+-- function scan
+select * from median(10);
+-- wrong type argument
+select percentile_disc('a') within group (order by a) from perct;
+-- nested case
+select count(median(a)) from perct;
+select median(count(*)) from perct;
+select percentile_cont(0.2) within group (order by count(*) over()) from perct;
+select percentile_disc(0.1) within group (order by group_id()) from perct;
+-- subquery in argument
+select percentile_cont((select 0.1 from gp_id)) within group (order by a) from perct;
+-- volatile argument
+explain select percentile_cont(floor(random()*0.1)+0.5) within group (order by a) from perct;
+select percentile_cont(floor(random()*0.1)+0.5) within group (order by a) from perct;
+-- out of range
+explain select percentile_cont(-0.1) within group (order by a) from perct;
+select percentile_cont(-0.1) within group (order by a) from perct;
+explain select percentile_cont(1.00000001) within group (order by a) from perct;
+select percentile_cont(1.00000001) within group (order by a) from perct;
+-- correlated subquery
+explain select sum((select median(a) from perct where b = t.b)) from perct t;
+select sum((select median(a) from perct where b = t.b)) from perct t;
+-- used in LIMIT
+select * from perct limit median(a);
+-- multiple sort key
+select percentile_cont(0.8) within group (order by a, a + 1, a + 2) from perct;
+-- set-returning
+explain select generate_series(1, 2), median(a) from perct;
+select generate_series(1, 2), median(a) from perct;
+-- GROUPING SETS
+explain select median(a) from perct group by grouping sets((), (b));
+select median(a) from perct group by grouping sets((), (b));
+-- wrong type in ORDER BY
+select median('text') from perct;
+select percentile_cont(now()) within group (order by a) from percts;
+select percentile_cont(0.5) within group (order by point(0,0)) from perct;
+-- outer references
+explain select (select a from perct where median(t.a) = 5) from perct t;
+select (select a from perct where median(t.a) = 5) from perct t;
+explain select (select array_agg(a ORDER BY a) from perct where median(t.a) = 50.5) from (select * from perct t order by a offset 0) as t;
+select (select array_agg(a ORDER BY a) from perct where median(t.a) = 50.5) from (select * from perct t order by a offset 0) as t;
+
+-- MPP-22219
+select count(*) from
+(SELECT b.dkey_a, MEDIAN(B.VALUE)
+FROM     mpp_22219 B
+GROUP BY b.dkey_a) s;
+
+select count(*) from
+(SELECT b.dkey_a, percentile_cont(0.5) within  group (order by b.VALUE)
+FROM     mpp_22219 B
+GROUP BY b.dkey_a) s;
+
+-- MPP-21026
+select median(t2) from mpp_21026 group by t1;
+
+-- MPP-20076
+select 1, to_char(col1, 'YYYY'), median(col2) from mpp_20076 group by 1, 2;
+select 1, col1, median(col2) from mpp_20076 group by 1, 2;
+select to_char(col1, 'YYYY') AS tstmp_column, median(col2) from mpp_20076 group by 1;
+select 1, median(col2) from mpp_20076 group by 1;
+
+-- MPP-22413
+select median(value1), count(*)
+from  mpp_22413
+where d2 ='55'
+group by d1, d2, d3, value2;
+
+select median(value1), count(*)
+from  mpp_22413
+where d2 ='55'
+group by d1, d2, d3, value2::int;
+
+select median(value1), count(*)
+from  mpp_22413
+where d2 ='55'
+group by d1, d2, d3, value2::varchar;
+
+select median(value1), count(*)
+from  mpp_22413
+where d2 ='55'
+group by d1, d2, value2;
+
+select median(value1), count(*)
+from  mpp_22413
+where d2 ='55'
+group by d1, d2, value2, d3;
+
+select median(value1), count(*)
+from  mpp_22413
+where d2 ='55'
+group by d1, d2;
+
+drop view percv2;
+drop view percv;
+drop table perct;
+drop table perct2;
+drop table perct3;
+drop table perct4;
+drop table percts;
+drop table perctsz;
+drop table mpp_22219;
+drop table mpp_21026;
+drop table mpp_20076;
+drop table mpp_22413;

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -659,12 +659,12 @@ gpdb::IsAggPartialCapable(Oid aggid)
 }
 
 Oid
-gpdb::GetAggregate(const char *agg, Oid type_oid)
+gpdb::GetAggregate(const char *agg, Oid type_oid, int nargs)
 {
 	GP_WRAP_START;
 	{
 		/* catalog tables: pg_aggregate */
-		return get_aggregate(agg, type_oid);
+		return get_aggregate(agg, type_oid, nargs);
 	}
 	GP_WRAP_END;
 	return 0;

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -1606,13 +1606,13 @@ CTranslatorRelcacheToDXL::RetrieveType(CMemoryPool *mp, IMDId *mdid)
 
 	// get standard aggregates
 	CMDIdGPDB *mdid_min =
-		GPOS_NEW(mp) CMDIdGPDB(gpdb::GetAggregate("min", oid_type));
+		GPOS_NEW(mp) CMDIdGPDB(gpdb::GetAggregate("min", oid_type, 1));
 	CMDIdGPDB *mdid_max =
-		GPOS_NEW(mp) CMDIdGPDB(gpdb::GetAggregate("max", oid_type));
+		GPOS_NEW(mp) CMDIdGPDB(gpdb::GetAggregate("max", oid_type, 1));
 	CMDIdGPDB *mdid_avg =
-		GPOS_NEW(mp) CMDIdGPDB(gpdb::GetAggregate("avg", oid_type));
+		GPOS_NEW(mp) CMDIdGPDB(gpdb::GetAggregate("avg", oid_type, 1));
 	CMDIdGPDB *mdid_sum =
-		GPOS_NEW(mp) CMDIdGPDB(gpdb::GetAggregate("sum", oid_type));
+		GPOS_NEW(mp) CMDIdGPDB(gpdb::GetAggregate("sum", oid_type, 1));
 
 	// count aggregate is the same for all types
 	CMDIdGPDB *mdid_count = GPOS_NEW(mp) CMDIdGPDB(COUNT_ANY_OID);

--- a/src/backend/gporca/data/dxl/minidump/CTAS_OrderedAgg_multiple_cols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS_OrderedAgg_multiple_cols.mdp
@@ -1,0 +1,2869 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Objective:
+Test pre-processing step converts CTAS with multiple ordered-set aggs into NLJ
+joining GbAgg expression containing different ordered aggs split to gp_percentile
+
+CREATE EXTENSION gp_percentile_agg;
+SET optimizer_enable_orderedagg=on;
+CREATE TABLE foo1(a int, b int, c int);
+INSERT INTO foo1 SELECT i,i,i FROM generate_series(1,100)i;
+ANALYZE foo1;
+
+EXPLAIN CREATE TABLE test AS
+  SELECT
+	ARRAY[percentile_cont(0.25) WITHIN GROUP(ORDER BY a), percentile_cont(0.25) WITHIN GROUP(ORDER BY b), percentile_cont(0.25) WITHIN GROUP(ORDER BY c)] first_quartile,
+	ARRAY[percentile_cont(0.5) WITHIN GROUP(ORDER BY a), percentile_cont(0.5) WITHIN GROUP(ORDER BY b), percentile_cont(0.5) WITHIN GROUP(ORDER BY c)] median_quartile,
+	ARRAY[percentile_cont(0.75) WITHIN GROUP(ORDER BY a), percentile_cont(0.75) WITHIN GROUP(ORDER BY b), percentile_cont(0.75) WITHIN GROUP(ORDER BY c)] third_quartile
+  FROM foo1;
+
+                                                   QUERY PLAN
+ Result  (cost=0.00..0.00 rows=0 width=0)
+   ->  Result  (cost=0.00..2778510692279.12 rows=1 width=24)
+         ->  Result  (cost=0.00..2778510692279.08 rows=1 width=24)
+               ->  Sequence  (cost=0.00..2778510692279.08 rows=1 width=72)
+                     ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=34 width=1)
+                           ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
+                                 ->  Seq Scan on foo1  (cost=0.00..431.00 rows=34 width=42)
+                     ->  Redistribute Motion 1:3  (slice10; segments: 1)  (cost=0.00..2778510691848.08 rows=1 width=72)
+                           ->  Nested Loop  (cost=0.00..2778510691848.08 rows=1 width=72)
+                                 Join Filter: true
+                                 ->  Nested Loop  (cost=0.00..2712064881.58 rows=1 width=48)
+                                       Join Filter: true
+                                       ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=24)
+                                             ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
+                                                   ->  Gather Motion 3:1  (slice9; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
+                                                         Merge Key: share0_ref6.b
+                                                         ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
+                                                               Sort Key: share0_ref6.b
+                                                               ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
+                                                                     Join Filter: true
+                                                                     ->  Broadcast Motion 1:3  (slice8; segments: 1)  (cost=0.00..431.00 rows=3 width=8)
+                                                                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                 ->  Gather Motion 3:1  (slice7; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                             ->  Shared Scan (share slice:id 7:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                                     ->  Shared Scan (share slice:id 9:0)  (cost=0.00..431.00 rows=34 width=4)
+                                       ->  Materialize  (cost=0.00..1324034.93 rows=1 width=24)
+                                             ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=24)
+                                                   ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
+                                                         ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
+                                                               Merge Key: share0_ref4.a
+                                                               ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
+                                                                     Sort Key: share0_ref4.a
+                                                                     ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
+                                                                           Join Filter: true
+                                                                           ->  Broadcast Motion 1:3  (slice5; segments: 1)  (cost=0.00..431.00 rows=3 width=8)
+                                                                                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                       ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                                             ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                                   ->  Shared Scan (share slice:id 4:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                                           ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=34 width=4)
+                                 ->  Materialize  (cost=0.00..1324034.93 rows=1 width=24)
+                                       ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=24)
+                                             ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
+                                                   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
+                                                         Merge Key: share0_ref2.c
+                                                         ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
+                                                               Sort Key: share0_ref2.c
+                                                               ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
+                                                                     Join Filter: true
+                                                                     ->  Broadcast Motion 1:3  (slice2; segments: 1)  (cost=0.00..431.00 rows=3 width=8)
+                                                                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                             ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                                     ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(57 rows)
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,103043,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.CTAS,0.GPDB">
+      <dxl:GPDBAgg Mdid="0.3974.1.0" Name="percentile_cont" IsOrdered="true" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.17.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:GPDBAgg Mdid="0.327945.1.0" Name="gp_percentile_cont" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.164167.1.0.2" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="52"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="58"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="82"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="92"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.672.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.701.1.0"/>
+        <dxl:RightType Mdid="0.701.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.295.1.0"/>
+        <dxl:Commutator Mdid="0.674.1.0"/>
+        <dxl:InverseOp Mdid="0.675.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1970.1.0"/>
+          <dxl:Opfamily Mdid="0.7024.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:CTASRelation Mdid="5.1.1.0" Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" VarTypeModList="-1,-1,-1" DistributionPolicy="Random">
+        <dxl:Columns>
+          <dxl:Column Name="first_quartile" Attno="1" Mdid="0.1022.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="median_quartile" Attno="2" Mdid="0.1022.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="third_quartile" Attno="3" Mdid="0.1022.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:CTASOptions OnCommitAction="NOOP"/>
+        <dxl:DistrOpfamilies/>
+        <dxl:DistrOpclasses/>
+      </dxl:CTASRelation>
+      <dxl:ColumnStatistics Mdid="1.164167.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="52"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="58"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="82"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="92"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.164167.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="52"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="58"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="82"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="92"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:GPDBFunc Mdid="0.316.1.0" Name="float8" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
+        <dxl:EqualityOp Mdid="0.670.1.0"/>
+        <dxl:InequalityOp Mdid="0.671.1.0"/>
+        <dxl:LessThanOp Mdid="0.672.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
+        <dxl:ComparisonOp Mdid="0.355.1.0"/>
+        <dxl:ArrayType Mdid="0.1022.1.0"/>
+        <dxl:MinAgg Mdid="0.2136.1.0"/>
+        <dxl:MaxAgg Mdid="0.2120.1.0"/>
+        <dxl:AvgAgg Mdid="0.2105.1.0"/>
+        <dxl:SumAgg Mdid="0.2111.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.164167.1.0" Name="foo1" Rows="100.000000" RelPages="3" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.164167.1.0" Name="foo1" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBAgg Mdid="0.2147.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:MDCast Mdid="3.23.1.0;701.1.0" Name="float8" BinaryCoercible="false" SourceTypeId="0.23.1.0" DestinationTypeId="0.701.1.0" CastFuncId="0.316.1.0" CoercePathType="1"/>
+      <dxl:Type Mdid="0.1022.1.0" Name="_float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.627.1.0"/>
+        <dxl:EqualityOp Mdid="0.1070.1.0"/>
+        <dxl:InequalityOp Mdid="0.1071.1.0"/>
+        <dxl:LessThanOp Mdid="0.1072.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1074.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1073.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1075.1.0"/>
+        <dxl:ComparisonOp Mdid="0.382.1.0"/>
+        <dxl:ArrayType Mdid="0.0.0.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.6219.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="20" ColName="first_quartile" TypeMdid="0.1022.1.0"/>
+        <dxl:Ident ColId="21" ColName="median_quartile" TypeMdid="0.1022.1.0"/>
+        <dxl:Ident ColId="22" ColName="third_quartile" TypeMdid="0.1022.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalCTAS Mdid="5.1.1.0" Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" DistributionPolicy="Random" InsertColumns="20,21,22" VarTypeModList="-1,-1,-1">
+        <dxl:Columns>
+          <dxl:Column ColId="23" Attno="1" ColName="first_quartile" TypeMdid="0.1022.1.0"/>
+          <dxl:Column ColId="24" Attno="2" ColName="median_quartile" TypeMdid="0.1022.1.0"/>
+          <dxl:Column ColId="25" Attno="3" ColName="third_quartile" TypeMdid="0.1022.1.0"/>
+        </dxl:Columns>
+        <dxl:CTASOptions OnCommitAction="NOOP"/>
+        <dxl:DistrOpfamilies/>
+        <dxl:DistrOpclasses/>
+        <dxl:LogicalProject>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="20" Alias="first_quartile">
+              <dxl:Array ArrayType="0.1022.1.0" ElementType="0.701.1.0" MultiDimensional="false">
+                <dxl:Ident ColId="11" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+              </dxl:Array>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="21" Alias="median_quartile">
+              <dxl:Array ArrayType="0.1022.1.0" ElementType="0.701.1.0" MultiDimensional="false">
+                <dxl:Ident ColId="14" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                <dxl:Ident ColId="15" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                <dxl:Ident ColId="16" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+              </dxl:Array>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="22" Alias="third_quartile">
+              <dxl:Array ArrayType="0.1022.1.0" ElementType="0.701.1.0" MultiDimensional="false">
+                <dxl:Ident ColId="17" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                <dxl:Ident ColId="18" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                <dxl:Ident ColId="19" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+              </dxl:Array>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:LogicalGroupBy>
+            <dxl:GroupingColumns/>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="11" Alias="percentile_cont">
+                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.327945.1.0">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
+                      <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:FuncExpr>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs">
+                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA0D8=" DoubleValue="0.250000"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggorder">
+                    <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="672" SortNullsFirst="false" IsHashable="true"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="12" Alias="percentile_cont">
+                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.327945.1.0">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
+                      <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:FuncExpr>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs">
+                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA0D8=" DoubleValue="0.250000"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggorder">
+                    <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="672" SortNullsFirst="false" IsHashable="true"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="13" Alias="percentile_cont">
+                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.327945.1.0">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
+                      <dxl:Ident ColId="3" ColName="c" TypeMdid="0.23.1.0"/>
+                    </dxl:FuncExpr>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs">
+                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA0D8=" DoubleValue="0.250000"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggorder">
+                    <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="672" SortNullsFirst="false" IsHashable="true"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="14" Alias="percentile_cont">
+                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.327945.1.0">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
+                      <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:FuncExpr>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs">
+                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggorder">
+                    <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="672" SortNullsFirst="false" IsHashable="true"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="15" Alias="percentile_cont">
+                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.327945.1.0">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
+                      <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:FuncExpr>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs">
+                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggorder">
+                    <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="672" SortNullsFirst="false" IsHashable="true"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="16" Alias="percentile_cont">
+                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.327945.1.0">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
+                      <dxl:Ident ColId="3" ColName="c" TypeMdid="0.23.1.0"/>
+                    </dxl:FuncExpr>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs">
+                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggorder">
+                    <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="672" SortNullsFirst="false" IsHashable="true"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="17" Alias="percentile_cont">
+                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.327945.1.0">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
+                      <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:FuncExpr>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs">
+                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA6D8=" DoubleValue="0.750000"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggorder">
+                    <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="672" SortNullsFirst="false" IsHashable="true"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="18" Alias="percentile_cont">
+                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.327945.1.0">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
+                      <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:FuncExpr>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs">
+                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA6D8=" DoubleValue="0.750000"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggorder">
+                    <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="672" SortNullsFirst="false" IsHashable="true"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="19" Alias="percentile_cont">
+                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.327945.1.0">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
+                      <dxl:Ident ColId="3" ColName="c" TypeMdid="0.23.1.0"/>
+                    </dxl:FuncExpr>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs">
+                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA6D8=" DoubleValue="0.750000"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggorder">
+                    <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="672" SortNullsFirst="false" IsHashable="true"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:LogicalGet>
+              <dxl:TableDescriptor Mdid="0.164167.1.0" TableName="foo1">
+                <dxl:Columns>
+                  <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:LogicalGet>
+          </dxl:LogicalGroupBy>
+        </dxl:LogicalProject>
+      </dxl:LogicalCTAS>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="506989368">
+      <dxl:PhysicalCTAS Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" DistributionPolicy="Random" InsertColumns="19,20,21" VarTypeModList="-1,-1,-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="2778510692279.118164" Rows="1.000000" Width="24"/>
+        </dxl:Properties>
+        <dxl:DistrOpclasses/>
+        <dxl:Columns>
+          <dxl:Column ColId="49" Attno="1" ColName="first_quartile" TypeMdid="0.1022.1.0"/>
+          <dxl:Column ColId="50" Attno="2" ColName="median_quartile" TypeMdid="0.1022.1.0"/>
+          <dxl:Column ColId="51" Attno="3" ColName="third_quartile" TypeMdid="0.1022.1.0"/>
+        </dxl:Columns>
+        <dxl:CTASOptions OnCommitAction="NOOP"/>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="19" Alias="first_quartile">
+            <dxl:Ident ColId="19" ColName="first_quartile" TypeMdid="0.1022.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="20" Alias="median_quartile">
+            <dxl:Ident ColId="20" ColName="median_quartile" TypeMdid="0.1022.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="21" Alias="third_quartile">
+            <dxl:Ident ColId="21" ColName="third_quartile" TypeMdid="0.1022.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="2778510692279.081543" Rows="1.000000" Width="28"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="19" Alias="first_quartile">
+              <dxl:Ident ColId="19" ColName="first_quartile" TypeMdid="0.1022.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="20" Alias="median_quartile">
+              <dxl:Ident ColId="20" ColName="median_quartile" TypeMdid="0.1022.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="21" Alias="third_quartile">
+              <dxl:Ident ColId="21" ColName="third_quartile" TypeMdid="0.1022.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="48" Alias="ColRef_0048">
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:Result>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="2778510692279.081543" Rows="1.000000" Width="24"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="19" Alias="first_quartile">
+                <dxl:Array ArrayType="0.1022.1.0" ElementType="0.701.1.0" MultiDimensional="false">
+                  <dxl:Ident ColId="10" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                  <dxl:Ident ColId="11" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                  <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                </dxl:Array>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="20" Alias="median_quartile">
+                <dxl:Array ArrayType="0.1022.1.0" ElementType="0.701.1.0" MultiDimensional="false">
+                  <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                  <dxl:Ident ColId="14" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                  <dxl:Ident ColId="15" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                </dxl:Array>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="21" Alias="third_quartile">
+                <dxl:Array ArrayType="0.1022.1.0" ElementType="0.701.1.0" MultiDimensional="false">
+                  <dxl:Ident ColId="16" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                  <dxl:Ident ColId="17" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                  <dxl:Ident ColId="18" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                </dxl:Array>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:OneTimeFilter/>
+            <dxl:Sequence>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="2778510692279.081543" Rows="1.000000" Width="72"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="10" Alias="percentile_cont">
+                  <dxl:Ident ColId="10" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="11" Alias="percentile_cont">
+                  <dxl:Ident ColId="11" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="12" Alias="percentile_cont">
+                  <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="13" Alias="percentile_cont">
+                  <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="14" Alias="percentile_cont">
+                  <dxl:Ident ColId="14" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="15" Alias="percentile_cont">
+                  <dxl:Ident ColId="15" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="16" Alias="percentile_cont">
+                  <dxl:Ident ColId="16" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="17" Alias="percentile_cont">
+                  <dxl:Ident ColId="17" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="18" Alias="percentile_cont">
+                  <dxl:Ident ColId="18" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:CTEProducer CTEId="0" Columns="22,23,24,25,26,27,28,29,30,31">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.003407" Rows="100.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="22" Alias="a">
+                    <dxl:Ident ColId="22" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="23" Alias="b">
+                    <dxl:Ident ColId="23" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="24" Alias="c">
+                    <dxl:Ident ColId="24" ColName="c" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="25" Alias="ctid">
+                    <dxl:Ident ColId="25" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="26" Alias="xmin">
+                    <dxl:Ident ColId="26" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="27" Alias="cmin">
+                    <dxl:Ident ColId="27" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="28" Alias="xmax">
+                    <dxl:Ident ColId="28" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="29" Alias="cmax">
+                    <dxl:Ident ColId="29" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="30" Alias="tableoid">
+                    <dxl:Ident ColId="30" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="31" Alias="gp_segment_id">
+                    <dxl:Ident ColId="31" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000770" Rows="100.000000" Width="42"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="22" Alias="a">
+                      <dxl:Ident ColId="22" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="23" Alias="b">
+                      <dxl:Ident ColId="23" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="24" Alias="c">
+                      <dxl:Ident ColId="24" ColName="c" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="25" Alias="ctid">
+                      <dxl:Ident ColId="25" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="26" Alias="xmin">
+                      <dxl:Ident ColId="26" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="27" Alias="cmin">
+                      <dxl:Ident ColId="27" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="28" Alias="xmax">
+                      <dxl:Ident ColId="28" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="29" Alias="cmax">
+                      <dxl:Ident ColId="29" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="30" Alias="tableoid">
+                      <dxl:Ident ColId="30" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="31" Alias="gp_segment_id">
+                      <dxl:Ident ColId="31" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.164167.1.0" TableName="foo1">
+                    <dxl:Columns>
+                      <dxl:Column ColId="22" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="23" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="24" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="26" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="27" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="28" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="29" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="30" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="31" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:CTEProducer>
+              <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="2778510691848.078125" Rows="1.000000" Width="72"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="10" Alias="percentile_cont">
+                    <dxl:Ident ColId="10" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="11" Alias="percentile_cont">
+                    <dxl:Ident ColId="11" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="12" Alias="percentile_cont">
+                    <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="13" Alias="percentile_cont">
+                    <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="14" Alias="percentile_cont">
+                    <dxl:Ident ColId="14" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="15" Alias="percentile_cont">
+                    <dxl:Ident ColId="15" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="16" Alias="percentile_cont">
+                    <dxl:Ident ColId="16" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="17" Alias="percentile_cont">
+                    <dxl:Ident ColId="17" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="18" Alias="percentile_cont">
+                    <dxl:Ident ColId="18" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="2778510691848.078125" Rows="1.000000" Width="72"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="10" Alias="percentile_cont">
+                      <dxl:Ident ColId="10" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="11" Alias="percentile_cont">
+                      <dxl:Ident ColId="11" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="12" Alias="percentile_cont">
+                      <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="13" Alias="percentile_cont">
+                      <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="14" Alias="percentile_cont">
+                      <dxl:Ident ColId="14" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="15" Alias="percentile_cont">
+                      <dxl:Ident ColId="15" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="16" Alias="percentile_cont">
+                      <dxl:Ident ColId="16" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="17" Alias="percentile_cont">
+                      <dxl:Ident ColId="17" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="18" Alias="percentile_cont">
+                      <dxl:Ident ColId="18" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:JoinFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:JoinFilter>
+                  <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="2712064881.577200" Rows="1.000000" Width="48"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="10" Alias="percentile_cont">
+                        <dxl:Ident ColId="10" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="11" Alias="percentile_cont">
+                        <dxl:Ident ColId="11" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="13" Alias="percentile_cont">
+                        <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="14" Alias="percentile_cont">
+                        <dxl:Ident ColId="14" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="16" Alias="percentile_cont">
+                        <dxl:Ident ColId="16" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="17" Alias="percentile_cont">
+                        <dxl:Ident ColId="17" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:JoinFilter>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:JoinFilter>
+                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="1324034.930325" Rows="1.000000" Width="24"/>
+                      </dxl:Properties>
+                      <dxl:GroupingColumns/>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="11" Alias="percentile_cont">
+                          <dxl:AggFunc AggMdid="0.327945.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                              </dxl:Cast>
+                              <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA0D8=" DoubleValue="0.250000"/>
+                              <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
+                              <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="14" Alias="percentile_cont">
+                          <dxl:AggFunc AggMdid="0.327945.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                              </dxl:Cast>
+                              <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+                              <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
+                              <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="17" Alias="percentile_cont">
+                          <dxl:AggFunc AggMdid="0.327945.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                              </dxl:Cast>
+                              <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA6D8=" DoubleValue="0.750000"/>
+                              <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
+                              <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:Limit>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="1324034.929519" Rows="100.000000" Width="12"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="1" Alias="b">
+                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="43" Alias="ColRef_0043">
+                            <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="1324034.928319" Rows="100.000000" Width="12"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="1" Alias="b">
+                              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="43" Alias="ColRef_0043">
+                              <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList>
+                            <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                          </dxl:SortingColumnList>
+                          <dxl:Sort SortDiscardDuplicates="false">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="1324034.923847" Rows="100.000000" Width="12"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="1" Alias="b">
+                                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="43" Alias="ColRef_0043">
+                                <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:SortingColumnList>
+                              <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                            </dxl:SortingColumnList>
+                            <dxl:LimitCount/>
+                            <dxl:LimitOffset/>
+                            <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="1324034.912373" Rows="100.000000" Width="12"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="1" Alias="b">
+                                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="43" Alias="ColRef_0043">
+                                  <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:JoinFilter>
+                                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                              </dxl:JoinFilter>
+                              <dxl:BroadcastMotion InputSegments="0" OutputSegments="0,1,2">
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000797" Rows="3.000000" Width="8"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="43" Alias="ColRef_0043">
+                                    <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:SortingColumnList/>
+                                <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000367" Rows="1.000000" Width="8"/>
+                                  </dxl:Properties>
+                                  <dxl:GroupingColumns/>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="43" Alias="ColRef_0043">
+                                      <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
+                                        <dxl:ValuesList ParamType="aggargs">
+                                          <dxl:Ident ColId="46" ColName="ColRef_0046" TypeMdid="0.20.1.0"/>
+                                        </dxl:ValuesList>
+                                        <dxl:ValuesList ParamType="aggdirectargs"/>
+                                        <dxl:ValuesList ParamType="aggorder"/>
+                                        <dxl:ValuesList ParamType="aggdistinct"/>
+                                      </dxl:AggFunc>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.000366" Rows="1.000000" Width="8"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="46" Alias="ColRef_0046">
+                                        <dxl:Ident ColId="46" ColName="ColRef_0046" TypeMdid="0.20.1.0"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:SortingColumnList/>
+                                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="431.000336" Rows="1.000000" Width="8"/>
+                                      </dxl:Properties>
+                                      <dxl:GroupingColumns/>
+                                      <dxl:ProjList>
+                                        <dxl:ProjElem ColId="46" Alias="ColRef_0046">
+                                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
+                                            <dxl:ValuesList ParamType="aggargs">
+                                              <dxl:Ident ColId="33" ColName="b" TypeMdid="0.23.1.0"/>
+                                            </dxl:ValuesList>
+                                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                                            <dxl:ValuesList ParamType="aggorder"/>
+                                            <dxl:ValuesList ParamType="aggdistinct"/>
+                                          </dxl:AggFunc>
+                                        </dxl:ProjElem>
+                                      </dxl:ProjList>
+                                      <dxl:Filter/>
+                                      <dxl:CTEConsumer CTEId="0" Columns="32,33,34,35,36,37,38,39,40,41">
+                                        <dxl:Properties>
+                                          <dxl:Cost StartupCost="0" TotalCost="431.000321" Rows="100.000000" Width="4"/>
+                                        </dxl:Properties>
+                                        <dxl:ProjList>
+                                          <dxl:ProjElem ColId="32" Alias="a">
+                                            <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="33" Alias="b">
+                                            <dxl:Ident ColId="33" ColName="b" TypeMdid="0.23.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="34" Alias="c">
+                                            <dxl:Ident ColId="34" ColName="c" TypeMdid="0.23.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="35" Alias="ctid">
+                                            <dxl:Ident ColId="35" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="36" Alias="xmin">
+                                            <dxl:Ident ColId="36" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="37" Alias="cmin">
+                                            <dxl:Ident ColId="37" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="38" Alias="xmax">
+                                            <dxl:Ident ColId="38" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="39" Alias="cmax">
+                                            <dxl:Ident ColId="39" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="40" Alias="tableoid">
+                                            <dxl:Ident ColId="40" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="41" Alias="gp_segment_id">
+                                            <dxl:Ident ColId="41" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                          </dxl:ProjElem>
+                                        </dxl:ProjList>
+                                      </dxl:CTEConsumer>
+                                    </dxl:Aggregate>
+                                  </dxl:GatherMotion>
+                                </dxl:Aggregate>
+                              </dxl:BroadcastMotion>
+                              <dxl:CTEConsumer CTEId="0" Columns="0,1,2,3,4,5,6,7,8,9">
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000321" Rows="100.000000" Width="4"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="0" Alias="a">
+                                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="1" Alias="b">
+                                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="2" Alias="c">
+                                    <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="3" Alias="ctid">
+                                    <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="4" Alias="xmin">
+                                    <dxl:Ident ColId="4" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="5" Alias="cmin">
+                                    <dxl:Ident ColId="5" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="6" Alias="xmax">
+                                    <dxl:Ident ColId="6" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="7" Alias="cmax">
+                                    <dxl:Ident ColId="7" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="8" Alias="tableoid">
+                                    <dxl:Ident ColId="8" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="9" Alias="gp_segment_id">
+                                    <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                              </dxl:CTEConsumer>
+                            </dxl:NestedLoopJoin>
+                          </dxl:Sort>
+                        </dxl:GatherMotion>
+                        <dxl:LimitCount>
+                          <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
+                        </dxl:LimitCount>
+                        <dxl:LimitOffset>
+                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                        </dxl:LimitOffset>
+                      </dxl:Limit>
+                    </dxl:Aggregate>
+                    <dxl:Materialize Eager="true">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="1324034.930349" Rows="1.000000" Width="24"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="10" Alias="percentile_cont">
+                          <dxl:Ident ColId="10" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="13" Alias="percentile_cont">
+                          <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="16" Alias="percentile_cont">
+                          <dxl:Ident ColId="16" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="1324034.930325" Rows="1.000000" Width="24"/>
+                        </dxl:Properties>
+                        <dxl:GroupingColumns/>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="10" Alias="percentile_cont">
+                            <dxl:AggFunc AggMdid="0.327945.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                              <dxl:ValuesList ParamType="aggargs">
+                                <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                                </dxl:Cast>
+                                <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA0D8=" DoubleValue="0.250000"/>
+                                <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                                <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                              </dxl:ValuesList>
+                              <dxl:ValuesList ParamType="aggdirectargs"/>
+                              <dxl:ValuesList ParamType="aggorder"/>
+                              <dxl:ValuesList ParamType="aggdistinct"/>
+                            </dxl:AggFunc>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="13" Alias="percentile_cont">
+                            <dxl:AggFunc AggMdid="0.327945.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                              <dxl:ValuesList ParamType="aggargs">
+                                <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                                </dxl:Cast>
+                                <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+                                <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                                <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                              </dxl:ValuesList>
+                              <dxl:ValuesList ParamType="aggdirectargs"/>
+                              <dxl:ValuesList ParamType="aggorder"/>
+                              <dxl:ValuesList ParamType="aggdistinct"/>
+                            </dxl:AggFunc>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="16" Alias="percentile_cont">
+                            <dxl:AggFunc AggMdid="0.327945.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                              <dxl:ValuesList ParamType="aggargs">
+                                <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                                </dxl:Cast>
+                                <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA6D8=" DoubleValue="0.750000"/>
+                                <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                                <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                              </dxl:ValuesList>
+                              <dxl:ValuesList ParamType="aggdirectargs"/>
+                              <dxl:ValuesList ParamType="aggorder"/>
+                              <dxl:ValuesList ParamType="aggdistinct"/>
+                            </dxl:AggFunc>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:Limit>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="1324034.929519" Rows="100.000000" Width="12"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="0" Alias="a">
+                              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                              <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="1324034.928319" Rows="100.000000" Width="12"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="0" Alias="a">
+                                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                                <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:SortingColumnList>
+                              <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                            </dxl:SortingColumnList>
+                            <dxl:Sort SortDiscardDuplicates="false">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="1324034.923847" Rows="100.000000" Width="12"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="0" Alias="a">
+                                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                                  <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:SortingColumnList>
+                                <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                              </dxl:SortingColumnList>
+                              <dxl:LimitCount/>
+                              <dxl:LimitOffset/>
+                              <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="1324034.912373" Rows="100.000000" Width="12"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="0" Alias="a">
+                                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                                    <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:JoinFilter>
+                                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                </dxl:JoinFilter>
+                                <dxl:BroadcastMotion InputSegments="0" OutputSegments="0,1,2">
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000797" Rows="3.000000" Width="8"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                                      <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:SortingColumnList/>
+                                  <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.000367" Rows="1.000000" Width="8"/>
+                                    </dxl:Properties>
+                                    <dxl:GroupingColumns/>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                                        <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
+                                          <dxl:ValuesList ParamType="aggargs">
+                                            <dxl:Ident ColId="47" ColName="ColRef_0047" TypeMdid="0.20.1.0"/>
+                                          </dxl:ValuesList>
+                                          <dxl:ValuesList ParamType="aggdirectargs"/>
+                                          <dxl:ValuesList ParamType="aggorder"/>
+                                          <dxl:ValuesList ParamType="aggdistinct"/>
+                                        </dxl:AggFunc>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="431.000366" Rows="1.000000" Width="8"/>
+                                      </dxl:Properties>
+                                      <dxl:ProjList>
+                                        <dxl:ProjElem ColId="47" Alias="ColRef_0047">
+                                          <dxl:Ident ColId="47" ColName="ColRef_0047" TypeMdid="0.20.1.0"/>
+                                        </dxl:ProjElem>
+                                      </dxl:ProjList>
+                                      <dxl:Filter/>
+                                      <dxl:SortingColumnList/>
+                                      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                                        <dxl:Properties>
+                                          <dxl:Cost StartupCost="0" TotalCost="431.000336" Rows="1.000000" Width="8"/>
+                                        </dxl:Properties>
+                                        <dxl:GroupingColumns/>
+                                        <dxl:ProjList>
+                                          <dxl:ProjElem ColId="47" Alias="ColRef_0047">
+                                            <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
+                                              <dxl:ValuesList ParamType="aggargs">
+                                                <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>
+                                              </dxl:ValuesList>
+                                              <dxl:ValuesList ParamType="aggdirectargs"/>
+                                              <dxl:ValuesList ParamType="aggorder"/>
+                                              <dxl:ValuesList ParamType="aggdistinct"/>
+                                            </dxl:AggFunc>
+                                          </dxl:ProjElem>
+                                        </dxl:ProjList>
+                                        <dxl:Filter/>
+                                        <dxl:CTEConsumer CTEId="0" Columns="32,33,34,35,36,37,38,39,40,41">
+                                          <dxl:Properties>
+                                            <dxl:Cost StartupCost="0" TotalCost="431.000321" Rows="100.000000" Width="4"/>
+                                          </dxl:Properties>
+                                          <dxl:ProjList>
+                                            <dxl:ProjElem ColId="32" Alias="a">
+                                              <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>
+                                            </dxl:ProjElem>
+                                            <dxl:ProjElem ColId="33" Alias="b">
+                                              <dxl:Ident ColId="33" ColName="b" TypeMdid="0.23.1.0"/>
+                                            </dxl:ProjElem>
+                                            <dxl:ProjElem ColId="34" Alias="c">
+                                              <dxl:Ident ColId="34" ColName="c" TypeMdid="0.23.1.0"/>
+                                            </dxl:ProjElem>
+                                            <dxl:ProjElem ColId="35" Alias="ctid">
+                                              <dxl:Ident ColId="35" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                            </dxl:ProjElem>
+                                            <dxl:ProjElem ColId="36" Alias="xmin">
+                                              <dxl:Ident ColId="36" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                            </dxl:ProjElem>
+                                            <dxl:ProjElem ColId="37" Alias="cmin">
+                                              <dxl:Ident ColId="37" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                            </dxl:ProjElem>
+                                            <dxl:ProjElem ColId="38" Alias="xmax">
+                                              <dxl:Ident ColId="38" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                            </dxl:ProjElem>
+                                            <dxl:ProjElem ColId="39" Alias="cmax">
+                                              <dxl:Ident ColId="39" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                            </dxl:ProjElem>
+                                            <dxl:ProjElem ColId="40" Alias="tableoid">
+                                              <dxl:Ident ColId="40" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                            </dxl:ProjElem>
+                                            <dxl:ProjElem ColId="41" Alias="gp_segment_id">
+                                              <dxl:Ident ColId="41" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                            </dxl:ProjElem>
+                                          </dxl:ProjList>
+                                        </dxl:CTEConsumer>
+                                      </dxl:Aggregate>
+                                    </dxl:GatherMotion>
+                                  </dxl:Aggregate>
+                                </dxl:BroadcastMotion>
+                                <dxl:CTEConsumer CTEId="0" Columns="0,1,2,3,4,5,6,7,8,9">
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000321" Rows="100.000000" Width="4"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="0" Alias="a">
+                                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="1" Alias="b">
+                                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="2" Alias="c">
+                                      <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="3" Alias="ctid">
+                                      <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="4" Alias="xmin">
+                                      <dxl:Ident ColId="4" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="5" Alias="cmin">
+                                      <dxl:Ident ColId="5" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="6" Alias="xmax">
+                                      <dxl:Ident ColId="6" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="7" Alias="cmax">
+                                      <dxl:Ident ColId="7" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="8" Alias="tableoid">
+                                      <dxl:Ident ColId="8" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="9" Alias="gp_segment_id">
+                                      <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                </dxl:CTEConsumer>
+                              </dxl:NestedLoopJoin>
+                            </dxl:Sort>
+                          </dxl:GatherMotion>
+                          <dxl:LimitCount>
+                            <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
+                          </dxl:LimitCount>
+                          <dxl:LimitOffset>
+                            <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                          </dxl:LimitOffset>
+                        </dxl:Limit>
+                      </dxl:Aggregate>
+                    </dxl:Materialize>
+                  </dxl:NestedLoopJoin>
+                  <dxl:Materialize Eager="true">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="1324034.930349" Rows="1.000000" Width="24"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="12" Alias="percentile_cont">
+                        <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="15" Alias="percentile_cont">
+                        <dxl:Ident ColId="15" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="18" Alias="percentile_cont">
+                        <dxl:Ident ColId="18" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="1324034.930325" Rows="1.000000" Width="24"/>
+                      </dxl:Properties>
+                      <dxl:GroupingColumns/>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="12" Alias="percentile_cont">
+                          <dxl:AggFunc AggMdid="0.327945.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                              </dxl:Cast>
+                              <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA0D8=" DoubleValue="0.250000"/>
+                              <dxl:Ident ColId="44" ColName="ColRef_0044" TypeMdid="0.20.1.0"/>
+                              <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="15" Alias="percentile_cont">
+                          <dxl:AggFunc AggMdid="0.327945.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                              </dxl:Cast>
+                              <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+                              <dxl:Ident ColId="44" ColName="ColRef_0044" TypeMdid="0.20.1.0"/>
+                              <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="18" Alias="percentile_cont">
+                          <dxl:AggFunc AggMdid="0.327945.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                              </dxl:Cast>
+                              <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA6D8=" DoubleValue="0.750000"/>
+                              <dxl:Ident ColId="44" ColName="ColRef_0044" TypeMdid="0.20.1.0"/>
+                              <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:Limit>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="1324034.929519" Rows="100.000000" Width="12"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="2" Alias="c">
+                            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="44" Alias="ColRef_0044">
+                            <dxl:Ident ColId="44" ColName="ColRef_0044" TypeMdid="0.20.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="1324034.928319" Rows="100.000000" Width="12"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="2" Alias="c">
+                              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="44" Alias="ColRef_0044">
+                              <dxl:Ident ColId="44" ColName="ColRef_0044" TypeMdid="0.20.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList>
+                            <dxl:SortingColumn ColId="2" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                          </dxl:SortingColumnList>
+                          <dxl:Sort SortDiscardDuplicates="false">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="1324034.923847" Rows="100.000000" Width="12"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="2" Alias="c">
+                                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="44" Alias="ColRef_0044">
+                                <dxl:Ident ColId="44" ColName="ColRef_0044" TypeMdid="0.20.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:SortingColumnList>
+                              <dxl:SortingColumn ColId="2" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                            </dxl:SortingColumnList>
+                            <dxl:LimitCount/>
+                            <dxl:LimitOffset/>
+                            <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="1324034.912373" Rows="100.000000" Width="12"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="2" Alias="c">
+                                  <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="44" Alias="ColRef_0044">
+                                  <dxl:Ident ColId="44" ColName="ColRef_0044" TypeMdid="0.20.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:JoinFilter>
+                                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                              </dxl:JoinFilter>
+                              <dxl:BroadcastMotion InputSegments="0" OutputSegments="0,1,2">
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000797" Rows="3.000000" Width="8"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="44" Alias="ColRef_0044">
+                                    <dxl:Ident ColId="44" ColName="ColRef_0044" TypeMdid="0.20.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:SortingColumnList/>
+                                <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000367" Rows="1.000000" Width="8"/>
+                                  </dxl:Properties>
+                                  <dxl:GroupingColumns/>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="44" Alias="ColRef_0044">
+                                      <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
+                                        <dxl:ValuesList ParamType="aggargs">
+                                          <dxl:Ident ColId="45" ColName="ColRef_0045" TypeMdid="0.20.1.0"/>
+                                        </dxl:ValuesList>
+                                        <dxl:ValuesList ParamType="aggdirectargs"/>
+                                        <dxl:ValuesList ParamType="aggorder"/>
+                                        <dxl:ValuesList ParamType="aggdistinct"/>
+                                      </dxl:AggFunc>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.000366" Rows="1.000000" Width="8"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="45" Alias="ColRef_0045">
+                                        <dxl:Ident ColId="45" ColName="ColRef_0045" TypeMdid="0.20.1.0"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:SortingColumnList/>
+                                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="431.000336" Rows="1.000000" Width="8"/>
+                                      </dxl:Properties>
+                                      <dxl:GroupingColumns/>
+                                      <dxl:ProjList>
+                                        <dxl:ProjElem ColId="45" Alias="ColRef_0045">
+                                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
+                                            <dxl:ValuesList ParamType="aggargs">
+                                              <dxl:Ident ColId="34" ColName="c" TypeMdid="0.23.1.0"/>
+                                            </dxl:ValuesList>
+                                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                                            <dxl:ValuesList ParamType="aggorder"/>
+                                            <dxl:ValuesList ParamType="aggdistinct"/>
+                                          </dxl:AggFunc>
+                                        </dxl:ProjElem>
+                                      </dxl:ProjList>
+                                      <dxl:Filter/>
+                                      <dxl:CTEConsumer CTEId="0" Columns="32,33,34,35,36,37,38,39,40,41">
+                                        <dxl:Properties>
+                                          <dxl:Cost StartupCost="0" TotalCost="431.000321" Rows="100.000000" Width="4"/>
+                                        </dxl:Properties>
+                                        <dxl:ProjList>
+                                          <dxl:ProjElem ColId="32" Alias="a">
+                                            <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="33" Alias="b">
+                                            <dxl:Ident ColId="33" ColName="b" TypeMdid="0.23.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="34" Alias="c">
+                                            <dxl:Ident ColId="34" ColName="c" TypeMdid="0.23.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="35" Alias="ctid">
+                                            <dxl:Ident ColId="35" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="36" Alias="xmin">
+                                            <dxl:Ident ColId="36" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="37" Alias="cmin">
+                                            <dxl:Ident ColId="37" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="38" Alias="xmax">
+                                            <dxl:Ident ColId="38" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="39" Alias="cmax">
+                                            <dxl:Ident ColId="39" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="40" Alias="tableoid">
+                                            <dxl:Ident ColId="40" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="41" Alias="gp_segment_id">
+                                            <dxl:Ident ColId="41" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                          </dxl:ProjElem>
+                                        </dxl:ProjList>
+                                      </dxl:CTEConsumer>
+                                    </dxl:Aggregate>
+                                  </dxl:GatherMotion>
+                                </dxl:Aggregate>
+                              </dxl:BroadcastMotion>
+                              <dxl:CTEConsumer CTEId="0" Columns="0,1,2,3,4,5,6,7,8,9">
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000321" Rows="100.000000" Width="4"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="0" Alias="a">
+                                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="1" Alias="b">
+                                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="2" Alias="c">
+                                    <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="3" Alias="ctid">
+                                    <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="4" Alias="xmin">
+                                    <dxl:Ident ColId="4" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="5" Alias="cmin">
+                                    <dxl:Ident ColId="5" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="6" Alias="xmax">
+                                    <dxl:Ident ColId="6" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="7" Alias="cmax">
+                                    <dxl:Ident ColId="7" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="8" Alias="tableoid">
+                                    <dxl:Ident ColId="8" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="9" Alias="gp_segment_id">
+                                    <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                              </dxl:CTEConsumer>
+                            </dxl:NestedLoopJoin>
+                          </dxl:Sort>
+                        </dxl:GatherMotion>
+                        <dxl:LimitCount>
+                          <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
+                        </dxl:LimitCount>
+                        <dxl:LimitOffset>
+                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                        </dxl:LimitOffset>
+                      </dxl:Limit>
+                    </dxl:Aggregate>
+                  </dxl:Materialize>
+                </dxl:NestedLoopJoin>
+              </dxl:RandomMotion>
+            </dxl:Sequence>
+          </dxl:Result>
+        </dxl:Result>
+      </dxl:PhysicalCTAS>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_array_fraction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_array_fraction.mdp
@@ -1,0 +1,384 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Objective:
+Test pre-processing step does not split the ordered-set aggs into NLJ when
+passing in an ARRAY of fractions
+
+CREATE EXTENSION gp_percentile_agg;
+SET optimizer_enable_orderedagg=on;
+CREATE TABLE foo(a1 int, a2 double precision, a3 interval, a4 timestamp, a5 timestamptz);
+EXPLAIN SELECT percentile_cont(ARRAY[0.25, 0.5]) WITHIN GROUP(ORDER BY a1) FROM foo;
+
+                                     QUERY PLAN
+ Aggregate  (cost=0.00..431.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+         ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=4)
+Optimizer: Pivotal Optimizer (GPORCA)
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,103043,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBAgg Mdid="0.3980.1.0" Name="percentile_cont" IsOrdered="true" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.1022.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.17.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1184.1.0" Name="timestamptz" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1999.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7112.1.0"/>
+        <dxl:EqualityOp Mdid="0.1320.1.0"/>
+        <dxl:InequalityOp Mdid="0.1321.1.0"/>
+        <dxl:LessThanOp Mdid="0.1322.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1323.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1324.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1325.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1314.1.0"/>
+        <dxl:ArrayType Mdid="0.1185.1.0"/>
+        <dxl:MinAgg Mdid="0.2143.1.0"/>
+        <dxl:MaxAgg Mdid="0.2127.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1186.1.0" Name="interval" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="16" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1983.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7116.1.0"/>
+        <dxl:EqualityOp Mdid="0.1330.1.0"/>
+        <dxl:InequalityOp Mdid="0.1331.1.0"/>
+        <dxl:LessThanOp Mdid="0.1332.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1333.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1334.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1335.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1315.1.0"/>
+        <dxl:ArrayType Mdid="0.1187.1.0"/>
+        <dxl:MinAgg Mdid="0.2144.1.0"/>
+        <dxl:MaxAgg Mdid="0.2128.1.0"/>
+        <dxl:AvgAgg Mdid="0.2106.1.0"/>
+        <dxl:SumAgg Mdid="0.2113.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.164182.1.0.0" Name="a1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
+        <dxl:EqualityOp Mdid="0.670.1.0"/>
+        <dxl:InequalityOp Mdid="0.671.1.0"/>
+        <dxl:LessThanOp Mdid="0.672.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
+        <dxl:ComparisonOp Mdid="0.355.1.0"/>
+        <dxl:ArrayType Mdid="0.1022.1.0"/>
+        <dxl:MinAgg Mdid="0.2136.1.0"/>
+        <dxl:MaxAgg Mdid="0.2120.1.0"/>
+        <dxl:AvgAgg Mdid="0.2105.1.0"/>
+        <dxl:SumAgg Mdid="0.2111.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBFunc Mdid="0.316.1.0" Name="float8" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:RelationStatistics Mdid="2.164182.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.164182.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="11,5" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a2" Attno="2" Mdid="0.701.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a3" Attno="3" Mdid="0.1186.1.0" Nullable="true" ColWidth="16">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a4" Attno="4" Mdid="0.1114.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a5" Attno="5" Mdid="0.1184.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.1114.1.0" Name="timestamp" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2040.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7111.1.0"/>
+        <dxl:EqualityOp Mdid="0.2060.1.0"/>
+        <dxl:InequalityOp Mdid="0.2061.1.0"/>
+        <dxl:LessThanOp Mdid="0.2062.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2063.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2064.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2065.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2045.1.0"/>
+        <dxl:ArrayType Mdid="0.1115.1.0"/>
+        <dxl:MinAgg Mdid="0.2142.1.0"/>
+        <dxl:MaxAgg Mdid="0.2126.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:MDCast Mdid="3.23.1.0;701.1.0" Name="float8" BinaryCoercible="false" SourceTypeId="0.23.1.0" DestinationTypeId="0.701.1.0" CastFuncId="0.316.1.0" CoercePathType="1"/>
+      <dxl:Type Mdid="0.1022.1.0" Name="_float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.627.1.0"/>
+        <dxl:EqualityOp Mdid="0.1070.1.0"/>
+        <dxl:InequalityOp Mdid="0.1071.1.0"/>
+        <dxl:LessThanOp Mdid="0.1072.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1074.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1073.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1075.1.0"/>
+        <dxl:ComparisonOp Mdid="0.382.1.0"/>
+        <dxl:ArrayType Mdid="0.0.0.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.6219.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.1022.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalGroupBy>
+        <dxl:GroupingColumns/>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="13" Alias="percentile_cont">
+            <dxl:AggFunc AggMdid="0.3980.1.0" AggDistinct="false" AggStage="Normal" AggKind="o">
+              <dxl:ValuesList ParamType="aggargs">
+                <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
+                  <dxl:Ident ColId="1" ColName="a1" TypeMdid="0.23.1.0"/>
+                </dxl:FuncExpr>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdirectargs">
+                <dxl:ConstValue TypeMdid="0.1022.1.0" Value="AAAAKAEAAAAAAAAAvQIAAAIAAAABAAAAAAAAAAAA0D8AAAAAAADgPw=="/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggorder">
+                <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="672" SortNullsFirst="false" IsHashable="true"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdistinct"/>
+            </dxl:AggFunc>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
+              <dxl:Column ColId="3" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
+              <dxl:Column ColId="4" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
+              <dxl:Column ColId="5" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
+              <dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="7" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="12" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalGroupBy>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.000093" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:GroupingColumns/>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="12" Alias="percentile_cont">
+            <dxl:AggFunc AggMdid="0.3980.1.0" AggDistinct="false" AggStage="Normal" AggKind="o">
+              <dxl:ValuesList ParamType="aggargs">
+                <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                  <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                </dxl:Cast>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdirectargs">
+                <dxl:ConstValue TypeMdid="0.1022.1.0" Value="AAAAKAEAAAAAAAAAvQIAAAIAAAABAAAAAAAAAAAA0D8AAAAAAADgPw=="/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggorder">
+                <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="672" SortNullsFirst="false" IsHashable="true"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdistinct"/>
+            </dxl:AggFunc>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000093" Rows="1.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a1">
+              <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000041" Rows="1.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a1">
+                <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="6" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="9" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="10" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="11" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:GatherMotion>
+      </dxl:Aggregate>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>
+

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_computed_col.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_computed_col.mdp
@@ -1,0 +1,380 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Objective:
+Test pre-processing step does not split the ordered-set aggs into NLJ when
+ordering on a computed column
+
+CREATE EXTENSION gp_percentile_agg;
+SET optimizer_enable_orderedagg=on;
+CREATE TABLE foo(a1 int, a2 double precision, a3 interval, a4 timestamp, a5 timestamptz);
+EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1+10) FROM foo;
+
+                                     QUERY PLAN
+ Aggregate  (cost=0.00..431.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+         ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=4)
+Optimizer: Pivotal Optimizer (GPORCA)
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,103043,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBAgg Mdid="0.3974.1.0" Name="percentile_cont" IsOrdered="true" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.17.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1184.1.0" Name="timestamptz" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1999.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7112.1.0"/>
+        <dxl:EqualityOp Mdid="0.1320.1.0"/>
+        <dxl:InequalityOp Mdid="0.1321.1.0"/>
+        <dxl:LessThanOp Mdid="0.1322.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1323.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1324.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1325.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1314.1.0"/>
+        <dxl:ArrayType Mdid="0.1185.1.0"/>
+        <dxl:MinAgg Mdid="0.2143.1.0"/>
+        <dxl:MaxAgg Mdid="0.2127.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1186.1.0" Name="interval" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="16" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1983.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7116.1.0"/>
+        <dxl:EqualityOp Mdid="0.1330.1.0"/>
+        <dxl:InequalityOp Mdid="0.1331.1.0"/>
+        <dxl:LessThanOp Mdid="0.1332.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1333.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1334.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1335.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1315.1.0"/>
+        <dxl:ArrayType Mdid="0.1187.1.0"/>
+        <dxl:MinAgg Mdid="0.2144.1.0"/>
+        <dxl:MaxAgg Mdid="0.2128.1.0"/>
+        <dxl:AvgAgg Mdid="0.2106.1.0"/>
+        <dxl:SumAgg Mdid="0.2113.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.551.1.0" Name="+" ComparisonType="Other" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.23.1.0"/>
+        <dxl:OpFunc Mdid="0.177.1.0"/>
+        <dxl:Commutator Mdid="0.551.1.0"/>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.164182.1.0.0" Name="a1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBFunc Mdid="0.316.1.0" Name="float8" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
+        <dxl:EqualityOp Mdid="0.670.1.0"/>
+        <dxl:InequalityOp Mdid="0.671.1.0"/>
+        <dxl:LessThanOp Mdid="0.672.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
+        <dxl:ComparisonOp Mdid="0.355.1.0"/>
+        <dxl:ArrayType Mdid="0.1022.1.0"/>
+        <dxl:MinAgg Mdid="0.2136.1.0"/>
+        <dxl:MaxAgg Mdid="0.2120.1.0"/>
+        <dxl:AvgAgg Mdid="0.2105.1.0"/>
+        <dxl:SumAgg Mdid="0.2111.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.164182.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.164182.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="11,5" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a2" Attno="2" Mdid="0.701.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a3" Attno="3" Mdid="0.1186.1.0" Nullable="true" ColWidth="16">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a4" Attno="4" Mdid="0.1114.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a5" Attno="5" Mdid="0.1184.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.1114.1.0" Name="timestamp" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2040.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7111.1.0"/>
+        <dxl:EqualityOp Mdid="0.2060.1.0"/>
+        <dxl:InequalityOp Mdid="0.2061.1.0"/>
+        <dxl:LessThanOp Mdid="0.2062.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2063.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2064.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2065.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2045.1.0"/>
+        <dxl:ArrayType Mdid="0.1115.1.0"/>
+        <dxl:MinAgg Mdid="0.2142.1.0"/>
+        <dxl:MaxAgg Mdid="0.2126.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:MDCast Mdid="3.23.1.0;701.1.0" Name="float8" BinaryCoercible="false" SourceTypeId="0.23.1.0" DestinationTypeId="0.701.1.0" CastFuncId="0.316.1.0" CoercePathType="1"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalGroupBy>
+        <dxl:GroupingColumns/>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="13" Alias="percentile_cont">
+            <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.164162.1.0">
+              <dxl:ValuesList ParamType="aggargs">
+                <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
+                  <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                    <dxl:Ident ColId="1" ColName="a1" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                  </dxl:OpExpr>
+                </dxl:FuncExpr>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdirectargs">
+                <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggorder">
+                <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="672" SortNullsFirst="false" IsHashable="true"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdistinct"/>
+            </dxl:AggFunc>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
+              <dxl:Column ColId="3" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
+              <dxl:Column ColId="4" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
+              <dxl:Column ColId="5" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
+              <dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="7" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="12" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalGroupBy>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.000093" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:GroupingColumns/>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="12" Alias="percentile_cont">
+            <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o">
+              <dxl:ValuesList ParamType="aggargs">
+                <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                  <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                    <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                  </dxl:OpExpr>
+                </dxl:Cast>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdirectargs">
+                <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggorder">
+                <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="672" SortNullsFirst="false" IsHashable="true"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdistinct"/>
+            </dxl:AggFunc>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000093" Rows="1.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a1">
+              <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000041" Rows="1.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a1">
+                <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="6" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="9" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="10" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="11" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:GatherMotion>
+      </dxl:Aggregate>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_diffcol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_diffcol.mdp
@@ -1,0 +1,924 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Objective:
+Test pre-processing step converts multiple ordered-set aggs on different columns
+into a NLJ joining GbAgg expression containing ordered aggs split to
+gp_percentile agg on different sorted columns
+
+CREATE EXTENSION gp_percentile_agg;
+SET optimizer_enable_orderedagg=on;
+CREATE TABLE foo(a1 int, a2 double precision, a3 interval, a4 timestamp, a5 timestamptz);
+EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_cont(0.5) WITHIN GROUP(ORDER BY a2) FROM foo;
+
+                                                   QUERY PLAN
+ Sequence  (cost=0.00..2712059529.06 rows=1 width=16)
+   ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=1)
+         ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=42)
+                     ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=42)
+   ->  Nested Loop  (cost=0.00..2712059098.06 rows=1 width=16)
+         Join Filter: true
+         ->  Aggregate  (cost=0.00..1324032.08 rows=1 width=8)
+               ->  Limit  (cost=0.00..1324032.08 rows=1 width=12)
+                     ->  Sort  (cost=0.00..1324032.08 rows=1 width=12)
+                           Sort Key: share0_ref4.a1
+                           ->  Nested Loop  (cost=0.00..1324032.08 rows=1 width=12)
+                                 Join Filter: true
+                                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                                       ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=4)
+         ->  Aggregate  (cost=0.00..1324032.13 rows=1 width=8)
+               ->  Limit  (cost=0.00..1324032.13 rows=1 width=16)
+                     ->  Sort  (cost=0.00..1324032.13 rows=1 width=16)
+                           Sort Key: share0_ref3.a2
+                           ->  Nested Loop  (cost=0.00..1324032.13 rows=1 width=16)
+                                 Join Filter: true
+                                 ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,103043,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBAgg Mdid="0.3974.1.0" Name="percentile_cont" IsOrdered="true" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.17.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.672.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.701.1.0"/>
+        <dxl:RightType Mdid="0.701.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.295.1.0"/>
+        <dxl:Commutator Mdid="0.674.1.0"/>
+        <dxl:InverseOp Mdid="0.675.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1970.1.0"/>
+          <dxl:Opfamily Mdid="0.7024.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.1184.1.0" Name="timestamptz" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1999.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7112.1.0"/>
+        <dxl:EqualityOp Mdid="0.1320.1.0"/>
+        <dxl:InequalityOp Mdid="0.1321.1.0"/>
+        <dxl:LessThanOp Mdid="0.1322.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1323.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1324.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1325.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1314.1.0"/>
+        <dxl:ArrayType Mdid="0.1185.1.0"/>
+        <dxl:MinAgg Mdid="0.2143.1.0"/>
+        <dxl:MaxAgg Mdid="0.2127.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1186.1.0" Name="interval" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="16" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1983.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7116.1.0"/>
+        <dxl:EqualityOp Mdid="0.1330.1.0"/>
+        <dxl:InequalityOp Mdid="0.1331.1.0"/>
+        <dxl:LessThanOp Mdid="0.1332.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1333.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1334.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1335.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1315.1.0"/>
+        <dxl:ArrayType Mdid="0.1187.1.0"/>
+        <dxl:MinAgg Mdid="0.2144.1.0"/>
+        <dxl:MaxAgg Mdid="0.2128.1.0"/>
+        <dxl:AvgAgg Mdid="0.2106.1.0"/>
+        <dxl:SumAgg Mdid="0.2113.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.164182.1.0.1" Name="a2" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.164182.1.0.0" Name="a1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBFunc Mdid="0.316.1.0" Name="float8" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
+        <dxl:EqualityOp Mdid="0.670.1.0"/>
+        <dxl:InequalityOp Mdid="0.671.1.0"/>
+        <dxl:LessThanOp Mdid="0.672.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
+        <dxl:ComparisonOp Mdid="0.355.1.0"/>
+        <dxl:ArrayType Mdid="0.1022.1.0"/>
+        <dxl:MinAgg Mdid="0.2136.1.0"/>
+        <dxl:MaxAgg Mdid="0.2120.1.0"/>
+        <dxl:AvgAgg Mdid="0.2105.1.0"/>
+        <dxl:SumAgg Mdid="0.2111.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.164162.1.0" Name="gp_percentile_cont" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:RelationStatistics Mdid="2.164182.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.164182.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="11,5" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a2" Attno="2" Mdid="0.701.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a3" Attno="3" Mdid="0.1186.1.0" Nullable="true" ColWidth="16">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a4" Attno="4" Mdid="0.1114.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a5" Attno="5" Mdid="0.1184.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.1114.1.0" Name="timestamp" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2040.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7111.1.0"/>
+        <dxl:EqualityOp Mdid="0.2060.1.0"/>
+        <dxl:InequalityOp Mdid="0.2061.1.0"/>
+        <dxl:LessThanOp Mdid="0.2062.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2063.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2064.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2065.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2045.1.0"/>
+        <dxl:ArrayType Mdid="0.1115.1.0"/>
+        <dxl:MinAgg Mdid="0.2142.1.0"/>
+        <dxl:MaxAgg Mdid="0.2126.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBAgg Mdid="0.2147.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:MDCast Mdid="3.23.1.0;701.1.0" Name="float8" BinaryCoercible="false" SourceTypeId="0.23.1.0" DestinationTypeId="0.701.1.0" CastFuncId="0.316.1.0" CoercePathType="1"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+        <dxl:Ident ColId="14" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalGroupBy>
+        <dxl:GroupingColumns/>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="13" Alias="percentile_cont">
+            <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.164162.1.0">
+              <dxl:ValuesList ParamType="aggargs">
+                <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
+                  <dxl:Ident ColId="1" ColName="a1" TypeMdid="0.23.1.0"/>
+                </dxl:FuncExpr>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdirectargs">
+                <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggorder">
+                <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="672" SortNullsFirst="false" IsHashable="true"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdistinct"/>
+            </dxl:AggFunc>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="14" Alias="percentile_cont">
+            <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.164162.1.0">
+              <dxl:ValuesList ParamType="aggargs">
+                <dxl:Ident ColId="2" ColName="a2" TypeMdid="0.701.1.0"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdirectargs">
+                <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggorder">
+                <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="672" SortNullsFirst="false" IsHashable="true"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdistinct"/>
+            </dxl:AggFunc>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
+              <dxl:Column ColId="3" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
+              <dxl:Column ColId="4" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
+              <dxl:Column ColId="5" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
+              <dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="7" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="12" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalGroupBy>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="244">
+      <dxl:Sequence>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="2712059529.061808" Rows="1.000000" Width="16"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="12" Alias="percentile_cont">
+            <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="13" Alias="percentile_cont">
+            <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:CTEProducer CTEId="0" Columns="14,15,16,17,18,19,20,21,22">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000197" Rows="1.000000" Width="1"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="14" Alias="a1">
+              <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="15" Alias="a2">
+              <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="16" Alias="ctid">
+              <dxl:Ident ColId="16" ColName="ctid" TypeMdid="0.27.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="17" Alias="xmin">
+              <dxl:Ident ColId="17" ColName="xmin" TypeMdid="0.28.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="18" Alias="cmin">
+              <dxl:Ident ColId="18" ColName="cmin" TypeMdid="0.29.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="19" Alias="xmax">
+              <dxl:Ident ColId="19" ColName="xmax" TypeMdid="0.28.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="20" Alias="cmax">
+              <dxl:Ident ColId="20" ColName="cmax" TypeMdid="0.29.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="21" Alias="tableoid">
+              <dxl:Ident ColId="21" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="22" Alias="gp_segment_id">
+              <dxl:Ident ColId="22" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000196" Rows="1.000000" Width="42"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="14" Alias="a1">
+                <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="15" Alias="a2">
+                <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="16" Alias="ctid">
+                <dxl:Ident ColId="16" ColName="ctid" TypeMdid="0.27.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="17" Alias="xmin">
+                <dxl:Ident ColId="17" ColName="xmin" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="18" Alias="cmin">
+                <dxl:Ident ColId="18" ColName="cmin" TypeMdid="0.29.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="19" Alias="xmax">
+                <dxl:Ident ColId="19" ColName="xmax" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="20" Alias="cmax">
+                <dxl:Ident ColId="20" ColName="cmax" TypeMdid="0.29.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="21" Alias="tableoid">
+                <dxl:Ident ColId="21" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="22" Alias="gp_segment_id">
+                <dxl:Ident ColId="22" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="42"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="14" Alias="a1">
+                  <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="15" Alias="a2">
+                  <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="16" Alias="ctid">
+                  <dxl:Ident ColId="16" ColName="ctid" TypeMdid="0.27.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="17" Alias="xmin">
+                  <dxl:Ident ColId="17" ColName="xmin" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="18" Alias="cmin">
+                  <dxl:Ident ColId="18" ColName="cmin" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="19" Alias="xmax">
+                  <dxl:Ident ColId="19" ColName="xmax" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="20" Alias="cmax">
+                  <dxl:Ident ColId="20" ColName="cmax" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="21" Alias="tableoid">
+                  <dxl:Ident ColId="21" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="22" Alias="gp_segment_id">
+                  <dxl:Ident ColId="22" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
+                <dxl:Columns>
+                  <dxl:Column ColId="14" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="15" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="23" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
+                  <dxl:Column ColId="24" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="25" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="16" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="17" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="18" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="19" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="20" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:GatherMotion>
+        </dxl:CTEProducer>
+        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="2712059098.061594" Rows="1.000000" Width="16"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="12" Alias="percentile_cont">
+              <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="13" Alias="percentile_cont">
+              <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:JoinFilter>
+            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+          </dxl:JoinFilter>
+          <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.082180" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:GroupingColumns/>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="12" Alias="percentile_cont">
+                <dxl:AggFunc AggMdid="0.164162.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                      <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                    </dxl:Cast>
+                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+                    <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                  <dxl:ValuesList ParamType="aggorder"/>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:Limit>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.082178" Rows="1.000000" Width="12"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="a1">
+                  <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                  <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Sort SortDiscardDuplicates="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1324032.082166" Rows="1.000000" Width="12"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="a1">
+                    <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                    <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="1324032.082166" Rows="1.000000" Width="12"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="a1">
+                      <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                      <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:JoinFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:JoinFilter>
+                  <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:GroupingColumns/>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                        <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                          <dxl:ValuesList ParamType="aggargs">
+                            <dxl:Ident ColId="26" ColName="a1" TypeMdid="0.23.1.0"/>
+                          </dxl:ValuesList>
+                          <dxl:ValuesList ParamType="aggdirectargs"/>
+                          <dxl:ValuesList ParamType="aggorder"/>
+                          <dxl:ValuesList ParamType="aggdistinct"/>
+                        </dxl:AggFunc>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:CTEConsumer CTEId="0" Columns="26,27,28,29,30,31,32,33,34">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="26" Alias="a1">
+                          <dxl:Ident ColId="26" ColName="a1" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="27" Alias="a2">
+                          <dxl:Ident ColId="27" ColName="a2" TypeMdid="0.701.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="28" Alias="ctid">
+                          <dxl:Ident ColId="28" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="29" Alias="xmin">
+                          <dxl:Ident ColId="29" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="30" Alias="cmin">
+                          <dxl:Ident ColId="30" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="31" Alias="xmax">
+                          <dxl:Ident ColId="31" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="32" Alias="cmax">
+                          <dxl:Ident ColId="32" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="33" Alias="tableoid">
+                          <dxl:Ident ColId="33" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="34" Alias="gp_segment_id">
+                          <dxl:Ident ColId="34" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                    </dxl:CTEConsumer>
+                  </dxl:Aggregate>
+                  <dxl:Materialize Eager="true">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="a1">
+                        <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="1" Alias="a2">
+                        <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="5" Alias="ctid">
+                        <dxl:Ident ColId="5" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="6" Alias="xmin">
+                        <dxl:Ident ColId="6" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="7" Alias="cmin">
+                        <dxl:Ident ColId="7" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="8" Alias="xmax">
+                        <dxl:Ident ColId="8" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="9" Alias="cmax">
+                        <dxl:Ident ColId="9" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="10" Alias="tableoid">
+                        <dxl:Ident ColId="10" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="11" Alias="gp_segment_id">
+                        <dxl:Ident ColId="11" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:CTEConsumer CTEId="0" Columns="0,1,5,6,7,8,9,10,11">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="0" Alias="a1">
+                          <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="1" Alias="a2">
+                          <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="5" Alias="ctid">
+                          <dxl:Ident ColId="5" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="6" Alias="xmin">
+                          <dxl:Ident ColId="6" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="7" Alias="cmin">
+                          <dxl:Ident ColId="7" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="8" Alias="xmax">
+                          <dxl:Ident ColId="8" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="9" Alias="cmax">
+                          <dxl:Ident ColId="9" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="10" Alias="tableoid">
+                          <dxl:Ident ColId="10" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="11" Alias="gp_segment_id">
+                          <dxl:Ident ColId="11" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                    </dxl:CTEConsumer>
+                  </dxl:Materialize>
+                </dxl:NestedLoopJoin>
+              </dxl:Sort>
+              <dxl:LimitCount>
+                <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
+              </dxl:LimitCount>
+              <dxl:LimitOffset>
+                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+              </dxl:LimitOffset>
+            </dxl:Limit>
+          </dxl:Aggregate>
+          <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.130690" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:GroupingColumns/>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="13" Alias="percentile_cont">
+                <dxl:AggFunc AggMdid="0.164162.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+                    <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                  <dxl:ValuesList ParamType="aggorder"/>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:Limit>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.130687" Rows="1.000000" Width="16"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="1" Alias="a2">
+                  <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                  <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Sort SortDiscardDuplicates="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="1" Alias="a2">
+                    <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                    <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="1" SortOperatorMdid="0.672.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="1" Alias="a2">
+                      <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                      <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:JoinFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:JoinFilter>
+                  <dxl:CTEConsumer CTEId="0" Columns="0,1,5,6,7,8,9,10,11">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="a1">
+                        <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="1" Alias="a2">
+                        <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="5" Alias="ctid">
+                        <dxl:Ident ColId="5" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="6" Alias="xmin">
+                        <dxl:Ident ColId="6" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="7" Alias="cmin">
+                        <dxl:Ident ColId="7" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="8" Alias="xmax">
+                        <dxl:Ident ColId="8" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="9" Alias="cmax">
+                        <dxl:Ident ColId="9" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="10" Alias="tableoid">
+                        <dxl:Ident ColId="10" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="11" Alias="gp_segment_id">
+                        <dxl:Ident ColId="11" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                  </dxl:CTEConsumer>
+                  <dxl:Materialize Eager="true">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                        <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:GroupingColumns/>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Ident ColId="27" ColName="a2" TypeMdid="0.701.1.0"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:CTEConsumer CTEId="0" Columns="26,27,28,29,30,31,32,33,34">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="26" Alias="a1">
+                            <dxl:Ident ColId="26" ColName="a1" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="27" Alias="a2">
+                            <dxl:Ident ColId="27" ColName="a2" TypeMdid="0.701.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="28" Alias="ctid">
+                            <dxl:Ident ColId="28" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="29" Alias="xmin">
+                            <dxl:Ident ColId="29" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="30" Alias="cmin">
+                            <dxl:Ident ColId="30" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="31" Alias="xmax">
+                            <dxl:Ident ColId="31" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="32" Alias="cmax">
+                            <dxl:Ident ColId="32" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="33" Alias="tableoid">
+                            <dxl:Ident ColId="33" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="34" Alias="gp_segment_id">
+                            <dxl:Ident ColId="34" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                      </dxl:CTEConsumer>
+                    </dxl:Aggregate>
+                  </dxl:Materialize>
+                </dxl:NestedLoopJoin>
+              </dxl:Sort>
+              <dxl:LimitCount>
+                <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
+              </dxl:LimitCount>
+              <dxl:LimitOffset>
+                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+              </dxl:LimitOffset>
+            </dxl:Limit>
+          </dxl:Aggregate>
+        </dxl:NestedLoopJoin>
+      </dxl:Sequence>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_samecol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_samecol.mdp
@@ -1,0 +1,714 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Objective:
+Test pre-processing step converts multiple ordered-set aggs on same column into
+a GbAgg expression containing multiple ordered aggs split to multiple
+gp_percentile aggs on the same sorted input from NLJ between the column value
+and count
+
+CREATE EXTENSION gp_percentile_agg;
+SET optimizer_enable_orderedagg=on;
+CREATE TABLE foo(a1 int, a2 double precision, a3 interval, a4 timestamp, a5 timestamptz);
+EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_disc(0.5) WITHIN GROUP(ORDER BY a2) FROM foo;
+
+                                                   QUERY PLAN
+ Sequence  (cost=0.00..1324463.13 rows=1 width=16)
+   ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=1)
+         ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=42)
+                     ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=42)
+   ->  Aggregate  (cost=0.00..1324032.13 rows=1 width=16)
+         ->  Limit  (cost=0.00..1324032.13 rows=1 width=16)
+               ->  Sort  (cost=0.00..1324032.13 rows=1 width=16)
+                     Sort Key: share0_ref3.a2
+                     ->  Nested Loop  (cost=0.00..1324032.13 rows=1 width=16)
+                           Join Filter: true
+                           ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(16 rows)
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,103043,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBAgg Mdid="0.3972.1.0" Name="percentile_disc" IsOrdered="true" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.2283.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.17.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:GPDBAgg Mdid="0.3974.1.0" Name="percentile_cont" IsOrdered="true" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.17.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.672.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.701.1.0"/>
+        <dxl:RightType Mdid="0.701.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.295.1.0"/>
+        <dxl:Commutator Mdid="0.674.1.0"/>
+        <dxl:InverseOp Mdid="0.675.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1970.1.0"/>
+          <dxl:Opfamily Mdid="0.7024.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.1184.1.0" Name="timestamptz" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1999.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7112.1.0"/>
+        <dxl:EqualityOp Mdid="0.1320.1.0"/>
+        <dxl:InequalityOp Mdid="0.1321.1.0"/>
+        <dxl:LessThanOp Mdid="0.1322.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1323.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1324.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1325.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1314.1.0"/>
+        <dxl:ArrayType Mdid="0.1185.1.0"/>
+        <dxl:MinAgg Mdid="0.2143.1.0"/>
+        <dxl:MaxAgg Mdid="0.2127.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1186.1.0" Name="interval" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="16" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1983.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7116.1.0"/>
+        <dxl:EqualityOp Mdid="0.1330.1.0"/>
+        <dxl:InequalityOp Mdid="0.1331.1.0"/>
+        <dxl:LessThanOp Mdid="0.1332.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1333.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1334.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1335.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1315.1.0"/>
+        <dxl:ArrayType Mdid="0.1187.1.0"/>
+        <dxl:MinAgg Mdid="0.2144.1.0"/>
+        <dxl:MaxAgg Mdid="0.2128.1.0"/>
+        <dxl:AvgAgg Mdid="0.2106.1.0"/>
+        <dxl:SumAgg Mdid="0.2113.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.164182.1.0.1" Name="a2" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.164182.1.0.0" Name="a1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
+        <dxl:EqualityOp Mdid="0.670.1.0"/>
+        <dxl:InequalityOp Mdid="0.671.1.0"/>
+        <dxl:LessThanOp Mdid="0.672.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
+        <dxl:ComparisonOp Mdid="0.355.1.0"/>
+        <dxl:ArrayType Mdid="0.1022.1.0"/>
+        <dxl:MinAgg Mdid="0.2136.1.0"/>
+        <dxl:MaxAgg Mdid="0.2120.1.0"/>
+        <dxl:AvgAgg Mdid="0.2105.1.0"/>
+        <dxl:SumAgg Mdid="0.2111.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.164166.1.0" Name="gp_percentile_disc" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.2283.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.2283.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:GPDBAgg Mdid="0.164162.1.0" Name="gp_percentile_cont" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:RelationStatistics Mdid="2.164182.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.164182.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="11,5" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a2" Attno="2" Mdid="0.701.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a3" Attno="3" Mdid="0.1186.1.0" Nullable="true" ColWidth="16">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a4" Attno="4" Mdid="0.1114.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a5" Attno="5" Mdid="0.1184.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.1114.1.0" Name="timestamp" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2040.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7111.1.0"/>
+        <dxl:EqualityOp Mdid="0.2060.1.0"/>
+        <dxl:InequalityOp Mdid="0.2061.1.0"/>
+        <dxl:LessThanOp Mdid="0.2062.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2063.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2064.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2065.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2045.1.0"/>
+        <dxl:ArrayType Mdid="0.1115.1.0"/>
+        <dxl:MinAgg Mdid="0.2142.1.0"/>
+        <dxl:MaxAgg Mdid="0.2126.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.2147.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:Type Mdid="0.2283.1.0" Name="anyelement" IsRedistributable="false" IsHashable="false" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.0.0.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.0.0.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+        <dxl:Ident ColId="14" ColName="percentile_disc" TypeMdid="0.701.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalGroupBy>
+        <dxl:GroupingColumns/>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="13" Alias="percentile_cont">
+            <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.164162.1.0">
+              <dxl:ValuesList ParamType="aggargs">
+                <dxl:Ident ColId="2" ColName="a2" TypeMdid="0.701.1.0"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdirectargs">
+                <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggorder">
+                <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="672" SortNullsFirst="false" IsHashable="true"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdistinct"/>
+            </dxl:AggFunc>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="14" Alias="percentile_disc">
+            <dxl:AggFunc AggMdid="0.3972.1.0" AggDistinct="false" AggStage="Normal" TypeMdid="0.701.1.0" AggKind="o" GpAggMdid="0.164166.1.0">
+              <dxl:ValuesList ParamType="aggargs">
+                <dxl:Ident ColId="2" ColName="a2" TypeMdid="0.701.1.0"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdirectargs">
+                <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggorder">
+                <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="672" SortNullsFirst="false" IsHashable="true"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdistinct"/>
+            </dxl:AggFunc>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
+              <dxl:Column ColId="3" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
+              <dxl:Column ColId="4" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
+              <dxl:Column ColId="5" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
+              <dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="7" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="12" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalGroupBy>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="10">
+      <dxl:Sequence>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1324463.130907" Rows="1.000000" Width="16"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="12" Alias="percentile_cont">
+            <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="13" Alias="percentile_disc">
+            <dxl:Ident ColId="13" ColName="percentile_disc" TypeMdid="0.701.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:CTEProducer CTEId="0" Columns="14,15,16,17,18,19,20,21,22">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000197" Rows="1.000000" Width="1"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="14" Alias="a1">
+              <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="15" Alias="a2">
+              <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="16" Alias="ctid">
+              <dxl:Ident ColId="16" ColName="ctid" TypeMdid="0.27.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="17" Alias="xmin">
+              <dxl:Ident ColId="17" ColName="xmin" TypeMdid="0.28.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="18" Alias="cmin">
+              <dxl:Ident ColId="18" ColName="cmin" TypeMdid="0.29.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="19" Alias="xmax">
+              <dxl:Ident ColId="19" ColName="xmax" TypeMdid="0.28.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="20" Alias="cmax">
+              <dxl:Ident ColId="20" ColName="cmax" TypeMdid="0.29.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="21" Alias="tableoid">
+              <dxl:Ident ColId="21" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="22" Alias="gp_segment_id">
+              <dxl:Ident ColId="22" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000196" Rows="1.000000" Width="42"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="14" Alias="a1">
+                <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="15" Alias="a2">
+                <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="16" Alias="ctid">
+                <dxl:Ident ColId="16" ColName="ctid" TypeMdid="0.27.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="17" Alias="xmin">
+                <dxl:Ident ColId="17" ColName="xmin" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="18" Alias="cmin">
+                <dxl:Ident ColId="18" ColName="cmin" TypeMdid="0.29.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="19" Alias="xmax">
+                <dxl:Ident ColId="19" ColName="xmax" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="20" Alias="cmax">
+                <dxl:Ident ColId="20" ColName="cmax" TypeMdid="0.29.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="21" Alias="tableoid">
+                <dxl:Ident ColId="21" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="22" Alias="gp_segment_id">
+                <dxl:Ident ColId="22" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="42"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="14" Alias="a1">
+                  <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="15" Alias="a2">
+                  <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="16" Alias="ctid">
+                  <dxl:Ident ColId="16" ColName="ctid" TypeMdid="0.27.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="17" Alias="xmin">
+                  <dxl:Ident ColId="17" ColName="xmin" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="18" Alias="cmin">
+                  <dxl:Ident ColId="18" ColName="cmin" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="19" Alias="xmax">
+                  <dxl:Ident ColId="19" ColName="xmax" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="20" Alias="cmax">
+                  <dxl:Ident ColId="20" ColName="cmax" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="21" Alias="tableoid">
+                  <dxl:Ident ColId="21" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="22" Alias="gp_segment_id">
+                  <dxl:Ident ColId="22" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
+                <dxl:Columns>
+                  <dxl:Column ColId="14" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="15" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="23" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
+                  <dxl:Column ColId="24" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="25" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="16" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="17" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="18" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="19" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="20" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:GatherMotion>
+        </dxl:CTEProducer>
+        <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1324032.130694" Rows="1.000000" Width="16"/>
+          </dxl:Properties>
+          <dxl:GroupingColumns/>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="12" Alias="percentile_cont">
+              <dxl:AggFunc AggMdid="0.164162.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                <dxl:ValuesList ParamType="aggargs">
+                  <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+                  <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                </dxl:ValuesList>
+                <dxl:ValuesList ParamType="aggdirectargs"/>
+                <dxl:ValuesList ParamType="aggorder"/>
+                <dxl:ValuesList ParamType="aggdistinct"/>
+              </dxl:AggFunc>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="13" Alias="percentile_disc">
+              <dxl:AggFunc AggMdid="0.164166.1.0" AggDistinct="false" AggStage="Normal" TypeMdid="0.701.1.0" AggKind="n">
+                <dxl:ValuesList ParamType="aggargs">
+                  <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+                  <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                </dxl:ValuesList>
+                <dxl:ValuesList ParamType="aggdirectargs"/>
+                <dxl:ValuesList ParamType="aggorder"/>
+                <dxl:ValuesList ParamType="aggdistinct"/>
+              </dxl:AggFunc>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:Limit>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.130687" Rows="1.000000" Width="16"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="1" Alias="a2">
+                <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Sort SortDiscardDuplicates="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="1" Alias="a2">
+                  <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                  <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="1" SortOperatorMdid="0.672.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:LimitCount/>
+              <dxl:LimitOffset/>
+              <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="1" Alias="a2">
+                    <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                    <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:JoinFilter>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:JoinFilter>
+                <dxl:CTEConsumer CTEId="0" Columns="0,1,5,6,7,8,9,10,11">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="a1">
+                      <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="1" Alias="a2">
+                      <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="5" Alias="ctid">
+                      <dxl:Ident ColId="5" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="6" Alias="xmin">
+                      <dxl:Ident ColId="6" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="7" Alias="cmin">
+                      <dxl:Ident ColId="7" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="8" Alias="xmax">
+                      <dxl:Ident ColId="8" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="9" Alias="cmax">
+                      <dxl:Ident ColId="9" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="10" Alias="tableoid">
+                      <dxl:Ident ColId="10" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="11" Alias="gp_segment_id">
+                      <dxl:Ident ColId="11" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                </dxl:CTEConsumer>
+                <dxl:Materialize Eager="true">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                      <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:GroupingColumns/>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                        <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                          <dxl:ValuesList ParamType="aggargs">
+                            <dxl:Ident ColId="27" ColName="a2" TypeMdid="0.701.1.0"/>
+                          </dxl:ValuesList>
+                          <dxl:ValuesList ParamType="aggdirectargs"/>
+                          <dxl:ValuesList ParamType="aggorder"/>
+                          <dxl:ValuesList ParamType="aggdistinct"/>
+                        </dxl:AggFunc>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:CTEConsumer CTEId="0" Columns="26,27,28,29,30,31,32,33,34">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="26" Alias="a1">
+                          <dxl:Ident ColId="26" ColName="a1" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="27" Alias="a2">
+                          <dxl:Ident ColId="27" ColName="a2" TypeMdid="0.701.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="28" Alias="ctid">
+                          <dxl:Ident ColId="28" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="29" Alias="xmin">
+                          <dxl:Ident ColId="29" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="30" Alias="cmin">
+                          <dxl:Ident ColId="30" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="31" Alias="xmax">
+                          <dxl:Ident ColId="31" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="32" Alias="cmax">
+                          <dxl:Ident ColId="32" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="33" Alias="tableoid">
+                          <dxl:Ident ColId="33" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="34" Alias="gp_segment_id">
+                          <dxl:Ident ColId="34" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                    </dxl:CTEConsumer>
+                  </dxl:Aggregate>
+                </dxl:Materialize>
+              </dxl:NestedLoopJoin>
+            </dxl:Sort>
+            <dxl:LimitCount>
+              <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
+            </dxl:LimitCount>
+            <dxl:LimitOffset>
+              <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+            </dxl:LimitOffset>
+          </dxl:Limit>
+        </dxl:Aggregate>
+      </dxl:Sequence>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_samecol_difforderespec.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_samecol_difforderespec.mdp
@@ -1,0 +1,893 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Objective:
+Test pre-processing step converts multiple ordered-set aggs on same column(with
+diff order specification) into a NLJ joining GbAgg expression containing ordered
+aggs split to gp_percentile on same sorted column with different ordering
+
+CREATE EXTENSION gp_percentile_agg;
+SET optimizer_enable_orderedagg=on;
+CREATE TABLE foo(a1 int, a2 double precision, a3 interval, a4 timestamp, a5 timestamptz);
+EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_cont(0.5) WITHIN GROUP(ORDER BY a2 desc) FROM foo;
+
+                                                      QUERY PLAN
+ Sequence  (cost=0.00..2712059578.74 rows=1 width=16)
+   ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=1)
+         ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=42)
+                     ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=42)
+   ->  Nested Loop  (cost=0.00..2712059147.74 rows=1 width=16)
+         Join Filter: true
+         ->  Aggregate  (cost=0.00..1324032.13 rows=1 width=8)
+               ->  Limit  (cost=0.00..1324032.13 rows=1 width=16)
+                     ->  Sort  (cost=0.00..1324032.13 rows=1 width=16)
+                           Sort Key: share0_ref5.a2
+                           ->  Nested Loop  (cost=0.00..1324032.13 rows=1 width=16)
+                                 Join Filter: true
+                                 ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..1324032.13 rows=1 width=8)
+               ->  Limit  (cost=0.00..1324032.13 rows=1 width=16)
+                     ->  Sort  (cost=0.00..1324032.13 rows=1 width=16)
+                           Sort Key: share0_ref3.a2
+                           ->  Nested Loop  (cost=0.00..1324032.13 rows=1 width=16)
+                                 Join Filter: true
+                                 ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(28 rows)
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,103043,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBAgg Mdid="0.3974.1.0" Name="percentile_cont" IsOrdered="true" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.17.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.672.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.701.1.0"/>
+        <dxl:RightType Mdid="0.701.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.295.1.0"/>
+        <dxl:Commutator Mdid="0.674.1.0"/>
+        <dxl:InverseOp Mdid="0.675.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1970.1.0"/>
+          <dxl:Opfamily Mdid="0.7024.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.1184.1.0" Name="timestamptz" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1999.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7112.1.0"/>
+        <dxl:EqualityOp Mdid="0.1320.1.0"/>
+        <dxl:InequalityOp Mdid="0.1321.1.0"/>
+        <dxl:LessThanOp Mdid="0.1322.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1323.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1324.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1325.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1314.1.0"/>
+        <dxl:ArrayType Mdid="0.1185.1.0"/>
+        <dxl:MinAgg Mdid="0.2143.1.0"/>
+        <dxl:MaxAgg Mdid="0.2127.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.674.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.701.1.0"/>
+        <dxl:RightType Mdid="0.701.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.297.1.0"/>
+        <dxl:Commutator Mdid="0.672.1.0"/>
+        <dxl:InverseOp Mdid="0.673.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1970.1.0"/>
+          <dxl:Opfamily Mdid="0.7024.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.1186.1.0" Name="interval" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="16" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1983.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7116.1.0"/>
+        <dxl:EqualityOp Mdid="0.1330.1.0"/>
+        <dxl:InequalityOp Mdid="0.1331.1.0"/>
+        <dxl:LessThanOp Mdid="0.1332.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1333.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1334.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1335.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1315.1.0"/>
+        <dxl:ArrayType Mdid="0.1187.1.0"/>
+        <dxl:MinAgg Mdid="0.2144.1.0"/>
+        <dxl:MaxAgg Mdid="0.2128.1.0"/>
+        <dxl:AvgAgg Mdid="0.2106.1.0"/>
+        <dxl:SumAgg Mdid="0.2113.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.164182.1.0.1" Name="a2" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.164182.1.0.0" Name="a1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
+        <dxl:EqualityOp Mdid="0.670.1.0"/>
+        <dxl:InequalityOp Mdid="0.671.1.0"/>
+        <dxl:LessThanOp Mdid="0.672.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
+        <dxl:ComparisonOp Mdid="0.355.1.0"/>
+        <dxl:ArrayType Mdid="0.1022.1.0"/>
+        <dxl:MinAgg Mdid="0.2136.1.0"/>
+        <dxl:MaxAgg Mdid="0.2120.1.0"/>
+        <dxl:AvgAgg Mdid="0.2105.1.0"/>
+        <dxl:SumAgg Mdid="0.2111.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.164162.1.0" Name="gp_percentile_cont" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:RelationStatistics Mdid="2.164182.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.164182.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="11,5" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a2" Attno="2" Mdid="0.701.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a3" Attno="3" Mdid="0.1186.1.0" Nullable="true" ColWidth="16">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a4" Attno="4" Mdid="0.1114.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a5" Attno="5" Mdid="0.1184.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.1114.1.0" Name="timestamp" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2040.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7111.1.0"/>
+        <dxl:EqualityOp Mdid="0.2060.1.0"/>
+        <dxl:InequalityOp Mdid="0.2061.1.0"/>
+        <dxl:LessThanOp Mdid="0.2062.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2063.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2064.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2065.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2045.1.0"/>
+        <dxl:ArrayType Mdid="0.1115.1.0"/>
+        <dxl:MinAgg Mdid="0.2142.1.0"/>
+        <dxl:MaxAgg Mdid="0.2126.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.2147.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+        <dxl:Ident ColId="14" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalGroupBy>
+        <dxl:GroupingColumns/>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="13" Alias="percentile_cont">
+            <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.164162.1.0">
+              <dxl:ValuesList ParamType="aggargs">
+                <dxl:Ident ColId="2" ColName="a2" TypeMdid="0.701.1.0"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdirectargs">
+                <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggorder">
+                <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="672" SortNullsFirst="false" IsHashable="true"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdistinct"/>
+            </dxl:AggFunc>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="14" Alias="percentile_cont">
+            <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.164162.1.0">
+              <dxl:ValuesList ParamType="aggargs">
+                <dxl:Ident ColId="2" ColName="a2" TypeMdid="0.701.1.0"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdirectargs">
+                <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggorder">
+                <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="674" SortNullsFirst="true" IsHashable="true"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdistinct"/>
+            </dxl:AggFunc>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
+              <dxl:Column ColId="3" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
+              <dxl:Column ColId="4" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
+              <dxl:Column ColId="5" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
+              <dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="7" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="12" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalGroupBy>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="244">
+      <dxl:Sequence>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="2712059578.735769" Rows="1.000000" Width="16"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="12" Alias="percentile_cont">
+            <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="13" Alias="percentile_cont">
+            <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:CTEProducer CTEId="0" Columns="14,15,16,17,18,19,20,21,22">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000197" Rows="1.000000" Width="1"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="14" Alias="a1">
+              <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="15" Alias="a2">
+              <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="16" Alias="ctid">
+              <dxl:Ident ColId="16" ColName="ctid" TypeMdid="0.27.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="17" Alias="xmin">
+              <dxl:Ident ColId="17" ColName="xmin" TypeMdid="0.28.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="18" Alias="cmin">
+              <dxl:Ident ColId="18" ColName="cmin" TypeMdid="0.29.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="19" Alias="xmax">
+              <dxl:Ident ColId="19" ColName="xmax" TypeMdid="0.28.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="20" Alias="cmax">
+              <dxl:Ident ColId="20" ColName="cmax" TypeMdid="0.29.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="21" Alias="tableoid">
+              <dxl:Ident ColId="21" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="22" Alias="gp_segment_id">
+              <dxl:Ident ColId="22" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000196" Rows="1.000000" Width="42"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="14" Alias="a1">
+                <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="15" Alias="a2">
+                <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="16" Alias="ctid">
+                <dxl:Ident ColId="16" ColName="ctid" TypeMdid="0.27.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="17" Alias="xmin">
+                <dxl:Ident ColId="17" ColName="xmin" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="18" Alias="cmin">
+                <dxl:Ident ColId="18" ColName="cmin" TypeMdid="0.29.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="19" Alias="xmax">
+                <dxl:Ident ColId="19" ColName="xmax" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="20" Alias="cmax">
+                <dxl:Ident ColId="20" ColName="cmax" TypeMdid="0.29.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="21" Alias="tableoid">
+                <dxl:Ident ColId="21" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="22" Alias="gp_segment_id">
+                <dxl:Ident ColId="22" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="42"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="14" Alias="a1">
+                  <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="15" Alias="a2">
+                  <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="16" Alias="ctid">
+                  <dxl:Ident ColId="16" ColName="ctid" TypeMdid="0.27.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="17" Alias="xmin">
+                  <dxl:Ident ColId="17" ColName="xmin" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="18" Alias="cmin">
+                  <dxl:Ident ColId="18" ColName="cmin" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="19" Alias="xmax">
+                  <dxl:Ident ColId="19" ColName="xmax" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="20" Alias="cmax">
+                  <dxl:Ident ColId="20" ColName="cmax" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="21" Alias="tableoid">
+                  <dxl:Ident ColId="21" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="22" Alias="gp_segment_id">
+                  <dxl:Ident ColId="22" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
+                <dxl:Columns>
+                  <dxl:Column ColId="14" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="15" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="23" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
+                  <dxl:Column ColId="24" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="25" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="16" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="17" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="18" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="19" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="20" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:GatherMotion>
+        </dxl:CTEProducer>
+        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="2712059147.735556" Rows="1.000000" Width="16"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="12" Alias="percentile_cont">
+              <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="13" Alias="percentile_cont">
+              <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:JoinFilter>
+            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+          </dxl:JoinFilter>
+          <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.130690" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:GroupingColumns/>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="12" Alias="percentile_cont">
+                <dxl:AggFunc AggMdid="0.164162.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+                    <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                  <dxl:ValuesList ParamType="aggorder"/>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:Limit>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.130687" Rows="1.000000" Width="16"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="1" Alias="a2">
+                  <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                  <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Sort SortDiscardDuplicates="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="1" Alias="a2">
+                    <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                    <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="1" SortOperatorMdid="0.672.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="1" Alias="a2">
+                      <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                      <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:JoinFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:JoinFilter>
+                  <dxl:CTEConsumer CTEId="0" Columns="0,1,5,6,7,8,9,10,11">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="a1">
+                        <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="1" Alias="a2">
+                        <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="5" Alias="ctid">
+                        <dxl:Ident ColId="5" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="6" Alias="xmin">
+                        <dxl:Ident ColId="6" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="7" Alias="cmin">
+                        <dxl:Ident ColId="7" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="8" Alias="xmax">
+                        <dxl:Ident ColId="8" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="9" Alias="cmax">
+                        <dxl:Ident ColId="9" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="10" Alias="tableoid">
+                        <dxl:Ident ColId="10" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="11" Alias="gp_segment_id">
+                        <dxl:Ident ColId="11" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                  </dxl:CTEConsumer>
+                  <dxl:Materialize Eager="true">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                        <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:GroupingColumns/>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Ident ColId="27" ColName="a2" TypeMdid="0.701.1.0"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:CTEConsumer CTEId="0" Columns="26,27,28,29,30,31,32,33,34">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="26" Alias="a1">
+                            <dxl:Ident ColId="26" ColName="a1" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="27" Alias="a2">
+                            <dxl:Ident ColId="27" ColName="a2" TypeMdid="0.701.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="28" Alias="ctid">
+                            <dxl:Ident ColId="28" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="29" Alias="xmin">
+                            <dxl:Ident ColId="29" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="30" Alias="cmin">
+                            <dxl:Ident ColId="30" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="31" Alias="xmax">
+                            <dxl:Ident ColId="31" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="32" Alias="cmax">
+                            <dxl:Ident ColId="32" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="33" Alias="tableoid">
+                            <dxl:Ident ColId="33" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="34" Alias="gp_segment_id">
+                            <dxl:Ident ColId="34" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                      </dxl:CTEConsumer>
+                    </dxl:Aggregate>
+                  </dxl:Materialize>
+                </dxl:NestedLoopJoin>
+              </dxl:Sort>
+              <dxl:LimitCount>
+                <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
+              </dxl:LimitCount>
+              <dxl:LimitOffset>
+                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+              </dxl:LimitOffset>
+            </dxl:Limit>
+          </dxl:Aggregate>
+          <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.130690" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:GroupingColumns/>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="13" Alias="percentile_cont">
+                <dxl:AggFunc AggMdid="0.164162.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+                    <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                  <dxl:ValuesList ParamType="aggorder"/>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:Limit>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.130687" Rows="1.000000" Width="16"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="1" Alias="a2">
+                  <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                  <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Sort SortDiscardDuplicates="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="1" Alias="a2">
+                    <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                    <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="1" SortOperatorMdid="0.674.1.0" SortOperatorName="&gt;" SortNullsFirst="true"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="1" Alias="a2">
+                      <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                      <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:JoinFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:JoinFilter>
+                  <dxl:CTEConsumer CTEId="0" Columns="0,1,5,6,7,8,9,10,11">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="a1">
+                        <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="1" Alias="a2">
+                        <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="5" Alias="ctid">
+                        <dxl:Ident ColId="5" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="6" Alias="xmin">
+                        <dxl:Ident ColId="6" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="7" Alias="cmin">
+                        <dxl:Ident ColId="7" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="8" Alias="xmax">
+                        <dxl:Ident ColId="8" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="9" Alias="cmax">
+                        <dxl:Ident ColId="9" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="10" Alias="tableoid">
+                        <dxl:Ident ColId="10" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="11" Alias="gp_segment_id">
+                        <dxl:Ident ColId="11" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                  </dxl:CTEConsumer>
+                  <dxl:Materialize Eager="true">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                        <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:GroupingColumns/>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Ident ColId="27" ColName="a2" TypeMdid="0.701.1.0"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:CTEConsumer CTEId="0" Columns="26,27,28,29,30,31,32,33,34">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="26" Alias="a1">
+                            <dxl:Ident ColId="26" ColName="a1" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="27" Alias="a2">
+                            <dxl:Ident ColId="27" ColName="a2" TypeMdid="0.701.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="28" Alias="ctid">
+                            <dxl:Ident ColId="28" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="29" Alias="xmin">
+                            <dxl:Ident ColId="29" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="30" Alias="cmin">
+                            <dxl:Ident ColId="30" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="31" Alias="xmax">
+                            <dxl:Ident ColId="31" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="32" Alias="cmax">
+                            <dxl:Ident ColId="32" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="33" Alias="tableoid">
+                            <dxl:Ident ColId="33" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="34" Alias="gp_segment_id">
+                            <dxl:Ident ColId="34" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                      </dxl:CTEConsumer>
+                    </dxl:Aggregate>
+                  </dxl:Materialize>
+                </dxl:NestedLoopJoin>
+              </dxl:Sort>
+              <dxl:LimitCount>
+                <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
+              </dxl:LimitCount>
+              <dxl:LimitOffset>
+                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+              </dxl:LimitOffset>
+            </dxl:Limit>
+          </dxl:Aggregate>
+        </dxl:NestedLoopJoin>
+      </dxl:Sequence>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_single.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_single.mdp
@@ -1,0 +1,659 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Objective:
+Test pre-processing step converts an ordered-set agg into GbAgg expression
+containing ordered aggs split to gp_percentile on a sorted input from NLJ between
+the column value and count
+
+CREATE EXTENSION gp_percentile_agg;
+SET optimizer_enable_orderedagg=on;
+CREATE TABLE foo(a1 int, a2 double precision, a3 interval, a4 timestamp, a5 timestamptz);
+EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2) FROM foo;
+
+                                                   QUERY PLAN
+ Sequence  (cost=0.00..1324463.13 rows=1 width=8)
+   ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=1)
+         ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=42)
+                     ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=42)
+   ->  Aggregate  (cost=0.00..1324032.13 rows=1 width=8)
+         ->  Limit  (cost=0.00..1324032.13 rows=1 width=16)
+               ->  Sort  (cost=0.00..1324032.13 rows=1 width=16)
+                     Sort Key: share0_ref3.a2
+                     ->  Nested Loop  (cost=0.00..1324032.13 rows=1 width=16)
+                           Join Filter: true
+                           ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(16 rows)
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,103043,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBAgg Mdid="0.3974.1.0" Name="percentile_cont" IsOrdered="true" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.17.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.672.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.701.1.0"/>
+        <dxl:RightType Mdid="0.701.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.295.1.0"/>
+        <dxl:Commutator Mdid="0.674.1.0"/>
+        <dxl:InverseOp Mdid="0.675.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1970.1.0"/>
+          <dxl:Opfamily Mdid="0.7024.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.1184.1.0" Name="timestamptz" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1999.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7112.1.0"/>
+        <dxl:EqualityOp Mdid="0.1320.1.0"/>
+        <dxl:InequalityOp Mdid="0.1321.1.0"/>
+        <dxl:LessThanOp Mdid="0.1322.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1323.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1324.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1325.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1314.1.0"/>
+        <dxl:ArrayType Mdid="0.1185.1.0"/>
+        <dxl:MinAgg Mdid="0.2143.1.0"/>
+        <dxl:MaxAgg Mdid="0.2127.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1186.1.0" Name="interval" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="16" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1983.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7116.1.0"/>
+        <dxl:EqualityOp Mdid="0.1330.1.0"/>
+        <dxl:InequalityOp Mdid="0.1331.1.0"/>
+        <dxl:LessThanOp Mdid="0.1332.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1333.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1334.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1335.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1315.1.0"/>
+        <dxl:ArrayType Mdid="0.1187.1.0"/>
+        <dxl:MinAgg Mdid="0.2144.1.0"/>
+        <dxl:MaxAgg Mdid="0.2128.1.0"/>
+        <dxl:AvgAgg Mdid="0.2106.1.0"/>
+        <dxl:SumAgg Mdid="0.2113.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.164182.1.0.1" Name="a2" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.164182.1.0.0" Name="a1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
+        <dxl:EqualityOp Mdid="0.670.1.0"/>
+        <dxl:InequalityOp Mdid="0.671.1.0"/>
+        <dxl:LessThanOp Mdid="0.672.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
+        <dxl:ComparisonOp Mdid="0.355.1.0"/>
+        <dxl:ArrayType Mdid="0.1022.1.0"/>
+        <dxl:MinAgg Mdid="0.2136.1.0"/>
+        <dxl:MaxAgg Mdid="0.2120.1.0"/>
+        <dxl:AvgAgg Mdid="0.2105.1.0"/>
+        <dxl:SumAgg Mdid="0.2111.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.164162.1.0" Name="gp_percentile_cont" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:RelationStatistics Mdid="2.164182.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.164182.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="11,5" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a2" Attno="2" Mdid="0.701.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a3" Attno="3" Mdid="0.1186.1.0" Nullable="true" ColWidth="16">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a4" Attno="4" Mdid="0.1114.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a5" Attno="5" Mdid="0.1184.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.1114.1.0" Name="timestamp" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2040.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7111.1.0"/>
+        <dxl:EqualityOp Mdid="0.2060.1.0"/>
+        <dxl:InequalityOp Mdid="0.2061.1.0"/>
+        <dxl:LessThanOp Mdid="0.2062.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2063.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2064.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2065.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2045.1.0"/>
+        <dxl:ArrayType Mdid="0.1115.1.0"/>
+        <dxl:MinAgg Mdid="0.2142.1.0"/>
+        <dxl:MaxAgg Mdid="0.2126.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.2147.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalGroupBy>
+        <dxl:GroupingColumns/>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="13" Alias="percentile_cont">
+            <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.164162.1.0">
+              <dxl:ValuesList ParamType="aggargs">
+                <dxl:Ident ColId="2" ColName="a2" TypeMdid="0.701.1.0"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdirectargs">
+                <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggorder">
+                <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="672" SortNullsFirst="false" IsHashable="true"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdistinct"/>
+            </dxl:AggFunc>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
+              <dxl:Column ColId="3" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
+              <dxl:Column ColId="4" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
+              <dxl:Column ColId="5" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
+              <dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="7" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="12" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalGroupBy>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="10">
+      <dxl:Sequence>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1324463.130895" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="12" Alias="percentile_cont">
+            <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:CTEProducer CTEId="0" Columns="13,14,15,16,17,18,19,20,21">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000197" Rows="1.000000" Width="1"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="13" Alias="a1">
+              <dxl:Ident ColId="13" ColName="a1" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="14" Alias="a2">
+              <dxl:Ident ColId="14" ColName="a2" TypeMdid="0.701.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="15" Alias="ctid">
+              <dxl:Ident ColId="15" ColName="ctid" TypeMdid="0.27.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="16" Alias="xmin">
+              <dxl:Ident ColId="16" ColName="xmin" TypeMdid="0.28.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="17" Alias="cmin">
+              <dxl:Ident ColId="17" ColName="cmin" TypeMdid="0.29.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="18" Alias="xmax">
+              <dxl:Ident ColId="18" ColName="xmax" TypeMdid="0.28.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="19" Alias="cmax">
+              <dxl:Ident ColId="19" ColName="cmax" TypeMdid="0.29.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="20" Alias="tableoid">
+              <dxl:Ident ColId="20" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="21" Alias="gp_segment_id">
+              <dxl:Ident ColId="21" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000196" Rows="1.000000" Width="42"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="13" Alias="a1">
+                <dxl:Ident ColId="13" ColName="a1" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="14" Alias="a2">
+                <dxl:Ident ColId="14" ColName="a2" TypeMdid="0.701.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="15" Alias="ctid">
+                <dxl:Ident ColId="15" ColName="ctid" TypeMdid="0.27.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="16" Alias="xmin">
+                <dxl:Ident ColId="16" ColName="xmin" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="17" Alias="cmin">
+                <dxl:Ident ColId="17" ColName="cmin" TypeMdid="0.29.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="18" Alias="xmax">
+                <dxl:Ident ColId="18" ColName="xmax" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="19" Alias="cmax">
+                <dxl:Ident ColId="19" ColName="cmax" TypeMdid="0.29.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="20" Alias="tableoid">
+                <dxl:Ident ColId="20" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="21" Alias="gp_segment_id">
+                <dxl:Ident ColId="21" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="42"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="13" Alias="a1">
+                  <dxl:Ident ColId="13" ColName="a1" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="14" Alias="a2">
+                  <dxl:Ident ColId="14" ColName="a2" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="15" Alias="ctid">
+                  <dxl:Ident ColId="15" ColName="ctid" TypeMdid="0.27.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="16" Alias="xmin">
+                  <dxl:Ident ColId="16" ColName="xmin" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="17" Alias="cmin">
+                  <dxl:Ident ColId="17" ColName="cmin" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="18" Alias="xmax">
+                  <dxl:Ident ColId="18" ColName="xmax" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="19" Alias="cmax">
+                  <dxl:Ident ColId="19" ColName="cmax" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="20" Alias="tableoid">
+                  <dxl:Ident ColId="20" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="21" Alias="gp_segment_id">
+                  <dxl:Ident ColId="21" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
+                <dxl:Columns>
+                  <dxl:Column ColId="13" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="14" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="22" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
+                  <dxl:Column ColId="23" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="24" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="15" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="16" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="17" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="18" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="19" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="20" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="21" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:GatherMotion>
+        </dxl:CTEProducer>
+        <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1324032.130690" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:GroupingColumns/>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="12" Alias="percentile_cont">
+              <dxl:AggFunc AggMdid="0.164162.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                <dxl:ValuesList ParamType="aggargs">
+                  <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+                  <dxl:Ident ColId="40" ColName="ColRef_0040" TypeMdid="0.20.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                </dxl:ValuesList>
+                <dxl:ValuesList ParamType="aggdirectargs"/>
+                <dxl:ValuesList ParamType="aggorder"/>
+                <dxl:ValuesList ParamType="aggdistinct"/>
+              </dxl:AggFunc>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:Limit>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.130687" Rows="1.000000" Width="16"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="1" Alias="a2">
+                <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="40" Alias="ColRef_0040">
+                <dxl:Ident ColId="40" ColName="ColRef_0040" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Sort SortDiscardDuplicates="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="1" Alias="a2">
+                  <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="40" Alias="ColRef_0040">
+                  <dxl:Ident ColId="40" ColName="ColRef_0040" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="1" SortOperatorMdid="0.672.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:LimitCount/>
+              <dxl:LimitOffset/>
+              <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="1" Alias="a2">
+                    <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="40" Alias="ColRef_0040">
+                    <dxl:Ident ColId="40" ColName="ColRef_0040" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:JoinFilter>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:JoinFilter>
+                <dxl:CTEConsumer CTEId="0" Columns="0,1,5,6,7,8,9,10,11">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="a1">
+                      <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="1" Alias="a2">
+                      <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="5" Alias="ctid">
+                      <dxl:Ident ColId="5" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="6" Alias="xmin">
+                      <dxl:Ident ColId="6" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="7" Alias="cmin">
+                      <dxl:Ident ColId="7" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="8" Alias="xmax">
+                      <dxl:Ident ColId="8" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="9" Alias="cmax">
+                      <dxl:Ident ColId="9" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="10" Alias="tableoid">
+                      <dxl:Ident ColId="10" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="11" Alias="gp_segment_id">
+                      <dxl:Ident ColId="11" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                </dxl:CTEConsumer>
+                <dxl:Materialize Eager="true">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="40" Alias="ColRef_0040">
+                      <dxl:Ident ColId="40" ColName="ColRef_0040" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:GroupingColumns/>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="40" Alias="ColRef_0040">
+                        <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                          <dxl:ValuesList ParamType="aggargs">
+                            <dxl:Ident ColId="26" ColName="a2" TypeMdid="0.701.1.0"/>
+                          </dxl:ValuesList>
+                          <dxl:ValuesList ParamType="aggdirectargs"/>
+                          <dxl:ValuesList ParamType="aggorder"/>
+                          <dxl:ValuesList ParamType="aggdistinct"/>
+                        </dxl:AggFunc>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:CTEConsumer CTEId="0" Columns="25,26,27,28,29,30,31,32,33">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="25" Alias="a1">
+                          <dxl:Ident ColId="25" ColName="a1" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="26" Alias="a2">
+                          <dxl:Ident ColId="26" ColName="a2" TypeMdid="0.701.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="27" Alias="ctid">
+                          <dxl:Ident ColId="27" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="28" Alias="xmin">
+                          <dxl:Ident ColId="28" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="29" Alias="cmin">
+                          <dxl:Ident ColId="29" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="30" Alias="xmax">
+                          <dxl:Ident ColId="30" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="31" Alias="cmax">
+                          <dxl:Ident ColId="31" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="32" Alias="tableoid">
+                          <dxl:Ident ColId="32" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="33" Alias="gp_segment_id">
+                          <dxl:Ident ColId="33" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                    </dxl:CTEConsumer>
+                  </dxl:Aggregate>
+                </dxl:Materialize>
+              </dxl:NestedLoopJoin>
+            </dxl:Sort>
+            <dxl:LimitCount>
+              <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
+            </dxl:LimitCount>
+            <dxl:LimitOffset>
+              <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+            </dxl:LimitOffset>
+          </dxl:Limit>
+        </dxl:Aggregate>
+      </dxl:Sequence>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_with_groupby.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_with_groupby.mdp
@@ -1,0 +1,418 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Objective:
+Test pre-processing step does not split the ordered-set aggs into NLJ when
+the query has a GROUP BY clause
+
+CREATE EXTENSION gp_percentile_agg;
+SET optimizer_enable_orderedagg=on;
+CREATE TABLE foo(a1 int, a2 double precision, a3 interval, a4 timestamp, a5 timestamptz);
+EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1) FROM foo GROUP BY a1;
+
+                                  QUERY PLAN
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+   ->  Result  (cost=0.00..431.00 rows=1 width=8)
+         ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=8)
+               Group Key: a1
+               ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                     Sort Key: a1
+                     ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,103043,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBAgg Mdid="0.3974.1.0" Name="percentile_cont" IsOrdered="true" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.17.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1184.1.0" Name="timestamptz" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1999.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7112.1.0"/>
+        <dxl:EqualityOp Mdid="0.1320.1.0"/>
+        <dxl:InequalityOp Mdid="0.1321.1.0"/>
+        <dxl:LessThanOp Mdid="0.1322.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1323.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1324.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1325.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1314.1.0"/>
+        <dxl:ArrayType Mdid="0.1185.1.0"/>
+        <dxl:MinAgg Mdid="0.2143.1.0"/>
+        <dxl:MaxAgg Mdid="0.2127.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1186.1.0" Name="interval" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="16" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1983.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7116.1.0"/>
+        <dxl:EqualityOp Mdid="0.1330.1.0"/>
+        <dxl:InequalityOp Mdid="0.1331.1.0"/>
+        <dxl:LessThanOp Mdid="0.1332.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1333.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1334.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1335.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1315.1.0"/>
+        <dxl:ArrayType Mdid="0.1187.1.0"/>
+        <dxl:MinAgg Mdid="0.2144.1.0"/>
+        <dxl:MaxAgg Mdid="0.2128.1.0"/>
+        <dxl:AvgAgg Mdid="0.2106.1.0"/>
+        <dxl:SumAgg Mdid="0.2113.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.164182.1.0.0" Name="a1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBFunc Mdid="0.316.1.0" Name="float8" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
+        <dxl:EqualityOp Mdid="0.670.1.0"/>
+        <dxl:InequalityOp Mdid="0.671.1.0"/>
+        <dxl:LessThanOp Mdid="0.672.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
+        <dxl:ComparisonOp Mdid="0.355.1.0"/>
+        <dxl:ArrayType Mdid="0.1022.1.0"/>
+        <dxl:MinAgg Mdid="0.2136.1.0"/>
+        <dxl:MaxAgg Mdid="0.2120.1.0"/>
+        <dxl:AvgAgg Mdid="0.2105.1.0"/>
+        <dxl:SumAgg Mdid="0.2111.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.164182.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.164182.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="11,5" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a2" Attno="2" Mdid="0.701.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a3" Attno="3" Mdid="0.1186.1.0" Nullable="true" ColWidth="16">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a4" Attno="4" Mdid="0.1114.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a5" Attno="5" Mdid="0.1184.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.1114.1.0" Name="timestamp" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2040.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7111.1.0"/>
+        <dxl:EqualityOp Mdid="0.2060.1.0"/>
+        <dxl:InequalityOp Mdid="0.2061.1.0"/>
+        <dxl:LessThanOp Mdid="0.2062.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2063.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2064.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2065.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2045.1.0"/>
+        <dxl:ArrayType Mdid="0.1115.1.0"/>
+        <dxl:MinAgg Mdid="0.2142.1.0"/>
+        <dxl:MaxAgg Mdid="0.2126.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:MDCast Mdid="3.23.1.0;701.1.0" Name="float8" BinaryCoercible="false" SourceTypeId="0.23.1.0" DestinationTypeId="0.701.1.0" CastFuncId="0.316.1.0" CoercePathType="1"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalGroupBy>
+        <dxl:GroupingColumns>
+          <dxl:GroupingColumn ColId="1"/>
+        </dxl:GroupingColumns>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="13" Alias="percentile_cont">
+            <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.164162.1.0">
+              <dxl:ValuesList ParamType="aggargs">
+                <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
+                  <dxl:Ident ColId="1" ColName="a1" TypeMdid="0.23.1.0"/>
+                </dxl:FuncExpr>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdirectargs">
+                <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggorder">
+                <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="672" SortNullsFirst="false" IsHashable="true"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdistinct"/>
+            </dxl:AggFunc>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
+              <dxl:Column ColId="3" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
+              <dxl:Column ColId="4" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
+              <dxl:Column ColId="5" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
+              <dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="7" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="12" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalGroupBy>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.000083" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="12" Alias="percentile_cont">
+            <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="12" Alias="percentile_cont">
+              <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:GroupingColumns>
+              <dxl:GroupingColumn ColId="0"/>
+            </dxl:GroupingColumns>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="12" Alias="percentile_cont">
+                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                      <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                    </dxl:Cast>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs">
+                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggorder">
+                    <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="672" SortNullsFirst="false" IsHashable="true"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="0" Alias="a1">
+                <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:Sort SortDiscardDuplicates="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000048" Rows="1.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="a1">
+                  <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:LimitCount/>
+              <dxl:LimitOffset/>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000041" Rows="1.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="a1">
+                    <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="6" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="7" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="8" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="9" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="10" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="11" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:Sort>
+          </dxl:Aggregate>
+        </dxl:Result>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_with_nonOrderedAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_with_nonOrderedAgg.mdp
@@ -1,0 +1,1045 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Objective:
+Test pre-processing step converts multiple ordered-set aggs combined with non-ordered aggs into a NLJ joining GbAgg expression containing ordered
+aggs and GbAgg expression containing remaining non-ordered aggs
+
+CREATE EXTENSION gp_percentile_agg;
+SET optimizer_enable_orderedagg=on;
+CREATE TABLE foo(a1 int, a2 double precision, a3 interval, a4 timestamp, a5 timestamptz);
+EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_disc(0.5) WITHIN GROUP(ORDER BY a2 desc), count(*) FROM foo;
+
+                                                      QUERY PLAN
+ Sequence  (cost=0.00..1390608387896.22 rows=1 width=24)
+   ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=1)
+         ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=42)
+                     ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=42)
+   ->  Nested Loop  (cost=0.00..1390608387465.22 rows=1 width=24)
+         Join Filter: true
+         ->  Nested Loop  (cost=0.00..1356691540.25 rows=1 width=16)
+               Join Filter: true
+               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                           ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=1)
+               ->  Aggregate  (cost=0.00..1324032.08 rows=1 width=8)
+                     ->  Limit  (cost=0.00..1324032.08 rows=1 width=12)
+                           ->  Sort  (cost=0.00..1324032.08 rows=1 width=12)
+                                 Sort Key: share0_ref4.a1
+                                 ->  Nested Loop  (cost=0.00..1324032.08 rows=1 width=12)
+                                       Join Filter: true
+                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=4)
+                                       ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                                             ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=4)
+         ->  Aggregate  (cost=0.00..1324032.13 rows=1 width=8)
+               ->  Limit  (cost=0.00..1324032.13 rows=1 width=16)
+                     ->  Sort  (cost=0.00..1324032.13 rows=1 width=16)
+                           Sort Key: share0_ref3.a2
+                           ->  Nested Loop  (cost=0.00..1324032.13 rows=1 width=16)
+                                 Join Filter: true
+                                 ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(33 rows)
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,103043,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBAgg Mdid="0.3972.1.0" Name="percentile_disc" IsOrdered="true" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.2283.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.17.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:GPDBAgg Mdid="0.3974.1.0" Name="percentile_cont" IsOrdered="true" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.17.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.672.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.701.1.0"/>
+        <dxl:RightType Mdid="0.701.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.295.1.0"/>
+        <dxl:Commutator Mdid="0.674.1.0"/>
+        <dxl:InverseOp Mdid="0.675.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1970.1.0"/>
+          <dxl:Opfamily Mdid="0.7024.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.1184.1.0" Name="timestamptz" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1999.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7112.1.0"/>
+        <dxl:EqualityOp Mdid="0.1320.1.0"/>
+        <dxl:InequalityOp Mdid="0.1321.1.0"/>
+        <dxl:LessThanOp Mdid="0.1322.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1323.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1324.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1325.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1314.1.0"/>
+        <dxl:ArrayType Mdid="0.1185.1.0"/>
+        <dxl:MinAgg Mdid="0.2143.1.0"/>
+        <dxl:MaxAgg Mdid="0.2127.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.674.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.701.1.0"/>
+        <dxl:RightType Mdid="0.701.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.297.1.0"/>
+        <dxl:Commutator Mdid="0.672.1.0"/>
+        <dxl:InverseOp Mdid="0.673.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1970.1.0"/>
+          <dxl:Opfamily Mdid="0.7024.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.1186.1.0" Name="interval" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="16" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1983.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7116.1.0"/>
+        <dxl:EqualityOp Mdid="0.1330.1.0"/>
+        <dxl:InequalityOp Mdid="0.1331.1.0"/>
+        <dxl:LessThanOp Mdid="0.1332.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1333.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1334.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1335.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1315.1.0"/>
+        <dxl:ArrayType Mdid="0.1187.1.0"/>
+        <dxl:MinAgg Mdid="0.2144.1.0"/>
+        <dxl:MaxAgg Mdid="0.2128.1.0"/>
+        <dxl:AvgAgg Mdid="0.2106.1.0"/>
+        <dxl:SumAgg Mdid="0.2113.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.164182.1.0.1" Name="a2" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.164182.1.0.0" Name="a1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBFunc Mdid="0.316.1.0" Name="float8" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
+        <dxl:EqualityOp Mdid="0.670.1.0"/>
+        <dxl:InequalityOp Mdid="0.671.1.0"/>
+        <dxl:LessThanOp Mdid="0.672.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
+        <dxl:ComparisonOp Mdid="0.355.1.0"/>
+        <dxl:ArrayType Mdid="0.1022.1.0"/>
+        <dxl:MinAgg Mdid="0.2136.1.0"/>
+        <dxl:MaxAgg Mdid="0.2120.1.0"/>
+        <dxl:AvgAgg Mdid="0.2105.1.0"/>
+        <dxl:SumAgg Mdid="0.2111.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.164166.1.0" Name="gp_percentile_disc" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.2283.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.2283.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:GPDBAgg Mdid="0.164162.1.0" Name="gp_percentile_cont" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:RelationStatistics Mdid="2.164182.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.164182.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="11,5" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a2" Attno="2" Mdid="0.701.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a3" Attno="3" Mdid="0.1186.1.0" Nullable="true" ColWidth="16">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a4" Attno="4" Mdid="0.1114.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a5" Attno="5" Mdid="0.1184.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.1114.1.0" Name="timestamp" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2040.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7111.1.0"/>
+        <dxl:EqualityOp Mdid="0.2060.1.0"/>
+        <dxl:InequalityOp Mdid="0.2061.1.0"/>
+        <dxl:LessThanOp Mdid="0.2062.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2063.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2064.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2065.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2045.1.0"/>
+        <dxl:ArrayType Mdid="0.1115.1.0"/>
+        <dxl:MinAgg Mdid="0.2142.1.0"/>
+        <dxl:MaxAgg Mdid="0.2126.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBAgg Mdid="0.2147.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:Type Mdid="0.2283.1.0" Name="anyelement" IsRedistributable="false" IsHashable="false" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.0.0.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.0.0.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.2803.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:MDCast Mdid="3.23.1.0;701.1.0" Name="float8" BinaryCoercible="false" SourceTypeId="0.23.1.0" DestinationTypeId="0.701.1.0" CastFuncId="0.316.1.0" CoercePathType="1"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+        <dxl:Ident ColId="14" ColName="percentile_disc" TypeMdid="0.701.1.0"/>
+        <dxl:Ident ColId="15" ColName="count" TypeMdid="0.20.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalGroupBy>
+        <dxl:GroupingColumns/>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="13" Alias="percentile_cont">
+            <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.164162.1.0">
+              <dxl:ValuesList ParamType="aggargs">
+                <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
+                  <dxl:Ident ColId="1" ColName="a1" TypeMdid="0.23.1.0"/>
+                </dxl:FuncExpr>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdirectargs">
+                <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggorder">
+                <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="672" SortNullsFirst="false" IsHashable="true"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdistinct"/>
+            </dxl:AggFunc>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="14" Alias="percentile_disc">
+            <dxl:AggFunc AggMdid="0.3972.1.0" AggDistinct="false" AggStage="Normal" TypeMdid="0.701.1.0" AggKind="o" GpAggMdid="0.164166.1.0">
+              <dxl:ValuesList ParamType="aggargs">
+                <dxl:Ident ColId="2" ColName="a2" TypeMdid="0.701.1.0"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdirectargs">
+                <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggorder">
+                <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="674" SortNullsFirst="true" IsHashable="true"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdistinct"/>
+            </dxl:AggFunc>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="15" Alias="count">
+            <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+              <dxl:ValuesList ParamType="aggargs"/>
+              <dxl:ValuesList ParamType="aggdirectargs"/>
+              <dxl:ValuesList ParamType="aggorder"/>
+              <dxl:ValuesList ParamType="aggdistinct"/>
+            </dxl:AggFunc>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
+              <dxl:Column ColId="3" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
+              <dxl:Column ColId="4" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
+              <dxl:Column ColId="5" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
+              <dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="7" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="12" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalGroupBy>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="6318">
+      <dxl:Sequence>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1390608387896.216797" Rows="1.000000" Width="24"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="12" Alias="percentile_cont">
+            <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="13" Alias="percentile_disc">
+            <dxl:Ident ColId="13" ColName="percentile_disc" TypeMdid="0.701.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="14" Alias="count">
+            <dxl:Ident ColId="14" ColName="count" TypeMdid="0.20.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:CTEProducer CTEId="0" Columns="15,16,17,18,19,20,21,22,23">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000197" Rows="1.000000" Width="1"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="15" Alias="a1">
+              <dxl:Ident ColId="15" ColName="a1" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="16" Alias="a2">
+              <dxl:Ident ColId="16" ColName="a2" TypeMdid="0.701.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="17" Alias="ctid">
+              <dxl:Ident ColId="17" ColName="ctid" TypeMdid="0.27.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="18" Alias="xmin">
+              <dxl:Ident ColId="18" ColName="xmin" TypeMdid="0.28.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="19" Alias="cmin">
+              <dxl:Ident ColId="19" ColName="cmin" TypeMdid="0.29.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="20" Alias="xmax">
+              <dxl:Ident ColId="20" ColName="xmax" TypeMdid="0.28.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="21" Alias="cmax">
+              <dxl:Ident ColId="21" ColName="cmax" TypeMdid="0.29.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="22" Alias="tableoid">
+              <dxl:Ident ColId="22" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="23" Alias="gp_segment_id">
+              <dxl:Ident ColId="23" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000196" Rows="1.000000" Width="42"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="15" Alias="a1">
+                <dxl:Ident ColId="15" ColName="a1" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="16" Alias="a2">
+                <dxl:Ident ColId="16" ColName="a2" TypeMdid="0.701.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="17" Alias="ctid">
+                <dxl:Ident ColId="17" ColName="ctid" TypeMdid="0.27.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="18" Alias="xmin">
+                <dxl:Ident ColId="18" ColName="xmin" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="19" Alias="cmin">
+                <dxl:Ident ColId="19" ColName="cmin" TypeMdid="0.29.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="20" Alias="xmax">
+                <dxl:Ident ColId="20" ColName="xmax" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="21" Alias="cmax">
+                <dxl:Ident ColId="21" ColName="cmax" TypeMdid="0.29.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="22" Alias="tableoid">
+                <dxl:Ident ColId="22" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="23" Alias="gp_segment_id">
+                <dxl:Ident ColId="23" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="42"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="15" Alias="a1">
+                  <dxl:Ident ColId="15" ColName="a1" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="16" Alias="a2">
+                  <dxl:Ident ColId="16" ColName="a2" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="17" Alias="ctid">
+                  <dxl:Ident ColId="17" ColName="ctid" TypeMdid="0.27.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="18" Alias="xmin">
+                  <dxl:Ident ColId="18" ColName="xmin" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="19" Alias="cmin">
+                  <dxl:Ident ColId="19" ColName="cmin" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="20" Alias="xmax">
+                  <dxl:Ident ColId="20" ColName="xmax" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="21" Alias="cmax">
+                  <dxl:Ident ColId="21" ColName="cmax" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="22" Alias="tableoid">
+                  <dxl:Ident ColId="22" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="23" Alias="gp_segment_id">
+                  <dxl:Ident ColId="23" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
+                <dxl:Columns>
+                  <dxl:Column ColId="15" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="16" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="24" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
+                  <dxl:Column ColId="25" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="26" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="17" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="18" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="19" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="20" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="21" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="22" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="23" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:GatherMotion>
+        </dxl:CTEProducer>
+        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1390608387465.216553" Rows="1.000000" Width="24"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="12" Alias="percentile_cont">
+              <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="13" Alias="percentile_disc">
+              <dxl:Ident ColId="13" ColName="percentile_disc" TypeMdid="0.701.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="14" Alias="count">
+              <dxl:Ident ColId="14" ColName="count" TypeMdid="0.20.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:JoinFilter>
+            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+          </dxl:JoinFilter>
+          <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1356691540.253197" Rows="1.000000" Width="16"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="12" Alias="percentile_cont">
+                <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="14" Alias="count">
+                <dxl:Ident ColId="14" ColName="count" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:JoinFilter>
+              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+            </dxl:JoinFilter>
+            <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:GroupingColumns/>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="14" Alias="count">
+                  <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                    <dxl:ValuesList ParamType="aggargs"/>
+                    <dxl:ValuesList ParamType="aggdirectargs"/>
+                    <dxl:ValuesList ParamType="aggorder"/>
+                    <dxl:ValuesList ParamType="aggdistinct"/>
+                  </dxl:AggFunc>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList/>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="1"/>
+                  </dxl:Properties>
+                  <dxl:ProjList/>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
+                    <dxl:Columns>
+                      <dxl:Column ColId="0" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="1" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
+                      <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="6" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="7" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="8" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="9" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="10" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="11" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:GatherMotion>
+            </dxl:Aggregate>
+            <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.082180" Rows="1.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:GroupingColumns/>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="12" Alias="percentile_cont">
+                  <dxl:AggFunc AggMdid="0.164162.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                    <dxl:ValuesList ParamType="aggargs">
+                      <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                        <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                      </dxl:Cast>
+                      <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+                      <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                    </dxl:ValuesList>
+                    <dxl:ValuesList ParamType="aggdirectargs"/>
+                    <dxl:ValuesList ParamType="aggorder"/>
+                    <dxl:ValuesList ParamType="aggdistinct"/>
+                  </dxl:AggFunc>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:Limit>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1324032.082178" Rows="1.000000" Width="12"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="a1">
+                    <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                    <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Sort SortDiscardDuplicates="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="1324032.082166" Rows="1.000000" Width="12"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="a1">
+                      <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                      <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  </dxl:SortingColumnList>
+                  <dxl:LimitCount/>
+                  <dxl:LimitOffset/>
+                  <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="1324032.082166" Rows="1.000000" Width="12"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="a1">
+                        <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                        <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:JoinFilter>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:JoinFilter>
+                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:GroupingColumns/>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Ident ColId="27" ColName="a1" TypeMdid="0.23.1.0"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:CTEConsumer CTEId="0" Columns="27,28,29,30,31,32,33,34,35">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="27" Alias="a1">
+                            <dxl:Ident ColId="27" ColName="a1" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="28" Alias="a2">
+                            <dxl:Ident ColId="28" ColName="a2" TypeMdid="0.701.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="29" Alias="ctid">
+                            <dxl:Ident ColId="29" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="30" Alias="xmin">
+                            <dxl:Ident ColId="30" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="31" Alias="cmin">
+                            <dxl:Ident ColId="31" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="32" Alias="xmax">
+                            <dxl:Ident ColId="32" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="33" Alias="cmax">
+                            <dxl:Ident ColId="33" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="34" Alias="tableoid">
+                            <dxl:Ident ColId="34" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="35" Alias="gp_segment_id">
+                            <dxl:Ident ColId="35" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                      </dxl:CTEConsumer>
+                    </dxl:Aggregate>
+                    <dxl:Materialize Eager="true">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="0" Alias="a1">
+                          <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="1" Alias="a2">
+                          <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="5" Alias="ctid">
+                          <dxl:Ident ColId="5" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="6" Alias="xmin">
+                          <dxl:Ident ColId="6" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="7" Alias="cmin">
+                          <dxl:Ident ColId="7" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="8" Alias="xmax">
+                          <dxl:Ident ColId="8" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="9" Alias="cmax">
+                          <dxl:Ident ColId="9" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="10" Alias="tableoid">
+                          <dxl:Ident ColId="10" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="11" Alias="gp_segment_id">
+                          <dxl:Ident ColId="11" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:CTEConsumer CTEId="0" Columns="0,1,5,6,7,8,9,10,11">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="0" Alias="a1">
+                            <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="1" Alias="a2">
+                            <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="5" Alias="ctid">
+                            <dxl:Ident ColId="5" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="6" Alias="xmin">
+                            <dxl:Ident ColId="6" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="7" Alias="cmin">
+                            <dxl:Ident ColId="7" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="8" Alias="xmax">
+                            <dxl:Ident ColId="8" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="9" Alias="cmax">
+                            <dxl:Ident ColId="9" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="10" Alias="tableoid">
+                            <dxl:Ident ColId="10" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="11" Alias="gp_segment_id">
+                            <dxl:Ident ColId="11" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                      </dxl:CTEConsumer>
+                    </dxl:Materialize>
+                  </dxl:NestedLoopJoin>
+                </dxl:Sort>
+                <dxl:LimitCount>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
+                </dxl:LimitCount>
+                <dxl:LimitOffset>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                </dxl:LimitOffset>
+              </dxl:Limit>
+            </dxl:Aggregate>
+          </dxl:NestedLoopJoin>
+          <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.130690" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:GroupingColumns/>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="13" Alias="percentile_disc">
+                <dxl:AggFunc AggMdid="0.164166.1.0" AggDistinct="false" AggStage="Normal" TypeMdid="0.701.1.0" AggKind="n">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+                    <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                  <dxl:ValuesList ParamType="aggorder"/>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:Limit>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.130687" Rows="1.000000" Width="16"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="1" Alias="a2">
+                  <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="43" Alias="ColRef_0043">
+                  <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Sort SortDiscardDuplicates="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="1" Alias="a2">
+                    <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="43" Alias="ColRef_0043">
+                    <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="1" SortOperatorMdid="0.674.1.0" SortOperatorName="&gt;" SortNullsFirst="true"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="1" Alias="a2">
+                      <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="43" Alias="ColRef_0043">
+                      <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:JoinFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:JoinFilter>
+                  <dxl:CTEConsumer CTEId="0" Columns="0,1,5,6,7,8,9,10,11">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="a1">
+                        <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="1" Alias="a2">
+                        <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="5" Alias="ctid">
+                        <dxl:Ident ColId="5" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="6" Alias="xmin">
+                        <dxl:Ident ColId="6" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="7" Alias="cmin">
+                        <dxl:Ident ColId="7" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="8" Alias="xmax">
+                        <dxl:Ident ColId="8" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="9" Alias="cmax">
+                        <dxl:Ident ColId="9" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="10" Alias="tableoid">
+                        <dxl:Ident ColId="10" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="11" Alias="gp_segment_id">
+                        <dxl:Ident ColId="11" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                  </dxl:CTEConsumer>
+                  <dxl:Materialize Eager="true">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="43" Alias="ColRef_0043">
+                        <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:GroupingColumns/>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="43" Alias="ColRef_0043">
+                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Ident ColId="28" ColName="a2" TypeMdid="0.701.1.0"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:CTEConsumer CTEId="0" Columns="27,28,29,30,31,32,33,34,35">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="27" Alias="a1">
+                            <dxl:Ident ColId="27" ColName="a1" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="28" Alias="a2">
+                            <dxl:Ident ColId="28" ColName="a2" TypeMdid="0.701.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="29" Alias="ctid">
+                            <dxl:Ident ColId="29" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="30" Alias="xmin">
+                            <dxl:Ident ColId="30" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="31" Alias="cmin">
+                            <dxl:Ident ColId="31" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="32" Alias="xmax">
+                            <dxl:Ident ColId="32" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="33" Alias="cmax">
+                            <dxl:Ident ColId="33" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="34" Alias="tableoid">
+                            <dxl:Ident ColId="34" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="35" Alias="gp_segment_id">
+                            <dxl:Ident ColId="35" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                      </dxl:CTEConsumer>
+                    </dxl:Aggregate>
+                  </dxl:Materialize>
+                </dxl:NestedLoopJoin>
+              </dxl:Sort>
+              <dxl:LimitCount>
+                <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
+              </dxl:LimitCount>
+              <dxl:LimitOffset>
+                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+              </dxl:LimitOffset>
+            </dxl:Limit>
+          </dxl:Aggregate>
+        </dxl:NestedLoopJoin>
+      </dxl:Sequence>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_with_nonconst_fraction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_with_nonconst_fraction.mdp
@@ -1,0 +1,893 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Objective:
+Test pre-processing step converts multiple ordered-set aggs with non ScalarConst
+fraction into a NLJ joining GbAgg expression containing ordered aggs split to
+gp_percentile aggs
+
+CREATE EXTENSION gp_percentile_agg;
+SET optimizer_enable_orderedagg=on;
+CREATE TABLE foo(a1 int, a2 double precision, a3 interval, a4 timestamp, a5 timestamptz);
+EXPLAIN SELECT percentile_cont(floor(random()*0.1)+0.5) WITHIN GROUP(ORDER BY a1) FROM foo;
+
+                                                QUERY PLAN
+ Sequence  (cost=0.00..2712059578.74 rows=1 width=16)
+   ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=1)
+         ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=42)
+                     ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=42)
+   ->  Nested Loop  (cost=0.00..2712059147.74 rows=1 width=16)
+         Join Filter: true
+         ->  Aggregate  (cost=0.00..1324032.13 rows=1 width=8)
+               ->  Limit  (cost=0.00..1324032.13 rows=1 width=16)
+                     ->  Sort  (cost=0.00..1324032.13 rows=1 width=16)
+                           Sort Key: share0_ref5.a2
+                           ->  Nested Loop  (cost=0.00..1324032.13 rows=1 width=16)
+                                 Join Filter: true
+                                 ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..1324032.13 rows=1 width=8)
+               ->  Limit  (cost=0.00..1324032.13 rows=1 width=16)
+                     ->  Sort  (cost=0.00..1324032.13 rows=1 width=16)
+                           Sort Key: share0_ref3.a2
+                           ->  Nested Loop  (cost=0.00..1324032.13 rows=1 width=16)
+                                 Join Filter: true
+                                 ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(28 rows)
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,103043,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBAgg Mdid="0.3974.1.0" Name="percentile_cont" IsOrdered="true" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.17.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.672.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.701.1.0"/>
+        <dxl:RightType Mdid="0.701.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.295.1.0"/>
+        <dxl:Commutator Mdid="0.674.1.0"/>
+        <dxl:InverseOp Mdid="0.675.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1970.1.0"/>
+          <dxl:Opfamily Mdid="0.7024.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.1184.1.0" Name="timestamptz" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1999.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7112.1.0"/>
+        <dxl:EqualityOp Mdid="0.1320.1.0"/>
+        <dxl:InequalityOp Mdid="0.1321.1.0"/>
+        <dxl:LessThanOp Mdid="0.1322.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1323.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1324.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1325.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1314.1.0"/>
+        <dxl:ArrayType Mdid="0.1185.1.0"/>
+        <dxl:MinAgg Mdid="0.2143.1.0"/>
+        <dxl:MaxAgg Mdid="0.2127.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.674.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.701.1.0"/>
+        <dxl:RightType Mdid="0.701.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.297.1.0"/>
+        <dxl:Commutator Mdid="0.672.1.0"/>
+        <dxl:InverseOp Mdid="0.673.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1970.1.0"/>
+          <dxl:Opfamily Mdid="0.7024.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.1186.1.0" Name="interval" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="16" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1983.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7116.1.0"/>
+        <dxl:EqualityOp Mdid="0.1330.1.0"/>
+        <dxl:InequalityOp Mdid="0.1331.1.0"/>
+        <dxl:LessThanOp Mdid="0.1332.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1333.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1334.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1335.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1315.1.0"/>
+        <dxl:ArrayType Mdid="0.1187.1.0"/>
+        <dxl:MinAgg Mdid="0.2144.1.0"/>
+        <dxl:MaxAgg Mdid="0.2128.1.0"/>
+        <dxl:AvgAgg Mdid="0.2106.1.0"/>
+        <dxl:SumAgg Mdid="0.2113.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.164182.1.0.1" Name="a2" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.164182.1.0.0" Name="a1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
+        <dxl:EqualityOp Mdid="0.670.1.0"/>
+        <dxl:InequalityOp Mdid="0.671.1.0"/>
+        <dxl:LessThanOp Mdid="0.672.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
+        <dxl:ComparisonOp Mdid="0.355.1.0"/>
+        <dxl:ArrayType Mdid="0.1022.1.0"/>
+        <dxl:MinAgg Mdid="0.2136.1.0"/>
+        <dxl:MaxAgg Mdid="0.2120.1.0"/>
+        <dxl:AvgAgg Mdid="0.2105.1.0"/>
+        <dxl:SumAgg Mdid="0.2111.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.164162.1.0" Name="gp_percentile_cont" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:RelationStatistics Mdid="2.164182.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.164182.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="11,5" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a2" Attno="2" Mdid="0.701.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a3" Attno="3" Mdid="0.1186.1.0" Nullable="true" ColWidth="16">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a4" Attno="4" Mdid="0.1114.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a5" Attno="5" Mdid="0.1184.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.1114.1.0" Name="timestamp" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2040.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7111.1.0"/>
+        <dxl:EqualityOp Mdid="0.2060.1.0"/>
+        <dxl:InequalityOp Mdid="0.2061.1.0"/>
+        <dxl:LessThanOp Mdid="0.2062.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2063.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2064.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2065.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2045.1.0"/>
+        <dxl:ArrayType Mdid="0.1115.1.0"/>
+        <dxl:MinAgg Mdid="0.2142.1.0"/>
+        <dxl:MaxAgg Mdid="0.2126.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.2147.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+        <dxl:Ident ColId="14" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalGroupBy>
+        <dxl:GroupingColumns/>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="13" Alias="percentile_cont">
+            <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.164162.1.0">
+              <dxl:ValuesList ParamType="aggargs">
+                <dxl:Ident ColId="2" ColName="a2" TypeMdid="0.701.1.0"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdirectargs">
+                <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggorder">
+                <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="672" SortNullsFirst="false" IsHashable="true"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdistinct"/>
+            </dxl:AggFunc>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="14" Alias="percentile_cont">
+            <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.164162.1.0">
+              <dxl:ValuesList ParamType="aggargs">
+                <dxl:Ident ColId="2" ColName="a2" TypeMdid="0.701.1.0"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdirectargs">
+                <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggorder">
+                <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="674" SortNullsFirst="true" IsHashable="true"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdistinct"/>
+            </dxl:AggFunc>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
+              <dxl:Column ColId="3" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
+              <dxl:Column ColId="4" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
+              <dxl:Column ColId="5" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
+              <dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="7" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="12" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalGroupBy>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="244">
+      <dxl:Sequence>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="2712059578.735769" Rows="1.000000" Width="16"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="12" Alias="percentile_cont">
+            <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="13" Alias="percentile_cont">
+            <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:CTEProducer CTEId="0" Columns="14,15,16,17,18,19,20,21,22">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000197" Rows="1.000000" Width="1"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="14" Alias="a1">
+              <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="15" Alias="a2">
+              <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="16" Alias="ctid">
+              <dxl:Ident ColId="16" ColName="ctid" TypeMdid="0.27.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="17" Alias="xmin">
+              <dxl:Ident ColId="17" ColName="xmin" TypeMdid="0.28.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="18" Alias="cmin">
+              <dxl:Ident ColId="18" ColName="cmin" TypeMdid="0.29.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="19" Alias="xmax">
+              <dxl:Ident ColId="19" ColName="xmax" TypeMdid="0.28.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="20" Alias="cmax">
+              <dxl:Ident ColId="20" ColName="cmax" TypeMdid="0.29.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="21" Alias="tableoid">
+              <dxl:Ident ColId="21" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="22" Alias="gp_segment_id">
+              <dxl:Ident ColId="22" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000196" Rows="1.000000" Width="42"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="14" Alias="a1">
+                <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="15" Alias="a2">
+                <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="16" Alias="ctid">
+                <dxl:Ident ColId="16" ColName="ctid" TypeMdid="0.27.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="17" Alias="xmin">
+                <dxl:Ident ColId="17" ColName="xmin" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="18" Alias="cmin">
+                <dxl:Ident ColId="18" ColName="cmin" TypeMdid="0.29.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="19" Alias="xmax">
+                <dxl:Ident ColId="19" ColName="xmax" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="20" Alias="cmax">
+                <dxl:Ident ColId="20" ColName="cmax" TypeMdid="0.29.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="21" Alias="tableoid">
+                <dxl:Ident ColId="21" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="22" Alias="gp_segment_id">
+                <dxl:Ident ColId="22" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="42"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="14" Alias="a1">
+                  <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="15" Alias="a2">
+                  <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="16" Alias="ctid">
+                  <dxl:Ident ColId="16" ColName="ctid" TypeMdid="0.27.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="17" Alias="xmin">
+                  <dxl:Ident ColId="17" ColName="xmin" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="18" Alias="cmin">
+                  <dxl:Ident ColId="18" ColName="cmin" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="19" Alias="xmax">
+                  <dxl:Ident ColId="19" ColName="xmax" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="20" Alias="cmax">
+                  <dxl:Ident ColId="20" ColName="cmax" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="21" Alias="tableoid">
+                  <dxl:Ident ColId="21" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="22" Alias="gp_segment_id">
+                  <dxl:Ident ColId="22" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
+                <dxl:Columns>
+                  <dxl:Column ColId="14" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="15" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="23" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
+                  <dxl:Column ColId="24" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="25" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="16" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="17" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="18" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="19" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="20" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:GatherMotion>
+        </dxl:CTEProducer>
+        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="2712059147.735556" Rows="1.000000" Width="16"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="12" Alias="percentile_cont">
+              <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="13" Alias="percentile_cont">
+              <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:JoinFilter>
+            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+          </dxl:JoinFilter>
+          <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.130690" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:GroupingColumns/>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="12" Alias="percentile_cont">
+                <dxl:AggFunc AggMdid="0.164162.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+                    <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                  <dxl:ValuesList ParamType="aggorder"/>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:Limit>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.130687" Rows="1.000000" Width="16"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="1" Alias="a2">
+                  <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                  <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Sort SortDiscardDuplicates="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="1" Alias="a2">
+                    <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                    <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="1" SortOperatorMdid="0.672.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="1" Alias="a2">
+                      <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                      <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:JoinFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:JoinFilter>
+                  <dxl:CTEConsumer CTEId="0" Columns="0,1,5,6,7,8,9,10,11">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="a1">
+                        <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="1" Alias="a2">
+                        <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="5" Alias="ctid">
+                        <dxl:Ident ColId="5" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="6" Alias="xmin">
+                        <dxl:Ident ColId="6" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="7" Alias="cmin">
+                        <dxl:Ident ColId="7" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="8" Alias="xmax">
+                        <dxl:Ident ColId="8" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="9" Alias="cmax">
+                        <dxl:Ident ColId="9" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="10" Alias="tableoid">
+                        <dxl:Ident ColId="10" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="11" Alias="gp_segment_id">
+                        <dxl:Ident ColId="11" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                  </dxl:CTEConsumer>
+                  <dxl:Materialize Eager="true">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                        <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:GroupingColumns/>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Ident ColId="27" ColName="a2" TypeMdid="0.701.1.0"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:CTEConsumer CTEId="0" Columns="26,27,28,29,30,31,32,33,34">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="26" Alias="a1">
+                            <dxl:Ident ColId="26" ColName="a1" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="27" Alias="a2">
+                            <dxl:Ident ColId="27" ColName="a2" TypeMdid="0.701.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="28" Alias="ctid">
+                            <dxl:Ident ColId="28" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="29" Alias="xmin">
+                            <dxl:Ident ColId="29" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="30" Alias="cmin">
+                            <dxl:Ident ColId="30" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="31" Alias="xmax">
+                            <dxl:Ident ColId="31" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="32" Alias="cmax">
+                            <dxl:Ident ColId="32" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="33" Alias="tableoid">
+                            <dxl:Ident ColId="33" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="34" Alias="gp_segment_id">
+                            <dxl:Ident ColId="34" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                      </dxl:CTEConsumer>
+                    </dxl:Aggregate>
+                  </dxl:Materialize>
+                </dxl:NestedLoopJoin>
+              </dxl:Sort>
+              <dxl:LimitCount>
+                <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
+              </dxl:LimitCount>
+              <dxl:LimitOffset>
+                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+              </dxl:LimitOffset>
+            </dxl:Limit>
+          </dxl:Aggregate>
+          <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.130690" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:GroupingColumns/>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="13" Alias="percentile_cont">
+                <dxl:AggFunc AggMdid="0.164162.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+                    <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                  <dxl:ValuesList ParamType="aggorder"/>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:Limit>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.130687" Rows="1.000000" Width="16"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="1" Alias="a2">
+                  <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                  <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Sort SortDiscardDuplicates="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="1" Alias="a2">
+                    <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                    <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="1" SortOperatorMdid="0.674.1.0" SortOperatorName="&gt;" SortNullsFirst="true"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="1" Alias="a2">
+                      <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                      <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:JoinFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:JoinFilter>
+                  <dxl:CTEConsumer CTEId="0" Columns="0,1,5,6,7,8,9,10,11">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="a1">
+                        <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="1" Alias="a2">
+                        <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="5" Alias="ctid">
+                        <dxl:Ident ColId="5" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="6" Alias="xmin">
+                        <dxl:Ident ColId="6" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="7" Alias="cmin">
+                        <dxl:Ident ColId="7" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="8" Alias="xmax">
+                        <dxl:Ident ColId="8" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="9" Alias="cmax">
+                        <dxl:Ident ColId="9" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="10" Alias="tableoid">
+                        <dxl:Ident ColId="10" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="11" Alias="gp_segment_id">
+                        <dxl:Ident ColId="11" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                  </dxl:CTEConsumer>
+                  <dxl:Materialize Eager="true">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                        <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:GroupingColumns/>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Ident ColId="27" ColName="a2" TypeMdid="0.701.1.0"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:CTEConsumer CTEId="0" Columns="26,27,28,29,30,31,32,33,34">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="26" Alias="a1">
+                            <dxl:Ident ColId="26" ColName="a1" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="27" Alias="a2">
+                            <dxl:Ident ColId="27" ColName="a2" TypeMdid="0.701.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="28" Alias="ctid">
+                            <dxl:Ident ColId="28" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="29" Alias="xmin">
+                            <dxl:Ident ColId="29" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="30" Alias="cmin">
+                            <dxl:Ident ColId="30" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="31" Alias="xmax">
+                            <dxl:Ident ColId="31" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="32" Alias="cmax">
+                            <dxl:Ident ColId="32" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="33" Alias="tableoid">
+                            <dxl:Ident ColId="33" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="34" Alias="gp_segment_id">
+                            <dxl:Ident ColId="34" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                      </dxl:CTEConsumer>
+                    </dxl:Aggregate>
+                  </dxl:Materialize>
+                </dxl:NestedLoopJoin>
+              </dxl:Sort>
+              <dxl:LimitCount>
+                <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
+              </dxl:LimitCount>
+              <dxl:LimitOffset>
+                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+              </dxl:LimitOffset>
+            </dxl:Limit>
+          </dxl:Aggregate>
+        </dxl:NestedLoopJoin>
+      </dxl:Sequence>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdPropScalar.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDrvdPropScalar.h
@@ -51,6 +51,7 @@ class CDrvdPropScalar : public CDrvdProp
 		EdptPfp,
 		EdptFHasNonScalarFunction,
 		EdptUlDistinctAggs,
+		EdptUlOrderedAggs,
 		EdptFHasMultipleDistinctAggs,
 		EdptFHasScalarArrayCmp,
 		EdptFHasScalarFuncProject,
@@ -93,6 +94,7 @@ private:
 	// does operator define Distinct Aggs on different arguments (e.g., count(distinct a), sum(distinct b)),
 	// only applicable to project lists
 	BOOL m_fHasMultipleDistinctAggs;
+	ULONG m_ulOrderedAggs;
 
 	// does expression contain ScalarArrayCmp generated for "scalar op ANY/ALL (array)" construct
 	BOOL m_fHasScalarArrayCmp;
@@ -135,6 +137,7 @@ protected:
 	BOOL DeriveHasMultipleDistinctAggs(CExpressionHandle &);
 
 	BOOL DeriveHasScalarArrayCmp(CExpressionHandle &);
+	ULONG DeriveTotalOrderedAggs(CExpressionHandle &);
 
 public:
 	// ctor

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CUtils.h
@@ -691,6 +691,9 @@ public:
 	// returns if the scalar array has all constant elements or children
 	static BOOL FScalarConstArray(CExpression *pexpr);
 
+	// returns if the scalar constant is an array
+	static BOOL FIsConstArray(CExpression *pexpr);
+
 	// returns if the scalar constant array has already been collapased
 	static BOOL FScalarArrayCollapsed(CExpression *pexprArray);
 
@@ -959,6 +962,12 @@ public:
 
 	// return true if given expression contains window aggregate function
 	static BOOL FHasAggWindowFunc(CExpression *pexpr);
+
+	// return true if given mdid is a supported ordered aggregate function
+	static BOOL FIsInbuiltOrderedAgg(IMDId *mdid);
+
+	// return true if given expression contains ordered aggregate function
+	static BOOL FHasOrderedAggToSplit(CExpression *pexpr);
 
 	// return true if the given expression is a cross join
 	static BOOL FCrossJoin(CExpression *pexpr);

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CExpression.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CExpression.h
@@ -317,6 +317,7 @@ public:
 	BOOL DeriveHasMultipleDistinctAggs();
 	BOOL DeriveHasScalarArrayCmp();
 	BOOL DeriveHasScalarFuncProject();
+	ULONG DeriveTotalOrderedAggs();
 
 };	// class CExpression
 

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/COrderedAggPreprocessor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/COrderedAggPreprocessor.h
@@ -1,0 +1,76 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2022 VMware, Inc. or its affiliates.
+//
+//	@filename:
+//		COrderedAggPreprocessor.h
+//
+//	@doc:
+//		Preprocessing routines of ordered-set aggregates
+//---------------------------------------------------------------------------
+#ifndef GPOPT_COrderedAggPreprocessor_H
+#define GPOPT_COrderedAggPreprocessor_H
+
+#include "gpos/base.h"
+
+#include "gpopt/base/COrderSpec.h"
+#include "gpopt/base/CWindowFrame.h"
+#include "gpopt/operators/CExpression.h"
+
+namespace gpopt
+{
+//---------------------------------------------------------------------------
+//	@class:
+//		COrderedAggPreprocessor
+//
+//	@doc:
+//		Preprocessing routines of window functions
+//
+//---------------------------------------------------------------------------
+class COrderedAggPreprocessor
+{
+private:
+	// private copy ctor
+	COrderedAggPreprocessor(const COrderedAggPreprocessor &);
+
+	// iterate over project elements and split elements between Ordered Aggs
+	// list, and Others list
+	static void SplitPrjList(CMemoryPool *mp, CExpression *pexprInputAggPrj,
+							 CExpressionArray **ppdrgpexprOrderedAggsPrEl,
+							 CExpressionArray **ppdrgpexprOtherPrjElems);
+
+	// split given InputAgg expression into:
+	//	- A GbAgg expression containing ordered aggs split to gp_percentile agg, and
+	//	- A GbAgg expression containing all other non-ordered agg functions
+	static void SplitOrderedAggsPrj(CMemoryPool *mp,
+									CExpression *pexprInputAggPrj,
+									CExpression **ppexprGbAgg,
+									CExpression **ppexprOutputSeqPrj);
+
+	// create a CTE with two consumers using the child expression of Sequence
+	// Project
+	static void CreateCTE(CMemoryPool *mp, CExpression *pexprInputAggPrj,
+						  CExpression **ppexprFirstConsumer,
+						  CExpression **ppexprSecondConsumer);
+
+	// create an expression for final agg function
+	static CExpression *PexprFinalAgg(CMemoryPool *mp,
+									  CExpression *pexprAggFunc,
+									  CColRef *arg_col_ref,
+									  CColRef *total_count_colref);
+
+	// transform sequence project expression into an inner join expression
+	static CExpression *PexprInputAggPrj2Join(CMemoryPool *mp,
+											  CExpression *pexprInputAggPrj);
+
+public:
+	// main driver
+	static CExpression *PexprPreprocess(CMemoryPool *mp, CExpression *pexpr);
+
+};	// class COrderedAggPreprocessor
+}  // namespace gpopt
+
+
+#endif	// !GPOPT_COrderedAggPreprocessor_H
+
+// EOF

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarAggFunc.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarAggFunc.h
@@ -84,6 +84,9 @@ private:
 	// is result of splitting aggregates
 	BOOL m_fSplit;
 
+	// corresponding gp_agg mdid for supported ordered aggs
+	IMDId *m_gp_agg_mdid;
+
 	// private copy ctor
 	CScalarAggFunc(const CScalarAggFunc &);
 
@@ -92,7 +95,7 @@ public:
 	CScalarAggFunc(CMemoryPool *mp, IMDId *pmdidAggFunc,
 				   IMDId *resolved_rettype, const CWStringConst *pstrAggFunc,
 				   BOOL is_distinct, EAggfuncStage eaggfuncstage, BOOL fSplit,
-				   EAggfuncKind aggkind);
+				   EAggfuncKind aggkind, IMDId *gp_agg_mdid = NULL);
 
 	// dtor
 	virtual ~CScalarAggFunc()
@@ -100,6 +103,7 @@ public:
 		m_pmdidAggFunc->Release();
 		CRefCount::SafeRelease(m_pmdidResolvedRetType);
 		CRefCount::SafeRelease(m_return_type_mdid);
+		CRefCount::SafeRelease(m_gp_agg_mdid);
 		GPOS_DELETE(m_pstrAggFunc);
 	}
 
@@ -216,6 +220,20 @@ public:
 	FHasAmbiguousReturnType() const
 	{
 		return (NULL != m_pmdidResolvedRetType);
+	}
+
+	// set gp_agg MDId
+	void
+	SetGpAggMDId(IMDId *mdid)
+	{
+		m_gp_agg_mdid = mdid;
+	}
+
+	// return gp_agg MDId. Valid only for supported ordered aggs, else NULL
+	IMDId *
+	GetGpAggMDId() const
+	{
+		return m_gp_agg_mdid;
 	}
 
 	// is function count(*)?

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarProjectList.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarProjectList.h
@@ -93,6 +93,9 @@ public:
 	// return number of distinct aggs in project list attached to given handle
 	static ULONG UlDistinctAggs(CExpressionHandle &exprhdl);
 
+	// return number of ordered aggs in project list attached to given handle
+	static ULONG UlOrderedAggs(CExpressionHandle &exprhdl);
+
 	// check if a project list has multiple distinct aggregates
 	static BOOL FHasMultipleDistinctAggs(CExpressionHandle &exprhdl);
 

--- a/src/backend/gporca/libgpopt/src/base/CDrvdPropScalar.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDrvdPropScalar.cpp
@@ -40,6 +40,7 @@ CDrvdPropScalar::CDrvdPropScalar(CMemoryPool *mp)
 	  m_fHasNonScalarFunction(false),
 	  m_ulDistinctAggs(0),
 	  m_fHasMultipleDistinctAggs(false),
+	  m_ulOrderedAggs(0),
 	  m_fHasScalarArrayCmp(false),
 	  m_is_complete(false)
 {
@@ -417,6 +418,16 @@ CDrvdPropScalar::DeriveHasScalarArrayCmp(CExpressionHandle &exprhdl)
 	return m_fHasScalarArrayCmp;
 }
 
+ULONG
+CDrvdPropScalar::DeriveTotalOrderedAggs(CExpressionHandle &exprhdl)
+{
+	if (COperator::EopScalarProjectList == exprhdl.Pop()->Eopid() &&
+		!m_is_prop_derived->ExchangeSet(EdptUlOrderedAggs))
+	{
+		m_ulOrderedAggs = CScalarProjectList::UlOrderedAggs(exprhdl);
+	}
+	return m_ulOrderedAggs;
+}
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/base/CUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CUtils.cpp
@@ -566,6 +566,16 @@ CUtils::FScalarConstArray(CExpression *pexprArray)
 	return fAllConsts;
 }
 
+// returns if the scalar const is an array
+BOOL
+CUtils::FIsConstArray(CExpression *pexpr)
+{
+	CScalarConst *popScalarConst = CScalarConst::PopConvert(pexpr->Pop());
+	CMDAccessor *mda = COptCtxt::PoctxtFromTLS()->Pmda();
+	const IMDType *expr_type = mda->RetrieveType(popScalarConst->MdidType());
+	return !IMDId::IsValid(expr_type->GetArrayTypeMdid());
+}
+
 // returns if the scalar constant array has already been collapased
 BOOL
 CUtils::FScalarArrayCollapsed(CExpression *pexprArray)
@@ -4576,6 +4586,43 @@ CUtils::FHasAggWindowFunc(CExpression *pexpr)
 	}
 
 	return fHasAggWindowFunc;
+}
+
+
+// returns true if mdid is a supported ordered agg.
+// Currently we only support inbuilt ordered aggs
+// percentile_disc and percentile_cont for splitting
+BOOL
+CUtils::FIsInbuiltOrderedAgg(IMDId *mdid)
+{
+	GPOS_ASSERT(mdid->IsValid());
+
+	OID agg_oid = CMDIdGPDB::CastMdid(mdid)->Oid();
+	return (agg_oid == GPDB_PERCENTILE_DISC || agg_oid == GPDB_MEDIAN_FLOAT8 ||
+			agg_oid == GPDB_MEDIAN_INTERVAL ||
+			agg_oid == GPDB_MEDIAN_TIMESTAMP ||
+			agg_oid == GPDB_MEDIAN_TIMESTAMPTZ ||
+			agg_oid == GPDB_PERCENTILE_CONT_FLOAT8 ||
+			agg_oid == GPDB_PERCENTILE_CONT_INTERVAL ||
+			agg_oid == GPDB_PERCENTILE_CONT_TIMESTAMP ||
+			agg_oid == GPDB_PERCENTILE_CONT_TIMESTAMPTZ);
+}
+
+
+// returns true if expression contains ordered aggregate function
+BOOL
+CUtils::FHasOrderedAggToSplit(CExpression *pexpr)
+{
+	GPOS_ASSERT(NULL != pexpr);
+
+	CScalarAggFunc *popScAggFunc = CScalarAggFunc::PopConvert(pexpr->Pop());
+	return popScAggFunc->AggKind() == EaggfunckindOrderedSet &&
+		   FIsInbuiltOrderedAgg(popScAggFunc->MDId()) &&
+		   (NULL != popScAggFunc->GetGpAggMDId()) &&
+		   (!FScalarConst((*(*pexpr)[1])[0]) ||
+			!FIsConstArray((*(*pexpr)[1])[0])) &&
+		   (FScalarIdent((*(*pexpr)[0])[0]) ||
+			CScalarIdent::FCastedScId((*(*pexpr)[0])[0]));
 }
 
 BOOL

--- a/src/backend/gporca/libgpopt/src/operators/CExpression.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpression.cpp
@@ -1624,4 +1624,11 @@ CExpression::DeriveHasScalarFuncProject()
 	exprhdl.Attach(this);
 	return m_pdpscalar->DeriveHasScalarFuncProject(exprhdl);
 }
+ULONG
+CExpression::DeriveTotalOrderedAggs()
+{
+	CExpressionHandle exprhdl(m_mp);
+	exprhdl.Attach(this);
+	return m_pdpscalar->DeriveTotalOrderedAggs(exprhdl);
+}
 // EOF

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -38,6 +38,7 @@
 #include "gpopt/operators/CLogicalUnion.h"
 #include "gpopt/operators/CLogicalUnionAll.h"
 #include "gpopt/operators/CNormalizer.h"
+#include "gpopt/operators/COrderedAggPreprocessor.h"
 #include "gpopt/operators/CPredicateUtils.h"
 #include "gpopt/operators/CScalarCmp.h"
 #include "gpopt/operators/CScalarIdent.h"
@@ -2684,70 +2685,76 @@ CExpressionPreprocessor::PexprPreprocess(
 	GPOS_CHECK_ABORT;
 	pexprFactorized->Release();
 
-	// (15) pre-process window functions
-	CExpression *pexprWindowPreprocessed =
-		CWindowPreprocessor::PexprPreprocess(mp, pexprPrefiltersExtracted);
+	// (15) pre-process ordered agg functions
+	CExpression *pexprOrderedAggPreprocessed =
+		COrderedAggPreprocessor::PexprPreprocess(mp, pexprPrefiltersExtracted);
 	GPOS_CHECK_ABORT;
 	pexprPrefiltersExtracted->Release();
 
-	// (16) eliminate unused computed columns
+	// (16) pre-process window functions
+	CExpression *pexprWindowPreprocessed =
+		CWindowPreprocessor::PexprPreprocess(mp, pexprOrderedAggPreprocessed);
+	GPOS_CHECK_ABORT;
+	pexprOrderedAggPreprocessed->Release();
+
+	// (17) eliminate unused computed columns
 	CExpression *pexprNoUnusedPrEl = PexprPruneUnusedComputedCols(
 		mp, pexprWindowPreprocessed, pcrsOutputAndOrderCols);
 	GPOS_CHECK_ABORT;
 	pexprWindowPreprocessed->Release();
 
-	// (17) normalize expression
+	// (18) normalize expression
 	CExpression *pexprNormalized1 =
 		CNormalizer::PexprNormalize(mp, pexprNoUnusedPrEl);
 	GPOS_CHECK_ABORT;
 	pexprNoUnusedPrEl->Release();
 
-	// (18) transform outer join into inner join whenever possible
+	// (19) transform outer join into inner join whenever possible
 	CExpression *pexprLOJToIJ = PexprOuterJoinToInnerJoin(mp, pexprNormalized1);
 	GPOS_CHECK_ABORT;
 	pexprNormalized1->Release();
 
-	// (19) collapse cascaded inner and left outer joins
+	// (20) collapse cascaded inner and left outer joins
 	CExpression *pexprCollapsed = PexprCollapseJoins(mp, pexprLOJToIJ);
 	GPOS_CHECK_ABORT;
 	pexprLOJToIJ->Release();
 
-	// (20) after transforming outer joins to inner joins, we may be able to generate more predicates from constraints
+	// (21) after transforming outer joins to inner joins, we may be able to generate more predicates from constraints
 	CExpression *pexprWithPreds =
 		PexprAddPredicatesFromConstraints(mp, pexprCollapsed);
 	GPOS_CHECK_ABORT;
 	pexprCollapsed->Release();
 
-	// (21) eliminate empty subtrees
+	// (22) eliminate empty subtrees
 	CExpression *pexprPruned = PexprPruneEmptySubtrees(mp, pexprWithPreds);
 	GPOS_CHECK_ABORT;
 	pexprWithPreds->Release();
 
-	// (22) collapse cascade of projects
+	// (23) collapse cascade of projects
 	CExpression *pexprCollapsedProjects =
 		PexprCollapseProjects(mp, pexprPruned);
 	GPOS_CHECK_ABORT;
 	pexprPruned->Release();
 
-	// (23) insert dummy project when the scalar subquery is under a project and returns an outer reference
+	// (24) insert dummy project when the scalar subquery is under a project and returns an outer reference
 	CExpression *pexprSubquery = PexprProjBelowSubquery(
 		mp, pexprCollapsedProjects, false /* fUnderPrList */);
 	GPOS_CHECK_ABORT;
 	pexprCollapsedProjects->Release();
 
-	// (24) reorder the children of scalar cmp operator to ensure that left child is scalar ident and right child is scalar const
+	// (25) reorder the children of scalar cmp operator to ensure that left child is scalar ident and right child is scalar const
 	CExpression *pexrReorderedScalarCmpChildren =
 		PexprReorderScalarCmpChildren(mp, pexprSubquery);
 	GPOS_CHECK_ABORT;
 	pexprSubquery->Release();
 
-	// (25) rewrite IN subquery to EXIST subquery with a predicate
+	// (26) rewrite IN subquery to EXIST subquery with a predicate
 	CExpression *pexprExistWithPredFromINSubq =
 		PexprExistWithPredFromINSubq(mp, pexrReorderedScalarCmpChildren);
 	GPOS_CHECK_ABORT;
 	pexrReorderedScalarCmpChildren->Release();
 
-	// (26) normalize expression again
+	// (27) normalize expression again
 	CExpression *pexprNormalized2 =
 		CNormalizer::PexprNormalize(mp, pexprExistWithPredFromINSubq);
 	GPOS_CHECK_ABORT;

--- a/src/backend/gporca/libgpopt/src/operators/COrderedAggPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/COrderedAggPreprocessor.cpp
@@ -1,0 +1,603 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright 2022 VMware, Inc. or its affiliates.
+//
+//	@filename:
+//		COrderedAggPreprocessor.cpp
+//
+//	@doc:
+//		Preprocessing routines of ordered-set aggregate
+//---------------------------------------------------------------------------
+
+#include "gpopt/operators/COrderedAggPreprocessor.h"
+
+#include "gpos/base.h"
+
+#include "gpopt/base/COptCtxt.h"
+#include "gpopt/base/CUtils.h"
+#include "gpopt/operators/CLogicalCTEAnchor.h"
+#include "gpopt/operators/CLogicalCTEConsumer.h"
+#include "gpopt/operators/CLogicalGbAgg.h"
+#include "gpopt/operators/CLogicalInnerJoin.h"
+#include "gpopt/operators/CLogicalLimit.h"
+#include "gpopt/operators/CLogicalSequenceProject.h"
+#include "gpopt/operators/CPredicateUtils.h"
+#include "gpopt/operators/CScalarIdent.h"
+#include "gpopt/operators/CScalarProjectElement.h"
+#include "gpopt/operators/CScalarProjectList.h"
+#include "gpopt/operators/CScalarSortGroupClause.h"
+#include "gpopt/operators/CScalarValuesList.h"
+#include "gpopt/operators/CScalarWindowFunc.h"
+#include "gpopt/xforms/CXformUtils.h"
+
+using namespace gpopt;
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		COrderedAggPreprocessor::SplitPrjList
+//
+//	@doc:
+//		Iterate over project elements and split them elements between
+//		Ordered Aggs list, and Other Aggs list
+//
+//---------------------------------------------------------------------------
+void
+COrderedAggPreprocessor::SplitPrjList(
+	CMemoryPool *mp, CExpression *pexprInputAggPrj,
+	CExpressionArray **
+		ppdrgpexprOrderedAggsPrEl,	// output: list of project elements with Ordered Aggs
+	CExpressionArray **
+		ppdrgpexprOtherPrEl	 // output: list of project elements with Other aggregate functions
+)
+{
+	GPOS_ASSERT(NULL != pexprInputAggPrj);
+	GPOS_ASSERT(NULL != ppdrgpexprOrderedAggsPrEl);
+	GPOS_ASSERT(NULL != ppdrgpexprOtherPrEl);
+
+	CExpression *pexprPrjList = (*pexprInputAggPrj)[1];
+
+	CExpressionArray *pdrgpexprOrderedAggsPrEl =
+		GPOS_NEW(mp) CExpressionArray(mp);
+
+	CExpressionArray *pdrgpexprOtherPrEl = GPOS_NEW(mp) CExpressionArray(mp);
+	// create CTE using SeqPrj child expression
+	CExpression *pexprRemappedAggConsumer = NULL;
+	CExpression *pexprAggConsumer = NULL;
+	CreateCTE(mp, pexprInputAggPrj, &pexprRemappedAggConsumer,
+			  &pexprAggConsumer);
+
+	// iterate over project list and split project elements between
+	// Ordered Aggs list, and Other aggs list
+	const ULONG arity = pexprPrjList->Arity();
+	CColRefArray *colref_array = NULL;
+	CExpressionArray *pdrgpexprSortClauseArray = NULL;
+
+	for (ULONG ul = 0; ul < arity; ul++)
+	{
+		CExpression *pexprPrjEl = (*pexprPrjList)[ul];
+		CExpression *pexprAggFunc = (*pexprPrjEl)[0];
+		CScalarProjectElement *popScPrjElem =
+			CScalarProjectElement::PopConvert(pexprPrjEl->Pop());
+		CColRef *pcrPrjElem = popScPrjElem->Pcr();
+
+		if (CUtils::FHasOrderedAggToSplit(pexprAggFunc))
+		{
+			CExpression *pexprSortCol = (*(*pexprAggFunc)[0])[0];
+			CExpression *pexprSortGroupClause = (*(*pexprAggFunc)[2])[0];
+			CScalarSortGroupClause *curr_sort_clause =
+				CScalarSortGroupClause::PopConvert(pexprSortGroupClause->Pop());
+
+			const CColRef *colref =
+				CCastUtils::PcrExtractFromScIdOrCastScId(pexprSortCol);
+			BOOL skip = false;
+			if (NULL == pdrgpexprSortClauseArray)
+			{
+				colref_array = GPOS_NEW(mp) CColRefArray(mp);
+				colref_array->Append(const_cast<CColRef *>(colref));
+				pdrgpexprSortClauseArray = GPOS_NEW(mp) CExpressionArray(mp);
+				pexprSortGroupClause->AddRef();
+				pdrgpexprSortClauseArray->Append(pexprSortGroupClause);
+			}
+			else
+			{
+				for (ULONG uidx = 0; uidx < pdrgpexprSortClauseArray->Size();
+					 uidx++)
+				{
+					// For multiple ordered-set aggs on the same ORDERING column and ORDERING SPEC(ASC/DESC), we optimize
+					// to add the new aggregate as a ProjectiElement to the ProjectList of an existing JOIN, instead of
+					// creating a new JOIN for doing the same SORT.
+					// Eg. SELECT percentile_cont(0.25) WITHIN GROUP(ORDER BY a), percentile_cont(0.5) WITHIN GROUP(ORDER BY a) from tab;
+					// Currently, to check if colref's SORT ORDER Spec(Asc/Desc) is same, we match only the SortOp and NullFirst
+					// as that is what is used for creating the OrderSpec
+					// TO-DO: (enhancement) Instead of this loop, we can probably use a map (colref->SortGroupClause)
+					CScalarSortGroupClause *visited_sort_clause =
+						CScalarSortGroupClause::PopConvert(
+							(*pdrgpexprSortClauseArray)[uidx]->Pop());
+					if (colref == (*colref_array)[uidx] &&
+						curr_sort_clause->SortOp() ==
+							visited_sort_clause->SortOp() &&
+						curr_sort_clause->NullsFirst() ==
+							visited_sort_clause->NullsFirst())
+					{
+						// Create the new ordered agg function and append it as a ProjElement to the existing ProjectList
+						// created for and already split ordered agg on the same column with same ORDERING SPEC
+						// Existing ProjList:
+						// +--CScalarProjectList
+						// +--CScalarProjectElement \"percentile_cont\" (12)
+						//    +--CScalarAggFunc
+						//       |--CScalarValuesList
+						//       |  |--CScalarIdent \"a\" (1)
+						//       |  |--CScalarConst (0.2500)
+						//       |  +--CScalarIdent \"ColRef_0041\" (41)
+						//       ...
+						CExpression *pCurrExprProjList =
+							(*(*pdrgpexprOrderedAggsPrEl)[uidx])[1];
+						CExpression *pCurrExprAggFunc =
+							(*(*pCurrExprProjList)[0])[0];
+						const CColRef *total_count_colref =
+							CCastUtils::PcrExtractFromScIdOrCastScId(
+								(*(*pCurrExprAggFunc)[0])[2]);
+
+						CExpression *pexprNewAggFunc = PexprFinalAgg(
+							mp, pexprAggFunc, pcrPrjElem,
+							const_cast<CColRef *>(total_count_colref));
+						CExpression *pexprAddPrjElem =
+							CUtils::PexprScalarProjectElement(mp, pcrPrjElem,
+															  pexprNewAggFunc);
+						// Updated ProjList:
+						// +--CScalarProjectList
+						//    |--CScalarProjectElement \"percentile_cont\" (12)
+						//    |  +--CScalarAggFunc
+						//    |     |--CScalarValuesList
+						//    |     |  |--CScalarIdent \"a\" (1)
+						//    |     |  |--CScalarConst (0.2500)
+						//    |     |  +--CScalarIdent \"ColRef_0041\" (41)
+						//    |     ...
+						//    +--CScalarProjectElement \"percentile_cont\" (13)
+						//       +--CScalarAggFunc
+						//          |--CScalarValuesList
+						//          |  |--CScalarIdent \"a\" (1)
+						//          |  |--CScalarConst (0.500)
+						//          |  +--CScalarIdent \"ColRef_0041\" (41)
+						//          ...
+						CExpressionArray *pCurrProjList =
+							pCurrExprProjList->PdrgPexpr();
+						pCurrProjList->Append(pexprAddPrjElem);
+						skip = true;
+						break;
+					}
+				}
+				if (!skip)
+				{
+					colref_array->Append(const_cast<CColRef *>(colref));
+					pexprSortGroupClause->AddRef();
+					pdrgpexprSortClauseArray->Append(pexprSortGroupClause);
+				}
+			}
+			if (skip)
+				continue;
+			if (0 < ul)
+			{
+				pexprRemappedAggConsumer->AddRef();
+				pexprAggConsumer->AddRef();
+			}
+			// CREATE total count aggregate
+			CColumnFactory *col_factory = COptCtxt::PoctxtFromTLS()->Pcf();
+			CMDAccessor *md_accessor = COptCtxt::PoctxtFromTLS()->Pmda();
+			CExpression *pexprAgg = CUtils::PexprAgg(
+				mp, md_accessor, IMDType::EaggCount, colref, false);
+			CColRef *total_count_colref = col_factory->PcrCreate(
+				md_accessor->RetrieveType(
+					CScalarAggFunc::PopConvert(pexprAgg->Pop())->MdidType()),
+				CScalarAggFunc::PopConvert(pexprAgg->Pop())->TypeModifier());
+			CExpression *pexprNewPrjElem = CUtils::PexprScalarProjectElement(
+				mp, total_count_colref, pexprAgg);
+			CExpression *pexprCountAggPrjList = GPOS_NEW(mp) CExpression(
+				mp, GPOS_NEW(mp) CScalarProjectList(mp), pexprNewPrjElem);
+			(*pexprInputAggPrj)[0]->AddRef();
+			CExpression *pexprTotalCountAgg = CUtils::PexprLogicalGbAggGlobal(
+				mp, GPOS_NEW(mp) CColRefArray(mp), (*pexprInputAggPrj)[0],
+				pexprCountAggPrjList);
+
+			// to match requested columns upstream, we have to re-use the same computed
+			// columns that define the aggregates, we avoid recreating new columns during
+			// expression copy by passing must_exist as false
+			CColRefArray *pdrgpcrChildOutput =
+				pexprAggConsumer->DeriveOutputColumns()->Pdrgpcr(mp);
+			CColRefArray *pdrgpcrConsumerOutput =
+				CLogicalCTEConsumer::PopConvert(pexprRemappedAggConsumer->Pop())
+					->Pdrgpcr();
+			UlongToColRefMap *colref_mapping = CUtils::PhmulcrMapping(
+				mp, pdrgpcrChildOutput, pdrgpcrConsumerOutput);
+			CExpression *pexprTotalCountAggRemapped =
+				pexprTotalCountAgg->PexprCopyWithRemappedColumns(
+					mp, colref_mapping, false /*must_exist*/);
+			colref_mapping->Release();
+			pdrgpcrChildOutput->Release();
+			pexprTotalCountAgg->Release();
+
+			// finalize total count agg expression by replacing its child with CTE consumer
+			pexprTotalCountAggRemapped->Pop()->AddRef();
+			(*pexprTotalCountAggRemapped)[1]->AddRef();
+			CExpression *pexprFinalGbAgg = GPOS_NEW(mp) CExpression(
+				mp, pexprTotalCountAggRemapped->Pop(), pexprRemappedAggConsumer,
+				(*pexprTotalCountAggRemapped)[1]);
+			pexprTotalCountAggRemapped->Release();
+
+
+			CExpression *pexprJoinCondition =
+				CUtils::PexprScalarConstBool(mp, true /*value*/);
+
+			// create a join between expanded total count and CTE Consumer expressions
+			CExpression *pexprJoin =
+				CUtils::PexprLogicalJoin<CLogicalInnerJoin>(
+					mp, pexprAggConsumer, pexprFinalGbAgg, pexprJoinCondition);
+
+			// create ordered spec for the Join to merge on the colref passed in as part
+			// of the ordered agg's WITHIN(ORDER BY) clause
+			COrderSpec *pos = GPOS_NEW(mp) COrderSpec(mp);
+			IMDId *mdid_curr_sortop =
+				GPOS_NEW(mp) CMDIdGPDB(curr_sort_clause->SortOp());
+			IMDType::ECmpType curr_cmp_type =
+				CUtils::ParseCmpType(mdid_curr_sortop);
+			// Instead of using the SortOp directly, we use the colref's operator for the comparison type
+			// to avoid incorret results for cast related columns
+			IMDId *mdid_pos =
+				colref->RetrieveType()->GetMdidForCmpType(curr_cmp_type);
+			mdid_curr_sortop->Release();
+			COrderSpec::ENullTreatment ent = COrderSpec::EntLast;
+			if (curr_sort_clause->NullsFirst())
+			{
+				ent = COrderSpec::EntFirst;
+			}
+			mdid_pos->AddRef();
+			pos->Append(mdid_pos, colref, ent);
+			CLogicalLimit *popLimit = GPOS_NEW(mp)
+				CLogicalLimit(mp, pos, true /* fGlobal */, true /* fHasCount */,
+							  false /*fTopLimitUnderDML*/);
+			CExpression *pexprLimitOffset = CUtils::PexprScalarConstInt8(mp, 0);
+			CExpression *pexprLimitCount =
+				CUtils::PexprScalarConstInt8(mp, 1, true);
+
+			CExpression *pexprJoinLimit = GPOS_NEW(mp) CExpression(
+				mp, popLimit, pexprJoin, pexprLimitOffset, pexprLimitCount);
+
+			// Create the final gp_percentile agg on top
+			CExpression *pexprNewAggFunc =
+				PexprFinalAgg(mp, pexprAggFunc, pcrPrjElem, total_count_colref);
+			CExpression *pexprExistingPrjElem =
+				CUtils::PexprScalarProjectElement(mp, pcrPrjElem,
+												  pexprNewAggFunc);
+			CExpression *pexprNewAggPrjList = GPOS_NEW(mp) CExpression(
+				mp, GPOS_NEW(mp) CScalarProjectList(mp), pexprExistingPrjElem);
+			CColRefArray *colref_array = GPOS_NEW(mp) CColRefArray(mp);
+			CExpression *pexprNewAgg = CUtils::PexprLogicalGbAggGlobal(
+				mp, colref_array, pexprJoinLimit, pexprNewAggPrjList);
+			pdrgpexprOrderedAggsPrEl->Append(pexprNewAgg);
+		}
+		else
+		{
+			pexprAggFunc->AddRef();
+			CExpression *pexprNewPrjElem =
+				CUtils::PexprScalarProjectElement(mp, pcrPrjElem, pexprAggFunc);
+			pdrgpexprOtherPrEl->Append(pexprNewPrjElem);
+		}
+	}
+	CRefCount::SafeRelease(colref_array);
+	CRefCount::SafeRelease(pdrgpexprSortClauseArray);
+	*ppdrgpexprOrderedAggsPrEl = pdrgpexprOrderedAggsPrEl;
+	*ppdrgpexprOtherPrEl = pdrgpexprOtherPrEl;
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		COrderedAggPreprocessor::SplitOrderedAggsPrj
+//
+//	@doc:
+//		Split InputAgg expression into:
+//		- A GbAgg expression containing ordered aggs split to gp_percentile agg, and
+//		- A GbAgg expression containing all remaining non-ordered agg functions
+//
+//---------------------------------------------------------------------------
+void
+COrderedAggPreprocessor::SplitOrderedAggsPrj(
+	CMemoryPool *mp, CExpression *pexprInputAggPrj,
+	CExpression **
+		ppexprOrderedGbAgg,	 // output: GbAgg expression containing ordered aggs split to normal agg
+	CExpression **
+		ppexprRemainingAgg	// output: GbAgg expression containing all remaining agg functions
+)
+{
+	GPOS_ASSERT(NULL != pexprInputAggPrj);
+	GPOS_ASSERT(NULL != ppexprOrderedGbAgg);
+	GPOS_ASSERT(NULL != ppexprRemainingAgg);
+
+	// split project elements between ordered Aggs list, and Other aggs list
+	CExpressionArray *ppdrgpexprOrderedAggsPrEl = NULL;
+	CExpressionArray *pdrgpexprOtherPrEl = NULL;
+	SplitPrjList(mp, pexprInputAggPrj, &ppdrgpexprOrderedAggsPrEl,
+				 &pdrgpexprOtherPrEl);
+
+	CExpression *pexprInputAggPrjChild = (*pexprInputAggPrj)[0];
+
+	CExpression *pexpr = (*ppdrgpexprOrderedAggsPrEl)[0];
+	pexpr->AddRef();
+	// in case of multiple ordered aggs, we need to expand the GbAgg expression
+	// into a join expression where leaves carry split ordered aggs
+	for (ULONG ul = 1; ul < ppdrgpexprOrderedAggsPrEl->Size(); ul++)
+	{
+		CExpression *pexprWindowConsumer = (*ppdrgpexprOrderedAggsPrEl)[ul];
+		CExpression *pexprJoinCondition =
+			CUtils::PexprScalarConstBool(mp, true /*value*/);
+
+		// create a join between expanded DQAs and Window expressions
+		pexprWindowConsumer->AddRef();
+		CExpression *pexprJoin = CUtils::PexprLogicalJoin<CLogicalInnerJoin>(
+			mp, pexpr, pexprWindowConsumer, pexprJoinCondition);
+		pexpr = pexprJoin;
+	}
+
+	*ppexprOrderedGbAgg = pexpr;
+	if (0 == pdrgpexprOtherPrEl->Size())
+	{
+		// no remaining aggregate functions after excluding ordered aggs,
+		// reuse the original InputAggPrj child in this case
+		pdrgpexprOtherPrEl->Release();
+		ppdrgpexprOrderedAggsPrEl->Release();
+		*ppexprRemainingAgg = pexprInputAggPrjChild;
+
+		return;
+	}
+
+	// create a new GbAgg expression for remaining aggregate functions
+	CColRefArray *pdrgpcrGrpCols = NULL;
+	pdrgpcrGrpCols = GPOS_NEW(mp) CColRefArray(mp);
+	pexprInputAggPrjChild->AddRef();
+	*ppexprRemainingAgg = GPOS_NEW(mp) CExpression(
+		mp,
+		GPOS_NEW(mp)
+			CLogicalGbAgg(mp, pdrgpcrGrpCols, COperator::EgbaggtypeGlobal),
+		pexprInputAggPrjChild,
+		GPOS_NEW(mp) CExpression(mp, GPOS_NEW(mp) CScalarProjectList(mp),
+								 pdrgpexprOtherPrEl));
+	ppdrgpexprOrderedAggsPrEl->Release();
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		COrderedAggPreprocessor::CreateCTE
+//
+//	@doc:
+//		Create a CTE with two consumers using the child expression of
+//		Sequence Project
+//
+//---------------------------------------------------------------------------
+void
+COrderedAggPreprocessor::CreateCTE(CMemoryPool *mp,
+								   CExpression *pexprInputAggPrj,
+								   CExpression **ppexprFirstConsumer,
+								   CExpression **ppexprSecondConsumer)
+{
+	GPOS_ASSERT(NULL != pexprInputAggPrj);
+	GPOS_ASSERT(COperator::EopLogicalGbAgg == pexprInputAggPrj->Pop()->Eopid());
+	GPOS_ASSERT(NULL != ppexprFirstConsumer);
+	GPOS_ASSERT(NULL != ppexprSecondConsumer);
+
+	CExpression *pexprChild = (*pexprInputAggPrj)[0];
+	CColRefSet *pcrsChildOutput = pexprChild->DeriveOutputColumns();
+	CColRefArray *pdrgpcrChildOutput = pcrsChildOutput->Pdrgpcr(mp);
+
+	// create a CTE producer based on SeqPrj child expression
+	CCTEInfo *pcteinfo = COptCtxt::PoctxtFromTLS()->Pcteinfo();
+	const ULONG ulCTEId = pcteinfo->next_id();
+	CExpression *pexprCTEProd = CXformUtils::PexprAddCTEProducer(
+		mp, ulCTEId, pdrgpcrChildOutput, pexprChild);
+	CColRefArray *pdrgpcrProducerOutput =
+		pexprCTEProd->DeriveOutputColumns()->Pdrgpcr(mp);
+
+	//	 first consumer creates new output columns to be used later as input to GbAgg expression
+	*ppexprFirstConsumer = GPOS_NEW(mp) CExpression(
+		mp, GPOS_NEW(mp) CLogicalCTEConsumer(
+				mp, ulCTEId, CUtils::PdrgpcrCopy(mp, pdrgpcrProducerOutput)));
+	pcteinfo->IncrementConsumers(ulCTEId);
+	pdrgpcrProducerOutput->Release();
+
+	// second consumer reuses the same output columns of SeqPrj child to be able to provide any requested columns upstream
+	*ppexprSecondConsumer = GPOS_NEW(mp) CExpression(
+		mp, GPOS_NEW(mp) CLogicalCTEConsumer(mp, ulCTEId, pdrgpcrChildOutput));
+	pcteinfo->IncrementConsumers(ulCTEId);
+}
+
+
+//---------------------------------------------------------------------------
+//    @function:
+//        COrderedAggPreprocessor::PexprFinalAgg
+//
+//    @doc:
+//        Return expression for final agg function
+//        Input:
+//          expression for percentile_cont(direct_arg) WITHIN GROUP(ORDER BY col)
+//          total_count
+//        Returns:
+//          expression for gp_percentile_cont(col, direct_arg, total_count, peer_count)
+//
+//---------------------------------------------------------------------------
+CExpression *
+COrderedAggPreprocessor::PexprFinalAgg(CMemoryPool *mp,
+									   CExpression *pexprAggFunc,
+									   CColRef *arg_col_ref,
+									   CColRef *total_count_colref)
+{
+	CScalarAggFunc *popScAggFunc =
+		CScalarAggFunc::PopConvert(pexprAggFunc->Pop());
+	CExpressionArray *pdrgpexpr = GPOS_NEW(mp) CExpressionArray(mp);
+	CMDIdGPDB *mdid = CMDIdGPDB::CastMdid(popScAggFunc->GetGpAggMDId());
+
+	CScalarValuesList *popScalarValuesList = GPOS_NEW(mp) CScalarValuesList(mp);
+	CExpressionArray *pdrgpexprChildren = GPOS_NEW(mp) CExpressionArray(mp);
+
+	CExpression *pexprAggFuncArg = (*(*pexprAggFunc)[0])[0];
+	pexprAggFuncArg->AddRef();
+	pdrgpexprChildren->Append(pexprAggFuncArg);
+
+	CExpression *pexprAggFuncDirectArg = (*(*pexprAggFunc)[1])[0];
+	pexprAggFuncDirectArg->AddRef();
+	pdrgpexprChildren->Append(pexprAggFuncDirectArg);
+	pdrgpexprChildren->Append(CUtils::PexprScalarIdent(mp, total_count_colref));
+	// Currently passing dummy peer_count as 1 always. Will pass along the
+	// calculated peer_count col_ref once we dedup data for handling skew
+	CExpression *pexprDummyPeerCount =
+		CUtils::PexprScalarConstInt8(mp, 1 /*val*/);
+	pdrgpexprChildren->Append(pexprDummyPeerCount);
+
+	pdrgpexpr->Append(
+		GPOS_NEW(mp) CExpression(mp, popScalarValuesList, pdrgpexprChildren));
+
+	pdrgpexpr->Append(GPOS_NEW(mp)
+						  CExpression(mp, GPOS_NEW(mp) CScalarValuesList(mp),
+									  GPOS_NEW(mp) CExpressionArray(mp)));
+
+	pdrgpexpr->Append(GPOS_NEW(mp)
+						  CExpression(mp, GPOS_NEW(mp) CScalarValuesList(mp),
+									  GPOS_NEW(mp) CExpressionArray(mp)));
+
+	pdrgpexpr->Append(GPOS_NEW(mp)
+						  CExpression(mp, GPOS_NEW(mp) CScalarValuesList(mp),
+									  GPOS_NEW(mp) CExpressionArray(mp)));
+
+	IMDId *ret_type = NULL;
+	if (popScAggFunc->FHasAmbiguousReturnType())
+	{
+		popScAggFunc->MdidType()->AddRef();
+		ret_type = popScAggFunc->MdidType();
+	}
+	mdid->AddRef();
+	CScalarAggFunc *popNewAggFunc = CUtils::PopAggFunc(
+		mp, mdid, arg_col_ref->Name().Pstr(), false /*is_distinct*/,
+		EaggfuncstageGlobal /*eaggfuncstage*/, false /*fSplit*/, ret_type,
+		EaggfunckindNormal);
+
+	return GPOS_NEW(mp) CExpression(mp, popNewAggFunc, pdrgpexpr);
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		COrderedAggPreprocessor::PexprInputAggPrj2Join
+//
+//	@doc:
+//		Transform GbAgg project expression with ordered aggregates
+//		into an inner join expression,
+//			- the outer child of the join is a GbAgg expression that computes
+//			gp_percentile aggs,
+//			- the inner child of the join is a GbAgg expression that computes
+//			remaining aggregate functions
+//
+//		we use a CTE to compute the input to both join children, while maintaining
+//		all column references upstream by reusing the same computed columns in the
+//		original input expression
+//
+//---------------------------------------------------------------------------
+CExpression *
+COrderedAggPreprocessor::PexprInputAggPrj2Join(CMemoryPool *mp,
+											   CExpression *pexprInputAggPrj)
+{
+	GPOS_ASSERT(NULL != pexprInputAggPrj);
+	GPOS_ASSERT(COperator::EopLogicalGbAgg == pexprInputAggPrj->Pop()->Eopid());
+	GPOS_ASSERT(0 < (*pexprInputAggPrj)[1]->DeriveTotalOrderedAggs());
+
+	// split InputAgg expression into a GbAgg expression (for ordered Aggs), and
+	// another GbAgg expression (for remaining aggregate functions)
+	CExpression *pexprOrderedAgg = NULL;
+	CExpression *pexprOtherAgg = NULL;
+	SplitOrderedAggsPrj(mp, pexprInputAggPrj, &pexprOrderedAgg, &pexprOtherAgg);
+
+	CExpression *pexprFinalJoin = NULL;
+	if (COperator::EopLogicalGbAgg == pexprOtherAgg->Pop()->Eopid())
+	{
+		CExpression *pexprJoinCondition =
+			CUtils::PexprScalarConstBool(mp, true /*value*/);
+		pexprFinalJoin = CUtils::PexprLogicalJoin<CLogicalInnerJoin>(
+			mp, pexprOtherAgg, pexprOrderedAgg, pexprJoinCondition);
+	}
+	else
+	{
+		pexprFinalJoin = pexprOrderedAgg;
+	}
+	ULONG arity = pexprOrderedAgg->Arity();
+	BOOL has_nlj_ontop =
+		(COperator::EopLogicalInnerJoin == pexprOrderedAgg->Pop()->Eopid());
+	CExpression *pexprTopmostCTE = pexprOrderedAgg;
+	while (COperator::EopLogicalGbAgg != pexprTopmostCTE->Pop()->Eopid())
+	{
+		pexprTopmostCTE = (*pexprTopmostCTE)[0];
+	}
+	ULONG ulCTEIdStart = CLogicalCTEConsumer::PopConvert(
+							 (*(*(*(*pexprTopmostCTE)[0])[0])[1])[0]->Pop())
+							 ->UlCTEId();
+	ULONG ulCTEIdEnd = ulCTEIdStart;
+	if (has_nlj_ontop)
+		ulCTEIdEnd =
+			CLogicalCTEConsumer::PopConvert(
+				(*(*(*(*(*pexprOrderedAgg)[arity - 2])[0])[0])[1])[0]->Pop())
+				->UlCTEId();
+	CExpression *pexpResult = pexprFinalJoin;
+	for (ULONG ul = ulCTEIdEnd; ul > ulCTEIdStart; ul--)
+	{
+		CExpression *ctenext = GPOS_NEW(mp)
+			CExpression(mp, GPOS_NEW(mp) CLogicalCTEAnchor(mp, ul), pexpResult);
+		pexpResult = ctenext;
+	}
+	pexpResult = GPOS_NEW(mp) CExpression(
+		mp, GPOS_NEW(mp) CLogicalCTEAnchor(mp, ulCTEIdStart), pexpResult);
+	return pexpResult;
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		COrderedAggPreprocessor::PexprPreprocess
+//
+//	@doc:
+//		Main driver
+//
+//---------------------------------------------------------------------------
+CExpression *
+COrderedAggPreprocessor::PexprPreprocess(CMemoryPool *mp, CExpression *pexpr)
+{
+	// protect against stack overflow during recursion
+	GPOS_CHECK_STACK_SIZE;
+	GPOS_ASSERT(NULL != mp);
+	GPOS_ASSERT(NULL != pexpr);
+
+	COperator *pop = pexpr->Pop();
+	if (COperator::EopLogicalGbAgg == pop->Eopid() &&
+		0 == CLogicalGbAgg::PopConvert(pop)->Pdrgpcr()->Size() &&
+		0 < (*pexpr)[1]->DeriveTotalOrderedAggs())
+	{
+		CExpression *pexprJoin = PexprInputAggPrj2Join(mp, pexpr);
+
+		// recursively process the resulting expression
+		CExpression *pexprResult = PexprPreprocess(mp, pexprJoin);
+		pexprJoin->Release();
+
+		return pexprResult;
+	}
+
+	// recursively process child expressions
+	const ULONG arity = pexpr->Arity();
+	CExpressionArray *pdrgpexprChildren = GPOS_NEW(mp) CExpressionArray(mp);
+	for (ULONG ul = 0; ul < arity; ul++)
+	{
+		CExpression *pexprChild = PexprPreprocess(mp, (*pexpr)[ul]);
+		pdrgpexprChildren->Append(pexprChild);
+	}
+
+	pop->AddRef();
+	return GPOS_NEW(mp) CExpression(mp, pop, pdrgpexprChildren);
+}
+
+// EOF

--- a/src/backend/gporca/libgpopt/src/operators/CScalarAggFunc.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CScalarAggFunc.cpp
@@ -36,7 +36,8 @@ CScalarAggFunc::CScalarAggFunc(CMemoryPool *mp, IMDId *pmdidAggFunc,
 							   IMDId *resolved_rettype,
 							   const CWStringConst *pstrAggFunc,
 							   BOOL is_distinct, EAggfuncStage eaggfuncstage,
-							   BOOL fSplit, EAggfuncKind aggkind)
+							   BOOL fSplit, EAggfuncKind aggkind,
+							   IMDId *gp_agg_mdid)
 	: CScalar(mp),
 	  m_pmdidAggFunc(pmdidAggFunc),
 	  m_pmdidResolvedRetType(resolved_rettype),
@@ -45,7 +46,8 @@ CScalarAggFunc::CScalarAggFunc(CMemoryPool *mp, IMDId *pmdidAggFunc,
 	  m_is_distinct(is_distinct),
 	  m_aggkind(aggkind),
 	  m_eaggfuncstage(eaggfuncstage),
-	  m_fSplit(fSplit)
+	  m_fSplit(fSplit),
+	  m_gp_agg_mdid(gp_agg_mdid)
 {
 	GPOS_ASSERT(NULL != pmdidAggFunc);
 	GPOS_ASSERT(NULL != pstrAggFunc);

--- a/src/backend/gporca/libgpopt/src/operators/CScalarProjectList.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CScalarProjectList.cpp
@@ -118,6 +118,37 @@ CScalarProjectList::UlDistinctAggs(CExpressionHandle &exprhdl)
 	return ulDistinctAggs;
 }
 
+ULONG
+CScalarProjectList::UlOrderedAggs(CExpressionHandle &exprhdl)
+{
+	// We make do with an inexact representative expression returned by exprhdl.PexprScalarRep(),
+	// knowing that at this time, aggregate functions are accurately contained in it. What's not
+	// exact are subqueries. This is better than just returning 0 for project lists with subqueries.
+	CExpression *pexprPrjList = exprhdl.PexprScalarRep();
+
+	GPOS_ASSERT(NULL != pexprPrjList);
+	GPOS_ASSERT(COperator::EopScalarProjectList ==
+				pexprPrjList->Pop()->Eopid());
+
+	ULONG ulOrderedAggs = 0;
+	const ULONG arity = pexprPrjList->Arity();
+	for (ULONG ul = 0; ul < arity; ul++)
+	{
+		CExpression *pexprPrjEl = (*pexprPrjList)[ul];
+		CExpression *pexprChild = (*pexprPrjEl)[0];
+		COperator::EOperatorId eopidChild = pexprChild->Pop()->Eopid();
+
+		if (COperator::EopScalarAggFunc == eopidChild)
+		{
+			if (CUtils::FHasOrderedAggToSplit(pexprChild))
+			{
+				ulOrderedAggs++;
+			}
+		}
+	}
+
+	return ulOrderedAggs;
+}
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/operators/Makefile
+++ b/src/backend/gporca/libgpopt/src/operators/Makefile
@@ -187,7 +187,8 @@ OBJS        = CExpression.o \
               CScalarSwitchCase.o \
               CScalarWindowFunc.o \
               CStrictHashedDistributions.o \
-              CWindowPreprocessor.o
+              CWindowPreprocessor.o \
+              COrderedAggPreprocessor.o
 
 include $(top_srcdir)/src/backend/common.mk
 

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -3106,6 +3106,7 @@ CTranslatorDXLToExpr::PexprAggFunc(const CDXLNode *pdxlnAggref)
 		// use the resolved type provided in DXL
 		resolved_return_type_mdid->AddRef();
 	}
+	IMDId *gp_agg_mdid = dxl_op->GetGpAggMDid();
 
 	CScalarAggFunc *popScAggFunc = CUtils::PopAggFunc(
 		m_mp, agg_func_mdid,
@@ -3113,6 +3114,12 @@ CTranslatorDXLToExpr::PexprAggFunc(const CDXLNode *pdxlnAggref)
 			CWStringConst(m_mp, (pmdagg->Mdname().GetMDName())->GetBuffer()),
 		dxl_op->IsDistinct(), agg_func_stage, fSplit, resolved_return_type_mdid,
 		agg_func_kind);
+
+	if (NULL != gp_agg_mdid)
+	{
+		gp_agg_mdid->AddRef();
+		popScAggFunc->SetGpAggMDId(gp_agg_mdid);
+	}
 
 	CExpression *pexprAggFunc = NULL;
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/gpdb_types.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/gpdb_types.h
@@ -65,6 +65,23 @@ typedef ULONG OID;
 #define GPDB_COUNT_ANY OID(2147)   // count(Any)
 #define GPDB_UUID OID(2950)
 #define GPDB_ANY OID(2283)
+#define GPDB_PERCENTILE_DISC \
+	OID(3972)  // percentile_disc(fraction) group within(ANYELEMENT)
+#define GPDB_PERCENTILE_CONT_FLOAT8 \
+	OID(3974)  // percentile_cont(fraction) group within(FLOAT8)
+#define GPDB_PERCENTILE_CONT_INTERVAL \
+	OID(3976)  // percentile_cont(fraction) group within(INTERVAL)
+#define GPDB_PERCENTILE_CONT_TIMESTAMP \
+	OID(6119)  // percentile_cont(fraction) group within(timestamp)
+#define GPDB_PERCENTILE_CONT_TIMESTAMPTZ \
+	OID(6123)  // percentile_cont(fraction) group within(timestamptz)
+#define GPDB_MEDIAN_FLOAT8 OID(6127)  // median(fraction) group within(FLOAT8)
+#define GPDB_MEDIAN_INTERVAL \
+	OID(6128)  // median(fraction) group within(INTERVAL)
+#define GPDB_MEDIAN_TIMESTAMP \
+	OID(6129)  // median(fraction) group within(timestamp)
+#define GPDB_MEDIAN_TIMESTAMPTZ \
+	OID(6130)  // median(fraction) group within(timestamptz)
 
 #endif	// !GPDXL_gpdb_types_H
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLScalarAggref.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLScalarAggref.h
@@ -74,6 +74,9 @@ private:
 
 	EdxlAggrefKind m_agg_kind;
 
+	// MDId of corresponding gp_agg for supported ordered aggs (optional)
+	IMDId *m_gp_agg_mdid;
+
 	// private copy ctor
 	CDXLScalarAggref(const CDXLScalarAggref &);
 
@@ -81,7 +84,7 @@ public:
 	// ctor/dtor
 	CDXLScalarAggref(CMemoryPool *mp, IMDId *agg_mdid, IMDId *resolved_rettype,
 					 BOOL is_distinct, EdxlAggrefStage agg_stage,
-					 EdxlAggrefKind aggkind);
+					 EdxlAggrefKind aggkind, IMDId *gp_agg_mdid = NULL);
 
 	virtual ~CDXLScalarAggref();
 
@@ -106,6 +109,12 @@ public:
 	GetAggKind() const
 	{
 		return m_agg_kind;
+	}
+
+	IMDId *
+	GetGpAggMDid() const
+	{
+		return m_gp_agg_mdid;
 	}
 
 	// serialize operator in DXL format

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -304,6 +304,7 @@ enum Edxltoken
 	EdxltokenAggrefOid,
 	EdxltokenAggrefDistinct,
 	EdxltokenAggrefKind,
+	EdxltokenAggrefGpAggOid,
 	EdxltokenAggrefStage,
 	EdxltokenAggrefLookups,
 	EdxltokenAggrefStageNormal,

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
@@ -1088,6 +1088,16 @@ CDXLOperatorFactory::MakeDXLAggFunc(CDXLMemoryManager *dxl_memory_manager,
 		resolved_rettype = ExtractConvertAttrValueToMdId(
 			dxl_memory_manager, attrs, EdxltokenTypeId, EdxltokenScalarAggref);
 	}
+	IMDId *gp_agg_oid = ExtractConvertAttrValueToMdId(
+		dxl_memory_manager, attrs, EdxltokenAggrefGpAggOid,
+		EdxltokenScalarAggref, true);
+
+	if (NULL != gp_agg_oid)
+	{
+		return GPOS_NEW(mp)
+			CDXLScalarAggref(mp, agg_mdid, resolved_rettype, is_distinct,
+							 agg_stage, agg_kind, gp_agg_oid);
+	}
 
 	return GPOS_NEW(mp) CDXLScalarAggref(mp, agg_mdid, resolved_rettype,
 										 is_distinct, agg_stage, agg_kind);

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLScalarAggref.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLScalarAggref.cpp
@@ -34,13 +34,14 @@ using namespace gpdxl;
 CDXLScalarAggref::CDXLScalarAggref(CMemoryPool *mp, IMDId *agg_func_mdid,
 								   IMDId *resolved_rettype_mdid,
 								   BOOL is_distinct, EdxlAggrefStage agg_stage,
-								   EdxlAggrefKind agg_kind)
+								   EdxlAggrefKind agg_kind, IMDId *gp_agg_mdid)
 	: CDXLScalar(mp),
 	  m_agg_func_mdid(agg_func_mdid),
 	  m_resolved_rettype_mdid(resolved_rettype_mdid),
 	  m_is_distinct(is_distinct),
 	  m_agg_stage(agg_stage),
-	  m_agg_kind(agg_kind)
+	  m_agg_kind(agg_kind),
+	  m_gp_agg_mdid(gp_agg_mdid)
 {
 	GPOS_ASSERT(NULL != agg_func_mdid);
 	GPOS_ASSERT_IMP(NULL != resolved_rettype_mdid,
@@ -60,6 +61,7 @@ CDXLScalarAggref::~CDXLScalarAggref()
 {
 	m_agg_func_mdid->Release();
 	CRefCount::SafeRelease(m_resolved_rettype_mdid);
+	CRefCount::SafeRelease(m_gp_agg_mdid);
 }
 
 
@@ -241,6 +243,11 @@ CDXLScalarAggref::SerializeToDXL(CXMLSerializer *xml_serializer,
 	}
 	xml_serializer->AddAttribute(
 		CDXLTokens::GetDXLTokenStr(EdxltokenAggrefKind), GetDXLStrAggKind());
+	if (NULL != m_gp_agg_mdid)
+	{
+		m_gp_agg_mdid->Serialize(xml_serializer, CDXLTokens::GetDXLTokenStr(
+													 EdxltokenAggrefGpAggOid));
+	}
 
 	SerializeValuesListChildToDXL(xml_serializer, dxlnode, 0, "aggargs");
 	SerializeValuesListChildToDXL(xml_serializer, dxlnode, 1, "aggdirectargs");

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -356,6 +356,7 @@ CDXLTokens::Init(CMemoryPool *mp)
 		{EdxltokenAggrefOid, GPOS_WSZ_LIT("AggMdid")},
 		{EdxltokenAggrefDistinct, GPOS_WSZ_LIT("AggDistinct")},
 		{EdxltokenAggrefKind, GPOS_WSZ_LIT("AggKind")},
+		{EdxltokenAggrefGpAggOid, GPOS_WSZ_LIT("GpAggMdid")},
 		{EdxltokenAggrefStage, GPOS_WSZ_LIT("AggStage")},
 		{EdxltokenAggrefLookups, GPOS_WSZ_LIT("AggLookups")},
 		{EdxltokenAggrefStageNormal, GPOS_WSZ_LIT("Normal")},

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -356,7 +356,12 @@ CSqlFunctionTest:
 SqlFuncNullReject SqlFuncPredFactorize SqlFuncDmlScalar SqlFuncDmlTvf;
 
 CScalarFuncPushDownTest:
-ScalarFuncPushedBelowGather ConstScalarFuncNotPushedBelowGather
+ScalarFuncPushedBelowGather ConstScalarFuncNotPushedBelowGather;
+
+COrderedAggTest:
+CTAS_OrderedAgg_multiple_cols OrderedAgg_multiple_diffcol OrderedAgg_with_groupby OrderedAgg_computed_col
+OrderedAggUsingGroupColumnInDirectArg OrderedAgg_multiple_samecol OrderedAgg_with_nonOrderedAgg OrderedAgg_single
+OrderedAgg_array_fraction OrderedAgg_multiple_samecol_difforderespec OrderedAgg_with_nonconst_fraction
 ")
 
 set(mdp_dir "../data/dxl/minidump/")

--- a/src/backend/utils/cache/lsyscache.c
+++ b/src/backend/utils/cache/lsyscache.c
@@ -3783,7 +3783,7 @@ aggregate_exists(Oid oid)
 
 // Get oid of aggregate with given name and argument type
 Oid
-get_aggregate(const char *aggname, Oid oidType)
+get_aggregate(const char *aggname, Oid oidType, int nargs)
 {
 	CatCList   *catlist;
 	int			i;
@@ -3801,7 +3801,7 @@ get_aggregate(const char *aggname, Oid oidType)
 		Form_pg_proc proctuple = (Form_pg_proc) GETSTRUCT(htup);
 
 		// skip functions with the wrong number of type of arguments
-		if (1 != proctuple->pronargs || oidType != proctuple->proargtypes.values[0])
+		if (nargs != (int) proctuple->pronargs || oidType != proctuple->proargtypes.values[0])
 		{
 			continue;
 		}

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -181,7 +181,7 @@ bool IsOrderedAgg(Oid aggid);
 bool IsAggPartialCapable(Oid aggid);
 
 // intermediate result type of given aggregate
-Oid GetAggregate(const char *agg, Oid type_oid);
+Oid GetAggregate(const char *agg, Oid type_oid, int nargs);
 
 // array type oid
 Oid GetArrayType(Oid typid);

--- a/src/include/utils/lsyscache.h
+++ b/src/include/utils/lsyscache.h
@@ -218,7 +218,7 @@ extern bool type_exists(Oid oid);
 extern bool function_exists(Oid oid);
 extern bool operator_exists(Oid oid);
 extern bool aggregate_exists(Oid oid);
-extern Oid get_aggregate(const char *aggname, Oid oidType);
+extern Oid get_aggregate(const char *aggname, Oid oidType, int nargs);
 extern List *get_relation_keys(Oid relid);
 extern bool attname_exists(Oid relid, const char *attname);
 extern bool trigger_exists(Oid oid);


### PR DESCRIPTION
This is a backport of the PR https://github.com/greenplum-db/gpdb/pull/13341 on master.
The difference from master PR includes the following:
- Instead of adding the gp_percentile aggs as part of the catalog, created a new gpcontrib module for it
- Translator changes to pass along the OID for the gp_percentile agg functions if the extension is created else, ORCA will generate the same plan as current 6X
- Updated get_aggregate function(this is only used by ORCA) that fetches the aggregates OID based on the name for fetching gp_percentile aggregate OID correctly as extension will generate a different OID

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
