### PR TITLE
skip red-zone check in some situations

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3708,7 +3708,7 @@ struct config_int ConfigureNamesInt_gp[] =
 
 	{
 		{"runaway_detector_activation_percent", PGC_POSTMASTER, RESOURCES_MEM,
-			gettext_noop("The runaway detector activates if the used vmem exceeds this percentage of the vmem quota. Set to 100 to disable runaway detection."),
+			gettext_noop("The runaway detector activates if the used vmem exceeds this percentage of the vmem quota. Set to 0 or 100 to disable runaway detection."),
 			NULL,
 		},
 		&runaway_detector_activation_percent,


### PR DESCRIPTION
When we set `runaway_detector_activation_percent` to 100 means to disable runaway detection,
this should apply to Vmem Tracker and Resource Group. 

However, in current implementation, we will still invoke `IsGroupInRedZone()` if we enabled resource
group if we set `runaway_detector_activation_percent` to 0 or 100. And in function `IsGroupInRedZone()`
has some automatic operation to read variables. At the same time `RedZoneHandler_IsVmemRedZone` 
is a very frequently called function, so this will waste a lot of CPU resources.

When we init Red-Zone Handler, will set `redZoneChunks` to `INT32_MAX` if we disable runaway
detection, so we can use it to judge whether we are in Red-Zone or not quickly.

No more tests need, since current unit tests already have cases covering this situation.

Besides, remove the wrong test file of `resgroup_memory_runaway.source`, runaway detection should be
disabled when we enable resource group.