### PR TITLE
[WIP]Resolve GPDB_12_MERGE_FIXME in test: index_constraint_naming_upgrade

### DIFF
--- a/src/test/regress/expected/index_constraint_naming_upgrade.out
+++ b/src/test/regress/expected/index_constraint_naming_upgrade.out
@@ -86,10 +86,6 @@ SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text='part_
  part_table_for_upgrade | part_table_for_upgrade | part_table_for_upgrade_pkey | part_table_for_upgrade_pkey | p
 (1 row)
 
--- GPDB_12_MERGE_FIXME: only tables are renamed in exchange partition,
--- constraints or indexes used to be renamed as well pre-GPDB7, not
--- any more. Does it surprise users (functionally it doesn't affect
--- anything)?
 SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text='like_table';
  table_name | table_name |            constraint_name             |               index_name               | constraint_type 
 ------------+------------+----------------------------------------+----------------------------------------+-----------------

--- a/src/test/regress/sql/index_constraint_naming_upgrade.sql
+++ b/src/test/regress/sql/index_constraint_naming_upgrade.sql
@@ -72,10 +72,6 @@ ALTER TABLE part_table_for_upgrade EXCHANGE PARTITION beta WITH TABLE like_table
 -- show constraint and index names for each table
 SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text='part_table_for_upgrade';
 
--- GPDB_12_MERGE_FIXME: only tables are renamed in exchange partition,
--- constraints or indexes used to be renamed as well pre-GPDB7, not
--- any more. Does it surprise users (functionally it doesn't affect
--- anything)?
 SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text='like_table';
 
 -- Drop part_table_for_upgrade before upgrade since that is not where the issue is.


### PR DESCRIPTION
Constraints and indexes used to be renamed as well as tables in exchange partition pre-GPDB7.
GPDB7 gets rid of the pre-GPDB7 ALTER PARTITION implementation and reuses much of the ALTER
TABLE to implement GPDB-specific ALTER PARTITION commands. The exchange partition is one of
them which reuses ALTER TABLE RENAME. Because only tables are renamed in ALTER TABLE RENAME
on GPDB and postgres, constraints or indexes won't be renamed in exchange partition anymore.
Functionally it doesn't affect anything. So just keep consistent with ALTER TABLE RENAME.

postgres ATLER TABLE RENAME:
```
postgres=# CREATE TABLE rename_table_o (a INT, b INT, UNIQUE (a,b));
CREATE TABLE
postgres=# SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text='rename_table_o';
   table_name   |   table_name   |    constraint_name     |       index_name       | constraint_type
----------------+----------------+------------------------+------------------------+-----------------
 rename_table_o | rename_table_o | rename_table_o_a_b_key | rename_table_o_a_b_key | u
(1 row)

postgres=#
postgres=# ALTER TABLE rename_table_o RENAME TO rename_table_r;
ALTER TABLE
postgres=# SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text='rename_table_r';
   table_name   |   table_name   |    constraint_name     |       index_name       | constraint_type
----------------+----------------+------------------------+------------------------+-----------------
 rename_table_r | rename_table_r | rename_table_o_a_b_key | rename_table_o_a_b_key | u

```
------------------------------------------------------------------------------------------------------------------------
6X_STABLE ALTER TABLE RENAME:
```
postgres=# SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text='rename_table_o';
   table_name   |   table_name   |    constraint_name     |       index_name       | constraint_type
----------------+----------------+------------------------+------------------------+-----------------
 rename_table_o | rename_table_o | rename_table_o_a_b_key | rename_table_o_a_b_key | u
(1 row)

postgres=#
postgres=# ALTER TABLE rename_table_o RENAME TO rename_table_r;

ALTER TABLE
postgres=# SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text='rename_table_r';
   table_name   |   table_name   |    constraint_name     |       index_name       | constraint_type
----------------+----------------+------------------------+------------------------+-----------------
 rename_table_r | rename_table_r | rename_table_o_a_b_key | rename_table_o_a_b_key | u
(1 row)
```
------------------------------------------------------------------------------------------------------------------------
6X_STABLE ALTER TABLE EXCHANGE PARTITION:
```
postgres=# CREATE TABLE part_table_for_upgrade (a INT, b INT) DISTRIBUTED BY (a) PARTITION BY RANGE(b) (PARTITION alpha  END (3), PARTITION beta START (3));
NOTICE:  CREATE TABLE will create partition "part_table_for_upgrade_1_prt_alpha" for table "part_table_for_upgrade"
NOTICE:  CREATE TABLE will create partition "part_table_for_upgrade_1_prt_beta" for table "part_table_for_upgrade"

CREATE TABLE
postgres=# ALTER TABLE part_table_for_upgrade ADD PRIMARY KEY(a, b);
ALTER TABLE
postgres=# CREATE TABLE like_table (like part_table_for_upgrade INCLUDING CONSTRAINTS INCLUDING INDEXES) DISTRIBUTED BY (a) ;
CREATE TABLE
postgres=#
postgres=# SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text='part_table_for_upgrade';
       table_name       |       table_name       |       constraint_name       |         index_name          | constraint_type
------------------------+------------------------+-----------------------------+-----------------------------+-----------------
 part_table_for_upgrade | part_table_for_upgrade | part_table_for_upgrade_pkey | part_table_for_upgrade_pkey | p
(1 row)

postgres=# SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text='like_table';
 table_name | table_name | constraint_name |   index_name    | constraint_type
------------+------------+-----------------+-----------------+-----------------
 like_table | like_table | like_table_pkey | like_table_pkey | p
(1 row)

postgres=#
postgres=# ALTER TABLE part_table_for_upgrade EXCHANGE PARTITION beta WITH TABLE like_table;
ALTER TABLE
postgres=#
postgres=# -- show constraint and index names for each table
postgres=# SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text='part_table_for_upgrade';
       table_name       |       table_name       |       constraint_name       |         index_name          | constraint_type
------------------------+------------------------+-----------------------------+-----------------------------+-----------------
 part_table_for_upgrade | part_table_for_upgrade | part_table_for_upgrade_pkey | part_table_for_upgrade_pkey | p
(1 row)

postgres=#
postgres=# SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text='like_table';
 table_name | table_name | constraint_name |   index_name    | constraint_type
------------+------------+-----------------+-----------------+-----------------
 like_table | like_table | like_table_pkey | like_table_pkey | p
(1 row)
```
------------------------------------------------------------------------------------------------------------------------
master ALTER TABLE RENAME:
```
postgres=# SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text='rename_table_o';
   table_name   |   table_name   |    constraint_name     |       index_name       | constraint_type
----------------+----------------+------------------------+------------------------+-----------------
 rename_table_o | rename_table_o | rename_table_o_a_b_key | rename_table_o_a_b_key | u
(1 row)

postgres=#
postgres=# ALTER TABLE rename_table_o RENAME TO rename_table_r;
ALTER TABLE
postgres=# SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text='rename_table_r';
   table_name   |   table_name   |    constraint_name     |       index_name       | constraint_type
----------------+----------------+------------------------+------------------------+-----------------
 rename_table_r | rename_table_r | rename_table_o_a_b_key | rename_table_o_a_b_key | u
(1 row)
```
------------------------------------------------------------------------------------------------------------------------
master ALTER TABLE EXCHANGE PARTITION:
```
postgres=# CREATE TABLE part_table_for_upgrade (a INT, b INT) DISTRIBUTED BY (a) PARTITION BY RANGE(b) (PARTITION alpha  END (3), PARTITION beta START (3));
CREATE TABLE
postgres=# ALTER TABLE part_table_for_upgrade ADD PRIMARY KEY(a, b);
ALTER TABLE
postgres=# CREATE TABLE like_table (like part_table_for_upgrade INCLUDING CONSTRAINTS INCLUDING INDEXES) DISTRIBUTED BY (a) ;
CREATE TABLE
postgres=# SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text='part_table_for_upgrade';
       table_name       |       table_name       |       constraint_name       |         index_name          | constraint_type
------------------------+------------------------+-----------------------------+-----------------------------+-----------------
 part_table_for_upgrade | part_table_for_upgrade | part_table_for_upgrade_pkey | part_table_for_upgrade_pkey | p
(1 row)

postgres=# SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text='like_table';
 table_name | table_name | constraint_name |   index_name    | constraint_type
------------+------------+-----------------+-----------------+-----------------
 like_table | like_table | like_table_pkey | like_table_pkey | p
(1 row)

postgres=# ALTER TABLE part_table_for_upgrade EXCHANGE PARTITION beta WITH TABLE like_table;
ALTER TABLE
postgres=# SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text='part_table_for_upgrade';
       table_name       |       table_name       |       constraint_name       |         index_name          | constraint_type
------------------------+------------------------+-----------------------------+-----------------------------+-----------------
 part_table_for_upgrade | part_table_for_upgrade | part_table_for_upgrade_pkey | part_table_for_upgrade_pkey | p
(1 row)

postgres=# SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text='like_table';
 table_name | table_name |            constraint_name             |               index_name               | constraint_type
------------+------------+----------------------------------------+----------------------------------------+-----------------
 like_table | like_table | part_table_for_upgrade_1_prt_beta_pkey | part_table_for_upgrade_1_prt_beta_pkey | p
(1 row)
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
