### PR TITLE
[ORCA] Implement Pre-Unique Limit for queries with LIMIT and DISTINCT

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/LimitBtwLocalNGlobalAgg1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LimitBtwLocalNGlobalAgg1.mdp
@@ -1,0 +1,1239 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+create table bar1(x1 int, x2 int, x3 int);
+insert into bar1 select i,1,i from generate_series(1,10000000) i;
+
+explain select distinct sum(x1) s from bar1 b group by b.x3 limit 1
+
+ Limit  (cost=0.00..1469.48 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1469.48 rows=1 width=8)
+         ->  Limit  (cost=0.00..1469.48 rows=1 width=8)
+               ->  GroupAggregate  (cost=0.00..1469.48 rows=1 width=8)
+                     Group Key: (sum(x1))
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1469.48 rows=1 width=8)
+                           Hash Key: (sum(x1))
+                           ->  Limit  (cost=0.00..1469.48 rows=1 width=8)
+                                 ->  Streaming HashAggregate  (cost=0.00..1469.48 rows=334 width=8)
+                                       Group Key: sum(x1)
+                                       ->  HashAggregate  (cost=0.00..1059.01 rows=3333334 width=8)
+                                             Group Key: x3
+                                             Planned Partitions: 16
+                                             ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..641.07 rows=3333334 width=8)
+                                                   Hash Key: x3
+                                                   ->  Seq Scan on bar1  (cost=0.00..508.00 rows=3333334 width=8)
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:ColumnStatistics Mdid="1.17334.1.0.0" Name="x1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="227"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89120"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89120"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="183179"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="183179"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="268093"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="268093"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="359313"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="359313"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="454083"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="454083"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="556281"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="556281"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="659864"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="659864"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="769470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="769470"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="877257"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="877257"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="980703"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="980703"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1084674"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1084674"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1186131"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1186131"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1291414"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1291414"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1386126"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1386126"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1478953"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1478953"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1578223"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1578223"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1681468"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1681468"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1792892"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1792892"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1901380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1901380"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2003465"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2003465"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2102204"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2102204"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2208689"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2208689"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2312653"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2312653"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2413700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2413700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2510937"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2510937"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2609170"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2609170"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2713732"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2713732"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2817105"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2817105"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2899895"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2899895"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2996010"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2996010"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3091465"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3091465"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3191599"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3191599"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3296874"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3296874"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3392786"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3392786"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3485109"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3485109"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3593299"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3593299"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3700149"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3700149"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3799868"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3799868"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3899339"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3899339"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3997510"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3997510"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4110223"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4110223"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4208244"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4208244"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4301019"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4301019"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4399838"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4399838"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4495307"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4495307"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4601286"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4601286"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4697413"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4697413"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4789787"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4789787"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4883107"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4883107"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4973744"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4973744"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5072722"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5072722"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5170672"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5170672"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5272577"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5272577"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5374814"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5374814"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5474546"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5474546"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5568475"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5568475"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5679413"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5679413"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5769266"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5769266"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5871457"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5871457"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5970792"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5970792"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6071393"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6071393"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6173600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6173600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6280550"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6280550"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6386130"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6386130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6485106"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6485106"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6582624"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6582624"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6681697"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6681697"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6781587"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6781587"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6888729"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6888729"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6988507"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6988507"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7093605"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7093605"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7189193"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7189193"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7294209"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7294209"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7398833"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7398833"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7509097"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7509097"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7607466"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7607466"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7698197"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7698197"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7800864"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7800864"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7906982"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7906982"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8007739"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8007739"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8107928"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8107928"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8214580"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8214580"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8310118"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8310118"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8407894"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8407894"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8510646"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8510646"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8609908"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8609908"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8721064"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8721064"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8819365"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8819365"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8914431"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8914431"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9019711"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9019711"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9124462"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9124462"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9229862"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9229862"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9327634"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9327634"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9418140"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9418140"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9514275"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9514275"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9612873"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9612873"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9707453"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9707453"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9796216"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9796216"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9897000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9897000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="9999479"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.17334.1.0.2" Name="x3" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="227"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89120"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89120"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="183179"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="183179"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="268093"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="268093"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="359313"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="359313"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="454083"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="454083"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="556281"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="556281"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="659864"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="659864"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="769470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="769470"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="877257"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="877257"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="980703"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="980703"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1084674"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1084674"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1186131"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1186131"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1291414"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1291414"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1386126"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1386126"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1478953"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1478953"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1578223"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1578223"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1681468"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1681468"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1792892"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1792892"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1901380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1901380"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2003465"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2003465"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2102204"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2102204"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2208689"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2208689"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2312653"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2312653"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2413700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2413700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2510937"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2510937"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2609170"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2609170"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2713732"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2713732"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2817105"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2817105"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2899895"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2899895"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2996010"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2996010"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3091465"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3091465"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3191599"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3191599"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3296874"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3296874"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3392786"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3392786"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3485109"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3485109"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3593299"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3593299"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3700149"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3700149"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3799868"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3799868"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3899339"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3899339"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3997510"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3997510"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4110223"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4110223"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4208244"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4208244"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4301019"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4301019"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4399838"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4399838"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4495307"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4495307"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4601286"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4601286"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4697413"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4697413"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4789787"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4789787"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4883107"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4883107"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4973744"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4973744"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5072722"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5072722"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5170672"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5170672"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5272577"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5272577"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5374814"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5374814"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5474546"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5474546"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5568475"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5568475"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5679413"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5679413"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5769266"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5769266"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5871457"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5871457"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5970792"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5970792"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6071393"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6071393"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6173600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6173600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6280550"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6280550"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6386130"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6386130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6485106"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6485106"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6582624"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6582624"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6681697"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6681697"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6781587"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6781587"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6888729"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6888729"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6988507"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6988507"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7093605"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7093605"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7189193"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7189193"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7294209"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7294209"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7398833"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7398833"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7509097"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7509097"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7607466"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7607466"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7698197"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7698197"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7800864"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7800864"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7906982"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7906982"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8007739"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8007739"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8107928"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8107928"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8214580"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8214580"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8310118"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8310118"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8407894"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8407894"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8510646"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8510646"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8609908"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8609908"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8721064"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8721064"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8819365"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8819365"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8914431"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8914431"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9019711"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9019711"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9124462"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9124462"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9229862"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9229862"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9327634"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9327634"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9418140"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9418140"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9514275"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9514275"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9612873"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9612873"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9707453"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9707453"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9796216"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9796216"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9897000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9897000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="9999479"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:RelationStatistics Mdid="2.17334.1.0" Name="bar1" Rows="10000000.000000" RelPages="13443" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.17334.1.0" Name="bar1" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="x1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="x2" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="x3" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:GPDBAgg Mdid="0.2108.1.0" Name="sum" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="11" ColName="s" TypeMdid="0.20.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalLimit>
+        <dxl:SortingColumnList/>
+        <dxl:LimitCount>
+          <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+        </dxl:LimitCount>
+        <dxl:LimitOffset/>
+        <dxl:LogicalGroupBy>
+          <dxl:GroupingColumns>
+            <dxl:GroupingColumn ColId="11"/>
+          </dxl:GroupingColumns>
+          <dxl:ProjList/>
+          <dxl:LogicalGroupBy>
+            <dxl:GroupingColumns>
+              <dxl:GroupingColumn ColId="3"/>
+            </dxl:GroupingColumns>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="11" Alias="s">
+                <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="23">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:Ident ColId="1" ColName="x1" TypeMdid="0.23.1.0"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                  <dxl:ValuesList ParamType="aggorder"/>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:LogicalGet>
+              <dxl:TableDescriptor Mdid="0.17334.1.0" TableName="bar1" LockMode="1">
+                <dxl:Columns>
+                  <dxl:Column ColId="1" Attno="1" ColName="x1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="2" Attno="2" ColName="x2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="3" Attno="3" ColName="x3" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:LogicalGet>
+          </dxl:LogicalGroupBy>
+        </dxl:LogicalGroupBy>
+      </dxl:LogicalLimit>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="360">
+      <dxl:Limit>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1469.480813" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="10" Alias="s">
+            <dxl:Ident ColId="10" ColName="s" TypeMdid="0.20.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1469.480805" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="10" Alias="s">
+              <dxl:Ident ColId="10" ColName="s" TypeMdid="0.20.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:Limit>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1469.480775" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="10" Alias="s">
+                <dxl:Ident ColId="10" ColName="s" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1469.480773" Rows="1.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:GroupingColumns>
+                <dxl:GroupingColumn ColId="10"/>
+              </dxl:GroupingColumns>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="10" Alias="s">
+                  <dxl:Ident ColId="10" ColName="s" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1469.480763" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="10" Alias="s">
+                    <dxl:Ident ColId="10" ColName="s" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr Opfamily="0.1977.1.0">
+                    <dxl:Ident ColId="10" ColName="s" TypeMdid="0.20.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:Limit>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="1469.480751" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="10" Alias="s">
+                      <dxl:Ident ColId="10" ColName="s" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="1469.480748" Rows="1000.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="10"/>
+                    </dxl:GroupingColumns>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="10" Alias="s">
+                        <dxl:Ident ColId="10" ColName="s" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="1059.013333" Rows="10000000.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:GroupingColumns>
+                        <dxl:GroupingColumn ColId="2"/>
+                      </dxl:GroupingColumns>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="10" Alias="s">
+                          <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="23">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Ident ColId="0" ColName="x1" TypeMdid="0.23.1.0"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="2" Alias="x3">
+                          <dxl:Ident ColId="2" ColName="x3" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="641.066667" Rows="10000000.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="0" Alias="x1">
+                            <dxl:Ident ColId="0" ColName="x1" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="2" Alias="x3">
+                            <dxl:Ident ColId="2" ColName="x3" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:HashExprList>
+                          <dxl:HashExpr Opfamily="0.1977.1.0">
+                            <dxl:Ident ColId="2" ColName="x3" TypeMdid="0.23.1.0"/>
+                          </dxl:HashExpr>
+                        </dxl:HashExprList>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="508.000000" Rows="10000000.000000" Width="8"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="0" Alias="x1">
+                              <dxl:Ident ColId="0" ColName="x1" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="2" Alias="x3">
+                              <dxl:Ident ColId="2" ColName="x3" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="0.17334.1.0" TableName="bar1" LockMode="1">
+                            <dxl:Columns>
+                              <dxl:Column ColId="0" Attno="1" ColName="x1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="2" Attno="3" ColName="x3" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:RedistributeMotion>
+                    </dxl:Aggregate>
+                  </dxl:Aggregate>
+                  <dxl:LimitCount>
+                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                  </dxl:LimitCount>
+                  <dxl:LimitOffset>
+                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                  </dxl:LimitOffset>
+                </dxl:Limit>
+              </dxl:RedistributeMotion>
+            </dxl:Aggregate>
+            <dxl:LimitCount>
+              <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+            </dxl:LimitCount>
+            <dxl:LimitOffset>
+              <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+            </dxl:LimitOffset>
+          </dxl:Limit>
+        </dxl:GatherMotion>
+        <dxl:LimitCount>
+          <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+        </dxl:LimitCount>
+        <dxl:LimitOffset>
+          <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+        </dxl:LimitOffset>
+      </dxl:Limit>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/LimitBtwLocalNGlobalAgg2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LimitBtwLocalNGlobalAgg2.mdp
@@ -1,0 +1,1239 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+create table bar1(x1 int, x2 int, x3 int);
+insert into bar1 select i,1,i from generate_series(1,10000000) i;
+
+explain select distinct sum(x1) s from bar1 b group by b.x3 limit 1
+
+Limit  (cost=0.00..1469.48 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1469.48 rows=1 width=8)
+         ->  Limit  (cost=0.00..1469.48 rows=1 width=8)
+               ->  GroupAggregate  (cost=0.00..1469.48 rows=1 width=8)
+                     Group Key: (count(x1))
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1469.48 rows=1 width=8)
+                           Hash Key: (count(x1))
+                           ->  Limit  (cost=0.00..1469.48 rows=1 width=8)
+                                 ->  Streaming HashAggregate  (cost=0.00..1469.48 rows=334 width=8)
+                                       Group Key: count(x1)
+                                       ->  HashAggregate  (cost=0.00..1059.01 rows=3333334 width=8)
+                                             Group Key: x3
+                                             Planned Partitions: 16
+                                             ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..641.07 rows=3333334 width=8)
+                                                   Hash Key: x3
+                                                   ->  Seq Scan on bar1  (cost=0.00..508.00 rows=3333334 width=8)
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:ColumnStatistics Mdid="1.17334.1.0.0" Name="x1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="227"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89120"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89120"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="183179"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="183179"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="268093"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="268093"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="359313"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="359313"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="454083"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="454083"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="556281"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="556281"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="659864"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="659864"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="769470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="769470"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="877257"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="877257"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="980703"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="980703"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1084674"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1084674"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1186131"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1186131"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1291414"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1291414"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1386126"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1386126"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1478953"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1478953"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1578223"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1578223"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1681468"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1681468"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1792892"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1792892"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1901380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1901380"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2003465"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2003465"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2102204"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2102204"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2208689"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2208689"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2312653"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2312653"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2413700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2413700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2510937"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2510937"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2609170"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2609170"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2713732"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2713732"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2817105"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2817105"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2899895"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2899895"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2996010"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2996010"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3091465"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3091465"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3191599"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3191599"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3296874"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3296874"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3392786"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3392786"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3485109"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3485109"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3593299"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3593299"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3700149"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3700149"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3799868"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3799868"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3899339"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3899339"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3997510"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3997510"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4110223"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4110223"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4208244"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4208244"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4301019"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4301019"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4399838"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4399838"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4495307"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4495307"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4601286"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4601286"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4697413"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4697413"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4789787"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4789787"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4883107"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4883107"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4973744"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4973744"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5072722"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5072722"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5170672"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5170672"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5272577"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5272577"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5374814"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5374814"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5474546"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5474546"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5568475"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5568475"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5679413"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5679413"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5769266"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5769266"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5871457"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5871457"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5970792"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5970792"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6071393"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6071393"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6173600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6173600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6280550"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6280550"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6386130"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6386130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6485106"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6485106"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6582624"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6582624"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6681697"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6681697"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6781587"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6781587"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6888729"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6888729"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6988507"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6988507"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7093605"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7093605"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7189193"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7189193"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7294209"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7294209"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7398833"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7398833"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7509097"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7509097"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7607466"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7607466"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7698197"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7698197"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7800864"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7800864"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7906982"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7906982"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8007739"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8007739"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8107928"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8107928"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8214580"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8214580"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8310118"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8310118"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8407894"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8407894"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8510646"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8510646"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8609908"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8609908"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8721064"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8721064"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8819365"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8819365"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8914431"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8914431"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9019711"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9019711"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9124462"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9124462"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9229862"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9229862"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9327634"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9327634"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9418140"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9418140"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9514275"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9514275"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9612873"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9612873"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9707453"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9707453"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9796216"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9796216"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9897000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9897000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="9999479"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.17334.1.0.2" Name="x3" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="227"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89120"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89120"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="183179"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="183179"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="268093"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="268093"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="359313"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="359313"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="454083"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="454083"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="556281"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="556281"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="659864"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="659864"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="769470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="769470"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="877257"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="877257"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="980703"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="980703"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1084674"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1084674"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1186131"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1186131"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1291414"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1291414"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1386126"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1386126"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1478953"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1478953"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1578223"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1578223"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1681468"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1681468"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1792892"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1792892"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1901380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1901380"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2003465"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2003465"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2102204"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2102204"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2208689"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2208689"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2312653"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2312653"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2413700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2413700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2510937"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2510937"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2609170"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2609170"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2713732"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2713732"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2817105"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2817105"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2899895"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2899895"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2996010"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2996010"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3091465"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3091465"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3191599"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3191599"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3296874"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3296874"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3392786"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3392786"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3485109"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3485109"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3593299"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3593299"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3700149"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3700149"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3799868"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3799868"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3899339"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3899339"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3997510"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3997510"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4110223"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4110223"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4208244"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4208244"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4301019"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4301019"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4399838"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4399838"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4495307"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4495307"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4601286"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4601286"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4697413"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4697413"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4789787"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4789787"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4883107"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4883107"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4973744"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4973744"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5072722"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5072722"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5170672"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5170672"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5272577"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5272577"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5374814"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5374814"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5474546"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5474546"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5568475"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5568475"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5679413"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5679413"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5769266"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5769266"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5871457"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5871457"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5970792"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5970792"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6071393"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6071393"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6173600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6173600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6280550"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6280550"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6386130"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6386130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6485106"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6485106"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6582624"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6582624"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6681697"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6681697"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6781587"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6781587"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6888729"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6888729"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6988507"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6988507"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7093605"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7093605"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7189193"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7189193"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7294209"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7294209"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7398833"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7398833"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7509097"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7509097"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7607466"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7607466"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7698197"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7698197"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7800864"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7800864"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7906982"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7906982"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8007739"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8007739"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8107928"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8107928"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8214580"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8214580"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8310118"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8310118"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8407894"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8407894"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8510646"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8510646"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8609908"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8609908"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8721064"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8721064"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8819365"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8819365"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8914431"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8914431"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9019711"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9019711"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9124462"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9124462"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9229862"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9229862"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9327634"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9327634"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9418140"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9418140"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9514275"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9514275"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9612873"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9612873"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9707453"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9707453"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9796216"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9796216"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9897000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="100000.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9897000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="9999479"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:RelationStatistics Mdid="2.17334.1.0" Name="bar1" Rows="10000000.000000" RelPages="13443" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.17334.1.0" Name="bar1" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="x1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="x2" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="x3" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:GPDBAgg Mdid="0.2147.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="11" ColName="s" TypeMdid="0.20.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalLimit>
+        <dxl:SortingColumnList/>
+        <dxl:LimitCount>
+          <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+        </dxl:LimitCount>
+        <dxl:LimitOffset/>
+        <dxl:LogicalGroupBy>
+          <dxl:GroupingColumns>
+            <dxl:GroupingColumn ColId="11"/>
+          </dxl:GroupingColumns>
+          <dxl:ProjList/>
+          <dxl:LogicalGroupBy>
+            <dxl:GroupingColumns>
+              <dxl:GroupingColumn ColId="3"/>
+            </dxl:GroupingColumns>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="11" Alias="s">
+                <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="23">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:Ident ColId="1" ColName="x1" TypeMdid="0.23.1.0"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                  <dxl:ValuesList ParamType="aggorder"/>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:LogicalGet>
+              <dxl:TableDescriptor Mdid="0.17334.1.0" TableName="bar1" LockMode="1">
+                <dxl:Columns>
+                  <dxl:Column ColId="1" Attno="1" ColName="x1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="2" Attno="2" ColName="x2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="3" Attno="3" ColName="x3" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:LogicalGet>
+          </dxl:LogicalGroupBy>
+        </dxl:LogicalGroupBy>
+      </dxl:LogicalLimit>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="360">
+      <dxl:Limit>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1469.480813" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="10" Alias="s">
+            <dxl:Ident ColId="10" ColName="s" TypeMdid="0.20.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1469.480805" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="10" Alias="s">
+              <dxl:Ident ColId="10" ColName="s" TypeMdid="0.20.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:Limit>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1469.480775" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="10" Alias="s">
+                <dxl:Ident ColId="10" ColName="s" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1469.480773" Rows="1.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:GroupingColumns>
+                <dxl:GroupingColumn ColId="10"/>
+              </dxl:GroupingColumns>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="10" Alias="s">
+                  <dxl:Ident ColId="10" ColName="s" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1469.480763" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="10" Alias="s">
+                    <dxl:Ident ColId="10" ColName="s" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr Opfamily="0.1977.1.0">
+                    <dxl:Ident ColId="10" ColName="s" TypeMdid="0.20.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:Limit>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="1469.480751" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="10" Alias="s">
+                      <dxl:Ident ColId="10" ColName="s" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="1469.480748" Rows="1000.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="10"/>
+                    </dxl:GroupingColumns>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="10" Alias="s">
+                        <dxl:Ident ColId="10" ColName="s" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="1059.013333" Rows="10000000.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:GroupingColumns>
+                        <dxl:GroupingColumn ColId="2"/>
+                      </dxl:GroupingColumns>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="10" Alias="s">
+                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="23">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Ident ColId="0" ColName="x1" TypeMdid="0.23.1.0"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="2" Alias="x3">
+                          <dxl:Ident ColId="2" ColName="x3" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="641.066667" Rows="10000000.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="0" Alias="x1">
+                            <dxl:Ident ColId="0" ColName="x1" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="2" Alias="x3">
+                            <dxl:Ident ColId="2" ColName="x3" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:HashExprList>
+                          <dxl:HashExpr Opfamily="0.1977.1.0">
+                            <dxl:Ident ColId="2" ColName="x3" TypeMdid="0.23.1.0"/>
+                          </dxl:HashExpr>
+                        </dxl:HashExprList>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="508.000000" Rows="10000000.000000" Width="8"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="0" Alias="x1">
+                              <dxl:Ident ColId="0" ColName="x1" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="2" Alias="x3">
+                              <dxl:Ident ColId="2" ColName="x3" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="0.17334.1.0" TableName="bar1" LockMode="1">
+                            <dxl:Columns>
+                              <dxl:Column ColId="0" Attno="1" ColName="x1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="2" Attno="3" ColName="x3" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:RedistributeMotion>
+                    </dxl:Aggregate>
+                  </dxl:Aggregate>
+                  <dxl:LimitCount>
+                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                  </dxl:LimitCount>
+                  <dxl:LimitOffset>
+                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                  </dxl:LimitOffset>
+                </dxl:Limit>
+              </dxl:RedistributeMotion>
+            </dxl:Aggregate>
+            <dxl:LimitCount>
+              <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+            </dxl:LimitCount>
+            <dxl:LimitOffset>
+              <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+            </dxl:LimitOffset>
+          </dxl:Limit>
+        </dxl:GatherMotion>
+        <dxl:LimitCount>
+          <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+        </dxl:LimitCount>
+        <dxl:LimitOffset>
+          <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+        </dxl:LimitOffset>
+      </dxl:Limit>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXform.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXform.h
@@ -223,6 +223,7 @@ public:
 		ExfLeftJoin2RightJoin,
 		ExfRightOuterJoin2HashJoin,
 		ExfImplementInnerJoin,
+		ExfAddLimitAfterSplitGbAgg,
 		ExfInvalid,
 		ExfSentinel = ExfInvalid
 	};

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformAddLimitAfterSplitGbAgg.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformAddLimitAfterSplitGbAgg.h
@@ -1,0 +1,79 @@
+//
+// Created by Sanath Kumar Vobilisetty on 6/6/22.
+//
+
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2017 VMware, Inc. or its affiliates.
+//
+//	@filename:
+//		CXformAddLimitAfterSplitGbAgg.h
+//
+//	@doc:
+//		Transform that adds limit in between local and global aggregate if
+//		the expression has limit and distinct operators.
+//---------------------------------------------------------------------------
+
+#ifndef GPOPT_MASTER_CXFORMADDLIMITAFTERSPLITGBAGG_H
+#define GPOPT_MASTER_CXFORMADDLIMITAFTERSPLITGBAGG_H
+
+#include "gpos/base.h"
+
+#include "gpopt/xforms/CXformExploration.h"
+
+
+namespace gpopt
+{
+using namespace gpos;
+
+class CXformAddLimitAfterSplitGbAgg : public CXformExploration
+{
+private:
+	static CExpression *PexprLimit(
+		CMemoryPool *mp,				// memory pool
+		CExpression *pexprRelational,	// relational child
+		CExpression *pexprScalarStart,	// limit offset
+		CExpression *pexprScalarRows,	// limit count
+		COrderSpec *pos,				// ordering specification
+		BOOL fGlobal,					// is it a local or global limit
+		BOOL fHasCount,					// does limit specify a number of rows
+		BOOL fTopLimitUnderDML);
+
+public:
+	CXformAddLimitAfterSplitGbAgg(const CXformAddLimitAfterSplitGbAgg &) =
+		delete;
+
+	// ctor
+	explicit CXformAddLimitAfterSplitGbAgg(CMemoryPool *mp);
+
+	// dtor
+	~CXformAddLimitAfterSplitGbAgg() override = default;
+
+	// ident accessors
+	EXformId
+	Exfid() const override
+	{
+		return ExfAddLimitAfterSplitGbAgg;
+	}
+
+	// return a string for xform name
+	const CHAR *
+	SzId() const override
+	{
+		return "CXformAddLimitAfterSplitGbAgg";
+	}
+
+	// compute xform promise for a given expression handle
+	EXformPromise Exfp(CExpressionHandle &exprhdl) const override;
+
+	// actual transform
+	void Transform(CXformContext *pxfctxt, CXformResult *pxfres,
+				   CExpression *pexpr) const override;
+
+};	// class CXformAddLimitAfterSplitGbAgg
+
+}  // namespace gpopt
+
+#endif	// GPOPT_MASTER_CXFORMADDLIMITAFTERSPLITGBAGG_H
+
+// EOF

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformSplitGbAgg.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformSplitGbAgg.h
@@ -78,7 +78,8 @@ public:
 	{
 		return ((CXform::ExfSplitDQA != exfid) &&
 				(CXform::ExfSplitGbAgg != exfid) &&
-				(CXform::ExfEagerAgg != exfid));
+				(CXform::ExfEagerAgg != exfid) &&
+				(CXform::ExfAddLimitAfterSplitGbAgg != exfid));
 	}
 
 	// compute xform promise for a given expression handle

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/xforms.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/xforms.h
@@ -12,6 +12,7 @@
 #define GPOPT_xforms_H
 
 #include "gpopt/xforms/CXform.h"
+#include "gpopt/xforms/CXformAddLimitAfterSplitGbAgg.h"
 #include "gpopt/xforms/CXformAntiSemiJoinAntiSemiJoinNotInSwap.h"
 #include "gpopt/xforms/CXformAntiSemiJoinAntiSemiJoinSwap.h"
 #include "gpopt/xforms/CXformAntiSemiJoinInnerJoinSwap.h"

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalLimit.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalLimit.cpp
@@ -229,6 +229,7 @@ CLogicalLimit::PxfsCandidates(CMemoryPool *mp) const
 
 	(void) xform_set->ExchangeSet(CXform::ExfImplementLimit);
 	(void) xform_set->ExchangeSet(CXform::ExfSplitLimit);
+	(void) xform_set->ExchangeSet(CXform::ExfAddLimitAfterSplitGbAgg);
 
 	return xform_set;
 }

--- a/src/backend/gporca/libgpopt/src/xforms/CXformAddLimitAfterSplitGbAgg.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformAddLimitAfterSplitGbAgg.cpp
@@ -1,0 +1,200 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2017 VMware, Inc. or its affiliates.
+//
+//	@filename:
+//		CXformAddLimitAfterSplitGbAgg.cpp
+//
+//	@doc:
+//		Implementation of the transform that adds a local limit in between
+//   	splitted local and global aggregate containing distinct.
+//---------------------------------------------------------------------------
+
+#include "gpopt/xforms/CXformAddLimitAfterSplitGbAgg.h"
+
+#include "gpos/base.h"
+
+#include "gpopt/operators/CLogicalGbAgg.h"
+#include "gpopt/operators/CLogicalLimit.h"
+#include "gpopt/operators/CPatternLeaf.h"
+#include "gpopt/search/CGroupProxy.h"
+#include "gpopt/xforms/CXformUtils.h"
+
+using namespace gpopt;
+
+CXformAddLimitAfterSplitGbAgg::CXformAddLimitAfterSplitGbAgg(CMemoryPool *mp)
+	:  // pattern
+	  CXformExploration(GPOS_NEW(mp) CExpression(
+		  mp, GPOS_NEW(mp) CLogicalLimit(mp),  // Outer limit operator
+		  GPOS_NEW(mp) CExpression(
+			  mp,
+			  GPOS_NEW(mp) CLogicalLimit(
+				  mp),	// Inner limit(Local Limit after splitting)
+			  GPOS_NEW(mp) CExpression(
+				  mp,
+				  GPOS_NEW(mp)
+					  CLogicalGbAgg(mp),  // GbAgg, first child of local limit
+				  GPOS_NEW(mp) CExpression(
+					  mp,
+					  GPOS_NEW(mp) CLogicalGbAgg(
+						  mp),	// Inner Aggregate(Local GbAgg after splitting)
+					  GPOS_NEW(mp)
+						  CExpression(mp, GPOS_NEW(mp) CPatternLeaf(mp)),
+					  GPOS_NEW(mp)
+						  CExpression(mp, GPOS_NEW(mp) CPatternLeaf(mp))),
+				  GPOS_NEW(mp) CExpression(mp, GPOS_NEW(mp) CPatternTree(mp))),
+			  GPOS_NEW(mp) CExpression(
+				  mp, GPOS_NEW(mp) CPatternLeaf(
+						  mp)),	 // Second child of inner limit, Limit offset
+			  GPOS_NEW(mp) CExpression(
+				  mp, GPOS_NEW(mp) CPatternLeaf(
+						  mp))),  // Third child of inner limit, Number of rows
+		  GPOS_NEW(mp) CExpression(
+			  mp, GPOS_NEW(mp) CPatternLeaf(
+					  mp)),	 // Second child of outer limit, Limit offset
+		  GPOS_NEW(mp) CExpression(
+			  mp, GPOS_NEW(mp) CPatternLeaf(
+					  mp))	// Third child of outer limit, Number of rows
+		  ))
+{
+}
+
+CXform::EXformPromise
+CXformAddLimitAfterSplitGbAgg::Exfp(CExpressionHandle &exprhdl) const
+{
+	CLogicalLimit *popLimit = CLogicalLimit::PopConvert(exprhdl.Pop());
+	// Transform is not applicable if limit operator doesn't have rows or if the
+	// operator is not global.
+	if (!popLimit->FGlobal() || !popLimit->FHasCount())
+	{
+		return CXform::ExfpNone;
+	}
+
+	return CXform::ExfpHigh;
+}
+
+
+// Applying this transform converts below
+
+// Input Pattern
+//+--CLogicalLimit <empty> global
+//   |--CLogicalLimit <empty> local
+//		|--CLogicalGbAgg( Global )
+//		|--|--CLogicalGbAgg( Local )
+//		|  +--CScalarProjectList
+//	 |--CScalarConst (0)
+//	 +--CScalarConst (3)
+
+// Transformed Pattern
+//+--CLogicalLimit <empty> global
+//   |--CLogicalLimit <empty> local
+//		|--CLogicalGbAgg( Global )
+//			|--CLogicalLimit( Local )
+//				|--CLogicalGbAgg( Local )
+//		    |--CScalarConst (0)
+//	        +--CScalarConst (3)
+//	    +--CScalarProjectList
+//	|--CScalarConst (0)
+//  +--CScalarConst (3)
+void
+CXformAddLimitAfterSplitGbAgg::Transform(CXformContext *pxfctxt,
+										 CXformResult *pxfres,
+										 CExpression *pexpr) const
+{
+	GPOS_ASSERT(nullptr != pxfctxt);
+	GPOS_ASSERT(nullptr != pxfres);
+	GPOS_ASSERT(FPromising(pxfctxt->Pmp(), this, pexpr));
+	GPOS_ASSERT(FCheckPattern(pexpr));
+
+
+	CMemoryPool *mp = pxfctxt->Pmp();
+	// extract components
+	CLogicalLimit *popOuterLimit = CLogicalLimit::PopConvert(pexpr->Pop());
+	CExpression *pexprInnerLimit = (*pexpr)[0];
+	CLogicalLimit *popInnerLimit =
+		CLogicalLimit::PopConvert(pexprInnerLimit->Pop());
+	if (!popInnerLimit->FGlobal())
+	{
+		CExpression *pexpOuterGbAgg = (*pexprInnerLimit)[0];
+		COperator *outerGbAggOp = pexpOuterGbAgg->Pop();
+		CLogicalGbAgg *popOuterAgg = CLogicalGbAgg::PopConvert(outerGbAggOp);
+		// Check for global/local status of outer gb agg.
+		if (popOuterAgg->FGlobal())
+		{
+			CExpression *pexprGbAggProjectionList = (*pexpOuterGbAgg)[1];
+			// If Gb Aggregate does not have any other aggregate functions but Distinct
+			if (pexprGbAggProjectionList->Arity() == 0)
+			{
+				// Take first child of global Gb Agg
+				CExpression *pexprInnerGbAgg = (*pexpOuterGbAgg)[0];
+				CLogicalGbAgg *popInnerGbAgg =
+					CLogicalGbAgg::PopConvert(pexprInnerGbAgg->Pop());
+				if (!popInnerGbAgg->FGlobal())
+				{
+					// Add limit on top of it with scalar start and scalar rows.
+					CExpression *pexprScalarStart = (*pexpr)[1];
+					CExpression *pexprScalarRows = (*pexpr)[2];
+					COrderSpec *pos = popOuterLimit->Pos();
+					pexprInnerGbAgg->AddRef();
+					// assemble local limit operator
+					CExpression *pexprLimitLocal =
+						PexprLimit(mp, pexprInnerGbAgg, pexprScalarStart,
+								   pexprScalarRows, pos,
+								   false,  // fGlobal
+								   popOuterLimit->FHasCount(),
+								   popOuterLimit->IsTopLimitUnderDMLorCTAS());
+
+					outerGbAggOp->AddRef();
+					pexprGbAggProjectionList->AddRef();
+
+					// Create new first global Logical Aggregate
+					CExpression *pexprNewFirstAgg = GPOS_NEW(mp)
+						CExpression(mp, outerGbAggOp, pexprLimitLocal,
+									pexprGbAggProjectionList);
+
+					// Create local limit wrapper on top of newly created global aggregate
+					CExpression *pexprNewExprLocal =
+						PexprLimit(mp, pexprNewFirstAgg, pexprScalarStart,
+								   pexprScalarRows, pos,
+								   false,  // fGlobal
+								   popOuterLimit->FHasCount(),
+								   popOuterLimit->IsTopLimitUnderDMLorCTAS());
+
+					// Create final global limit wrapper on top of local limit created above
+					CExpression *pexprNewExpr =
+						PexprLimit(mp, pexprNewExprLocal, pexprScalarStart,
+								   pexprScalarRows, pos,
+								   true,  // fGlobal
+								   popOuterLimit->FHasCount(),
+								   popOuterLimit->IsTopLimitUnderDMLorCTAS());
+
+					pxfres->Add(pexprNewExpr);
+				}
+			}
+		}
+	}
+}
+
+
+// Function to assemble limit expressions
+CExpression *
+CXformAddLimitAfterSplitGbAgg::PexprLimit(
+	CMemoryPool *mp, CExpression *pexprRelational,
+	CExpression *pexprScalarStart, CExpression *pexprScalarRows,
+	COrderSpec *pos, BOOL fGlobal, BOOL fHasCount, BOOL fTopLimitUnderDML)
+{
+	pexprScalarStart->AddRef();
+	pexprScalarRows->AddRef();
+	pos->AddRef();
+
+	CExpression *pexprLimit = GPOS_NEW(mp) CExpression(
+		mp,
+		GPOS_NEW(mp)
+			CLogicalLimit(mp, pos, fGlobal, fHasCount, fTopLimitUnderDML),
+		pexprRelational, pexprScalarStart, pexprScalarRows);
+
+	return pexprLimit;
+}
+
+
+// EOF

--- a/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
@@ -290,6 +290,7 @@ CXformFactory::Instantiate()
 	Add(GPOS_NEW(m_mp) CXformLeftJoin2RightJoin(m_mp));
 	Add(GPOS_NEW(m_mp) CXformRightOuterJoin2HashJoin(m_mp));
 	Add(GPOS_NEW(m_mp) CXformImplementInnerJoin(m_mp));
+	Add(GPOS_NEW(m_mp) CXformAddLimitAfterSplitGbAgg(m_mp));
 
 	GPOS_ASSERT(nullptr != m_rgpxf[CXform::ExfSentinel - 1] &&
 				"Not all xforms have been instantiated");

--- a/src/backend/gporca/libgpopt/src/xforms/Makefile
+++ b/src/backend/gporca/libgpopt/src/xforms/Makefile
@@ -132,7 +132,8 @@ OBJS        = CDecorrelator.o \
               CXformUnnestTVF.o \
               CXformUpdate2DML.o \
               CXformUtils.o \
-              CxformSelect2DynamicBitmapBoolOp.o
+              CxformSelect2DynamicBitmapBoolOp.o \
+              CXformAddLimitAfterSplitGbAgg.o
 
 include $(top_srcdir)/src/backend/common.mk
 

--- a/src/backend/gporca/server/src/unittest/gpopt/minidump/CAggTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/minidump/CAggTest.cpp
@@ -90,14 +90,14 @@ const CHAR *rgszAggFileNames[] = {
 	"../data/dxl/minidump/ComputedGroupByCol.mdp",
 	"../data/dxl/minidump/GroupByOuterRef.mdp",
 	"../data/dxl/minidump/DuplicateGrpCol.mdp",
-	"../data/dxl/minidump/CountAny.mdp",
-	"../data/dxl/minidump/CountStar.mdp",
+	"../data/dxl/minidump/CountAny.mdp", "../data/dxl/minidump/CountStar.mdp",
 	"../data/dxl/minidump/ProjectCountStar.mdp",
 	"../data/dxl/minidump/ProjectOutsideCountStar.mdp",
 	"../data/dxl/minidump/NestedProjectCountStarWithOuterRefs.mdp",
 	"../data/dxl/minidump/AggregateWithSkew.mdp",
 	"../data/dxl/minidump/OrderedAggUsingGroupColumnInDirectArg.mdp",
-};
+	"../data/dxl/minidump/LimitBtwLocalNGlobalAgg1.mdp",
+	"../data/dxl/minidump/LimitBtwLocalNGlobalAgg2.mdp"};
 
 
 //---------------------------------------------------------------------------

--- a/src/test/regress/expected/limit_gp.out
+++ b/src/test/regress/expected/limit_gp.out
@@ -193,24 +193,22 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x1' a
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into bar1 select i,1,i from generate_series(1,10000000) i;
 analyze bar1;
-explain select distinct sum(x1) s from bar1 b group by b.x3 limit 1;
-                                                           QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=265773.32..265773.33 rows=1 width=12)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=265773.32..265773.37 rows=3 width=12)
-         ->  Limit  (cost=265773.32..265773.33 rows=1 width=12)
-               ->  HashAggregate  (cost=262033.08..299435.43 rows=3333333 width=12)
+explain (costs off) select distinct sum(x1) s from bar1 b group by b.x3 limit 1;
+                                     QUERY PLAN
+------------------------------------------------------------------------------------
+ Limit
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Limit
+               ->  HashAggregate
                      Group Key: (sum(x1))
-                     Planned Partitions: 64
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=134168.50..237423.71 rows=3333333 width=12)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: (sum(x1))
-                           ->  HashAggregate  (cost=134168.50..170757.04 rows=3333333 width=12)
+                           ->  HashAggregate
                                  Group Key: x3
-                                 Planned Partitions: 32
-                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..104481.00 rows=3333333 width=8)
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                        Hash Key: x3
-                                       ->  Seq Scan on bar1 b  (cost=0.00..37814.33 rows=3333333 width=8)
+                                       ->  Seq Scan on bar1 b
  Optimizer: Postgres query optimizer
-(15 rows)
+(13 rows)
 
 drop table bar1;

--- a/src/test/regress/expected/limit_gp.out
+++ b/src/test/regress/expected/limit_gp.out
@@ -188,3 +188,29 @@ select array(select b from t_limit_all order by b asc limit all) t;
 (1 row)
 
 drop table t_limit_all;
+create table bar1(x1 int, x2 int, x3 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into bar1 select i,1,i from generate_series(1,10000000) i;
+analyze bar1;
+explain select distinct sum(x1) s from bar1 b group by b.x3 limit 1;
+                                                           QUERY PLAN
+---------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=265773.32..265773.33 rows=1 width=12)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=265773.32..265773.37 rows=3 width=12)
+         ->  Limit  (cost=265773.32..265773.33 rows=1 width=12)
+               ->  HashAggregate  (cost=262033.08..299435.43 rows=3333333 width=12)
+                     Group Key: (sum(x1))
+                     Planned Partitions: 64
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=134168.50..237423.71 rows=3333333 width=12)
+                           Hash Key: (sum(x1))
+                           ->  HashAggregate  (cost=134168.50..170757.04 rows=3333333 width=12)
+                                 Group Key: x3
+                                 Planned Partitions: 32
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..104481.00 rows=3333333 width=8)
+                                       Hash Key: x3
+                                       ->  Seq Scan on bar1 b  (cost=0.00..37814.33 rows=3333333 width=8)
+ Optimizer: Postgres query optimizer
+(15 rows)
+
+drop table bar1;

--- a/src/test/regress/expected/limit_gp_optimizer.out
+++ b/src/test/regress/expected/limit_gp_optimizer.out
@@ -184,3 +184,31 @@ select array(select b from t_limit_all order by b asc limit all) t;
 (1 row)
 
 drop table t_limit_all;
+create table bar1(x1 int, x2 int, x3 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into bar1 select i,1,i from generate_series(1,10000000) i;
+analyze bar1;
+explain select distinct sum(x1) s from bar1 b group by b.x3 limit 1;
+                                                                QUERY PLAN
+------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..1469.48 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1469.48 rows=1 width=8)
+         ->  Limit  (cost=0.00..1469.48 rows=1 width=8)
+               ->  GroupAggregate  (cost=0.00..1469.48 rows=1 width=8)
+                     Group Key: (sum(x1))
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1469.48 rows=1 width=8)
+                           Hash Key: (sum(x1))
+                           ->  Limit  (cost=0.00..1469.48 rows=1 width=8)
+                                 ->  Streaming HashAggregate  (cost=0.00..1469.48 rows=334 width=8)
+                                       Group Key: sum(x1)
+                                       ->  HashAggregate  (cost=0.00..1059.01 rows=3333334 width=8)
+                                             Group Key: x3
+                                             Planned Partitions: 32
+                                             ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..641.07 rows=3333334 width=8)
+                                                   Hash Key: x3
+                                                   ->  Seq Scan on bar1  (cost=0.00..508.00 rows=3333334 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(17 rows)
+
+drop table bar1;

--- a/src/test/regress/expected/limit_gp_optimizer.out
+++ b/src/test/regress/expected/limit_gp_optimizer.out
@@ -189,26 +189,25 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x1' a
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into bar1 select i,1,i from generate_series(1,10000000) i;
 analyze bar1;
-explain select distinct sum(x1) s from bar1 b group by b.x3 limit 1;
-                                                                QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=0.00..1469.48 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1469.48 rows=1 width=8)
-         ->  Limit  (cost=0.00..1469.48 rows=1 width=8)
-               ->  GroupAggregate  (cost=0.00..1469.48 rows=1 width=8)
+explain (costs off) select distinct sum(x1) s from bar1 b group by b.x3 limit 1;
+                                           QUERY PLAN
+------------------------------------------------------------------------------------------------
+ Limit
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Limit
+               ->  GroupAggregate
                      Group Key: (sum(x1))
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1469.48 rows=1 width=8)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: (sum(x1))
-                           ->  Limit  (cost=0.00..1469.48 rows=1 width=8)
-                                 ->  Streaming HashAggregate  (cost=0.00..1469.48 rows=334 width=8)
+                           ->  Limit
+                                 ->  Streaming HashAggregate
                                        Group Key: sum(x1)
-                                       ->  HashAggregate  (cost=0.00..1059.01 rows=3333334 width=8)
+                                       ->  HashAggregate
                                              Group Key: x3
-                                             Planned Partitions: 32
-                                             ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..641.07 rows=3333334 width=8)
+                                             ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                                    Hash Key: x3
-                                                   ->  Seq Scan on bar1  (cost=0.00..508.00 rows=3333334 width=8)
+                                                   ->  Seq Scan on bar1
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(16 rows)
 
 drop table bar1;

--- a/src/test/regress/sql/limit_gp.sql
+++ b/src/test/regress/sql/limit_gp.sql
@@ -65,3 +65,9 @@ select array(select b from t_limit_all order by b asc limit all) t;
 select array(select b from t_limit_all order by b asc limit all) t;
 
 drop table t_limit_all;
+
+create table bar1(x1 int, x2 int, x3 int);
+insert into bar1 select i,1,i from generate_series(1,10000000) i;
+analyze bar1;
+explain select distinct sum(x1) s from bar1 b group by b.x3 limit 1;
+drop table bar1;

--- a/src/test/regress/sql/limit_gp.sql
+++ b/src/test/regress/sql/limit_gp.sql
@@ -69,5 +69,5 @@ drop table t_limit_all;
 create table bar1(x1 int, x2 int, x3 int);
 insert into bar1 select i,1,i from generate_series(1,10000000) i;
 analyze bar1;
-explain select distinct sum(x1) s from bar1 b group by b.x3 limit 1;
+explain (costs off) select distinct sum(x1) s from bar1 b group by b.x3 limit 1;
 drop table bar1;


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community

The following query should produce add a new LIMIT in the plan between global and local of the LogicalGlobalAggregate operator. 
`
select distinct sum(x1) s from bar1 b group by b.x3 limit 1;
`

Prior to this commit, the plan for the above query didn't have an extra limit. As part of this PR, added a new transformation rule that identifies the required pattern and adds the new limit. 

Below are the plan changes before and after the transformation for the above query.

Old Plan:
```
                                        QUERY PLAN                                        
------------------------------------------------------------------------------------------
 Limit
   ->  Gather Motion 3:1  (slice1; segments: 3)
         ->  Limit
               ->  HashAggregate
                     Group Key: (sum(x1))
                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
                           Hash Key: (sum(x1))
                           ->  Streaming HashAggregate
                                 Group Key: sum(x1)
                                 ->  HashAggregate
                                       Group Key: x3
                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                             Hash Key: x3
                                             ->  Seq Scan on bar1
 Optimizer: Pivotal Optimizer (GPORCA)
(15 rows)
```

New Plan:
```
                                           QUERY PLAN                                           
------------------------------------------------------------------------------------------------
 Limit
   ->  Gather Motion 3:1  (slice1; segments: 3)
         ->  Limit
               ->  GroupAggregate
                     Group Key: (sum(x1))
                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
                           Hash Key: (sum(x1))
                           ->  Limit
                                 ->  Streaming HashAggregate
                                       Group Key: sum(x1)
                                       ->  HashAggregate
                                             Group Key: x3
                                             ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                                   Hash Key: x3
                                                   ->  Seq Scan on bar1
 Optimizer: Pivotal Optimizer (GPORCA)
(16 rows)
```