### PR TITLE
[ORCA] Fix memory leaks in translator (#13656)

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -282,7 +282,6 @@ CTranslatorUtils::ConvertToCDXLLogicalTVF(CMemoryPool *mp,
 
 		CMDName *func_name =
 			CDXLUtils::CreateMDNameFromCharArray(mp, rte->eref->aliasname);
-		mdid_return_type->AddRef();
 
 		// if TVF evaluates to const, pass invalid key as funcid
 		CDXLLogicalTVF *tvf_dxl = GPOS_NEW(mp)
@@ -2606,6 +2605,8 @@ CTranslatorUtils::IsCompositeConst(CMemoryPool *mp, CMDAccessor *md_accessor,
 	CMDIdGPDB *mdid_return_type = GPOS_NEW(mp) CMDIdGPDB(constExpr->consttype);
 
 	const IMDType *type = md_accessor->RetrieveType(mdid_return_type);
+
+	mdid_return_type->Release();
 
 	return type->IsComposite();
 }


### PR DESCRIPTION
Found while rebasing Jesse's WIP refcount branch that is attempting to
remove manual refcounting.  Example demonstrating leak:

  ```
  $ gpconfig -c optimizer_use_gpdb_allocators -v off --skipvalidation
  $ gpstop -air
  test=# CREATE TYPE myType as (a int, b int);
  test=# CREATE OR REPLACE FUNCTION myFunc() RETURNS myType IMMUTABLE as $$ SELECT 1, 2 $$ LANGUAGE SQL;
  test=# EXPLAIN SELECT * FROM myFunc();
  ```

(cherry picked from commit 6bbef9ec1228e4212e226a13804a2c5503a93403)