### PR TITLE
6X: Print errno for QE->QD dispatch checks

### DIFF
--- a/src/backend/cdb/endpoint/cdbendpoint.c
+++ b/src/backend/cdb/endpoint/cdbendpoint.c
@@ -635,7 +635,7 @@ wait_receiver(void)
 			if (!checkQDConnectionAlive())
 			{
 				ereport(LOG,
-						(errmsg("CDB_ENDPOINT: sender found that the connection to QD is broken")));
+						(errmsg("CDB_ENDPOINT: sender found that the connection to QD is broken: %m")));
 				abort_endpoint();
 				proc_exit(0);
 			}
@@ -790,7 +790,7 @@ wait_parallel_retrieve_close(void)
 			if (!checkQDConnectionAlive())
 			{
 				ereport(LOG,
-						(errmsg("CDB_ENDPOINT: sender found that the connection to QD is broken")));
+						(errmsg("CDB_ENDPOINT: sender found that the connection to QD is broken: %m")));
 				proc_exit(0);
 			}
 		}

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -5807,7 +5807,7 @@ checkQDConnectionAlive(void)
 		if (!dispatcherAYT())
 			ereport(ERROR,
 					(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
-					 errmsg("interconnect error segment lost contact with master (recv)")));
+					 errmsg("interconnect error segment lost contact with master (recv): %m")));
 	}
 }
 


### PR DESCRIPTION
We should print the error message associated with the errno populated by
the recv() call inside checkQDConnectionAlive() and dispatcherAYT().

(cherry picked from commit 13902f8b335ca5085327da456532cc2dbeb57498)