### PR TITLE
Lock leaf partitions for Insert Statement when GDD disabled.

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -2050,6 +2050,8 @@ InitPlan(QueryDesc *queryDesc, int eflags)
 						break;
 				}
 			}
+
+	SIMPLE_FAULT_INJECTOR("func_init_plan_end");
 }
 
 /*

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -29,6 +29,7 @@
 #include "catalog/pg_amproc.h"
 #include "catalog/pg_collation.h"
 #include "catalog/pg_constraint.h"
+#include "catalog/pg_inherits.h"
 #include "catalog/pg_type.h"
 #include "commands/defrem.h"
 #include "nodes/makefuncs.h"
@@ -272,6 +273,7 @@ setTargetTable(ParseState *pstate, RangeVar *relation,
 	int			rtindex;
 	ParseCallbackState pcbstate;
 	bool lockUpgraded = false;
+	LOCKMODE    lockmode;
 
 	/*
 	 * ENRs hide tables of the same name, so we need to check for them first.
@@ -318,11 +320,35 @@ setTargetTable(ParseState *pstate, RangeVar *relation,
 		pstate->p_target_relation = parserOpenTable(pstate, relation, RowExclusiveLock, &lockUpgraded);
 	}
 
+	lockmode = lockUpgraded ? ExclusiveLock : RowExclusiveLock;
+
+	if (Gp_role == GP_ROLE_DISPATCH &&
+		pstate->p_is_insert &&
+		!gp_enable_global_deadlock_detector &&
+		pstate->p_target_relation->rd_rel->relkind == RELKIND_PARTITIONED_TABLE)
+	{
+		/*
+		 * Greenplum specific code:
+		 * When GDD is disabled, and we are inserting into a partition table,
+		 * then we need to lock all leaf partitions. The reason is:
+		 *    1. we cannot predict which leaf partitions will be inserted
+		 *    2. if we do not hold lock on leaf partitions on QD, then this
+		 *       insert statement will be dispatched to QEs, and not dispatch
+		 *       is async, so on some segments, this session's insert will
+		 *       first hold locks on leaf partition and block others; however,
+		 *       on some segments, this session's insert will be blocked by
+		 *       others. Thus we have risk to have global deadlock.
+		 * See issue https://github.com/greenplum-db/gpdb/issues/13652 for details.
+		 */
+		(void) find_all_inheritors(RelationGetRelid(pstate->p_target_relation),
+								   lockmode, NULL);
+	}
+
 	/*
 	 * Now build an RTE.
 	 */
 	rte = addRangeTableEntryForRelation(pstate, pstate->p_target_relation,
-										lockUpgraded ? ExclusiveLock : RowExclusiveLock, /* CDB */
+										lockmode, /* CDB */
 										relation->alias, inh, false);
 	pstate->p_target_rangetblentry = rte;
 

--- a/src/test/isolation2/expected/gdd/insert_root_partition_truncate_deadlock.out
+++ b/src/test/isolation2/expected/gdd/insert_root_partition_truncate_deadlock.out
@@ -1,0 +1,46 @@
+-- Insert statement on root partition, if GDD is enabled, QD will not lock leaf
+-- parititions for better concurrency performance. So when the insert statement
+-- is dispatched to segments async, some of statement will lock leaf partition
+-- and execute, some might be blocked by other sessions and lead to global
+-- deadlock. This test file is in GDD suites, it verify that such deadlock can
+-- be broken by GDD.
+-- See Issue https://github.com/greenplum-db/gpdb/issues/13652 for details.
+
+-- NOTE: this test case is better to run both with GDD and withoug GDD.
+-- with GDD it is running within gdd test suites to test GDD can break the deadlock;
+-- without GDD it is running to show that no deadlock happens.
+
+create table rank_13652 (id int, year int) partition by range (year) (start (2006) end (2009) every (1));
+CREATE
+
+select gp_inject_fault('func_init_plan_end', 'suspend', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1&: insert into rank_13652 select i,i%3+2006 from generate_series(1, 30)i;  <waiting ...>
+select gp_wait_until_triggered_fault('func_init_plan_end', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+2&: truncate rank_13652_1_prt_2;  <waiting ...>
+
+select gp_inject_fault('func_init_plan_end', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+INSERT 30
+2<:  <... completed>
+ERROR:  canceling statement due to user request: "cancelled by global deadlock detector"
+
+1q: ... <quitting>
+2q: ... <quitting>
+
+drop table rank_13652;
+DROP

--- a/src/test/isolation2/expected/insert_root_partition_truncate_deadlock_without_gdd.out
+++ b/src/test/isolation2/expected/insert_root_partition_truncate_deadlock_without_gdd.out
@@ -1,0 +1,46 @@
+-- Insert statement on root partition, if GDD is enabled, QD will not lock leaf
+-- parititions for better concurrency performance. So when the insert statement
+-- is dispatched to segments async, some of statement will lock leaf partition
+-- and execute, some might be blocked by other sessions and lead to global
+-- deadlock. This test file is in GDD suites, it verify that such deadlock can
+-- be broken by GDD.
+-- See Issue https://github.com/greenplum-db/gpdb/issues/13652 for details.
+
+-- NOTE: this test case is better to run both with GDD and withoug GDD.
+-- with GDD it is running within gdd test suites to test GDD can break the deadlock;
+-- without GDD it is running to show that no deadlock happens.
+
+create table rank_13652 (id int, year int) partition by range (year) (start (2006) end (2009) every (1));
+CREATE
+
+select gp_inject_fault('func_init_plan_end', 'suspend', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1&: insert into rank_13652 select i,i%3+2006 from generate_series(1, 30)i;  <waiting ...>
+select gp_wait_until_triggered_fault('func_init_plan_end', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+2&: truncate rank_13652_1_prt_2;  <waiting ...>
+
+select gp_inject_fault('func_init_plan_end', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+INSERT 30
+2<:  <... completed>
+TRUNCATE
+
+1q: ... <quitting>
+2q: ... <quitting>
+
+drop table rank_13652;
+DROP

--- a/src/test/isolation2/expected/lockmodes.out
+++ b/src/test/isolation2/expected/lockmodes.out
@@ -1024,30 +1024,44 @@ ABORT
 -- For detailed behavior and notes, please refer below
 -- cases's comments.
 -- Details: https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/wAPKpJzhbpM
--- start_ignore
-1:DROP TABLE IF EXISTS t_lockmods_part_tbl_upd_del;
+-- Issue: https://github.com/greenplum-db/gpdb/issues/13652
+1:DROP TABLE IF EXISTS t_lockmods_part_tbl_dml;
 DROP
--- end_ignore
 
-1:CREATE TABLE t_lockmods_part_tbl_upd_del (a int, b int, c int) PARTITION BY RANGE(b) (START(1) END(3) EVERY(1));
+1:CREATE TABLE t_lockmods_part_tbl_dml (a int, b int, c int) PARTITION BY RANGE(b) (START(1) END(3) EVERY(1));
 CREATE
-1:INSERT INTO t_lockmods_part_tbl_upd_del SELECT i, 1, i FROM generate_series(1,10)i;
+1:INSERT INTO t_lockmods_part_tbl_dml SELECT i, 1, i FROM generate_series(1,10)i;
 INSERT 10
 
 --
 1: BEGIN;
 BEGIN
-1: DELETE FROM t_lockmods_part_tbl_upd_del;
+1: DELETE FROM t_lockmods_part_tbl_dml;
 DELETE 10
 -- on QD, there's a lock on the root and the target partition
 1: select * from show_locks_lockmodes;
- locktype | mode            | granted | relation                            
-----------+-----------------+---------+-------------------------------------
- relation | AccessShareLock | t       | t_lockmods_part_tbl_upd_del         
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del         
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del_1_prt_1 
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del_1_prt_2 
+ locktype | mode            | granted | relation                        
+----------+-----------------+---------+---------------------------------
+ relation | AccessShareLock | t       | t_lockmods_part_tbl_dml         
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml         
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml_1_prt_2 
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml_1_prt_1 
 (4 rows)
+1: ROLLBACK;
+ROLLBACK
+
+1: BEGIN;
+BEGIN
+1: INSERT INTO t_lockmods_part_tbl_dml SELECT i, 1, i FROM generate_series(1,10)i;
+INSERT 10
+-- without GDD, it will lock all leaf partitions on QD
+1: select * from show_locks_lockmodes;
+ locktype | mode             | granted | relation                        
+----------+------------------+---------+---------------------------------
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_2 
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml         
+(3 rows)
 1: ROLLBACK;
 ROLLBACK
 
@@ -1076,16 +1090,16 @@ ROLLBACK
 
 1: BEGIN;
 BEGIN
-1: UPDATE t_lockmods_part_tbl_upd_del SET c = 1 WHERE c = 1;
+1: UPDATE t_lockmods_part_tbl_dml SET c = 1 WHERE c = 1;
 UPDATE 1
 -- on QD, there's a lock on the root and the target partition
 1: select * from show_locks_lockmodes;
- locktype | mode            | granted | relation                            
-----------+-----------------+---------+-------------------------------------
- relation | AccessShareLock | t       | t_lockmods_part_tbl_upd_del         
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del         
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del_1_prt_1 
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del_1_prt_2 
+ locktype | mode            | granted | relation                        
+----------+-----------------+---------+---------------------------------
+ relation | AccessShareLock | t       | t_lockmods_part_tbl_dml         
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml         
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml_1_prt_2 
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml_1_prt_1 
 (4 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -1093,14 +1107,14 @@ ROLLBACK
 
 1: BEGIN;
 BEGIN
-1: DELETE FROM t_lockmods_part_tbl_upd_del_1_prt_1;
+1: DELETE FROM t_lockmods_part_tbl_dml_1_prt_1;
 DELETE 10
 -- since the delete operation is on leaf part, there will be a lock on QD
 1: select * from show_locks_lockmodes;
- locktype | mode            | granted | relation                            
-----------+-----------------+---------+-------------------------------------
- relation | AccessShareLock | t       | t_lockmods_part_tbl_upd_del         
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del_1_prt_1 
+ locktype | mode            | granted | relation                        
+----------+-----------------+---------+---------------------------------
+ relation | AccessShareLock | t       | t_lockmods_part_tbl_dml         
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml_1_prt_1 
 (2 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -1108,14 +1122,14 @@ ROLLBACK
 
 1: BEGIN;
 BEGIN
-1: UPDATE t_lockmods_part_tbl_upd_del_1_prt_1 SET c = 1 WHERE c = 1;
+1: UPDATE t_lockmods_part_tbl_dml_1_prt_1 SET c = 1 WHERE c = 1;
 UPDATE 1
 -- since the update operation is on leaf part, there will be a lock on QD
 1: select * from show_locks_lockmodes;
- locktype | mode            | granted | relation                            
-----------+-----------------+---------+-------------------------------------
- relation | AccessShareLock | t       | t_lockmods_part_tbl_upd_del         
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del_1_prt_1 
+ locktype | mode            | granted | relation                        
+----------+-----------------+---------+---------------------------------
+ relation | AccessShareLock | t       | t_lockmods_part_tbl_dml         
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml_1_prt_1 
 (2 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -2126,16 +2140,16 @@ ABORT
 
 1: BEGIN;
 BEGIN
-1: DELETE FROM t_lockmods_part_tbl_upd_del;
+1: DELETE FROM t_lockmods_part_tbl_dml;
 DELETE 10
 -- on QD, there's a lock on the root and the target partition
 1: select * from show_locks_lockmodes;
- locktype | mode             | granted | relation                            
-----------+------------------+---------+-------------------------------------
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_upd_del_1_prt_2 
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_upd_del_1_prt_1 
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_upd_del         
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_upd_del         
+ locktype | mode             | granted | relation                        
+----------+------------------+---------+---------------------------------
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_2 
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
+ relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml         
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml         
 (4 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -2143,16 +2157,16 @@ ROLLBACK
 
 1: BEGIN;
 BEGIN
-1: UPDATE t_lockmods_part_tbl_upd_del SET c = 1 WHERE c = 1;
+1: UPDATE t_lockmods_part_tbl_dml SET c = 1 WHERE c = 1;
 UPDATE 1
 -- on QD, there's a lock on the root and the target partition
 1: select * from show_locks_lockmodes;
- locktype | mode             | granted | relation                            
-----------+------------------+---------+-------------------------------------
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_upd_del_1_prt_2 
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_upd_del_1_prt_1 
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_upd_del         
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_upd_del         
+ locktype | mode             | granted | relation                        
+----------+------------------+---------+---------------------------------
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_2 
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
+ relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml         
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml         
 (4 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -2160,14 +2174,14 @@ ROLLBACK
 
 1: BEGIN;
 BEGIN
-1: DELETE FROM t_lockmods_part_tbl_upd_del_1_prt_1;
+1: DELETE FROM t_lockmods_part_tbl_dml_1_prt_1;
 DELETE 10
 -- since the delete operation is on leaf part, there will be a lock on QD
 1: select * from show_locks_lockmodes;
- locktype | mode             | granted | relation                            
-----------+------------------+---------+-------------------------------------
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_upd_del         
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_upd_del_1_prt_1 
+ locktype | mode             | granted | relation                        
+----------+------------------+---------+---------------------------------
+ relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml         
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
 (2 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -2175,15 +2189,29 @@ ROLLBACK
 
 1: BEGIN;
 BEGIN
-1: UPDATE t_lockmods_part_tbl_upd_del_1_prt_1 SET c = 1 WHERE c = 1;
+1: UPDATE t_lockmods_part_tbl_dml_1_prt_1 SET c = 1 WHERE c = 1;
 UPDATE 1
 -- since the update operation is on leaf part, there will be a lock on QD
 1: select * from show_locks_lockmodes;
- locktype | mode             | granted | relation                            
-----------+------------------+---------+-------------------------------------
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_upd_del         
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_upd_del_1_prt_1 
+ locktype | mode             | granted | relation                        
+----------+------------------+---------+---------------------------------
+ relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml         
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
 (2 rows)
+1: ROLLBACK;
+ROLLBACK
+1q: ... <quitting>
+
+1: BEGIN;
+BEGIN
+1: INSERT INTO t_lockmods_part_tbl_dml SELECT i, 1, i FROM generate_series(1,10)i;
+INSERT 10
+-- With GDD enabled, QD will only hold lock on root for insert
+1: select * from show_locks_lockmodes;
+ locktype | mode             | granted | relation                
+----------+------------------+---------+-------------------------
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml 
+(1 row)
 1: ROLLBACK;
 ROLLBACK
 1q: ... <quitting>

--- a/src/test/isolation2/expected/lockmodes_optimizer.out
+++ b/src/test/isolation2/expected/lockmodes_optimizer.out
@@ -1024,30 +1024,44 @@ ABORT
 -- For detailed behavior and notes, please refer below
 -- cases's comments.
 -- Details: https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/wAPKpJzhbpM
--- start_ignore
-1:DROP TABLE IF EXISTS t_lockmods_part_tbl_upd_del;
+-- Issue: https://github.com/greenplum-db/gpdb/issues/13652
+1:DROP TABLE IF EXISTS t_lockmods_part_tbl_dml;
 DROP
--- end_ignore
 
-1:CREATE TABLE t_lockmods_part_tbl_upd_del (a int, b int, c int) PARTITION BY RANGE(b) (START(1) END(3) EVERY(1));
+1:CREATE TABLE t_lockmods_part_tbl_dml (a int, b int, c int) PARTITION BY RANGE(b) (START(1) END(3) EVERY(1));
 CREATE
-1:INSERT INTO t_lockmods_part_tbl_upd_del SELECT i, 1, i FROM generate_series(1,10)i;
+1:INSERT INTO t_lockmods_part_tbl_dml SELECT i, 1, i FROM generate_series(1,10)i;
 INSERT 10
 
 --
 1: BEGIN;
 BEGIN
-1: DELETE FROM t_lockmods_part_tbl_upd_del;
+1: DELETE FROM t_lockmods_part_tbl_dml;
 DELETE 10
 -- on QD, there's a lock on the root and the target partition
 1: select * from show_locks_lockmodes;
- locktype | mode            | granted | relation                            
-----------+-----------------+---------+-------------------------------------
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del_1_prt_1 
- relation | AccessShareLock | t       | t_lockmods_part_tbl_upd_del         
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del         
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del_1_prt_2 
+ locktype | mode            | granted | relation                        
+----------+-----------------+---------+---------------------------------
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml_1_prt_1 
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml_1_prt_2 
+ relation | AccessShareLock | t       | t_lockmods_part_tbl_dml         
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml         
 (4 rows)
+1: ROLLBACK;
+ROLLBACK
+
+1: BEGIN;
+BEGIN
+1: INSERT INTO t_lockmods_part_tbl_dml SELECT i, 1, i FROM generate_series(1,10)i;
+INSERT 10
+-- without GDD, it will lock all leaf partitions on QD
+1: select * from show_locks_lockmodes;
+ locktype | mode             | granted | relation                        
+----------+------------------+---------+---------------------------------
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_2 
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml         
+(3 rows)
 1: ROLLBACK;
 ROLLBACK
 
@@ -1076,16 +1090,16 @@ ROLLBACK
 
 1: BEGIN;
 BEGIN
-1: UPDATE t_lockmods_part_tbl_upd_del SET c = 1 WHERE c = 1;
+1: UPDATE t_lockmods_part_tbl_dml SET c = 1 WHERE c = 1;
 UPDATE 1
 -- on QD, there's a lock on the root and the target partition
 1: select * from show_locks_lockmodes;
- locktype | mode            | granted | relation                            
-----------+-----------------+---------+-------------------------------------
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del_1_prt_1 
- relation | AccessShareLock | t       | t_lockmods_part_tbl_upd_del         
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del         
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del_1_prt_2 
+ locktype | mode            | granted | relation                        
+----------+-----------------+---------+---------------------------------
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml_1_prt_1 
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml_1_prt_2 
+ relation | AccessShareLock | t       | t_lockmods_part_tbl_dml         
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml         
 (4 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -1093,14 +1107,14 @@ ROLLBACK
 
 1: BEGIN;
 BEGIN
-1: DELETE FROM t_lockmods_part_tbl_upd_del_1_prt_1;
+1: DELETE FROM t_lockmods_part_tbl_dml_1_prt_1;
 DELETE 10
 -- since the delete operation is on leaf part, there will be a lock on QD
 1: select * from show_locks_lockmodes;
- locktype | mode            | granted | relation                            
-----------+-----------------+---------+-------------------------------------
- relation | AccessShareLock | t       | t_lockmods_part_tbl_upd_del         
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del_1_prt_1 
+ locktype | mode            | granted | relation                        
+----------+-----------------+---------+---------------------------------
+ relation | AccessShareLock | t       | t_lockmods_part_tbl_dml         
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml_1_prt_1 
 (2 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -1108,14 +1122,14 @@ ROLLBACK
 
 1: BEGIN;
 BEGIN
-1: UPDATE t_lockmods_part_tbl_upd_del_1_prt_1 SET c = 1 WHERE c = 1;
+1: UPDATE t_lockmods_part_tbl_dml_1_prt_1 SET c = 1 WHERE c = 1;
 UPDATE 1
 -- since the update operation is on leaf part, there will be a lock on QD
 1: select * from show_locks_lockmodes;
- locktype | mode            | granted | relation                            
-----------+-----------------+---------+-------------------------------------
- relation | AccessShareLock | t       | t_lockmods_part_tbl_upd_del         
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_upd_del_1_prt_1 
+ locktype | mode            | granted | relation                        
+----------+-----------------+---------+---------------------------------
+ relation | AccessShareLock | t       | t_lockmods_part_tbl_dml         
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml_1_prt_1 
 (2 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -1159,9 +1173,9 @@ BEGIN
 1: explain select * from t_lockmods for update;
  QUERY PLAN                                                                  
 -----------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.10 rows=5 width=10) 
-   ->  LockRows  (cost=0.00..3.10 rows=2 width=10)                           
-         ->  Seq Scan on t_lockmods  (cost=0.00..3.05 rows=2 width=10)       
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.10 rows=5 width=10) 
+   ->  LockRows  (cost=0.00..1.03 rows=2 width=10)                           
+         ->  Seq Scan on t_lockmods  (cost=0.00..1.02 rows=2 width=10)       
  Optimizer: Postgres query optimizer                                         
 (4 rows)
 1: select * from t_lockmods for update;
@@ -2127,16 +2141,16 @@ ABORT
 
 1: BEGIN;
 BEGIN
-1: DELETE FROM t_lockmods_part_tbl_upd_del;
+1: DELETE FROM t_lockmods_part_tbl_dml;
 DELETE 10
 -- on QD, there's a lock on the root and the target partition
 1: select * from show_locks_lockmodes;
- locktype | mode             | granted | relation                            
-----------+------------------+---------+-------------------------------------
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_upd_del_1_prt_2 
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_upd_del_1_prt_1 
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_upd_del         
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_upd_del         
+ locktype | mode             | granted | relation                        
+----------+------------------+---------+---------------------------------
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_2 
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
+ relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml         
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml         
 (4 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -2144,16 +2158,16 @@ ROLLBACK
 
 1: BEGIN;
 BEGIN
-1: UPDATE t_lockmods_part_tbl_upd_del SET c = 1 WHERE c = 1;
+1: UPDATE t_lockmods_part_tbl_dml SET c = 1 WHERE c = 1;
 UPDATE 1
 -- on QD, there's a lock on the root and the target partition
 1: select * from show_locks_lockmodes;
- locktype | mode             | granted | relation                            
-----------+------------------+---------+-------------------------------------
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_upd_del_1_prt_2 
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_upd_del_1_prt_1 
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_upd_del         
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_upd_del         
+ locktype | mode             | granted | relation                        
+----------+------------------+---------+---------------------------------
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_2 
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
+ relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml         
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml         
 (4 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -2161,14 +2175,14 @@ ROLLBACK
 
 1: BEGIN;
 BEGIN
-1: DELETE FROM t_lockmods_part_tbl_upd_del_1_prt_1;
+1: DELETE FROM t_lockmods_part_tbl_dml_1_prt_1;
 DELETE 10
 -- since the delete operation is on leaf part, there will be a lock on QD
 1: select * from show_locks_lockmodes;
- locktype | mode             | granted | relation                            
-----------+------------------+---------+-------------------------------------
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_upd_del         
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_upd_del_1_prt_1 
+ locktype | mode             | granted | relation                        
+----------+------------------+---------+---------------------------------
+ relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml         
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
 (2 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -2176,15 +2190,29 @@ ROLLBACK
 
 1: BEGIN;
 BEGIN
-1: UPDATE t_lockmods_part_tbl_upd_del_1_prt_1 SET c = 1 WHERE c = 1;
+1: UPDATE t_lockmods_part_tbl_dml_1_prt_1 SET c = 1 WHERE c = 1;
 UPDATE 1
 -- since the update operation is on leaf part, there will be a lock on QD
 1: select * from show_locks_lockmodes;
- locktype | mode             | granted | relation                            
-----------+------------------+---------+-------------------------------------
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_upd_del         
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_upd_del_1_prt_1 
+ locktype | mode             | granted | relation                        
+----------+------------------+---------+---------------------------------
+ relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml         
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
 (2 rows)
+1: ROLLBACK;
+ROLLBACK
+1q: ... <quitting>
+
+1: BEGIN;
+BEGIN
+1: INSERT INTO t_lockmods_part_tbl_dml SELECT i, 1, i FROM generate_series(1,10)i;
+INSERT 10
+-- With GDD enabled, QD will only hold lock on root for insert
+1: select * from show_locks_lockmodes;
+ locktype | mode             | granted | relation                
+----------+------------------+---------+-------------------------
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml 
+(1 row)
 1: ROLLBACK;
 ROLLBACK
 1q: ... <quitting>

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -31,8 +31,10 @@ test: prevent_ao_wal
 # so must be scheduled after that one.
 test: packcore
 
+test: insert_root_partition_truncate_deadlock_without_gdd
 # Tests on global deadlock detector
 test: gdd/prepare
+test: gdd/insert_root_partition_truncate_deadlock
 test: gdd/concurrent_update
 test: gdd/dist-deadlock-01 gdd/dist-deadlock-04 gdd/dist-deadlock-05 gdd/dist-deadlock-06 gdd/dist-deadlock-07 gdd/dist-deadlock-102 gdd/dist-deadlock-103 gdd/dist-deadlock-104 gdd/dist-deadlock-106 gdd/non-lock-105
 test: gdd/dist-deadlock-upsert

--- a/src/test/isolation2/sql/gdd/insert_root_partition_truncate_deadlock.sql
+++ b/src/test/isolation2/sql/gdd/insert_root_partition_truncate_deadlock.sql
@@ -1,0 +1,32 @@
+-- Insert statement on root partition, if GDD is enabled, QD will not lock leaf
+-- parititions for better concurrency performance. So when the insert statement
+-- is dispatched to segments async, some of statement will lock leaf partition
+-- and execute, some might be blocked by other sessions and lead to global
+-- deadlock. This test file is in GDD suites, it verify that such deadlock can
+-- be broken by GDD.
+-- See Issue https://github.com/greenplum-db/gpdb/issues/13652 for details.
+
+-- NOTE: this test case is better to run both with GDD and withoug GDD.
+-- with GDD it is running within gdd test suites to test GDD can break the deadlock;
+-- without GDD it is running to show that no deadlock happens.
+
+create table rank_13652 (id int, year int)
+partition by range (year)
+(start (2006) end (2009) every (1));
+
+select gp_inject_fault('func_init_plan_end', 'suspend', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+
+1&: insert into rank_13652 select i,i%3+2006 from generate_series(1, 30)i;
+select gp_wait_until_triggered_fault('func_init_plan_end', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+
+2&: truncate rank_13652_1_prt_2;
+
+select gp_inject_fault('func_init_plan_end', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+
+1<:
+2<:
+
+1q:
+2q:
+
+drop table rank_13652;

--- a/src/test/isolation2/sql/insert_root_partition_truncate_deadlock_without_gdd.sql
+++ b/src/test/isolation2/sql/insert_root_partition_truncate_deadlock_without_gdd.sql
@@ -1,0 +1,32 @@
+-- Insert statement on root partition, if GDD is enabled, QD will not lock leaf
+-- parititions for better concurrency performance. So when the insert statement
+-- is dispatched to segments async, some of statement will lock leaf partition
+-- and execute, some might be blocked by other sessions and lead to global
+-- deadlock. This test file is in GDD suites, it verify that such deadlock can
+-- be broken by GDD.
+-- See Issue https://github.com/greenplum-db/gpdb/issues/13652 for details.
+
+-- NOTE: this test case is better to run both with GDD and withoug GDD.
+-- with GDD it is running within gdd test suites to test GDD can break the deadlock;
+-- without GDD it is running to show that no deadlock happens.
+
+create table rank_13652 (id int, year int)
+partition by range (year)
+(start (2006) end (2009) every (1));
+
+select gp_inject_fault('func_init_plan_end', 'suspend', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+
+1&: insert into rank_13652 select i,i%3+2006 from generate_series(1, 30)i;
+select gp_wait_until_triggered_fault('func_init_plan_end', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+
+2&: truncate rank_13652_1_prt_2;
+
+select gp_inject_fault('func_init_plan_end', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+
+1<:
+2<:
+
+1q:
+2q:
+
+drop table rank_13652;

--- a/src/test/regress/expected/partition_locking.out
+++ b/src/test/regress/expected/partition_locking.out
@@ -261,10 +261,13 @@ insert into partlockt values(1), (2), (3);
 insert into partlockt values(1), (2), (3);
 insert into partlockt values(1), (2), (3);
 select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
- coalesce  |       mode       | locktype |  node  
------------+------------------+----------+--------
- partlockt | RowExclusiveLock | relation | master
-(1 row)
+     coalesce      |       mode       | locktype |  node  
+-------------------+------------------+----------+--------
+ partlockt         | RowExclusiveLock | relation | master
+ partlockt_1_prt_1 | RowExclusiveLock | relation | master
+ partlockt_1_prt_2 | RowExclusiveLock | relation | master
+ partlockt_1_prt_3 | RowExclusiveLock | relation | master
+(4 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
      coalesce      |       mode       | locktype |    node    
@@ -420,10 +423,19 @@ begin;
 -- insert locking
 insert into partlockt values(3, 'f');
 select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
- coalesce  |       mode       | locktype |  node  
------------+------------------+----------+--------
- partlockt | RowExclusiveLock | relation | master
-(1 row)
+     coalesce      |       mode       | locktype |  node  
+-------------------+------------------+----------+--------
+ partlockt         | RowExclusiveLock | relation | master
+ partlockt_1_prt_1 | RowExclusiveLock | relation | master
+ partlockt_1_prt_2 | RowExclusiveLock | relation | master
+ partlockt_1_prt_3 | RowExclusiveLock | relation | master
+ partlockt_1_prt_4 | RowExclusiveLock | relation | master
+ partlockt_1_prt_5 | RowExclusiveLock | relation | master
+ partlockt_1_prt_6 | RowExclusiveLock | relation | master
+ partlockt_1_prt_7 | RowExclusiveLock | relation | master
+ partlockt_1_prt_8 | RowExclusiveLock | relation | master
+ partlockt_1_prt_9 | RowExclusiveLock | relation | master
+(10 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
      coalesce      |       mode       | locktype |   node    

--- a/src/test/regress/expected/partition_locking_optimizer.out
+++ b/src/test/regress/expected/partition_locking_optimizer.out
@@ -261,10 +261,13 @@ insert into partlockt values(1), (2), (3);
 insert into partlockt values(1), (2), (3);
 insert into partlockt values(1), (2), (3);
 select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
- coalesce  |       mode       | locktype |  node  
------------+------------------+----------+--------
- partlockt | RowExclusiveLock | relation | master
-(1 row)
+     coalesce      |       mode       | locktype |  node  
+-------------------+------------------+----------+--------
+ partlockt         | RowExclusiveLock | relation | master
+ partlockt_1_prt_1 | RowExclusiveLock | relation | master
+ partlockt_1_prt_2 | RowExclusiveLock | relation | master
+ partlockt_1_prt_3 | RowExclusiveLock | relation | master
+(4 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
      coalesce      |       mode       | locktype |    node    
@@ -423,10 +426,19 @@ begin;
 -- insert locking
 insert into partlockt values(3, 'f');
 select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
- coalesce  |       mode       | locktype |  node  
------------+------------------+----------+--------
- partlockt | RowExclusiveLock | relation | master
-(1 row)
+     coalesce      |       mode       | locktype |  node  
+-------------------+------------------+----------+--------
+ partlockt         | RowExclusiveLock | relation | master
+ partlockt_1_prt_1 | RowExclusiveLock | relation | master
+ partlockt_1_prt_2 | RowExclusiveLock | relation | master
+ partlockt_1_prt_3 | RowExclusiveLock | relation | master
+ partlockt_1_prt_4 | RowExclusiveLock | relation | master
+ partlockt_1_prt_5 | RowExclusiveLock | relation | master
+ partlockt_1_prt_6 | RowExclusiveLock | relation | master
+ partlockt_1_prt_7 | RowExclusiveLock | relation | master
+ partlockt_1_prt_8 | RowExclusiveLock | relation | master
+ partlockt_1_prt_9 | RowExclusiveLock | relation | master
+(10 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
      coalesce      |       mode       | locktype |   node    


### PR DESCRIPTION
Greenplum will lock relation on QD during parse-analyze stage and then
dispatch the plan to QEs to execute. Note the dispatch is async. For
insert statement on root, we cannot predict which leaf partitions will
be inserted. Thus, if we never lock leaf partitions on QD, this leads
to async dispatch to QEs, means, some of the session's QEs will
execute insert and hold locks, some of the session's QEs might be
blocked by other sessions. The problematical lock pattern in MPP
database  is: without locks on QD and first time hold lock is on QEs.

An global deadlock case is:

First, create a partition table

```sql
create table rank (id int, year int)
distributed randomly
partition by range (year)
(start (2006) end (2009) every (1));
```

Second, in a new session (named `sess1`)

```sql
set gp_vmem_idle_resource_timeout = 1000000; -- make sure IDLE QEs not recycled
select pg_backend_pid(); -- find the QD's process id
select sess_id from pg_stat_activity where pid = pg_backend_pid(); -- this is to find the session id
select * from gp_dist_random('gp_id'); -- this is to create a gang
-- now run ps -ef | grep postgres | grep con<session id> we can get the QEs' pids

-- Use GDB to attach to one of this session's  QE
-- In GDB, set a break point at exec_mpp_query
-- (gdb) b exec_mpp_query
-- then continue
-- (gdb) c

-- now we run insert into this partition table by directly inserting into the root
insert into rank select i,i%3+2006 from generate_series(1, 1000)i;
-- the above insert will hang, because we set a break point on one of its QE
```

Third, start a new session (named `sess2`)

```sql
truncate rank_1_prt_2; -- truncate a leaf
-- the above truncate SQL will not be blocked on QD, because sess 1's insert do not hold locks for leafs on QD
-- so the above truncate will be dispatched to segments
-- on the segments that we do not set break point of sess1's QE, this truncation can execute, and hold locks on the
-- leaf relation; however, on the other segments, this truncation will be blocked by the insert statement on leaf locks
-- it will hang now
```

Finally, quit the gdb of session 1's QE, then that QE will continue and try to hold locks on leaf, and will be blocked by
the truncate.

Thus deadlock happens:
* on one segment, sess1 wait for sess 2 (insert wait for the truncate)
* on the other segments, sess 2 wait for sess 1(truncate wait for insert)

See Issue https://github.com/greenplum-db/gpdb/issues/13652 for
details.

This commit fixes the issue by locking all leaf partitions on QD
during parse-analyze stage when GDD is disabled. If GDD is enabled, we
can break global deadlock.
