### PR TITLE
[6X] Dispatch encoding for creating external table

### DIFF
--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -335,7 +335,11 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 
 	/* If encoding is defaulted, use database encoding */
 	if (encoding < 0)
+	{
 		encoding = pg_get_client_encoding();
+		createExtStmt->encoding = lappend(createExtStmt->encoding,
+			makeDefElem("encoding", (Node *)makeInteger(encoding)));
+	}
 
 	/*
 	 * If the number of locations (file or http URIs) exceed the number of

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -264,6 +264,15 @@ CREATE PROTOCOL demoprot_non_superuser (readfunc = 'read_from_file', writefunc =
 CREATE TRUSTED PROTOCOL demoprot_non_superuser (readfunc = 'read_from_file', writefunc = 'write_to_file');
 RESET ROLE;
 
+-- Test pg_exttable's encoding: QE's encoding should be consistent with QD
+-- GitHub Issue #9727: https://github.com/greenplum-db/gpdb/issues/9727
+SET client_encoding = 'ISO-8859-1';
+CREATE EXTERNAL TABLE issue_9727 (d varchar(20)) location ('gpfdist://9727/d.dat') format 'csv' (DELIMITER '|');
+SELECT encoding from pg_exttable where urilocation='{gpfdist://9727:8080/d.dat}';
+SELECT encoding from gp_dist_random('pg_exttable') where urilocation='{gpfdist://9727:8080/d.dat}';
+DROP EXTERNAL TABLE issue_9727;
+RESET client_encoding;
+
 --
 -- WET tests
 --

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -342,6 +342,26 @@ ERROR:  must be superuser to create an external protocol
 CREATE TRUSTED PROTOCOL demoprot_non_superuser (readfunc = 'read_from_file', writefunc = 'write_to_file');
 ERROR:  must be superuser to create an external protocol
 RESET ROLE;
+-- Test pg_exttable's encoding: QE's encoding should be consistent with QD
+-- GitHub Issue #9727: https://github.com/greenplum-db/gpdb/issues/9727
+SET client_encoding = 'ISO-8859-1';
+CREATE EXTERNAL TABLE issue_9727 (d varchar(20)) location ('gpfdist://9727/d.dat') format 'csv' (DELIMITER '|');
+SELECT encoding from pg_exttable where urilocation='{gpfdist://9727:8080/d.dat}';
+ encoding 
+----------
+        8
+(1 row)
+
+SELECT encoding from gp_dist_random('pg_exttable') where urilocation='{gpfdist://9727:8080/d.dat}';
+ encoding 
+----------
+        8
+        8
+        8
+(3 rows)
+
+DROP EXTERNAL TABLE issue_9727;
+RESET client_encoding;
 --
 -- WET tests
 --


### PR DESCRIPTION
This PR backports from https://github.com/greenplum-db/gpdb/pull/13597
It will fix https://github.com/greenplum-db/gpdb/issues/9727 in 6X.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
