### PR TITLE
Fix wrong results with a WITH RECURSIVE query

### DIFF
--- a/src/backend/executor/nodeRecursiveunion.c
+++ b/src/backend/executor/nodeRecursiveunion.c
@@ -128,6 +128,9 @@ ExecRecursiveUnion(PlanState *pstate)
 
 			/* intermediate table becomes working table */
 			node->working_table = node->intermediate_table;
+			for (int k = 1; k < node->refcount; k++)
+				/* The work table hasn't been scanned yet, it must be at start, don't need to rescan here */
+				tuplestore_alloc_read_pointer(node->working_table, EXEC_FLAG_REWIND);
 
 			/* create new empty intermediate table */
 			node->intermediate_table = tuplestore_begin_heap(false, false,
@@ -199,6 +202,7 @@ ExecInitRecursiveUnion(RecursiveUnion *node, EState *estate, int eflags)
 	rustate->intermediate_empty = true;
 	rustate->working_table = tuplestore_begin_heap(false, false, work_mem);
 	rustate->intermediate_table = tuplestore_begin_heap(false, false, work_mem);
+	rustate->refcount = 0;
 
 	/*
 	 * If hashing, we need a per-tuple memory context for comparisons, and a

--- a/src/backend/executor/nodeRecursiveunion.c
+++ b/src/backend/executor/nodeRecursiveunion.c
@@ -129,8 +129,10 @@ ExecRecursiveUnion(PlanState *pstate)
 			/* intermediate table becomes working table */
 			node->working_table = node->intermediate_table;
 			for (int k = 1; k < node->refcount; k++)
+			{
 				/* The work table hasn't been scanned yet, it must be at start, don't need to rescan here */
 				tuplestore_alloc_read_pointer(node->working_table, EXEC_FLAG_REWIND);
+			}
 
 			/* create new empty intermediate table */
 			node->intermediate_table = tuplestore_begin_heap(false, false,

--- a/src/backend/executor/nodeWorktablescan.c
+++ b/src/backend/executor/nodeWorktablescan.c
@@ -140,8 +140,10 @@ ExecInitWorkTableScan(WorkTableScan *node, EState *estate, int eflags)
 	if (scanstate->rustate->refcount == 0)
 		scanstate->readptr = 0;
 	else
+	{
 		/* during node init, the work table hasn't been scanned yet, it must be at start, don't need to rescan here*/
 		scanstate->readptr = tuplestore_alloc_read_pointer(scanstate->rustate->working_table, EXEC_FLAG_REWIND);
+	}
 	scanstate->rustate->refcount++;
 
 	/*

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -2946,7 +2946,8 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 
 	}
 
-	/* since shareinputscan with outer refs is not supported by GPDB, if
+	/*
+	 * since shareinputscan with outer refs is not supported by GPDB, if
 	 * contain outer self references, the cte need to be inlined.
 	 */
 	if (is_shared && contain_outer_selfref(cte->ctequery))

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -2946,6 +2946,9 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 
 	}
 
+	/* since shareinputscan with outer refs is not supported by GPDB, if
+	 * contain outer self references, the cte need to be inlined.
+	 */
 	if (is_shared && contain_outer_selfref(cte->ctequery))
 		is_shared = false;
 

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -43,6 +43,7 @@
 #include "optimizer/planmain.h"
 #include "optimizer/planner.h"
 #include "optimizer/restrictinfo.h"
+#include "optimizer/subselect.h"
 #include "optimizer/tlist.h"
 #include "optimizer/planshare.h"
 #include "parser/parse_clause.h"
@@ -2944,6 +2945,9 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 			is_shared =  root->config->gp_cte_sharing && (cte->cterefcount > 1 || contain_volatile_function);
 
 	}
+
+	if (is_shared && contain_outer_selfref(cte->ctequery))
+		is_shared = false;
 
 	if (!is_shared)
 	{

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -118,6 +118,7 @@ static bool finalize_primnode(Node *node, finalize_primnode_context *context);
 static bool finalize_agg_primnode(Node *node, finalize_primnode_context *context);
 
 extern	double global_work_mem(PlannerInfo *root);
+static bool contain_outer_selfref_walker(Node *node, Index *depth);
 
 /*
  * Get the datatype/typmod/collation of the first column of the plan's output.
@@ -1236,11 +1237,11 @@ contain_dml_walker(Node *node, void *context)
 	}
 	return expression_tree_walker(node, contain_dml_walker, context);
 }
-
+#endif
 /*
  * contain_outer_selfref: is there an external recursive self-reference?
  */
-static bool
+bool
 contain_outer_selfref(Node *node)
 {
 	Index		depth = 0;
@@ -1291,7 +1292,7 @@ contain_outer_selfref_walker(Node *node, Index *depth)
 	return expression_tree_walker(node, contain_outer_selfref_walker,
 								  (void *) depth);
 }
-
+#if 0
 /*
  * inline_cte: convert RTE_CTE references to given CTE into RTE_SUBQUERYs
  */

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1337,6 +1337,7 @@ typedef struct MergeAppendState
  *
  *		recursing			T when we're done scanning the non-recursive term
  *		intermediate_empty	T if intermediate_table is currently empty
+ *		refcount		numer of WorkTableScans which will scan the working table
  *		working_table		working table (to be scanned by recursive term)
  *		intermediate_table	current recursive output (next generation of WT)
  * ----------------
@@ -1346,6 +1347,7 @@ typedef struct RecursiveUnionState
 	PlanState	ps;				/* its first field is NodeTag */
 	bool		recursing;
 	bool		intermediate_empty;
+	int		refcount;
 	Tuplestorestate *working_table;
 	Tuplestorestate *intermediate_table;
 	/* Remaining fields are unused in UNION ALL case */
@@ -1999,11 +2001,22 @@ typedef struct NamedTuplestoreScanState
  *		WorkTableScan nodes are used to scan the work table created by
  *		a RecursiveUnion node.  We locate the RecursiveUnion node
  *		during executor startup.
+ *		In postgres, multiple recursive slef-references is disallowed
+ *		by the SQL spec, and prevent inlining of multiply-referenced
+ *		CTEs with outer recursive refs, so they only have one WorkTable
+ *		correlate to one RecursiveUnion. But in GPDB, we don't support
+ *		CTE scan plan, if exists multiply-referenced CTEs with outer
+ *		recursive, there will be multiple WorkTable scan correlate to
+ *		one RecursiveUnion, and they share the same readptr of working
+ *		table which cause wrong results. We create a readptr for each
+ *		WorkTable scan, so that they won't influence each other.
+ *
  * ----------------
  */
 typedef struct WorkTableScanState
 {
 	ScanState	ss;				/* its first field is NodeTag */
+	int		readptr;			/* index of work table's tuplestore read pointer */
 	RecursiveUnionState *rustate;
 } WorkTableScanState;
 

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1337,7 +1337,7 @@ typedef struct MergeAppendState
  *
  *		recursing			T when we're done scanning the non-recursive term
  *		intermediate_empty	T if intermediate_table is currently empty
- *		refcount		numer of WorkTableScans which will scan the working table
+ *		refcount		number of WorkTableScans which will scan the working table
  *		working_table		working table (to be scanned by recursive term)
  *		intermediate_table	current recursive output (next generation of WT)
  * ----------------
@@ -2001,7 +2001,7 @@ typedef struct NamedTuplestoreScanState
  *		WorkTableScan nodes are used to scan the work table created by
  *		a RecursiveUnion node.  We locate the RecursiveUnion node
  *		during executor startup.
- *		In postgres, multiple recursive slef-references is disallowed
+ *		In postgres, multiple recursive self-references is disallowed
  *		by the SQL spec, and prevent inlining of multiply-referenced
  *		CTEs with outer recursive refs, so they only have one WorkTable
  *		correlate to one RecursiveUnion. But in GPDB, we don't support

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1337,7 +1337,7 @@ typedef struct MergeAppendState
  *
  *		recursing			T when we're done scanning the non-recursive term
  *		intermediate_empty	T if intermediate_table is currently empty
- *		refcount		number of WorkTableScans which will scan the working table
+ *		refcount 			number of WorkTableScans which will scan the working table
  *		working_table		working table (to be scanned by recursive term)
  *		intermediate_table	current recursive output (next generation of WT)
  * ----------------
@@ -1347,7 +1347,7 @@ typedef struct RecursiveUnionState
 	PlanState	ps;				/* its first field is NodeTag */
 	bool		recursing;
 	bool		intermediate_empty;
-	int		refcount;
+	int			refcount;
 	Tuplestorestate *working_table;
 	Tuplestorestate *intermediate_table;
 	/* Remaining fields are unused in UNION ALL case */
@@ -2016,7 +2016,7 @@ typedef struct NamedTuplestoreScanState
 typedef struct WorkTableScanState
 {
 	ScanState	ss;				/* its first field is NodeTag */
-	int		readptr;			/* index of work table's tuplestore read pointer */
+	int			readptr;		/* index of work table's tuplestore read pointer */
 	RecursiveUnionState *rustate;
 } WorkTableScanState;
 

--- a/src/include/optimizer/subselect.h
+++ b/src/include/optimizer/subselect.h
@@ -54,5 +54,6 @@ extern bool IsSubqueryMultiLevelCorrelated(Query *sq);
 extern List *generate_subquery_vars(PlannerInfo *root, List *tlist,
 					   Index varno);
 extern bool QueryHasDistributedRelation(Query *q, bool recursive);
+extern bool contain_outer_selfref(Node *node);
 
 #endif							/* SUBSELECT_H */

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -1406,11 +1406,6 @@ select * from x, x x2 where x.n = x2.n;
 (19 rows)
 
 -- Multiply-referenced CTEs can't be inlined if they contain outer self-refs
--- start_ignore
--- GPDB_12_MERGE_FIXME: This currenty produces incorrect results on GPDB.
--- It's not a new issue, but it was exposed by this new upstream test case
--- with the PostgreSQL v12 merge.
--- See https://github.com/greenplum-db/gpdb/issues/10014
 explain (verbose, costs off)
 with recursive x(a) as
   ((values ('a'), ('b'))
@@ -1419,25 +1414,22 @@ with recursive x(a) as
     select z.a || z1.a as a from z cross join z as z1
     where length(z.a || z1.a) < 5))
 select * from x;
-                        QUERY PLAN                        
-----------------------------------------------------------
- CTE Scan on x
-   Output: x.a
-   CTE x
-     ->  Recursive Union
-           ->  Values Scan on "*VALUES*"
-                 Output: "*VALUES*".column1
-           ->  Nested Loop
-                 Output: (z.a || z1.a)
-                 Join Filter: (length((z.a || z1.a)) < 5)
-                 CTE z
-                   ->  WorkTable Scan on x x_1
-                         Output: x_1.a
-                 ->  CTE Scan on z
-                       Output: z.a
-                 ->  CTE Scan on z z1
-                       Output: z1.a
-(16 rows)
+                    QUERY PLAN                     
+---------------------------------------------------
+ Recursive Union
+   ->  Values Scan on "*VALUES*"
+         Output: "*VALUES*".column1
+   ->  Nested Loop
+         Output: (x.a || x_1.a)
+         Join Filter: (length((x.a || x_1.a)) < 5)
+         ->  WorkTable Scan on x
+               Output: x.a
+         ->  Materialize
+               Output: x_1.a
+               ->  WorkTable Scan on x x_1
+                     Output: x_1.a
+ Optimizer: Postgres query optimizer
+(13 rows)
 
 with recursive x(a) as
   ((values ('a'), ('b'))
@@ -1472,7 +1464,6 @@ select * from x;
  bbbb
 (22 rows)
 
--- end_ignore
 explain (verbose, costs off)
 with recursive x(a) as
   ((values ('a'), ('b'))

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -1443,11 +1443,6 @@ select * from x, x x2 where x.n = x2.n;
 (19 rows)
 
 -- Multiply-referenced CTEs can't be inlined if they contain outer self-refs
--- start_ignore
--- GPDB_12_MERGE_FIXME: This currenty produces incorrect results on GPDB.
--- It's not a new issue, but it was exposed by this new upstream test case
--- with the PostgreSQL v12 merge.
--- See https://github.com/greenplum-db/gpdb/issues/10014
 explain (verbose, costs off)
 with recursive x(a) as
   ((values ('a'), ('b'))
@@ -1481,13 +1476,32 @@ with recursive x(a) as
     select z.a || z1.a as a from z cross join z as z1
     where length(z.a || z1.a) < 5))
 select * from x;
- a 
----
+  a   
+------
  a
  b
-(2 rows)
+ aa
+ ab
+ ba
+ bb
+ aaaa
+ aaab
+ aaba
+ aabb
+ abaa
+ abab
+ abba
+ abbb
+ baaa
+ baab
+ baba
+ babb
+ bbaa
+ bbab
+ bbba
+ bbbb
+(22 rows)
 
--- end_ignore
 explain (verbose, costs off)
 with recursive x(a) as
   ((values ('a'), ('b'))

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -732,11 +732,6 @@ with x as not materialized (select * from (select f1, current_database() as n fr
 select * from x, x x2 where x.n = x2.n;
 
 -- Multiply-referenced CTEs can't be inlined if they contain outer self-refs
--- start_ignore
--- GPDB_12_MERGE_FIXME: This currenty produces incorrect results on GPDB.
--- It's not a new issue, but it was exposed by this new upstream test case
--- with the PostgreSQL v12 merge.
--- See https://github.com/greenplum-db/gpdb/issues/10014
 explain (verbose, costs off)
 with recursive x(a) as
   ((values ('a'), ('b'))
@@ -753,7 +748,6 @@ with recursive x(a) as
     select z.a || z1.a as a from z cross join z as z1
     where length(z.a || z1.a) < 5))
 select * from x;
--- end_ignore
 
 explain (verbose, costs off)
 with recursive x(a) as


### PR DESCRIPTION
If a WITH RECURSIVE query has multiply-referenced CTEs with outer
recursive refs, it will generate multiple WorkTable scans which
scan the same working table with the same readptr, so that it will
lose some datas. Create a readptr for each WorkTable scan to generate
rigrt results.
Remove GPDB_12_MERGE_FIXME in subselect.sql which describes the issue.

-----

Fix https://github.com/greenplum-db/gpdb/issues/10014

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
