### PR TITLE
Remove one fixme in cdbgroupingpaths.c

### DIFF
--- a/src/backend/cdb/cdbgroupingpaths.c
+++ b/src/backend/cdb/cdbgroupingpaths.c
@@ -1053,10 +1053,6 @@ add_first_stage_hash_agg_path(PlannerInfo *root,
 	dNumGroups = estimate_num_groups_on_segment(ctx->dNumGroupsTotal,
 												path->rows, path->locus);
 
-	/*
-	 * FIXME:
-	 * Shall we compute hash table size and compare with work_mem here?
-	 */
 
 	if (parse->groupingSets && ctx->new_rollups)
 	{


### PR DESCRIPTION
It is a long hard issue how to estimate hash table during creating path stage, and also the GUC `work_mem` is confirmed deprecated in GPDB. So we just remove this FIXME.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
