### PR TITLE
[6X] skip red-zone check in some situations

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4088,7 +4088,7 @@ struct config_int ConfigureNamesInt_gp[] =
 
 	{
 		{"runaway_detector_activation_percent", PGC_POSTMASTER, RESOURCES_MEM,
-			gettext_noop("The runaway detector activates if the used vmem exceeds this percentage of the vmem quota. Set to 100 to disable runaway detection."),
+			gettext_noop("The runaway detector activates if the used vmem exceeds this percentage of the vmem quota. Set to 0 or 100 to disable runaway detection."),
 			NULL,
 		},
 		&runaway_detector_activation_percent,

--- a/src/backend/utils/mmgr/test/redzone_handler_test.c
+++ b/src/backend/utils/mmgr/test/redzone_handler_test.c
@@ -120,24 +120,23 @@ test__RedZoneHandler_ShmemInit__InitializesGlobalVarsWhenPostmaster(void **state
 	fakeIsRunawayDetector = 1234;
 	isRunawayDetector = NULL;
 
-	expect_any_count(ShmemInitStruct, name, 2);
-	expect_any_count(ShmemInitStruct, size, 2);
-	expect_any_count(ShmemInitStruct, foundPtr, 2);
+	expect_any_count(ShmemInitStruct, name, 3);
+	expect_any_count(ShmemInitStruct, size, 3);
+	expect_any_count(ShmemInitStruct, foundPtr, 3);
 	will_assign_value(ShmemInitStruct, foundPtr, false);
 	will_assign_value(ShmemInitStruct, foundPtr, false);
-	will_return_count(ShmemInitStruct, &fakeIsRunawayDetector, 2);
+	will_assign_value(ShmemInitStruct, foundPtr, false);
+	will_return_count(ShmemInitStruct, &fakeIsRunawayDetector, 3);
 
-	/*
-	 * When vmem limit is not activated or runaway_detector_activation_percent is
-	 * set to 0,, red zone should be very high (i.e., red-zone will be disabled).
-	 * Note, it doesn't matter what runaway_detector_activation_percent is set for
-	 * this test, as the VmemTracker_ConvertVmemMBToChunks is returning 0.
-	 */
 	will_return(VmemTracker_ConvertVmemMBToChunks, 0);
 	expect_any(VmemTracker_ConvertVmemMBToChunks, mb);
 
+	/*
+	 * When vmem limit is not activated or runaway_detector_activation_percent is
+	 * set to 0, red zone should be very high (i.e., red-zone will be disabled).
+	 */
+	runaway_detector_activation_percent = 0;
 	RedZoneHandler_ShmemInit();
-
 	assert_true(isRunawayDetector == &fakeIsRunawayDetector);
 	assert_true(redZoneChunks == INT32_MAX);
 	assert_true(*isRunawayDetector == 0);
@@ -151,6 +150,9 @@ test__RedZoneHandler_ShmemInit__InitializesGlobalVarsWhenPostmaster(void **state
 	redZoneChunks = 0;
 	RedZoneHandler_ShmemInit();
 	assert_true(redZoneChunks == INT32_MAX);
+
+	runaway_detector_activation_percent = 80;
+	RedZoneHandler_ShmemInit();
 }
 
 /*


### PR DESCRIPTION
This is the backport of #13668.

When we set runaway_detector_activation_percent to 0 or 100 means to disable runaway detection,
this should apply to Vmem Tracker and Resource Group.

However, in the current implementation, we will still invoke IsGroupInRedZone() if we enabled resource
group if we set runaway_detector_activation_percent to 0 or 100. And in function IsGroupInRedZone()
has some automatic operation to read variables. At the same time RedZoneHandler_IsVmemRedZone
is a very frequently called function, so this will waste a lot of CPU resources.

When we init Red-Zone Handler, will set redZoneChunks to INT32_MAX if we disable runaway
detection, so we can use it to judge whether we are in Red-Zone or not quickly.

No more tests need, since already have case covering this situation.