### PR TITLE
added cluster health check for gpexpand

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -259,6 +259,16 @@ def gpexpand_status_file_exists(coordinator_data_directory):
     return os.path.exists(coordinator_data_directory + '/gpexpand.status')
 
 
+def is_cluster_up_and_balanced(dburl):
+    conn = dbconn.connect(dburl, encoding='UTF8')
+    try:
+        count = dbconn.querySingleton(conn,
+                                      "select count(*) from gp_segment_configuration where status <> 'u' or preferred_role <> role;")
+    finally:
+        conn.close()
+
+    return count == 0
+
 # -------------------------------------------------------------------------
 # expansion schema
 
@@ -2389,6 +2399,11 @@ def main(options, args, parser):
         configurationInterface.getConfigurationProvider().initializeProvider(gpEnv.getCoordinatorPort())
 
         dburl = dbconn.DbURL(dbname=DBNAME, port=gpEnv.getCoordinatorPort())
+
+        # check if the cluster is in good health if not exit from gpexpand
+        if not is_cluster_up_and_balanced(dburl):
+            logger.error('One or more segments are either down or not in preferred role. Please fix the issue before running gpexpand.')
+            sys.exit(1)
 
         gpexpand_db_status = gpexpand.prepare_gpdb_state(logger, dburl, options)
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpexpand.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpexpand.py
@@ -9,6 +9,7 @@ from gppylib.db import catalog
 from gppylib.gplog import *
 from gppylib.system.configurationInterface import GpConfigurationProvider
 from gppylib.system.environment import GpCoordinatorEnvironment
+from gppylib.db import dbconn
 import io
 import sys
 
@@ -71,8 +72,8 @@ class GpExpand(GpTestCase):
         sys.argv = self.old_sys_argv
         super(GpExpand, self).tearDown()
 
-    # @patch('gpexpand.PgControlData.return_value.get_value', side_effect=[1, 1, 0])
-    def test_validate_heap_checksums_aborts_when_cluster_inconsistent(self):
+    @patch('gpexpand.is_cluster_up_and_balanced', return_value=True)
+    def test_validate_heap_checksums_aborts_when_cluster_inconsistent(self, mock1):
         self.options.filename = '/tmp/doesnotexist' # Replacement of the sys.argv
 
         self.mock_heap_checksum.return_value.get_segments_checksum_settings.return_value = ([1], [0])
@@ -94,8 +95,8 @@ class GpExpand(GpTestCase):
 
     @patch('gpexpand.FileDirExists.return_value.filedir_exists', return_value=True)
     @patch('gpexpand.FileDirExists', return_value=Mock())
-    # @patch('gpexpand.HeapChecksum.PgControlData.return_value.get_value', side_effect=[1, 1, 1])
-    def test_validate_heap_checksums_completes_when_cluster_consistent(self, mock1, mock2):
+    @patch('gpexpand.is_cluster_up_and_balanced', return_value=True)
+    def test_validate_heap_checksums_completes_when_cluster_consistent(self, mock1, mock2, mock3):
         """
         If all the segment checksums match the checksum at the coordinator, then the cluster is consistent.
         This is essentially making sure that the validate_heap_checksums() internal method has not detected any
@@ -127,6 +128,25 @@ class GpExpand(GpTestCase):
             self.assertIn('The current system appears to be non-standard.', mock_stdout.getvalue())
 
         self.subject.logger.info.assert_any_call("User Aborted. Exiting...")
+
+    @patch('gppylib.db.dbconn.querySingleton', return_value=0)
+    def test_unit_cluster_up_and_balanced_true(self,mock1):
+        expected = True
+        actual = self.subject.is_cluster_up_and_balanced(dbconn.DbURL())
+        self.assertEqual(actual, expected)
+
+    @patch('gppylib.db.dbconn.querySingleton', return_value=2)
+    def test_unit_cluster_up_and_balanced_false(self, mock):
+        expected = False
+        actual = self.subject.is_cluster_up_and_balanced(dbconn.DbURL())
+        self.assertEqual(actual, expected)
+
+    @patch('gppylib.db.dbconn.querySingleton', side_effect=Exception())
+    def test_unit_cluster_up_and_balanced_exception(self, mock1):
+        with self.assertRaises(Exception):
+            self.subject.is_cluster_up_and_balanced(dbconn.DbURL())
+
+
     #
     # end tests for interview_setup()
     #

--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -474,3 +474,38 @@ Feature: expand the cluster by adding more segments
         Then the number of segments have been saved
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         Then verify that pg_hba.conf file has "replication" entries in each segment data directories
+
+    @gpexpand_segment
+    Scenario: on expand check if one or more cluster is down
+        Given the database is not running
+        And a working directory of the test as '/data/gpdata/gpexpand'
+        And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
+        And a cluster is created with mirrors on "mdw" and "sdw1"
+        And database "gptest" exists
+        And there are no gpexpand_inputfiles
+        And the cluster is setup for an expansion on hosts "mdw,sdw1"
+        And the primary on content 0 is stopped
+        And an FTS probe is triggered
+        And the status of the primary on content 0 should be "d"
+        When the user runs gpexpand with a static inputfile for a single-node cluster with mirrors without ret code check
+        Then gpexpand should return a return code of 1
+        Then gpexpand should print "One or more segments are either down or not in preferred role. Please fix the issue before running gpexpand." to stdout
+
+    Scenario: on expand check if one or more cluster is not in their preferred role
+        Given the database is not running
+        And a working directory of the test as '/data/gpdata/gpexpand'
+        And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
+        And a cluster is created with mirrors on "mdw" and "sdw1"
+        And database "gptest" exists
+        And there are no gpexpand_inputfiles
+        And the cluster is setup for an expansion on hosts "mdw,sdw1"
+        And the primary on content 0 is stopped
+        And an FTS probe is triggered
+        And the status of the primary on content 0 should be "d"
+        When the user runs "gprecoverseg -a"
+        Then gprecoverseg should return a return code of 0
+        And all the segments are running
+        And the segments are synchronized
+        When the user runs gpexpand with a static inputfile for a single-node cluster with mirrors without ret code check
+        Then gpexpand should return a return code of 1
+        And gpexpand should print "One or more segments are either down or not in preferred role. Please fix the issue before running gpexpand." to stdout


### PR DESCRIPTION
Issue: when one or more cluster is down or not in their preferred role, the assignment of port on expanded nodes are going wrong. the reason behind that the calculation of port using function get_max_primary_port() and get_max_mirror_port(). 

one of the suggested fix is to check if clusters are in good state as soon as we run gpexpand. this will also avoid any further issues which can be cause due to nodes are not in their preferred role. 

Added feature test for bot the scenario when either of node is down or they are not in preferred role. 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
