### PR TITLE
Fix gppkg's coordinator hook not execute.

### DIFF
--- a/gpMgmt/bin/gppylib/operations/package.py
+++ b/gpMgmt/bin/gppylib/operations/package.py
@@ -1141,7 +1141,7 @@ class PerformHooks(Operation):
             if key is None:
                 return
             key_str = key[0]
-            if key_str.lower() == 'coordinator':
+            if key_str.lower() in ('coordinator', 'master'):
                 if self.standby_host:
                     RemoteCommand(hook[key_str], [self.standby_host]).run()
                 LocalCommand(hook[key_str], True).run()


### PR DESCRIPTION
old (and current) gppkg create the package like this format:

```
PostInstall:
  - Master:  "sh ./master.sh"
  - Segment: "sh ./segment.sh';"
  - All:     "echo 'install successful'"
```

sed -i s/master/coordinator/g will break this behavior.

#11365
