### PR TITLE
[doc] fix some gpinitsystem usage and doc mismatch

### DIFF
--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -120,7 +120,7 @@ USAGE () {
 		$ECHO "      -q, quiet mode, do not log progress to screen [default:- verbose output to screen]"
 		$ECHO
 		$ECHO "      Configuration options:"
-		$ECHO "      -b, shared_buffers per instance [default $DEFAULT_BUFFERS]"
+		$ECHO "      -b, <size> shared_buffers per instance [default $DEFAULT_BUFFERS]"
 		$ECHO "          Specify either the number of database I/O buffers (without suffix) or the"
 		$ECHO "          amount of memory to use for buffers (with suffix 'kB', 'MB' or 'GB')."
 		$ECHO "          Applies to coordinator and all segments."
@@ -129,7 +129,7 @@ USAGE () {
 		$ECHO "          Supplies all Greenplum configuration information required by this utility."
 		$ECHO "          Full description of all parameters contained within the example file"
 		$ECHO "          supplied with this distribution."
-		$ECHO "          Also see gpinitsystem_INSTRUCTIONS file for greater detail on"
+		$ECHO "          Also see file $HELP_DOC_NAME for greater detail on"
 		$ECHO "          the operation and configuration of this script"
 		$ECHO "      -e, <password>, password to set for Greenplum superuser in database [default $GP_PASSWD]"
 		$ECHO "      -S, standby_datadir [optional]"

--- a/gpMgmt/doc/gpinitsystem_help
+++ b/gpMgmt/doc/gpinitsystem_help
@@ -12,9 +12,9 @@ gpinitsystem -c <gpinitsystem_config>
             [-h <hostfile_gpinitsystem>]
             [-B <parallel_processes>] 
             [-p <postgresql_conf_param_file>]
-            [-s <standby_coordinator_host>
+            [-s <standby_coordinator_host>]
                 [-P <standby_coordinator_port>] [ {-S | --standby-datadir} <standby_coordinator_datadir>]
-            [-m number | --max_connections=<number>] [--shared_buffers=<size>]
+            [-m number | --max_connections=<number>] [-b size | --shared_buffers=<size>]
             [-n locale | --locale=<locale>] [--lc-collate=<locale>]
             [--lc-ctype=<locale>] [--lc-messages=<locale>] 
             [--lc-monetary=<locale>] [--lc-numeric=<locale>] 


### PR DESCRIPTION
In gpinitsystem USAGE, the recommended `gpinitsystem_INSTRUCTIONS`
file cannot be found in the codebase and the internet, so I guess
this should be the gpinitsystem_help, which was referenced by
$HELP_DOC_NAME variable.

Signed-off-by: Junwang Zhao <zhjwpku@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
