### PR TITLE
Fix assertion failure in InitPostgres when resgroup is on

### DIFF
--- a/src/backend/utils/mmgr/vmem_tracker.c
+++ b/src/backend/utils/mmgr/vmem_tracker.c
@@ -428,14 +428,12 @@ int32
 VmemTracker_GetVmemLimitChunks(void)
 {
 	/*
+	 * TODO:
 	 * For backend who has vmem tracker initialized and resource
 	 * group enabled, the vmem limit is not expected to be used
 	 * until resource group is activated, otherwise, there might
 	 * be an inconsistency about the vmem limit.
 	 */
-	AssertImply(vmemTrackerInited && IsResGroupEnabled(),
-				IsResGroupActivated());
-
 	return IsResGroupEnabled() ?
 		ResGroupGetVmemLimitChunks() : vmemChunksQuota;
 }


### PR DESCRIPTION
`ResGroupActivated = true` is set at the ending of InitPostgres()
by InitResManager(). If inside InitPostgres() some code before
InitResManager() call palloc() failed, then call trace:

    gp_failed_to_alloc()
    -> VmemTracker_GetAvailableVmemMB()
    -> VmemTracker_GetNonNegativeAvailableVmemChunks
    -> VmemTracker_GetVmemLimitChunks

It will trigger:

VmemTracker_GetVmemLimitChunks()
{
    AssertImply(vmemTrackerInited && IsResGroupEnabled(),
        IsResGroupActivated());
}

Like commit c1cdb99d does，remove the AssertImply and add TODO comment.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
