### PR TITLE
[gpdemo] polish checkDemoConfig

### DIFF
--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -82,9 +82,8 @@ checkDemoConfig(){
         return 1
     fi
 
-    for (( i=0; i<`expr 4 \* $NUM_PRIMARY_MIRROR_PAIRS`; i++ )); do
-	PORT_NUM=`expr $DEMO_PORT_BASE + $i`
-
+    # Check if all Segment Ports are free
+    for PORT_NUM in ${DEMO_SEG_PORTS_LIST}; do
         echo "  Segment port check .. : ${PORT_NUM}"
         PORT_FILE="/tmp/.s.PGSQL.${PORT_NUM}"
         if [ -f ${PORT_FILE} -o -S ${PORT_FILE} ] ; then 


### PR DESCRIPTION
Here is the case:

If one gpdemo cluster with `PORT_BASE=7008` is running on the
machine, then a second gpdemo cluster with `PORT_BASE=7000`
runs `make check` will fail due to extra segment ports check.

It make no sense to check `4 * $NUM_PRIMARY_MIRROR_PAIRS` ports
since the needed segment ports are already list in
${DEMO_SEG_PORTS_LIST}, check only what we need.

Signed-off-by: Junwang Zhao <zhjwpku@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
