### PR TITLE
[6X] Backporting "Fix the logic in pg_lock_status() to keep track of which row to return."

### DIFF
--- a/src/backend/utils/adt/lockfuncs.c
+++ b/src/backend/utils/adt/lockfuncs.c
@@ -57,8 +57,8 @@ typedef struct
 
 	int			numSegLocks;	/* Total number of locks being reported back to client */
 	int			numsegresults;	/* If we dispatch to segDBs, the number of segresults */
-	int			whichResultset; /* which result set is being processed */
-	int			whichRow;	/* which row in current result set is being processed */
+	int			nextResultset;	/* which result set is being processed */
+	int			nextRow;		/* which row in current result set will be processed next */
 	struct pg_result **segresults;	/* pg_result for each segDB */
 } PG_Lock_Status;
 
@@ -168,8 +168,8 @@ pg_lock_status(PG_FUNCTION_ARGS)
 
 		mystatus->numSegLocks = 0;
 		mystatus->numsegresults = 0;
-		mystatus->whichResultset = 0;
-		mystatus->whichRow = 0;
+		mystatus->nextResultset = 0;
+		mystatus->nextRow = 0;
 		mystatus->segresults = NULL;
 
 		/*
@@ -493,48 +493,45 @@ pg_lock_status(PG_FUNCTION_ARGS)
 	}
 
 	/*
-	 * This loop only executes on the masterDB and only in dispatch mode, because that
-	 * is the only time we dispatched to the segDBs.
+	 * This loop only executes on the masterDB and only in dispatch mode,
+	 * because that is the only time we dispatched to the segDBs.
 	 */
-
 	while (mystatus->currIdx >= lockData->nelements && mystatus->currIdx < lockData->nelements + mystatus->numSegLocks)
 	{
 		HeapTuple	tuple;
 		Datum		result;
 		Datum		values[NUM_LOCK_STATUS_COLUMNS];
 		bool		nulls[NUM_LOCK_STATUS_COLUMNS];
-		int i;
-		int whichresultset = mystatus->whichResultset;
-		int whichrow = mystatus->whichRow;
+		int			i;
+		int			whichresultset;
+		int			whichrow;
 
 		Assert(Gp_role == GP_ROLE_DISPATCH);
 
 		/*
-		 * Because we have one result set per segDB (rather than one big result set with everything),
-		 * we use mystatus->whichResultset and mystatus->whichRow to track which result set we are on,
-		 * and which row within that result set we are returning, respectively.
+		 * Because we have one result set per segDB (rather than one big result
+		 * set with everything), we use mystatus->nextResultset and
+		 * mystatus->nextRow to track which result set we are on, and which row
+		 * within that result set we are returning, respectively.
 		 */
-		if (whichrow < PQntuples(mystatus->segresults[whichresultset]))
+		whichresultset = mystatus->nextResultset;
+		whichrow = mystatus->nextRow;
+		Assert(whichresultset < mystatus->numsegresults);
+		Assert(whichrow < PQntuples(mystatus->segresults[whichresultset]));
+
+		/*
+		 * Advance to next row. If we're out of rows in this result set,
+		 * advance to next one.
+		 */
+		if (mystatus->nextRow + 1 < PQntuples(mystatus->segresults[mystatus->nextResultset]))
 		{
-			/* Advance to next row in current result set. */
-			mystatus->whichRow++;
+			mystatus->nextRow++;
 		}
 		else
 		{
-			/* Advance to next result set. */
-			mystatus->whichResultset++;
-			mystatus->whichRow = 0;
-			whichresultset++;
-			whichrow = 0;
-
-			/*
-			 * If this condition is true, we have already sent everything back,
-			 * and we just want to do the SRF_RETURN_DONE
-			 */
-			if (whichresultset >= mystatus->numsegresults)
-				break;
+			mystatus->nextResultset++;
+			mystatus->nextRow = 0;
 		}
-
 		mystatus->currIdx++;
 
 		/*

--- a/src/test/regress/expected/gp_lock.out
+++ b/src/test/regress/expected/gp_lock.out
@@ -1,9 +1,7 @@
 CREATE TABLE gp_lock_test (a int);
 BEGIN;
 LOCK TABLE gp_lock_test IN ACCESS SHARE MODE;
--- This resultset could be different in ORCA/planner, adding DISTINCT
--- to make sure test passes in both
-SELECT DISTINCT l.gp_segment_id, c.relname, l.mode, l.granted
+SELECT l.gp_segment_id, c.relname, l.mode, l.granted
 FROM pg_locks l, pg_class c WHERE l.relation = c.oid and c.relname = 'gp_lock_test';
  gp_segment_id |   relname    |      mode       | granted 
 ---------------+--------------+-----------------+---------

--- a/src/test/regress/sql/gp_lock.sql
+++ b/src/test/regress/sql/gp_lock.sql
@@ -3,9 +3,7 @@ CREATE TABLE gp_lock_test (a int);
 BEGIN;
 LOCK TABLE gp_lock_test IN ACCESS SHARE MODE;
 
--- This resultset could be different in ORCA/planner, adding DISTINCT
--- to make sure test passes in both
-SELECT DISTINCT l.gp_segment_id, c.relname, l.mode, l.granted
+SELECT l.gp_segment_id, c.relname, l.mode, l.granted
 FROM pg_locks l, pg_class c WHERE l.relation = c.oid and c.relname = 'gp_lock_test';
 ROLLBACK;
 


### PR DESCRIPTION
A bug exists in pg_lock_status() which resulted in wrong view in pg_locks. E.g.:

```
postgres=# CREATE TABLE gp_lock_test (a int);
NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
CREATE TABLE
postgres=# begin;
BEGIN
postgres=# LOCK TABLE gp_lock_test IN ACCESS SHARE MODE;
LOCK TABLE
postgres=# SELECT l.gp_segment_id, c.relname, l.mode, l.granted
FROM pg_locks l, pg_class c WHERE l.relation = c.oid and c.relname = 'gp_lock_test';
 gp_segment_id |   relname    |      mode       | granted
---------------+--------------+-----------------+---------
            -1 | gp_lock_test | AccessShareLock | t
             0 | gp_lock_test | AccessShareLock | t
             1 | gp_lock_test | AccessShareLock | t
             1 | gp_lock_test | AccessShareLock | t
             2 | gp_lock_test | AccessShareLock | t
(5 rows)
postgres=# select l.gp_segment_id, c.relname, l.mode, l.granted from gp_dist_random('pg_locks') l , gp_dist_random('pg_class') c where l.gp_segment_id = 1 and c.gp_segment_id = 1 and l.relation = c.oid and c.relname like 'gp_lock_test%' order by relname;
 gp_segment_id |    relname    |      mode       | granted
---------------+---------------+-----------------+---------
             1 | gp_lock_test  | AccessShareLock | t
(1 row)
```
So, results on master node has one more entry for seg1, but if directly checking pg_locks on seg1 we see no such extra entry.

It's fixed in https://github.com/greenplum-db/gpdb/commit/90634b6aaac825e58e8b66a533412c34491eb3b9 in GPDB7. Backporting the same. It's a straightforward backport w/o any conflict.

Also, remove the `DISTINCT` clause in the `gp_locks` test which was mistakenly added because I thought setting optimizer=on and off would change the result for some reason (probably due to the unexpected outcome produced by the same bug).