### PR TITLE
change partition FIXME to FEATURE NOT SUPPORTED

### DIFF
--- a/src/backend/parser/parse_partition_gp.c
+++ b/src/backend/parser/parse_partition_gp.c
@@ -942,10 +942,12 @@ generateRangePartitions(ParseState *pstate,
 	partkey = RelationGetPartitionKey(parentrel);
 
 	/*
-	 * GPDB_12_MERGE_FIXME: We currently disabled support for multi column
-	 * range partitioned tables. PostgreSQL doesn't support that. Not sure
-	 * what to do about that.  Add support for it to PostgreSQL? Simplify the
-	 * grammar to not allow that?
+	 * GPDB_12_MERGE_FEATURE_NOT_SUPPORTED: We currently disabled support for multi-column
+	 * range partitioned tables. If user want to define partition table with multi-column
+	 * range, can use PostgreSQL's grammar:
+	 *
+	 * create table z (a int, b int, c int) partition by range(b, c);
+	 * create table z1 partition of z for values from (10, 10) TO (20, 20);
 	 */
 	if (partkey->partnatts != 1)
 		ereport(ERROR,


### PR DESCRIPTION
For now, Greenplum native partition table statement is not supported for multi-column
partition key create. But we can use PostgreSQL's grammar to do that:

```
create table z (a int, b int, c int) partition by range(b, c);
create table z1 partition of z for values from (10, 10) TO (20, 20);
```

So change the `GPDB_12_MERGE_FIXME` to `GPDB_12_MERGE_FEATURE_NOT_SUPPORTED`.
