### PR TITLE
Resolve GPDB_12_MERGE_FIXME in subselect.sql

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -2848,6 +2848,8 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 	RelOptInfo *sub_final_rel;
 	Relids		required_outer;
 	bool		is_shared;
+	Query           *subquery = NULL;
+	bool            contain_volatile_function = false;
 
 	/*
 	 * Find the referenced CTE based on the given range table entry
@@ -2874,6 +2876,12 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 		elog(ERROR, "could not find CTE \"%s\"", rte->ctename);
 
 	Assert(IsA(cte->ctequery, Query));
+	/*
+	 * Copy query node since subquery_planner may trash it, and we need it
+	 * intact in case we need to create another plan for the CTE
+	 */
+	subquery = (Query *) copyObject(cte->ctequery);
+	contain_volatile_function = contain_volatile_functions((Node *) subquery);
 
 	/*
 	 * In PostgreSQL, we use the index to look up the plan ID in the
@@ -2932,19 +2940,14 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 			is_shared = true;
 			break;
 		default:
-			is_shared =  root->config->gp_cte_sharing && cte->cterefcount > 1;
+			/* if plan sharing is enabled and contains volatile functions in the CTE query, also generate a shared scan plan */
+			is_shared =  root->config->gp_cte_sharing && (cte->cterefcount > 1 || contain_volatile_function);
 
 	}
 
 	if (!is_shared)
 	{
 		PlannerConfig *config = CopyPlannerConfig(root->config);
-
-		/*
-		 * Copy query node since subquery_planner may trash it, and we need it
-		 * intact in case we need to create another plan for the CTE
-		 */
-		Query	   *subquery = (Query *) copyObject(cte->ctequery);
 
 		/*
 		 * Having multiple SharedScans can lead to deadlocks. For now,
@@ -2969,8 +2972,13 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 
 			/*
 			 * Push down quals, like we do in set_subquery_pathlist()
+			 *
+			 * If the subquery contains volatile functions, like we prevent inlining
+			 * when gp_cte_sharing is enables, we don't push down quals when gp_cte_sharing
+			 * is disabled either, as push down may cause wrong results.
 			 */
-			subquery = push_down_restrict(root, rel, rte, rel->relid, subquery);
+			if (!contain_volatile_function)
+				subquery = push_down_restrict(root, rel, rte, rel->relid, subquery);
 
 			subroot = subquery_planner(cteroot->glob, subquery, root,
 									   cte->cterecursive,
@@ -2998,12 +3006,6 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 		if (cteplaninfo->subroot == NULL)
 		{
 			PlannerConfig *config = CopyPlannerConfig(root->config);
-
-			/*
-			 * Copy query node since subquery_planner may trash it and we need
-			 * it intact in case we need to create another plan for the CTE
-			 */
-			Query	   *subquery = (Query *) copyObject(cte->ctequery);
 
 			/*
 			 * Having multiple SharedScans can lead to deadlocks. For now,

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -1154,16 +1154,10 @@ set optimizer to off;
 -- Test that LIMIT can be pushed to SORT through a subquery that just projects
 -- columns.  We check for that having happened by looking to see if EXPLAIN
 -- ANALYZE shows that a top-N sort was used.  We must suppress or filter away
--- all the non-invariant parts of the EXPLAIN ANALYZE output.
+-- all the non-invariant parts of the EXPLAIN ANALYZE output. Use a replicated
+-- table to genarate a plan like: Limit -> Subquery -> Sort
 --
--- GPDB_12_MERGE_FIXME: we need to revisit the following test because it is not
--- testing what it advertized in the above comment. Specificly, we don't
--- execute top-N sort for the planner plan. Orca on the other hand never honors
--- ORDER BY in a subquery, as permitted by the SQL spec.  Consider rewriting
--- the test using a replicated table so that we get the plan stucture like
--- this: Limit -> Subquery -> Sort
---
-create table sq_limit (pk int primary key, c1 int, c2 int);
+create table sq_limit (pk int primary key, c1 int, c2 int) distributed replicated;
 insert into sq_limit values
     (1, 1, 1),
     (2, 2, 2),
@@ -1189,18 +1183,17 @@ begin
 end;
 $$;
 select * from explain_sq_limit();
-                              explain_sq_limit                              
-----------------------------------------------------------------------------
- Limit (actual rows=3 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
-         ->  Limit (actual rows=3 loops=1)
-               ->  Subquery Scan on x (actual rows=3 loops=1)
-                     ->  Sort (actual rows=3 loops=1)
-                           Sort Key: sq_limit.c1, sq_limit.pk
-                           Sort Method:  quicksort  Memory: xxx
-                           ->  Seq Scan on sq_limit (actual rows=5 loops=1)
+                           explain_sq_limit                           
+----------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1) (actual rows=3 loops=1)
+   ->  Limit (actual rows=3 loops=1)
+         ->  Subquery Scan on x (actual rows=3 loops=1)
+               ->  Sort (actual rows=3 loops=1)
+                     Sort Key: sq_limit.c1, sq_limit.pk
+                     Sort Method:  top-N heapsort  Memory: xxx
+                     ->  Seq Scan on sq_limit (actual rows=8 loops=1)
  Optimizer: Postgres query optimizer
-(9 rows)
+(8 rows)
 
 -- a subpath is sorted under a subqueryscan. however, the subqueryscan is not.
 -- whether the order of subpath can applied to the subqueryscan is up-to-implement.
@@ -1292,24 +1285,48 @@ select * from x where f1 = 1;
 (7 rows)
 
 -- Volatile functions prevent inlining
--- GPDB_12_MERGE_FIXME: inlining happens on GPDB: But the plan seems OK
--- nevertheless. Is the GPDB planner smart, and notices that this is
--- ok to inline, or is it doing something that would be unsafe in more
--- complicated queries? Investigte
+-- Prevent inlining happens on GPDB, inlining may cause wrong results.
+-- For example, nextval() function.
 explain (verbose, costs off)
 with x as (select * from (select f1, random() from subselect_tbl) ss)
 select * from x where f1 = 1;
-                 QUERY PLAN                 
---------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)
-   Output: subselect_tbl.f1, (random())
-   ->  Seq Scan on public.subselect_tbl
-         Output: subselect_tbl.f1, random()
-         Filter: (subselect_tbl.f1 = 1)
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: x.f1, x.random
+   ->  Subquery Scan on x
+         Output: x.f1, x.random
+         Filter: (x.f1 = 1)
+         ->  Shared Scan (share slice:id 1:0)
+               Output: share0_ref1.f1, share0_ref1.random
+               ->  Seq Scan on public.subselect_tbl
+                     Output: subselect_tbl.f1, random()
  Optimizer: Postgres query optimizer
- Settings: gp_cte_sharing=on, optimizer=off
-(7 rows)
+(10 rows)
 
+create temporary sequence ts;
+create table vol_test(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+explain (verbose, costs off)
+with x as (select * from (select a, nextval('ts') from vol_test) ss)
+select * from x where a = 1;
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: x.a, x.nextval
+   ->  Subquery Scan on x
+         Output: x.a, x.nextval
+         Filter: (x.a = 1)
+         ->  Shared Scan (share slice:id 1:0)
+               Output: share0_ref1.a, share0_ref1.nextval
+               ->  Seq Scan on public.vol_test
+                     Output: vol_test.a, nextval('ts'::regclass)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+drop sequence ts;
+drop table vol_test;
 -- SELECT FOR UPDATE cannot be inlined
 -- GPDB: select statement with locking clause is not easy to fully supported
 -- in greenplum. The following case even with GDD enabled greenplum will still

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -1190,16 +1190,10 @@ set optimizer to off;
 -- Test that LIMIT can be pushed to SORT through a subquery that just projects
 -- columns.  We check for that having happened by looking to see if EXPLAIN
 -- ANALYZE shows that a top-N sort was used.  We must suppress or filter away
--- all the non-invariant parts of the EXPLAIN ANALYZE output.
+-- all the non-invariant parts of the EXPLAIN ANALYZE output. Use a replicated
+-- table to genarate a plan like: Limit -> Subquery -> Sort
 --
--- GPDB_12_MERGE_FIXME: we need to revisit the following test because it is not
--- testing what it advertized in the above comment. Specificly, we don't
--- execute top-N sort for the planner plan. Orca on the other hand never honors
--- ORDER BY in a subquery, as permitted by the SQL spec.  Consider rewriting
--- the test using a replicated table so that we get the plan stucture like
--- this: Limit -> Subquery -> Sort
---
-create table sq_limit (pk int primary key, c1 int, c2 int);
+create table sq_limit (pk int primary key, c1 int, c2 int) distributed replicated;
 insert into sq_limit values
     (1, 1, 1),
     (2, 2, 2),
@@ -1225,18 +1219,17 @@ begin
 end;
 $$;
 select * from explain_sq_limit();
-                              explain_sq_limit                              
-----------------------------------------------------------------------------
- Limit (actual rows=3 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
-         ->  Limit (actual rows=3 loops=1)
-               ->  Subquery Scan on x (actual rows=3 loops=1)
-                     ->  Sort (actual rows=3 loops=1)
-                           Sort Key: sq_limit.c1, sq_limit.pk
-                           Sort Method:  quicksort  Memory: xxx
-                           ->  Seq Scan on sq_limit (actual rows=5 loops=1)
+                           explain_sq_limit                           
+----------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1) (actual rows=3 loops=1)
+   ->  Limit (actual rows=3 loops=1)
+         ->  Subquery Scan on x (actual rows=3 loops=1)
+               ->  Sort (actual rows=3 loops=1)
+                     Sort Key: sq_limit.c1, sq_limit.pk
+                     Sort Method:  top-N heapsort  Memory: xxx
+                     ->  Seq Scan on sq_limit (actual rows=8 loops=1)
  Optimizer: Postgres query optimizer
-(9 rows)
+(8 rows)
 
 -- a subpath is sorted under a subqueryscan. however, the subqueryscan is not.
 -- whether the order of subpath can applied to the subqueryscan is up-to-implement.
@@ -1319,10 +1312,8 @@ select * from x where f1 = 1;
 (7 rows)
 
 -- Volatile functions prevent inlining
--- GPDB_12_MERGE_FIXME: inlining happens on GPDB: But the plan seems OK
--- nevertheless. Is the GPDB planner smart, and notices that this is
--- ok to inline, or is it doing something that would be unsafe in more
--- complicated queries? Investigte
+-- Prevent inlining happens on GPDB, inlining may cause wrong results.
+-- For example, nextval() function.
 explain (verbose, costs off)
 with x as (select * from (select f1, random() from subselect_tbl) ss)
 select * from x where f1 = 1;
@@ -1344,8 +1335,37 @@ select * from x where f1 = 1;
                      Output: share0_ref2.f1, share0_ref2.random
  Optimizer: Pivotal Optimizer (GPORCA)
  Settings: gp_cte_sharing=on, optimizer=on
-(18 rows)
+(16 rows)
 
+create temporary sequence ts;
+create table vol_test(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+explain (verbose, costs off)
+with x as (select * from (select a, nextval('ts') from vol_test) ss)
+select * from x where a = 1;
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   Output: share0_ref2.a, share0_ref2.nextval
+   ->  Sequence
+         Output: share0_ref2.a, share0_ref2.nextval
+         ->  Shared Scan (share slice:id 1:0)
+               Output: share0_ref1.a, share0_ref1.nextval
+               ->  Seq Scan on public.vol_test
+                     Output: vol_test.a, nextval('ts'::regclass)
+                     Filter: (vol_test.a = 1)
+         ->  Result
+               Output: share0_ref2.a, share0_ref2.nextval
+               Filter: (share0_ref2.a = 1)
+               ->  Shared Scan (share slice:id 1:0)
+                     Output: share0_ref2.a, share0_ref2.nextval
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: gp_cte_sharing=on, optimizer=on
+(16 rows)
+
+drop sequence ts;
+drop table vol_test;
 -- SELECT FOR UPDATE cannot be inlined
 -- GPDB: select statement with locking clause is not easy to fully supported
 -- in greenplum. The following case even with GDD enabled greenplum will still


### PR DESCRIPTION
1. use replicated table to generate a plan like this:
Limit -> Subquery -> Sort. And insert more values into sq_limit to
make the sort use a top-N sort method.
2. prevent inlining happens if exists volatile function in CTE.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
