### PR TITLE
[AORO] change addition assignment to assigment

### DIFF
--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -461,7 +461,7 @@ GetAllFileSegInfo_pg_aoseg_rel(char *relationName,
 			ereport(ERROR,
 					(errcode(ERRCODE_UNDEFINED_OBJECT),
 					 errmsg("got invalid eof value: NULL")));
-		oneseginfo->eof += DatumGetInt64(eof);
+		oneseginfo->eof = DatumGetInt64(eof);
 
 		/* get the tupcount */
 		tupcount = fastgetattr(tuple, Anum_pg_aoseg_tupcount, pg_aoseg_dsc, &isNull);
@@ -469,7 +469,7 @@ GetAllFileSegInfo_pg_aoseg_rel(char *relationName,
 			ereport(ERROR,
 					(errcode(ERRCODE_UNDEFINED_OBJECT),
 					 errmsg("got invalid tupcount value: NULL")));
-		oneseginfo->total_tupcount += DatumGetInt64(tupcount);
+		oneseginfo->total_tupcount = DatumGetInt64(tupcount);
 
 		/* get the varblock count */
 		varblockcount = fastgetattr(tuple, Anum_pg_aoseg_varblockcount, pg_aoseg_dsc, &isNull);
@@ -477,7 +477,7 @@ GetAllFileSegInfo_pg_aoseg_rel(char *relationName,
 			ereport(ERROR,
 					(errcode(ERRCODE_UNDEFINED_OBJECT),
 					 errmsg("got invalid varblockcount value: NULL")));
-		oneseginfo->varblockcount += DatumGetInt64(varblockcount);
+		oneseginfo->varblockcount = DatumGetInt64(varblockcount);
 
 		/* get the modcount */
 		modcount = fastgetattr(tuple, Anum_pg_aoseg_modcount, pg_aoseg_dsc, &isNull);
@@ -485,7 +485,7 @@ GetAllFileSegInfo_pg_aoseg_rel(char *relationName,
 			ereport(ERROR,
 					(errcode(ERRCODE_UNDEFINED_OBJECT),
 					 errmsg("got invalid modcount value: NULL")));
-		oneseginfo->modcount += DatumGetInt64(modcount);
+		oneseginfo->modcount = DatumGetInt64(modcount);
 
 		/* get the file format version number */
 		formatversion = fastgetattr(tuple, Anum_pg_aoseg_formatversion, pg_aoseg_dsc, &isNull);
@@ -519,7 +519,7 @@ GetAllFileSegInfo_pg_aoseg_rel(char *relationName,
 			oneseginfo->eof_uncompressed = InvalidUncompressedEof;
 		}
 		else
-			oneseginfo->eof_uncompressed += DatumGetInt64(eof_uncompressed);
+			oneseginfo->eof_uncompressed = DatumGetInt64(eof_uncompressed);
 
 		elogif(Debug_appendonly_print_scan, LOG,
 			   "Append-only found existing segno %d with eof " INT64_FORMAT " for table '%s'",


### PR DESCRIPTION
In function `GetAllFileSegInfo_pg_aoseg_rel`, when handling each
tuple, we `palloc0` a FileSegInfo, `oneseginfo` is just a pointer
to the zero-allocated memory, using `+=` with the left operand 0
is the same effect as `=`, and `+=` should burn more cpu cycles
than `=`.

I'm not sure the compiler will optimize this kind of `+=` to `=`,
even if it does, using `=` is more accurate since here it is not
a accumulate semantic.

Signed-off-by: Junwang Zhao <zhjwpku@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
