### PR TITLE
Set the search_path correctly when CREATE EXTENSION WITH SCHEMA

### DIFF
--- a/gpcontrib/gp_inject_fault/gp_inject_fault.control
+++ b/gpcontrib/gp_inject_fault/gp_inject_fault.control
@@ -2,4 +2,4 @@
 comment = 'simulate various faults for testing purposes'
 default_version = '1.0'
 module_pathname = '$libdir/gp_inject_fault'
-relocatable = true
+relocatable = false

--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -811,6 +811,37 @@ is_begin_state(const Node *stmt)
 #endif
 
 /*
+ * Set up the search path to contain the target schema, then the schemas
+ * of any prerequisite extensions, and nothing else.  In particular this
+ * makes the target schema be the default creation target namespace.
+ *
+ * Note: it might look tempting to use PushOverrideSearchPath for this,
+ * but we cannot do that.  We have to actually set the search_path GUC in
+ * case the extension script examines or changes it.  In any case, the
+ * GUC_ACTION_SAVE method is just as convenient.
+ */
+static void
+set_serach_path_for_extension(List *requiredSchemas, const char *schemaName)
+{
+	StringInfoData pathbuf;
+	ListCell *lc;
+	initStringInfo(&pathbuf);
+	appendStringInfoString(&pathbuf, quote_identifier(schemaName));
+	foreach(lc, requiredSchemas)
+	{
+		Oid			reqschema = lfirst_oid(lc);
+		char	   *reqname = get_namespace_name(reqschema);
+
+		if (reqname)
+			appendStringInfo(&pathbuf, ", %s", quote_identifier(reqname));
+	}
+
+	(void) set_config_option("search_path", pathbuf.data,
+							 PGC_USERSET, PGC_S_SESSION,
+							 GUC_ACTION_SAVE, true, 0, false);
+}
+
+/*
  * Execute the appropriate script file for installing or updating the extension
  *
  * If from_version isn't NULL, it's an update
@@ -823,13 +854,10 @@ execute_extension_script(Node *stmt,
 						 Oid extensionOid, ExtensionControlFile *control,
 						 const char *from_version,
 						 const char *version,
-						 List *requiredSchemas,
 						 const char *schemaName, Oid schemaOid)
 {
 	char	   *filename;
 	int			save_nestlevel;
-	StringInfoData pathbuf;
-	ListCell   *lc;
 
 	AssertState(Gp_role != GP_ROLE_EXECUTE);
 	AssertImply(Gp_role == GP_ROLE_DISPATCH, stmt != NULL &&
@@ -878,31 +906,6 @@ execute_extension_script(Node *stmt,
 		(void) set_config_option("log_min_messages", "warning",
 								 PGC_SUSET, PGC_S_SESSION,
 								 GUC_ACTION_SAVE, true, 0, false);
-
-	/*
-	 * Set up the search path to contain the target schema, then the schemas
-	 * of any prerequisite extensions, and nothing else.  In particular this
-	 * makes the target schema be the default creation target namespace.
-	 *
-	 * Note: it might look tempting to use PushOverrideSearchPath for this,
-	 * but we cannot do that.  We have to actually set the search_path GUC in
-	 * case the extension script examines or changes it.  In any case, the
-	 * GUC_ACTION_SAVE method is just as convenient.
-	 */
-	initStringInfo(&pathbuf);
-	appendStringInfoString(&pathbuf, quote_identifier(schemaName));
-	foreach(lc, requiredSchemas)
-	{
-		Oid			reqschema = lfirst_oid(lc);
-		char	   *reqname = get_namespace_name(reqschema);
-
-		if (reqname)
-			appendStringInfo(&pathbuf, ", %s", quote_identifier(reqname));
-	}
-
-	(void) set_config_option("search_path", pathbuf.data,
-							 PGC_USERSET, PGC_S_SESSION,
-							 GUC_ACTION_SAVE, true, 0, false);
 
 	/*
 	 * Set creating_extension and related variables so that
@@ -1641,11 +1644,12 @@ CreateExtensionInternal(char *extensionName,
 		stmt = NULL;
 	}
 
+	set_serach_path_for_extension(requiredSchemas, schemaName);
+
 	if (Gp_role != GP_ROLE_EXECUTE)
 	{
 		execute_extension_script((Node *) stmt, extensionOid, control,
 							 oldVersionName, versionName,
-							 requiredSchemas,
 							 schemaName, schemaOid);
 
 		/*
@@ -3320,6 +3324,8 @@ ApplyExtensionUpdates(Oid extensionOid,
 
 		InvokeObjectPostAlterHook(ExtensionRelationId, extensionOid, 0);
 
+		set_serach_path_for_extension(requiredSchemas, schemaName);
+
 		if (Gp_role != GP_ROLE_EXECUTE)
 		{
 			Node *stmt = NULL;
@@ -3345,7 +3351,6 @@ ApplyExtensionUpdates(Oid extensionOid,
 			 */
 			execute_extension_script(stmt, extensionOid, control,
 									 oldVersionName, versionName,
-									 requiredSchemas,
 									 schemaName, schemaOid);
 		}
 		else

--- a/src/test/regress/expected/create_extension_fail.out
+++ b/src/test/regress/expected/create_extension_fail.out
@@ -59,3 +59,11 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 \c
 drop table t_12713;
 drop role user_12713;
+--
+-- Another Test from Issue: https://github.com/greenplum-db/gpdb/issues/6716
+--
+drop extension if exists gp_inject_fault;
+create schema issue6716;
+create extension gp_inject_fault with schema issue6716;
+drop extension gp_inject_fault;
+drop schema issue6716;

--- a/src/test/regress/sql/create_extension_fail.sql
+++ b/src/test/regress/sql/create_extension_fail.sql
@@ -46,3 +46,12 @@ create table t_12713(a int);
 \c
 drop table t_12713;
 drop role user_12713;
+
+--
+-- Another Test from Issue: https://github.com/greenplum-db/gpdb/issues/6716
+--
+drop extension if exists gp_inject_fault;
+create schema issue6716;
+create extension gp_inject_fault with schema issue6716;
+drop extension gp_inject_fault;
+drop schema issue6716;


### PR DESCRIPTION
This commit fixes https://github.com/greenplum-db/gpdb/issues/6716.
------------------------------------------------------------------
In postgres, CREATE EXTENSION WITH SCHEMA will set up the `search_path`
to contain the target schema and required schemas before execute extension
script. Because the commands of the extension script will be dispatched to
QE, GPDB needs to set up the `search_path` on both QD and QE.

NOTE: `search_path` will be reset during transaction commit.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
