### PR TITLE
Fix possible wrong mocking path in mocker.py

### DIFF
--- a/src/test/unit/mock/mocker.py
+++ b/src/test/unit/mock/mocker.py
@@ -36,7 +36,7 @@ class CFile(object):
     # Currently this requires static keyword at the beginning of line.
     ###staticvar_pat = re.compile(r'^static.+?;', re.MULTILINE | re.DOTALL)
     def __init__(self, path, options):
-        self.path = os.path.abspath(path)
+        self.path = os.path.join(os.path.realpath(os.path.dirname(path)), os.path.basename(path))
         self.options = options
         #with open(self.make_i()) as f:
         with open(self.path) as f:


### PR DESCRIPTION
The mocker.py uses all of `os.path.abspath`, `os.path.realpath` and
 `os.path.relpath`. When we configure greenplum source using a soft
path, unit test will error out because file relative path returned
by mocker.py is wrong.

Maybe we can replace `os.path.abspath` with `os.path.realpath`
. However there are some special paths:

    fe-auth.c -> ../../../src/interfaces/libpq/fe-auth.c
    fe-exec.c -> ../../../src/interfaces/libpq/fe-exec.c
    ...

Use os.path.realpath(os.path.dirname(path) can gain the
correct path.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
