### PR TITLE
[6X] Fix issue caused by primary restart after streamed an incomplete cross-segment WAL

### DIFF
--- a/src/backend/access/rmgrdesc/xlogdesc.c
+++ b/src/backend/access/rmgrdesc/xlogdesc.c
@@ -223,6 +223,16 @@ xlog_desc(StringInfo buf, XLogRecord *record)
 						 xlrec.ThisTimeLineID, xlrec.PrevTimeLineID,
 						 timestamptz_to_str(xlrec.end_time));
 	}
+	else if (info == XLOG_OVERWRITE_CONTRECORD)
+	{
+		xl_overwrite_contrecord xlrec;
+
+		memcpy(&xlrec, rec, sizeof(xl_overwrite_contrecord));
+		appendStringInfo(buf, "lsn %X/%X; time %s",
+						 (uint32) (xlrec.overwritten_lsn >> 32),
+						 (uint32) xlrec.overwritten_lsn,
+						 timestamptz_to_str(xlrec.overwrite_time));
+	}
 	else
 		appendStringInfoString(buf, "UNKNOWN");
 }

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -10526,7 +10526,7 @@ VerifyOverwriteContrecord(XLogRecord *record, XLogReaderState *state)
 			 (uint32) state->overwrittenRecPtr);
 
 	ereport(LOG,
-			(errmsg("sucessfully skipped missing contrecord at %X/%X, overwritten at %s",
+			(errmsg("successfully skipped missing contrecord at %X/%X, overwritten at %s",
 					(uint32) (xlrec.overwritten_lsn >> 32),
 					(uint32) xlrec.overwritten_lsn,
 					timestamptz_to_str(xlrec.overwrite_time))));

--- a/src/backend/replication/logical/decode.c
+++ b/src/backend/replication/logical/decode.c
@@ -194,6 +194,7 @@ DecodeXLogOp(LogicalDecodingContext *ctx, XLogRecordBuffer *buf)
 		case XLOG_RESTORE_POINT:
 		case XLOG_FPW_CHANGE:
 		case XLOG_FPI:
+		case XLOG_OVERWRITE_CONTRECORD:
 			break;
 		default:
 			elog(ERROR, "unexpected RM_XLOG_ID record type: %u", info);

--- a/src/include/access/xlog_internal.h
+++ b/src/include/access/xlog_internal.h
@@ -103,8 +103,10 @@ typedef XLogLongPageHeaderData *XLogLongPageHeader;
 #define XLP_LONG_HEADER				0x0002
 /* This flag indicates backup blocks starting in this page are optional */
 #define XLP_BKP_REMOVABLE			0x0004
+/* Replaces a missing contrecord; see CreateOverwriteContrecordRecord */
+#define XLP_FIRST_IS_OVERWRITE_CONTRECORD 0x0008
 /* All defined flag bits in xlp_info (used for validity checking of header) */
-#define XLP_ALL_FLAGS				0x0007
+#define XLP_ALL_FLAGS				0x000F
 
 #define XLogPageHeaderSize(hdr)		\
 	(((hdr)->xlp_info & XLP_LONG_HEADER) ? SizeOfXLogLongPHD : SizeOfXLogShortPHD)
@@ -218,6 +220,13 @@ typedef struct xl_restore_point
 	TimestampTz rp_time;
 	char		rp_name[MAXFNAMELEN];
 } xl_restore_point;
+
+/* Overwrite of prior contrecord */
+typedef struct xl_overwrite_contrecord
+{
+	XLogRecPtr	overwritten_lsn;
+	TimestampTz overwrite_time;
+} xl_overwrite_contrecord;
 
 /* End of recovery mark, when we don't do an END_OF_RECOVERY checkpoint */
 typedef struct xl_end_of_recovery

--- a/src/include/access/xlogreader.h
+++ b/src/include/access/xlogreader.h
@@ -122,6 +122,16 @@ struct XLogReaderState
 
 	/* Buffer to hold error message */
 	char	   *errormsg_buf;
+
+	/*
+	 * Set at the end of recovery: the start point of a partial record at the
+	 * end of WAL (InvalidXLogRecPtr if there wasn't one), and the start
+	 * location of its first contrecord that went missing.
+	 */
+	XLogRecPtr	abortedRecPtr;
+	XLogRecPtr	missingContrecPtr;
+	/* Set when XLP_FIRST_IS_OVERWRITE_CONTRECORD is found */
+	XLogRecPtr	overwrittenRecPtr;
 };
 
 /* Get a new XLogReader */

--- a/src/include/catalog/pg_control.h
+++ b/src/include/catalog/pg_control.h
@@ -77,6 +77,7 @@ typedef struct CheckPoint
 #define XLOG_END_OF_RECOVERY			0x90
 #define XLOG_FPI						0xA0
 #define XLOG_NEXTRELFILENODE			0xB0
+#define XLOG_OVERWRITE_CONTRECORD		0xC0
 
 
 /*

--- a/src/test/perl/PostgresNode.pm
+++ b/src/test/perl/PostgresNode.pm
@@ -424,6 +424,12 @@ sub init
 	# print $conf "wal_retrieve_retry_interval = '500ms'\n";
 	print $conf "port = $port\n";
 
+	# In GPDB, logging_collector is enabled by default. Disable it, so that
+	# upstream tests behave the same as in PostgreSQL. In particular, the
+	# issues_sql_like() doesn't work if logging_collector is enabled.
+	# Individual tests can override this.
+	print $conf "logging_collector = off\n";
+
 	if ($params{allows_streaming})
 	{
 		print $conf "wal_level = hot_standby\n";
@@ -699,7 +705,7 @@ sub start
 	BAIL_OUT("node \"$name\" is already running") if defined $self->{_pid};
 	print("### Starting node \"$name\"\n");
 	my $ret = TestLib::system_log('pg_ctl', '-w', '-D', $self->data_dir, '-l',
-		$self->logfile, '-o', "-c gp_role=utility --gp_dbid=$self->{_dbid} --gp_contentid=0 --logging-collector=on",
+		$self->logfile, '-o', "-c gp_role=utility --gp_dbid=$self->{_dbid} --gp_contentid=0",
 		'start');
 
 	if ($ret != 0)

--- a/src/test/recovery/t/026_overwrite_contrecord.pl
+++ b/src/test/recovery/t/026_overwrite_contrecord.pl
@@ -107,7 +107,7 @@ ok($node->safe_psql('postgres', 'select * from foo') eq 'hello',
 my $log = slurp_file($node_standby->logfile);
 like(
 	$log,
-	qr[sucessfully skipped missing contrecord at],
+	qr[successfully skipped missing contrecord at],
 	"found log line in standby");
 
 $node_standby->stop;

--- a/src/test/recovery/t/026_overwrite_contrecord.pl
+++ b/src/test/recovery/t/026_overwrite_contrecord.pl
@@ -25,39 +25,35 @@ $node->append_conf('postgresql.conf', 'wal_keep_segments=16');
 $node->append_conf('postgresql.conf', 'hot_standby=off');
 $node->start;
 
-$node->safe_psql('postgres', 'create table filler (a int)');
+$node->safe_psql('postgres', 'create table filler (a int, b text)');
 $node->safe_psql('postgres', 'create table t (a int, b int[]) WITH (appendonly=true, blocksize=2097152)');
-
-# First, measure how many bytes does the insertion of 1000 rows produce
-my $start_lsn = $node->safe_psql('postgres',
-	q{select pg_current_xlog_insert_location() - '0/0'});
-$node->safe_psql('postgres',
-	'insert into filler select * from generate_series(1, 1000)');
-my $end_lsn = $node->safe_psql('postgres',
-	q{select pg_current_xlog_insert_location() - '0/0'});
-my $rows_walsize = $end_lsn - $start_lsn;
-note "rows walsize $rows_walsize";
-
-note "before fill ",
-  $node->safe_psql('postgres', 'select pg_current_xlog_insert_location()');
 
 # Now consume all remaining room in the current WAL segment, leaving
 # space enough only for the start of a largish record.
 $node->safe_psql(
-	'postgres', qq{
-WITH segsize AS (
-  SELECT setting::int
-    FROM pg_settings WHERE name = 'wal_segment_size'
-), walblksz AS (
-  SELECT setting::int
-    FROM pg_settings WHERE name = 'wal_block_size'
-), setting AS (
-  SELECT segsize.setting * walblksz.setting AS wal_segsize
-    FROM segsize, walblksz
-)
-INSERT INTO filler
-SELECT g FROM setting,
-  generate_series(1, (1000 * (wal_segsize - ((pg_current_xlog_insert_location() - '0/0') % wal_segsize)) / $rows_walsize)::bigint) g
+	'postgres', q{
+DO $$
+DECLARE
+    wal_segsize int :=
+        (max(setting) filter (where name = 'wal_segment_size'))::int *
+        (max(setting) filter (where name = 'wal_block_size'))::int from pg_settings ;
+    remain int;
+    iters  int := 0;
+BEGIN
+    LOOP
+        INSERT into filler
+        select g, repeat(md5(g::text), (random() * 60 + 1)::int)
+        from generate_series(1, 10) g;
+
+        remain := wal_segsize - (pg_current_xlog_insert_location() - '0/0') % wal_segsize;
+        IF remain < 2 * setting::int from pg_settings where name = 'block_size' THEN
+            RAISE log 'exiting after % iterations, % bytes to end of WAL segment', iters, remain;
+            EXIT;
+        END IF;
+        iters := iters + 1;
+    END LOOP;
+END
+$$;
 });
 
 $node->safe_psql('postgres', 'checkpoint');

--- a/src/test/recovery/t/026_overwrite_contrecord.pl
+++ b/src/test/recovery/t/026_overwrite_contrecord.pl
@@ -1,0 +1,118 @@
+# Copyright (c) 2021, PostgreSQL Global Development Group
+
+# Tests for already-propagated WAL segments ending in incomplete WAL records.
+
+use strict;
+use warnings;
+
+use FindBin;
+use PostgresNode;
+use TestLib;
+use Test::More;
+
+plan tests => 3;
+
+# Test: Create a physical replica that's missing the last WAL file,
+# then restart the primary to create a divergent WAL file and observe
+# that the replica replays the "overwrite contrecord" from that new
+# file.
+
+my $node = PostgresNode->get_new_node('primary');
+$node->init(allows_streaming => 1);
+$node->append_conf('postgresql.conf', 'wal_keep_segments=16');
+# TAP tests enabled this by default. Unfornately it would create a 
+# PANIC on standby for the end-of-recovery checkpoint of primary.
+$node->append_conf('postgresql.conf', 'hot_standby=off');
+$node->start;
+
+$node->safe_psql('postgres', 'create table filler (a int)');
+$node->safe_psql('postgres', 'create table t (a int, b int[]) WITH (appendonly=true, blocksize=2097152)');
+
+# First, measure how many bytes does the insertion of 1000 rows produce
+my $start_lsn = $node->safe_psql('postgres',
+	q{select pg_current_xlog_insert_location() - '0/0'});
+$node->safe_psql('postgres',
+	'insert into filler select * from generate_series(1, 1000)');
+my $end_lsn = $node->safe_psql('postgres',
+	q{select pg_current_xlog_insert_location() - '0/0'});
+my $rows_walsize = $end_lsn - $start_lsn;
+note "rows walsize $rows_walsize";
+
+note "before fill ",
+  $node->safe_psql('postgres', 'select pg_current_xlog_insert_location()');
+
+# Now consume all remaining room in the current WAL segment, leaving
+# space enough only for the start of a largish record.
+$node->safe_psql(
+	'postgres', qq{
+WITH segsize AS (
+  SELECT setting::int
+    FROM pg_settings WHERE name = 'wal_segment_size'
+), walblksz AS (
+  SELECT setting::int
+    FROM pg_settings WHERE name = 'wal_block_size'
+), setting AS (
+  SELECT segsize.setting * walblksz.setting AS wal_segsize
+    FROM segsize, walblksz
+)
+INSERT INTO filler
+SELECT g FROM setting,
+  generate_series(1, (1000 * (wal_segsize - ((pg_current_xlog_insert_location() - '0/0') % wal_segsize)) / $rows_walsize)::bigint) g
+});
+
+$node->safe_psql('postgres', 'checkpoint');
+
+note "start ",
+  $node->safe_psql('postgres', 'select pg_current_xlog_insert_location()');
+my $initfile = $node->safe_psql('postgres',
+	'SELECT pg_xlogfile_name(pg_current_xlog_insert_location())');
+$node->safe_psql('postgres',
+qq{INSERT INTO t SELECT 1, array_agg(x) from generate_series(1, 24000) x}
+);
+
+my $endfile = $node->safe_psql('postgres',
+	'SELECT pg_xlogfile_name(pg_current_xlog_insert_location())');
+note "end: ",
+  $node->safe_psql('postgres', 'select pg_current_xlog_insert_location()');
+ok($initfile != $endfile, "$initfile differs from $endfile");
+
+# Now stop abruptly, to avoid a stop checkpoint.  We can remove the tail file
+# afterwards, and on startup the large message should be overwritten with new
+# contents
+$node->stop('immediate');
+
+unlink $node->basedir . "/pgdata/pg_xlog/$endfile"
+  or die "could not unlink "
+  . $node->basedir
+  . "/pgdata/pg_xlog/$endfile: $!";
+
+# OK, create a standby at this spot.
+$node->backup_fs_cold('backup');
+my $node_standby = PostgresNode->get_new_node('standby');
+$node_standby->init_from_backup($node, 'backup', has_streaming => 1);
+
+$node_standby->start;
+$node->start;
+
+$node->safe_psql('postgres',
+	qq{create table foo (a text); insert into foo values ('hello')});
+
+# Have to query primary for mirror's replay status because hot_standby is disabled 
+my $until_lsn =
+  $node->safe_psql('postgres', "SELECT pg_current_xlog_insert_location()");
+my $caughtup_query =
+  "SELECT '$until_lsn'::pg_lsn <= replay_location from pg_stat_replication";
+$node->poll_query_until('postgres', $caughtup_query)
+  or die "Timed out while waiting for standby to catch up";
+ok($node->safe_psql('postgres', 'select * from foo') eq 'hello',
+	'standby replays past overwritten contrecord');
+
+# Verify message appears in standby's log
+my $log = slurp_file($node_standby->logfile);
+like(
+	$log,
+	qr[sucessfully skipped missing contrecord at],
+	"found log line in standby");
+
+$node_standby->stop;
+$node->stop;

--- a/src/tools/pgindent/typedefs.list
+++ b/src/tools/pgindent/typedefs.list
@@ -2579,6 +2579,7 @@ xl_invalid_page
 xl_invalid_page_key
 xl_multi_insert_tuple
 xl_multixact_create
+xl_overwrite_contrecord
 xl_parameter_change
 xl_relmap_update
 xl_restore_point


### PR DESCRIPTION
Backport from upstream commit 148c6ee3be39be61968d580eaafc93795aed1f0c
The corresponding 7X PR for GPDB is https://github.com/greenplum-db/gpdb/pull/13648

GPDB related message
====================
We saw similar issue in GPDB where an incomplete cross-segment WAL
record can cause the mirror to try to stream from the next segment,
whereas the primary has a flush point somewhere at the end of the
previous segment. So the primary saw:
    requested starting point D81/54000000 is ahead of the WAL flush position of this server D81/53FF7FE8

In fact, the test scenario in this commit (026_overwrite_contrecord.pl)
would produce the above error w/o the fix, instead of the one mentioned
in the upstream commit message, at least for GPDB.
But the main difference is just whether the primary has written &
flushed enough data to move its flush point beyond the segment boundary.
The fix would fix both errors.

Note that, because there are some differences between GPDB6 (which
based on PG9.4) and PG9.6 which is the closest version that this fix
has been backported to in upstream, we had to make some changes in
order to cherrypick it to GPDB6:
* Move VerifyOverwriteContrecord() to StartupXLOG because we need the
  xlogreader which isn't there in xlog_redo.
* Change CreateOverwriteContrecordRecord() accordingly because of the
  difference in XLogInsert();
* Disable log collector because we need to examine the log. I brought
  the related changes from GPDB7 for this.
* Use AO table insertion instead of pg_logical_emit_message() which
  isn't there in GPDB6.
* Disable hot standby in the test because it causes an issue. Have to
  use sleep instead of querying the mirror to wait for it to catch up.

Original commit message
==========================

Physical replication always ships WAL segment files to replicas once
they are complete.  This is a problem if one WAL record is split across
a segment boundary and the primary server crashes before writing down
the segment with the next portion of the WAL record: WAL writing after
crash recovery would happily resume at the point where the broken record
started, overwriting that record ... but any standby or backup may have
already received a copy of that segment, and they are not rewinding.
This causes standbys to stop following the primary after the latter
crashes:
  LOG:  invalid contrecord length 7262 at A8/D9FFFBC8
because the standby is still trying to read the continuation record
(contrecord) for the original long WAL record, but it is not there and
it will never be.  A workaround is to stop the replica, delete the WAL
file, and restart it -- at which point a fresh copy is brought over from
the primary.  But that's pretty labor intensive, and I bet many users
would just give up and re-clone the standby instead.

A fix for this problem was already attempted in commit 515e3d84a0b5, but
it only addressed the case for the scenario of WAL archiving, so
streaming replication would still be a problem (as well as other things
such as taking a filesystem-level backup while the server is down after
having crashed), and it had performance scalability problems too; so it
had to be reverted.

This commit fixes the problem using an approach suggested by Andres
Freund, whereby the initial portion(s) of the split-up WAL record are
kept, and a special type of WAL record is written where the contrecord
was lost, so that WAL replay in the replica knows to skip the broken
parts.  With this approach, we can continue to stream/archive segment
files as soon as they are complete, and replay of the broken records
will proceed across the crash point without a hitch.

Because a new type of WAL record is added, users should be careful to
upgrade standbys first, primaries later. Otherwise they risk the standby
being unable to start if the primary happens to write such a record.

A new TAP test that exercises this is added, but the portability of it
is yet to be seen.

This has been wrong since the introduction of physical replication, so
backpatch all the way back.  In stable branches, keep the new
XLogReaderState members at the end of the struct, to avoid an ABI
break.

Author: Álvaro Herrera <alvherre@alvh.no-ip.org>
Reviewed-by: Kyotaro Horiguchi <horikyota.ntt@gmail.com>
Reviewed-by: Nathan Bossart <bossartn@amazon.com>
Discussion: https://postgr.es/m/202108232252.dh7uxf6oxwcy@alvherre.pgsql