### PR TITLE
6X: Ban utility mode COPY/INSERT on partition/inh roots

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -3562,6 +3562,13 @@ CopyFrom(CopyState cstate)
 							RelationGetRelationName(cstate->rel))));
 	}
 
+	if (Gp_role == GP_ROLE_UTILITY && rel_is_parent(cstate->rel->rd_id))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					errmsg("COPY FROM in utility mode is not supported on roots "
+						   "of inheritance and partition hierarchies"),
+					errhint("consider using COPY FROM with the ON SEGMENT clause")));
+
 	tupDesc = RelationGetDescr(cstate->rel);
 	num_phys_attrs = tupDesc->natts;
 	attr_count = list_length(cstate->attnumlist);

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1928,6 +1928,12 @@ InitPlan(QueryDesc *queryDesc, int eflags)
 			Oid            relid = getrelid(linitial_int(resultRelations), rangeTable);
 			bool           containRoot = false;
 
+			if(Gp_role == GP_ROLE_UTILITY && operation == CMD_INSERT && rel_is_parent(relid))
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							errmsg("INSERT in utility mode is not supported "
+								   "on roots of inheritance and partition hierarchies")));
+
 			if (rel_is_child_partition(relid))
 				relid = rel_partition_get_master(relid);
 			else

--- a/src/test/isolation2/expected/copy_insert_utility_mode_hierarchies.out
+++ b/src/test/isolation2/expected/copy_insert_utility_mode_hierarchies.out
@@ -1,0 +1,56 @@
+-- We should disallow COPY FROM and INSERT in utility mode if the target table
+-- is a root of a partition/inheritance hierarchy.
+
+CREATE TABLE utility_part_root (a int, b int, c int) DISTRIBUTED BY (a) PARTITION BY range(b) SUBPARTITION BY range(c) SUBPARTITION TEMPLATE ( START(40) END(46) EVERY(3) ) (START(0) END(4) EVERY(2));
+CREATE
+
+-- should complain as we are trying copy on a root or subroot
+1U: COPY utility_part_root FROM '/dev/null';
+ERROR:  COPY FROM in utility mode is not supported on roots of inheritance and partition hierarchies
+HINT:  consider using COPY FROM with the ON SEGMENT clause
+1U: COPY utility_part_root_1_prt_1 FROM '/dev/null';
+ERROR:  COPY FROM in utility mode is not supported on roots of inheritance and partition hierarchies
+HINT:  consider using COPY FROM with the ON SEGMENT clause
+
+-- should be fine as we are trying it on a leaf
+1U: COPY utility_part_root_1_prt_1_2_prt_1 FROM '/dev/null';
+COPY 0
+
+-- should complain as we are trying insert on a root or subroot
+1U: INSERT INTO utility_part_root VALUES(1, 2, 41);
+ERROR:  INSERT in utility mode is not supported on roots of inheritance and partition hierarchies
+1U: INSERT INTO utility_part_root_1_prt_1 VALUES(1,0,40);
+ERROR:  INSERT in utility mode is not supported on roots of inheritance and partition hierarchies
+
+-- should be fine as we are trying it on a leaf
+1U: INSERT INTO utility_part_root_1_prt_1_2_prt_1 VALUES(1,0,40);
+INSERT 1
+
+CREATE TABLE utility_inh_root ( a int );
+CREATE
+CREATE TABLE utility_inh_subroot ( b int ) INHERITS (utility_inh_root);
+CREATE
+CREATE TABLE utility_inh_leaf ( c int ) INHERITS (utility_inh_subroot);
+CREATE
+
+-- should complain as we are trying copy on a root or subroot
+1U: COPY utility_inh_root FROM '/dev/null';
+ERROR:  COPY FROM in utility mode is not supported on roots of inheritance and partition hierarchies
+HINT:  consider using COPY FROM with the ON SEGMENT clause
+1U: COPY utility_inh_subroot FROM '/dev/null';
+ERROR:  COPY FROM in utility mode is not supported on roots of inheritance and partition hierarchies
+HINT:  consider using COPY FROM with the ON SEGMENT clause
+
+-- should be fine as we are trying it on a leaf
+1U: COPY utility_inh_leaf FROM '/dev/null';
+COPY 0
+
+-- should complain as we are trying insert on a root or subroot
+1U: INSERT INTO utility_inh_root VALUES(1);
+ERROR:  INSERT in utility mode is not supported on roots of inheritance and partition hierarchies
+1U: INSERT INTO utility_inh_subroot VALUES(1, 2);
+ERROR:  INSERT in utility mode is not supported on roots of inheritance and partition hierarchies
+
+-- should be fine as we are trying it on a leaf
+1U: INSERT INTO utility_inh_leaf VALUES(1, 2, 3);
+INSERT 1

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -309,3 +309,6 @@ test: motion_socket
 
 # test alter owner of partition table in utility mode
 test: alter_partition_table_owner
+
+# test copy/insert in utility mode on partition/inheritance hierarchies
+test: copy_insert_utility_mode_hierarchies

--- a/src/test/isolation2/sql/copy_insert_utility_mode_hierarchies.sql
+++ b/src/test/isolation2/sql/copy_insert_utility_mode_hierarchies.sql
@@ -1,0 +1,49 @@
+-- We should disallow COPY FROM and INSERT in utility mode if the target table
+-- is a root of a partition/inheritance hierarchy.
+
+CREATE TABLE utility_part_root (a int, b int, c int)
+    DISTRIBUTED BY (a)
+    PARTITION BY range(b)
+        SUBPARTITION BY range(c)
+            SUBPARTITION TEMPLATE (
+            START(40) END(46) EVERY(3)
+            )
+        (START(0) END(4) EVERY(2));
+
+-- should complain as we are trying copy on a root or subroot
+1U: COPY utility_part_root FROM '/dev/null';
+1U: COPY utility_part_root_1_prt_1 FROM '/dev/null';
+
+-- should be fine as we are trying it on a leaf
+1U: COPY utility_part_root_1_prt_1_2_prt_1 FROM '/dev/null';
+
+-- should complain as we are trying insert on a root or subroot
+1U: INSERT INTO utility_part_root VALUES(1, 2, 41);
+1U: INSERT INTO utility_part_root_1_prt_1 VALUES(1,0,40);
+
+-- should be fine as we are trying it on a leaf
+1U: INSERT INTO utility_part_root_1_prt_1_2_prt_1 VALUES(1,0,40);
+
+CREATE TABLE utility_inh_root (
+    a int
+);
+CREATE TABLE utility_inh_subroot (
+    b int
+) INHERITS (utility_inh_root);
+CREATE TABLE utility_inh_leaf (
+    c int
+) INHERITS (utility_inh_subroot);
+
+-- should complain as we are trying copy on a root or subroot
+1U: COPY utility_inh_root FROM '/dev/null';
+1U: COPY utility_inh_subroot FROM '/dev/null';
+
+-- should be fine as we are trying it on a leaf
+1U: COPY utility_inh_leaf FROM '/dev/null';
+
+-- should complain as we are trying insert on a root or subroot
+1U: INSERT INTO utility_inh_root VALUES(1);
+1U: INSERT INTO utility_inh_subroot VALUES(1, 2);
+
+-- should be fine as we are trying it on a leaf
+1U: INSERT INTO utility_inh_leaf VALUES(1, 2, 3);


### PR DESCRIPTION
Ban utility mode COPY/INSERT on partition/inh roots

For advanced parallel data loading use cases w/ COPY (such as one recent
use case in gprestore on different sized clusters), one may be tempted to
load the data parallely with COPY FROM over utility mode connections.
(Even though COPY FROM .. ON SEGMENT exists, one may not have a segment
specific data file etc)

Allowing the above leads to a bug where the data gets loaded directly
into the partition root (and does not flow into the respective partiton
leaves), causing wrong results and mayhem.

Unfortunately, since only the master carries partitioning related
catalogs (pg_partition, pg_partition_rule), it is impossible to obtain
partiioning info in utility mode on the segments. Note that this
info is usually dispatched from the master.

INSERT in utility mode suffers similarly.

Thus, to prevent the aforementioned unsupported behvaior, ban such
usage on partition roots (COPY/INSERT on leaves is still allowed)

Notes:

* Unfortunately, since we have no way to determine whether a table is
the root of a partition vs inheritance hierarchy, we have to ban the
action on inheritance roots as well, as a side effect.

* This is not an issue on the master branch, as we don't have such QD vs
QE catalog inconsistencies there.
