### PR TITLE
Improvement of insert speed for AO/CO tables on segments.

### DIFF
--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -2555,7 +2555,6 @@ appendonly_insert_init(Relation rel, int segno, int64 num_rows)
 	AppendOnlyStorageAttributes *attr;
 
 	StringInfoData titleBuf;
-	Oid segrelid;
 	int32 blocksize;
 	int32 safefswritesize;
 	int16 compresslevel;
@@ -2739,11 +2738,13 @@ appendonly_insert_init(Relation rel, int segno, int64 num_rows)
 	 */
 	Assert(aoInsertDesc->fsInfo->segno == segno);
 
-	GetAppendOnlyEntryAuxOids(aoInsertDesc->aoi_rel->rd_id, NULL, &segrelid,
+	GetAppendOnlyEntryAuxOids(aoInsertDesc->aoi_rel->rd_id, NULL, &aoInsertDesc->segrelid,
 			NULL, NULL, NULL, NULL);
 
-	firstSequence = GetFastSequences(segrelid, segno, num_rows);
+	firstSequence = GetFastSequences(aoInsertDesc->segrelid, segno, num_rows);
 	aoInsertDesc->numSequences = num_rows;
+
+	/* Set last_sequence value */
 	Assert(firstSequence > aoInsertDesc->rowCount);
 	aoInsertDesc->lastSequence = firstSequence - 1;
 
@@ -2970,16 +2971,9 @@ appendonly_insert(AppendOnlyInsertDesc aoInsertDesc,
 	 */
 	if (aoInsertDesc->numSequences == 0)
 	{
-		int64		firstSequence;
-		Oid segrelid;
-
-		GetAppendOnlyEntryAuxOids(aoInsertDesc->aoi_rel->rd_id, NULL,
-				&segrelid, NULL, NULL, NULL, NULL);
-
-		firstSequence =
-			GetFastSequences(segrelid,
-							 aoInsertDesc->cur_segno,
-							 NUM_FAST_SEQUENCES);
+		int64 firstSequence = GetFastSequences(aoInsertDesc->segrelid,
+											   aoInsertDesc->cur_segno,
+											   NUM_FAST_SEQUENCES);
 
 		Assert(firstSequence == aoInsertDesc->lastSequence + 1);
 		aoInsertDesc->numSequences = NUM_FAST_SEQUENCES;

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -1295,12 +1295,11 @@ appendonly_relation_copy_for_cluster(Relation OldHeap, Relation NewHeap,
 			/* Here we are trying to avoid reallocation of temp mtuple */
 			if (mtuple != NULL)
 				pfree(mtuple);
-			mtuple = palloc(len);
+			mtuple = NULL;
 			prev_memtuple_len = len;
 		}
 
-		memtuple_form_to(mt_bind, values, isnull, len, null_save_len, has_nulls,
-					mtuple);
+		mtuple = memtuple_form_to(mt_bind, values, isnull, len, null_save_len, has_nulls, mtuple);
 
 		appendonly_insert(aoInsertDesc, mtuple, &aoTupleId);
 	}

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -1276,7 +1276,6 @@ appendonly_relation_copy_for_cluster(Relation OldHeap, Relation NewHeap,
 	for (;;)
 	{
 		HeapTuple	tuple;
-		uint32		prev_memtuple_len = 0;
 		uint32		len;
 		uint32		null_save_len;
 		bool		has_nulls;
@@ -1290,13 +1289,11 @@ appendonly_relation_copy_for_cluster(Relation OldHeap, Relation NewHeap,
 		heap_deform_tuple(tuple, oldTupDesc, values, isnull);
 
 		len = compute_memtuple_size(mt_bind, values, isnull, &null_save_len, &has_nulls);
-		if (len > prev_memtuple_len)
+		if (len > 0)
 		{
-			/* Here we are trying to avoid reallocation of temp mtuple */
 			if (mtuple != NULL)
 				pfree(mtuple);
 			mtuple = NULL;
-			prev_memtuple_len = len;
 		}
 
 		mtuple = memtuple_form_to(mt_bind, values, isnull, len, null_save_len, has_nulls, mtuple);

--- a/src/include/access/memtup.h
+++ b/src/include/access/memtup.h
@@ -144,9 +144,9 @@ extern uint32 compute_memtuple_size(MemTupleBinding *pbind, Datum *values, bool 
 
 extern MemTuple memtuple_copy(MemTuple mtup);
 extern MemTuple memtuple_form(MemTupleBinding *pbind, Datum *values, bool *isnull);
-extern void memtuple_form_to(MemTupleBinding *pbind, Datum *values, bool *isnull,
-							 uint32 len, uint32 null_save_len, bool hasnull,
-							 MemTuple mtup);
+extern MemTuple memtuple_form_to(MemTupleBinding *pbind, Datum *values, bool *isnull,
+								 uint32 len, uint32 null_save_len, bool hasnull,
+								 MemTuple mtup);
 extern void memtuple_deform(MemTuple mtup, MemTupleBinding *pbind, Datum *datum, bool *isnull);
 extern void memtuple_deform_misaligned(MemTuple mtup, MemTupleBinding *pbind, Datum *datum, bool *isnull);
 

--- a/src/include/cdb/cdbappendonlyam.h
+++ b/src/include/cdb/cdbappendonlyam.h
@@ -109,6 +109,7 @@ typedef struct AppendOnlyInsertDescData
 
 	/* The block directory for the appendonly relation. */
 	AppendOnlyBlockDirectory blockDirectory;
+	Oid segrelid;
 } AppendOnlyInsertDescData;
 
 typedef AppendOnlyInsertDescData *AppendOnlyInsertDesc;


### PR DESCRIPTION
This(and the following two commits) is intended to improve segment
local insert speed for AO/CO tables. The findings were observed from
experiments during code review of ALTER TABLE SET ACCESS METHOD from
HEAP to AO (AT Heap to AO) PR https://github.com/greenplum-db/gpdb/pull/13571.

It contains the following optimizable aspects:

- remove GetAppendOnlyEntryAuxOids() call from appendonly_insert()
  (same as aocs_insert() existing bits) to reduce unnecessary catelog
  scans as the required segrelid was already obtained from
  appendonly_insert_init();

- code adjustment in memtuple_form_to() to replace memset() to
  combination with palloc0() in condition to reduce memset()
  calls for performance consideration in bulk inserts cases.

- having NUM_FAST_SEQUENCES configurable by introducing new GUC
  gp_num_fast_sequences in developer option to tune pre-allocating
  number of sequences to reduce GetFastSequences() calls for better
  performance in bulk inserts. This may still have optimizable room
  like introducing some algorithm to adjust the number dynamically
  other than configure it manually.

These changes could benefit the performance in segment-wise bulk inserts
cases such like AT Heap to AO, COPY on segment or so.

A simple demo to improve AT Heap to AO speed listed below:
```
CREATE TABLE heap2ao(a int, b int) DISTRIBUTED BY (a);
\timing
```

[7x-baseline]
```
testdb=# INSERT INTO heap2ao SELECT i,i FROM generate_series(1,500000000) i;
INSERT 0 500000000
Time: 269396.357 ms (04:29.396)
testdb=# ALTER TABLE heap2ao SET ACCESS METHOD ao_row;
ALTER TABLE
Time: 119383.728 ms (01:59.384)
testdb=#
```
[7x-patch]
```
testdb=# INSERT INTO heap2ao SELECT i,i FROM generate_series(1,500000000) i;
INSERT 0 500000000
Time: 278306.418 ms (04:38.306)
testdb=# \d+
                            List of relations
 Schema |  Name   | Type  |  Owner  |   Storage   |  Size  | Description
--------+---------+-------+---------+-------------+--------+-------------
 public | heap2ao | table | gpadmin | heap        | 17 GB  |
(2 rows)

testdb=# set gp_num_fast_sequences = 1000000;
SET
testdb=# ALTER TABLE heap2ao SET ACCESS METHOD ao_row;
ALTER TABLE
Time: 44849.846 ms (00:44.850)
testdb=#
```
~60%+ spending time reduced.

One primary factor depends on the value of gp_num_fast_sequences that
the larger pre-allocating number of sequences, the smaller times of
gp_fastsequences scans.

Of course how would this value impact the indexscan or other related
scenarios still needs to be well considered.

These changes seem no significant impact on distributed inserts since
the bottleneck is mainly on network communication and packets processing
between motion sender and receiver, which could be another topic to
investigate.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
