### PR TITLE
Remove fixme in nodeAgg.c:ExecSquelchAgg.

### DIFF
--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -5021,26 +5021,5 @@ ExecEagerFreeAgg(AggState *node)
 void
 ExecSquelchAgg(AggState *node)
 {
-	/*
-	 * GPDB_12_MERGE_FIXME: Sometimes, ExecSquelchAgg() is called, but then
-	 * the node is rescanned anyway. If we destroy the hash table here,
-	 * then we need to rebuild it later. I saw this happen with this test
-	 * query from the 'eagerfree' test:
-	 *
-	 *   with my_group_sum(d, total) as (select d, sum(i) from smallt group by d)
-	 *   select smallt2.* from smallt2
-	 *   where 0 < all (select total from my_group_sum, smallt, smallt2 as tmp where my_group_sum.d = smallt.d and smallt.d = tmp.d and my_group_sum.d = smallt2.d)
-	 *   and i = 0 ;
-	 *
-	 * That was broken, because ExecEagerFreeAgg() currently doesn't set
-	 * table_filled=false, even though it destroys the 'hashcontext'.
-	 * But it also doesn't destroy the hash table itself (or does go away
-	 * along with 'hashcontext'?) Freeing stuff aggressively here seems like
-	 * a premature optimization to me, so instead of trying to fix all that
-	 * I just disabled this attempt at eagerly freeing stuff. Revisit later?
-	 * I've got a feeling that Squelch is being called when it shouldn't, in
-	 * queries like above that involve a SubPlan.
-	 */
-	//ExecEagerFreeAgg(node);
 	ExecSquelchNode(outerPlanState(node));
 }

--- a/src/include/executor/nodeAgg.h
+++ b/src/include/executor/nodeAgg.h
@@ -326,5 +326,6 @@ extern void hash_agg_set_limits(AggState *aggstate, double hashentrysize, uint64
 extern Datum aggregate_dummy(PG_FUNCTION_ARGS);
 
 extern void ExecSquelchAgg(AggState *aggstate);
+extern bool ReuseHashTable(AggState *node);
 
 #endif							/* NODEAGG_H */

--- a/src/test/regress/expected/eagerfree.out
+++ b/src/test/regress/expected/eagerfree.out
@@ -1925,6 +1925,42 @@ and i = 0 order by 1,2,3; --order 1,2,3
  0 | text 5 | 01-06-2011
 (3 rows)
 
+-- Test Subplan with Agg
+with my_group_sum(d, total) as (select d, sum(i) from smallt group by d)
+select count(*) from smallt2
+where 0 < all (select total from my_group_sum, smallt2 as tmp where my_group_sum.d = smallt2.d);
+ count 
+-------
+    43
+(1 row)
+
+--start_ignore
+explain with my_group_sum(d, total) as (select d, sum(i) from smallt group by d)
+select count(*) from smallt2
+where 0 < all (select total from my_group_sum, smallt2 as tmp where my_group_sum.d = smallt2.d);
+                                                            QUERY PLAN
+-----------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=1.41..1.42 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=1.19..1.40 rows=3 width=8)
+         ->  Partial Aggregate  (cost=1.19..1.20 rows=1 width=8)
+               ->  Seq Scan on smallt2  (cost=0.00..1.17 rows=8 width=0)
+                     Filter: (SubPlan 1)
+                     SubPlan 1
+                       ->  Nested Loop  (cost=10000000009.00..10000000027.17 rows=1050 width=8)
+                             ->  Result  (cost=9.00..9.42 rows=21 width=12)
+                                   Filter: (smallt.d = smallt2.d)
+                                   ->  HashAggregate  (cost=9.00..9.21 rows=21 width=12)
+                                         Group Key: smallt.d
+                                         ->  Materialize  (cost=0.00..8.50 rows=100 width=8)
+                                               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..8.00 rows=100 width=8)
+                                                     ->  Seq Scan on smallt  (cost=0.00..1.33 rows=33 width=8)
+                             ->  Materialize  (cost=0.00..4.75 rows=50 width=0)
+                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..4.50 rows=50 width=0)
+                                         ->  Seq Scan on smallt2 tmp  (cost=0.00..1.17 rows=17 width=0)
+ Optimizer: Postgres query optimizer
+(18 rows)
+
+--end_ignore
 -- Nested Subplan
 create table eager_free_r (r1 int, r2 int, r3 int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'r1' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/expected/eagerfree_optimizer.out
+++ b/src/test/regress/expected/eagerfree_optimizer.out
@@ -1933,6 +1933,49 @@ and i = 0 order by 1,2,3; --order 1,2,3
  0 | text 5 | 01-06-2011
 (3 rows)
 
+-- Test Subplan with Agg
+with my_group_sum(d, total) as (select d, sum(i) from smallt group by d)
+select count(*) from smallt2
+where 0 < all (select total from my_group_sum, smallt2 as tmp where my_group_sum.d = smallt2.d);
+ count 
+-------
+    43
+(1 row)
+
+--start_ignore
+explain with my_group_sum(d, total) as (select d, sum(i) from smallt group by d)
+        select count(*) from smallt2
+        where 0 < all (select total from my_group_sum, smallt2 as tmp where my_group_sum.d = smallt2.d);
+
+              QUERY PLAN
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..1324486.07 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324486.07 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..1324486.07 rows=1 width=8)
+               ->  Hash Join  (cost=0.00..1324486.07 rows=6 width=1)
+                     Hash Cond: (smallt2.d = smallt.d)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=17 width=4)
+                           Hash Key: smallt2.d
+                           ->  Seq Scan on smallt2  (cost=0.00..431.00 rows=17 width=4)
+                     ->  Hash  (cost=1324055.07..1324055.07 rows=3 width=4)
+                           ->  Result  (cost=0.00..1324055.07 rows=3 width=4)
+                                 Filter: ((CASE WHEN (sum((CASE WHEN (0 >= (sum(smallt.i))) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN ((sum(smallt.i)) IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (0 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (0 >= (sum(smallt.i))) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
+                                 ->  HashAggregate  (cost=0.00..1324055.07 rows=7 width=20)
+                                       Group Key: smallt.d
+                                       ->  Nested Loop  (cost=0.00..1324055.03 rows=334 width=12)
+                                             Join Filter: true
+                                             ->  HashAggregate  (cost=0.00..431.01 rows=7 width=12)
+                                                   Group Key: smallt.d
+                                                   ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=34 width=8)
+                                                         Hash Key: smallt.d
+                                                         ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=8)
+                                             ->  Materialize  (cost=0.00..431.00 rows=50 width=1)
+                                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=50 width=1)
+                                                         ->  Seq Scan on smallt2 smallt2_1  (cost=0.00..431.00 rows=17 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(24 rows)
+
+--end_ignore
 -- Nested Subplan
 create table eager_free_r (r1 int, r2 int, r3 int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'r1' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/sql/eagerfree.sql
+++ b/src/test/regress/sql/eagerfree.sql
@@ -159,6 +159,16 @@ where i < all (select total from (select d, sum(i) as total from smallt group by
     where my_group_sum.d = smallt.d and smallt.d = tmp.d and my_group_sum.d = smallt2.d)
 and i = 0 order by 1,2,3; --order 1,2,3
 
+-- Test Subplan with Agg
+with my_group_sum(d, total) as (select d, sum(i) from smallt group by d)
+select count(*) from smallt2
+where 0 < all (select total from my_group_sum, smallt2 as tmp where my_group_sum.d = smallt2.d);
+--start_ignore
+explain with my_group_sum(d, total) as (select d, sum(i) from smallt group by d)
+        select count(*) from smallt2
+        where 0 < all (select total from my_group_sum, smallt2 as tmp where my_group_sum.d = smallt2.d);
+--end_ignore
+
 -- Nested Subplan
 create table eager_free_r (r1 int, r2 int, r3 int);
 create table eager_free_s (s1 int, s2 int, s3 int);


### PR DESCRIPTION
As the comment mentioned, for the test query from 'eagerfree' test, it will break before.
```
with my_group_sum(d, total) as (select d, sum(i) from smallt group by d)
select smallt2.* from smallt2
where 0 < all (select total from my_group_sum, smallt2 as tmp where my_group_sum.d = smallt2.d);
```
The query plan looks like
```
                                                      QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.50 rows=25 width=15)
   ->  Seq Scan on smallt2  (cost=0.00..1.17 rows=8 width=15)
         Filter: (SubPlan 1)
         SubPlan 1
           ->  Nested Loop  (cost=10000000003.67..10000000019.17 rows=1050 width=8)
                 ->  Result  (cost=3.67..4.09 rows=21 width=12)
                       Filter: (smallt.d = smallt2.d)
                       ->  HashAggregate  (cost=3.67..3.88 rows=21 width=12)
                             Group Key: smallt.d
                             ->  Materialize  (cost=0.00..3.17 rows=100 width=8)
                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..2.67 rows=100 width=8)
                                         ->  Seq Scan on smallt  (cost=0.00..1.33 rows=33 width=8)
                 ->  Materialize  (cost=0.00..2.08 rows=50 width=0)
                       ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1.83 rows=50 width=0)
                             ->  Seq Scan on smallt2 tmp  (cost=0.00..1.17 rows=17 width=0)
 Optimizer: Postgres query optimizer
(16 rows)
```
Sometimes, when `ExecSquelchAgg()` is called, if `ExecEagerFreeAgg()` here, it will destroy the hash context. When the node is rescanning, it will call `ExecReScanAgg()`,`resetTupleHashIterator()` will raise error.
```
 /*
  * If we do have the hash table, and it never spilled, and the subplan
  * does not have any parameter changes, and none of our own parameter
  * changes affect input expressions of the aggregated functions, then
  * we can just rescan the existing hash table; no need to build it
  * again.
  */
  if (outerPlan->chgParam == NULL && !node->hash_ever_spilled &&
      !bms_overlap(node->ss.ps.chgParam, aggnode->aggParams))
  {
      ResetTupleHashIterator(node->perhash[0].hashtable,
                          &node->perhash[0].hashiter);
      select_current_set(node, 0, true);
      return;
  }
```
```
#2  0x0000000000a5b329 in CdbProgramErrorHandler (postgres_signal_arg=11) at postgres.c:3640
#3  <signal handler called>
#4  0x00000000007b6c86 in tuplehash_start_iterate (tb=0x7f7f7f7f7f7f7f7f, iter=0x2fa56d8) at ../../../src/include/lib/simplehash.h:839
#5  0x00000000007e0c98 in ExecReScanAgg (node=0x2f6b418) at nodeAgg.c:4679
#6  0x00000000007a4ecb in ExecReScan (node=0x2f6b418) at execAmi.c:294
```

The reason why GP6 doesn't have this problem is that it doesn't reuse the hash table, and this reuse hash table logic brought after merging PG12 is a kind of optimization.

In order to keep ExecEagerFreeAgg() optimization inside ExecSquelchAgg(), but also fix this kind of broken query, this PR checks if subplan has any params change, if no change, it will not clean the hash and reuse the hash table later.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
