### PR TITLE
Fix possible reentrance of cdbdisp_destroyDispatcherState()

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -383,6 +383,8 @@ cdbdisp_destroyDispatcherState(CdbDispatcherState *ds)
 	results = ds->primaryResults;
 	h = find_dispatcher_handle(ds);
 
+	HOLD_INTERRUPTS();
+
 	if (results != NULL && results->resultArray != NULL)
 	{
 		int			i;
@@ -406,6 +408,8 @@ cdbdisp_destroyDispatcherState(CdbDispatcherState *ds)
 
 		RecycleGang(gp, ds->forceDestroyGang);
 	}
+
+	RESUME_INTERRUPTS();
 
 	/*
 	 * Destroy all the idle reader gangs when flag destroyIdleReaderGang is true

--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -383,6 +383,11 @@ cdbdisp_destroyDispatcherState(CdbDispatcherState *ds)
 	results = ds->primaryResults;
 	h = find_dispatcher_handle(ds);
 
+#ifdef FAULT_INJECTOR
+	SIMPLE_FAULT_INJECTOR("cancel_destroy_dispatch_state");
+	elog(LOG, "log during destroying dispatch state");
+#endif
+
 	HOLD_INTERRUPTS();
 
 	if (results != NULL && results->resultArray != NULL)


### PR DESCRIPTION
PR https://github.com/greenplum-db/gpdb/pull/8893 has replaced some elog(FATAL) with elog(LOG) to
prevent reentrance of cdbdisp_destroyDispatcherState()
, but it does not hold user INTERRUPT request.

If one user cancel request is comeing during the
cdbdisp_destroyDispatcherState(), some elog(LOG)
will trigger CHECK_FOR_INTERRUPTS() and throw

  > ERROR: canceling statement due to user request

Then AbortTransaction() -> AtAbort_DispatcherState()
 -> cdbdisp_destroyDispatcherState() again.

Avoid it by adding a HOLD_INTERRUPTS/RESUME_INTERRUPTS scope.

----

Second commit is just a test case, no need to merge it. Without first commit:

```
postgres=# create table test(id int, name text);
cloud=# insert into test select generate_series,'xxx'||generate_series from generate_series(1, 200);

postgres=# select gp_inject_fault('cancel_destroy_dispatch_state', 'interrupt', 1);
 gp_inject_fault
-----------------
 Success:
(1 row)

postgres=# select * from test;
ERROR:  canceling statement due to user request
FATAL:  Unexpected internal error (cdbdisp.c:343)
DETAIL:  FailedAssertion("!(!ds->isGangDestroying)", File: "cdbdisp.c", Line: 343)
Note that its locks and other resources will not be released until then.
server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.
The connection to the server was lost. Attempting reset: Succeeded.
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community