### PR TITLE
[AOCO] remove the useless if condition

### DIFF
--- a/src/backend/access/aocs/aocssegfiles.c
+++ b/src/backend/access/aocs/aocssegfiles.c
@@ -387,8 +387,7 @@ GetAllAOCSFileSegInfo_pg_aocsseg_rel(int numOfColumns,
 			aocs_seginfo->modcount = DatumGetInt64(d[Anum_pg_aocs_modcount - 1]);
 
 		Assert(!null[Anum_pg_aocs_formatversion - 1]);
-		if (!null[Anum_pg_aocs_formatversion - 1])
-			aocs_seginfo->formatversion = DatumGetInt16(d[Anum_pg_aocs_formatversion - 1]);
+		aocs_seginfo->formatversion = DatumGetInt16(d[Anum_pg_aocs_formatversion - 1]);
 
 		Assert(!null[Anum_pg_aocs_state - 1] || snapshot == SnapshotAny);
 		if (!null[Anum_pg_aocs_state - 1])


### PR DESCRIPTION
according to the comment, when `GetAllAOCSFileSegInfo_pg_aocsseg_rel`
was called from `gp_aoseg_history` after an upgrade, the `state` and
`modcount` might not be set, but no `formatversion`, the if conditon
should always be true, so just remove it to make the code more clean.

Signed-off-by: Junwang Zhao <zhjwpku@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
