### PR TITLE
[README][typo] fix gpdemo path typo

### DIFF
--- a/configure
+++ b/configure
@@ -570,7 +570,6 @@ ac_hostname=`(hostname || uname -n) 2>/dev/null | sed 1q`
 #
 # Initializations.
 #
-ac_default_prefix=/usr/local
 ac_clean_files=
 ac_config_libobj_dir=.
 LIBOBJS=

--- a/gpAux/gpdemo/README
+++ b/gpAux/gpdemo/README
@@ -37,7 +37,7 @@ RUNNING GP DEMO
 
 3. Source greenplum_path.sh
 
-	. /usr/local/greenplum-db/greenplum_path.sh
+	. /usr/local/gpdb/greenplum_path.sh
 
    Note: There is a space between the dot and the slash.
 


### PR DESCRIPTION
The configure default prefix is `/usr/local/gpdb`, and the top
README also use `/usr/local/gpdb` as the prefix, so there is
large chance that developer will use `/usr/local/gpdb` instead
of `/usr/local/greenplum_db`.

This change will eliminate the newcomers' confusion.

The patch also remove the duplicate init of `ac_default_prefix`

Signed-off-by: Junwang Zhao <zhjwpku@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
