### PR TITLE
Fix the issue CREATE OR REPLACE TRANSFORM failed

### DIFF
--- a/contrib/hstore_plperl/Makefile
+++ b/contrib/hstore_plperl/Makefile
@@ -37,3 +37,5 @@ endif
 
 # As with plperl we need to include the perl_includespec directory last.
 override CPPFLAGS := $(CPPFLAGS) $(perl_embed_ccflags) $(perl_includespec)
+
+REGRESS_OPTS = --init-file=init_file

--- a/contrib/hstore_plperl/expected/create_transform.out
+++ b/contrib/hstore_plperl/expected/create_transform.out
@@ -39,6 +39,26 @@ ERROR:  language "foo" does not exist
 DROP TRANSFORM FOR hstore LANGUAGE plperl;
 DROP TRANSFORM IF EXISTS FOR hstore LANGUAGE plperl;
 NOTICE:  transform for type hstore language "plperl" does not exist, skipping
+-- test pg_stat_last_operation
+CREATE TRANSFORM FOR hstore LANGUAGE plperl (FROM SQL WITH FUNCTION hstore_to_plperl(internal), TO SQL WITH FUNCTION plperl_to_hstore(internal));
+SELECT oid INTO temp transform_oid FROM pg_transform WHERE trfFROMsql='hstore_to_plperl'::regproc AND trftosql='plperl_to_hstore'::regproc;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'oid' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT COUNT(*) = 1 FROM pg_stat_last_operation WHERE classid='pg_transform'::regclass AND objid=(SELECT oid FROM transform_oid limit 1);
+ ?column? 
+----------
+ t
+(1 row)
+
+DROP TRANSFORM FOR hstore LANGUAGE plperl;
+SELECT COUNT(*) = 0 FROM pg_stat_last_operation WHERE classid='pg_transform'::regclass AND objid=(SELECT oid FROM transform_oid limit 1);
+ ?column? 
+----------
+ t
+(1 row)
+
+DROP TABLE transform_oid;
+-- end of test pg_stat_last_operation
 DROP FUNCTION hstore_to_plperl(val internal);
 DROP FUNCTION plperl_to_hstore(val internal);
 CREATE EXTENSION hstore_plperl;

--- a/contrib/hstore_plperl/init_file
+++ b/contrib/hstore_plperl/init_file
@@ -1,0 +1,3 @@
+-- start_matchignore
+m/^(?:HINT|NOTICE):\s+.+\'DISTRIBUTED BY\' clause.*/
+-- end_matchignore

--- a/contrib/hstore_plperl/sql/create_transform.sql
+++ b/contrib/hstore_plperl/sql/create_transform.sql
@@ -35,6 +35,15 @@ DROP TRANSFORM FOR hstore LANGUAGE foo;
 DROP TRANSFORM FOR hstore LANGUAGE plperl;
 DROP TRANSFORM IF EXISTS FOR hstore LANGUAGE plperl;
 
+-- test pg_stat_last_operation
+CREATE TRANSFORM FOR hstore LANGUAGE plperl (FROM SQL WITH FUNCTION hstore_to_plperl(internal), TO SQL WITH FUNCTION plperl_to_hstore(internal));
+SELECT oid INTO temp transform_oid FROM pg_transform WHERE trfFROMsql='hstore_to_plperl'::regproc AND trftosql='plperl_to_hstore'::regproc;
+SELECT COUNT(*) = 1 FROM pg_stat_last_operation WHERE classid='pg_transform'::regclass AND objid=(SELECT oid FROM transform_oid limit 1);
+DROP TRANSFORM FOR hstore LANGUAGE plperl;
+SELECT COUNT(*) = 0 FROM pg_stat_last_operation WHERE classid='pg_transform'::regclass AND objid=(SELECT oid FROM transform_oid limit 1);
+DROP TABLE transform_oid;
+-- end of test pg_stat_last_operation
+
 DROP FUNCTION hstore_to_plperl(val internal);
 DROP FUNCTION plperl_to_hstore(val internal);
 

--- a/src/backend/commands/functioncmds.c
+++ b/src/backend/commands/functioncmds.c
@@ -2569,12 +2569,19 @@ CreateTransform(CreateTransformStmt *stmt)
 									DF_NEED_TWO_PHASE,
 									GetAssignedOidsForDispatch(),
 									NULL);
-
-		/* MPP-6929: metadata tracking */
-		MetaTrackAddObject(TransformRelationId,
-						   myself.objectId,
-						   GetUserId(),
-						   "CREATE", "TRANSFORM");
+		if (is_replace)
+		{
+			MetaTrackUpdObject(TransformRelationId,
+							   myself.objectId,
+							   GetUserId(),
+							   "ALTER", "TRANSFORM");
+		} else {
+			/* MPP-6929: metadata tracking */
+			MetaTrackAddObject(TransformRelationId,
+							   myself.objectId,
+							   GetUserId(),
+							   "CREATE", "TRANSFORM");
+		}
 	}
 
 	return myself;
@@ -2626,6 +2633,11 @@ DropTransformById(Oid transformOid)
 	if (!HeapTupleIsValid(tuple))
 		elog(ERROR, "could not find tuple for transform %u", transformOid);
 	CatalogTupleDelete(relation, &tuple->t_self);
+
+	if (Gp_role == GP_ROLE_DISPATCH)
+	{
+		MetaTrackDropObject(TransformRelationId, transformOid);
+	}
 
 	systable_endscan(scan);
 	table_close(relation, RowExclusiveLock);

--- a/src/backend/commands/functioncmds.c
+++ b/src/backend/commands/functioncmds.c
@@ -2575,7 +2575,9 @@ CreateTransform(CreateTransformStmt *stmt)
 							   myself.objectId,
 							   GetUserId(),
 							   "ALTER", "TRANSFORM");
-		} else {
+		}
+		else
+		{
 			/* MPP-6929: metadata tracking */
 			MetaTrackAddObject(TransformRelationId,
 							   myself.objectId,


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community


Fix issue #13611 , see it for more details.
The issue also exists in 6x and 5x.

Exec `CREATE OR REPLACE TRANSFORM` twice will fail in gpdb.
catalog `pg_stat_last_operation` with unique index
`pg_statlastop_classid_objid_staactionname_index` will collect metadata
tracking information about operations on database objects.

When exec `CREATE OR REPLACE TRANSFORM` the previous objid's record is
only added but not updated. And the unique index reports a
duplicate key error.

Another similar issue is that a transform is dropped, the record in
`pg_stat_last_operation` still exists. It should be dropped too.

Update the transform's `pg_stat_last_operation` record if exists.
Drop the transform's `pg_stat_last_operation` record when dropping a
transform. This pr fix it too.

The test cases are already in contrib dir which seems not be tested by GPDB's pipeline. 
Add some cases and check it by `make installcheck` under dir: contrib/hstore_plperl.


