### PR TITLE
Materialize aggregations in NL Join inner child

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/AnyPredicate-Over-UnionOfConsts.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnyPredicate-Over-UnionOfConsts.mdp
@@ -167,7 +167,7 @@
         </dxl:LogicalConstTable>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1998">
+    <dxl:Plan Id="0" SpaceSize="1266">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.000506" Rows="1.000000" Width="1"/>

--- a/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-1.mdp
@@ -471,7 +471,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2616">
+    <dxl:Plan Id="0" SpaceSize="2643">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1389253302051.813232" Rows="1.000000" Width="15"/>

--- a/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-2.mdp
@@ -451,7 +451,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="296">
+    <dxl:Plan Id="0" SpaceSize="299">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356691815.392586" Rows="1.000000" Width="15"/>

--- a/src/backend/gporca/data/dxl/minidump/CTEWithMergedGroup.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTEWithMergedGroup.mdp
@@ -425,7 +425,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="100573150272">
+    <dxl:Plan Id="0" SpaceSize="91069351488">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356250696.455244" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/CannotPullGrpColAboveAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CannotPullGrpColAboveAgg.mdp
@@ -3762,7 +3762,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
         </dxl:LogicalJoin>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="19837440">
+    <dxl:Plan Id="0" SpaceSize="15376896">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="57937329.740768" Rows="2959212724800.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedIN-LeftSemiJoin-Limit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedIN-LeftSemiJoin-Limit.mdp
@@ -306,7 +306,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="188">
+    <dxl:Plan Id="0" SpaceSize="192">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324032.151091" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedIN-LeftSemiJoin-True.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedIN-LeftSemiJoin-True.mdp
@@ -702,7 +702,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="82">
+    <dxl:Plan Id="0" SpaceSize="86">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324039.870686" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedLeftSemiNLJoinWithLimit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedLeftSemiNLJoinWithLimit.mdp
@@ -317,7 +317,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="84">
+    <dxl:Plan Id="0" SpaceSize="88">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324032.157856" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/Correlation-With-Casting-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Correlation-With-Casting-1.mdp
@@ -432,7 +432,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="17595">
+    <dxl:Plan Id="0" SpaceSize="18507">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2155.680679" Rows="70.000000" Width="10"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
@@ -1298,7 +1298,7 @@
         </dxl:Or>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="9877549">
+    <dxl:Plan Id="0" SpaceSize="9183946">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1357145192.840398" Rows="1.000000" Width="1"/>

--- a/src/backend/gporca/data/dxl/minidump/InSubqWithPrjListOuterRefNoInnerRefColumnIn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InSubqWithPrjListOuterRefNoInnerRefColumnIn.mdp
@@ -622,7 +622,7 @@ EXPLAIN SELECT * FROM foo WHERE a IN (SELECT b+1 FROM bar);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="82">
+    <dxl:Plan Id="0" SpaceSize="86">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.005496" Rows="40.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/InSubqWithPrjListOuterRefNoInnerRefColumnPlusConstIn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InSubqWithPrjListOuterRefNoInnerRefColumnPlusConstIn.mdp
@@ -625,7 +625,7 @@ EXPLAIN SELECT * FROM foo WHERE 1+a IN (SELECT b+1 FROM bar);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="82">
+    <dxl:Plan Id="0" SpaceSize="86">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.005496" Rows="40.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/InSubqWithPrjListOuterRefNoInnerRefConstIn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InSubqWithPrjListOuterRefNoInnerRefConstIn.mdp
@@ -619,7 +619,7 @@ SELECT * FROM foo WHERE 2 IN (SELECT b+1 FROM bar);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="82">
+    <dxl:Plan Id="0" SpaceSize="86">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.004400" Rows="40.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-With-Subq-Preds-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-With-Subq-Preds-1.mdp
@@ -783,7 +783,7 @@
         </dxl:Or>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="29572">
+    <dxl:Plan Id="0" SpaceSize="9720">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="10867.964640" Rows="10000000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-With-Subq-Preds-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-With-Subq-Preds-2.mdp
@@ -809,7 +809,7 @@
         </dxl:Or>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="234125728">
+    <dxl:Plan Id="0" SpaceSize="9772576">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="9312.745178" Rows="520834.333333" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/Join_OuterChild_DistUniversal.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join_OuterChild_DistUniversal.mdp
@@ -271,7 +271,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="235">
+    <dxl:Plan Id="0" SpaceSize="229">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000327" Rows="3.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJNullRejectingZeroPlacePredicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJNullRejectingZeroPlacePredicates.mdp
@@ -414,10 +414,10 @@
         </dxl:LogicalConstTable>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="120">
+    <dxl:Plan Id="0" SpaceSize="180">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324032.584049" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324032.591012" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="19" Alias="cnt">
@@ -431,7 +431,7 @@
         <dxl:OneTimeFilter/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324032.584041" Rows="2.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324032.591004" Rows="2.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="20" Alias="ColRef_0020">
@@ -442,7 +442,7 @@
           <dxl:OneTimeFilter/>
           <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324032.584025" Rows="2.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.590988" Rows="2.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="18" Alias="cnt">
@@ -465,27 +465,31 @@
               <dxl:Filter/>
               <dxl:OneTimeFilter/>
             </dxl:Result>
-            <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+            <dxl:Materialize Eager="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.000479" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000485" Rows="1.000000" Width="8"/>
               </dxl:Properties>
-              <dxl:GroupingColumns/>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="18" Alias="cnt">
-                  <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                    <dxl:ValuesList ParamType="aggargs"/>
-                    <dxl:ValuesList ParamType="aggdirectargs"/>
-                    <dxl:ValuesList ParamType="aggorder"/>
-                    <dxl:ValuesList ParamType="aggdistinct"/>
-                  </dxl:AggFunc>
+                  <dxl:Ident ColId="18" ColName="cnt" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:Materialize Eager="false">
+              <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.000479" Rows="1.200000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000477" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
-                <dxl:ProjList/>
+                <dxl:GroupingColumns/>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="18" Alias="cnt">
+                    <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                      <dxl:ValuesList ParamType="aggargs"/>
+                      <dxl:ValuesList ParamType="aggdirectargs"/>
+                      <dxl:ValuesList ParamType="aggorder"/>
+                      <dxl:ValuesList ParamType="aggdistinct"/>
+                    </dxl:AggFunc>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
                 <dxl:Filter/>
                 <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                   <dxl:Properties>
@@ -561,8 +565,8 @@
                     </dxl:TableScan>
                   </dxl:HashJoin>
                 </dxl:GatherMotion>
-              </dxl:Materialize>
-            </dxl:Aggregate>
+              </dxl:Aggregate>
+            </dxl:Materialize>
           </dxl:NestedLoopJoin>
         </dxl:Result>
       </dxl:Result>

--- a/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin-Tpcds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin-Tpcds.mdp
@@ -11631,7 +11631,7 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
         </dxl:LogicalCTEAnchor>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="87522">
+    <dxl:Plan Id="0" SpaceSize="85902">
       <dxl:Limit>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="5904.512295" Rows="5.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin.mdp
@@ -301,7 +301,7 @@ and ei.entity_id  = i.ad_id;
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3148">
+    <dxl:Plan Id="0" SpaceSize="3034">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2586.003103" Rows="2.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/MultiLevel-CorrelatedExec.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultiLevel-CorrelatedExec.mdp
@@ -732,7 +732,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="49">
+    <dxl:Plan Id="0" SpaceSize="48">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1818691.526596" Rows="1000.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/NLJ-Rewindability-CTAS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NLJ-Rewindability-CTAS.mdp
@@ -1,0 +1,789 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Objective: The aggregate should have a materialize on top if it is the
+    inner child of a nested loop join. This will help with the performance.
+
+    EXPLAIN
+    CREATE TABLE t1 AS
+    WITH un1 AS (
+        SELECT
+            unnest('{rerum,velit,p,q,r,s,t,um,v,q,w,e,r,t,y,u,i}'::text[]) val,
+            unnest(coalesce( CASE
+                WHEN array_length('{rerum,velit}'::text[],1) =
+                    array_length(array[1.0]::float[],1)
+                THEN array[1.0]::float[]
+                END,
+                array_fill(1.0::double precision,
+                    array[coalesce(array_length('{rerum,velit,p,q,r,s,t,u,v,w}'::text[], 1), 0)]
+                    )
+            )) wt
+    ),
+    mw AS (
+        SELECT avg(wt) AS w FROM un1
+    ),
+    un2 AS (
+        SELECT unnest('{odio,beatae, a, b, c ,d, e, f,g}'::text[]) val
+    )
+    SELECT coalesce(
+        sum(CASE when u1.val is not distinct FROM u2.val then u1.wt else 0.0 end * 2) /
+            nullif(
+                sum(CASE
+                    WHEN u1.val is not distinct FROM u2.val
+                    THEN 2 ELSE 1
+                    END
+                    * coalesce(u1.wt,m.w)
+                ),
+            0),
+        0)
+    FROM
+        un1 u1
+        FULL OUTER JOIN
+        un2 u2
+            on u1.val = u2.val
+        CROSS JOIN
+        mw m ;
+                                                             QUERY PLAN
+    -----------------------------------------------------------------------------------------------------------------------------
+     Result  (cost=0.00..0.00 rows=0 width=0)
+       ->  Result  (cost=0.00..1324033.17 rows=1 width=8)
+             ->  Sequence  (cost=0.00..1324033.15 rows=1 width=8)
+                   ->  Shared Scan (share slice:id 0:0)  (cost=0.00..0.00 rows=1 width=1)
+                         ->  Materialize  (cost=0.00..0.00 rows=1 width=1)
+                               ->  Result  (cost=0.00..0.00 rows=1 width=16)
+                                     ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                   ->  Result  (cost=0.00..1324033.15 rows=1 width=8)
+                         One-Time Filter: (gp_execution_segment() = 1)
+                         ->  Result  (cost=0.00..1324033.15 rows=1 width=8)
+                               ->  Aggregate  (cost=0.00..1324033.15 rows=1 width=16)
+                                     ->  Nested Loop  (cost=0.00..1324033.15 rows=1 width=32)
+                                           Join Filter: true
+                                           ->  Merge Full Join  (cost=0.00..431.00 rows=1 width=24)
+                                                 Merge Cond: (share0_ref3.val = (unnest('{odio,beatae,a,b,c,d,e,f,g}'::text[])))
+                                                 ->  Sort  (cost=0.00..431.00 rows=1 width=16)
+                                                       Sort Key: share0_ref3.val
+                                                       ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=16)
+                                                 ->  Sort  (cost=0.00..0.00 rows=1 width=8)
+                                                       Sort Key: (unnest('{odio,beatae,a,b,c,d,e,f,g}'::text[]))
+                                                       ->  Result  (cost=0.00..0.00 rows=1 width=8)
+                                                             ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                                           ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                       ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+     Optimizer: Pivotal Optimizer (GPORCA)
+    (26 rows)
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.CTAS,0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.664.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.25.1.0"/>
+        <dxl:RightType Mdid="0.25.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.740.1.0"/>
+        <dxl:Commutator Mdid="0.666.1.0"/>
+        <dxl:InverseOp Mdid="0.667.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1994.1.0"/>
+          <dxl:Opfamily Mdid="0.4017.1.0"/>
+          <dxl:Opfamily Mdid="0.7035.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1009.1.0"/>
+        <dxl:MinAgg Mdid="0.2145.1.0"/>
+        <dxl:MaxAgg Mdid="0.2129.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBFunc Mdid="0.2331.1.0" Name="unnest" ReturnsSet="true" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.2283.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:GPDBScalarOp Mdid="0.670.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.701.1.0"/>
+        <dxl:RightType Mdid="0.701.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.293.1.0"/>
+        <dxl:Commutator Mdid="0.670.1.0"/>
+        <dxl:InverseOp Mdid="0.671.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1971.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7102.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1970.1.0"/>
+          <dxl:Opfamily Mdid="0.1971.1.0"/>
+          <dxl:Opfamily Mdid="0.7024.1.0"/>
+          <dxl:Opfamily Mdid="0.7102.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:CTASRelation Mdid="5.1.1.0" Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" VarTypeModList="-1" DistributionPolicy="Random">
+        <dxl:Columns>
+          <dxl:Column Name="coalesce" Attno="1" Mdid="0.701.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:CTASOptions OnCommitAction="NOOP"/>
+        <dxl:DistrOpfamilies/>
+        <dxl:DistrOpclasses/>
+      </dxl:CTASRelation>
+      <dxl:MDCast Mdid="3.25.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.25.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.25.1.0" CoercePathType="0"/>
+      <dxl:GPDBAgg Mdid="0.2105.1.0" Name="avg" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.1022.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:MDCast Mdid="3.1009.1.0;25.1.0" Name="text" BinaryCoercible="false" SourceTypeId="0.1009.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.25.1.0" CoercePathType="0"/>
+      <dxl:GPDBFunc Mdid="0.316.1.0" Name="float8" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
+        <dxl:EqualityOp Mdid="0.670.1.0"/>
+        <dxl:InequalityOp Mdid="0.671.1.0"/>
+        <dxl:LessThanOp Mdid="0.672.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
+        <dxl:ComparisonOp Mdid="0.355.1.0"/>
+        <dxl:ArrayType Mdid="0.1022.1.0"/>
+        <dxl:MinAgg Mdid="0.2136.1.0"/>
+        <dxl:MaxAgg Mdid="0.2120.1.0"/>
+        <dxl:AvgAgg Mdid="0.2105.1.0"/>
+        <dxl:SumAgg Mdid="0.2111.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.2111.1.0" Name="sum" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:GPDBScalarOp Mdid="0.593.1.0" Name="/" ComparisonType="Other" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.701.1.0"/>
+        <dxl:RightType Mdid="0.701.1.0"/>
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:OpFunc Mdid="0.217.1.0"/>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.594.1.0" Name="*" ComparisonType="Other" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.701.1.0"/>
+        <dxl:RightType Mdid="0.701.1.0"/>
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:OpFunc Mdid="0.216.1.0"/>
+        <dxl:Commutator Mdid="0.594.1.0"/>
+      </dxl:GPDBScalarOp>
+      <dxl:MDCast Mdid="3.1022.1.0;701.1.0" Name="float8" BinaryCoercible="false" SourceTypeId="0.1022.1.0" DestinationTypeId="0.701.1.0" CastFuncId="0.701.1.0" CoercePathType="0"/>
+      <dxl:GPDBScalarOp Mdid="0.98.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.25.1.0"/>
+        <dxl:RightType Mdid="0.25.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.67.1.0"/>
+        <dxl:Commutator Mdid="0.98.1.0"/>
+        <dxl:InverseOp Mdid="0.531.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7105.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1994.1.0"/>
+          <dxl:Opfamily Mdid="0.1995.1.0"/>
+          <dxl:Opfamily Mdid="0.2095.1.0"/>
+          <dxl:Opfamily Mdid="0.2229.1.0"/>
+          <dxl:Opfamily Mdid="0.4017.1.0"/>
+          <dxl:Opfamily Mdid="0.7035.1.0"/>
+          <dxl:Opfamily Mdid="0.7042.1.0"/>
+          <dxl:Opfamily Mdid="0.7105.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.1009.1.0" Name="_text" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.627.1.0"/>
+        <dxl:EqualityOp Mdid="0.1070.1.0"/>
+        <dxl:InequalityOp Mdid="0.1071.1.0"/>
+        <dxl:LessThanOp Mdid="0.1072.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1074.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1073.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1075.1.0"/>
+        <dxl:ComparisonOp Mdid="0.382.1.0"/>
+        <dxl:ArrayType Mdid="0.0.0.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:MDCast Mdid="3.23.1.0;701.1.0" Name="float8" BinaryCoercible="false" SourceTypeId="0.23.1.0" DestinationTypeId="0.701.1.0" CastFuncId="0.316.1.0" CoercePathType="1"/>
+      <dxl:Type Mdid="0.1022.1.0" Name="_float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.627.1.0"/>
+        <dxl:EqualityOp Mdid="0.1070.1.0"/>
+        <dxl:InequalityOp Mdid="0.1071.1.0"/>
+        <dxl:LessThanOp Mdid="0.1072.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1074.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1073.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1075.1.0"/>
+        <dxl:ComparisonOp Mdid="0.382.1.0"/>
+        <dxl:ArrayType Mdid="0.0.0.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.6219.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="15" ColName="coalesce" TypeMdid="0.701.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList>
+        <dxl:LogicalCTEProducer CTEId="1" Columns="2,3">
+          <dxl:LogicalProject>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="2" Alias="val">
+                <dxl:FuncExpr FuncId="0.2331.1.0" FuncRetSet="true" TypeMdid="0.25.1.0">
+                  <dxl:ConstValue TypeMdid="0.1009.1.0" Value="AAAAqAEAAAAAAAAAGQAAABEAAAABAAAAAAAACXJlcnVtAAAAAAAACXZlbGl0&#10;AAAAAAAABXAAAAAAAAAFcQAAAAAAAAVyAAAAAAAABXMAAAAAAAAFdAAAAAAA&#10;AAZ1bQAAAAAABXYAAAAAAAAFcQAAAAAAAAV3AAAAAAAABWUAAAAAAAAFcgAA&#10;AAAAAAV0AAAAAAAABXkAAAAAAAAFdQAAAAAAAAVpAAAA"/>
+                </dxl:FuncExpr>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="3" Alias="wt">
+                <dxl:FuncExpr FuncId="0.2331.1.0" FuncRetSet="true" TypeMdid="0.701.1.0">
+                  <dxl:ConstValue TypeMdid="0.1022.1.0" Value="AAAAoAEAAAAAAAAAvQIAABEAAAABAAAAAAAAAAAA8D8AAAAAAADwPwAAAAAA&#10;APA/AAAAAAAA8D8AAAAAAADwPwAAAAAAAPA/AAAAAAAA8D8AAAAAAADwPwAA&#10;AAAAAPA/AAAAAAAA8D8AAAAAAADwPwAAAAAAAPA/AAAAAAAA8D8AAAAAAADw&#10;PwAAAAAAAPA/AAAAAAAA8D8AAAAAAADwPw=="/>
+                </dxl:FuncExpr>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:LogicalConstTable>
+              <dxl:Columns>
+                <dxl:Column ColId="1" Attno="1" ColName="" TypeMdid="0.16.1.0"/>
+              </dxl:Columns>
+              <dxl:ConstTuple>
+                <dxl:Datum TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:ConstTuple>
+            </dxl:LogicalConstTable>
+          </dxl:LogicalProject>
+        </dxl:LogicalCTEProducer>
+        <dxl:LogicalCTEProducer CTEId="2" Columns="6">
+          <dxl:LogicalGroupBy>
+            <dxl:GroupingColumns/>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="6" Alias="w">
+                <dxl:AggFunc AggMdid="0.2105.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="701">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:Ident ColId="5" ColName="wt" TypeMdid="0.701.1.0"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                  <dxl:ValuesList ParamType="aggorder"/>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:LogicalCTEConsumer CTEId="1" Columns="4,5"/>
+          </dxl:LogicalGroupBy>
+        </dxl:LogicalCTEProducer>
+        <dxl:LogicalCTEProducer CTEId="3" Columns="8">
+          <dxl:LogicalProject>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="8" Alias="val">
+                <dxl:FuncExpr FuncId="0.2331.1.0" FuncRetSet="true" TypeMdid="0.25.1.0">
+                  <dxl:ConstValue TypeMdid="0.1009.1.0" Value="AAAAZAEAAAAAAAAAGQAAAAkAAAABAAAAAAAACG9kaW8AAAAKYmVhdGFlAAAA&#10;AAAFYQAAAAAAAAViAAAAAAAABWMAAAAAAAAFZAAAAAAAAAVlAAAAAAAABWYA&#10;AAAAAAAFZwAAAA=="/>
+                </dxl:FuncExpr>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:LogicalConstTable>
+              <dxl:Columns>
+                <dxl:Column ColId="7" Attno="1" ColName="" TypeMdid="0.16.1.0"/>
+              </dxl:Columns>
+              <dxl:ConstTuple>
+                <dxl:Datum TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:ConstTuple>
+            </dxl:LogicalConstTable>
+          </dxl:LogicalProject>
+        </dxl:LogicalCTEProducer>
+      </dxl:CTEList>
+      <dxl:LogicalCTAS Mdid="5.1.1.0" Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" DistributionPolicy="Random" InsertColumns="15" VarTypeModList="-1">
+        <dxl:Columns>
+          <dxl:Column ColId="16" Attno="1" ColName="coalesce" TypeMdid="0.701.1.0"/>
+        </dxl:Columns>
+        <dxl:CTASOptions OnCommitAction="NOOP"/>
+        <dxl:DistrOpfamilies/>
+        <dxl:DistrOpclasses/>
+        <dxl:LogicalCTEAnchor CTEId="1">
+          <dxl:LogicalCTEAnchor CTEId="2">
+            <dxl:LogicalCTEAnchor CTEId="3">
+              <dxl:LogicalProject>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="15" Alias="coalesce">
+                    <dxl:Coalesce TypeMdid="0.701.1.0">
+                      <dxl:OpExpr OperatorName="/" OperatorMdid="0.593.1.0" OperatorType="0.701.1.0">
+                        <dxl:Ident ColId="13" ColName="sum" TypeMdid="0.701.1.0"/>
+                        <dxl:NullIf OperatorMdid="0.670.1.0" TypeMdid="0.701.1.0">
+                          <dxl:Ident ColId="14" ColName="sum" TypeMdid="0.701.1.0"/>
+                          <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAAAAA=" DoubleValue="0.000000"/>
+                        </dxl:NullIf>
+                      </dxl:OpExpr>
+                      <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAAAAA=" DoubleValue="0.000000"/>
+                    </dxl:Coalesce>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:LogicalGroupBy>
+                  <dxl:GroupingColumns/>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="13" Alias="sum">
+                      <dxl:AggFunc AggMdid="0.2111.1.0" AggDistinct="false" AggStage="Normal" AggKind="n"  AggArgTypes="">
+                        <dxl:ValuesList ParamType="aggargs">
+                          <dxl:OpExpr OperatorName="*" OperatorMdid="0.594.1.0" OperatorType="0.701.1.0">
+                            <dxl:If TypeMdid="0.701.1.0">
+                              <dxl:Not>
+                                <dxl:IsDistinctFrom OperatorMdid="0.98.1.0">
+                                  <dxl:Ident ColId="9" ColName="val" TypeMdid="0.25.1.0"/>
+                                  <dxl:Ident ColId="11" ColName="val" TypeMdid="0.25.1.0"/>
+                                </dxl:IsDistinctFrom>
+                              </dxl:Not>
+                              <dxl:Ident ColId="10" ColName="wt" TypeMdid="0.701.1.0"/>
+                              <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAAAAA=" DoubleValue="0.000000"/>
+                            </dxl:If>
+                            <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAAAEA=" DoubleValue="2.000000"/>
+                          </dxl:OpExpr>
+                        </dxl:ValuesList>
+                        <dxl:ValuesList ParamType="aggdirectargs"/>
+                        <dxl:ValuesList ParamType="aggorder"/>
+                        <dxl:ValuesList ParamType="aggdistinct"/>
+                      </dxl:AggFunc>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="14" Alias="sum">
+                      <dxl:AggFunc AggMdid="0.2111.1.0" AggDistinct="false" AggStage="Normal" AggKind="n"  AggArgTypes="">
+                        <dxl:ValuesList ParamType="aggargs">
+                          <dxl:OpExpr OperatorName="*" OperatorMdid="0.594.1.0" OperatorType="0.701.1.0">
+                            <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
+                              <dxl:If TypeMdid="0.23.1.0">
+                                <dxl:Not>
+                                  <dxl:IsDistinctFrom OperatorMdid="0.98.1.0">
+                                    <dxl:Ident ColId="9" ColName="val" TypeMdid="0.25.1.0"/>
+                                    <dxl:Ident ColId="11" ColName="val" TypeMdid="0.25.1.0"/>
+                                  </dxl:IsDistinctFrom>
+                                </dxl:Not>
+                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                              </dxl:If>
+                            </dxl:FuncExpr>
+                            <dxl:Coalesce TypeMdid="0.701.1.0">
+                              <dxl:Ident ColId="10" ColName="wt" TypeMdid="0.701.1.0"/>
+                              <dxl:Ident ColId="12" ColName="w" TypeMdid="0.701.1.0"/>
+                            </dxl:Coalesce>
+                          </dxl:OpExpr>
+                        </dxl:ValuesList>
+                        <dxl:ValuesList ParamType="aggdirectargs"/>
+                        <dxl:ValuesList ParamType="aggorder"/>
+                        <dxl:ValuesList ParamType="aggdistinct"/>
+                      </dxl:AggFunc>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:LogicalJoin JoinType="Inner">
+                    <dxl:LogicalJoin JoinType="Full">
+                      <dxl:LogicalCTEConsumer CTEId="1" Columns="9,10"/>
+                      <dxl:LogicalCTEConsumer CTEId="3" Columns="11"/>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+                        <dxl:Ident ColId="9" ColName="val" TypeMdid="0.25.1.0"/>
+                        <dxl:Ident ColId="11" ColName="val" TypeMdid="0.25.1.0"/>
+                      </dxl:Comparison>
+                    </dxl:LogicalJoin>
+                    <dxl:LogicalCTEConsumer CTEId="2" Columns="12"/>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:LogicalJoin>
+                </dxl:LogicalGroupBy>
+              </dxl:LogicalProject>
+            </dxl:LogicalCTEAnchor>
+          </dxl:LogicalCTEAnchor>
+        </dxl:LogicalCTEAnchor>
+      </dxl:LogicalCTAS>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="84">
+      <dxl:PhysicalCTAS Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" DistributionPolicy="Random" InsertColumns="20" VarTypeModList="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1324033.167977" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:DistrOpclasses/>
+        <dxl:Columns>
+          <dxl:Column ColId="39" Attno="1" ColName="coalesce" TypeMdid="0.701.1.0"/>
+        </dxl:Columns>
+        <dxl:CTASOptions OnCommitAction="NOOP"/>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="20" Alias="coalesce">
+            <dxl:Ident ColId="20" ColName="coalesce" TypeMdid="0.701.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1324033.152352" Rows="1.000000" Width="12"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="20" Alias="coalesce">
+              <dxl:Ident ColId="20" ColName="coalesce" TypeMdid="0.701.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="38" Alias="ColRef_0038">
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:Sequence>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1324033.152348" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="20" Alias="coalesce">
+                <dxl:Ident ColId="20" ColName="coalesce" TypeMdid="0.701.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:CTEProducer CTEId="0" Columns="1,2">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="0.000018" Rows="1.000000" Width="1"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="1" Alias="val">
+                  <dxl:Ident ColId="1" ColName="val" TypeMdid="0.25.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="2" Alias="wt">
+                  <dxl:Ident ColId="2" ColName="wt" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000017" Rows="1.000000" Width="16"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="1" Alias="val">
+                    <dxl:FuncExpr FuncId="0.2331.1.0" FuncRetSet="true" TypeMdid="0.25.1.0">
+                      <dxl:ConstValue TypeMdid="0.1009.1.0" Value="AAAAqAEAAAAAAAAAGQAAABEAAAABAAAAAAAACXJlcnVtAAAAAAAACXZlbGl0&#xA;AAAAAAAABXAAAAAAAAAFcQAAAAAAAAVyAAAAAAAABXMAAAAAAAAFdAAAAAAA&#xA;AAZ1bQAAAAAABXYAAAAAAAAFcQAAAAAAAAV3AAAAAAAABWUAAAAAAAAFcgAA&#xA;AAAAAAV0AAAAAAAABXkAAAAAAAAFdQAAAAAAAAVpAAAA"/>
+                    </dxl:FuncExpr>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="2" Alias="wt">
+                    <dxl:FuncExpr FuncId="0.2331.1.0" FuncRetSet="true" TypeMdid="0.701.1.0">
+                      <dxl:ConstValue TypeMdid="0.1022.1.0" Value="AAAAoAEAAAAAAAAAvQIAABEAAAABAAAAAAAAAAAA8D8AAAAAAADwPwAAAAAA&#xA;APA/AAAAAAAA8D8AAAAAAADwPwAAAAAAAPA/AAAAAAAA8D8AAAAAAADwPwAA&#xA;AAAAAPA/AAAAAAAA8D8AAAAAAADwPwAAAAAAAPA/AAAAAAAA8D8AAAAAAADw&#xA;PwAAAAAAAPA/AAAAAAAA8D8AAAAAAADwPw=="/>
+                    </dxl:FuncExpr>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+                <dxl:Result>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="">
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:OneTimeFilter/>
+                </dxl:Result>
+              </dxl:Result>
+            </dxl:CTEProducer>
+            <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1324033.152328" Rows="1.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="20" Alias="coalesce">
+                  <dxl:Ident ColId="20" ColName="coalesce" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1324033.152307" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="20" Alias="coalesce">
+                    <dxl:Coalesce TypeMdid="0.701.1.0">
+                      <dxl:OpExpr OperatorName="/" OperatorMdid="0.593.1.0" OperatorType="0.701.1.0">
+                        <dxl:Ident ColId="18" ColName="sum" TypeMdid="0.701.1.0"/>
+                        <dxl:NullIf OperatorMdid="0.670.1.0" TypeMdid="0.701.1.0">
+                          <dxl:Ident ColId="19" ColName="sum" TypeMdid="0.701.1.0"/>
+                          <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAAAAA=" DoubleValue="0.000000"/>
+                        </dxl:NullIf>
+                      </dxl:OpExpr>
+                      <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAAAAA=" DoubleValue="0.000000"/>
+                    </dxl:Coalesce>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+                <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="1324033.152299" Rows="1.000000" Width="16"/>
+                  </dxl:Properties>
+                  <dxl:GroupingColumns/>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="18" Alias="sum">
+                      <dxl:AggFunc AggMdid="0.2111.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                        <dxl:ValuesList ParamType="aggargs">
+                          <dxl:OpExpr OperatorName="*" OperatorMdid="0.594.1.0" OperatorType="0.701.1.0">
+                            <dxl:If TypeMdid="0.701.1.0">
+                              <dxl:Not>
+                                <dxl:IsDistinctFrom OperatorMdid="0.98.1.0">
+                                  <dxl:Ident ColId="9" ColName="val" TypeMdid="0.25.1.0"/>
+                                  <dxl:Ident ColId="12" ColName="val" TypeMdid="0.25.1.0"/>
+                                </dxl:IsDistinctFrom>
+                              </dxl:Not>
+                              <dxl:Ident ColId="10" ColName="wt" TypeMdid="0.701.1.0"/>
+                              <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAAAAA=" DoubleValue="0.000000"/>
+                            </dxl:If>
+                            <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAAAEA=" DoubleValue="2.000000"/>
+                          </dxl:OpExpr>
+                        </dxl:ValuesList>
+                        <dxl:ValuesList ParamType="aggdirectargs"/>
+                        <dxl:ValuesList ParamType="aggorder"/>
+                        <dxl:ValuesList ParamType="aggdistinct"/>
+                      </dxl:AggFunc>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="19" Alias="sum">
+                      <dxl:AggFunc AggMdid="0.2111.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                        <dxl:ValuesList ParamType="aggargs">
+                          <dxl:OpExpr OperatorName="*" OperatorMdid="0.594.1.0" OperatorType="0.701.1.0">
+                            <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                              <dxl:If TypeMdid="0.23.1.0">
+                                <dxl:Not>
+                                  <dxl:IsDistinctFrom OperatorMdid="0.98.1.0">
+                                    <dxl:Ident ColId="9" ColName="val" TypeMdid="0.25.1.0"/>
+                                    <dxl:Ident ColId="12" ColName="val" TypeMdid="0.25.1.0"/>
+                                  </dxl:IsDistinctFrom>
+                                </dxl:Not>
+                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                              </dxl:If>
+                            </dxl:Cast>
+                            <dxl:Coalesce TypeMdid="0.701.1.0">
+                              <dxl:Ident ColId="10" ColName="wt" TypeMdid="0.701.1.0"/>
+                              <dxl:Ident ColId="14" ColName="w" TypeMdid="0.701.1.0"/>
+                            </dxl:Coalesce>
+                          </dxl:OpExpr>
+                        </dxl:ValuesList>
+                        <dxl:ValuesList ParamType="aggdirectargs"/>
+                        <dxl:ValuesList ParamType="aggorder"/>
+                        <dxl:ValuesList ParamType="aggdistinct"/>
+                      </dxl:AggFunc>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="1324033.152213" Rows="3.000000" Width="32"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="9" Alias="val">
+                        <dxl:Ident ColId="9" ColName="val" TypeMdid="0.25.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="10" Alias="wt">
+                        <dxl:Ident ColId="10" ColName="wt" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="12" Alias="val">
+                        <dxl:Ident ColId="12" ColName="val" TypeMdid="0.25.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="14" Alias="w">
+                        <dxl:Ident ColId="14" ColName="w" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:JoinFilter>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:JoinFilter>
+                    <dxl:MergeJoin JoinType="Full" UniqueOuter="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000659" Rows="3.000000" Width="24"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="9" Alias="val">
+                          <dxl:Ident ColId="9" ColName="val" TypeMdid="0.25.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="10" Alias="wt">
+                          <dxl:Ident ColId="10" ColName="wt" TypeMdid="0.701.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="12" Alias="val">
+                          <dxl:Ident ColId="12" ColName="val" TypeMdid="0.25.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:JoinFilter/>
+                      <dxl:MergeCondList>
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+                          <dxl:Ident ColId="9" ColName="val" TypeMdid="0.25.1.0"/>
+                          <dxl:Ident ColId="12" ColName="val" TypeMdid="0.25.1.0"/>
+                        </dxl:Comparison>
+                      </dxl:MergeCondList>
+                      <dxl:Sort SortDiscardDuplicates="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="16"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="9" Alias="val">
+                            <dxl:Ident ColId="9" ColName="val" TypeMdid="0.25.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="10" Alias="wt">
+                            <dxl:Ident ColId="10" ColName="wt" TypeMdid="0.701.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList>
+                          <dxl:SortingColumn ColId="9" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        </dxl:SortingColumnList>
+                        <dxl:LimitCount/>
+                        <dxl:LimitOffset/>
+                        <dxl:CTEConsumer CTEId="0" Columns="9,10">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="16"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="9" Alias="val">
+                              <dxl:Ident ColId="9" ColName="val" TypeMdid="0.25.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="10" Alias="wt">
+                              <dxl:Ident ColId="10" ColName="wt" TypeMdid="0.701.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                        </dxl:CTEConsumer>
+                      </dxl:Sort>
+                      <dxl:Sort SortDiscardDuplicates="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="12" Alias="val">
+                            <dxl:Ident ColId="12" ColName="val" TypeMdid="0.25.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList>
+                          <dxl:SortingColumn ColId="12" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        </dxl:SortingColumnList>
+                        <dxl:LimitCount/>
+                        <dxl:LimitOffset/>
+                        <dxl:Result>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="12" Alias="val">
+                              <dxl:FuncExpr FuncId="0.2331.1.0" FuncRetSet="true" TypeMdid="0.25.1.0">
+                                <dxl:ConstValue TypeMdid="0.1009.1.0" Value="AAAAZAEAAAAAAAAAGQAAAAkAAAABAAAAAAAACG9kaW8AAAAKYmVhdGFlAAAA&#xA;AAAFYQAAAAAAAAViAAAAAAAABWMAAAAAAAAFZAAAAAAAAAVlAAAAAAAABWYA&#xA;AAAAAAAFZwAAAA=="/>
+                              </dxl:FuncExpr>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:OneTimeFilter/>
+                          <dxl:Result>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="13" Alias="">
+                                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:OneTimeFilter/>
+                          </dxl:Result>
+                        </dxl:Result>
+                      </dxl:Sort>
+                    </dxl:MergeJoin>
+                    <dxl:Materialize Eager="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="14" Alias="w">
+                          <dxl:Ident ColId="14" ColName="w" TypeMdid="0.701.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:GroupingColumns/>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="14" Alias="w">
+                            <dxl:AggFunc AggMdid="0.2105.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                              <dxl:ValuesList ParamType="aggargs">
+                                <dxl:Ident ColId="16" ColName="wt" TypeMdid="0.701.1.0"/>
+                              </dxl:ValuesList>
+                              <dxl:ValuesList ParamType="aggdirectargs"/>
+                              <dxl:ValuesList ParamType="aggorder"/>
+                              <dxl:ValuesList ParamType="aggdistinct"/>
+                            </dxl:AggFunc>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:CTEConsumer CTEId="0" Columns="15,16">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="15" Alias="val">
+                              <dxl:Ident ColId="15" ColName="val" TypeMdid="0.25.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="16" Alias="wt">
+                              <dxl:Ident ColId="16" ColName="wt" TypeMdid="0.701.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                        </dxl:CTEConsumer>
+                      </dxl:Aggregate>
+                    </dxl:Materialize>
+                  </dxl:NestedLoopJoin>
+                </dxl:Aggregate>
+              </dxl:Result>
+            </dxl:RandomMotion>
+          </dxl:Sequence>
+        </dxl:Result>
+      </dxl:PhysicalCTAS>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/NLJ-Rewindability.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NLJ-Rewindability.mdp
@@ -1,0 +1,724 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Objective: The aggregate should have a materialize on top if it is the
+    inner child of a nested loop join. This will help with the performance.
+
+    EXPLAIN
+    WITH un1 AS (
+        SELECT
+            unnest('{rerum,velit,p,q,r,s,t,um,v,q,w,e,r,t,y,u,i}'::text[]) val,
+            unnest(coalesce( CASE
+                WHEN array_length('{rerum,velit}'::text[],1) =
+                    array_length(array[1.0]::float[],1)
+                THEN array[1.0]::float[]
+                END,
+                array_fill(1.0::double precision,
+                    array[coalesce(array_length('{rerum,velit,p,q,r,s,t,u,v,w}'::text[], 1), 0)]
+                    )
+            )) wt
+    ),
+    mw AS (
+        SELECT avg(wt) AS w FROM un1
+    ),
+    un2 AS (
+        SELECT unnest('{odio,beatae, a, b, c ,d, e, f,g}'::text[]) val
+    )
+    SELECT coalesce(
+        sum(CASE when u1.val is not distinct FROM u2.val then u1.wt else 0.0 end * 2) /
+            nullif(
+                sum(CASE
+                    WHEN u1.val is not distinct FROM u2.val
+                    THEN 2 ELSE 1
+                    END
+                    * coalesce(u1.wt,m.w)
+                ),
+            0),
+        0)
+    FROM
+        un1 u1
+        FULL OUTER JOIN
+        un2 u2
+            on u1.val = u2.val
+        CROSS JOIN
+        mw m ;
+                                                  QUERY PLAN
+    -------------------------------------------------------------------------------------------------------
+     Sequence  (cost=0.00..1324033.15 rows=1 width=8)
+       ->  Shared Scan (share slice:id 0:0)  (cost=0.00..0.00 rows=1 width=1)
+             ->  ProjectSet  (cost=0.00..0.00 rows=1 width=16)
+                   ->  Result  (cost=0.00..0.00 rows=1 width=1)
+       ->  Aggregate  (cost=0.00..1324033.15 rows=1 width=16)
+             ->  Nested Loop  (cost=0.00..1324033.15 rows=3 width=32)
+                   Join Filter: true
+                   ->  Merge Full Join  (cost=0.00..431.00 rows=3 width=24)
+                         Merge Cond: (share0_ref3.val = (unnest('{odio,beatae,a,b,c,d,e,f,g}'::anyarray)))
+                         ->  Sort  (cost=0.00..431.00 rows=1 width=16)
+                               Sort Key: share0_ref3.val
+                               ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=16)
+                         ->  Sort  (cost=0.00..0.00 rows=1 width=8)
+                               Sort Key: (unnest('{odio,beatae,a,b,c,d,e,f,g}'::anyarray))
+                               ->  ProjectSet  (cost=0.00..0.00 rows=1 width=8)
+                                     ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                   ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                               ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+     Optimizer: Pivotal Optimizer (GPORCA)
+    (20 rows)
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103003,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.664.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.25.1.0"/>
+        <dxl:RightType Mdid="0.25.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.740.1.0"/>
+        <dxl:Commutator Mdid="0.666.1.0"/>
+        <dxl:InverseOp Mdid="0.667.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1994.1.0"/>
+          <dxl:Opfamily Mdid="0.4017.1.0"/>
+          <dxl:Opfamily Mdid="0.4056.1.0"/>
+          <dxl:Opfamily Mdid="0.10018.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1009.1.0"/>
+        <dxl:MinAgg Mdid="0.2145.1.0"/>
+        <dxl:MaxAgg Mdid="0.2129.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBFunc Mdid="0.2331.1.0" Name="unnest" ReturnsSet="true" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.2283.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:GPDBScalarOp Mdid="0.670.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.701.1.0"/>
+        <dxl:RightType Mdid="0.701.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.293.1.0"/>
+        <dxl:Commutator Mdid="0.670.1.0"/>
+        <dxl:InverseOp Mdid="0.671.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1971.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7102.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1970.1.0"/>
+          <dxl:Opfamily Mdid="0.1971.1.0"/>
+          <dxl:Opfamily Mdid="0.4070.1.0"/>
+          <dxl:Opfamily Mdid="0.7102.1.0"/>
+          <dxl:Opfamily Mdid="0.10007.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:MDCast Mdid="3.2277.1.0;25.1.0" Name="text" BinaryCoercible="false" SourceTypeId="0.2277.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.25.1.0" CoercePathType="0"/>
+      <dxl:MDCast Mdid="3.25.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.25.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.25.1.0" CoercePathType="0"/>
+      <dxl:GPDBAgg Mdid="0.2105.1.0" Name="avg" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.1022.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:GPDBFunc Mdid="0.316.1.0" Name="float8" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
+        <dxl:EqualityOp Mdid="0.670.1.0"/>
+        <dxl:InequalityOp Mdid="0.671.1.0"/>
+        <dxl:LessThanOp Mdid="0.672.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
+        <dxl:ComparisonOp Mdid="0.355.1.0"/>
+        <dxl:ArrayType Mdid="0.1022.1.0"/>
+        <dxl:MinAgg Mdid="0.2136.1.0"/>
+        <dxl:MaxAgg Mdid="0.2120.1.0"/>
+        <dxl:AvgAgg Mdid="0.2105.1.0"/>
+        <dxl:SumAgg Mdid="0.2111.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.2111.1.0" Name="sum" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:GPDBScalarOp Mdid="0.593.1.0" Name="/" ComparisonType="Other" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.701.1.0"/>
+        <dxl:RightType Mdid="0.701.1.0"/>
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:OpFunc Mdid="0.217.1.0"/>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.594.1.0" Name="*" ComparisonType="Other" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.701.1.0"/>
+        <dxl:RightType Mdid="0.701.1.0"/>
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:OpFunc Mdid="0.216.1.0"/>
+        <dxl:Commutator Mdid="0.594.1.0"/>
+      </dxl:GPDBScalarOp>
+      <dxl:MDCast Mdid="3.1022.1.0;701.1.0" Name="float8" BinaryCoercible="false" SourceTypeId="0.1022.1.0" DestinationTypeId="0.701.1.0" CastFuncId="0.701.1.0" CoercePathType="0"/>
+      <dxl:GPDBScalarOp Mdid="0.98.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.25.1.0"/>
+        <dxl:RightType Mdid="0.25.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.67.1.0"/>
+        <dxl:Commutator Mdid="0.98.1.0"/>
+        <dxl:InverseOp Mdid="0.531.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7105.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1994.1.0"/>
+          <dxl:Opfamily Mdid="0.1995.1.0"/>
+          <dxl:Opfamily Mdid="0.2095.1.0"/>
+          <dxl:Opfamily Mdid="0.2229.1.0"/>
+          <dxl:Opfamily Mdid="0.4017.1.0"/>
+          <dxl:Opfamily Mdid="0.4056.1.0"/>
+          <dxl:Opfamily Mdid="0.7105.1.0"/>
+          <dxl:Opfamily Mdid="0.10018.1.0"/>
+          <dxl:Opfamily Mdid="0.10022.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.2277.1.0" Name="anyarray" IsRedistributable="false" IsHashable="false" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.0.0.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.0.0.0"/>
+        <dxl:MinAgg Mdid="0.2051.1.0"/>
+        <dxl:MaxAgg Mdid="0.2050.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:MDCast Mdid="3.23.1.0;701.1.0" Name="float8" BinaryCoercible="false" SourceTypeId="0.23.1.0" DestinationTypeId="0.701.1.0" CastFuncId="0.316.1.0" CoercePathType="1"/>
+      <dxl:Type Mdid="0.1022.1.0" Name="_float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.627.1.0"/>
+        <dxl:EqualityOp Mdid="0.1070.1.0"/>
+        <dxl:InequalityOp Mdid="0.1071.1.0"/>
+        <dxl:LessThanOp Mdid="0.1072.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1074.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1073.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1075.1.0"/>
+        <dxl:ComparisonOp Mdid="0.382.1.0"/>
+        <dxl:ArrayType Mdid="0.0.0.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.6219.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="15" ColName="coalesce" TypeMdid="0.701.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList>
+        <dxl:LogicalCTEProducer CTEId="1" Columns="2,3">
+          <dxl:LogicalProject>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="2" Alias="val">
+                <dxl:FuncExpr FuncId="0.2331.1.0" FuncRetSet="true" TypeMdid="0.25.1.0">
+                  <dxl:ConstValue TypeMdid="0.2277.1.0" Value="AAAAqAEAAAAAAAAAGQAAABEAAAABAAAAAAAACXJlcnVtAAAAAAAACXZlbGl0&#10;AAAAAAAABXAAAAAAAAAFcQAAAAAAAAVyAAAAAAAABXMAAAAAAAAFdAAAAAAA&#10;AAZ1bQAAAAAABXYAAAAAAAAFcQAAAAAAAAV3AAAAAAAABWUAAAAAAAAFcgAA&#10;AAAAAAV0AAAAAAAABXkAAAAAAAAFdQAAAAAAAAVpAAAA"/>
+                </dxl:FuncExpr>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="3" Alias="wt">
+                <dxl:FuncExpr FuncId="0.2331.1.0" FuncRetSet="true" TypeMdid="0.701.1.0">
+                  <dxl:ConstValue TypeMdid="0.1022.1.0" Value="AAAAaAEAAAAAAAAAvQIAAAoAAAABAAAAAAAAAAAA8D8AAAAAAADwPwAAAAAA&#10;APA/AAAAAAAA8D8AAAAAAADwPwAAAAAAAPA/AAAAAAAA8D8AAAAAAADwPwAA&#10;AAAAAPA/AAAAAAAA8D8="/>
+                </dxl:FuncExpr>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:LogicalConstTable>
+              <dxl:Columns>
+                <dxl:Column ColId="1" Attno="1" ColName="" TypeMdid="0.16.1.0"/>
+              </dxl:Columns>
+              <dxl:ConstTuple>
+                <dxl:Datum TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:ConstTuple>
+            </dxl:LogicalConstTable>
+          </dxl:LogicalProject>
+        </dxl:LogicalCTEProducer>
+        <dxl:LogicalCTEProducer CTEId="2" Columns="6">
+          <dxl:LogicalGroupBy>
+            <dxl:GroupingColumns/>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="6" Alias="w">
+                <dxl:AggFunc AggMdid="0.2105.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="701">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:Ident ColId="5" ColName="wt" TypeMdid="0.701.1.0"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                  <dxl:ValuesList ParamType="aggorder"/>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:LogicalCTEConsumer CTEId="1" Columns="4,5"/>
+          </dxl:LogicalGroupBy>
+        </dxl:LogicalCTEProducer>
+        <dxl:LogicalCTEProducer CTEId="3" Columns="8">
+          <dxl:LogicalProject>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="8" Alias="val">
+                <dxl:FuncExpr FuncId="0.2331.1.0" FuncRetSet="true" TypeMdid="0.25.1.0">
+                  <dxl:ConstValue TypeMdid="0.2277.1.0" Value="AAAAZAEAAAAAAAAAGQAAAAkAAAABAAAAAAAACG9kaW8AAAAKYmVhdGFlAAAA&#10;AAAFYQAAAAAAAAViAAAAAAAABWMAAAAAAAAFZAAAAAAAAAVlAAAAAAAABWYA&#10;AAAAAAAFZwAAAA=="/>
+                </dxl:FuncExpr>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:LogicalConstTable>
+              <dxl:Columns>
+                <dxl:Column ColId="7" Attno="1" ColName="" TypeMdid="0.16.1.0"/>
+              </dxl:Columns>
+              <dxl:ConstTuple>
+                <dxl:Datum TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:ConstTuple>
+            </dxl:LogicalConstTable>
+          </dxl:LogicalProject>
+        </dxl:LogicalCTEProducer>
+      </dxl:CTEList>
+      <dxl:LogicalCTEAnchor CTEId="1">
+        <dxl:LogicalCTEAnchor CTEId="2">
+          <dxl:LogicalCTEAnchor CTEId="3">
+            <dxl:LogicalProject>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="15" Alias="coalesce">
+                  <dxl:Coalesce TypeMdid="0.701.1.0">
+                    <dxl:OpExpr OperatorName="/" OperatorMdid="0.593.1.0" OperatorType="0.701.1.0">
+                      <dxl:Ident ColId="13" ColName="sum" TypeMdid="0.701.1.0"/>
+                      <dxl:NullIf OperatorMdid="0.670.1.0" TypeMdid="0.701.1.0">
+                        <dxl:Ident ColId="14" ColName="sum" TypeMdid="0.701.1.0"/>
+                        <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAAAAA=" DoubleValue="0.000000"/>
+                      </dxl:NullIf>
+                    </dxl:OpExpr>
+                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAAAAA=" DoubleValue="0.000000"/>
+                  </dxl:Coalesce>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:LogicalGroupBy>
+                <dxl:GroupingColumns/>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="13" Alias="sum">
+                    <dxl:AggFunc AggMdid="0.2111.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="701">
+                      <dxl:ValuesList ParamType="aggargs">
+                        <dxl:OpExpr OperatorName="*" OperatorMdid="0.594.1.0" OperatorType="0.701.1.0">
+                          <dxl:If TypeMdid="0.701.1.0">
+                            <dxl:Not>
+                              <dxl:IsDistinctFrom OperatorMdid="0.98.1.0">
+                                <dxl:Ident ColId="9" ColName="val" TypeMdid="0.25.1.0"/>
+                                <dxl:Ident ColId="11" ColName="val" TypeMdid="0.25.1.0"/>
+                              </dxl:IsDistinctFrom>
+                            </dxl:Not>
+                            <dxl:Ident ColId="10" ColName="wt" TypeMdid="0.701.1.0"/>
+                            <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAAAAA=" DoubleValue="0.000000"/>
+                          </dxl:If>
+                          <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAAAEA=" DoubleValue="2.000000"/>
+                        </dxl:OpExpr>
+                      </dxl:ValuesList>
+                      <dxl:ValuesList ParamType="aggdirectargs"/>
+                      <dxl:ValuesList ParamType="aggorder"/>
+                      <dxl:ValuesList ParamType="aggdistinct"/>
+                    </dxl:AggFunc>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="14" Alias="sum">
+                    <dxl:AggFunc AggMdid="0.2111.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="701">
+                      <dxl:ValuesList ParamType="aggargs">
+                        <dxl:OpExpr OperatorName="*" OperatorMdid="0.594.1.0" OperatorType="0.701.1.0">
+                          <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
+                            <dxl:If TypeMdid="0.23.1.0">
+                              <dxl:Not>
+                                <dxl:IsDistinctFrom OperatorMdid="0.98.1.0">
+                                  <dxl:Ident ColId="9" ColName="val" TypeMdid="0.25.1.0"/>
+                                  <dxl:Ident ColId="11" ColName="val" TypeMdid="0.25.1.0"/>
+                                </dxl:IsDistinctFrom>
+                              </dxl:Not>
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                            </dxl:If>
+                          </dxl:FuncExpr>
+                          <dxl:Coalesce TypeMdid="0.701.1.0">
+                            <dxl:Ident ColId="10" ColName="wt" TypeMdid="0.701.1.0"/>
+                            <dxl:Ident ColId="12" ColName="w" TypeMdid="0.701.1.0"/>
+                          </dxl:Coalesce>
+                        </dxl:OpExpr>
+                      </dxl:ValuesList>
+                      <dxl:ValuesList ParamType="aggdirectargs"/>
+                      <dxl:ValuesList ParamType="aggorder"/>
+                      <dxl:ValuesList ParamType="aggdistinct"/>
+                    </dxl:AggFunc>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:LogicalJoin JoinType="Inner">
+                  <dxl:LogicalJoin JoinType="Full">
+                    <dxl:LogicalCTEConsumer CTEId="1" Columns="9,10"/>
+                    <dxl:LogicalCTEConsumer CTEId="3" Columns="11"/>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+                      <dxl:Ident ColId="9" ColName="val" TypeMdid="0.25.1.0"/>
+                      <dxl:Ident ColId="11" ColName="val" TypeMdid="0.25.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:LogicalJoin>
+                  <dxl:LogicalCTEConsumer CTEId="2" Columns="12"/>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:LogicalJoin>
+              </dxl:LogicalGroupBy>
+            </dxl:LogicalProject>
+          </dxl:LogicalCTEAnchor>
+        </dxl:LogicalCTEAnchor>
+      </dxl:LogicalCTEAnchor>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="432">
+      <dxl:Sequence>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1324033.152333" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="20" Alias="coalesce">
+            <dxl:Ident ColId="20" ColName="coalesce" TypeMdid="0.701.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:CTEProducer CTEId="0" Columns="1,2">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="0.000018" Rows="1.000000" Width="1"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="1" Alias="val">
+              <dxl:Ident ColId="1" ColName="val" TypeMdid="0.25.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="wt">
+              <dxl:Ident ColId="2" ColName="wt" TypeMdid="0.701.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Result>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="0.000017" Rows="1.000000" Width="16"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="1" Alias="val">
+                <dxl:FuncExpr FuncId="0.2331.1.0" FuncRetSet="true" TypeMdid="0.25.1.0">
+                  <dxl:ConstValue TypeMdid="0.2277.1.0" Value="AAAAqAEAAAAAAAAAGQAAABEAAAABAAAAAAAACXJlcnVtAAAAAAAACXZlbGl0&#xA;AAAAAAAABXAAAAAAAAAFcQAAAAAAAAVyAAAAAAAABXMAAAAAAAAFdAAAAAAA&#xA;AAZ1bQAAAAAABXYAAAAAAAAFcQAAAAAAAAV3AAAAAAAABWUAAAAAAAAFcgAA&#xA;AAAAAAV0AAAAAAAABXkAAAAAAAAFdQAAAAAAAAVpAAAA"/>
+                </dxl:FuncExpr>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="2" Alias="wt">
+                <dxl:FuncExpr FuncId="0.2331.1.0" FuncRetSet="true" TypeMdid="0.701.1.0">
+                  <dxl:ConstValue TypeMdid="0.1022.1.0" Value="AAAAaAEAAAAAAAAAvQIAAAoAAAABAAAAAAAAAAAA8D8AAAAAAADwPwAAAAAA&#xA;APA/AAAAAAAA8D8AAAAAAADwPwAAAAAAAPA/AAAAAAAA8D8AAAAAAADwPwAA&#xA;AAAAAPA/AAAAAAAA8D8="/>
+                </dxl:FuncExpr>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:OneTimeFilter/>
+            <dxl:Result>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="">
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+            </dxl:Result>
+          </dxl:Result>
+        </dxl:CTEProducer>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1324033.152307" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="20" Alias="coalesce">
+              <dxl:Coalesce TypeMdid="0.701.1.0">
+                <dxl:OpExpr OperatorName="/" OperatorMdid="0.593.1.0" OperatorType="0.701.1.0">
+                  <dxl:Ident ColId="18" ColName="sum" TypeMdid="0.701.1.0"/>
+                  <dxl:NullIf OperatorMdid="0.670.1.0" TypeMdid="0.701.1.0">
+                    <dxl:Ident ColId="19" ColName="sum" TypeMdid="0.701.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAAAAA=" DoubleValue="0.000000"/>
+                  </dxl:NullIf>
+                </dxl:OpExpr>
+                <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAAAAA=" DoubleValue="0.000000"/>
+              </dxl:Coalesce>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1324033.152299" Rows="1.000000" Width="16"/>
+            </dxl:Properties>
+            <dxl:GroupingColumns/>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="18" Alias="sum">
+                <dxl:AggFunc AggMdid="0.2111.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:OpExpr OperatorName="*" OperatorMdid="0.594.1.0" OperatorType="0.701.1.0">
+                      <dxl:If TypeMdid="0.701.1.0">
+                        <dxl:Not>
+                          <dxl:IsDistinctFrom OperatorMdid="0.98.1.0">
+                            <dxl:Ident ColId="9" ColName="val" TypeMdid="0.25.1.0"/>
+                            <dxl:Ident ColId="12" ColName="val" TypeMdid="0.25.1.0"/>
+                          </dxl:IsDistinctFrom>
+                        </dxl:Not>
+                        <dxl:Ident ColId="10" ColName="wt" TypeMdid="0.701.1.0"/>
+                        <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAAAAA=" DoubleValue="0.000000"/>
+                      </dxl:If>
+                      <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAAAEA=" DoubleValue="2.000000"/>
+                    </dxl:OpExpr>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                  <dxl:ValuesList ParamType="aggorder"/>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="19" Alias="sum">
+                <dxl:AggFunc AggMdid="0.2111.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:OpExpr OperatorName="*" OperatorMdid="0.594.1.0" OperatorType="0.701.1.0">
+                      <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                        <dxl:If TypeMdid="0.23.1.0">
+                          <dxl:Not>
+                            <dxl:IsDistinctFrom OperatorMdid="0.98.1.0">
+                              <dxl:Ident ColId="9" ColName="val" TypeMdid="0.25.1.0"/>
+                              <dxl:Ident ColId="12" ColName="val" TypeMdid="0.25.1.0"/>
+                            </dxl:IsDistinctFrom>
+                          </dxl:Not>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                        </dxl:If>
+                      </dxl:Cast>
+                      <dxl:Coalesce TypeMdid="0.701.1.0">
+                        <dxl:Ident ColId="10" ColName="wt" TypeMdid="0.701.1.0"/>
+                        <dxl:Ident ColId="14" ColName="w" TypeMdid="0.701.1.0"/>
+                      </dxl:Coalesce>
+                    </dxl:OpExpr>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                  <dxl:ValuesList ParamType="aggorder"/>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1324033.152213" Rows="3.000000" Width="32"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="9" Alias="val">
+                  <dxl:Ident ColId="9" ColName="val" TypeMdid="0.25.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="10" Alias="wt">
+                  <dxl:Ident ColId="10" ColName="wt" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="12" Alias="val">
+                  <dxl:Ident ColId="12" ColName="val" TypeMdid="0.25.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="14" Alias="w">
+                  <dxl:Ident ColId="14" ColName="w" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:JoinFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:JoinFilter>
+              <dxl:MergeJoin JoinType="Full" UniqueOuter="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000659" Rows="3.000000" Width="24"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="9" Alias="val">
+                    <dxl:Ident ColId="9" ColName="val" TypeMdid="0.25.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="10" Alias="wt">
+                    <dxl:Ident ColId="10" ColName="wt" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="12" Alias="val">
+                    <dxl:Ident ColId="12" ColName="val" TypeMdid="0.25.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:JoinFilter/>
+                <dxl:MergeCondList>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+                    <dxl:Ident ColId="9" ColName="val" TypeMdid="0.25.1.0"/>
+                    <dxl:Ident ColId="12" ColName="val" TypeMdid="0.25.1.0"/>
+                  </dxl:Comparison>
+                </dxl:MergeCondList>
+                <dxl:Sort SortDiscardDuplicates="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="16"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="9" Alias="val">
+                      <dxl:Ident ColId="9" ColName="val" TypeMdid="0.25.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="10" Alias="wt">
+                      <dxl:Ident ColId="10" ColName="wt" TypeMdid="0.701.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="9" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  </dxl:SortingColumnList>
+                  <dxl:LimitCount/>
+                  <dxl:LimitOffset/>
+                  <dxl:CTEConsumer CTEId="0" Columns="9,10">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="16"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="9" Alias="val">
+                        <dxl:Ident ColId="9" ColName="val" TypeMdid="0.25.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="10" Alias="wt">
+                        <dxl:Ident ColId="10" ColName="wt" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                  </dxl:CTEConsumer>
+                </dxl:Sort>
+                <dxl:Sort SortDiscardDuplicates="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="12" Alias="val">
+                      <dxl:Ident ColId="12" ColName="val" TypeMdid="0.25.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="12" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  </dxl:SortingColumnList>
+                  <dxl:LimitCount/>
+                  <dxl:LimitOffset/>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="12" Alias="val">
+                        <dxl:FuncExpr FuncId="0.2331.1.0" FuncRetSet="true" TypeMdid="0.25.1.0">
+                          <dxl:ConstValue TypeMdid="0.2277.1.0" Value="AAAAZAEAAAAAAAAAGQAAAAkAAAABAAAAAAAACG9kaW8AAAAKYmVhdGFlAAAA&#xA;AAAFYQAAAAAAAAViAAAAAAAABWMAAAAAAAAFZAAAAAAAAAVlAAAAAAAABWYA&#xA;AAAAAAAFZwAAAA=="/>
+                        </dxl:FuncExpr>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="13" Alias="">
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                    </dxl:Result>
+                  </dxl:Result>
+                </dxl:Sort>
+              </dxl:MergeJoin>
+              <dxl:Materialize Eager="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="14" Alias="w">
+                    <dxl:Ident ColId="14" ColName="w" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:GroupingColumns/>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="14" Alias="w">
+                      <dxl:AggFunc AggMdid="0.2105.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                        <dxl:ValuesList ParamType="aggargs">
+                          <dxl:Ident ColId="16" ColName="wt" TypeMdid="0.701.1.0"/>
+                        </dxl:ValuesList>
+                        <dxl:ValuesList ParamType="aggdirectargs"/>
+                        <dxl:ValuesList ParamType="aggorder"/>
+                        <dxl:ValuesList ParamType="aggdistinct"/>
+                      </dxl:AggFunc>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:CTEConsumer CTEId="0" Columns="15,16">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="15" Alias="val">
+                        <dxl:Ident ColId="15" ColName="val" TypeMdid="0.25.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="16" Alias="wt">
+                        <dxl:Ident ColId="16" ColName="wt" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                  </dxl:CTEConsumer>
+                </dxl:Aggregate>
+              </dxl:Materialize>
+            </dxl:NestedLoopJoin>
+          </dxl:Aggregate>
+        </dxl:Result>
+      </dxl:Sequence>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/NestedInSubqWithPrjListOuterRefNoInnerRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NestedInSubqWithPrjListOuterRefNoInnerRef.mdp
@@ -702,7 +702,7 @@ EXPLAIN SELECT * FROM foo WHERE foo.a IN (SELECT foo.b + 1 FROM (SELECT * FROM b
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6716">
+    <dxl:Plan Id="0" SpaceSize="6496">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2155.006784" Rows="40.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/OneLevel-CorrelatedExec.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OneLevel-CorrelatedExec.mdp
@@ -740,7 +740,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3513">
+    <dxl:Plan Id="0" SpaceSize="2890">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="14873.784860" Rows="400.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SubqueryOuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SubqueryOuterRef.mdp
@@ -433,7 +433,7 @@ explain select * from t1 where a = 1 and b in (select b from t2);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="82">
+    <dxl:Plan Id="0" SpaceSize="86">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.004074" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Project-With-NonScalar-Func.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Project-With-NonScalar-Func.mdp
@@ -195,7 +195,7 @@
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="441344.165616" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="441344.177904" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="3" Alias="?column?">
@@ -209,7 +209,7 @@
         <dxl:OneTimeFilter/>
         <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="441344.165615" Rows="2.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="441344.177903" Rows="2.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="ColRef_0009">
@@ -234,7 +234,7 @@
           </dxl:Result>
           <dxl:Assert ErrorCode="P0003">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.000070" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000082" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="ColRef_0009">
@@ -251,7 +251,7 @@
             </dxl:AssertConstraintList>
             <dxl:Window PartitionColumns="">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000062" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000074" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="12" Alias="row_number">
@@ -264,7 +264,7 @@
               <dxl:Filter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.000062" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000074" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="ColRef_0009">
@@ -287,52 +287,39 @@
                 </dxl:ProjList>
                 <dxl:Filter/>
                 <dxl:OneTimeFilter/>
-                <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                <dxl:Materialize Eager="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000054" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000066" Rows="1.000000" Width="16"/>
                   </dxl:Properties>
-                  <dxl:GroupingColumns/>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="7" Alias="ColRef_0007">
-                      <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
-                        <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.20.1.0"/>
-                        </dxl:ValuesList>
-                        <dxl:ValuesList ParamType="aggdirectargs"/>
-                        <dxl:ValuesList ParamType="aggorder"/>
-                        <dxl:ValuesList ParamType="aggdistinct"/>
-                      </dxl:AggFunc>
+                      <dxl:Ident ColId="7" ColName="ColRef_0007" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                     <dxl:ProjElem ColId="8" Alias="ColRef_0008">
-                      <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
-                        <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.20.1.0"/>
-                        </dxl:ValuesList>
-                        <dxl:ValuesList ParamType="aggdirectargs"/>
-                        <dxl:ValuesList ParamType="aggorder"/>
-                        <dxl:ValuesList ParamType="aggdistinct"/>
-                      </dxl:AggFunc>
+                      <dxl:Ident ColId="8" ColName="ColRef_0008" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000047" Rows="1.000000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000050" Rows="1.000000" Width="16"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns/>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-                        <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
-                          <dxl:ValuesList ParamType="aggargs"/>
+                      <dxl:ProjElem ColId="7" Alias="ColRef_0007">
+                        <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
+                          <dxl:ValuesList ParamType="aggargs">
+                            <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.20.1.0"/>
+                          </dxl:ValuesList>
                           <dxl:ValuesList ParamType="aggdirectargs"/>
                           <dxl:ValuesList ParamType="aggorder"/>
                           <dxl:ValuesList ParamType="aggdistinct"/>
                         </dxl:AggFunc>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="11" Alias="ColRef_0011">
-                        <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
+                      <dxl:ProjElem ColId="8" Alias="ColRef_0008">
+                        <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
                           <dxl:ValuesList ParamType="aggargs">
-                            <dxl:Ident ColId="6" ColName="ColRef_0006" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.20.1.0"/>
                           </dxl:ValuesList>
                           <dxl:ValuesList ParamType="aggdirectargs"/>
                           <dxl:ValuesList ParamType="aggorder"/>
@@ -341,54 +328,70 @@
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:Result>
+                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.000046" Rows="1.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000043" Rows="1.000000" Width="16"/>
                       </dxl:Properties>
+                      <dxl:GroupingColumns/>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="6" Alias="ColRef_0006">
-                          <dxl:If TypeMdid="0.23.1.0">
-                            <dxl:IsNull>
-                              <dxl:Ident ColId="2" ColName="generate_series" TypeMdid="0.23.1.0"/>
-                            </dxl:IsNull>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                          </dxl:If>
+                        <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+                          <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
+                            <dxl:ValuesList ParamType="aggargs"/>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="11" Alias="ColRef_0011">
+                          <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Ident ColId="6" ColName="ColRef_0006" TypeMdid="0.23.1.0"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:OneTimeFilter/>
                       <dxl:Result>
                         <dxl:Properties>
                           <dxl:Cost StartupCost="0" TotalCost="0.000042" Rows="1.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="2" Alias="generate_series">
-                            <dxl:Ident ColId="2" ColName="generate_series" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="6" Alias="ColRef_0006">
+                            <dxl:If TypeMdid="0.23.1.0">
+                              <dxl:IsNull>
+                                <dxl:Ident ColId="2" ColName="generate_series" TypeMdid="0.23.1.0"/>
+                              </dxl:IsNull>
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                            </dxl:If>
                           </dxl:ProjElem>
                         </dxl:ProjList>
-                        <dxl:Filter>
-                          <dxl:Or>
-                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                              <dxl:Ident ColId="2" ColName="generate_series" TypeMdid="0.23.1.0"/>
-                            </dxl:Comparison>
-                            <dxl:IsNull>
-                              <dxl:Ident ColId="2" ColName="generate_series" TypeMdid="0.23.1.0"/>
-                            </dxl:IsNull>
-                          </dxl:Or>
-                        </dxl:Filter>
+                        <dxl:Filter/>
                         <dxl:OneTimeFilter/>
-                        <dxl:Materialize Eager="false">
+                        <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="4"/>
+                            <dxl:Cost StartupCost="0" TotalCost="0.000038" Rows="1.000000" Width="4"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="2" Alias="generate_series">
                               <dxl:Ident ColId="2" ColName="generate_series" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
-                          <dxl:Filter/>
+                          <dxl:Filter>
+                            <dxl:Or>
+                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                                <dxl:Ident ColId="2" ColName="generate_series" TypeMdid="0.23.1.0"/>
+                              </dxl:Comparison>
+                              <dxl:IsNull>
+                                <dxl:Ident ColId="2" ColName="generate_series" TypeMdid="0.23.1.0"/>
+                              </dxl:IsNull>
+                            </dxl:Or>
+                          </dxl:Filter>
+                          <dxl:OneTimeFilter/>
                           <dxl:Result>
                             <dxl:Properties>
                               <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
@@ -416,11 +419,11 @@
                               <dxl:OneTimeFilter/>
                             </dxl:Result>
                           </dxl:Result>
-                        </dxl:Materialize>
+                        </dxl:Result>
                       </dxl:Result>
-                    </dxl:Result>
+                    </dxl:Aggregate>
                   </dxl:Aggregate>
-                </dxl:Aggregate>
+                </dxl:Materialize>
               </dxl:Result>
               <dxl:WindowKeyList>
                 <dxl:WindowKey>

--- a/src/backend/gporca/data/dxl/minidump/PushSelectWithOuterRefBelowUnion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushSelectWithOuterRefBelowUnion.mdp
@@ -4981,7 +4981,7 @@
         </dxl:Or>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="55602">
+    <dxl:Plan Id="0" SpaceSize="8868">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="25985.808128" Rows="60175000.000000" Width="14"/>

--- a/src/backend/gporca/data/dxl/minidump/ScalarSubqueryCountStarInJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ScalarSubqueryCountStarInJoin.mdp
@@ -399,7 +399,7 @@ SELECT (SELECT jazz.count FROM (SELECT count(*) FROM bar GROUP BY c LIMIT 1) AS 
         </dxl:LogicalGet>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="544">
+    <dxl:Plan Id="0" SpaceSize="464">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.000816" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/SimplifyExistsSubquery2Limit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SimplifyExistsSubquery2Limit.mdp
@@ -714,7 +714,7 @@ explain select * from foo where foo.a = 10 and exists (select * from bar);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="82">
+    <dxl:Plan Id="0" SpaceSize="86">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1311.703352" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Subq-With-OuterRefCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq-With-OuterRefCol.mdp
@@ -532,7 +532,7 @@ pivotal=# explain select a, c from r, s where a in (select c from r) order by a,
         </dxl:LogicalJoin>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3124">
+    <dxl:Plan Id="0" SpaceSize="3164">
       <dxl:Limit>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.005263" Rows="10.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqueryInsideScalarIf.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqueryInsideScalarIf.mdp
@@ -2462,7 +2462,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1734">
+    <dxl:Plan Id="0" SpaceSize="1562">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356710918.164982" Rows="10002.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqueryNoPullUpTableValueFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqueryNoPullUpTableValueFunction.mdp
@@ -144,10 +144,10 @@ SELECT 0 IS DISTINCT FROM (SELECT COUNT(*) FROM (SELECT UNNEST(ARRAY[1,2,3,4])) 
         </dxl:LogicalConstTable>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18">
+    <dxl:Plan Id="0" SpaceSize="12">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000113" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000120" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="4" Alias="?column?">
@@ -164,7 +164,7 @@ SELECT 0 IS DISTINCT FROM (SELECT COUNT(*) FROM (SELECT UNNEST(ARRAY[1,2,3,4])) 
         <dxl:OneTimeFilter/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000112" Rows="2.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000119" Rows="2.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="5" Alias="ColRef_0005">
@@ -173,9 +173,9 @@ SELECT 0 IS DISTINCT FROM (SELECT COUNT(*) FROM (SELECT UNNEST(ARRAY[1,2,3,4])) 
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false">
+          <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000096" Rows="2.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000103" Rows="2.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="3" Alias="count">
@@ -198,21 +198,13 @@ SELECT 0 IS DISTINCT FROM (SELECT COUNT(*) FROM (SELECT UNNEST(ARRAY[1,2,3,4])) 
               <dxl:Filter/>
               <dxl:OneTimeFilter/>
             </dxl:Result>
-            <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+            <dxl:Materialize Eager="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000011" Rows="1.000000" Width="8"/>
               </dxl:Properties>
-              <dxl:GroupingColumns/>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="3" Alias="count">
-                  <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
-                    <dxl:ValuesList ParamType="aggargs">
-                    <dxl:Ident ColId="6" ColName="ColRef_0006" TypeMdid="0.20.1.0"/>
-                    </dxl:ValuesList>
-                    <dxl:ValuesList ParamType="aggdirectargs"/>
-                    <dxl:ValuesList ParamType="aggorder"/>
-                    <dxl:ValuesList ParamType="aggdistinct"/>
-                  </dxl:AggFunc>
+                  <dxl:Ident ColId="3" ColName="count" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
@@ -222,9 +214,11 @@ SELECT 0 IS DISTINCT FROM (SELECT COUNT(*) FROM (SELECT UNNEST(ARRAY[1,2,3,4])) 
                 </dxl:Properties>
                 <dxl:GroupingColumns/>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="6" Alias="ColRef_0006">
-                    <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
-                      <dxl:ValuesList ParamType="aggargs"/>
+                  <dxl:ProjElem ColId="3" Alias="count">
+                    <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
+                      <dxl:ValuesList ParamType="aggargs">
+                        <dxl:Ident ColId="6" ColName="ColRef_0006" TypeMdid="0.20.1.0"/>
+                      </dxl:ValuesList>
                       <dxl:ValuesList ParamType="aggdirectargs"/>
                       <dxl:ValuesList ParamType="aggorder"/>
                       <dxl:ValuesList ParamType="aggdistinct"/>
@@ -232,13 +226,19 @@ SELECT 0 IS DISTINCT FROM (SELECT COUNT(*) FROM (SELECT UNNEST(ARRAY[1,2,3,4])) 
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:Materialize Eager="false">
+                <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000003" Rows="1.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000002" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
+                  <dxl:GroupingColumns/>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="2" Alias="unnest">
-                      <dxl:Ident ColId="2" ColName="unnest" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="6" Alias="ColRef_0006">
+                      <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
+                        <dxl:ValuesList ParamType="aggargs"/>
+                        <dxl:ValuesList ParamType="aggdirectargs"/>
+                        <dxl:ValuesList ParamType="aggorder"/>
+                        <dxl:ValuesList ParamType="aggdistinct"/>
+                      </dxl:AggFunc>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
@@ -273,9 +273,9 @@ SELECT 0 IS DISTINCT FROM (SELECT COUNT(*) FROM (SELECT UNNEST(ARRAY[1,2,3,4])) 
                       <dxl:OneTimeFilter/>
                     </dxl:Result>
                   </dxl:Result>
-                </dxl:Materialize>
+                </dxl:Aggregate>
               </dxl:Aggregate>
-            </dxl:Aggregate>
+            </dxl:Materialize>
           </dxl:NestedLoopJoin>
         </dxl:Result>
       </dxl:Result>

--- a/src/backend/gporca/data/dxl/minidump/TVF-With-Deep-Subq-Args.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TVF-With-Deep-Subq-Args.mdp
@@ -286,7 +286,7 @@ SELECT generate_series((
         </dxl:OpExpr>
       </dxl:LogicalTVF>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="126">
+    <dxl:Plan Id="0" SpaceSize="342">
       <dxl:TableValuedFunction FuncId="0.1068.1.0" Name="generate_series" TypeMdid="0.20.1.0">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="0.008000" Rows="1000.000000" Width="8"/>
@@ -301,7 +301,7 @@ SELECT generate_series((
           <dxl:ParamList/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6896.001799" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="6896.001855" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="51" Alias="ColRef_0024">
@@ -312,7 +312,7 @@ SELECT generate_series((
             <dxl:OneTimeFilter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="6896.001799" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="6896.001855" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="51" Alias="ColRef_0024">
@@ -335,7 +335,7 @@ SELECT generate_series((
               <dxl:OneTimeFilter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="6896.001783" Rows="4.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="6896.001839" Rows="4.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="76" Alias="ColRef_0076">
@@ -349,7 +349,7 @@ SELECT generate_series((
                 <dxl:OneTimeFilter/>
                 <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="6896.001719" Rows="4.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="6896.001775" Rows="4.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="64" Alias="count">
@@ -365,7 +365,7 @@ SELECT generate_series((
                   </dxl:JoinFilter>
                   <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="862.000110" Rows="2.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="862.000117" Rows="2.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="64" Alias="count">
@@ -388,27 +388,31 @@ SELECT generate_series((
                       <dxl:Filter/>
                       <dxl:OneTimeFilter/>
                     </dxl:Result>
-                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                    <dxl:Materialize Eager="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
-                      <dxl:GroupingColumns/>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="64" Alias="count">
-                          <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" >
-                            <dxl:ValuesList ParamType="aggargs"/>
-                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                            <dxl:ValuesList ParamType="aggorder"/>
-                            <dxl:ValuesList ParamType="aggdistinct"/>
-                          </dxl:AggFunc>
+                          <dxl:Ident ColId="64" ColName="count" TypeMdid="0.20.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:Materialize Eager="false">
+                      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="1"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
-                        <dxl:ProjList/>
+                        <dxl:GroupingColumns/>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="64" Alias="count">
+                            <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                              <dxl:ValuesList ParamType="aggargs"/>
+                              <dxl:ValuesList ParamType="aggdirectargs"/>
+                              <dxl:ValuesList ParamType="aggorder"/>
+                              <dxl:ValuesList ParamType="aggdistinct"/>
+                            </dxl:AggFunc>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
                         <dxl:Filter/>
                         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                           <dxl:Properties>
@@ -439,30 +443,34 @@ SELECT generate_series((
                             </dxl:TableDescriptor>
                           </dxl:TableScan>
                         </dxl:GatherMotion>
-                      </dxl:Materialize>
-                    </dxl:Aggregate>
+                      </dxl:Aggregate>
+                    </dxl:Materialize>
                   </dxl:NestedLoopJoin>
-                  <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                  <dxl:Materialize Eager="true">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
-                    <dxl:GroupingColumns/>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="75" Alias="count">
-                        <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" >
-                          <dxl:ValuesList ParamType="aggargs"/>
-                          <dxl:ValuesList ParamType="aggdirectargs"/>
-                          <dxl:ValuesList ParamType="aggorder"/>
-                          <dxl:ValuesList ParamType="aggdistinct"/>
-                        </dxl:AggFunc>
+                        <dxl:Ident ColId="75" ColName="count" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:Materialize Eager="true">
+                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
-                      <dxl:ProjList/>
+                      <dxl:GroupingColumns/>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="75" Alias="count">
+                          <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                            <dxl:ValuesList ParamType="aggargs"/>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
                       <dxl:Filter/>
                       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                         <dxl:Properties>
@@ -493,8 +501,8 @@ SELECT generate_series((
                           </dxl:TableDescriptor>
                         </dxl:TableScan>
                       </dxl:GatherMotion>
-                    </dxl:Materialize>
-                  </dxl:Aggregate>
+                    </dxl:Aggregate>
+                  </dxl:Materialize>
                 </dxl:NestedLoopJoin>
               </dxl:Result>
             </dxl:Result>
@@ -506,7 +514,7 @@ SELECT generate_series((
           <dxl:ParamList/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6896.001799" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="6896.001855" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="52" Alias="ColRef_0025">
@@ -517,7 +525,7 @@ SELECT generate_series((
             <dxl:OneTimeFilter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="6896.001799" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="6896.001855" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="51" Alias="ColRef_0024">
@@ -540,7 +548,7 @@ SELECT generate_series((
               <dxl:OneTimeFilter/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="6896.001783" Rows="4.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="6896.001839" Rows="4.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="76" Alias="ColRef_0076">
@@ -554,7 +562,7 @@ SELECT generate_series((
                 <dxl:OneTimeFilter/>
                 <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="6896.001719" Rows="4.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="6896.001775" Rows="4.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="64" Alias="count">
@@ -570,7 +578,7 @@ SELECT generate_series((
                   </dxl:JoinFilter>
                   <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="862.000110" Rows="2.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="862.000117" Rows="2.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="64" Alias="count">
@@ -593,27 +601,31 @@ SELECT generate_series((
                       <dxl:Filter/>
                       <dxl:OneTimeFilter/>
                     </dxl:Result>
-                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                    <dxl:Materialize Eager="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
-                      <dxl:GroupingColumns/>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="64" Alias="count">
-                          <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" >
-                            <dxl:ValuesList ParamType="aggargs"/>
-                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                            <dxl:ValuesList ParamType="aggorder"/>
-                            <dxl:ValuesList ParamType="aggdistinct"/>
-                          </dxl:AggFunc>
+                          <dxl:Ident ColId="64" ColName="count" TypeMdid="0.20.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:Materialize Eager="false">
+                      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="1"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
-                        <dxl:ProjList/>
+                        <dxl:GroupingColumns/>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="64" Alias="count">
+                            <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                              <dxl:ValuesList ParamType="aggargs"/>
+                              <dxl:ValuesList ParamType="aggdirectargs"/>
+                              <dxl:ValuesList ParamType="aggorder"/>
+                              <dxl:ValuesList ParamType="aggdistinct"/>
+                            </dxl:AggFunc>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
                         <dxl:Filter/>
                         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                           <dxl:Properties>
@@ -644,30 +656,34 @@ SELECT generate_series((
                             </dxl:TableDescriptor>
                           </dxl:TableScan>
                         </dxl:GatherMotion>
-                      </dxl:Materialize>
-                    </dxl:Aggregate>
+                      </dxl:Aggregate>
+                    </dxl:Materialize>
                   </dxl:NestedLoopJoin>
-                  <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                  <dxl:Materialize Eager="true">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
-                    <dxl:GroupingColumns/>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="75" Alias="count">
-                        <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" >
-                          <dxl:ValuesList ParamType="aggargs"/>
-                          <dxl:ValuesList ParamType="aggdirectargs"/>
-                          <dxl:ValuesList ParamType="aggorder"/>
-                          <dxl:ValuesList ParamType="aggdistinct"/>
-                        </dxl:AggFunc>
+                        <dxl:Ident ColId="75" ColName="count" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:Materialize Eager="true">
+                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
-                      <dxl:ProjList/>
+                      <dxl:GroupingColumns/>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="75" Alias="count">
+                          <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                            <dxl:ValuesList ParamType="aggargs"/>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
                       <dxl:Filter/>
                       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                         <dxl:Properties>
@@ -698,8 +714,8 @@ SELECT generate_series((
                           </dxl:TableDescriptor>
                         </dxl:TableScan>
                       </dxl:GatherMotion>
-                    </dxl:Materialize>
-                  </dxl:Aggregate>
+                    </dxl:Aggregate>
+                  </dxl:Materialize>
                 </dxl:NestedLoopJoin>
               </dxl:Result>
             </dxl:Result>

--- a/src/backend/gporca/data/dxl/minidump/UnnestSQJoins.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnnestSQJoins.mdp
@@ -1282,7 +1282,7 @@ WHERE
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="52727">
+    <dxl:Plan Id="0" SpaceSize="51614">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1306.824501" Rows="199.680000" Width="148"/>

--- a/src/backend/gporca/data/dxl/minidump/WinFunc-Redistribute-Sort-CTE-Producer.mdp
+++ b/src/backend/gporca/data/dxl/minidump/WinFunc-Redistribute-Sort-CTE-Producer.mdp
@@ -455,7 +455,7 @@ with v as (select * from t1) select  row_number() over(partition by v1.b), rank(
         </dxl:LogicalWindow>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="14896">
+    <dxl:Plan Id="0" SpaceSize="13616">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="3141.988407" Rows="333333.333333" Width="24"/>

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CRewindabilitySpec.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CRewindabilitySpec.h
@@ -115,10 +115,14 @@ private:
 	// Motion Hazard
 	EMotionHazardType m_motion_hazard;
 
+	// Is NL Join
+	BOOL m_origin_nl_join;
+
 public:
 	// ctor
 	explicit CRewindabilitySpec(ERewindabilityType rewindability_type,
-								EMotionHazardType motion_hazard);
+								EMotionHazardType motion_hazard,
+								BOOL origin_nl_join = false);
 
 	// dtor
 	virtual ~CRewindabilitySpec();
@@ -166,6 +170,12 @@ public:
 	Emht() const
 	{
 		return m_motion_hazard;
+	}
+
+	BOOL
+	IsOriginNLJoin() const
+	{
+		return m_origin_nl_join;
 	}
 
 	BOOL

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
@@ -1077,8 +1077,8 @@ CXformUtils::ImplementMergeJoin(CXformContext *pxfctxt, CXformResult *pxfres,
 		// clean up
 		pdrgpexprOuter->Release();
 		pdrgpexprInner->Release();
-		CRefCount::SafeRelease(join_opfamilies);
 	}
+	CRefCount::SafeRelease(join_opfamilies);
 
 	pexprResult->Release();
 }

--- a/src/backend/gporca/libgpopt/src/base/CRewindabilitySpec.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CRewindabilitySpec.cpp
@@ -26,11 +26,13 @@ using namespace gpopt;
 //
 //---------------------------------------------------------------------------
 CRewindabilitySpec::CRewindabilitySpec(ERewindabilityType rewindability_type,
-									   EMotionHazardType motion_hazard)
-	: m_rewindability(rewindability_type), m_motion_hazard(motion_hazard)
+									   EMotionHazardType motion_hazard,
+									   BOOL origin_nl_join)
+	: m_rewindability(rewindability_type),
+	  m_motion_hazard(motion_hazard),
+	  m_origin_nl_join(origin_nl_join)
 {
 }
-
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalAgg.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalAgg.cpp
@@ -387,7 +387,17 @@ CPhysicalAgg::PrsRequired(CMemoryPool *mp, CExpressionHandle &exprhdl,
 {
 	GPOS_ASSERT(0 == child_index);
 
-	return PrsPassThru(mp, exprhdl, prsRequired, child_index);
+	CRewindabilitySpec *prsChild =
+		PrsPassThru(mp, exprhdl, prsRequired, child_index);
+	if (prsRequired->IsOriginNLJoin())
+	{
+		CRewindabilitySpec *prs = GPOS_NEW(mp)
+			CRewindabilitySpec(CRewindabilitySpec::ErtNone, prsChild->Emht());
+		prsChild->Release();
+		return prs;
+	}
+
+	return prsChild;
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalNLJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalNLJoin.cpp
@@ -113,7 +113,7 @@ CPhysicalNLJoin::PrsRequired(CMemoryPool *mp, CExpressionHandle &exprhdl,
 		{
 			// for index nested loop joins, inner child is optimized first
 			return GPOS_NEW(mp) CRewindabilitySpec(
-				CRewindabilitySpec::ErtRewindable, prsRequired->Emht());
+				CRewindabilitySpec::ErtRewindable, prsRequired->Emht(), true);
 		}
 
 		CRewindabilitySpec *prsOuter =
@@ -126,7 +126,7 @@ CPhysicalNLJoin::PrsRequired(CMemoryPool *mp, CExpressionHandle &exprhdl,
 				: CRewindabilitySpec::EmhtNoMotion;
 
 		return GPOS_NEW(mp) CRewindabilitySpec(
-			CRewindabilitySpec::ErtRewindable, motion_hazard);
+			CRewindabilitySpec::ErtRewindable, motion_hazard, true);
 	}
 
 	GPOS_ASSERT(0 == child_index);

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -154,7 +154,8 @@ BroadcastSkewedHashjoin OrderByNullsFirst ConvertHashToRandomSelect ConvertHashT
 CTAS-random-distributed-from-replicated-distributed-table
 ProjectRepeatedColumn1 ProjectRepeatedColumn2 NLJ-BC-Outer-Spool-Inner Self-Comparison Self-Comparison-Nullable
 SelectCheckConstraint ExpandJoinOrder SelectOnBpchar EqualityJoin EffectsOfJoinFilter InnerJoin-With-OuterRefs
-UDA-AnyElement-1 UDA-AnyElement-2 Project-With-NonScalar-Func SixWayDPv2 Join-Varchar-Equality;
+UDA-AnyElement-1 UDA-AnyElement-2 Project-With-NonScalar-Func SixWayDPv2 Join-Varchar-Equality NLJ-Rewindability
+NLJ-Rewindability-CTAS;
 
 CJoinPredTest:
 MultipleDampedPredJoinCardinality MultipleIndependentPredJoinCardinality MultiDistKeyJoinCardinality

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -13392,9 +13392,9 @@ select * from foo join (select b, count(*) as cnt from tbtree group by b) grby o
          Join Filter: (foo.a = (count()))
          ->  Broadcast Motion 3:3  (slice2; segments: 3)
                ->  Seq Scan on foo
-         ->  HashAggregate
-               Group Key: tbtree.b
-               ->  Materialize
+         ->  Materialize
+               ->  HashAggregate
+                     Group Key: tbtree.b
                      ->  Redistribute Motion 3:3  (slice1; segments: 3)
                            Hash Key: tbtree.b
                            ->  Seq Scan on tbtree
@@ -13410,9 +13410,9 @@ select * from foo join (select min_a, count(*) as cnt from (select min(a) as min
    ->  Nested Loop
          Join Filter: (foo.a = (min(tbitmap.a)))
          ->  Seq Scan on foo
-         ->  HashAggregate
-               Group Key: (min(tbitmap.a))
-               ->  Materialize
+         ->  Materialize
+               ->  HashAggregate
+                     Group Key: (min(tbitmap.a))
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: (min(tbitmap.a))
                            ->  Result
@@ -14543,8 +14543,8 @@ EXPLAIN (COSTS OFF) SELECT (
          ->  Nested Loop Left Join
                Join Filter: true
                ->  Result
-               ->  Aggregate
-                     ->  Materialize
+               ->  Materialize
+                     ->  Aggregate
                            ->  Gather Motion 3:1  (slice1; segments: 3)
                                  ->  Hash Join
                                        Hash Cond: (join_null_rej1.i = join_null_rej2.i)


### PR DESCRIPTION
This commit adds a rewindablility spec for PhysicalAgg if it is created
by an NL Join. This addition ensures that there is a materialize on top
of the aggregate which improves the performance.

Co-authored-by: Ekta Khanna <ekhanna@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
