### PR TITLE
Error out if any segment has a running basebackup

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -35,6 +35,7 @@ try:
     from pgdb import DatabaseError
     from gppylib.gpcatalog import COORDINATOR_ONLY_TABLES
     from gppylib.operations.package import SyncPackages
+    from gppylib.programs.clsRecoverSegment_triples import get_segments_with_running_basebackup
     from gppylib.operations.utils import ParallelOperation
     from gppylib.parseutils import line_reader, check_values, canonicalize_address
     from gppylib.heapchecksum import HeapChecksum
@@ -1155,6 +1156,13 @@ class gpexpand:
         return dict(cursor.fetchall())
 
     def addNewSegments(self, inputFileEntryList):
+        segments_with_running_basebackup = get_segments_with_running_basebackup()
+        contentIds_with_running_basebackup = [seg.contentId for seg in inputFileEntryList if seg.contentId in segments_with_running_basebackup]
+
+        if len(contentIds_with_running_basebackup)>0:
+            raise Exception(
+            "Found pg_basebackup running for segments with contentIds %s" %contentIds_with_running_basebackup)
+
         for seg in inputFileEntryList:
             self.gparray.addExpansionSeg(content=int(seg.contentId)
                                          , preferred_role=seg.role

--- a/gpMgmt/bin/gpmovemirrors
+++ b/gpMgmt/bin/gpmovemirrors
@@ -373,12 +373,12 @@ try:
 
 
     """ Prepare common execution steps for running commands on segments """
-    mirrorsToDelete = [mirror for mirror in newConfig.oldMirrorList if not mirror.inPlace]
-    totalDirsToDelete = len(mirrorsToDelete)
+    oldMirrorsToMove = [mirror for mirror in newConfig.oldMirrorList if not mirror.inPlace]
+    totalDirsToDelete = len(oldMirrorsToMove)
     numberOfWorkers = min(totalDirsToDelete, options.batch_size)
 
     """ Fetch tablespace locations before mirror move """
-    for mirror in mirrorsToDelete:
+    for mirror in oldMirrorsToMove:
         mirror_tablespace_locations[mirror.dataDirectory] = get_tablespace_locations(False, mirror.dataDirectory)
 
     """ Update pg_hba.conf on primary segments with new mirror information """
@@ -400,6 +400,10 @@ try:
     """ Reinitialize gparray after the new mirrors are in place. """
     gpArrayInstance = GpArray.initFromCatalog(dburl, utility=True)
     mirrorDirectories = set((seg.getSegmentHostName(),seg.getSegmentContentId()) for seg in gpArrayInstance.getDbList() if seg.isSegmentMirror())
+    newMirrorAddressDir = set((seg.getSegmentAddress(), seg.getSegmentDataDirectory()) for seg in gpArrayInstance.getDbList() if seg.isSegmentMirror())
+
+    """If mirror has not moved to new location due to any reason, skip deletion of old mirror directory"""
+    mirrorsToDelete = [mirror for mirror in oldMirrorsToMove if (mirror.address, mirror.dataDirectory) not in newMirrorAddressDir]
 
     """ Delete old mirror directories. """
     if numberOfWorkers > 0:

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment_triples.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment_triples.py
@@ -1,12 +1,37 @@
 import abc
 from typing import List
 
+from contextlib import closing
+from gppylib.db import dbconn
+from gppylib import gplog
 from gppylib.mainUtils import ExceptionNoStackTraceNeeded
 from gppylib.operations.detect_unreachable_hosts import get_unreachable_segment_hosts
 from gppylib.parseutils import line_reader, check_values, canonicalize_address
 from gppylib.utils import checkNotNone, normalizeAndValidateInputPath
 from gppylib.gparray import GpArray, Segment
 
+logger = gplog.get_default_logger()
+
+def get_segments_with_running_basebackup():
+    """
+    Returns a list of contentIds of source segments of running pg_basebackup processes
+    At present gp_stat_replication table does not contain any info about datadir and dbid of the target of running pg_basebackup
+    """
+
+    sql = "select gp_segment_id from gp_stat_replication where application_name = 'pg_basebackup'"
+
+    try:
+        with closing(dbconn.connect(dbconn.DbURL())) as conn:
+            res = dbconn.query(conn, sql)
+            rows = res.fetchall()
+    except Exception as e:
+        raise Exception("Failed to query gp_stat_replication: %s" %str(e))
+
+    segments_with_running_basebackup = {row[0] for row in rows}
+
+    if len(segments_with_running_basebackup) == 0:
+        logger.debug("No basebackup running")
+    return segments_with_running_basebackup
 
 class RecoveryTriplet:
     """
@@ -150,7 +175,15 @@ class RecoveryTriplets(abc.ABC):
         unreachable_failover_hosts = self._get_unreachable_failover_hosts(requests)
 
         dbIdToPeerMap = self.gpArray.getDbIdToPeerMap()
+
+        failed_segments_with_running_basebackup = []
+        segments_with_running_basebackup = get_segments_with_running_basebackup()
+
         for req in requests:
+            if req.failed.getSegmentContentId() in segments_with_running_basebackup:
+                failed_segments_with_running_basebackup.append(req.failed.getSegmentContentId())
+                continue
+
             # TODO: These 2 cases have different behavior which might be confusing to the user.
             # "<failed_address>|<failed_port>|<failed_data_dir> <failed_address>|<failed_port>|<failed_data_dir>" does full recovery
             # "<failed_address>|<failed_port>|<failed_data_dir>" does incremental recovery
@@ -176,6 +209,11 @@ class RecoveryTriplets(abc.ABC):
             peer = dbIdToPeerMap.get(req.failed.getSegmentDbId())
 
             triplets.append(RecoveryTriplet(req.failed, peer, failover))
+
+        if len(failed_segments_with_running_basebackup) > 0:
+            logger.warning(
+                "Found pg_basebackup running for segments with contentIds %s, skipping recovery of these segments" % (
+                    failed_segments_with_running_basebackup))
 
         return triplets
 

--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -149,7 +149,7 @@ def after_scenario(context, scenario):
         return
 
     tags_to_cleanup = ['gpmovemirrors', 'gpssh-exkeys']
-    if set(context.feature.tags).intersection(tags_to_cleanup):
+    if set(context.feature.tags).intersection(tags_to_cleanup) and "skip_cleanup" not in scenario.effective_tags:
         if 'temp_base_dir' in context and os.path.exists(context.temp_base_dir):
             os.chmod(context.temp_base_dir, 0o700)
             shutil.rmtree(context.temp_base_dir)

--- a/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
@@ -178,6 +178,18 @@ Feature: Tests for gpaddmirrors
         And check segment conf: postgresql.conf
         And all files in gpAdminLogs directory are deleted
 
+    Scenario: gpaddmirrors errors out if the directory for the mirror to be added is not empty
+        Given the cluster is generated with "3" primaries only
+        And all files in gpAdminLogs directory are deleted
+        And a gaddmirrors directory under '/tmp' with mode '0700' is created
+        And a gpaddmirrors input file is created
+        And edit the input file to add mirror with content 0,1,2 to a new non-empty directory with mode 0700
+        When the user runs gpaddmirrors with input file and additional args "-a"
+        Then gpaddmirrors should print "Segment directory '/tmp/.*' exists but is not empty!" to stdout
+        And all the segments are running
+        And check segment conf: postgresql.conf
+        And all files in gpAdminLogs directory are deleted
+
 
 #    Scenario: gpaddmirrors deletes progress file on SIGINT
 #        Given the cluster is generated with "3" primaries only

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -588,6 +588,180 @@ Feature: gprecoverseg tests
     And the row count from table "test_recoverseg" in "postgres" is verified against the saved data
 
   @demo_cluster
+  Scenario: gprecoverseg should not give warning if pg_basebackup is running for the up segments
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user immediately stops all primary processes for content 0,1
+    And the user suspend the walsender on the primary on content 2
+    And the user asynchronously runs pg_basebackup with primary of content 2 as source and the process is saved
+    And an FTS probe is triggered
+    And gp_stat_replication table has pg_basebackup entry for content 2
+    When the user runs "gprecoverseg -avF"
+    Then gprecoverseg should not print "No basebackup running" to stdout
+    And gprecoverseg should return a return code of 0
+    And verify that mirror on content 0,1 is up
+    And an FTS probe is triggered
+    And gp_stat_replication table has pg_basebackup entry for content 2
+    And the user reset the walsender on the primary on content 2
+    And the user waits until saved async process is completed
+    And the user waits until mirror on content 2 is up
+    And user can start transactions
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And the cluster is rebalanced
+
+  @demo_cluster
+  @concourse_cluster
+  Scenario: gprecoverseg gives warning if pg_basebackup already running for one of the failed segments
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user immediately stops all primary processes for content 0,1,2
+    And user can start transactions
+    And the user suspend the walsender on the primary on content 0
+    And sql "DROP TABLE if exists test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,100000000) AS i" is executed in "postgres" db
+    And the "test_recoverseg" table row count in "postgres" is saved
+    And the user asynchronously runs "gprecoverseg -aF" and the process is saved
+    And the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
+    And the user waits until mirror on content 1,2 is up
+    And verify that mirror on content 0 is down
+    And the gprecoverseg lock directory is removed
+    And user immediately stops all primary processes for content 1,2
+    And the user waits until mirror on content 1,2 is down
+    When the user runs "gprecoverseg -avF"
+    Then gprecoverseg should print "Found pg_basebackup running for segments with contentIds [0], skipping recovery of these segments" to logfile
+    And gprecoverseg should return a return code of 0
+    And verify that mirror on content 1,2 is up
+    And verify that mirror on content 0 is down
+    And an FTS probe is triggered
+    And the user reset the walsender on the primary on content 0
+    And the user waits until saved async process is completed
+    And recovery_progress.file should not exist in gpAdminLogs
+    And verify that mirror on content 0 is up
+    And the user runs "gprecoverseg -avF"
+    Then gprecoverseg should print "No basebackup running" to stdout
+    And gprecoverseg should return a return code of 0
+    And the cluster is rebalanced
+    And the row count from table "test_recoverseg" in "postgres" is verified against the saved data
+
+  @demo_cluster
+  @concourse_cluster
+  Scenario: gprecoverseg gives warning if pg_basebackup already running for some of the failed segments
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user immediately stops all primary processes for content 0,1,2
+    And user can start transactions
+    And the user suspend the walsender on the primary on content 0
+    And the user suspend the walsender on the primary on content 1
+    And sql "DROP TABLE if exists test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,100000000) AS i" is executed in "postgres" db
+    And the "test_recoverseg" table row count in "postgres" is saved
+    And the user asynchronously runs "gprecoverseg -aF" and the process is saved
+    And the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
+    And the user waits until mirror on content 2 is up
+    And verify that mirror on content 0,1 is down
+    And the gprecoverseg lock directory is removed
+    And user immediately stops all primary processes for content 2
+    And the user waits until mirror on content 2 is down
+    When the user runs "gprecoverseg -avF"
+    Then gprecoverseg should print "Found pg_basebackup running for segments with contentIds [0, 1], skipping recovery of these segments" to logfile
+    And gprecoverseg should return a return code of 0
+    And verify that mirror on content 2 is up
+    And verify that mirror on content 0,1 is down
+    And an FTS probe is triggered
+    And the user reset the walsender on the primary on content 0
+    And the user reset the walsender on the primary on content 1
+    And the user waits until saved async process is completed
+    And recovery_progress.file should not exist in gpAdminLogs
+    And verify that mirror on content 0,1 is up
+    And the user runs "gprecoverseg -avF"
+    Then gprecoverseg should print "No basebackup running" to stdout
+    And gprecoverseg should return a return code of 0
+    And the cluster is rebalanced
+    And the row count from table "test_recoverseg" in "postgres" is verified against the saved data
+
+  @demo_cluster
+  @concourse_cluster
+  Scenario: gprecoverseg -aF gives warning if pg_basebackup already running for all of the failed segments
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user immediately stops all primary processes for content 0,1,2
+    And user can start transactions
+    And the user suspend the walsender on the primary on content 0
+    And the user suspend the walsender on the primary on content 1
+    And the user suspend the walsender on the primary on content 2
+    And sql "DROP TABLE if exists test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,100000000) AS i" is executed in "postgres" db
+    And the "test_recoverseg" table row count in "postgres" is saved
+    And the user asynchronously runs "gprecoverseg -aF" and the process is saved
+    And the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
+    And verify that mirror on content 0,1,2 is down
+    And the gprecoverseg lock directory is removed
+    When the user runs "gprecoverseg -aF"
+    Then gprecoverseg should print "Found pg_basebackup running for segments with contentIds [0, 1, 2], skipping recovery of these segments" to logfile
+    And gprecoverseg should print "No segments to recover" to stdout
+    And gprecoverseg should return a return code of 0
+    And verify that mirror on content 0,1,2 is down
+    And an FTS probe is triggered
+    And the user reset the walsender on the primary on content 0
+    And the user reset the walsender on the primary on content 1
+    And the user reset the walsender on the primary on content 2
+    And the user waits until saved async process is completed
+    And recovery_progress.file should not exist in gpAdminLogs
+    And verify that mirror on content 0,1,2 is up
+    And the user runs "gprecoverseg -avF"
+    Then gprecoverseg should print "No basebackup running" to stdout
+    And gprecoverseg should return a return code of 0
+    And verify that mirror on content 0,1,2 is up
+    And the cluster is rebalanced
+    And the row count from table "test_recoverseg" in "postgres" is verified against the saved data
+
+  @demo_cluster
+  @concourse_cluster
+  Scenario: gprecoverseg -i gives warning if pg_basebackup already running for all failed segments
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user immediately stops all primary processes for content 0,1,2
+    And user can start transactions
+    And the user suspend the walsender on the primary on content 0
+    And the user suspend the walsender on the primary on content 1
+    And the user suspend the walsender on the primary on content 2
+    And sql "DROP TABLE if exists test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,100000000) AS i" is executed in "postgres" db
+    And the "test_recoverseg" table row count in "postgres" is saved
+    And a gprecoverseg directory under '/tmp' with mode '0700' is created
+    And a gprecoverseg input file is created
+    And edit the input file to recover mirror with content 0 full inplace
+    And edit the input file to recover mirror with content 1 full inplace
+    And edit the input file to recover mirror with content 2 full inplace
+    When the user asynchronously runs gprecoverseg with input file and additional args "-a" and the process is saved
+    Then the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
+    And verify that mirror on content 0,1,2 is down
+    And the gprecoverseg lock directory is removed
+    When the user runs gprecoverseg with input file and additional args "-a"
+    Then gprecoverseg should print "Found pg_basebackup running for segments with contentIds [0, 1, 2], skipping recovery of these segments" to logfile
+    And gprecoverseg should print "No segments to recover" to stdout
+    And gprecoverseg should return a return code of 0
+    And verify that mirror on content 0,1,2 is down
+    And an FTS probe is triggered
+    And the user reset the walsender on the primary on content 0
+    And the user reset the walsender on the primary on content 1
+    And the user reset the walsender on the primary on content 2
+    And the user waits until saved async process is completed
+    And recovery_progress.file should not exist in gpAdminLogs
+    And verify that mirror on content 0,1,2 is up
+    When the user runs gprecoverseg with input file and additional args "-av"
+    Then gprecoverseg should print "No basebackup running" to stdout
+    And gprecoverseg should return a return code of 0
+    Then the cluster is rebalanced
+    And the row count from table "test_recoverseg" in "postgres" is verified against the saved data
+
+  @demo_cluster
   @concourse_cluster
   Scenario: gprecoverseg incremental recovery segments come up even if one rewind fails
     Given the database is running

--- a/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
@@ -385,13 +385,15 @@ def impl(context, content_ids, mode):
                 break
 
 
-@given("edit the input file to add mirror with content {content_ids} to a new directory with mode {mode}")
-def impl(context, content_ids, mode):
+@given("edit the input file to add mirror with content {content_ids} to a new {directory} with mode {mode}")
+def impl(context, content_ids, directory, mode):
     if content_ids == "None":
         return
     for content in [int(c) for c in content_ids.split(',')]:
         make_temp_dir(context, context.mirror_context.working_directory[0], mode)
         new_datadir = context.temp_base_dir
+        if directory == "non-empty directory":
+            make_temp_dir(context, new_datadir, mode)
         segments = GpArray.initFromCatalog(dbconn.DbURL()).getSegmentList()
 
         for seg in segments:
@@ -686,6 +688,8 @@ def impl(context, utility, extra_args=''):
 
 
 @when('the user asynchronously runs {utility} with input file and additional args "{extra_args}" and the process is saved')
+@given('the user asynchronously runs {utility} with input file and additional args "{extra_args}" and the process is saved')
+@then('the user asynchronously runs {utility} with input file and additional args "{extra_args}" and the process is saved')
 def impl(context, utility, extra_args=''):
     cmd = "%s -i %s %s" % (utility, context.mirror_context.input_file_path(), extra_args)
     run_gpcommand_async(context, cmd)

--- a/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
@@ -570,6 +570,8 @@ def impl(context):
     if len(dirs) > 0:
         raise Exception("One or more backout directories exist: %s" % dirs)
 
+@given('the gprecoverseg lock directory is removed')
+@when('the gprecoverseg lock directory is removed')
 @then('the gprecoverseg lock directory is removed')
 def impl(context):
     lock_dir = "%s/gprecoverseg.lock" % os.environ["COORDINATOR_DATA_DIRECTORY"]


### PR DESCRIPTION
gprecoverseg, gpmovemirrors should show warning and gpexpand should raise an exception if there is already a running instance of pg_basebackup for the segment that needs to be recovered/moved.

How this issue was produced:
- gprecoverseg -F was called to bring up down segments
- This gprecoverseg call was interrupted because of a disconnected putty session
- Because of this, the main gprecoverseg process was killed but the background pg_basebackup process was still running
- After this, gprecoverseg -F was run multiple times, all of which failed because of multiple parallel basebackup processes running per segment.
- One of the gprecoverseg ran till completion before running any other gprecoverseg operation. Once this basebackup process was finished, the background code also automatically started the segment
- Then gprecoverseg -ar was run which caused a PANIC because the multiple basebackups in parallel had already corrupted the data dir

### Fix:
Create a list segments_with_running_basebackup of segment dbids for which pg_basebackup is running and while creating the recovery triplets, check if the segment to be recovered/moved/added(expansion segments) is already present in the segments_with_running_basebackup list. If that's the case give warning or raise exception and terminate the utility execution.

Behaviour of gprecoverseg - Warning message is logged containing list of segment contentIds with running basebackup and for the rest of the segments gprecoverseg will proceed with recovery

Behaviour of gpmovemirrors - Warning message is logged containing list of segment contentIds with running basebackup and for the rest of the mirrors gpmovemirrors will proceed with movement

Behaviour of gpexpand - Exception is raised and execution is stopped immediately if segments to be added have running pg_basebackup 

Behaviour of gpaddmirrors - As gpaddmirrors does not use force-overwrite flag with pg_basebackup to sync newly added mirrors with primary, the check is not required here. Have added behave test case to ensure it fails when mirror directories are not empty

### Limitation of above fix: 
To get the list of segments with running pg_basebackup we are querying gp_stat_replication table, At present this table shows only content ID of the source segment for any running pg_basebackup process and no information about the target segment/DataDirectory

Added behave testcase for gprecoverseg, gpmovemirrors and gpaddmirrors

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
