### PR TITLE
Fix possible mirror startup failure by fts promotion

### DIFF
--- a/src/backend/fts/ftsmessagehandler.c
+++ b/src/backend/fts/ftsmessagehandler.c
@@ -384,7 +384,8 @@ HandleFtsWalRepPromote(void)
 	 * idempotent way.
 	 */
 	DBState state = GetCurrentDBState();
-	if (state == DB_IN_ARCHIVE_RECOVERY)
+	XLogRecPtr redo = GetRedoRecPtr();
+	if (state == DB_IN_ARCHIVE_RECOVERY && redo != InvalidXLogRecPtr)
 	{
 		/*
 		 * Reset sync_standby_names on promotion. This is to avoid commits
@@ -402,8 +403,8 @@ HandleFtsWalRepPromote(void)
 	}
 	else
 	{
-		elog(LOG, "ignoring promote request, walreceiver not running,"
-			 " DBState = %d", state);
+		elog(LOG, "ignoring promote request, not in archive recovery state,"
+			 " DBState = %d, RedoPtr = %X/%X", state, (uint32) (redo >> 32), (uint32) redo);
 	}
 
 	SendFtsResponse(&response, FTS_MSG_PROMOTE);

--- a/src/backend/fts/test/ftsmessagehandler_test.c
+++ b/src/backend/fts/test/ftsmessagehandler_test.c
@@ -9,6 +9,8 @@
 /* Actual function body */
 #include "../ftsmessagehandler.c"
 
+static XLogRecPtr fakeRedoRecPtr = 8948;
+
 static void
 expectSendFtsResponse(const char *expectedMessageType, const FtsResponse *expectedResponse)
 {
@@ -150,6 +152,7 @@ test_HandleFtsWalRepPromoteMirror(void **state)
 	am_mirror = true;
 
 	will_return(GetCurrentDBState, DB_IN_ARCHIVE_RECOVERY);
+	will_return(GetRedoRecPtr, &fakeRedoRecPtr);
 	will_be_called(UnsetSyncStandbysDefined);
 	will_be_called(SignalPromote);
 
@@ -185,6 +188,7 @@ test_HandleFtsWalRepPromotePrimary(void **state)
 	am_mirror = false;
 
 	will_return(GetCurrentDBState, DB_IN_PRODUCTION);
+	will_return(GetRedoRecPtr, &fakeRedoRecPtr);
 
 	FtsResponse mockresponse;
 	mockresponse.IsMirrorUp       = false;


### PR DESCRIPTION
If a mirror is stopped immediately by SIGQUIT or SIGKILL, its
state keeps DB_IN_ARCHIVE_RECOVERY, so its next startup needs
to spend some time to sync data directory. During the sync
time, master fts process may send promotion request to this
mirror, ftsmessage-handler will try to create one replication
slot, but ReplicationSlotReserveWal() call would be in loop
because the shared XLogCtl structure is not initialized yet
by startup process.

When the startup process calls
  ReplicationSlotDropIfExists(INTERNAL_WAL_REPLICATION_SLOT_NAME);
FATAL 'replication slot "internal_wal_replication_slot" is
  already active' reports and then startup process exits. It
can cause FTS double fault.

Avoid this issue by judging GetRedoRecPtr() != InvalidXlogRecPtr.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
