### PR TITLE
[WIP][6X] bugfix: Delete partition constraint on old_partition during EXCHANGE PARTITION

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -1244,6 +1244,17 @@ cdb_exchange_part_constraints(Relation table,
 					}
 				}
 			}
+			
+			/* 
+			 * The partition will become a normal table after exchange partition,
+			 * the partition check constraint should be deleted.
+			 */
+			ObjectAddress conobj;
+			conobj.classId = ConstraintRelationId;
+			conobj.objectId = HeapTupleGetOid(tuple);
+			conobj.objectSubId = 0;
+
+			performDeletion(&conobj, DROP_CASCADE, 0);
 		}
 		else if (list_length(entry->cand_cons) > 0) /* and none on whole or
 													 * part */

--- a/src/test/regress/expected/oid_consistency.out
+++ b/src/test/regress/expected/oid_consistency.out
@@ -270,7 +270,7 @@ select verify('constraint_pt1_1_prt_feb08');
 select verify('constraint_t1');
  verify 
 --------
-      1
+      0
 (1 row)
 
 SELECT * FROM constraint_pt1 ORDER BY date, id;
@@ -367,7 +367,7 @@ select verify('constraint_pt2_1_prt_feb08');
 select verify('constraint_t2');
  verify 
 --------
-      2
+      1
 (1 row)
 
 SELECT * FROM constraint_pt2 ORDER BY date, id;
@@ -512,7 +512,7 @@ select verify('constraint_pt3_1_prt_2_2_prt_3_3_prt_europe');
 select verify('constraint_t3');
  verify 
 --------
-      5
+      4
 (1 row)
 
 INSERT INTO constraint_pt3 SELECT i, 2001, 02, i, 'europe' FROM generate_series(11,15)i;

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -508,24 +508,13 @@ NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_9" for table "foo_p"
 create table bar_p(i int, j int) distributed by (i);
 insert into bar_p values(6, 6);
 alter table foo_p exchange partition for(rank(6)) with table bar_p;
--- Should fail.  Prior releases didn't convey constraints out via exchange
--- but we do now, so the following tries to insert a value that can't go
--- in part 6.
+-- issue#13663 Shouldn't fail. bar_p is still a normal table alter EXCHANGE PARTITION.
 insert into bar_p values(10, 10);
-ERROR:  new row for relation "bar_p" violates check constraint "foo_p_1_prt_6_check"  (seg2 127.0.0.1:25434 pid=10977)
-DETAIL:  Failing row contains (10, 10).
 drop table foo_p;
 select * from bar_p;
- i | j 
----+---
-(0 rows)
-
--- Should succeed.  Conveyed constraint matches.
-insert into bar_p values(6, 6);
-select * from bar_p;
- i | j 
----+---
- 6 | 6
+ i  | j  
+----+----
+ 10 | 10
 (1 row)
 
 drop table bar_p;

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -512,24 +512,13 @@ NOTICE:  CREATE TABLE will create partition "foo_p_1_prt_9" for table "foo_p"
 create table bar_p(i int, j int) distributed by (i);
 insert into bar_p values(6, 6);
 alter table foo_p exchange partition for(rank(6)) with table bar_p;
--- Should fail.  Prior releases didn't convey constraints out via exchange
--- but we do now, so the following tries to insert a value that can't go
--- in part 6.
+-- issue#13663 Shouldn't fail. bar_p is still a normal table alter EXCHANGE PARTITION.
 insert into bar_p values(10, 10);
-ERROR:  new row for relation "bar_p" violates check constraint "foo_p_1_prt_6_check"
-DETAIL:  Failing row contains (10, 10).
 drop table foo_p;
 select * from bar_p;
- i | j 
----+---
-(0 rows)
-
--- Should succeed.  Conveyed constraint matches.
-insert into bar_p values(6, 6);
-select * from bar_p;
- i | j 
----+---
- 6 | 6
+ i  | j  
+----+----
+ 10 | 10
 (1 row)
 
 drop table bar_p;

--- a/src/test/regress/expected/partition_storage.out
+++ b/src/test/regress/expected/partition_storage.out
@@ -111,8 +111,6 @@ Checksum: t
 Indexes:
     "pt_heap_tab_1_prt_pqr_a_idx" btree (a) WHERE c > 10
     "pt_heap_tab_1_prt_pqr_upper_idx" btree (upper(b))
-Check constraints:
-    "pt_heap_tab_1_prt_pqr_check" CHECK (b = 'pqr'::text OR b = 'pqr1'::text OR b = 'pqr2'::text)
 Distributed by: (a)
 Options: appendonly=true, orientation=column, compresslevel=5
 
@@ -133,8 +131,6 @@ Checksum: t
 Indexes:
     "pt_heap_tab_1_prt_def_a_idx" btree (a) WHERE c > 10
     "pt_heap_tab_1_prt_def_upper_idx" btree (upper(b))
-Check constraints:
-    "pt_heap_tab_1_prt_def_check" CHECK (b = 'def'::text OR b = 'def1'::text OR b = 'def3'::text)
 Distributed by: (a)
 Options: appendonly=true, compresslevel=1
 
@@ -151,8 +147,6 @@ Options: appendonly=true, compresslevel=1
 Indexes:
     "pt_heap_tab_1_prt_abc1_a_idx" btree (a) WHERE c > 10
     "pt_heap_tab_1_prt_abc1_upper_idx" btree (upper(b))
-Check constraints:
-    "pt_heap_tab_1_prt_abc1_check" CHECK (b = 'abc'::text OR b = 'abc2'::text)
 Distributed by: (a)
 Options: appendonly=false
 
@@ -309,8 +303,6 @@ Checksum: t
 Indexes:
     "pt_ao_tab_1_prt_pqr_a_idx" btree (a) WHERE c > 10
     "pt_ao_tab_1_prt_pqr_upper_idx" btree (upper(b))
-Check constraints:
-    "pt_ao_tab_1_prt_pqr_check" CHECK (b = 'pqr'::text OR b = 'pqr1'::text OR b = 'pqr2'::text)
 Distributed by: (a)
 Options: appendonly=true, orientation=column, compresslevel=5
 
@@ -331,8 +323,6 @@ Checksum: t
 Indexes:
     "pt_ao_tab_1_prt_def_a_idx" btree (a) WHERE c > 10
     "pt_ao_tab_1_prt_def_upper_idx" btree (upper(b))
-Check constraints:
-    "pt_ao_tab_1_prt_def_check" CHECK (b = 'def'::text OR b = 'def1'::text OR b = 'def3'::text)
 Distributed by: (a)
 Options: appendonly=true, compresslevel=1
 
@@ -349,8 +339,6 @@ Options: appendonly=true, compresslevel=1
 Indexes:
     "pt_ao_tab_1_prt_stu_a_idx" btree (a) WHERE c > 10
     "pt_ao_tab_1_prt_stu_upper_idx" btree (upper(b))
-Check constraints:
-    "pt_ao_tab_1_prt_stu_check" CHECK (b = 'stu'::text OR b = 'stu1'::text OR b = 'stu2'::text)
 Distributed by: (a)
 Options: appendonly=false
 
@@ -518,8 +506,6 @@ Checksum: t
 Indexes:
     "pt_co_tab_1_prt_xyz2_a_idx" btree (a) WHERE c > 10
     "pt_co_tab_1_prt_xyz2_upper_idx" btree (upper(b))
-Check constraints:
-    "pt_co_tab_1_prt_xyz2_check" CHECK (b = 'xyz1'::text)
 Distributed by: (a)
 Options: appendonly=true, orientation=column, compresslevel=5
 
@@ -540,8 +526,6 @@ Checksum: t
 Indexes:
     "pt_co_tab_1_prt_pqr_a_idx" btree (a) WHERE c > 10
     "pt_co_tab_1_prt_pqr_upper_idx" btree (upper(b))
-Check constraints:
-    "pt_co_tab_1_prt_pqr_check" CHECK (b = 'pqr'::text OR b = 'pqr1'::text OR b = 'pqr2'::text)
 Distributed by: (a)
 Options: appendonly=true, compresslevel=5
 
@@ -558,8 +542,6 @@ Options: appendonly=true, compresslevel=5
 Indexes:
     "pt_co_tab_1_prt_stu_a_idx" btree (a) WHERE c > 10
     "pt_co_tab_1_prt_stu_upper_idx" btree (upper(b))
-Check constraints:
-    "pt_co_tab_1_prt_stu_check" CHECK (b = 'stu'::text OR b = 'stu1'::text OR b = 'stu2'::text)
 Distributed by: (a)
 Options: appendonly=false
 
@@ -708,8 +690,6 @@ NOTICE:  CREATE TABLE will create partition "pt_heap_tab_rng_1_prt_newao" for ta
 Indexes:
     "pt_heap_tab_rng_1_prt_heap1_a_idx" btree (a) WHERE c > 10
     "pt_heap_tab_rng_1_prt_heap1_upper_idx" btree (upper(b))
-Check constraints:
-    "pt_heap_tab_rng_1_prt_heap1_check" CHECK (a >= 21 AND a < 23)
 Distributed by: (a)
 Options: appendonly=false
 
@@ -730,8 +710,6 @@ Checksum: t
 Indexes:
     "pt_heap_tab_rng_1_prt_newao_a_idx" btree (a) WHERE c > 10
     "pt_heap_tab_rng_1_prt_newao_upper_idx" btree (upper(b))
-Check constraints:
-    "pt_heap_tab_rng_1_prt_newao_check" CHECK (a >= 40 AND a < 45)
 Distributed by: (a)
 Options: appendonly=true
 
@@ -749,8 +727,6 @@ Checksum: t
 Indexes:
     "pt_heap_tab_rng_1_prt_newco_a_idx" btree (a) WHERE c > 10
     "pt_heap_tab_rng_1_prt_newco_upper_idx" btree (upper(b))
-Check constraints:
-    "pt_heap_tab_rng_1_prt_newco_check" CHECK (a >= 36 AND a < 40)
 Distributed by: (a)
 Options: appendonly=true, orientation=column
 
@@ -900,8 +876,6 @@ NOTICE:  CREATE TABLE will create partition "pt_ao_tab_rng_1_prt_newheap" for ta
 Indexes:
     "pt_ao_tab_rng_1_prt_newheap_a_idx" btree (a) WHERE c > 10
     "pt_ao_tab_rng_1_prt_newheap_upper_idx" btree (upper(b))
-Check constraints:
-    "pt_ao_tab_rng_1_prt_newheap_check" CHECK (a >= 40 AND a < 45)
 Distributed by: (a)
 Options: appendonly=false
 
@@ -922,8 +896,6 @@ Checksum: t
 Indexes:
     "pt_ao_tab_rng_1_prt_ao1_a_idx" btree (a) WHERE c > 10
     "pt_ao_tab_rng_1_prt_ao1_upper_idx" btree (upper(b))
-Check constraints:
-    "pt_ao_tab_rng_1_prt_ao1_check" CHECK (a >= 25 AND a < 27)
 Distributed by: (a)
 Options: appendonly=true
 
@@ -941,8 +913,6 @@ Checksum: t
 Indexes:
     "pt_ao_tab_rng_1_prt_newco_a_idx" btree (a) WHERE c > 10
     "pt_ao_tab_rng_1_prt_newco_upper_idx" btree (upper(b))
-Check constraints:
-    "pt_ao_tab_rng_1_prt_newco_check" CHECK (a >= 36 AND a < 40)
 Distributed by: (a)
 Options: appendonly=true, orientation=column
 
@@ -1092,8 +1062,6 @@ NOTICE:  CREATE TABLE will create partition "pt_co_tab_rng_1_prt_newheap" for ta
 Indexes:
     "pt_co_tab_rng_1_prt_newheap_a_idx" btree (a) WHERE c > 10
     "pt_co_tab_rng_1_prt_newheap_upper_idx" btree (upper(b))
-Check constraints:
-    "pt_co_tab_rng_1_prt_newheap_check" CHECK (a >= 40 AND a < 45)
 Distributed by: (a)
 Options: appendonly=false
 
@@ -1114,8 +1082,6 @@ Checksum: t
 Indexes:
     "pt_co_tab_rng_1_prt_newao_a_idx" btree (a) WHERE c > 10
     "pt_co_tab_rng_1_prt_newao_upper_idx" btree (upper(b))
-Check constraints:
-    "pt_co_tab_rng_1_prt_newao_check" CHECK (a >= 36 AND a < 40)
 Distributed by: (a)
 Options: appendonly=true
 
@@ -1133,8 +1099,6 @@ Checksum: t
 Indexes:
     "pt_co_tab_rng_1_prt_co1_a_idx" btree (a) WHERE c > 10
     "pt_co_tab_rng_1_prt_co1_upper_idx" btree (upper(b))
-Check constraints:
-    "pt_co_tab_rng_1_prt_co1_check" CHECK (a >= 31 AND a < 33)
 Distributed by: (a)
 Options: appendonly=true, orientation=column
 

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -277,14 +277,9 @@ create table bar_p(i int, j int) distributed by (i);
 
 insert into bar_p values(6, 6);
 alter table foo_p exchange partition for(rank(6)) with table bar_p;
--- Should fail.  Prior releases didn't convey constraints out via exchange
--- but we do now, so the following tries to insert a value that can't go
--- in part 6.
+-- issue#13663 Shouldn't fail. bar_p is still a normal table alter EXCHANGE PARTITION.
 insert into bar_p values(10, 10);
 drop table foo_p;
-select * from bar_p;
--- Should succeed.  Conveyed constraint matches.
-insert into bar_p values(6, 6);
 select * from bar_p;
 drop table bar_p;
 


### PR DESCRIPTION
This commit fixed [issue#13663](https://github.com/greenplum-db/gpdb/issues/13663)
Old partition will become a normal table after `EXCHANGE PARTITION`, the partition
constraint should be deleted.
Previous behavior:
```
postgres=# CREATE TABLE part_table_for_upgrade (a INT, b INT) DISTRIBUTED BY (a) PARTITION BY RANGE(b) (PARTITION alpha  END (3), PARTITION beta START (3));
NOTICE:  CREATE TABLE will create partition "part_table_for_upgrade_1_prt_alpha" for table "part_table_for_upgrade"
NOTICE:  CREATE TABLE will create partition "part_table_for_upgrade_1_prt_beta" for table "part_table_for_upgrade"
CREATE TABLE
postgres=# CREATE TABLE like_table (like part_table_for_upgrade INCLUDING CONSTRAINTS INCLUDING INDEXES) DISTRIBUTED BY (a) ;
CREATE TABLE
postgres=# ALTER TABLE part_table_for_upgrade EXCHANGE PARTITION beta WITH TABLE like_table;
ALTER TABLE
postgres=# \d+ like_table
                      Table "public.like_table"
 Column |  Type   | Modifiers | Storage | Stats target | Description
--------+---------+-----------+---------+--------------+-------------
 a      | integer |           | plain   |              |
 b      | integer |           | plain   |              |
Check constraints:
    "part_table_for_upgrade_1_prt_beta_check" CHECK (b >= 3)
Distributed by: (a)
```
Current behavior:
```
postgres=# CREATE TABLE part_table_for_upgrade (a INT, b INT) DISTRIBUTED BY (a) PARTITION BY RANGE(b) (PARTITION alpha  END (3), PARTITION beta START (3));
NOTICE:  CREATE TABLE will create partition "part_table_for_upgrade_1_prt_alpha" for table "part_table_for_upgrade"
NOTICE:  CREATE TABLE will create partition "part_table_for_upgrade_1_prt_beta" for table "part_table_for_upgrade"
CREATE TABLE
postgres=# CREATE TABLE like_table (like part_table_for_upgrade INCLUDING CONSTRAINTS INCLUDING INDEXES) DISTRIBUTED BY (a) ;
CREATE TABLE
postgres=# ALTER TABLE part_table_for_upgrade EXCHANGE PARTITION beta WITH TABLE like_table;
ALTER TABLE
postgres=# \d+ like_table
                      Table "public.like_table"
 Column |  Type   | Modifiers | Storage | Stats target | Description
--------+---------+-----------+---------+--------------+-------------
 a      | integer |           | plain   |              |
 b      | integer |           | plain   |              |
Distributed by: (a)
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
