### PR TITLE
Just use default on commit behavior to child tables when we create partition table

### DIFF
--- a/src/backend/parser/parse_partition_gp.c
+++ b/src/backend/parser/parse_partition_gp.c
@@ -891,7 +891,7 @@ makePartitionCreateStmt(Relation parentrel, char *partname, PartitionBoundSpec *
 	childstmt->ofTypename = NULL;
 	childstmt->constraints = NIL;
 	childstmt->options = elem->options ? copyObject(elem->options) : NIL;
-	childstmt->oncommit = ONCOMMIT_NOOP;  // FIXME: copy from parent stmt?
+	childstmt->oncommit = ONCOMMIT_NOOP;
 	childstmt->tablespacename = elem->tablespacename ? pstrdup(elem->tablespacename) : NULL;
 	childstmt->accessMethod = elem->accessMethod ? pstrdup(elem->accessMethod) : NULL;
 	childstmt->if_not_exists = false;

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -5917,3 +5917,24 @@ RESET ROLE;
 DROP TABLE public.t_part_acl;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE SELECT ON TABLES FROM user_prt_acl;
 DROP ROLE user_prt_acl;
+-- test on commit behavior used on partition table
+begin;
+create temp table temp_parent (a int) partition by range(a) (start(1) end(10) every(10)) on commit delete rows;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into temp_parent select i from generate_series(1, 5) i;
+select count(*) from temp_parent;
+ count 
+-------
+     5
+(1 row)
+
+commit;
+-- DELETE ROWS will not cascaded to its partitions when we use DELETE ROWS behavior
+select count(*) from temp_parent;
+ count 
+-------
+     5
+(1 row)
+
+drop table temp_parent;

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -5918,6 +5918,7 @@ DROP TABLE public.t_part_acl;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE SELECT ON TABLES FROM user_prt_acl;
 DROP ROLE user_prt_acl;
 -- test on commit behavior used on partition table
+-- test on commit delete rows
 begin;
 create temp table temp_parent (a int) partition by range(a) (start(1) end(10) every(10)) on commit delete rows;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
@@ -5938,3 +5939,23 @@ select count(*) from temp_parent;
 (1 row)
 
 drop table temp_parent;
+-- test on commit drop
+begin;
+create temp table temp_parent (a int) partition by range(a) (start(1) end(10) every(1)) on commit drop;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into temp_parent select i from generate_series(1, 5) i;
+select count(*) from pg_class where relname like 'temp_parent_%';
+ count 
+-------
+     9
+(1 row)
+
+commit;
+-- no relations remain in this case.
+select count(*) from pg_class where relname like 'temp_parent_%';
+ count 
+-------
+     0
+(1 row)
+

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -5917,3 +5917,24 @@ RESET ROLE;
 DROP TABLE public.t_part_acl;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE SELECT ON TABLES FROM user_prt_acl;
 DROP ROLE user_prt_acl;
+-- test on commit behavior used on partition table
+begin;
+create temp table temp_parent (a int) partition by range(a) (start(1) end(10) every(10)) on commit delete rows;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into temp_parent select i from generate_series(1, 5) i;
+select count(*) from temp_parent;
+ count 
+-------
+     5
+(1 row)
+
+commit;
+-- DELETE ROWS will not cascaded to its partitions when we use DELETE ROWS behavior
+select count(*) from temp_parent;
+ count 
+-------
+     5
+(1 row)
+
+drop table temp_parent;

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -5918,6 +5918,7 @@ DROP TABLE public.t_part_acl;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE SELECT ON TABLES FROM user_prt_acl;
 DROP ROLE user_prt_acl;
 -- test on commit behavior used on partition table
+-- test on commit delete rows
 begin;
 create temp table temp_parent (a int) partition by range(a) (start(1) end(10) every(10)) on commit delete rows;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
@@ -5938,3 +5939,23 @@ select count(*) from temp_parent;
 (1 row)
 
 drop table temp_parent;
+-- test on commit drop
+begin;
+create temp table temp_parent (a int) partition by range(a) (start(1) end(10) every(1)) on commit drop;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into temp_parent select i from generate_series(1, 5) i;
+select count(*) from pg_class where relname like 'temp_parent_%';
+ count 
+-------
+     9
+(1 row)
+
+commit;
+-- no relations remain in this case.
+select count(*) from pg_class where relname like 'temp_parent_%';
+ count 
+-------
+     0
+(1 row)
+

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -3816,9 +3816,3 @@ commit;
 -- no relations remain in this case.
 select count(*) from pg_class where relname like 'temp_parent_%';
 
-
-
-
-
-
-

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -3796,14 +3796,29 @@ DROP ROLE user_prt_acl;
 
 
 -- test on commit behavior used on partition table
+
+-- test on commit delete rows
 begin;
 create temp table temp_parent (a int) partition by range(a) (start(1) end(10) every(10)) on commit delete rows;
 insert into temp_parent select i from generate_series(1, 5) i;
 select count(*) from temp_parent;
 commit;
-
 -- DELETE ROWS will not cascaded to its partitions when we use DELETE ROWS behavior
 select count(*) from temp_parent;
-
 drop table temp_parent;
+
+-- test on commit drop
+begin;
+create temp table temp_parent (a int) partition by range(a) (start(1) end(10) every(1)) on commit drop;
+insert into temp_parent select i from generate_series(1, 5) i;
+select count(*) from pg_class where relname like 'temp_parent_%';
+commit;
+-- no relations remain in this case.
+select count(*) from pg_class where relname like 'temp_parent_%';
+
+
+
+
+
+
 

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -3793,3 +3793,17 @@ RESET ROLE;
 DROP TABLE public.t_part_acl;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE SELECT ON TABLES FROM user_prt_acl;
 DROP ROLE user_prt_acl;
+
+
+-- test on commit behavior used on partition table
+begin;
+create temp table temp_parent (a int) partition by range(a) (start(1) end(10) every(10)) on commit delete rows;
+insert into temp_parent select i from generate_series(1, 5) i;
+select count(*) from temp_parent;
+commit;
+
+-- DELETE ROWS will not cascaded to its partitions when we use DELETE ROWS behavior
+select count(*) from temp_parent;
+
+drop table temp_parent;
+


### PR DESCRIPTION
When we create a temporary table, we can use `ON COMMIT` to control the behavior 
of temporary tables at the end of a transaction block, such as `DELETE ROWS`, means
delete all rows in this temporary table after this transaction is committed.

But when used on a partitioned table, this is not cascaded to its partitions, so we can just
use `ONCOMMIT_NOOP` (default behavior) when we create child partition tables.

And If we use the parent on commit action, it will lead to inconsistent behavior between 
Greenplum and PostgreSQL, which we need to avoid.