### PR TITLE
Remove fixme in hashagg_spill test.

### DIFF
--- a/src/test/regress/expected/workfile/hashagg_spill.out
+++ b/src/test/regress/expected/workfile/hashagg_spill.out
@@ -71,31 +71,8 @@ select * from hashagg_spill.is_workfile_created('explain (analyze, verbose) sele
                    1
 (1 row)
 
--- Test HashAgg with increasing amount of overflows
 reset all;
 set search_path to hashagg_spill;
--- Returns the number of overflows from EXPLAIN ANALYZE output
--- GPDB_12_MERGE_FIXME we don't have hhashtable and num_overflows now, drop it?
-/*
- * create or replace function hashagg_spill.num_hashagg_overflows(explain_query text)
- * returns setof int as
- * $$
- * import re
- * query = "select count(*) as nsegments from gp_segment_configuration where role='p' and content >= 0;"
- * rv = plpy.execute(query)
- * rv = plpy.execute(explain_query)
- * result = []
- * for i in range(len(rv)):
- *     cur_line = rv[i]['QUERY PLAN']
- *     p = re.compile('.+\((seg\d+).+ (\d+) overflows;')
- *     m = p.match(cur_line)
- *     if m:
- *       overflows = int(m.group(2))
- *       result.append(overflows)
- * return result
- * $$
- * language plpython3u;
- */
 -- Test agg spilling scenarios
 create table aggspill (i int, j int, t text) distributed by (i);
 insert into aggspill select i, i*2, i::text from generate_series(1, 10000) i;
@@ -123,19 +100,6 @@ select count(*) from (select i, count(*) from aggspill group by i,j having count
  count 
 -------
  90000
-(1 row)
-
--- Reduce the statement memory, nbatches and entrysize even further to cause multiple overflows
-set gp_hashagg_default_nbatches = 4;
-set statement_mem = '5MB';
-/*
- * select overflows > 1 from hashagg_spill.num_hashagg_overflows('explain analyze
- * select count(*) from (select i, count(*) from aggspill group by i,j,t having count(*) = 3) g') overflows;
- */
-select count(*) from (select i, count(*) from aggspill group by i,j,t having count(*) = 3) g;
- count 
--------
- 10000
 (1 row)
 
 reset optimizer_force_multistage_agg;


### PR DESCRIPTION
After merging PG12, we removed the hybrid hash table and don't have hhashtable and num_overflows.
Remove the useless functions and sql in hashagg_spill test.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
