### PR TITLE
[WIP] Dispatch encoding for creating external table

### DIFF
--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -234,7 +234,11 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 
 	/* If encoding is defaulted, use database encoding */
 	if (encoding < 0)
+	{
 		encoding = pg_get_client_encoding();
+		createExtStmt->encoding = lappend(createExtStmt->encoding,
+			makeDefElem("encoding", (Node *)makeInteger(encoding), -1));
+	}
 
 	/*
 	 * If the number of locations (file or http URIs) exceed the number of

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -270,6 +270,15 @@ DROP OWNED BY test_role_issue_12748;
 DROP ROLE test_role_issue_12748;
 DROP PROTOCOL dummy_protocol_issue_12748;
 
+-- Test pg_exttable's encoding: QE's encoding should be consistent with QD
+-- GitHub Issue #9727: https://github.com/greenplum-db/gpdb/issues/9727
+SET client_encoding = 'ISO-8859-1';
+CREATE EXTERNAL TABLE issue_9727 (d varchar(20)) location ('gpfdist://9727/d.dat') format 'csv' (DELIMITER '|');
+SELECT encoding from pg_exttable where urilocation='{gpfdist://9727:8080/d.dat}';
+SELECT encoding from gp_dist_random('pg_exttable') where urilocation='{gpfdist://9727:8080/d.dat}';
+DROP FOREIGN TABLE issue_9727;
+RESET client_encoding;
+
 --
 -- WET tests
 --

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -343,6 +343,26 @@ DROP OWNED BY test_role_issue_12748;
 -- Clean up.
 DROP ROLE test_role_issue_12748;
 DROP PROTOCOL dummy_protocol_issue_12748;
+-- Test pg_exttable's encoding: QE's encoding should be consistent with QD
+-- GitHub Issue #9727: https://github.com/greenplum-db/gpdb/issues/9727
+SET client_encoding = 'ISO-8859-1';
+CREATE EXTERNAL TABLE issue_9727 (d varchar(20)) location ('gpfdist://9727/d.dat') format 'csv' (DELIMITER '|');
+SELECT encoding from pg_exttable where urilocation='{gpfdist://9727:8080/d.dat}';
+ encoding 
+----------
+        8
+(1 row)
+
+SELECT encoding from gp_dist_random('pg_exttable') where urilocation='{gpfdist://9727:8080/d.dat}';
+ encoding 
+----------
+        8
+        8
+        8
+(3 rows)
+
+DROP FOREIGN TABLE issue_9727;
+RESET client_encoding;
 --
 -- WET tests
 --


### PR DESCRIPTION
This PR fixes https://github.com/greenplum-db/gpdb/issues/9727 .

If user doesn't set the encoding option in `create external table` [statement](https://gpdb.docs.pivotal.io/6-16/ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.html), it applies the current `client_encoding` as the default value:
https://github.com/greenplum-db/gpdb/blob/93955a93da8131bd903b1042aeed80e37dbf4a76/src/backend/commands/exttablecmds.c#L235-L237

But this value doesn't dispatch to QEs subsequently, so if QD set a specific `client_encoding` and create an external table later: the encoding column of `pg_exttable` is different between QD and QEs (using its own `client_encoding` value).

Repro steps please look the issue: https://github.com/greenplum-db/gpdb/issues/9727 .

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
