### PR TITLE
Resolve fixmes in postgres.c and postmaster.c: refactor code and disable statement_timeout on QE

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -2691,11 +2691,6 @@ retry1:
 			/*
 			 * Allow connections if hot_standby is on and our postmaster is
 			 * acting as a standby.
-			 *
-			 * GPDB_12_MERGE_FIXME: checking a GUC is not a good idea here.
-			 * In upstream, postmaster allows hot-standby connections based on
-			 * pmState in canAcceptConnections.  We should revert to that
-			 * logic.
 			 */
 			if (EnableHotStandby)
 				break;


### PR DESCRIPTION
There are 3 Fixmes in this PR:
* ~~postmaster.c check EnableHotStandby guc~~
just a code refactor (if I understand the fixme message correctly).

* postgres.c T_Query sourceTag
not change it, reason: the sourceTag isn't dispatched to QE and current code works well.

* postgres.c statement_timeout
disable statement_timeout on QE (like gp5 and 6 did).
I think it's meaningless to enable it on QE, and user may encounter this scenario if enable it
```
// most of the time
ERROR:  canceling statement due to statement timeout

// but QE timeout first sometimes
ERROR:  canceling statement due to statement timeout  (seg0 slice1 127.0.1.1:6000 pid=99920)
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
