### PR TITLE
Remove a unnecessary MERGE_FIXME of multi aggregate

### DIFF
--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -839,14 +839,6 @@ advance_transition_function(AggState *aggstate,
  *
  * When called, CurrentMemoryContext should be the per-query context.
  */
-/*
- * GPDB_12_MERGE_FIXME: diff added in the following commits need to be
- * incorporated into aggstate->phase->evaltrans (most likely in
- * ExecBuildAggTrans)
- *
- * - commit 652e34adaf2e00e8 (Make use of serial/deserial functions to enable
- *   2-phase aggregates.)
- */
 static void
 advance_aggregates(AggState *aggstate)
 {


### PR DESCRIPTION
It was noted while resolving PG 12 conflicts, then we re-enabled
serial/deserial functions and multi-phase aggregates on the merge
branch.

This MERGE_FIXME is unnecessary, remove it.

Co-authored-by: Wenlin Zhang <zwenlin@vmware.com>