### PR TITLE
Combine Greenplum and Postgres's EXPLAIN SETTINGS

### DIFF
--- a/contrib/auto_explain/.gitignore
+++ b/contrib/auto_explain/.gitignore
@@ -1,0 +1,1 @@
+/results/

--- a/contrib/auto_explain/expected/auto_explain.out
+++ b/contrib/auto_explain/expected/auto_explain.out
@@ -38,6 +38,7 @@ Query Text: SELECT relname FROM pg_class WHERE relname='pg_class';
 Index Only Scan using pg_class_relname_nsp_index on pg_class  (cost=0.15..4.17 rows=1 width=64) (actual rows=1 loops=1)
   Index Cond: (relname = 'pg_class'::name)
   Heap Fetches: 0
+Optimizer: Postgres query optimizer
   (slice0)    Executor memory: 105K bytes.
 Memory used:  128000kB
  relname  
@@ -57,6 +58,7 @@ Finalize Aggregate  (cost=35148.64..35148.65 rows=1 width=8) (actual rows=1 loop
                     ->  Materialize  (cost=0.00..68.06 rows=1001 width=0) (actual rows=1001 loops=340)
                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..53.05 rows=1001 width=0) (actual rows=1001 loops=1)
                                 ->  Seq Scan on t2  (cost=0.00..13.01 rows=334 width=0) (actual rows=340 loops=1)
+Optimizer: Postgres query optimizer
   (slice0)    Executor memory: 131K bytes.
   (slice1)    Executor memory: 152K bytes avg x 3 workers, 152K bytes max (seg0).
   (slice2)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
@@ -98,6 +100,7 @@ Finalize Aggregate  (cost=35148.64..35148.65 rows=1 width=8) (actual rows=1 loop
                           work_mem: 142kB  Segments: 3  Max: 48kB (segment 0)  Workfile: (0 spilling)
                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..53.05 rows=1001 width=0) (actual rows=1001 loops=1)
                                 ->  Seq Scan on auto_explain_test.t2  (cost=0.00..13.01 rows=334 width=0) (actual rows=340 loops=1)
+Optimizer: Postgres query optimizer
   (slice0)    Executor memory: 131K bytes.
   (slice1)    Executor memory: 152K bytes avg x 3 workers, 152K bytes max (seg0).
   (slice2)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).

--- a/contrib/auto_explain/expected/auto_explain_optimizer.out
+++ b/contrib/auto_explain/expected/auto_explain_optimizer.out
@@ -42,6 +42,7 @@ Query Text: SELECT relname FROM pg_class WHERE relname='pg_class';
 Index Only Scan using pg_class_relname_nsp_index on pg_class  (cost=0.15..4.17 rows=1 width=64) (actual rows=1 loops=1)
   Index Cond: (relname = 'pg_class'::name)
   Heap Fetches: 0
+Optimizer: Postgres query optimizer
   (slice0)    Executor memory: 105K bytes.
 Memory used:  128000kB
  relname  
@@ -61,6 +62,7 @@ Finalize Aggregate  (cost=0.00..1326086.34 rows=1 width=8) (actual rows=1 loops=
                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.02 rows=1001 width=1) (actual rows=1001 loops=1)
                           ->  Seq Scan on t1  (cost=0.00..431.01 rows=334 width=1) (actual rows=340 loops=1)
                     ->  Seq Scan on t2  (cost=0.00..431.01 rows=334 width=1) (actual rows=340 loops=1002)
+Optimizer: Pivotal Optimizer (GPORCA)
   (slice0)    Executor memory: 67K bytes.
   (slice1)    Executor memory: 119K bytes avg x 3 workers, 119K bytes max (seg0).
   (slice2)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
@@ -104,6 +106,7 @@ Finalize Aggregate  (cost=0.00..1326086.34 rows=1 width=8) (actual rows=1 loops=
                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.02 rows=1001 width=1) (actual rows=1001 loops=1)
                           ->  Seq Scan on auto_explain_test.t1  (cost=0.00..431.01 rows=334 width=1) (actual rows=340 loops=1)
                     ->  Seq Scan on auto_explain_test.t2  (cost=0.00..431.01 rows=334 width=1) (actual rows=340 loops=1002)
+Optimizer: Pivotal Optimizer (GPORCA)
   (slice0)    Executor memory: 67K bytes.
   (slice1)    Executor memory: 119K bytes avg x 3 workers, 119K bytes max (seg0).
   (slice2)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -4947,7 +4947,7 @@ int get_num_guc_variables(void)
 /*
  * gp_guc_list_init
  *
- * Builds global lists of interesting GUCs for use with gp_guc_list_show()...
+ * Builds global lists of interesting GUCs...
  *
  * - gp_guc_list_for_explain: consists of planner GUCs, plus 'work_mem'
  * - gp_guc_list_for_no_plan: planner method enables for cdb_no_plan_for_query().
@@ -5002,41 +5002,6 @@ gp_guc_list_init(void)
             gp_guc_list_for_no_plan = lappend(gp_guc_list_for_no_plan, gconf);
 	}
 }                               /* gp_guc_list_init */
-
-
-/*
- * gp_guc_list_show
- *
- * Given a list of GUCs (a List of struct config_generic), construct a list
- * of human-readable strings of the option names and current values, skipping
- * any whose source <= 'excluding'.
- */
-List *
-gp_guc_list_show(GucSource excluding, List *guclist)
-{
-	List	   *options = NIL;
-	ListCell   *cell;
-	char	   *value;
-	char	 	buf[NAMEDATALEN];
-
-	foreach(cell, guclist)
-	{
-		struct config_generic *gconf = (struct config_generic *) lfirst(cell);
-
-		if (gconf->source > excluding)
-        {
-            value = _ShowOption(gconf, true);
-			snprintf(buf, sizeof(buf), "%s=%s", gconf->name, value);
-			options = lappend(options, pstrdup(buf));
-
-			memset(&buf, '\0', sizeof(buf));
-            pfree(value);
-        }
-	}
-
-	return options;
-}
-
 
 /*
  * Build the sorted array.  This is split out so that it could be
@@ -6306,8 +6271,8 @@ BeginReportingGUCOptions(void)
 {
 	int			i;
 
-    /* Build global lists of GUCs for use by callers of gp_guc_list_show(). */
-    gp_guc_list_init();
+	/* Build global lists of GUCs for use. */
+	gp_guc_list_init();
 
 	/*
 	 * Don't do anything unless talking to an interactive frontend of protocol

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -99,11 +99,11 @@ extern struct config_generic *find_option(const char *name, bool create_placehol
 
 extern int listenerBacklog;
 
-/* GUC lists for gp_guc_list_show().  (List of struct config_generic) */
+/* GUC lists for gp_guc_list_init().  (List of struct config_generic) */
 List	   *gp_guc_list_for_explain;
 List	   *gp_guc_list_for_no_plan;
 
-/* For synchornized GUC value is cache in HashTable,
+/* For synchronized GUC value is cache in HashTable,
  * dispatch value along with query when some guc changed
  */
 List       *gp_guc_restore_list = NIL;

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -247,7 +247,7 @@ typedef enum
 #define GUC_GPDB_NEED_SYNC     0x00400000  /* guc value is synced between master and primary */
 #define GUC_GPDB_NO_SYNC       0x00800000  /* guc value is not synced between master and primary */
 
-/* GUC lists for gp_guc_list_show().  (List of struct config_generic) */
+/* GUC lists for gp_guc_list_init().  (List of struct config_generic) */
 extern List    *gp_guc_list_for_explain;
 extern List    *gp_guc_list_for_no_plan;
 
@@ -735,8 +735,6 @@ extern ArrayType *GUCArrayDelete(ArrayType *array, const char *name);
 extern ArrayType *GUCArrayReset(ArrayType *array);
 
 extern void pg_timezone_abbrev_initialize(void);
-
-extern List *gp_guc_list_show(GucSource excluding, List *guclist);
 
 extern struct config_generic *find_option(const char *name,
 				bool create_placeholders, int elevel);

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -253,9 +253,53 @@ QUERY PLAN
                 Total Cost: 596.00
                 Plan Rows: 49600
                 Plan Width: 36
-  Settings: 
-    Optimizer: "Postgres query optimizer"
+  Optimizer: "Postgres query optimizer"
 (1 row)
+SET random_page_cost = 1;
+SET cpu_index_tuple_cost = 0.1;
+EXPLAIN (FORMAT YAML, VERBOSE, SETTINGS ON) SELECT * from boxes;
+QUERY PLAN
+- Plan: 
+    Node Type: "Gather Motion"
+    Senders: 3
+    Receivers: 1
+    Slice: 1
+    Segments: #
+    Gang Type: "primary reader"
+    Parallel Aware: false
+    Startup Cost: ###.##
+    Total Cost: ###.##
+    Plan Rows: #####
+    Plan Width: ##
+    Output: 
+      - "id"
+      - "apple_id"
+      - "location_id"
+    Plans: 
+      - Node Type: "Seq Scan"
+        Parent Relationship: "Outer"
+        Slice: 1
+        Segments: #
+        Gang Type: "primary reader"
+        Parallel Aware: false
+        Relation Name: "boxes"
+        Schema: "public"
+        Alias: "boxes"
+        Startup Cost: ###.##
+        Total Cost: ###.##
+        Plan Rows: #####
+        Plan Width: ##
+        Output: 
+          - "id"
+          - "apple_id"
+          - "location_id"
+  Optimizer: "Postgres query optimizer"
+  Settings: 
+    cpu_index_tuple_cost: "0.1"
+    random_page_cost: "1"
+(1 row)
+RESET random_page_cost;
+RESET cpu_index_tuple_cost;
 --- Check Explain Analyze YAML output that include the slices information
 -- explain_processing_off
 EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
@@ -437,6 +481,7 @@ QUERY PLAN
                 Actual Total Time: 0.000
                 Actual Rows: 0
                 Actual Loops: 0
+  Optimizer: "Postgres query optimizer"
   Planning Time: 5.148
   Triggers: 
   Slice statistics: 
@@ -461,8 +506,6 @@ QUERY PLAN
         Maximum Memory Used: 60624
   Statement statistics: 
     Memory used: 128000
-  Settings: 
-    Optimizer: "Postgres query optimizer"
   Execution Time: 72.942
 (1 row)
 -- explain_processing_on
@@ -491,9 +534,7 @@ QUERY PLAN
       "Function Name": "generate_series",
       "Alias": "generate_series"
     },
-    "Settings": {
-      "Optimizer": "Postgres query optimizer"
-    }
+    "Optimizer": "Postgres query optimizer"
   }
 ]
 (1 row)
@@ -510,9 +551,7 @@ QUERY PLAN
       <Function-Name>generate_series</Function-Name>
       <Alias>generate_series</Alias>
     </Plan>
-    <Settings>
-      <Optimizer>Postgres query optimizer</Optimizer>
-    </Settings>
+    <Optimizer>Postgres query optimizer</Optimizer>
   </Query>
 </explain>
 (1 row)
@@ -547,9 +586,7 @@ QUERY PLAN
         }
       ]
     },
-    "Settings": {
-      "Optimizer": "Postgres query optimizer"
-    }
+    "Optimizer": "Postgres query optimizer"
   }
 ]
 (1 row)

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -74,13 +74,13 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
                            Index Cond: (id = boxes.location_id)
          ->  Index Scan using apples_pkey on apples  (cost=0.00..12.00 rows=1 width=12) (never executed)
                Index Cond: (id = boxes.apple_id)
+ Optimizer: Pivotal Optimizer (GPORCA)
  Planning Time: 40.380 ms
    (slice0)    Executor memory: 56K bytes.
    (slice1)    Executor memory: 43K bytes avg x 3 workers, 43K bytes max (seg0).
    (slice2)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
    (slice3)    Executor memory: 39K bytes avg x 3 workers, 39K bytes max (seg0).
  Memory used:  256000kB
- Optimizer: Pivotal Optimizer (GPORCA)
  Execution Time: 19.964 ms
 (22 rows)
 
@@ -235,9 +235,53 @@ QUERY PLAN
             Plan Rows: 1
             Plan Width: 12
             Index Cond: "(id = boxes.apple_id)"
-  Settings: 
-    Optimizer: "Pivotal Optimizer (GPORCA)"
+  Optimizer: "Pivotal Optimizer (GPORCA)"
 (1 row)
+SET random_page_cost = 1;
+SET cpu_index_tuple_cost = 0.1;
+EXPLAIN (FORMAT YAML, VERBOSE, SETTINGS ON) SELECT * from boxes;
+QUERY PLAN
+- Plan: 
+    Node Type: "Gather Motion"
+    Senders: 3
+    Receivers: 1
+    Slice: 1
+    Segments: #
+    Gang Type: "primary reader"
+    Parallel Aware: false
+    Startup Cost: ###.##
+    Total Cost: ###.##
+    Plan Rows: #####
+    Plan Width: ##
+    Output: 
+      - "id"
+      - "apple_id"
+      - "location_id"
+    Plans: 
+      - Node Type: "Seq Scan"
+        Parent Relationship: "Outer"
+        Slice: 1
+        Segments: #
+        Gang Type: "primary reader"
+        Parallel Aware: false
+        Relation Name: "boxes"
+        Schema: "public"
+        Alias: "boxes"
+        Startup Cost: ###.##
+        Total Cost: ###.##
+        Plan Rows: #####
+        Plan Width: ##
+        Output: 
+          - "id"
+          - "apple_id"
+          - "location_id"
+  Optimizer: "Pivotal Optimizer (GPORCA)"
+  Settings: 
+    cpu_index_tuple_cost: "0.1"
+    random_page_cost: "1"
+(1 row)
+RESET random_page_cost;
+RESET cpu_index_tuple_cost;
 --- Check Explain Analyze YAML output that include the slices information
 -- explain_processing_off
 EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
@@ -389,6 +433,7 @@ QUERY PLAN
             Actual Loops: 0
             Index Cond: "(id = boxes.apple_id)"
             Rows Removed by Index Recheck: 0
+  Optimizer: "Pivotal Optimizer (GPORCA)"
   Planning Time: 14.827
   Triggers: 
   Slice statistics: 
@@ -411,8 +456,6 @@ QUERY PLAN
         Maximum Memory Used: 60624
   Statement statistics: 
     Memory used: 128000
-  Settings: 
-    Optimizer: "Pivotal Optimizer (GPORCA)"
   Execution Time: 3.332
 (1 row)
 -- explain_processing_on
@@ -441,9 +484,7 @@ QUERY PLAN
       "Function Name": "generate_series",
       "Alias": "generate_series"
     },
-    "Settings": {
-      "Optimizer": "Pivotal Optimizer (GPORCA)"
-    }
+    "Optimizer": "Pivotal Optimizer (GPORCA)"
   }
 ]
 (1 row)
@@ -460,9 +501,7 @@ QUERY PLAN
       <Function-Name>generate_series</Function-Name>
       <Alias>generate_series</Alias>
     </Plan>
-    <Settings>
-      <Optimizer>Pivotal Optimizer (GPORCA)</Optimizer>
-    </Settings>
+    <Optimizer>Pivotal Optimizer (GPORCA)</Optimizer>
   </Query>
 </explain>
 (1 row)
@@ -507,9 +546,7 @@ QUERY PLAN
         }
       ]
     },
-    "Settings": {
-      "Optimizer": "Pivotal Optimizer (GPORCA)"
-    }
+    "Optimizer": "Pivotal Optimizer (GPORCA)"
   }
 ]
 (1 row)

--- a/src/test/regress/expected/fast_default.out
+++ b/src/test/regress/expected/fast_default.out
@@ -306,9 +306,8 @@ SELECT c_bigint, c_text FROM T WHERE c_bigint = -1 LIMIT 1;
                ->  Seq Scan on fast_default.t
                      Output: c_bigint, c_text
                      Filter: (t.c_bigint = '-1'::integer)
- Optimizer: Postgres query optimizer
- Settings: optimizer=off
-(11 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
 
 SELECT c_bigint, c_text FROM T WHERE c_text = 'hello' LIMIT 1;
  c_bigint | c_text 
@@ -328,9 +327,8 @@ EXPLAIN (VERBOSE TRUE, COSTS FALSE) SELECT c_bigint, c_text FROM T WHERE c_text 
                ->  Seq Scan on fast_default.t
                      Output: c_bigint, c_text
                      Filter: (t.c_text = 'hello'::text)
- Optimizer: Postgres query optimizer
- Settings: optimizer=off
-(11 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
 
 -- COALESCE
 SELECT COALESCE(c_bigint, pk), COALESCE(c_text, pk::text)
@@ -389,9 +387,8 @@ SELECT * FROM T ORDER BY c_bigint, c_text, pk LIMIT 10;
                      Sort Key: t.c_bigint, t.c_text, t.pk
                      ->  Seq Scan on fast_default.t
                            Output: pk, c_bigint, c_text
- Optimizer: Postgres query optimizer
- Settings: optimizer=off
-(14 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
 
 -- LIMIT
 SELECT * FROM T WHERE c_bigint > -1 ORDER BY c_bigint, c_text, pk LIMIT 10;
@@ -426,9 +423,8 @@ SELECT * FROM T WHERE c_bigint > -1 ORDER BY c_bigint, c_text, pk LIMIT 10;
                      ->  Seq Scan on fast_default.t
                            Output: pk, c_bigint, c_text
                            Filter: (t.c_bigint > '-1'::integer)
- Optimizer: Postgres query optimizer
- Settings: optimizer=off
-(15 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(14 rows)
 
 --  DELETE with RETURNING
 DELETE FROM T WHERE pk BETWEEN 10 AND 20 RETURNING *;
@@ -459,8 +455,7 @@ DELETE FROM T WHERE pk BETWEEN 10 AND 20 RETURNING *;
                Output: ctid, gp_segment_id
                Filter: ((t.pk >= 10) AND (t.pk <= 20))
  Optimizer: Postgres query optimizer
- Settings: optimizer=off
-(9 rows)
+(8 rows)
 
 -- UPDATE
 UPDATE T SET c_text = '"' || c_text || '"'  WHERE pk < 10;

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -221,35 +221,33 @@ CREATE EXTERNAL WEB TABLE dummy_ext_tab (x text) EXECUTE 'echo foo' FORMAT 'text
 -- External Table Scan
 explain (format json, costs off) SELECT * FROM dummy_ext_tab;
                   QUERY PLAN                   
------------------------------------------------
- [                                            +
-   {                                          +
-     "Plan": {                                +
-       "Node Type": "Gather Motion",          +
-       "Senders": 3,                          +
-       "Receivers": 1,                        +
-       "Slice": 1,                            +
-       "Segments": 3,                         +
-       "Gang Type": "primary reader",         +
-       "Parallel Aware": false,               +
-       "Plans": [                             +
-         {                                    +
-           "Node Type": "Foreign Scan",       +
-           "Operation": "Select",             +
-           "Parent Relationship": "Outer",    +
-           "Slice": 1,                        +
-           "Segments": 3,                     +
-           "Gang Type": "primary reader",     +
-           "Parallel Aware": false,           +
-           "Relation Name": "dummy_ext_tab",  +
-           "Alias": "dummy_ext_tab"           +
-         }                                    +
-       ]                                      +
-     },                                       +
-     "Settings": {                            +
-       "Optimizer": "Postgres query optimizer"+
-     }                                        +
-   }                                          +
+---------------------------------------------
+ [                                          +
+   {                                        +
+     "Plan": {                              +
+       "Node Type": "Gather Motion",        +
+       "Senders": 3,                        +
+       "Receivers": 1,                      +
+       "Slice": 1,                          +
+       "Segments": 3,                       +
+       "Gang Type": "primary reader",       +
+       "Parallel Aware": false,             +
+       "Plans": [                           +
+         {                                  +
+           "Node Type": "Foreign Scan",     +
+           "Operation": "Select",           +
+           "Parent Relationship": "Outer",  +
+           "Slice": 1,                      +
+           "Segments": 3,                   +
+           "Gang Type": "primary reader",   +
+           "Parallel Aware": false,         +
+           "Relation Name": "dummy_ext_tab",+
+           "Alias": "dummy_ext_tab"         +
+         }                                  +
+       ]                                    +
+     },                                     +
+     "Optimizer": "Postgres query optimizer"+
+   }                                        +
  ]
 (1 row)
 
@@ -259,26 +257,25 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 explain (format yaml, costs off) SELECT * FROM dummy_aotab;
                 QUERY PLAN                 
--------------------------------------------
- - Plan:                                  +
-     Node Type: "Gather Motion"           +
-     Senders: 3                           +
-     Receivers: 1                         +
-     Slice: 1                             +
-     Segments: 3                          +
-     Gang Type: "primary reader"          +
-     Parallel Aware: false                +
-     Plans:                               +
-       - Node Type: "Seq Scan"            +
-         Parent Relationship: "Outer"     +
-         Slice: 1                         +
-         Segments: 3                      +
-         Gang Type: "primary reader"      +
-         Parallel Aware: false            +
-         Relation Name: "dummy_aotab"     +
-         Alias: "dummy_aotab"             +
-   Settings:                              +
-     Optimizer: "Postgres query optimizer"
+-----------------------------------------
+ - Plan:                                +
+     Node Type: "Gather Motion"         +
+     Senders: 3                         +
+     Receivers: 1                       +
+     Slice: 1                           +
+     Segments: 3                        +
+     Gang Type: "primary reader"        +
+     Parallel Aware: false              +
+     Plans:                             +
+       - Node Type: "Seq Scan"          +
+         Parent Relationship: "Outer"   +
+         Slice: 1                       +
+         Segments: 3                    +
+         Gang Type: "primary reader"    +
+         Parallel Aware: false          +
+         Relation Name: "dummy_aotab"   +
+         Alias: "dummy_aotab"           +
+   Optimizer: "Postgres query optimizer"
 (1 row)
 
 -- DML node (with ORCA)
@@ -307,9 +304,7 @@ explain (format xml, costs off) insert into dummy_aotab values (1);
          </Plan>                                            +
        </Plans>                                             +
      </Plan>                                                +
-     <Settings>                                             +
-       <Optimizer>Postgres query optimizer</Optimizer>      +
-     </Settings>                                            +
+     <Optimizer>Postgres query optimizer</Optimizer>        +
    </Query>                                                 +
  </explain>
 (1 row)
@@ -379,50 +374,48 @@ explain (slicetable, costs off) SELECT * FROM explaintest;
 -- same in JSON format
 explain (slicetable, costs off, format json) SELECT * FROM explaintest;
                   QUERY PLAN                   
------------------------------------------------
- [                                            +
-   {                                          +
-     "Plan": {                                +
-       "Node Type": "Gather Motion",          +
-       "Senders": 3,                          +
-       "Receivers": 1,                        +
-       "Slice": 1,                            +
-       "Segments": 3,                         +
-       "Gang Type": "primary reader",         +
-       "Parallel Aware": false,               +
-       "Plans": [                             +
-         {                                    +
-           "Node Type": "Seq Scan",           +
-           "Parent Relationship": "Outer",    +
-           "Slice": 1,                        +
-           "Segments": 3,                     +
-           "Gang Type": "primary reader",     +
-           "Parallel Aware": false,           +
-           "Relation Name": "explaintest",    +
-           "Alias": "explaintest"             +
-         }                                    +
-       ]                                      +
-     },                                       +
-     "Slice Table": [                         +
-       {                                      +
-         "Slice ID": 0,                       +
-         "Gang Type": "Dispatcher",           +
-         "Root": 0,                           +
-         "Parent": -1,                        +
-         "Gang Size": 0                       +
-       },                                     +
-       {                                      +
-         "Slice ID": 1,                       +
-         "Gang Type": "Reader",               +
-         "Root": 0,                           +
-         "Parent": 0,                         +
-         "Gang Size": 3                       +
-       }                                      +
-     ],                                       +
-     "Settings": {                            +
-       "Optimizer": "Postgres query optimizer"+
-     }                                        +
-   }                                          +
+----------------------------------------------
+ [                                           +
+   {                                         +
+     "Plan": {                               +
+       "Node Type": "Gather Motion",         +
+       "Senders": 3,                         +
+       "Receivers": 1,                       +
+       "Slice": 1,                           +
+       "Segments": 3,                        +
+       "Gang Type": "primary reader",        +
+       "Parallel Aware": false,              +
+       "Plans": [                            +
+         {                                   +
+           "Node Type": "Seq Scan",          +
+           "Parent Relationship": "Outer",   +
+           "Slice": 1,                       +
+           "Segments": 3,                    +
+           "Gang Type": "primary reader",    +
+           "Parallel Aware": false,          +
+           "Relation Name": "explaintest",   +
+           "Alias": "explaintest"            +
+         }                                   +
+       ]                                     +
+     },                                      +
+     "Optimizer": "Postgres query optimizer",+
+     "Slice Table": [                        +
+       {                                     +
+         "Slice ID": 0,                      +
+         "Gang Type": "Dispatcher",          +
+         "Root": 0,                          +
+         "Parent": -1,                       +
+         "Gang Size": 0                      +
+       },                                    +
+       {                                     +
+         "Slice ID": 1,                      +
+         "Gang Type": "Reader",              +
+         "Root": 0,                          +
+         "Parent": 0,                        +
+         "Gang Size": 3                      +
+       }                                     +
+     ]                                       +
+   }                                         +
  ]
 (1 row)
 

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -221,36 +221,34 @@ explain (costs off) select count(*) over (partition by g) from generate_series(1
 CREATE EXTERNAL WEB TABLE dummy_ext_tab (x text) EXECUTE 'echo foo' FORMAT 'text';
 -- External Table Scan
 explain (format json, costs off) SELECT * FROM dummy_ext_tab;
-                   QUERY PLAN                    
--------------------------------------------------
- [                                              +
-   {                                            +
-     "Plan": {                                  +
-       "Node Type": "Gather Motion",            +
-       "Senders": 3,                            +
-       "Receivers": 1,                          +
-       "Slice": 1,                              +
-       "Segments": 3,                           +
-       "Gang Type": "primary reader",           +
-       "Parallel Aware": false,                 +
-       "Plans": [                               +
-         {                                      +
-           "Node Type": "Foreign Scan",         +
-           "Operation": "Select",               +
-           "Parent Relationship": "Outer",      +
-           "Slice": 1,                          +
-           "Segments": 3,                       +
-           "Gang Type": "primary reader",       +
-           "Parallel Aware": false,             +
-           "Relation Name": "dummy_ext_tab",    +
-           "Alias": "dummy_ext_tab"             +
-         }                                      +
-       ]                                        +
-     },                                         +
-     "Settings": {                              +
-       "Optimizer": "Pivotal Optimizer (GPORCA)"+
-     }                                          +
-   }                                            +
+                  QUERY PLAN                   
+-----------------------------------------------
+ [                                            +
+   {                                          +
+     "Plan": {                                +
+       "Node Type": "Gather Motion",          +
+       "Senders": 3,                          +
+       "Receivers": 1,                        +
+       "Slice": 1,                            +
+       "Segments": 3,                         +
+       "Gang Type": "primary reader",         +
+       "Parallel Aware": false,               +
+       "Plans": [                             +
+         {                                    +
+           "Node Type": "Foreign Scan",       +
+           "Operation": "Select",             +
+           "Parent Relationship": "Outer",    +
+           "Slice": 1,                        +
+           "Segments": 3,                     +
+           "Gang Type": "primary reader",     +
+           "Parallel Aware": false,           +
+           "Relation Name": "dummy_ext_tab",  +
+           "Alias": "dummy_ext_tab"           +
+         }                                    +
+       ]                                      +
+     },                                       +
+     "Optimizer": "Pivotal Optimizer (GPORCA)"+
+   }                                          +
  ]
 (1 row)
 
@@ -259,27 +257,26 @@ CREATE TEMP TABLE dummy_aotab (x int4) WITH (appendonly=true);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 explain (format yaml, costs off) SELECT * FROM dummy_aotab;
-                 QUERY PLAN                  
----------------------------------------------
- - Plan:                                    +
-     Node Type: "Gather Motion"             +
-     Senders: 3                             +
-     Receivers: 1                           +
-     Slice: 1                               +
-     Segments: 3                            +
-     Gang Type: "primary reader"            +
-     Parallel Aware: false                  +
-     Plans:                                 +
-       - Node Type: "Seq Scan"              +
-         Parent Relationship: "Outer"       +
-         Slice: 1                           +
-         Segments: 3                        +
-         Gang Type: "primary reader"        +
-         Parallel Aware: false              +
-         Relation Name: "dummy_aotab"       +
-         Alias: "dummy_aotab"               +
-   Settings:                                +
-     Optimizer: "Pivotal Optimizer (GPORCA)"
+                QUERY PLAN                 
+-------------------------------------------
+ - Plan:                                  +
+     Node Type: "Gather Motion"           +
+     Senders: 3                           +
+     Receivers: 1                         +
+     Slice: 1                             +
+     Segments: 3                          +
+     Gang Type: "primary reader"          +
+     Parallel Aware: false                +
+     Plans:                               +
+       - Node Type: "Seq Scan"            +
+         Parent Relationship: "Outer"     +
+         Slice: 1                         +
+         Segments: 3                      +
+         Gang Type: "primary reader"      +
+         Parallel Aware: false            +
+         Relation Name: "dummy_aotab"     +
+         Alias: "dummy_aotab"             +
+   Optimizer: "Pivotal Optimizer (GPORCA)"
 (1 row)
 
 -- DML node (with ORCA)
@@ -328,9 +325,7 @@ explain (format xml, costs off) insert into dummy_aotab values (1);
          </Plan>                                                   +
        </Plans>                                                    +
      </Plan>                                                       +
-     <Settings>                                                    +
-       <Optimizer>Pivotal Optimizer (GPORCA)</Optimizer>           +
-     </Settings>                                                   +
+     <Optimizer>Pivotal Optimizer (GPORCA)</Optimizer>             +
    </Query>                                                        +
  </explain>
 (1 row)
@@ -398,51 +393,49 @@ explain (slicetable, costs off) SELECT * FROM explaintest;
 
 -- same in JSON format
 explain (slicetable, costs off, format json) SELECT * FROM explaintest;
-                   QUERY PLAN                    
--------------------------------------------------
- [                                              +
-   {                                            +
-     "Plan": {                                  +
-       "Node Type": "Gather Motion",            +
-       "Senders": 3,                            +
-       "Receivers": 1,                          +
-       "Slice": 1,                              +
-       "Segments": 3,                           +
-       "Gang Type": "primary reader",           +
-       "Parallel Aware": false,                 +
-       "Plans": [                               +
-         {                                      +
-           "Node Type": "Seq Scan",             +
-           "Parent Relationship": "Outer",      +
-           "Slice": 1,                          +
-           "Segments": 3,                       +
-           "Gang Type": "primary reader",       +
-           "Parallel Aware": false,             +
-           "Relation Name": "explaintest",      +
-           "Alias": "explaintest"               +
-         }                                      +
-       ]                                        +
-     },                                         +
-     "Slice Table": [                           +
-       {                                        +
-         "Slice ID": 0,                         +
-         "Gang Type": "Dispatcher",             +
-         "Root": 0,                             +
-         "Parent": -1,                          +
-         "Gang Size": 0                         +
-       },                                       +
-       {                                        +
-         "Slice ID": 1,                         +
-         "Gang Type": "Reader",                 +
-         "Root": 0,                             +
-         "Parent": 0,                           +
-         "Gang Size": 3                         +
-       }                                        +
-     ],                                         +
-     "Settings": {                              +
-       "Optimizer": "Pivotal Optimizer (GPORCA)"+
-     }                                          +
-   }                                            +
+                   QUERY PLAN                   
+------------------------------------------------
+ [                                             +
+   {                                           +
+     "Plan": {                                 +
+       "Node Type": "Gather Motion",           +
+       "Senders": 3,                           +
+       "Receivers": 1,                         +
+       "Slice": 1,                             +
+       "Segments": 3,                          +
+       "Gang Type": "primary reader",          +
+       "Parallel Aware": false,                +
+       "Plans": [                              +
+         {                                     +
+           "Node Type": "Seq Scan",            +
+           "Parent Relationship": "Outer",     +
+           "Slice": 1,                         +
+           "Segments": 3,                      +
+           "Gang Type": "primary reader",      +
+           "Parallel Aware": false,            +
+           "Relation Name": "explaintest",     +
+           "Alias": "explaintest"              +
+         }                                     +
+       ]                                       +
+     },                                        +
+     "Optimizer": "Pivotal Optimizer (GPORCA)",+
+     "Slice Table": [                          +
+       {                                       +
+         "Slice ID": 0,                        +
+         "Gang Type": "Dispatcher",            +
+         "Root": 0,                            +
+         "Parent": -1,                         +
+         "Gang Size": 0                        +
+       },                                      +
+       {                                       +
+         "Slice ID": 1,                        +
+         "Gang Type": "Reader",                +
+         "Root": 0,                            +
+         "Parent": 0,                          +
+         "Gang Size": 3                        +
+       }                                       +
+     ]                                         +
+   }                                           +
  ]
 (1 row)
 

--- a/src/test/regress/expected/insert_conflict.out
+++ b/src/test/regress/expected/insert_conflict.out
@@ -245,9 +245,7 @@ explain (costs off, format json) insert into insertconflicttest values (0, 'Bilb
          }                                                                 +
        ]                                                                   +
      },                                                                    +
-     "Settings": {                                                         +
-       "Optimizer": "Postgres query optimizer"                             +
-     }                                                                     +
+     "Optimizer": "Postgres query optimizer"                               +
    }                                                                       +
  ]
 (1 row)

--- a/src/test/regress/expected/partition_prune_optimizer.out
+++ b/src/test/regress/expected/partition_prune_optimizer.out
@@ -3418,7 +3418,7 @@ explain (analyze, costs off, summary off, timing off) execute mt_q1(15);
          ->  Index Scan using ma_test_p3_b_idx on ma_test_p3 (actual rows=1 loops=1)
                Filter: ((a >= $1) AND ((a % 10) = 5))
                Rows Removed by Filter: 2
- Optimizer: Postgres query optimizer
+ Optimizer: Pivotal Optimizer (GPORCA)
 (12 rows)
 
 execute mt_q1(15);
@@ -3439,7 +3439,7 @@ explain (analyze, costs off, summary off, timing off) execute mt_q1(25);
          ->  Index Scan using ma_test_p3_b_idx on ma_test_p3 (actual rows=1 loops=1)
                Filter: ((a >= $1) AND ((a % 10) = 5))
                Rows Removed by Filter: 2
- Optimizer: Postgres query optimizer
+ Optimizer: Pivotal Optimizer (GPORCA)
 (9 rows)
 
 execute mt_q1(25);
@@ -3459,7 +3459,7 @@ explain (analyze, costs off, summary off, timing off) execute mt_q1(35);
          Subplans Removed: 2
          ->  Index Scan using ma_test_p1_b_idx on ma_test_p1 (never executed)
                Filter: ((a >= $1) AND ((a % 10) = 5))
- Optimizer: Postgres query optimizer
+ Optimizer: Pivotal Optimizer (GPORCA)
 (8 rows)
 
 execute mt_q1(35);

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -80,6 +80,11 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
 -- end_matchsubs
 -- Check Explain YAML output
 EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
+SET random_page_cost = 1;
+SET cpu_index_tuple_cost = 0.1;
+EXPLAIN (FORMAT YAML, VERBOSE, SETTINGS ON) SELECT * from boxes;
+RESET random_page_cost;
+RESET cpu_index_tuple_cost;
 
 --- Check Explain Analyze YAML output that include the slices information
 -- explain_processing_off

--- a/src/test/regress/sql/fast_default.sql
+++ b/src/test/regress/sql/fast_default.sql
@@ -2,20 +2,6 @@
 -- ALTER TABLE ADD COLUMN DEFAULT test
 --
 
--- start_ignore
-
--- GPDB currently prints a "Settings: " line in the EXPLAIN output, if
--- there any GUCs are set. gpdiff masks them out, but it does not mask
--- out the differences in "(xx rows)" lines that happens if there is
--- no Settings line at all. The expected output does include some Settings.
--- To make those "(xx rows)" lines stable, set a GUC. Doesn't matter which
--- one, as long as it's printed in the Settings lines. The value doesn't
--- matter either, so use the default value, making it a no-op except for
--- the printing of the Settings lines.
-set seq_page_cost=1;
-
--- end_ignore
-
 SET search_path = fast_default;
 CREATE SCHEMA fast_default;
 CREATE TABLE m(id OID);


### PR DESCRIPTION
Greenplum lists the planner GUCs and work_mem on the verbose mode,
Postgres lists the non-default GUCs if SETTINGS on.

This commit combines them into one section, and keeps the behaviors.

Co-authored-by: Jian Guo <gjian@vmware.com>
