### PR TITLE
Rely on plan_cache_mode to force generic plans in partition_prune test.

### DIFF
--- a/src/test/regress/expected/partition_prune.out
+++ b/src/test/regress/expected/partition_prune.out
@@ -24,6 +24,8 @@
 -- m/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/
 -- s/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/xxx xx xx xx:xx:xx xxxx"/
 -- end_matchsubs
+-- Force generic plans to be used for all prepared statements in this file.
+set plan_cache_mode = force_generic_plan;
 create table lp (a char) partition by list (a);
 create table lp_default partition of lp default;
 create table lp_ef partition of lp for values in ('e', 'f');
@@ -1886,33 +1888,6 @@ create table ab_a3_b3 partition of ab_a3 for values in (3);
 set enable_indexonlyscan = off;
 prepare ab_q1 (int, int, int) as
 select * from ab where a between $1 and $2 and b <= $3;
--- Execute query 5 times to allow choose_custom_plan
--- to start considering a generic plan.
-execute ab_q1 (1, 8, 3);
- a | b 
----+---
-(0 rows)
-
-execute ab_q1 (1, 8, 3);
- a | b 
----+---
-(0 rows)
-
-execute ab_q1 (1, 8, 3);
- a | b 
----+---
-(0 rows)
-
-execute ab_q1 (1, 8, 3);
- a | b 
----+---
-(0 rows)
-
-execute ab_q1 (1, 8, 3);
- a | b 
----+---
-(0 rows)
-
 explain (analyze, costs off, summary off, timing off) execute ab_q1 (2, 2, 3);
                             QUERY PLAN                            
 ------------------------------------------------------------------
@@ -1953,33 +1928,6 @@ deallocate ab_q1;
 -- Runtime pruning after optimizer pruning
 prepare ab_q1 (int, int) as
 select a from ab where a between $1 and $2 and b < 3;
--- Execute query 5 times to allow choose_custom_plan
--- to start considering a generic plan.
-execute ab_q1 (1, 8);
- a 
----
-(0 rows)
-
-execute ab_q1 (1, 8);
- a 
----
-(0 rows)
-
-execute ab_q1 (1, 8);
- a 
----
-(0 rows)
-
-execute ab_q1 (1, 8);
- a 
----
-(0 rows)
-
-execute ab_q1 (1, 8);
- a 
----
-(0 rows)
-
 explain (analyze, costs off, summary off, timing off) execute ab_q1 (2, 2);
                             QUERY PLAN                            
 ------------------------------------------------------------------
@@ -2014,31 +1962,6 @@ explain (analyze, costs off, summary off, timing off) execute ab_q1 (2, 4);
 -- different levels of partitioning.
 prepare ab_q2 (int, int) as
 select a from ab where a between $1 and $2 and b < (select 3);
-execute ab_q2 (1, 8);
- a 
----
-(0 rows)
-
-execute ab_q2 (1, 8);
- a 
----
-(0 rows)
-
-execute ab_q2 (1, 8);
- a 
----
-(0 rows)
-
-execute ab_q2 (1, 8);
- a 
----
-(0 rows)
-
-execute ab_q2 (1, 8);
- a 
----
-(0 rows)
-
 explain (analyze, costs off, summary off, timing off) execute ab_q2 (2, 2);
                             QUERY PLAN                            
 ------------------------------------------------------------------
@@ -2059,31 +1982,6 @@ explain (analyze, costs off, summary off, timing off) execute ab_q2 (2, 2);
 -- As above, but swap the PARAM_EXEC Param to the first partition level
 prepare ab_q3 (int, int) as
 select a from ab where b between $1 and $2 and a < (select 3);
-execute ab_q3 (1, 8);
- a 
----
-(0 rows)
-
-execute ab_q3 (1, 8);
- a 
----
-(0 rows)
-
-execute ab_q3 (1, 8);
- a 
----
-(0 rows)
-
-execute ab_q3 (1, 8);
- a 
----
-(0 rows)
-
-execute ab_q3 (1, 8);
- a 
----
-(0 rows)
-
 explain (analyze, costs off, summary off, timing off) execute ab_q3 (2, 2);
                             QUERY PLAN                            
 ------------------------------------------------------------------
@@ -2195,38 +2093,6 @@ set parallel_setup_cost = 0;
 set parallel_tuple_cost = 0;
 set min_parallel_table_scan_size = 0;
 set max_parallel_workers_per_gather = 2;
--- Execute query 5 times to allow choose_custom_plan
--- to start considering a generic plan.
-execute ab_q4 (1, 8);
- avg 
------
-    
-(1 row)
-
-execute ab_q4 (1, 8);
- avg 
------
-    
-(1 row)
-
-execute ab_q4 (1, 8);
- avg 
------
-    
-(1 row)
-
-execute ab_q4 (1, 8);
- avg 
------
-    
-(1 row)
-
-execute ab_q4 (1, 8);
- avg 
------
-    
-(1 row)
-
 select explain_parallel_append('execute ab_q4 (2, 2)');
                          explain_parallel_append                         
 -------------------------------------------------------------------------
@@ -2247,38 +2113,6 @@ select explain_parallel_append('execute ab_q4 (2, 2)');
 -- Test run-time pruning with IN lists.
 prepare ab_q5 (int, int, int) as
 select avg(a) from ab where a in($1,$2,$3) and b < 4;
--- Execute query 5 times to allow choose_custom_plan
--- to start considering a generic plan.
-execute ab_q5 (1, 2, 3);
- avg 
------
-    
-(1 row)
-
-execute ab_q5 (1, 2, 3);
- avg 
------
-    
-(1 row)
-
-execute ab_q5 (1, 2, 3);
- avg 
------
-    
-(1 row)
-
-execute ab_q5 (1, 2, 3);
- avg 
------
-    
-(1 row)
-
-execute ab_q5 (1, 2, 3);
- avg 
------
-    
-(1 row)
-
 select explain_parallel_append('execute ab_q5 (1, 1, 1)');
                             explain_parallel_append                            
 -------------------------------------------------------------------------------
@@ -2730,7 +2564,6 @@ create table xy_1 (x int, y int);
 insert into xy_1 values(100,-10);
 set enable_bitmapscan = 0;
 set enable_indexscan = 0;
-set plan_cache_mode = 'force_generic_plan';
 prepare ab_q6 as
 select * from (
 	select tableoid::regclass,a,b from ab
@@ -2774,7 +2607,6 @@ execute ab_q6(100);
 
 reset enable_bitmapscan;
 reset enable_indexscan;
-reset plan_cache_mode;
 deallocate ab_q1;
 deallocate ab_q2;
 deallocate ab_q3;
@@ -3252,40 +3084,13 @@ alter table part_bac attach partition part_cab for values in(2);
 alter table part_cab attach partition part_abc_p1 for values in(3);
 prepare part_abc_q1 (int, int, int) as
 select * from part_abc where a = $1 and b = $2 and c = $3;
--- Execute query 5 times to allow choose_custom_plan
--- to start considering a generic plan.
-execute part_abc_q1 (1, 2, 3);
- a | b | c 
----+---+---
-(0 rows)
-
-execute part_abc_q1 (1, 2, 3);
- a | b | c 
----+---+---
-(0 rows)
-
-execute part_abc_q1 (1, 2, 3);
- a | b | c 
----+---+---
-(0 rows)
-
-execute part_abc_q1 (1, 2, 3);
- a | b | c 
----+---+---
-(0 rows)
-
-execute part_abc_q1 (1, 2, 3);
- a | b | c 
----+---+---
-(0 rows)
-
 -- Single partition should be scanned.
 explain (analyze, costs off, summary off, timing off) execute part_abc_q1 (1, 2, 3);
                             QUERY PLAN                            
 ------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1) (actual rows=0 loops=1)
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Seq Scan on part_abc_p1 (never executed)
-         Filter: ((a = 1) AND (b = 2) AND (c = 3))
+         Filter: ((a = $1) AND (b = $2) AND (c = $3))
  Optimizer: Postgres query optimizer
 (4 rows)
 
@@ -3307,31 +3112,6 @@ select * from listp where b = 1;
 -- partitions before finally detecting the correct set of 2nd level partitions
 -- which match the given parameter.
 prepare q1 (int,int) as select * from listp where b in ($1,$2);
-execute q1 (1,2);
- a | b 
----+---
-(0 rows)
-
-execute q1 (1,2);
- a | b 
----+---
-(0 rows)
-
-execute q1 (1,2);
- a | b 
----+---
-(0 rows)
-
-execute q1 (1,2);
- a | b 
----+---
-(0 rows)
-
-execute q1 (1,2);
- a | b 
----+---
-(0 rows)
-
 explain (analyze, costs off, summary off, timing off)  execute q1 (1,1);
                             QUERY PLAN                            
 ------------------------------------------------------------------
@@ -3370,31 +3150,6 @@ explain (analyze, costs off, summary off, timing off)  execute q1 (0,0);
 deallocate q1;
 -- Test more complex cases where a not-equal condition further eliminates partitions.
 prepare q1 (int,int,int,int) as select * from listp where b in($1,$2) and $3 <> b and $4 <> b;
-execute q1 (1,2,3,4);
- a | b 
----+---
-(0 rows)
-
-execute q1 (1,2,3,4);
- a | b 
----+---
-(0 rows)
-
-execute q1 (1,2,3,4);
- a | b 
----+---
-(0 rows)
-
-execute q1 (1,2,3,4);
- a | b 
----+---
-(0 rows)
-
-execute q1 (1,2,3,4);
- a | b 
----+---
-(0 rows)
-
 -- Both partitions allowed by IN clause, but one disallowed by <> clause
 explain (analyze, costs off, summary off, timing off)  execute q1 (1,2,2,0);
                                   QUERY PLAN                                   
@@ -3568,7 +3323,6 @@ select * from mc3p where a < 3 and abs(b) = 1;
 -- a combination of runtime parameters is specified, not all of whose values
 -- are available at the same time
 --
-set plan_cache_mode = force_generic_plan;
 prepare ps1 as
   select * from mc3p where a = $1 and abs(b) < (select 3);
 explain (analyze, costs off, summary off, timing off)
@@ -3605,7 +3359,6 @@ execute ps2(1);
 (10 rows)
 
 deallocate ps2;
-reset plan_cache_mode;
 drop table mc3p;
 -- Ensure runtime pruning works with initplans params with boolean types
 create table boolvalues (value bool not null);
@@ -3663,48 +3416,6 @@ insert into ma_test select x,x from generate_series(0,29) t(x);
 create index on ma_test (b);
 analyze ma_test;
 prepare mt_q1 (int) as select a from ma_test where a >= $1 and a % 10 = 5 order by b;
--- Execute query 5 times to allow choose_custom_plan
--- to start considering a generic plan.
-execute mt_q1(0);
- a  
-----
-  5
- 15
- 25
-(3 rows)
-
-execute mt_q1(0);
- a  
-----
-  5
- 15
- 25
-(3 rows)
-
-execute mt_q1(0);
- a  
-----
-  5
- 15
- 25
-(3 rows)
-
-execute mt_q1(0);
- a  
-----
-  5
- 15
- 25
-(3 rows)
-
-execute mt_q1(0);
- a  
-----
-  5
- 15
- 25
-(3 rows)
-
 explain (analyze, costs off, summary off, timing off) execute mt_q1(15);
                                      QUERY PLAN                                      
 -------------------------------------------------------------------------------------
@@ -4227,7 +3938,6 @@ from (
       select 1, 1, 1
      ) s(a, b, c)
 where s.a = $1 and s.b = $2 and s.c = (select 1);
-set plan_cache_mode to force_generic_plan;
 explain (costs off) execute q (1, 1);
                                 QUERY PLAN                                 
 ---------------------------------------------------------------------------
@@ -4253,7 +3963,6 @@ execute q (1, 1);
  1 | 1 | 1
 (1 row)
 
-reset plan_cache_mode;
 drop table p, q;
 -- Ensure run-time pruning works correctly when we match a partitioned table
 -- on the first level but find no matching partitions on the second level.

--- a/src/test/regress/expected/partition_prune_optimizer.out
+++ b/src/test/regress/expected/partition_prune_optimizer.out
@@ -24,6 +24,8 @@
 -- m/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/
 -- s/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/xxx xx xx xx:xx:xx xxxx"/
 -- end_matchsubs
+-- Force generic plans to be used for all prepared statements in this file.
+set plan_cache_mode = force_generic_plan;
 create table lp (a char) partition by list (a);
 create table lp_default partition of lp default;
 create table lp_ef partition of lp for values in ('e', 'f');
@@ -1196,7 +1198,7 @@ explain (costs off) select * from boolpart where a in (true, false);
                Filter: (a = ANY ('{t,f}'::boolean[]))
          ->  Seq Scan on boolpart_t
                Filter: (a = ANY ('{t,f}'::boolean[]))
- Optimizer: Postgres query optimizer
+ Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 
 explain (costs off) select * from boolpart where a = false;
@@ -1919,44 +1921,18 @@ create table ab_a3_b3 partition of ab_a3 for values in (3);
 set enable_indexonlyscan = off;
 prepare ab_q1 (int, int, int) as
 select * from ab where a between $1 and $2 and b <= $3;
--- Execute query 5 times to allow choose_custom_plan
--- to start considering a generic plan.
-execute ab_q1 (1, 8, 3);
- a | b 
----+---
-(0 rows)
-
-execute ab_q1 (1, 8, 3);
- a | b 
----+---
-(0 rows)
-
-execute ab_q1 (1, 8, 3);
- a | b 
----+---
-(0 rows)
-
-execute ab_q1 (1, 8, 3);
- a | b 
----+---
-(0 rows)
-
-execute ab_q1 (1, 8, 3);
- a | b 
----+---
-(0 rows)
-
 explain (analyze, costs off, summary off, timing off) execute ab_q1 (2, 2, 3);
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (never executed)
+         Subplans Removed: 6
          ->  Seq Scan on ab_a2_b1 (never executed)
-               Filter: ((a >= 2) AND (a <= 2) AND (b <= 3))
+               Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
          ->  Seq Scan on ab_a2_b2 (never executed)
-               Filter: ((a >= 2) AND (a <= 2) AND (b <= 3))
+               Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
          ->  Seq Scan on ab_a2_b3 (never executed)
-               Filter: ((a >= 2) AND (a <= 2) AND (b <= 3))
+               Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
  Optimizer: Postgres query optimizer
 (10 rows)
 
@@ -1965,18 +1941,19 @@ explain (analyze, costs off, summary off, timing off) execute ab_q1 (1, 2, 3);
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (never executed)
+         Subplans Removed: 3
          ->  Seq Scan on ab_a1_b1 (never executed)
-               Filter: ((a >= 1) AND (a <= 2) AND (b <= 3))
+               Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
          ->  Seq Scan on ab_a1_b2 (never executed)
-               Filter: ((a >= 1) AND (a <= 2) AND (b <= 3))
+               Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
          ->  Seq Scan on ab_a1_b3 (never executed)
-               Filter: ((a >= 1) AND (a <= 2) AND (b <= 3))
+               Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
          ->  Seq Scan on ab_a2_b1 (never executed)
-               Filter: ((a >= 1) AND (a <= 2) AND (b <= 3))
+               Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
          ->  Seq Scan on ab_a2_b2 (never executed)
-               Filter: ((a >= 1) AND (a <= 2) AND (b <= 3))
+               Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
          ->  Seq Scan on ab_a2_b3 (never executed)
-               Filter: ((a >= 1) AND (a <= 2) AND (b <= 3))
+               Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
  Optimizer: Postgres query optimizer
 (16 rows)
 
@@ -1984,42 +1961,16 @@ deallocate ab_q1;
 -- Runtime pruning after optimizer pruning
 prepare ab_q1 (int, int) as
 select a from ab where a between $1 and $2 and b < 3;
--- Execute query 5 times to allow choose_custom_plan
--- to start considering a generic plan.
-execute ab_q1 (1, 8);
- a 
----
-(0 rows)
-
-execute ab_q1 (1, 8);
- a 
----
-(0 rows)
-
-execute ab_q1 (1, 8);
- a 
----
-(0 rows)
-
-execute ab_q1 (1, 8);
- a 
----
-(0 rows)
-
-execute ab_q1 (1, 8);
- a 
----
-(0 rows)
-
 explain (analyze, costs off, summary off, timing off) execute ab_q1 (2, 2);
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (never executed)
+         Subplans Removed: 4
          ->  Seq Scan on ab_a2_b1 (never executed)
-               Filter: ((a >= 2) AND (a <= 2) AND (b < 3))
+               Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
          ->  Seq Scan on ab_a2_b2 (never executed)
-               Filter: ((a >= 2) AND (a <= 2) AND (b < 3))
+               Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
  Optimizer: Postgres query optimizer
 (8 rows)
 
@@ -2028,14 +1979,15 @@ explain (analyze, costs off, summary off, timing off) execute ab_q1 (2, 4);
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (never executed)
+         Subplans Removed: 2
          ->  Seq Scan on ab_a2_b1 (never executed)
-               Filter: ((a >= 2) AND (a <= 4) AND (b < 3))
+               Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
          ->  Seq Scan on ab_a2_b2 (never executed)
-               Filter: ((a >= 2) AND (a <= 4) AND (b < 3))
+               Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
          ->  Seq Scan on ab_a3_b1 (never executed)
-               Filter: ((a >= 2) AND (a <= 4) AND (b < 3))
+               Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
          ->  Seq Scan on ab_a3_b2 (never executed)
-               Filter: ((a >= 2) AND (a <= 4) AND (b < 3))
+               Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
  Optimizer: Postgres query optimizer
 (12 rows)
 
@@ -2043,31 +1995,6 @@ explain (analyze, costs off, summary off, timing off) execute ab_q1 (2, 4);
 -- different levels of partitioning.
 prepare ab_q2 (int, int) as
 select a from ab where a between $1 and $2 and b < (select 3);
-execute ab_q2 (1, 8);
- a 
----
-(0 rows)
-
-execute ab_q2 (1, 8);
- a 
----
-(0 rows)
-
-execute ab_q2 (1, 8);
- a 
----
-(0 rows)
-
-execute ab_q2 (1, 8);
- a 
----
-(0 rows)
-
-execute ab_q2 (1, 8);
- a 
----
-(0 rows)
-
 explain (analyze, costs off, summary off, timing off) execute ab_q2 (2, 2);
                             QUERY PLAN                            
 ------------------------------------------------------------------
@@ -2075,43 +2002,19 @@ explain (analyze, costs off, summary off, timing off) execute ab_q2 (2, 2);
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
    ->  Append (never executed)
+         Subplans Removed: 6
          ->  Seq Scan on ab_a2_b1 (never executed)
-               Filter: ((a >= 2) AND (a <= 2) AND (b < $0))
+               Filter: ((a >= $1) AND (a <= $2) AND (b < $0))
          ->  Seq Scan on ab_a2_b2 (never executed)
-               Filter: ((a >= 2) AND (a <= 2) AND (b < $0))
+               Filter: ((a >= $1) AND (a <= $2) AND (b < $0))
          ->  Seq Scan on ab_a2_b3 (never executed)
-               Filter: ((a >= 2) AND (a <= 2) AND (b < $0))
+               Filter: ((a >= $1) AND (a <= $2) AND (b < $0))
  Optimizer: Postgres query optimizer
 (12 rows)
 
 -- As above, but swap the PARAM_EXEC Param to the first partition level
 prepare ab_q3 (int, int) as
 select a from ab where b between $1 and $2 and a < (select 3);
-execute ab_q3 (1, 8);
- a 
----
-(0 rows)
-
-execute ab_q3 (1, 8);
- a 
----
-(0 rows)
-
-execute ab_q3 (1, 8);
- a 
----
-(0 rows)
-
-execute ab_q3 (1, 8);
- a 
----
-(0 rows)
-
-execute ab_q3 (1, 8);
- a 
----
-(0 rows)
-
 explain (analyze, costs off, summary off, timing off) execute ab_q3 (2, 2);
                             QUERY PLAN                            
 ------------------------------------------------------------------
@@ -2119,12 +2022,13 @@ explain (analyze, costs off, summary off, timing off) execute ab_q3 (2, 2);
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
    ->  Append (never executed)
+         Subplans Removed: 6
          ->  Seq Scan on ab_a1_b2 (never executed)
-               Filter: ((b >= 2) AND (b <= 2) AND (a < $0))
+               Filter: ((b >= $1) AND (b <= $2) AND (a < $0))
          ->  Seq Scan on ab_a2_b2 (never executed)
-               Filter: ((b >= 2) AND (b <= 2) AND (a < $0))
+               Filter: ((b >= $1) AND (b <= $2) AND (a < $0))
          ->  Seq Scan on ab_a3_b2 (never executed)
-               Filter: ((b >= 2) AND (b <= 2) AND (a < $0))
+               Filter: ((b >= $1) AND (b <= $2) AND (a < $0))
  Optimizer: Postgres query optimizer
 (12 rows)
 
@@ -2223,147 +2127,80 @@ set parallel_setup_cost = 0;
 set parallel_tuple_cost = 0;
 set min_parallel_table_scan_size = 0;
 set max_parallel_workers_per_gather = 2;
--- Execute query 5 times to allow choose_custom_plan
--- to start considering a generic plan.
-execute ab_q4 (1, 8);
- avg 
------
-    
-(1 row)
-
-execute ab_q4 (1, 8);
- avg 
------
-    
-(1 row)
-
-execute ab_q4 (1, 8);
- avg 
------
-    
-(1 row)
-
-execute ab_q4 (1, 8);
- avg 
------
-    
-(1 row)
-
-execute ab_q4 (1, 8);
- avg 
------
-    
-(1 row)
-
 select explain_parallel_append('execute ab_q4 (2, 2)');
-                        explain_parallel_append                         
-------------------------------------------------------------------------
+                         explain_parallel_append                         
+-------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
                ->  Append (never executed)
+                     Subplans Removed: 6
                      ->  Seq Scan on ab_a2_b1 (never executed)
-                           Filter: ((a >= 2) AND (a <= 2) AND (b < 4))
+                           Filter: ((a >= $1) AND (a <= $2) AND (b < 4))
                      ->  Seq Scan on ab_a2_b2 (never executed)
-                           Filter: ((a >= 2) AND (a <= 2) AND (b < 4))
+                           Filter: ((a >= $1) AND (a <= $2) AND (b < 4))
                      ->  Seq Scan on ab_a2_b3 (never executed)
-                           Filter: ((a >= 2) AND (a <= 2) AND (b < 4))
+                           Filter: ((a >= $1) AND (a <= $2) AND (b < 4))
  Optimizer: Postgres query optimizer
-(11 rows)
+(12 rows)
 
 -- Test run-time pruning with IN lists.
 prepare ab_q5 (int, int, int) as
 select avg(a) from ab where a in($1,$2,$3) and b < 4;
--- Execute query 5 times to allow choose_custom_plan
--- to start considering a generic plan.
-execute ab_q5 (1, 2, 3);
- avg 
------
-    
-(1 row)
-
-execute ab_q5 (1, 2, 3);
- avg 
------
-    
-(1 row)
-
-execute ab_q5 (1, 2, 3);
- avg 
------
-    
-(1 row)
-
-execute ab_q5 (1, 2, 3);
- avg 
------
-    
-(1 row)
-
-execute ab_q5 (1, 2, 3);
- avg 
------
-    
-(1 row)
-
--- start_ignore
--- GPDB_12_MERGE_FIXME: Planner's output file expects a 3:1 Gather
--- motion, but in this case even though we fallback, the Gather motion
--- is 1:1. Investigate why. 
--- end_ignore
 select explain_parallel_append('execute ab_q5 (1, 1, 1)');
-                             explain_parallel_append                              
-----------------------------------------------------------------------------------
+                            explain_parallel_append                            
+-------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
                ->  Append (never executed)
+                     Subplans Removed: 6
                      ->  Seq Scan on ab_a1_b1 (never executed)
-                           Filter: ((b < 4) AND (a = ANY ('{1,1,1}'::integer[])))
+                           Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
                      ->  Seq Scan on ab_a1_b2 (never executed)
-                           Filter: ((b < 4) AND (a = ANY ('{1,1,1}'::integer[])))
+                           Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
                      ->  Seq Scan on ab_a1_b3 (never executed)
-                           Filter: ((b < 4) AND (a = ANY ('{1,1,1}'::integer[])))
+                           Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
  Optimizer: Postgres query optimizer
 (12 rows)
 
--- start_ignore
--- GPDB_12_MERGE_FIXME: Planner's output file expects a 3:1 Gather
--- motion, but in this case even though we fallback, the Gather motion
--- is 1:1. Investigate why. 
--- end_ignore
 select explain_parallel_append('execute ab_q5 (2, 3, 3)');
-                             explain_parallel_append                              
-----------------------------------------------------------------------------------
+                            explain_parallel_append                            
+-------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
          ->  Partial Aggregate (actual rows=1 loops=1)
                ->  Append (never executed)
+                     Subplans Removed: 3
                      ->  Seq Scan on ab_a2_b1 (never executed)
-                           Filter: ((b < 4) AND (a = ANY ('{2,3,3}'::integer[])))
+                           Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
                      ->  Seq Scan on ab_a2_b2 (never executed)
-                           Filter: ((b < 4) AND (a = ANY ('{2,3,3}'::integer[])))
+                           Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
                      ->  Seq Scan on ab_a2_b3 (never executed)
-                           Filter: ((b < 4) AND (a = ANY ('{2,3,3}'::integer[])))
+                           Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
                      ->  Seq Scan on ab_a3_b1 (never executed)
-                           Filter: ((b < 4) AND (a = ANY ('{2,3,3}'::integer[])))
+                           Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
                      ->  Seq Scan on ab_a3_b2 (never executed)
-                           Filter: ((b < 4) AND (a = ANY ('{2,3,3}'::integer[])))
+                           Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
                      ->  Seq Scan on ab_a3_b3 (never executed)
-                           Filter: ((b < 4) AND (a = ANY ('{2,3,3}'::integer[])))
+                           Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
  Optimizer: Postgres query optimizer
 (18 rows)
 
 -- Try some params whose values do not belong to any partition.
 -- We'll still get a single subplan in this case, but it should not be scanned.
 select explain_parallel_append('execute ab_q5 (33, 44, 55)');
-       explain_parallel_append        
---------------------------------------
- Aggregate (actual rows=1 loops=1)
-   ->  Result (actual rows=0 loops=1)
-         One-Time Filter: false
+                            explain_parallel_append                            
+-------------------------------------------------------------------------------
+ Finalize Aggregate (actual rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
+         ->  Partial Aggregate (actual rows=1 loops=1)
+               ->  Append (never executed)
+                     Subplans Removed: 8
+                     ->  Seq Scan on ab_a1_b1 (never executed)
+                           Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
  Optimizer: Postgres query optimizer
-(4 rows)
+(8 rows)
 
 -- Test Parallel Append with PARAM_EXEC Params
 select explain_parallel_append('select count(*) from ab where (a = (select 1) or a = (select 3)) and b = 2');
@@ -2388,6 +2225,8 @@ select explain_parallel_append('select count(*) from ab where (a = (select 1) or
 
 -- Test pruning during parallel nested loop query
 create table lprt_a (a int not null);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- Insert some values we won't find in ab
 insert into lprt_a select 0 from generate_series(1,100);
 -- and insert some values that we should find.
@@ -2663,8 +2502,8 @@ select * from ab where a = (select max(a) from lprt_a) and b = (select max(a)-1 
 -- Test run-time partition pruning with UNION ALL parents
 explain (analyze, costs off, summary off, timing off)
 select * from (select * from ab where a = 1 union all select * from ab) ab where b = (select 1);
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
@@ -2704,13 +2543,13 @@ select * from (select * from ab where a = 1 union all select * from ab) ab where
          ->  Seq Scan on ab_a3_b3 (never executed)
                Filter: (b = $0)
  Optimizer: Postgres query optimizer
-(40 rows)
+(39 rows)
 
 -- A case containing a UNION ALL with a non-partitioned child.
 explain (analyze, costs off, summary off, timing off)
 select * from (select * from ab where a = 1 union all (values(10,5)) union all select * from ab) ab where b = (select 1);
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
@@ -2732,7 +2571,7 @@ select * from (select * from ab where a = 1 union all (values(10,5)) union all s
                      ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
                            Index Cond: (a = 1)
          ->  Result (never executed)
-               One-Time Filter: (gp_execution_segment() = 1)
+               One-Time Filter: (gp_execution_segment() = 0)
                ->  Result (never executed)
                      One-Time Filter: (5 = $0)
          ->  Seq Scan on ab_a1_b1 (never executed)
@@ -2754,14 +2593,15 @@ select * from (select * from ab where a = 1 union all (values(10,5)) union all s
          ->  Seq Scan on ab_a3_b3 (never executed)
                Filter: (b = $0)
  Optimizer: Postgres query optimizer
-(44 rows)
+(43 rows)
 
 -- Another UNION ALL test, but containing a mix of exec init and exec run-time pruning.
 create table xy_1 (x int, y int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into xy_1 values(100,-10);
 set enable_bitmapscan = 0;
 set enable_indexscan = 0;
-set plan_cache_mode = 'force_generic_plan';
 prepare ab_q6 as
 select * from (
 	select tableoid::regclass,a,b from ab
@@ -2772,8 +2612,8 @@ union all
 ) ab where a = $1 and b = (select -10);
 -- Ensure the xy_1 subplan is not pruned.
 explain (analyze, costs off, summary off, timing off) execute ab_q6(1);
-                             QUERY PLAN                             
---------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
@@ -2794,7 +2634,7 @@ explain (analyze, costs off, summary off, timing off) execute ab_q6(1);
          ->  Seq Scan on ab_a1_b3 ab_a1_b3_1 (never executed)
                Filter: ((a = $1) AND (b = $0))
  Optimizer: Postgres query optimizer
-(23 rows)
+(20 rows)
 
 -- Ensure we see just the xy_1 row.
 execute ab_q6(100);
@@ -2805,7 +2645,6 @@ execute ab_q6(100);
 
 reset enable_bitmapscan;
 reset enable_indexscan;
-reset plan_cache_mode;
 deallocate ab_q1;
 deallocate ab_q2;
 deallocate ab_q3;
@@ -2949,16 +2788,26 @@ select tableoid::regclass, * from ab;
 drop table ab, lprt_a;
 -- Join
 create table tbl1(col1 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into tbl1 values (501), (505);
 analyze tbl1;
 -- Basic table
 create table tprt (col1 int) partition by range (col1);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table tprt_1 partition of tprt for values from (1) to (501);
+NOTICE:  table has parent, setting distribution columns to match parent table
 create table tprt_2 partition of tprt for values from (501) to (1001);
+NOTICE:  table has parent, setting distribution columns to match parent table
 create table tprt_3 partition of tprt for values from (1001) to (2001);
+NOTICE:  table has parent, setting distribution columns to match parent table
 create table tprt_4 partition of tprt for values from (2001) to (3001);
+NOTICE:  table has parent, setting distribution columns to match parent table
 create table tprt_5 partition of tprt for values from (3001) to (4001);
+NOTICE:  table has parent, setting distribution columns to match parent table
 create table tprt_6 partition of tprt for values from (4001) to (5001);
+NOTICE:  table has parent, setting distribution columns to match parent table
 create index tprt1_idx on tprt_1 (col1);
 create index tprt2_idx on tprt_2 (col1);
 create index tprt3_idx on tprt_3 (col1);
@@ -2991,8 +2840,8 @@ select * from tbl1 join tprt on tbl1.col1 > tprt.col1;
 
 explain (analyze, costs off, summary off, timing off)
 select * from tbl1 join tprt on tbl1.col1 = tprt.col1;
-                             QUERY PLAN                             
---------------------------------------------------------------------
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=2 loops=1)
    ->  Hash Join (actual rows=1 loops=1)
          Hash Cond: (tbl1.col1 = tprt_1.col1)
@@ -3008,7 +2857,7 @@ select * from tbl1 join tprt on tbl1.col1 = tprt.col1;
                      ->  Seq Scan on tprt_5 (never executed)
                      ->  Seq Scan on tprt_6 (actual rows=1 loops=1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+(15 rows)
 
 select tbl1.col1, tprt.col1 from tbl1
 inner join tprt on tbl1.col1 > tprt.col1
@@ -3056,8 +2905,8 @@ select * from tbl1 inner join tprt on tbl1.col1 > tprt.col1;
 
 explain (analyze, costs off, summary off, timing off)
 select * from tbl1 inner join tprt on tbl1.col1 = tprt.col1;
-                             QUERY PLAN                             
---------------------------------------------------------------------
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
    ->  Hash Join (actual rows=2 loops=1)
          Hash Cond: (tbl1.col1 = tprt_1.col1)
@@ -3073,7 +2922,7 @@ select * from tbl1 inner join tprt on tbl1.col1 = tprt.col1;
                      ->  Seq Scan on tprt_5 (never executed)
                      ->  Seq Scan on tprt_6 (actual rows=1 loops=1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+(15 rows)
 
 select tbl1.col1, tprt.col1 from tbl1
 inner join tprt on tbl1.col1 > tprt.col1
@@ -3180,9 +3029,17 @@ order by tbl1.col1, tprt.col1;
 drop table tbl1, tprt;
 -- Test with columns defined in varying orders between each level
 create table part_abc (a int not null, b int not null, c int not null) partition by list (a);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table part_bac (b int not null, a int not null, c int not null) partition by list (b);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table part_cab (c int not null, a int not null, b int not null) partition by list (c);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table part_abc_p1 (a int not null, b int not null, c int not null);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- GPDB: the distribution keys must be the same in all parts of partition
 -- hierarchy.
 alter table part_bac set distributed by (a);
@@ -3192,40 +3049,13 @@ alter table part_bac attach partition part_cab for values in(2);
 alter table part_cab attach partition part_abc_p1 for values in(3);
 prepare part_abc_q1 (int, int, int) as
 select * from part_abc where a = $1 and b = $2 and c = $3;
--- Execute query 5 times to allow choose_custom_plan
--- to start considering a generic plan.
-execute part_abc_q1 (1, 2, 3);
- a | b | c 
----+---+---
-(0 rows)
-
-execute part_abc_q1 (1, 2, 3);
- a | b | c 
----+---+---
-(0 rows)
-
-execute part_abc_q1 (1, 2, 3);
- a | b | c 
----+---+---
-(0 rows)
-
-execute part_abc_q1 (1, 2, 3);
- a | b | c 
----+---+---
-(0 rows)
-
-execute part_abc_q1 (1, 2, 3);
- a | b | c 
----+---+---
-(0 rows)
-
 -- Single partition should be scanned.
 explain (analyze, costs off, summary off, timing off) execute part_abc_q1 (1, 2, 3);
                             QUERY PLAN                            
 ------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1) (actual rows=0 loops=1)
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Seq Scan on part_abc_p1 (never executed)
-         Filter: ((a = 1) AND (b = 2) AND (c = 3))
+         Filter: ((a = $1) AND (b = $2) AND (c = $3))
  Optimizer: Postgres query optimizer
 (4 rows)
 
@@ -3234,10 +3064,16 @@ drop table part_abc;
 -- Ensure that an Append node properly handles a sub-partitioned table
 -- matching without any of its leaf partitions matching the clause.
 create table listp (a int, b int) partition by list (a);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table listp_1 partition of listp for values in(1) partition by list (b);
+NOTICE:  table has parent, setting distribution columns to match parent table
 create table listp_1_1 partition of listp_1 for values in(1);
+NOTICE:  table has parent, setting distribution columns to match parent table
 create table listp_2 partition of listp for values in(2) partition by list (b);
+NOTICE:  table has parent, setting distribution columns to match parent table
 create table listp_2_1 partition of listp_2 for values in(2);
+NOTICE:  table has parent, setting distribution columns to match parent table
 select * from listp where b = 1;
  a | b 
 ---+---
@@ -3247,37 +3083,14 @@ select * from listp where b = 1;
 -- partitions before finally detecting the correct set of 2nd level partitions
 -- which match the given parameter.
 prepare q1 (int,int) as select * from listp where b in ($1,$2);
-execute q1 (1,2);
- a | b 
----+---
-(0 rows)
-
-execute q1 (1,2);
- a | b 
----+---
-(0 rows)
-
-execute q1 (1,2);
- a | b 
----+---
-(0 rows)
-
-execute q1 (1,2);
- a | b 
----+---
-(0 rows)
-
-execute q1 (1,2);
- a | b 
----+---
-(0 rows)
-
 explain (analyze, costs off, summary off, timing off)  execute q1 (1,1);
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Seq Scan on listp_1_1 (never executed)
-         Filter: (b = ANY ('{1,1}'::integer[]))
+   ->  Append (never executed)
+         Subplans Removed: 1
+         ->  Seq Scan on listp_1_1 (never executed)
+               Filter: (b = ANY (ARRAY[$1, $2]))
  Optimizer: Postgres query optimizer
 (6 rows)
 
@@ -3285,66 +3098,51 @@ explain (analyze, costs off, summary off, timing off)  execute q1 (2,2);
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Seq Scan on listp_2_1 (never executed)
-         Filter: (b = ANY ('{2,2}'::integer[]))
+   ->  Append (never executed)
+         Subplans Removed: 1
+         ->  Seq Scan on listp_2_1 (never executed)
+               Filter: (b = ANY (ARRAY[$1, $2]))
  Optimizer: Postgres query optimizer
 (6 rows)
 
 -- Try with no matching partitions. One subplan should remain in this case,
 -- but it shouldn't be executed.
 explain (analyze, costs off, summary off, timing off)  execute q1 (0,0);
-             QUERY PLAN              
--------------------------------------
- Result (actual rows=0 loops=1)
-   One-Time Filter: false
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
+   ->  Append (never executed)
+         Subplans Removed: 1
+         ->  Seq Scan on listp_1_1 (never executed)
+               Filter: (b = ANY (ARRAY[$1, $2]))
  Optimizer: Postgres query optimizer
 (6 rows)
 
 deallocate q1;
 -- Test more complex cases where a not-equal condition further eliminates partitions.
 prepare q1 (int,int,int,int) as select * from listp where b in($1,$2) and $3 <> b and $4 <> b;
-execute q1 (1,2,3,4);
- a | b 
----+---
-(0 rows)
-
-execute q1 (1,2,3,4);
- a | b 
----+---
-(0 rows)
-
-execute q1 (1,2,3,4);
- a | b 
----+---
-(0 rows)
-
-execute q1 (1,2,3,4);
- a | b 
----+---
-(0 rows)
-
-execute q1 (1,2,3,4);
- a | b 
----+---
-(0 rows)
-
 -- Both partitions allowed by IN clause, but one disallowed by <> clause
 explain (analyze, costs off, summary off, timing off)  execute q1 (1,2,2,0);
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Seq Scan on listp_1_1 (never executed)
-         Filter: ((b = ANY ('{1,2}'::integer[])) AND (2 <> b) AND (0 <> b))
+   ->  Append (never executed)
+         Subplans Removed: 1
+         ->  Seq Scan on listp_1_1 (never executed)
+               Filter: ((b = ANY (ARRAY[$1, $2])) AND ($3 <> b) AND ($4 <> b))
  Optimizer: Postgres query optimizer
 (6 rows)
 
 -- Both partitions allowed by IN clause, then both excluded again by <> clauses.
 -- One subplan will remain in this case, but it should not be executed.
 explain (analyze, costs off, summary off, timing off)  execute q1 (1,2,2,1);
-             QUERY PLAN              
--------------------------------------
- Result (actual rows=0 loops=1)
-   One-Time Filter: false
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
+   ->  Append (never executed)
+         Subplans Removed: 1
+         ->  Seq Scan on listp_1_1 (never executed)
+               Filter: ((b = ANY (ARRAY[$1, $2])) AND ($3 <> b) AND ($4 <> b))
  Optimizer: Postgres query optimizer
 (6 rows)
 
@@ -3373,10 +3171,13 @@ drop table listp;
 create table stable_qual_pruning (a timestamp) distributed randomly partition by range (a);
 create table stable_qual_pruning1 partition of stable_qual_pruning
   for values from ('2000-01-01') to ('2000-02-01');
+NOTICE:  table has parent, setting distribution columns to match parent table
 create table stable_qual_pruning2 partition of stable_qual_pruning
   for values from ('2000-02-01') to ('2000-03-01');
+NOTICE:  table has parent, setting distribution columns to match parent table
 create table stable_qual_pruning3 partition of stable_qual_pruning
   for values from ('3000-02-01') to ('3000-03-01');
+NOTICE:  table has parent, setting distribution columns to match parent table
 -- comparison against a stable value requires run-time pruning
 explain (analyze, costs off, summary off, timing off)
 select * from stable_qual_pruning where a < localtimestamp;
@@ -3385,9 +3186,9 @@ select * from stable_qual_pruning where a < localtimestamp;
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (never executed)
          ->  Seq Scan on stable_qual_pruning1 (never executed)
-               Filter: (a < 'Tue Mar 16 06:49:12.723026 2021'::timestamp without time zone)
+               Filter: (a < 'Sun Jun 12 19:59:06.937787 2022'::timestamp without time zone)
          ->  Seq Scan on stable_qual_pruning2 (never executed)
-               Filter: (a < 'Tue Mar 16 06:49:12.723026 2021'::timestamp without time zone)
+               Filter: (a < 'Sun Jun 12 19:59:06.937787 2022'::timestamp without time zone)
  Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 
@@ -3429,12 +3230,12 @@ select * from stable_qual_pruning
 explain (analyze, costs off, summary off, timing off)
 select * from stable_qual_pruning
   where a = any(array['2000-02-01', localtimestamp]::timestamp[]);
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (never executed)
          ->  Seq Scan on stable_qual_pruning2 (never executed)
-               Filter: (a = ANY ('{"Tue Feb 01 00:00:00 2000","Tue Mar 16 06:49:12.74736 2021"}'::timestamp without time zone[]))
+               Filter: (a = ANY ('{"Tue Feb 01 00:00:00 2000","Sun Jun 12 19:59:07.010496 2022"}'::timestamp without time zone[]))
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
@@ -3467,12 +3268,17 @@ drop table stable_qual_pruning;
 -- non-inclusive operator for an earlier key
 --
 create table mc3p (a int, b int, c int) partition by range (a, abs(b), c);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table mc3p0 partition of mc3p
   for values from (0, 0, 0) to (0, maxvalue, maxvalue);
+NOTICE:  table has parent, setting distribution columns to match parent table
 create table mc3p1 partition of mc3p
   for values from (1, 1, 1) to (2, minvalue, minvalue);
+NOTICE:  table has parent, setting distribution columns to match parent table
 create table mc3p2 partition of mc3p
   for values from (2, minvalue, minvalue) to (3, maxvalue, maxvalue);
+NOTICE:  table has parent, setting distribution columns to match parent table
 insert into mc3p values (0, 1, 1), (1, 1, 1), (2, 1, 1);
 explain (analyze, costs off, summary off, timing off)
 select * from mc3p where a < 3 and abs(b) = 1;
@@ -3494,7 +3300,6 @@ select * from mc3p where a < 3 and abs(b) = 1;
 -- a combination of runtime parameters is specified, not all of whose values
 -- are available at the same time
 --
-set plan_cache_mode = force_generic_plan;
 prepare ps1 as
   select * from mc3p where a = $1 and abs(b) < (select 3);
 explain (analyze, costs off, summary off, timing off)
@@ -3531,14 +3336,19 @@ execute ps2(1);
 (10 rows)
 
 deallocate ps2;
-reset plan_cache_mode;
 drop table mc3p;
 -- Ensure runtime pruning works with initplans params with boolean types
 create table boolvalues (value bool not null);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'value' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into boolvalues values('t'),('f');
 create table boolp (a bool) partition by list (a);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table boolp_t partition of boolp for values in('t');
+NOTICE:  table has parent, setting distribution columns to match parent table
 create table boolp_f partition of boolp for values in('f');
+NOTICE:  table has parent, setting distribution columns to match parent table
 explain (analyze, costs off, summary off, timing off)
 select * from boolp where a = (select value from boolvalues where value);
                                 QUERY PLAN                                
@@ -3582,73 +3392,34 @@ drop table boolp;
 set enable_seqscan = off;
 set enable_sort = off;
 create table ma_test (a int, b int) partition by range (a);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table ma_test_p1 partition of ma_test for values from (0) to (10);
+NOTICE:  table has parent, setting distribution columns to match parent table
 create table ma_test_p2 partition of ma_test for values from (10) to (20);
+NOTICE:  table has parent, setting distribution columns to match parent table
 create table ma_test_p3 partition of ma_test for values from (20) to (30);
+NOTICE:  table has parent, setting distribution columns to match parent table
 insert into ma_test select x,x from generate_series(0,29) t(x);
 create index on ma_test (b);
 analyze ma_test;
 prepare mt_q1 (int) as select a from ma_test where a >= $1 and a % 10 = 5 order by b;
--- Execute query 5 times to allow choose_custom_plan
--- to start considering a generic plan.
-execute mt_q1(0);
- a  
-----
-  5
- 15
- 25
-(3 rows)
-
-execute mt_q1(0);
- a  
-----
-  5
- 15
- 25
-(3 rows)
-
-execute mt_q1(0);
- a  
-----
-  5
- 15
- 25
-(3 rows)
-
-execute mt_q1(0);
- a  
-----
-  5
- 15
- 25
-(3 rows)
-
-execute mt_q1(0);
- a  
-----
-  5
- 15
- 25
-(3 rows)
-
 explain (analyze, costs off, summary off, timing off) execute mt_q1(15);
-                               QUERY PLAN                               
-------------------------------------------------------------------------
- Result (actual rows=2 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=2 loops=1)
-         Merge Key: ma_test_p2.b
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: ma_test_p2.b
-               Sort Method:  quicksort  Memory: 150kB
-               ->  Append (actual rows=1 loops=1)
-                     ->  Seq Scan on ma_test_p2 (actual rows=1 loops=1)
-                           Filter: ((a >= 15) AND ((a % 10) = 5))
-                           Rows Removed by Filter: 1
-                     ->  Seq Scan on ma_test_p3 (actual rows=1 loops=1)
-                           Filter: ((a >= 15) AND ((a % 10) = 5))
-                           Rows Removed by Filter: 2
- Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=2 loops=1)
+   Merge Key: ma_test_p2.b
+   ->  Merge Append (actual rows=1 loops=1)
+         Sort Key: ma_test_p2.b
+         Subplans Removed: 1
+         ->  Index Scan using ma_test_p2_b_idx on ma_test_p2 (actual rows=1 loops=1)
+               Filter: ((a >= $1) AND ((a % 10) = 5))
+               Rows Removed by Filter: 1
+         ->  Index Scan using ma_test_p3_b_idx on ma_test_p3 (actual rows=1 loops=1)
+               Filter: ((a >= $1) AND ((a % 10) = 5))
+               Rows Removed by Filter: 2
+ Optimizer: Postgres query optimizer
+(12 rows)
 
 execute mt_q1(15);
  a  
@@ -3658,20 +3429,18 @@ execute mt_q1(15);
 (2 rows)
 
 explain (analyze, costs off, summary off, timing off) execute mt_q1(25);
-                               QUERY PLAN                               
-------------------------------------------------------------------------
- Result (actual rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=1 loops=1)
-         Merge Key: ma_test_p3.b
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: ma_test_p3.b
-               Sort Method:  quicksort  Memory: 150kB
-               ->  Append (actual rows=1 loops=1)
-                     ->  Seq Scan on ma_test_p3 (actual rows=1 loops=1)
-                           Filter: ((a >= 25) AND ((a % 10) = 5))
-                           Rows Removed by Filter: 2
- Optimizer: Pivotal Optimizer (GPORCA)
-(11 rows)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=1 loops=1)
+   Merge Key: ma_test_p3.b
+   ->  Merge Append (actual rows=1 loops=1)
+         Sort Key: ma_test_p3.b
+         Subplans Removed: 2
+         ->  Index Scan using ma_test_p3_b_idx on ma_test_p3 (actual rows=1 loops=1)
+               Filter: ((a >= $1) AND ((a % 10) = 5))
+               Rows Removed by Filter: 2
+ Optimizer: Postgres query optimizer
+(9 rows)
 
 execute mt_q1(25);
  a  
@@ -3681,16 +3450,17 @@ execute mt_q1(25);
 
 -- Ensure MergeAppend behaves correctly when no subplans match
 explain (analyze, costs off, summary off, timing off) execute mt_q1(35);
-                  QUERY PLAN                   
------------------------------------------------
- Result (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
-         Sort Key: (NULL::integer)
-         Sort Method:  quicksort  Memory: 50kB
-         ->  Result (actual rows=0 loops=1)
-               One-Time Filter: false
- Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
+   Merge Key: ma_test_p1.b
+   ->  Merge Append (never executed)
+         Sort Key: ma_test_p1.b
+         Subplans Removed: 2
+         ->  Index Scan using ma_test_p1_b_idx on ma_test_p1 (never executed)
+               Filter: ((a >= $1) AND ((a % 10) = 5))
+ Optimizer: Postgres query optimizer
+(8 rows)
 
 execute mt_q1(35);
  a 
@@ -3732,8 +3502,12 @@ reset enable_indexonlyscan;
 --
 -- array type list partition key
 create table pp_arrpart (a int[]) partition by list (a);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table pp_arrpart1 partition of pp_arrpart for values in ('{1}');
+NOTICE:  table has parent, setting distribution columns to match parent table
 create table pp_arrpart2 partition of pp_arrpart for values in ('{2, 3}', '{4, 5}');
+NOTICE:  table has parent, setting distribution columns to match parent table
 explain (costs off) select * from pp_arrpart where a = '{1}';
                   QUERY PLAN                  
 ----------------------------------------------
@@ -3745,8 +3519,8 @@ explain (costs off) select * from pp_arrpart where a = '{1}';
 (5 rows)
 
 explain (costs off) select * from pp_arrpart where a = '{1, 2}';
-             QUERY PLAN              
--------------------------------------
+              QUERY PLAN               
+---------------------------------------
  Result
    One-Time Filter: false
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -3787,8 +3561,12 @@ explain (costs off) delete from pp_arrpart where a = '{1}';
 drop table pp_arrpart;
 -- array type hash partition key
 create table pph_arrpart (a int[]) partition by hash (a);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table pph_arrpart1 partition of pph_arrpart for values with (modulus 2, remainder 0);
+NOTICE:  table has parent, setting distribution columns to match parent table
 create table pph_arrpart2 partition of pph_arrpart for values with (modulus 2, remainder 1);
+NOTICE:  table has parent, setting distribution columns to match parent table
 insert into pph_arrpart values ('{1}'), ('{1, 2}'), ('{4, 5}');
 select tableoid::regclass, * from pph_arrpart order by 1;
    tableoid   |   a   
@@ -3832,8 +3610,12 @@ drop table pph_arrpart;
 -- enum type list partition key
 create type pp_colors as enum ('green', 'blue', 'black');
 create table pp_enumpart (a pp_colors) partition by list (a);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table pp_enumpart_green partition of pp_enumpart for values in ('green');
+NOTICE:  table has parent, setting distribution columns to match parent table
 create table pp_enumpart_blue partition of pp_enumpart for values in ('blue');
+NOTICE:  table has parent, setting distribution columns to match parent table
 explain (costs off) select * from pp_enumpart where a = 'blue';
                   QUERY PLAN                   
 -----------------------------------------------
@@ -3857,8 +3639,11 @@ drop type pp_colors;
 -- record type as partition key
 create type pp_rectype as (a int, b int);
 create table pp_recpart (a pp_rectype) partition by list (a);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 create table pp_recpart_11 partition of pp_recpart for values in ('(1,1)');
+NOTICE:  table has parent, setting distribution columns to match parent table
 create table pp_recpart_23 partition of pp_recpart for values in ('(2,3)');
+NOTICE:  table has parent, setting distribution columns to match parent table
 explain (costs off) select * from pp_recpart where a = '(1,1)'::pp_rectype;
                    QUERY PLAN                    
 -------------------------------------------------
@@ -3881,8 +3666,12 @@ drop table pp_recpart;
 drop type pp_rectype;
 -- range type partition key
 create table pp_intrangepart (a int4range) partition by list (a);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table pp_intrangepart12 partition of pp_intrangepart for values in ('[1,2]');
+NOTICE:  table has parent, setting distribution columns to match parent table
 create table pp_intrangepart2inf partition of pp_intrangepart for values in ('[2,)');
+NOTICE:  table has parent, setting distribution columns to match parent table
 explain (costs off) select * from pp_intrangepart where a = '[1,2]'::int4range;
                    QUERY PLAN                   
 ------------------------------------------------
@@ -3894,8 +3683,8 @@ explain (costs off) select * from pp_intrangepart where a = '[1,2]'::int4range;
 (5 rows)
 
 explain (costs off) select * from pp_intrangepart where a = '(1,2)'::int4range;
-        QUERY PLAN        
---------------------------
+              QUERY PLAN               
+---------------------------------------
  Result
    One-Time Filter: false
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -3906,8 +3695,12 @@ drop table pp_intrangepart;
 -- Ensure the enable_partition_prune GUC properly disables partition pruning.
 --
 create table pp_lp (a int, value int) partition by list (a);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table pp_lp1 partition of pp_lp for values in(1);
+NOTICE:  table has parent, setting distribution columns to match parent table
 create table pp_lp2 partition of pp_lp for values in(2);
+NOTICE:  table has parent, setting distribution columns to match parent table
 explain (costs off) select * from pp_lp where a = 1;
                 QUERY PLAN                
 ------------------------------------------
@@ -3919,8 +3712,8 @@ explain (costs off) select * from pp_lp where a = 1;
 (5 rows)
 
 explain (costs off) update pp_lp set value = 10 where a = 1;
-        QUERY PLAN        
---------------------------
+             QUERY PLAN              
+-------------------------------------
  Update on pp_lp
    Update on pp_lp1
    ->  Seq Scan on pp_lp1
@@ -3929,8 +3722,8 @@ explain (costs off) update pp_lp set value = 10 where a = 1;
 (5 rows)
 
 explain (costs off) delete from pp_lp where a = 1;
-        QUERY PLAN        
---------------------------
+             QUERY PLAN              
+-------------------------------------
  Delete on pp_lp
    Delete on pp_lp1
    ->  Seq Scan on pp_lp1
@@ -3951,8 +3744,8 @@ explain (costs off) select * from pp_lp where a = 1;
 (5 rows)
 
 explain (costs off) update pp_lp set value = 10 where a = 1;
-        QUERY PLAN        
---------------------------
+             QUERY PLAN              
+-------------------------------------
  Update on pp_lp
    Update on pp_lp1
    Update on pp_lp2
@@ -3964,8 +3757,8 @@ explain (costs off) update pp_lp set value = 10 where a = 1;
 (8 rows)
 
 explain (costs off) delete from pp_lp where a = 1;
-        QUERY PLAN        
---------------------------
+             QUERY PLAN              
+-------------------------------------
  Delete on pp_lp
    Delete on pp_lp1
    Delete on pp_lp2
@@ -3988,8 +3781,8 @@ explain (costs off) select * from pp_lp where a = 1;
 (5 rows)
 
 explain (costs off) update pp_lp set value = 10 where a = 1;
-        QUERY PLAN        
---------------------------
+             QUERY PLAN              
+-------------------------------------
  Update on pp_lp
    Update on pp_lp1
    Update on pp_lp2
@@ -4001,8 +3794,8 @@ explain (costs off) update pp_lp set value = 10 where a = 1;
 (8 rows)
 
 explain (costs off) delete from pp_lp where a = 1;
-        QUERY PLAN        
---------------------------
+             QUERY PLAN              
+-------------------------------------
  Delete on pp_lp
    Delete on pp_lp1
    Delete on pp_lp2
@@ -4016,10 +3809,14 @@ explain (costs off) delete from pp_lp where a = 1;
 drop table pp_lp;
 -- Ensure enable_partition_prune does not affect non-partitioned tables.
 create table inh_lp (a int, value int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table inh_lp1 (a int, value int, check(a = 1)) inherits (inh_lp);
+NOTICE:  table has parent, setting distribution columns to match parent table
 NOTICE:  merging column "a" with inherited definition
 NOTICE:  merging column "value" with inherited definition
 create table inh_lp2 (a int, value int, check(a = 2)) inherits (inh_lp);
+NOTICE:  table has parent, setting distribution columns to match parent table
 NOTICE:  merging column "a" with inherited definition
 NOTICE:  merging column "value" with inherited definition
 set constraint_exclusion = 'partition';
@@ -4037,8 +3834,8 @@ explain (costs off) select * from inh_lp where a = 1;
 (7 rows)
 
 explain (costs off) update inh_lp set value = 10 where a = 1;
-        QUERY PLAN         
----------------------------
+             QUERY PLAN              
+-------------------------------------
  Update on inh_lp
    Update on inh_lp
    Update on inh_lp1
@@ -4046,11 +3843,12 @@ explain (costs off) update inh_lp set value = 10 where a = 1;
          Filter: (a = 1)
    ->  Seq Scan on inh_lp1
          Filter: (a = 1)
-(7 rows)
+ Optimizer: Postgres query optimizer
+(8 rows)
 
 explain (costs off) delete from inh_lp where a = 1;
-        QUERY PLAN         
----------------------------
+             QUERY PLAN              
+-------------------------------------
  Delete on inh_lp
    Delete on inh_lp
    Delete on inh_lp1
@@ -4058,7 +3856,8 @@ explain (costs off) delete from inh_lp where a = 1;
          Filter: (a = 1)
    ->  Seq Scan on inh_lp1
          Filter: (a = 1)
-(7 rows)
+ Optimizer: Postgres query optimizer
+(8 rows)
 
 -- Ensure we don't exclude normal relations when we only expect to exclude
 -- inheritance children
@@ -4082,8 +3881,12 @@ reset enable_partition_pruning;
 reset constraint_exclusion;
 -- Check pruning for a partition tree containing only temporary relations
 create temp table pp_temp_parent (a int) partition by list (a);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create temp table pp_temp_part_1 partition of pp_temp_parent for values in (1);
+NOTICE:  table has parent, setting distribution columns to match parent table
 create temp table pp_temp_part_def partition of pp_temp_parent default;
+NOTICE:  table has parent, setting distribution columns to match parent table
 explain (costs off) select * from pp_temp_parent where true;
                 QUERY PLAN                
 ------------------------------------------
@@ -4091,7 +3894,7 @@ explain (costs off) select * from pp_temp_parent where true;
    ->  Append
          ->  Seq Scan on pp_temp_part_1
          ->  Seq Scan on pp_temp_part_def
- Optimizer: Postgres query optimizer
+ Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
 explain (costs off) select * from pp_temp_parent where a = 2;
@@ -4107,15 +3910,27 @@ explain (costs off) select * from pp_temp_parent where a = 2;
 drop table pp_temp_parent;
 -- Stress run-time partition pruning a bit more, per bug reports
 create temp table p (a int, b int, c int) partition by list (a);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create temp table p1 partition of p for values in (1);
+NOTICE:  table has parent, setting distribution columns to match parent table
 create temp table p2 partition of p for values in (2);
+NOTICE:  table has parent, setting distribution columns to match parent table
 create temp table q (a int, b int, c int) partition by list (a);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create temp table q1 partition of q for values in (1) partition by list (b);
+NOTICE:  table has parent, setting distribution columns to match parent table
 create temp table q11 partition of q1 for values in (1) partition by list (c);
+NOTICE:  table has parent, setting distribution columns to match parent table
 create temp table q111 partition of q11 for values in (1);
+NOTICE:  table has parent, setting distribution columns to match parent table
 create temp table q2 partition of q for values in (2) partition by list (b);
+NOTICE:  table has parent, setting distribution columns to match parent table
 create temp table q21 partition of q2 for values in (1);
+NOTICE:  table has parent, setting distribution columns to match parent table
 create temp table q22 partition of q2 for values in (2);
+NOTICE:  table has parent, setting distribution columns to match parent table
 insert into q22 values (2, 2, 3);
 -- GPDB: This is the query that needs the "matchsubs" rule at the top of the file
 -- The constant third branch of the UNION is executed at random segment. If the
@@ -4134,7 +3949,7 @@ from (
 where s.a = 1 and s.b = 1 and s.c = (select 1);
                          QUERY PLAN                          
 -------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)
+ Gather Motion 2:1  (slice1; segments: 2)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result
    ->  Append
@@ -4173,7 +3988,6 @@ from (
       select 1, 1, 1
      ) s(a, b, c)
 where s.a = $1 and s.b = $2 and s.c = (select 1);
-set plan_cache_mode to force_generic_plan;
 explain (costs off) execute q (1, 1);
                                 QUERY PLAN                                 
 ---------------------------------------------------------------------------
@@ -4191,7 +4005,7 @@ explain (costs off) execute q (1, 1);
                ->  Result
                      One-Time Filter: ((1 = $1) AND (1 = $2) AND (1 = $0))
  Optimizer: Postgres query optimizer
-(15 rows)
+(14 rows)
 
 execute q (1, 1);
  a | b | c 
@@ -4199,14 +4013,18 @@ execute q (1, 1);
  1 | 1 | 1
 (1 row)
 
-reset plan_cache_mode;
 drop table p, q;
 -- Ensure run-time pruning works correctly when we match a partitioned table
 -- on the first level but find no matching partitions on the second level.
 create table listp (a int, b int) partition by list (a);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table listp1 partition of listp for values in(1);
+NOTICE:  table has parent, setting distribution columns to match parent table
 create table listp2 partition of listp for values in(2) partition by list(b);
+NOTICE:  table has parent, setting distribution columns to match parent table
 create table listp2_10 partition of listp2 for values in (10);
+NOTICE:  table has parent, setting distribution columns to match parent table
 explain (analyze, costs off, summary off, timing off)
 select * from listp where a = (select 2) and b <> 10;
                             QUERY PLAN                            


### PR DESCRIPTION
This file had a very weird mix of tests that did "set plan_cache_mode =
force_generic_plan" to get a generic plan, and tests that relied on
using five dummy executions of a prepared statement.  Converting them
all to rely on plan_cache_mode is more consistent and shaves off a
noticeable fraction of the test script's runtime.

Discussion: https://postgr.es/m/11952.1569536725@sss.pgh.pa.us
(cherry picked from commit d52eaa094847d395f942827a6f413904e516994c)

-----

This PR is to remove merge_fixme by cherry-pick upstream commit. Previously ORCA
will fallback to planner and can not use generic plan, so it do direct dispatch. However,
planner will choose generic plan so that can not do direct dispatch.
