### PR TITLE
[ORCA] Fix memory leak in translator

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -2509,6 +2509,8 @@ CTranslatorUtils::IsCompositeConst(CMemoryPool *mp, CMDAccessor *md_accessor,
 
 	const IMDType *type = md_accessor->RetrieveType(mdid_return_type);
 
+	mdid_return_type->Release();
+
 	return type->IsComposite();
 }
 

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -284,7 +284,6 @@ CTranslatorUtils::ConvertToCDXLLogicalTVF(CMemoryPool *mp,
 
 		CMDName *func_name =
 			CDXLUtils::CreateMDNameFromCharArray(mp, rte->eref->aliasname);
-		mdid_return_type->AddRef();
 
 		// if TVF evaluates to const, pass invalid key as funcid
 		CDXLLogicalTVF *tvf_dxl = GPOS_NEW(mp)


### PR DESCRIPTION
Found while rebasing Jesse's WIP refcount branch that is attempting to
remove manual refcounting.

NOTE: I didn't think of a good way to test this.  And since this is in gpopt I don't think a MDP testcase will work. Looking for thoughts/suggestions.