### PR TITLE
[6X] Feat: Identify backends with suboverflowed transactions

### DIFF
--- a/gpcontrib/Makefile
+++ b/gpcontrib/Makefile
@@ -23,7 +23,8 @@ ifeq "$(enable_debug_extensions)" "yes"
                gp_legacy_string_agg \
                gp_array_agg \
                gp_percentile_agg \
-               gp_error_handling
+               gp_error_handling \
+               gp_subtransaction_overflow
 else
 	recurse_targets = gp_sparse_vector \
                gp_distribution_policy \
@@ -33,7 +34,8 @@ else
                gp_legacy_string_agg \
                gp_array_agg \
                gp_percentile_agg \
-               gp_error_handling
+               gp_error_handling \
+               gp_subtransaction_overflow
 endif
 
 ifeq "$(with_zstd)" "yes"
@@ -96,3 +98,4 @@ installcheck:
 	if [ "$(with_quicklz)" = "yes" ]; then $(MAKE) -C quicklz installcheck; fi
 	$(MAKE) -C gp_sparse_vector installcheck
 	$(MAKE) -C gp_percentile_agg installcheck
+	$(MAKE) -C gp_subtransaction_overflow installcheck

--- a/gpcontrib/gp_subtransaction_overflow/Makefile
+++ b/gpcontrib/gp_subtransaction_overflow/Makefile
@@ -1,0 +1,16 @@
+EXTENSION = gp_subtransaction_overflow
+DATA = gp_subtransaction_overflow--1.0.0.sql
+REGRESS = subtransaction_overflow_test
+MODULES = gp_subtransaction_overflow
+
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = gpcontrib/gp_subtransaction_overflow
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/gpcontrib/gp_subtransaction_overflow/expected/subtransaction_overflow_test.out
+++ b/gpcontrib/gp_subtransaction_overflow/expected/subtransaction_overflow_test.out
@@ -1,0 +1,142 @@
+CREATE EXTENSION gp_subtransaction_overflow;
+-- It will occur subtransaction overflow when insert data to segments 1000 times.
+-- All segments occur overflow.
+DROP TABLE IF EXISTS t_1352_1;
+NOTICE:  table "t_1352_1" does not exist, skipping
+CREATE TABLE t_1352_1(c1 int) DISTRIBUTED BY (c1);
+CREATE OR REPLACE FUNCTION transaction_test0()
+RETURNS void AS $$
+DECLARE
+    i int;
+BEGIN
+	FOR i in 0..1000
+	LOOP
+		BEGIN
+			INSERT INTO t_1352_1 VALUES(i);
+		EXCEPTION
+		WHEN UNIQUE_VIOLATION THEN
+			NULL;
+		END;
+	END LOOP;
+END;
+$$
+LANGUAGE plpgsql;
+-- It will occur subtransaction overflow when insert data to segments 1000 times.
+-- All segments occur overflow.
+DROP TABLE IF EXISTS t_1352_2;
+NOTICE:  table "t_1352_2" does not exist, skipping
+CREATE TABLE t_1352_2(c int PRIMARY KEY);
+CREATE OR REPLACE FUNCTION transaction_test1()
+RETURNS void AS $$
+DECLARE i int;
+BEGIN
+	for i in 0..1000
+	LOOP
+		BEGIN
+			INSERT INTO t_1352_2 values(i);
+		EXCEPTION
+			WHEN UNIQUE_VIOLATION THEN
+				NULL;
+		END;
+	END LOOP;
+END;
+$$
+LANGUAGE plpgsql;
+-- It occur subtransaction overflow for coordinator and all segments.
+CREATE OR REPLACE FUNCTION transaction_test2()
+RETURNS void AS $$
+DECLARE
+    i int;
+BEGIN
+	for i in 0..1000
+	LOOP
+		BEGIN
+			CREATE TEMP TABLE tmptab(c int) DISTRIBUTED BY (c);
+			DROP TABLE tmptab;
+		EXCEPTION
+			WHEN others THEN
+				NULL;
+		END;
+	END LOOP;
+END;
+$$
+LANGUAGE plpgsql;
+BEGIN;
+SELECT transaction_test0();
+ transaction_test0 
+-------------------
+ 
+(1 row)
+
+SELECT segid, count(*) as num_suboverflowed FROM gp_suboverflowed_backend
+WHERE array_length(pids, 1) > 0
+GROUP BY segid
+ORDER BY segid;
+ segid | num_suboverflowed 
+-------+-------------------
+     0 |                 1
+     1 |                 1
+     2 |                 1
+(3 rows)
+
+COMMIT;
+BEGIN;
+SELECT transaction_test1();
+ transaction_test1 
+-------------------
+ 
+(1 row)
+
+SELECT segid, count(*) as num_suboverflowed FROM gp_suboverflowed_backend
+WHERE array_length(pids, 1) > 0
+GROUP by segid
+ORDER BY segid;
+ segid | num_suboverflowed 
+-------+-------------------
+     0 |                 1
+     1 |                 1
+     2 |                 1
+(3 rows)
+
+COMMIT;
+BEGIN;
+SELECT transaction_test2();
+ transaction_test2 
+-------------------
+ 
+(1 row)
+
+SELECT segid, count(*) as num_suboverflowed FROM gp_suboverflowed_backend
+WHERE array_length(pids, 1) > 0
+GROUP BY segid
+ORDER BY segid;
+ segid | num_suboverflowed 
+-------+-------------------
+    -1 |                 1
+     0 |                 1
+     1 |                 1
+     2 |                 1
+(4 rows)
+
+COMMIT;
+BEGIN;
+SELECT transaction_test0();
+ transaction_test0 
+-------------------
+ 
+(1 row)
+
+select segid, count(*) as num_suboverflowed FROM
+	(SELECT segid, unnest(pids)
+	FROM gp_suboverflowed_backend
+	WHERE array_length(pids, 1) > 0) AS tmp
+GROUP BY segid
+ORDER BY segid;
+ segid | num_suboverflowed 
+-------+-------------------
+     0 |                 1
+     1 |                 1
+     2 |                 1
+(3 rows)
+
+COMMIT;

--- a/gpcontrib/gp_subtransaction_overflow/gp_subtransaction_overflow--1.0.0.sql
+++ b/gpcontrib/gp_subtransaction_overflow/gp_subtransaction_overflow--1.0.0.sql
@@ -1,0 +1,13 @@
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION gp_subtransaction_overflow" to load this file. \quit
+
+CREATE OR REPLACE FUNCTION gp_get_suboverflowed_backends()
+RETURNS int[]
+AS '$libdir/gp_subtransaction_overflow'
+LANGUAGE C;
+
+-- Dispatch and aggregate all backends from coordinator and segments
+CREATE VIEW gp_suboverflowed_backend(segid, pids) AS
+  SELECT -1, gp_get_suboverflowed_backends()
+UNION ALL
+  SELECT gp_segment_id, gp_get_suboverflowed_backends() FROM gp_dist_random('gp_id') order by 1;

--- a/gpcontrib/gp_subtransaction_overflow/gp_subtransaction_overflow.c
+++ b/gpcontrib/gp_subtransaction_overflow/gp_subtransaction_overflow.c
@@ -1,0 +1,54 @@
+/*-------------------------------------------------------------------------
+ *
+ * gp_subtransaction_overflow.c
+ *	  Get suboverflowed_backends - Backend
+ *
+ *
+ * Copyright (c) 2022-Present VMware Software, Inc.
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "fmgr.h"
+#include "funcapi.h"
+#include "storage/proc.h"
+#include "storage/procarray.h"
+#include "storage/lwlock.h"
+#include "string.h"
+#include "utils/builtins.h"
+#include "utils/array.h"
+#include "nodes/pg_list.h"
+
+Datum gp_get_suboverflowed_backends(PG_FUNCTION_ARGS);
+
+PG_MODULE_MAGIC;
+PG_FUNCTION_INFO_V1(gp_get_suboverflowed_backends);
+
+/*
+ * Find the backends where subtransaction overflowed.
+ */
+Datum
+gp_get_suboverflowed_backends(PG_FUNCTION_ARGS)
+{
+	int 			i;
+	ArrayBuildState *astate = NULL;
+	
+	LWLockAcquire(ProcArrayLock, LW_SHARED);
+	for (i = 0; i < ProcGlobal->allProcCount; i++)
+	{
+		if (ProcGlobal->allPgXact[i].overflowed)
+			astate = accumArrayResult(astate,
+									  Int32GetDatum(ProcGlobal->allProcs[i].pid),
+									  false, INT4OID, CurrentMemoryContext);
+	}
+	LWLockRelease(ProcArrayLock);
+
+	if (astate)
+		PG_RETURN_DATUM(makeArrayResult(astate,
+											CurrentMemoryContext));
+	else
+		PG_RETURN_NULL();
+}

--- a/gpcontrib/gp_subtransaction_overflow/gp_subtransaction_overflow.control
+++ b/gpcontrib/gp_subtransaction_overflow/gp_subtransaction_overflow.control
@@ -1,0 +1,5 @@
+# gp_subtransaction_overflow extension
+
+comment = 'get the pids of subtransactions overflowed'
+default_version = '1.0.0'
+relocatable = true

--- a/gpcontrib/gp_subtransaction_overflow/sql/subtransaction_overflow_test.sql
+++ b/gpcontrib/gp_subtransaction_overflow/sql/subtransaction_overflow_test.sql
@@ -1,0 +1,98 @@
+CREATE EXTENSION gp_subtransaction_overflow;
+
+-- It will occur subtransaction overflow when insert data to segments 1000 times.
+-- All segments occur overflow.
+DROP TABLE IF EXISTS t_1352_1;
+CREATE TABLE t_1352_1(c1 int) DISTRIBUTED BY (c1);
+CREATE OR REPLACE FUNCTION transaction_test0()
+RETURNS void AS $$
+DECLARE
+    i int;
+BEGIN
+	FOR i in 0..1000
+	LOOP
+		BEGIN
+			INSERT INTO t_1352_1 VALUES(i);
+		EXCEPTION
+		WHEN UNIQUE_VIOLATION THEN
+			NULL;
+		END;
+	END LOOP;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- It will occur subtransaction overflow when insert data to segments 1000 times.
+-- All segments occur overflow.
+DROP TABLE IF EXISTS t_1352_2;
+CREATE TABLE t_1352_2(c int PRIMARY KEY);
+CREATE OR REPLACE FUNCTION transaction_test1()
+RETURNS void AS $$
+DECLARE i int;
+BEGIN
+	for i in 0..1000
+	LOOP
+		BEGIN
+			INSERT INTO t_1352_2 values(i);
+		EXCEPTION
+			WHEN UNIQUE_VIOLATION THEN
+				NULL;
+		END;
+	END LOOP;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- It occur subtransaction overflow for coordinator and all segments.
+CREATE OR REPLACE FUNCTION transaction_test2()
+RETURNS void AS $$
+DECLARE
+    i int;
+BEGIN
+	for i in 0..1000
+	LOOP
+		BEGIN
+			CREATE TEMP TABLE tmptab(c int) DISTRIBUTED BY (c);
+			DROP TABLE tmptab;
+		EXCEPTION
+			WHEN others THEN
+				NULL;
+		END;
+	END LOOP;
+END;
+$$
+LANGUAGE plpgsql;
+
+BEGIN;
+SELECT transaction_test0();
+SELECT segid, count(*) as num_suboverflowed FROM gp_suboverflowed_backend
+WHERE array_length(pids, 1) > 0
+GROUP BY segid
+ORDER BY segid;
+COMMIT;
+
+BEGIN;
+SELECT transaction_test1();
+SELECT segid, count(*) as num_suboverflowed FROM gp_suboverflowed_backend
+WHERE array_length(pids, 1) > 0
+GROUP by segid
+ORDER BY segid;
+COMMIT;
+
+BEGIN;
+SELECT transaction_test2();
+SELECT segid, count(*) as num_suboverflowed FROM gp_suboverflowed_backend
+WHERE array_length(pids, 1) > 0
+GROUP BY segid
+ORDER BY segid;
+COMMIT;
+
+BEGIN;
+SELECT transaction_test0();
+select segid, count(*) as num_suboverflowed FROM
+	(SELECT segid, unnest(pids)
+	FROM gp_suboverflowed_backend
+	WHERE array_length(pids, 1) > 0) AS tmp
+GROUP BY segid
+ORDER BY segid;
+COMMIT;


### PR DESCRIPTION
Subtransaction overflow is a chronic problem for Postgres and Greenplum,
which arises when a backend creates more than PGPROC_MAX_CACHED_SUBXIDS
(64) subtransactions. This is often caused by the use of plpgsql
EXCEPTION blocks, SAVEPOINT etc.

Overflow implies that pg_subtrans needs to be consulted and the
in-memory XidCache is no longer sufficient.

The lookup cost is particularly felt when there are long running
transactions in the system, in addition to backends with suboverflow.

Long running transactions increase the xmin boundary, leading to more
lookups, especially older pages in pg_subtrans. Looking up older pages
while we are constantly generating new pg_subtrans pages (with the
suboverflowed backend(s)) leads to pg_subtrans LRU misses, exacerbating
the slowdown in overall system query performance.

Terminating the backend with suboverflow or backends with long running
transactions can help alleviate the potential performance problems. This
commit provides an extension and a view which can help DBAs identify
suboverflown backends, which they can subsequently terminate. Please
note that backends should be terminated from the master (which will
automatically terminate the corresponding backends on the segments)

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
