### PR TITLE
(6x only) Wrong subplans order in correlated subquery

### DIFF
--- a/src/test/regress/expected/partition_subquery.out
+++ b/src/test/regress/expected/partition_subquery.out
@@ -21,7 +21,7 @@ SELECT id FROM (
 DROP TABLE IF EXISTS pt1;
 --end_ignore
 -- When a query had a partitioned table and a correlated subquery, it 
--- failid with Query Optimizer. There was implemented a fix which
+-- failed with Query Optimizer. There was implemented a fix which
 -- fixes this problem.
 DROP TABLE IF EXISTS t1, t2;
 NOTICE:  table "t1" does not exist, skipping

--- a/src/test/regress/expected/partition_subquery.out
+++ b/src/test/regress/expected/partition_subquery.out
@@ -20,3 +20,65 @@ SELECT id FROM (
 --start_ignore
 DROP TABLE IF EXISTS pt1;
 --end_ignore
+-- When a query had a partitioned table and a correlated subquery, it 
+-- failid with Query Optimizer. There was implemented a fix which
+-- fixes this problem.
+DROP TABLE IF EXISTS t1, t2;
+NOTICE:  table "t1" does not exist, skipping
+NOTICE:  table "t2" does not exist, skipping
+CREATE TABLE t1 (a INT) PARTITION BY RANGE (a) (START (1) END (3) EVERY (1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "t1_1_prt_1" for table "t1"
+NOTICE:  CREATE TABLE will create partition "t1_1_prt_2" for table "t1"
+CREATE TABLE t2 (b INT8) DISTRIBUTED BY (b);
+INSERT INTO t1 VALUES (1), (2);
+INSERT INTO t2 VALUES (2), (3);
+EXPLAIN SELECT * FROM t1 WHERE a <= (
+    SELECT * FROM t2
+    WHERE t2.b <= (SELECT * FROM t2 AS t3 WHERE t3.b = t2.b)
+    AND t1.a = t2.b);
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..595815.50 rows=64200 width=4)
+   ->  Append  (cost=0.00..595815.50 rows=21400 width=4)
+         ->  Seq Scan on t1_1_prt_1  (cost=0.00..297907.75 rows=10700 width=4)
+               Filter: (a <= (SubPlan 2))
+               SubPlan 2  (slice5; segments: 3)
+                 ->  Result  (cost=0.00..3.08 rows=1 width=8)
+                       Filter: ((t1_1_prt_1.a = t2.b) AND (t2.b <= (SubPlan 1)))
+                       ->  Materialize  (cost=0.00..3.08 rows=1 width=8)
+                             ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..3.08 rows=1 width=8)
+                                   ->  Seq Scan on t2  (cost=0.00..3.08 rows=1 width=8)
+                       SubPlan 1  (slice5; segments: 3)
+                         ->  Result  (cost=0.00..1.03 rows=1 width=8)
+                               Filter: (t3.b = t2.b)
+                               ->  Materialize  (cost=0.00..1.03 rows=1 width=8)
+                                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.02 rows=1 width=8)
+                                           ->  Seq Scan on t2 t3  (cost=0.00..1.02 rows=1 width=8)
+         ->  Seq Scan on t1_1_prt_2  (cost=0.00..297907.75 rows=10700 width=4)
+               Filter: (a <= (SubPlan 2))
+               SubPlan 2  (slice5; segments: 3)
+                 ->  Result  (cost=0.00..3.08 rows=1 width=8)
+                       Filter: ((t1_1_prt_2.a = t2_1.b) AND (t2_1.b <= (SubPlan 1)))
+                       ->  Materialize  (cost=0.00..3.08 rows=1 width=8)
+                             ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..3.08 rows=1 width=8)
+                                   ->  Seq Scan on t2 t2_1  (cost=0.00..3.08 rows=1 width=8)
+                       SubPlan 1  (slice5; segments: 3)
+                         ->  Result  (cost=0.00..1.03 rows=1 width=8)
+                               Filter: (t3_1.b = t2_1.b)
+                               ->  Materialize  (cost=0.00..1.03 rows=1 width=8)
+                                     ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1.02 rows=1 width=8)
+                                           ->  Seq Scan on t2 t3_1  (cost=0.00..1.02 rows=1 width=8)
+ Optimizer: Postgres query optimizer
+(31 rows)
+
+SELECT * FROM t1 WHERE a <= (
+    SELECT * FROM t2
+    WHERE t2.b <= (SELECT * FROM t2 AS t3 WHERE t3.b = t2.b)
+    AND t1.a = t2.b);
+ a 
+---
+ 2
+(1 row)
+

--- a/src/test/regress/expected/partition_subquery_optimizer.out
+++ b/src/test/regress/expected/partition_subquery_optimizer.out
@@ -21,7 +21,7 @@ SELECT id FROM (
 DROP TABLE IF EXISTS pt1;
 --end_ignore
 -- When a query had a partitioned table and a correlated subquery, it 
--- failid with Query Optimizer. There was implemented a fix which
+-- failed with Query Optimizer. There was implemented a fix which
 -- fixes this problem.
 DROP TABLE IF EXISTS t1, t2;
 NOTICE:  table "t1" does not exist, skipping

--- a/src/test/regress/expected/partition_subquery_optimizer.out
+++ b/src/test/regress/expected/partition_subquery_optimizer.out
@@ -20,3 +20,55 @@ SELECT id FROM (
 --start_ignore
 DROP TABLE IF EXISTS pt1;
 --end_ignore
+-- When a query had a partitioned table and a correlated subquery, it 
+-- failid with Query Optimizer. There was implemented a fix which
+-- fixes this problem.
+DROP TABLE IF EXISTS t1, t2;
+NOTICE:  table "t1" does not exist, skipping
+NOTICE:  table "t2" does not exist, skipping
+CREATE TABLE t1 (a INT) PARTITION BY RANGE (a) (START (1) END (3) EVERY (1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "t1_1_prt_1" for table "t1"
+NOTICE:  CREATE TABLE will create partition "t1_1_prt_2" for table "t1"
+CREATE TABLE t2 (b INT8) DISTRIBUTED BY (b);
+INSERT INTO t1 VALUES (1), (2);
+INSERT INTO t2 VALUES (2), (3);
+EXPLAIN SELECT * FROM t1 WHERE a <= (
+    SELECT * FROM t2
+    WHERE t2.b <= (SELECT * FROM t2 AS t3 WHERE t3.b = t2.b)
+    AND t1.a = t2.b);
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1356692580.79 rows=1 width=4)
+   Filter: (t1.a <= (SubPlan 2))
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+         ->  Sequence  (cost=0.00..431.00 rows=1 width=4)
+               ->  Partition Selector for t1 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                     Partitions selected: 2 (out of 2)
+               ->  Dynamic Seq Scan on t1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=4)
+   SubPlan 2  (slice0)
+     ->  Result  (cost=0.00..1324033.10 rows=1 width=8)
+           Filter: (t1.a = t2.b)
+           ->  Materialize  (cost=0.00..1324033.10 rows=1 width=8)
+                 ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324033.10 rows=2 width=8)
+                       ->  Seq Scan on t2  (cost=0.00..1324033.10 rows=1 width=8)
+                             Filter: (b <= (SubPlan 1))
+                             SubPlan 1  (slice3; segments: 3)
+                               ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                     Filter: (t2_1.b = t2.b)
+                                     ->  Materialize  (cost=0.00..431.00 rows=2 width=8)
+                                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=8)
+                                                 ->  Seq Scan on t2 t2_1  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(21 rows)
+
+SELECT * FROM t1 WHERE a <= (
+    SELECT * FROM t2
+    WHERE t2.b <= (SELECT * FROM t2 AS t3 WHERE t3.b = t2.b)
+    AND t1.a = t2.b);
+ a 
+---
+ 2
+(1 row)
+


### PR DESCRIPTION
This problem occurs with Postgres Query Optimizer only, ORCA is not affected.

If we have a partitioned table and a nested correlated subquery, we can face an error 
that would say something like that:
```
FATAL:  Unexpected internal error (list.c:395)
DETAIL:  FailedAssertion("!(n < list->length)", File: "list.c", Line: 395)
```
In a case when a query has a partitioned table and InitPlan can't be created, 
GPDB will make copies of first level subplans by number of partitions, and
all more nested subplans will be added later. But all more nested subplans copies 
will be added in a wrong order and that they will go in a flat plan list after thier 
parent nodes, what will lead to a crash. 
```
create table t1 (a int) partition by range (a) (start (1) end (3) every (1));
create table t2 (b int8) distributed by (b);
set optimizer = off;
explain select 1 from t1 where a <= (
    SELECT 1 FROM t2
    WHERE t2.b <= (SELECT 1 from t2 as t3 where t3.b = t2.b)
    and t1.a = t2.b);
```
The intention of this patch is to create nested subplans right on the place. So,
by the time we get in nested_subplan_mutator, the plan already has dedicated
subplans for each partition. The intention of this part of
adjust_appendrel_attrs_mutator is to create a copy of the
most-closely-nested subplan and add it to subplans list. It's implied that
nested subplans of a copy will be added later in fixup_subplans, but it's the
cause of a crush: more nested subplans will be added after their parent subplans
in a flat list. The intension of this fix is to recursively traverse through
all the subplans and add them right on the spot. We make subplan copies
in nested_subplan_mutator and expect that when we get to fixup_subplans,
all the nested subplans are already initialized and fixup_subplans
doens't need to make any copies anymore.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
