### PR TITLE
remove parallel StreamBitmap scan FIXME

### DIFF
--- a/src/backend/executor/execParallel.c
+++ b/src/backend/executor/execParallel.c
@@ -476,7 +476,7 @@ ExecParallelInitializeDSM(PlanState *planstate,
 											d->pcxt);
 			break;
 		case T_BitmapHeapScanState:
-			/* GPDB_12_MERGE_TODO the parallel StreamBitmap scan is not implemented */
+			/* GPDB_12_MERGE_FEATURE_NOT_SUPPORTED: the parallel StreamBitmap scan is not implemented */
 			/*
 			 * if (planstate->plan->parallel_aware)
 			 *     ExecBitmapHeapInitializeDSM((BitmapHeapScanState *) planstate,

--- a/src/backend/executor/execParallel.c
+++ b/src/backend/executor/execParallel.c
@@ -476,7 +476,7 @@ ExecParallelInitializeDSM(PlanState *planstate,
 											d->pcxt);
 			break;
 		case T_BitmapHeapScanState:
-			/* GPDB_12_MERGE_FIXME the parallel StreamBitmap scan is not implemented */
+			/* GPDB_12_MERGE_TODO the parallel StreamBitmap scan is not implemented */
 			/*
 			 * if (planstate->plan->parallel_aware)
 			 *     ExecBitmapHeapInitializeDSM((BitmapHeapScanState *) planstate,

--- a/src/backend/executor/nodeBitmapHeapscan.c
+++ b/src/backend/executor/nodeBitmapHeapscan.c
@@ -169,7 +169,7 @@ BitmapHeapNext(BitmapHeapScanState *node)
 		else
 		{
 			/*
-			 * GPDB_12_MERGE_TODO the parallel StreamBitmap scan is not
+			 * GPDB_12_MERGE_FEATURE_NOT_SUPPORTED: the parallel StreamBitmap scan is not
 			 * implemented, it must be a TIDBitmap here
 			 */
 			/*

--- a/src/backend/executor/nodeBitmapHeapscan.c
+++ b/src/backend/executor/nodeBitmapHeapscan.c
@@ -169,7 +169,7 @@ BitmapHeapNext(BitmapHeapScanState *node)
 		else
 		{
 			/*
-			 * GPDB_12_MERGE_FIXME the parallel StreamBitmap scan is not
+			 * GPDB_12_MERGE_TODO the parallel StreamBitmap scan is not
 			 * implemented, it must be a TIDBitmap here
 			 */
 			/*

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -3601,7 +3601,7 @@ create_bitmap_scan_plan(PlannerInfo *root,
 	bitmapqualplan = create_bitmap_subplan(root, best_path->bitmapqual,
 										   &bitmapqualorig, &indexquals,
 										   &indexECs);
-	/* GPDB_12_MERGE_FIXME the parallel StreamBitmap scan is not implemented */
+	/* GPDB_12_MERGE_TODO the parallel StreamBitmap scan is not implemented */
 	/*
 	 * if (best_path->path.parallel_aware)
 	 *     bitmap_subplan_mark_shared(bitmapqualplan);

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -3601,7 +3601,7 @@ create_bitmap_scan_plan(PlannerInfo *root,
 	bitmapqualplan = create_bitmap_subplan(root, best_path->bitmapqual,
 										   &bitmapqualorig, &indexquals,
 										   &indexECs);
-	/* GPDB_12_MERGE_TODO the parallel StreamBitmap scan is not implemented */
+	/* GPDB_12_MERGE_FEATURE_NOT_SUPPORTED: the parallel StreamBitmap scan is not implemented */
 	/*
 	 * if (best_path->path.parallel_aware)
 	 *     bitmap_subplan_mark_shared(bitmapqualplan);


### PR DESCRIPTION
Thanks for working with @haolinw, Greenplum will not support parallel scan recently, so we can change
all the FIXME about parallel StreamBitmap scan to TODO tag, since it bases on the parallel scan.

No more tests need, this PR just change comments.