### PR TITLE
docs - new guc gp_resource_group_enable_recalculate_query_mem (6x)

### DIFF
--- a/gpdb-doc/markdown/admin_guide/workload_mgmt_resgroups.html.md
+++ b/gpdb-doc/markdown/admin_guide/workload_mgmt_resgroups.html.md
@@ -224,6 +224,21 @@ When `MEMORY_SPILL_RATIO` is 0, Greenplum Database uses the [`statement_mem`](..
 
 You can selectively set the `MEMORY_SPILL_RATIO` on a per-query basis at the session level with the [memory\_spill\_ratio](../ref_guide/config_params/guc-list.html) server configuration parameter.
 
+
+##### <a id="topic833maxalloc"></a>About How Greenplum Database Allocates Transaction Memory
+
+The query planner pre-computes the maximum amount of memory that each node in the plan tree can use. When resource group-based resource management is active and the `MEMORY_SPILL_RATIO` for the resource group is non-zero, the following formula roughly specifies the maximum amount of memory that Greenplum Database allocates to a transaction:
+
+``` pre
+query_mem = (rg_perseg_mem * memory_limit) * memory_spill_ratio / concurrency
+```
+
+Where `memory_limit`, `memory_spill_ratio`, and `concurrency` are specified by the resource group under which the transaction runs.
+
+By default, Greenplum Database calculates the maximum amount of segment host memory allocated to a transaction based on the `rg_perseg_mem` and the number of primary segments on the *master host*.
+
+If the memory configuration on your Greenplum Database master and segment hosts differ, you may prefer that the maximum per-transaction memory calculation be based on the segment host configuration. To instruct Greenplum Database to recalculate the maximum memory allocation per-transaction based on the `rg_perseg_mem` and the number of primary segments *on the segment host*, set the [gp_resource_group_enable_recalculate_query_mem](../ref_guide/config_params/guc-list.html#gp_resource_group_enable_recalculate_query_mem) server configuration parameter to `true`.
+
 ##### <a id="topic833low"></a>memory\_spill\_ratio and Low Memory Queries 
 
 A low `statement_mem` setting \(for example, in the 10MB range\) has been shown to increase the performance of queries with low memory requirements. Use the `memory_spill_ratio` and `statement_mem` server configuration parameters to override the setting on a per-query basis. For example:

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -1302,6 +1302,10 @@ Identifies the maximum percentage of system CPU resources to allocate to resourc
 
 Specifies whether or not Greenplum Database recalculates the maximum amount of memory to allocate per query running in a resource group. The default value is `false`, Greenplum database calculates the maximum per-query memory based on the memory configuration and the number of primary segments on the master host. When set to `true`, Greenplum Database recalculates the maximum per-query memory based on the memory configuration and the number of primary segments on the segment host.
 
+|Value Range|Default|Set Classifications|
+|-----------|-------|-------------------|
+|Boolean|false|master, session, reload|
+
 ## <a id="gp_resource_group_memory_limit"></a>gp\_resource\_group\_memory\_limit 
 
 **Note:** The `gp_resource_group_memory_limit` server configuration parameter is enforced only when resource group-based resource management is active.

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -1295,6 +1295,13 @@ Identifies the maximum percentage of system CPU resources to allocate to resourc
 |-----------|-------|-------------------|
 |0.1 - 1.0|0.9|local, system, restart|
 
+
+## <a id="gp_resource_group_enable_recalculate_query_mem"></a>gp\_resource\_group\_enable\_recalculate\_query\_mem
+
+**Note:** The `gp_resource_group_enable_recalculate_query_mem` server configuration parameter is enforced only when resource group-based resource management is active.
+
+Specifies whether or not Greenplum Database recalculates the maximum amount of memory to allocate per query running in a resource group. The default value is `false`, Greenplum database calculates the maximum per-query memory based on the memory configuration and the number of primary segments on the master host. When set to `true`, Greenplum Database recalculates the maximum per-query memory based on the memory configuration and the number of primary segments on the segment host.
+
 ## <a id="gp_resource_group_memory_limit"></a>gp\_resource\_group\_memory\_limit 
 
 **Note:** The `gp_resource_group_memory_limit` server configuration parameter is enforced only when resource group-based resource management is active.

--- a/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
@@ -389,6 +389,7 @@ The following parameters configure the Greenplum Database resource group workloa
 - [gp\_resource\_group\_bypass](guc-list.html)
 - [gp\_resource\_group\_cpu\_ceiling\_enforcement](guc-list.html)
 - [gp\_resource\_group\_cpu\_limit](guc-list.html)
+- [gp\_resource\_group\_enable\_recalculate\_query\_mem](guc-list.html)
 - [gp\_resource\_group\_memory\_limit](guc-list.html)
 - [gp\_resource\_group\_queuing\_timeout](guc-list.html)
 - [gp\_resource\_manager](guc-list.html)


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/13369 (6X_STABLE).

the PR above introduces a new guc: gp_resource_group_enable_recalculate_query_mem.  in this PR:
- add reference info about this guc (default value: false)
- add new topic "About How Greenplum Database Allocates Transaction Memory" to the "using resource groups" doc page

(the default value of this new guc is true on the master branch; i'll submit a separate PR for those doc changes.)

doc review site links (behind vpn):
- guc reference: https://docs-staging.vmware.com/en/VMware-Tanzu-Greenplum/lisa-rgg/greenplum-database/GUID-ref_guide-config_params-guc-list.html#gp_resource_group_enable_recalculate_query_mem
- using resource group topic: https://docs-staging.vmware.com/en/VMware-Tanzu-Greenplum/lisa-rgg/greenplum-database/GUID-admin_guide-workload_mgmt_resgroups.html#topic833maxalloc
