### PR TITLE
fix fixme in planner about calculating dNumGroups for grouping sets

### DIFF
--- a/src/backend/cdb/cdbgroupingpaths.c
+++ b/src/backend/cdb/cdbgroupingpaths.c
@@ -905,9 +905,7 @@ static void
 											  NIL,
 											  AGG_SORTED,
 											  ctx->rollups,
-											  ctx->agg_partial_costs,
-											  estimate_num_groups_on_segment(ctx->dNumGroupsTotal,
-																			 path->rows, path->locus));
+											  ctx->agg_partial_costs);
 		add_path(ctx->partial_rel, first_stage_agg_path);
 	}
 	else if (ctx->hasAggs || ctx->groupClause)
@@ -1064,8 +1062,7 @@ add_first_stage_hash_agg_path(PlannerInfo *root,
 											  NIL,
 											  ctx->strat,
 											  ctx->new_rollups,
-											  ctx->agg_partial_costs,
-											  dNumGroups);
+											  ctx->agg_partial_costs);
 		CdbPathLocus_MakeStrewn(&(first_stage_agg_path->locus),
 								CdbPathLocus_NumSegments(first_stage_agg_path->locus));
 		add_path(ctx->partial_rel, first_stage_agg_path);

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -4925,8 +4925,7 @@ consider_groupingsets_paths(PlannerInfo *root,
 										  (List *) parse->havingQual,
 										  srd->strat,
 										  srd->new_rollups,
-										  agg_costs,
-										  dNumGroups));
+										  agg_costs));
 		return;
 	}
 
@@ -5106,8 +5105,7 @@ consider_groupingsets_paths(PlannerInfo *root,
 											  (List *) parse->havingQual,
 											  AGG_MIXED,
 											  rollups,
-											  agg_costs,
-											  dNumGroups));
+											  agg_costs));
 		}
 	}
 
@@ -5123,8 +5121,7 @@ consider_groupingsets_paths(PlannerInfo *root,
 										  (List *) parse->havingQual,
 										  AGG_SORTED,
 										  gd->rollups,
-										  agg_costs,
-										  dNumGroups));
+										  agg_costs));
 }
 
 /*

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -4903,19 +4903,6 @@ consider_groupingsets_paths(PlannerInfo *root,
 											   parse->groupClause,
 											   srd->new_rollups);
 
-		// GPDB_12_MERGE_FIXME: fix computation of dNumGroups
-#if 0
-		/*
-		 * dNumGroupsTotal is the total number of groups across all segments. If the
-		 * Aggregate is distributed, then the number of groups in one segment
-		 * is only a fraction of the total.
-		 */
-		if (CdbPathLocus_IsPartitioned(path->locus))
-			dNumGroups = clamp_row_est(dNumGroupsTotal /
-										   CdbPathLocus_NumSegments(path->locus));
-		else
-			dNumGroups = dNumGroupsTotal;
-#endif
 
 		add_path(grouped_rel, (Path *)
 				 create_groupingsets_path(root,
@@ -7269,9 +7256,14 @@ add_paths_to_grouping_rel(PlannerInfo *root, RelOptInfo *input_rel,
 				/* Now decide what to stick atop it */
 				if (parse->groupingSets)
 				{
+					/*
+					 * the last param of consider_groupingsets_paths should be
+					 * dNumGroupsTotal. In consider_groupingsets_paths it will
+					 * calculate dNumGroups in one segment.
+					 */
 					consider_groupingsets_paths(root, grouped_rel,
 												path, true, can_hash,
-												gd, agg_costs, dNumGroups);
+												gd, agg_costs, dNumGroupsTotal);
 				}
 				else if (parse->hasAggs || parse->groupClause)
 				{

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -4621,7 +4621,6 @@ create_tup_split_path(PlannerInfo *root,
  * 'having_qual' is the HAVING quals if any
  * 'rollups' is a list of RollupData nodes
  * 'agg_costs' contains cost info about the aggregate functions to be computed
- * 'numGroups' is the estimated total number of groups
  */
 GroupingSetsPath *
 create_groupingsets_path(PlannerInfo *root,
@@ -4631,8 +4630,7 @@ create_groupingsets_path(PlannerInfo *root,
 						 List *having_qual,
 						 AggStrategy aggstrategy,
 						 List *rollups,
-						 const AggClauseCosts *agg_costs,
-						 double numGroups)
+						 const AggClauseCosts *agg_costs)
 {
 	GroupingSetsPath *pathnode = makeNode(GroupingSetsPath);
 	PathTarget *target = rel->reltarget;

--- a/src/include/optimizer/pathnode.h
+++ b/src/include/optimizer/pathnode.h
@@ -261,8 +261,7 @@ extern GroupingSetsPath *create_groupingsets_path(PlannerInfo *root,
 												  List *having_qual,
 												  AggStrategy aggstrategy,
 												  List *rollups,
-												  const AggClauseCosts *agg_costs,
-												  double numGroups);
+												  const AggClauseCosts *agg_costs);
 extern MinMaxAggPath *create_minmaxagg_path(PlannerInfo *root,
 											RelOptInfo *rel,
 											PathTarget *target,


### PR DESCRIPTION
1. the last param of create_groupingsets_path is not used, so remove it.

2. remove useless codes, the last param is removed in create_groupingsets_path, 
    so there is no need to calculate dNumGroups before create_groupingsets_path.

3. the last param of consider_groupingsets_paths should be dNumGroupsTotal. 
    in consider_groupingsets_paths it will calculate dNumGroups in one segment.


