### PR TITLE
docs - new gp_percentile_agg extension

### DIFF
--- a/gpdb-doc/markdown/install_guide/install_modules.html.md
+++ b/gpdb-doc/markdown/install_guide/install_modules.html.md
@@ -30,12 +30,13 @@ You can register the following modules in this manner:
 <li class="li"><a class="xref" href="../ref_guide/modules/fuzzystrmatch.html">fuzzystrmatch</a></li>
 <li class="li"><a class="xref" href="../ref_guide/modules/gp_array_agg.html">gp_array_agg</a></li>
 <li class="li"><a class="xref" href="../ref_guide/modules/gp_parallel_retrieve_cursor.html">gp_parallel_retrieve_cursor</a></li>
+<li class="li"><a class="xref" href="../ref_guide/modules/gp_percentile_agg.html">gp_percentile_agg</a></li>
 <li class="li"><a class="xref" href="../ref_guide/modules/gp_sparse_vector.html">gp_sparse_vector</a></li>
-<li class="li"><a class="xref" href="../ref_guide/modules/greenplum_fdw.html">greenplum_fdw</a></li>
 </ul>
 </td>
 <td style="vertical-align:top;">
 <ul class="ul">
+<li class="li"><a class="xref" href="../ref_guide/modules/greenplum_fdw.html">greenplum_fdw</a></li>
 <li class="li"><a class="xref" href="../ref_guide/modules/hstore.html">hstore</a></li>
 <li class="li"><a class="xref" href="../ref_guide/modules/orafce_ref.html">orafce</a> (Tanzu Greenplum only)</li>
 <li class="li"><a class="xref" href="../ref_guide/modules/pageinspect.html">pageinspect</a></li>

--- a/gpdb-doc/markdown/ref_guide/modules/gp_percentile_agg.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/gp_percentile_agg.html.md
@@ -1,0 +1,32 @@
+---
+title: gp_percentile_agg 
+---
+
+The `gp_percentile_agg` module introduces improved Pivotal Query Optimizer \(GPORCA\) performance for ordered-set aggregate functions including `percentile_cont()`, `percentile_disc()`, and `median()`. These improvements particularly benefit MADlib, which internally invokes these functions.
+
+The `gp_percentile_agg` module is a Greenplum Database extension.
+
+## <a id="topic_reg"></a>Installing and Registering the Module 
+
+The `gp_percentile_agg` module is installed when you install Greenplum Database. You must register the `gp_percentile_agg` extension in each database where you want to use the module:
+
+```
+CREATE EXTENSION gp_percentile_agg;
+```
+
+Refer to [Installing Additional Supplied Modules](../../install_guide/install_modules.html) for more information.
+
+## <a id="topic_use"></a>About Using the Module 
+
+To realize the GPORCA performance benefits when using ordered-set aggregate functions, in addition to registering the extension you must also enable the [optimizer_enable_orderedagg](../config_params/guc-list.html#optimizer_enable_orderedagg) server configuration parameter before you run the query. For example, to enable this parameter in a `psql` session:
+
+``` sql
+SET optimizer_enable_orderedagg = on;
+```
+
+When the extension is registered, `optimizer_enable_orderedagg` is enabled, and you invoke the `percentile_cont()`, `percentile_disc()`, or `median()` functions, GPORCA generates the more performant query plan.
+
+## <a id="topic_info"></a>Additional Module Documentation 
+
+Refer to [Ordered-Set Aggregate Functions](https://www.postgresql.org/docs/9.4/functions-aggregate.html#FUNCTIONS-ORDEREDSET-TABLE) in the PostgreSQL documentation for more information about using ordered-set aggregates.
+

--- a/gpdb-doc/markdown/ref_guide/modules/gp_percentile_agg.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/gp_percentile_agg.html.md
@@ -4,6 +4,12 @@ title: gp_percentile_agg
 
 The `gp_percentile_agg` module introduces improved Pivotal Query Optimizer \(GPORCA\) performance for ordered-set aggregate functions including `percentile_cont()`, `percentile_disc()`, and `median()`. These improvements particularly benefit MADlib, which internally invokes these functions.
 
+GPORCA generates a more performant query plan when:
+
+- The sort expression does not include any computed columns.
+- The `<fraction>` provided to the function is a `const` and not an `ARRAY`.
+- The query does not contain a `GROUP BY` clause.
+
 The `gp_percentile_agg` module is a Greenplum Database extension.
 
 ## <a id="topic_reg"></a>Installing and Registering the Module 

--- a/gpdb-doc/markdown/ref_guide/modules/intro.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/intro.html.md
@@ -18,6 +18,7 @@ The following Greenplum Database and PostgreSQL `contrib` modules are installed;
 -   [gp\_array\_agg](gp_array_agg.html) - Implements a parallel `array_agg()` aggregate function for Greenplum Database.
 -   [gp\_legacy\_string\_agg](gp_legacy_string_agg.html) - Implements a legacy, single-argument `string_agg()` aggregate function that was present in Greenplum Database 5.
 -   [gp\_parallel\_retrieve\_cursor](gp_parallel_retrieve_cursor.html) - Provides extended cursor functionality to retrieve data, in parallel, directly from Greenplum Database segments.
+-   [gp\_percentile\_agg](gp_percentile_agg.html) - Improves GPORCA performance for ordered-set aggregate functions.
 -   [gp\_sparse\_vector](gp_sparse_vector.html) - Implements a Greenplum Database data type that uses compressed storage of zeros to make vector computations on floating point numbers faster.
 -   [greenplum\_fdw](greenplum_fdw.html) - Provides a foreign data wrapper \(FDW\) for accessing data stored in one or more external Greenplum Database clusters.
 -   [hstore](hstore.html) - Provides a data type for storing sets of key/value pairs within a single PostgreSQL value.

--- a/gpdb-doc/markdown/ref_guide/toc.md
+++ b/gpdb-doc/markdown/ref_guide/toc.md
@@ -176,6 +176,7 @@ Doc Index
         - [gp\_array\_agg](./modules/gp_array_agg.md)
         - [gp\_legacy\_string\_agg](./modules/gp_legacy_string_agg.md)
         - [gp\_parallel\_retrieve\_cursor (Beta)](./modules/gp_parallel_retrieve_cursor.md)
+        - [gp\_percentile\_agg](./modules/gp_percentile_agg.md)
         - [gp\_sparse\_vector](./modules/gp_sparse_vector.md)
         - [greenplum\_fdw (Beta)](./modules/greenplum_fdw.md)
         - [hstore](./modules/hstore.md)


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/13596 (6x).

in this PR:
- add docs for new gp_percentile_agg module/extension 
- misc updates to related content

doc review site link (behind vpn):  https://docs-staging.vmware.com/en/VMware-Tanzu-Greenplum/lisa-review/greenplum-database/GUID-ref_guide-modules-gp_percentile_agg.html
