### PR TITLE
Avoid large replication lag due to FPI WAL records from hintbits

### DIFF
--- a/src/backend/access/transam/xloginsert.c
+++ b/src/backend/access/transam/xloginsert.c
@@ -987,6 +987,8 @@ XLogSaveBufferForHint(Buffer buffer, bool buffer_std)
 		XLogRegisterBlock(0, &rnode, forkno, blkno, copied_buffer.data, flags);
 
 		recptr = XLogInsert(RM_XLOG_ID, XLOG_FPI_FOR_HINT);
+
+		wait_to_avoid_large_repl_lag();
 	}
 
 	return recptr;

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -1454,10 +1454,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 
 	{
 		{"gp_disable_tuple_hints", PGC_USERSET, DEVELOPER_OPTIONS,
-			gettext_noop("Specify if reader should set hint bits on tuples."),
+			gettext_noop("Specify if hint bits on tuples should be deferred."),
 			NULL,
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
+		/*
+		 * If gp_disable_tuple_hints is off, always mark buffer dirty.
+		 * If gp_disable_tuple_hints is on, defer marking the buffer dirty
+		 * until after transaction is identified as old.
+		 * (unless it is a catalog table) See: markDirty
+		 */
 		&gp_disable_tuple_hints,
 		true,
 		NULL, NULL, NULL

--- a/src/test/isolation2/expected/segwalrep/select_throttle.out
+++ b/src/test/isolation2/expected/segwalrep/select_throttle.out
@@ -1,0 +1,100 @@
+-- Test: SELECT or other read-only operations which set hint bits on pages,
+-- and in turn generate Full Page Images (FPI) WAL records should be throttled.
+-- We will only throttle when our transaction wal exceeds
+-- wait_for_replication_threshold
+-- For this test we will:
+-- 1. Set wait_for_replication_threshold to 1kB for quicker test
+-- 2. create two tables (one small and one large)
+-- 3. set gp_disable_tuple_hints=off so buffer will be immediately marked dirty on hint bit change
+-- 4. Suspend walsender
+-- 5. Perform a read-only operation (SELECT) which would now set the hint bits
+--  For the small table this operation should finish,
+--  but for large table the SELECT should be throttled
+--  since it would generate a lot of WAL greater than wait_for_replication_threshold
+-- 6. Confirm that the query is waiting on Syncrep
+-- 7. Reset the walsender and the transaction should complete
+--
+
+-- set wait_for_replication_threshold to 1kB for quicker test
+ALTER SYSTEM SET wait_for_replication_threshold = 1;
+ALTER
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)
+
+CREATE TABLE select_no_throttle(a int) DISTRIBUTED BY (a);
+CREATE
+INSERT INTO select_no_throttle SELECT generate_series (1, 10);
+INSERT 10
+CREATE TABLE select_throttle(a int) DISTRIBUTED BY (a);
+CREATE
+INSERT INTO select_throttle SELECT generate_series (1, 100000);
+INSERT 100000
+
+-- Enable tuple hints so that buffer will be marked dirty upon a hint bit change
+-- (so that we don't have to wait for the tuple to age. See logic in markDirty)
+1U: SET gp_disable_tuple_hints=off;
+SET
+
+-- flush the data to disk
+checkpoint;
+CHECKPOINT
+
+-- Suspend walsender
+SELECT gp_inject_fault_infinite('wal_sender_loop', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- the following SELECTS will set the hint bit on (the buffer will be marked dirty)
+-- This query should not wait
+1U: SELECT count(*) FROM select_no_throttle;
+ count 
+-------
+ 1     
+(1 row)
+checkpoint;
+CHECKPOINT
+-- This query should wait for Syncrep since its WAL size for hint bits is greater than wait_for_replication_threshold
+1U&: SELECT count(*) FROM select_throttle;  <waiting ...>
+
+-- check if the above query is waiting on SyncRep in pg_stat_activity
+SELECT is_query_waiting_for_syncrep(50, 'SELECT count(*) FROM select_throttle;');
+ is_query_waiting_for_syncrep 
+------------------------------
+ t                            
+(1 row)
+
+-- reset walsender
+SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+-- after this, system continue to proceed
+
+1U<:  <... completed>
+ count 
+-------
+ 33327 
+(1 row)
+
+SELECT wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+1U: RESET gp_disable_tuple_hints;
+RESET
+1Uq: ... <quitting>
+
+ALTER SYSTEM RESET wait_for_replication_threshold;
+ALTER
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)

--- a/src/test/isolation2/expected/setup.out
+++ b/src/test/isolation2/expected/setup.out
@@ -89,6 +89,9 @@ CREATE
 create or replace function wait_until_all_segments_synchronized() returns text as $$ begin /* no-op for a mirrorless cluster */ if (select count(*) = 0 from gp_segment_configuration where role = 'm') then return 'OK'; /* in func */ end if; /* in func */ for i in 1..1200 loop if (select count(*) = 0 from gp_segment_configuration where content != -1 and mode != 's') then return 'OK'; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ perform gp_request_fts_probe_scan(); /* in func */ end loop; /* in func */ return 'Fail'; /* in func */ end; /* in func */ $$ language plpgsql;
 CREATE
 
+CREATE OR REPLACE FUNCTION is_query_waiting_for_syncrep(iterations int, check_query text) RETURNS bool AS $$ for i in range(iterations): results = plpy.execute("SELECT gp_execution_segment() AS content, query, wait_event\ FROM gp_dist_random('pg_stat_activity')\ WHERE gp_execution_segment() = 1 AND\ query = '%s' AND\ wait_event = 'SyncRep'" % check_query ) if results: return True return False $$ LANGUAGE plpython3u VOLATILE;
+CREATE
+
 create or replace function wait_for_replication_replay (segid int, retries int) returns bool as $$ declare i int; /* in func */ result bool; /* in func */ begin i := 0; /* in func */ -- Wait until the mirror/standby has replayed up to flush location loop SELECT flush_lsn = replay_lsn INTO result from gp_stat_replication where gp_segment_id = segid; /* in func */ if result then return true; /* in func */ end if; /* in func */ 
 if i >= retries then return false; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ perform pg_stat_clear_snapshot(); /* in func */ i := i + 1; /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
 CREATE

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -234,6 +234,7 @@ test: segwalrep/failover_with_many_records
 test: segwalrep/dtm_recovery_on_standby
 test: segwalrep/commit_blocking_on_standby
 test: segwalrep/dtx_recovery_wait_lsn
+test: segwalrep/select_throttle
 test: fts_manual_probe
 test: fts_session_reset
 test: fts_segment_reset

--- a/src/test/isolation2/sql/segwalrep/select_throttle.sql
+++ b/src/test/isolation2/sql/segwalrep/select_throttle.sql
@@ -1,0 +1,58 @@
+-- Test: SELECT or other read-only operations which set hint bits on pages,
+-- and in turn generate Full Page Images (FPI) WAL records should be throttled.
+-- We will only throttle when our transaction wal exceeds
+-- wait_for_replication_threshold
+-- For this test we will:
+-- 1. Set wait_for_replication_threshold to 1kB for quicker test
+-- 2. create two tables (one small and one large)
+-- 3. set gp_disable_tuple_hints=off so buffer will be immediately marked dirty on hint bit change
+-- 4. Suspend walsender
+-- 5. Perform a read-only operation (SELECT) which would now set the hint bits
+--  For the small table this operation should finish,
+--  but for large table the SELECT should be throttled
+--  since it would generate a lot of WAL greater than wait_for_replication_threshold
+-- 6. Confirm that the query is waiting on Syncrep
+-- 7. Reset the walsender and the transaction should complete
+--
+
+-- set wait_for_replication_threshold to 1kB for quicker test
+ALTER SYSTEM SET wait_for_replication_threshold = 1;
+SELECT pg_reload_conf();
+
+CREATE TABLE select_no_throttle(a int) DISTRIBUTED BY (a);
+INSERT INTO select_no_throttle SELECT generate_series (1, 10);
+CREATE TABLE select_throttle(a int) DISTRIBUTED BY (a);
+INSERT INTO select_throttle SELECT generate_series (1, 100000);
+
+-- Enable tuple hints so that buffer will be marked dirty upon a hint bit change
+-- (so that we don't have to wait for the tuple to age. See logic in markDirty)
+1U: SET gp_disable_tuple_hints=off;
+
+-- flush the data to disk
+checkpoint;
+
+-- Suspend walsender
+SELECT gp_inject_fault_infinite('wal_sender_loop', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
+
+-- the following SELECTS will set the hint bit on (the buffer will be marked dirty)
+-- This query should not wait
+1U: SELECT count(*) FROM select_no_throttle;
+checkpoint;
+-- This query should wait for Syncrep since its WAL size for hint bits is greater than wait_for_replication_threshold
+1U&: SELECT count(*) FROM select_throttle;
+
+-- check if the above query is waiting on SyncRep in pg_stat_activity
+SELECT is_query_waiting_for_syncrep(50, 'SELECT count(*) FROM select_throttle;');
+
+-- reset walsender
+SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
+-- after this, system continue to proceed
+
+1U<:
+
+SELECT wait_until_all_segments_synchronized();
+1U: RESET gp_disable_tuple_hints;
+1Uq:
+
+ALTER SYSTEM RESET wait_for_replication_threshold;
+SELECT pg_reload_conf();

--- a/src/test/isolation2/sql/setup.sql
+++ b/src/test/isolation2/sql/setup.sql
@@ -260,6 +260,18 @@ begin
 end; /* in func */
 $$ language plpgsql;
 
+CREATE OR REPLACE FUNCTION is_query_waiting_for_syncrep(iterations int, check_query text) RETURNS bool AS $$
+    for i in range(iterations):
+        results = plpy.execute("SELECT gp_execution_segment() AS content, query, wait_event\
+                                FROM gp_dist_random('pg_stat_activity')\
+                                WHERE gp_execution_segment() = 1 AND\
+                                query = '%s' AND\
+                                wait_event = 'SyncRep'" % check_query )
+        if results:
+            return True
+    return False
+$$ LANGUAGE plpython3u VOLATILE;
+
 create or replace function wait_for_replication_replay (segid int, retries int) returns bool as
 $$
 declare


### PR DESCRIPTION
SELECT or other read-only operations can result in setting hint bits on
pages, which in turn results in generating Full Page Images (FPI) WAL
records. These operations are not throttled currently and hence can
generate huge WAL traffic on primary without waiting for the mirror. This
causes concurrent transactions to suffer from replication lag.

One scenario this was seen in production was during SELECT post
restore of a large heap table from backup. Ideally, these situations
should be avoided by performing vacuum on such tables or via some
other mechanisms. Though there is still a possibility the best practice
guidance is not followed and hence to still avoid the situation better
to have throttling in writing the FPI code as well.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
