### PR TITLE
Fix a flakiness in recovery test overwrite_contrecord

### DIFF
--- a/src/test/perl/PostgresNode.pm
+++ b/src/test/perl/PostgresNode.pm
@@ -508,7 +508,9 @@ sub init
 		}
 		print $conf "max_wal_senders = 5\n";
 		print $conf "max_replication_slots = 5\n";
-		print $conf "max_wal_size = 128MB\n";
+		# PG sets this to 128MB but that makes checkpoint too frequent for GPDB. 
+		# 512MB corresponds to the ratio of GPDB seg size (64) over PG seg size (16).
+		print $conf "max_wal_size = 512MB\n";
 		print $conf "shared_buffers = 1MB\n";
 		print $conf "wal_log_hints = on\n";
 		print $conf "hot_standby = on\n";


### PR DESCRIPTION
The test fails on some pipelines because there's a checkpoint WAL
being written after we write a new segment. So when the standby
is created from the same backup directory, it will complain about
not finding the checkpoint WAL, since we deleted it in the test.

It's flaky in some pipeline but not others because if the checkpoint
creation is slower than we killed the primary, we'll avoid the failure.

The reason which it writes the checkpoint WAL is because TAP test
set max_wal_size to 128 when creating the node. So the calculation
for how many segments to create checkpoint becomes:
(see CalculateCheckpointSegments)
```
    floor(128 / 64 / 1.5) = 1
```
So basically it'll force a checkpoint for every new segment, which
is not good.

Also part of the reason is that GPDB has segment size = 64MB. In
upstream it's 16MB so the above calculation will get 5 which is ok.

Since the reason that the PG sets it to 128 seems to due to [saving
space consumption](https://github.com/postgres/postgres/blob/REL_12_STABLE/src/test/perl/PostgresNode.pm#L480-L481), let's consider still use a smaller value (i.e. <1024MB) but
increase it to 512MB which corresponds to the ratio of GPDB segment
size over PG segment size.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
