### PR TITLE
remove FIXME in execExpr.c:ExecInitExprRec

### DIFF
--- a/src/backend/executor/execExpr.c
+++ b/src/backend/executor/execExpr.c
@@ -835,25 +835,7 @@ ExecInitExprRec(Expr *node, ExprState *state,
 
 		case T_GroupId:
 			{
-				if (state->parent && IsA(state->parent, HashJoinState))
-				{
-					/*
-					 * GPDB_95_MERGE_FIXME: GPDB may choose a HashJoin to combine multiple
-					 * aggregations in targetlist, however, for queries with multiple
-					 * groups, the HashJoin combination will not be taken. For a single
-					 * group, the GROUP_ID() function should always return 0
-					 *
-					 * GPDB_12_MERGE_FIXME: Does GPDB still do that? I think that was
-					 * the old way of construting multi-DQA plans, but now we use the
-					 * TupleSplit node for it.
-					 */
-					scratch.opcode = EEOP_CONST;
-					scratch.d.constval.value = Int32GetDatum(0);
-					scratch.d.constval.isnull = false;
-
-					ExprEvalPushStep(state, &scratch);
-				}
-				else if (!state->parent || !IsA(state->parent, AggState) || !IsA(state->parent->plan, Agg))
+				if (!state->parent || !IsA(state->parent, AggState) || !IsA(state->parent->plan, Agg))
 					elog(ERROR, "parent of GROUP_ID is not Agg node");
 				else
 				{


### PR DESCRIPTION
As Heikki said, we will constructing multi-DQA plans using the TupleSplit node for it. So in the 
function `ExecInitExprRec` we can ignore the HashJoin to combine multiple aggregations in
target list. Just delete the MERGE_FIXME in `execExpr.c`.

No more tests need, since `gp_dqa.sql` has corresponding tests. Like:

```
set enable_hashagg=on;
set enable_groupagg=off;

create table dqa_f1(a int, b int, c int) distributed by (a);
create table dqa_f2(x int, y int, z int) distributed by (x);

insert into dqa_f1 select i%17, i%5 , i%3 from generate_series(1,1000) i;
insert into dqa_f2 select i % 13, i % 5 , i % 11 from generate_series(1,1000) i;

postgres=# explain select sum(distinct a) filter (where a > 0), sum(distinct b) filter (where a > 0) from dqa_f1 group by c;
                                                 QUERY PLAN                                                 
------------------------------------------------------------------------------------------------------------
 Finalize HashAggregate  (cost=10.19..10.22 rows=3 width=20)
   Group Key: c
   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=9.97..10.12 rows=9 width=20)
         ->  Partial HashAggregate  (cost=9.97..10.00 rows=3 width=20)
               Group Key: c
               ->  HashAggregate  (cost=9.47..9.69 rows=22 width=12)
                     Group Key: (AggExprId), a, b, c
                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=6.83..8.81 rows=66 width=12)
                           Hash Key: c, a, b, (AggExprId)
                           ->  Streaming HashAggregate  (cost=6.83..7.49 rows=66 width=12)
                                 Group Key: AggExprId, a, b, c
                                 ->  TupleSplit  (cost=4.33..5.17 rows=667 width=12)
                                       Split by Col: (a) FILTER (WHERE (a > 0)), (b) FILTER (WHERE (a > 0))
                                       Group Key: c
                                       ->  Seq Scan on dqa_f1  (cost=0.00..4.33 rows=333 width=12)
 Optimizer: Postgres query optimizer
(16 rows)
```
