### PR TITLE
fix gpfdist crash

### DIFF
--- a/src/backend/utils/misc/fstream/gfile.c
+++ b/src/backend/utils/misc/fstream/gfile.c
@@ -373,7 +373,11 @@ gz_file_write_one_chunk(gfile_t *fd, int do_flush)
 		z->s.avail_out = COMPRESSION_BUFFER_SIZE;
 		z->s.next_out = z->out;
 		ret1 = deflate(&(z->s), do_flush);    /* no bad return value */
-		assert(ret1 != Z_STREAM_ERROR);  /* state not clobbered */
+		if ( ret1 == Z_STREAM_ERROR )
+		{
+			gfile_printf_then_putc_newline("the gz file is unrepaired, stop writing");
+			return -1;
+		}
 		have = COMPRESSION_BUFFER_SIZE - z->s.avail_out;
 		
 		if ( write_and_retry(fd, z->out, have) != have ) 


### PR DESCRIPTION
Long log:
The bug is strongly related to special data and it will be triggered only if there is no extra space on the disk.
We reproduce the environment and find that such crash is random and do not happen every time.
The log shows that gpfdist: gfile.c:375: gz_file_write_one_chunk: Assertion 'ret1 != (-2)' failed.
The solution is to return -1 as long as ret1 == Z_STREAM_ERROR.

Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
