### PR TITLE
[5X] GUC: Bypass dtx visibility checks for tuples

### DIFF
--- a/src/backend/cdb/cdbdistributedsnapshot.c
+++ b/src/backend/cdb/cdbdistributedsnapshot.c
@@ -45,12 +45,19 @@
  * snapshot can't be checked it returns to not do anything to the tuple. For
  * example running vacuum in utility mode for particular QE directly, in which
  * case don't have distributed snapshot to check against, it will not allow
- * marking tuples DEAD just based on local information.
+ * marking tuples DEAD just based on local information (unless
+ * gp_disable_dtx_visibility_check is on)
  */
 bool
 localXidSatisfiesAnyDistributedSnapshot(TransactionId localXid)
 {
 	DistributedSnapshotCommitted distributedSnapshotCommitted;
+
+	/*
+	 * If the GUC is set, consider tuple as invisible.
+	 */
+	if (gp_disable_dtx_visibility_check)
+		return false;
 
 	/*
 	 * In the QD, the distributed transactions become visible at the same time

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -315,6 +315,8 @@ extern bool fts_diskio_check;
 
 extern bool gp_enable_relsize_collection;
 
+extern bool gp_disable_dtx_visibility_check;
+
 /* Debug DTM Action */
 typedef enum
 {

--- a/src/test/isolation2/expected/vacuum_full_recently_dead_tuple_due_to_distributed_snapshot.out
+++ b/src/test/isolation2/expected/vacuum_full_recently_dead_tuple_due_to_distributed_snapshot.out
@@ -41,3 +41,37 @@ count
 (1 row)
 2U: set gp_select_invisible=0;
 SET
+
+-- If gp_disable_dtx_visibility_check is set, all tuples should be vacuumed.
+delete from test_recently_dead_utility;
+DELETE 1000
+
+2U: set gp_select_invisible=1;
+SET
+2U: select count(*) from test_recently_dead_utility;
+count
+-----
+1000 
+(1 row)
+2U: set gp_select_invisible=0;
+SET
+
+2U: set gp_disable_dtx_visibility_check to on;
+SET
+2U: vacuum full test_recently_dead_utility;
+VACUUM
+
+2U: set gp_select_invisible=1;
+SET
+2U: select count(*) from test_recently_dead_utility;
+count
+-----
+0    
+(1 row)
+2U: set gp_select_invisible=0;
+SET
+
+-- Ensure that we ERROR out if gp_disable_dtx_visibility_check is set in
+-- non-utility mode.
+3: set gp_disable_dtx_visibility_check to on;
+ERROR:  gp_disable_dtx_visibility_check can only be set in utility mode (guc_gp.c:6347)

--- a/src/test/isolation2/sql/vacuum_full_recently_dead_tuple_due_to_distributed_snapshot.sql
+++ b/src/test/isolation2/sql/vacuum_full_recently_dead_tuple_due_to_distributed_snapshot.sql
@@ -26,3 +26,21 @@ update test_recently_dead_utility set b = 1;
 -- localXidSatisfiesAnyDistributedSnapshot() changes for utility mode.
 2U: select count(*) from test_recently_dead_utility;
 2U: set gp_select_invisible=0;
+
+-- If gp_disable_dtx_visibility_check is set, all tuples should be vacuumed.
+delete from test_recently_dead_utility;
+
+2U: set gp_select_invisible=1;
+2U: select count(*) from test_recently_dead_utility;
+2U: set gp_select_invisible=0;
+
+2U: set gp_disable_dtx_visibility_check to on;
+2U: vacuum full test_recently_dead_utility;
+
+2U: set gp_select_invisible=1;
+2U: select count(*) from test_recently_dead_utility;
+2U: set gp_select_invisible=0;
+
+-- Ensure that we ERROR out if gp_disable_dtx_visibility_check is set in
+-- non-utility mode.
+3: set gp_disable_dtx_visibility_check to on;


### PR DESCRIPTION
We have had recent reports of: "ERROR: maximum length exceeded" in
EndPrepare().

This was encountered at the segment level when running VACUUM FULL on a
thoroughly bloated system catalog table. This arose due to the sheer
number of tuples being moved in move_plain_tuple(). Around ~26M tuples
were being moved in each segment, and since each move generates 2*32 =
64bytes of cache inval messages, the 2PC record data grew to be 1.6G,
well over MaxAllocSize(1G).

As a workaround to users, we want to provide a way to vacuum the tables
in utility mode to avoid 2PC altogether. Currently all tuples are
considered live for the purposes of utility mode vacuum. We end up
hitting:

```c
/*
 * If don't have distributed snapshot to check, return it can be seen and
 * hence not to be cleaned-up.
 */
return true;
```

This means that no tuples are actually vacuumed.

So, we introduce gp_disable_dtx_visibility_check as a way to bypass
visibility checks. Upon setting the GUC, all tuples are considered
eligible for utility mode VACUUM. Users who have been backed into a
corner (facing the above ERROR) now have a way out.

Notes:
We need not consider this change for 6X+ because:
* 0a469c87692 overhauls sinval and vacuum full in a way where vacuum is
turned into a simple variant of cluster. No longer will sinval messages
be generated for heap tuples during vacuum full.
* efc16ea5206 also overhauls sinval infrastructure while introducing hot
standby. This eliminates AtPrepare_Inval(), another contributor to 2PC
record bloat.
* localXidSatisfiesAnyDistributedSnapshot() has been replaced and the
new mechanism is compatible with utility mode vacuum.

Co-authored-by: Ashwin Agrawal <aashwin@vmware.com>
Co-authored-by: Tao Tang <tang.tao.cn@gmail.com>
