### PR TITLE
docs - for ip4r contrib module

### DIFF
--- a/gpdb-doc/markdown/install_guide/install_modules.html.md
+++ b/gpdb-doc/markdown/install_guide/install_modules.html.md
@@ -34,6 +34,7 @@ You can register the following modules in this manner:
 <td style="vertical-align:top;">
 <ul class="ul">
 <li class="li"><a class="xref" href="../ref_guide/modules/hstore.html">hstore</a></li>
+<li class="li"><a class="xref" href="../ref_guide/modules/ip4r.html">ip4r</a></li>
 <li class="li"><a class="xref" href="../ref_guide/modules/orafce_ref.html">orafce</a> (Tanzu Greenplum only)</li>
 <li class="li"><a class="xref" href="../ref_guide/modules/pageinspect.html">pageinspect</a></li>
 <li class="li"><a class="xref" href="../ref_guide/modules/pg_trgm.html">pg_trgm</a></li>

--- a/gpdb-doc/markdown/ref_guide/modules/intro.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/intro.html.md
@@ -16,6 +16,7 @@ The following Greenplum Database and PostgreSQL `contrib` modules are installed;
 -   [gp\_legacy\_string\_agg](gp_legacy_string_agg.html) - Implements a legacy, single-argument `string_agg()` aggregate function that was present in Greenplum Database 5.
 -   [gp\_sparse\_vector](gp_sparse_vector.html) - Implements a Greenplum Database data type that uses compressed storage of zeros to make vector computations on floating point numbers faster.
 -   [hstore](hstore.html) - Provides a data type for storing sets of key/value pairs within a single PostgreSQL value.
+-   [ip4r](ip4r.html) - Provides data types for operations on IPv4 and IPv6 IP addresses.
 -   [orafce](orafce_ref.html) - Provides Greenplum Database-specific Oracle SQL compatibility functions.
 -   [pageinspect](pageinspect.html) - Provides functions for low level inspection of the contents of database pages; available to superusers only.
 -   [pg\_trgm](pg_trgm.html) - Provides functions and operators for determining the similarity of alphanumeric text based on trigram matching. The module also provides index operator classes that support fast searching for similar strings.

--- a/gpdb-doc/markdown/ref_guide/modules/ip4r.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/ip4r.html.md
@@ -2,7 +2,7 @@
 
 The `ip4r` module provides IPv4 and IPv6 data types, IPv4 and IPv6 range index data types, and related functions and operators.
 
-The Greenplum Database `ip4r` module is equivalent to the `ip4r` module used with PostgreSQL. There are no Greenplum Database or MPP-specific considerations for the module.
+The Greenplum Database `ip4r` module is equivalent to version 2.4.1 of the `ip4r` module used with PostgreSQL. There are no Greenplum Database or MPP-specific considerations for the module.
 
 ## <a id="topic_reg"></a>Installing and Registering the Module 
 
@@ -16,5 +16,5 @@ Refer to [Installing Additional Supplied Modules](../../install_guide/install_mo
 
 ## <a id="topic_info"></a>Module Documentation 
 
-The `ip4r` module was developed by `RhodiumToad`.  Refer to the [RhodiumToad/ip4r](https://github.com/RhodiumToad/ip4r) documentation on `github` for detailed information about using the module.
+Refer to the [ip4r github documentation](https://github.com/RhodiumToad/ip4r) for detailed information about using the module.
 

--- a/gpdb-doc/markdown/ref_guide/modules/ip4r.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/ip4r.html.md
@@ -1,0 +1,20 @@
+# ip4r 
+
+The `ip4r` module provides IPv4 and IPv6 data types, IPv4 and IPv6 range index data types, and related functions and operators.
+
+The Greenplum Database `ip4r` module is equivalent to the `ip4r` module used with PostgreSQL. There are no Greenplum Database or MPP-specific considerations for the module.
+
+## <a id="topic_reg"></a>Installing and Registering the Module 
+
+The `ip4r` module is installed when you install Greenplum Database. Before you can use any of the data types defined in the module, you must register the `ip4r` extension in each database in which you want to use the types:
+
+```
+CREATE EXTENSION ip4r;
+```
+
+Refer to [Installing Additional Supplied Modules](../../install_guide/install_modules.html) for more information.
+
+## <a id="topic_info"></a>Module Documentation 
+
+The `ip4r` module was developed by `RhodiumToad`.  Refer the [RhodiumToad/ip4r](https://github.com/RhodiumToad/ip4r) documentation on `github` for detailed information about using the module.
+

--- a/gpdb-doc/markdown/ref_guide/modules/ip4r.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/ip4r.html.md
@@ -16,5 +16,5 @@ Refer to [Installing Additional Supplied Modules](../../install_guide/install_mo
 
 ## <a id="topic_info"></a>Module Documentation 
 
-The `ip4r` module was developed by `RhodiumToad`.  Refer the [RhodiumToad/ip4r](https://github.com/RhodiumToad/ip4r) documentation on `github` for detailed information about using the module.
+The `ip4r` module was developed by `RhodiumToad`.  Refer to the [RhodiumToad/ip4r](https://github.com/RhodiumToad/ip4r) documentation on `github` for detailed information about using the module.
 

--- a/gpdb-doc/markdown/ref_guide/toc.md
+++ b/gpdb-doc/markdown/ref_guide/toc.md
@@ -176,6 +176,7 @@ Doc Index
         - [gp\_legacy\_string\_agg](./modules/gp_legacy_string_agg.md)
         - [gp\_sparse\_vector](./modules/gp_sparse_vector.md)
         - [hstore](./modules/hstore.md)
+        - [ip4r](./modules/ip4r.md)
         - [orafce](./modules/orafce_ref.md)
         - [pageinspect](./modules/pageinspect.md)
         - [pg\_trgm](./modules/pg_trgm.md)


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/13588 (master) and https://github.com/greenplum-db/gpdb/pull/13600 (6X_STABLE)

in this PR:  add topic for new ip4r module.
question:  did i appropriately state the attribution?

will be backported to 6X_STABLE.

doc review site link (behind vpn):  https://docs-staging.vmware.com/en/VMware-Tanzu-Greenplum/lisa-ip4r/greenplum-database/GUID-ref_guide-modules-ip4r.html
