### PR TITLE
[6X] Fix a flaky test checkpoint_memleak

### DIFF
--- a/src/test/isolation2/expected/checkpoint_memleak.out
+++ b/src/test/isolation2/expected/checkpoint_memleak.out
@@ -63,6 +63,15 @@ SELECT gp_request_fts_probe_scan();
  t                         
 (1 row)
 
+-- Bring back primary and wait until primary and mirror are up & running
+!\retcode gprecoverseg -a;
+(exited with code 0)
+SELECT wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
 -- If there's a memory leak we'll print a special log message. Search if such log record exists, if so,
 -- we might have a memory leak. Check the log for more information about the memory usage.
 -- Note that currently we are only checking MdCxt.
@@ -72,14 +81,7 @@ select count(*) from gp_toolkit.__gp_log_segment_ext where logsegment = 'seg1' a
  0     
 (1 row)
 
--- Bring back primary and re-balance.
-!\retcode gprecoverseg -a;
-(exited with code 0)
-SELECT wait_until_all_segments_synchronized();
- wait_until_all_segments_synchronized 
---------------------------------------
- OK                                   
-(1 row)
+-- re-balance
 !\retcode gprecoverseg -ra;
 (exited with code 0)
 SELECT wait_until_all_segments_synchronized();


### PR DESCRIPTION
The test fails sometimes because it takes too long for the mirror to be promoted. E.g.:

```
2022-06-03 22:00:54.035647 ,"statement: SELECT pg_ctl(datadir, 'stop', 'immediate') FROM gp_segment_configuration WHERE role = 'p' AND content = 1;",,,,,,"SELECT pg_ctl(datadir, 'stop', 'immediate') FROM gp_segment_configuration WHERE role = 'p' AND content = 1;"
...
2022-06-03 22:00:59.077389 ,"segment is in reset/recovery mode (seg1 10.254.0.10:6006)",,,,,,"select count(*) from gp_toolkit.__gp_log_segment_ext where logsegment = 'seg1' and logtime > (select * from t_ckpt_memleak_test_timestamp) and logmessage like '[CheckpointMemoryLeakTest] Possible memory leak %';"
...
2022-06-03 22:01:12.016995 ,"failed to acquire resources on one or more segments","Segments are in reset/recovery mode.",,,,,"select count(*) from gp_toolkit.__gp_log_segment_ext where logsegment = 'seg1' and logtime > (select * from t_ckpt_memleak_test_timestamp) and logmessage like '[CheckpointMemoryLeakTest] Possible memory leak %';",
```

Mirror took more than 15 seconds in reset/recovery mode and the query quickly errored out.

Fixing this by recover the old primary (now new mirror) first,
and simply relying on the existing wait_until_all_segments_synchronized()
function to make sure the new primary/mirror are up and running.

Thanks to @soumyadeep2007 who caught this issue and provided initial triage.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
