### PR TITLE
Fix predicate pushdown using cast'd column

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-PartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-PartTable.mdp
@@ -1741,10 +1741,10 @@ ORDER BY 1 asc ;
         </dxl:LogicalGroupBy>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="35">
+    <dxl:Plan Id="0" SpaceSize="60">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="889.240826" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="889.256729" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="23" Alias="fivemin">
@@ -1757,7 +1757,7 @@ ORDER BY 1 asc ;
         </dxl:SortingColumnList>
         <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="889.240790" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="889.256693" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="23" Alias="fivemin">
@@ -1772,7 +1772,7 @@ ORDER BY 1 asc ;
           <dxl:LimitOffset/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="889.240790" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="889.256693" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="23"/>
@@ -1785,7 +1785,7 @@ ORDER BY 1 asc ;
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="889.240780" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="889.256682" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="23" Alias="fivemin">
@@ -1800,7 +1800,7 @@ ORDER BY 1 asc ;
               <dxl:LimitOffset/>
               <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="889.240780" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="889.256682" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="23" Alias="fivemin">
@@ -1814,39 +1814,45 @@ ORDER BY 1 asc ;
                     <dxl:Ident ColId="23" ColName="fivemin" TypeMdid="0.20.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
-                <dxl:Result>
+                <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="889.240764" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="889.256667" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="23" Alias="fivemin">
-                      <dxl:OpExpr OperatorName="*" OperatorMdid="0.690.1.0" OperatorType="0.20.1.0">
-                        <dxl:OpExpr OperatorName="/" OperatorMdid="0.691.1.0" OperatorType="0.20.1.0">
-                          <dxl:OpExpr OperatorName="/" OperatorMdid="0.691.1.0" OperatorType="0.20.1.0">
-                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="100000"/>
-                          </dxl:OpExpr>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
-                        </dxl:OpExpr>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
-                      </dxl:OpExpr>
+                      <dxl:Ident ColId="23" ColName="fivemin" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                  <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
+                  <dxl:JoinFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:JoinFilter>
+                  <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="889.240760" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.306548" Rows="840.000000" Width="33"/>
                     </dxl:Properties>
                     <dxl:ProjList>
+                      <dxl:ProjElem ColId="23" Alias="fivemin">
+                        <dxl:OpExpr OperatorName="*" OperatorMdid="0.690.1.0" OperatorType="0.20.1.0">
+                          <dxl:OpExpr OperatorName="/" OperatorMdid="0.691.1.0" OperatorType="0.20.1.0">
+                            <dxl:OpExpr OperatorName="/" OperatorMdid="0.691.1.0" OperatorType="0.20.1.0">
+                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="100000"/>
+                            </dxl:OpExpr>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                          </dxl:OpExpr>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                        </dxl:OpExpr>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="0" Alias="symbol">
+                        <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
+                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="1" Alias="event_ts">
                         <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:JoinFilter>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:JoinFilter>
+                    <dxl:OneTimeFilter/>
                     <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                       <dxl:Properties>
                         <dxl:Cost StartupCost="0" TotalCost="431.292687" Rows="840.000000" Width="25"/>
@@ -1889,250 +1895,250 @@ ORDER BY 1 asc ;
                         </dxl:TableDescriptor>
                       </dxl:TableScan>
                     </dxl:BroadcastMotion>
-                    <dxl:Append IsTarget="false" IsZapped="false">
+                  </dxl:Result>
+                  <dxl:Append IsTarget="false" IsZapped="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="457.941664" Rows="1.000000" Width="1"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="11" Alias="ets">
+                        <dxl:Ident ColId="11" ColName="ets" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="12" Alias="sym">
+                        <dxl:Ident ColId="12" ColName="sym" TypeMdid="0.1043.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="15" Alias="end_ts">
+                        <dxl:Ident ColId="15" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:BitmapTableScan>
                       <dxl:Properties>
                         <dxl:Cost StartupCost="0" TotalCost="457.941664" Rows="1.000000" Width="1"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="11" Alias="ets">
-                          <dxl:Ident ColId="11" ColName="ets" TypeMdid="0.20.1.0"/>
+                        <dxl:ProjElem ColId="24" Alias="ets">
+                          <dxl:Ident ColId="24" ColName="ets" TypeMdid="0.20.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="12" Alias="sym">
-                          <dxl:Ident ColId="12" ColName="sym" TypeMdid="0.1043.1.0"/>
+                        <dxl:ProjElem ColId="25" Alias="sym">
+                          <dxl:Ident ColId="25" ColName="sym" TypeMdid="0.1043.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="15" Alias="end_ts">
-                          <dxl:Ident ColId="15" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                        <dxl:ProjElem ColId="28" Alias="end_ts">
+                          <dxl:Ident ColId="28" ColName="end_ts" TypeMdid="0.20.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:BitmapTableScan>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="457.941664" Rows="1.000000" Width="1"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="24" Alias="ets">
+                      <dxl:Filter>
+                        <dxl:And>
+                          <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
                             <dxl:Ident ColId="24" ColName="ets" TypeMdid="0.20.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="25" Alias="sym">
-                            <dxl:Ident ColId="25" ColName="sym" TypeMdid="0.1043.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="28" Alias="end_ts">
+                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                          </dxl:Comparison>
+                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
                             <dxl:Ident ColId="28" ColName="end_ts" TypeMdid="0.20.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter>
-                          <dxl:And>
-                            <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
-                              <dxl:Ident ColId="24" ColName="ets" TypeMdid="0.20.1.0"/>
-                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                            </dxl:Comparison>
-                            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-                              <dxl:Ident ColId="28" ColName="end_ts" TypeMdid="0.20.1.0"/>
-                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                            </dxl:Comparison>
-                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
-                              <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
-                                <dxl:Ident ColId="25" ColName="sym" TypeMdid="0.1043.1.0"/>
-                              </dxl:Cast>
-                              <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
-                            </dxl:Comparison>
-                          </dxl:And>
-                        </dxl:Filter>
-                        <dxl:RecheckCond>
-                          <dxl:And>
-                            <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
-                              <dxl:Ident ColId="24" ColName="ets" TypeMdid="0.20.1.0"/>
-                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                            </dxl:Comparison>
-                            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-                              <dxl:Ident ColId="28" ColName="end_ts" TypeMdid="0.20.1.0"/>
-                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                            </dxl:Comparison>
-                          </dxl:And>
-                        </dxl:RecheckCond>
-                        <dxl:BitmapIndexProbe>
-                          <dxl:IndexCondList>
-                            <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
-                              <dxl:Ident ColId="24" ColName="ets" TypeMdid="0.20.1.0"/>
-                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                            </dxl:Comparison>
-                            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-                              <dxl:Ident ColId="28" ColName="end_ts" TypeMdid="0.20.1.0"/>
-                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                            </dxl:Comparison>
-                          </dxl:IndexCondList>
-                          <dxl:IndexDescriptor Mdid="0.-1013039183.1.0" IndexName="my_tq_agg_small_ets_end_ts_ix_1_prt_p1"/>
-                        </dxl:BitmapIndexProbe>
-                        <dxl:TableDescriptor Mdid="0.-1013210183.1.1" TableName="my_tq_agg_small_prt_1">
-                          <dxl:Columns>
-                            <dxl:Column ColId="24" Attno="1" ColName="ets" TypeMdid="0.20.1.0" ColWidth="8"/>
-                            <dxl:Column ColId="25" Attno="2" ColName="sym" TypeMdid="0.1043.1.0" ColWidth="16"/>
-                            <dxl:Column ColId="26" Attno="3" ColName="bid_price" TypeMdid="0.1700.1.0" ColWidth="8"/>
-                            <dxl:Column ColId="27" Attno="4" ColName="ask_price" TypeMdid="0.1700.1.0" ColWidth="8"/>
-                            <dxl:Column ColId="28" Attno="5" ColName="end_ts" TypeMdid="0.20.1.0" ColWidth="8"/>
-                            <dxl:Column ColId="29" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                            <dxl:Column ColId="30" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="31" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="32" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="33" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="34" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="35" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:BitmapTableScan>
-                      <dxl:BitmapTableScan>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="457.941664" Rows="1.000000" Width="1"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="36" Alias="ets">
+                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                          </dxl:Comparison>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+                            <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
+                              <dxl:Ident ColId="25" ColName="sym" TypeMdid="0.1043.1.0"/>
+                            </dxl:Cast>
+                            <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:And>
+                      </dxl:Filter>
+                      <dxl:RecheckCond>
+                        <dxl:And>
+                          <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
+                            <dxl:Ident ColId="24" ColName="ets" TypeMdid="0.20.1.0"/>
+                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                          </dxl:Comparison>
+                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
+                            <dxl:Ident ColId="28" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:And>
+                      </dxl:RecheckCond>
+                      <dxl:BitmapIndexProbe>
+                        <dxl:IndexCondList>
+                          <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
+                            <dxl:Ident ColId="24" ColName="ets" TypeMdid="0.20.1.0"/>
+                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                          </dxl:Comparison>
+                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
+                            <dxl:Ident ColId="28" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:IndexCondList>
+                        <dxl:IndexDescriptor Mdid="0.-1013039183.1.0" IndexName="my_tq_agg_small_ets_end_ts_ix_1_prt_p1"/>
+                      </dxl:BitmapIndexProbe>
+                      <dxl:TableDescriptor Mdid="0.-1013210183.1.1" TableName="my_tq_agg_small_prt_1">
+                        <dxl:Columns>
+                          <dxl:Column ColId="24" Attno="1" ColName="ets" TypeMdid="0.20.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="25" Attno="2" ColName="sym" TypeMdid="0.1043.1.0" ColWidth="16"/>
+                          <dxl:Column ColId="26" Attno="3" ColName="bid_price" TypeMdid="0.1700.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="27" Attno="4" ColName="ask_price" TypeMdid="0.1700.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="28" Attno="5" ColName="end_ts" TypeMdid="0.20.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="29" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                          <dxl:Column ColId="30" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="31" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="32" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="33" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="34" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="35" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:BitmapTableScan>
+                    <dxl:BitmapTableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="457.941664" Rows="1.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="36" Alias="ets">
+                          <dxl:Ident ColId="36" ColName="ets" TypeMdid="0.20.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="37" Alias="sym">
+                          <dxl:Ident ColId="37" ColName="sym" TypeMdid="0.1043.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="40" Alias="end_ts">
+                          <dxl:Ident ColId="40" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter>
+                        <dxl:And>
+                          <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
                             <dxl:Ident ColId="36" ColName="ets" TypeMdid="0.20.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="37" Alias="sym">
-                            <dxl:Ident ColId="37" ColName="sym" TypeMdid="0.1043.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="40" Alias="end_ts">
+                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                          </dxl:Comparison>
+                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
                             <dxl:Ident ColId="40" ColName="end_ts" TypeMdid="0.20.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter>
-                          <dxl:And>
-                            <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
-                              <dxl:Ident ColId="36" ColName="ets" TypeMdid="0.20.1.0"/>
-                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                            </dxl:Comparison>
-                            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-                              <dxl:Ident ColId="40" ColName="end_ts" TypeMdid="0.20.1.0"/>
-                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                            </dxl:Comparison>
-                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
-                              <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
-                                <dxl:Ident ColId="37" ColName="sym" TypeMdid="0.1043.1.0"/>
-                              </dxl:Cast>
-                              <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
-                            </dxl:Comparison>
-                          </dxl:And>
-                        </dxl:Filter>
-                        <dxl:RecheckCond>
-                          <dxl:And>
-                            <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
-                              <dxl:Ident ColId="36" ColName="ets" TypeMdid="0.20.1.0"/>
-                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                            </dxl:Comparison>
-                            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-                              <dxl:Ident ColId="40" ColName="end_ts" TypeMdid="0.20.1.0"/>
-                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                            </dxl:Comparison>
-                          </dxl:And>
-                        </dxl:RecheckCond>
-                        <dxl:BitmapIndexProbe>
-                          <dxl:IndexCondList>
-                            <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
-                              <dxl:Ident ColId="36" ColName="ets" TypeMdid="0.20.1.0"/>
-                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                            </dxl:Comparison>
-                            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-                              <dxl:Ident ColId="40" ColName="end_ts" TypeMdid="0.20.1.0"/>
-                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                            </dxl:Comparison>
-                          </dxl:IndexCondList>
-                          <dxl:IndexDescriptor Mdid="0.-1013039182.1.0" IndexName="my_tq_agg_small_ets_end_ts_ix_1_prt_p1"/>
-                        </dxl:BitmapIndexProbe>
-                        <dxl:TableDescriptor Mdid="0.-1013210182.1.1" TableName="my_tq_agg_small_prt_2">
-                          <dxl:Columns>
-                            <dxl:Column ColId="36" Attno="1" ColName="ets" TypeMdid="0.20.1.0" ColWidth="8"/>
-                            <dxl:Column ColId="37" Attno="2" ColName="sym" TypeMdid="0.1043.1.0" ColWidth="16"/>
-                            <dxl:Column ColId="38" Attno="3" ColName="bid_price" TypeMdid="0.1700.1.0" ColWidth="8"/>
-                            <dxl:Column ColId="39" Attno="4" ColName="ask_price" TypeMdid="0.1700.1.0" ColWidth="8"/>
-                            <dxl:Column ColId="40" Attno="5" ColName="end_ts" TypeMdid="0.20.1.0" ColWidth="8"/>
-                            <dxl:Column ColId="41" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                            <dxl:Column ColId="42" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="43" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="44" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="45" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="46" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="47" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:BitmapTableScan>
-                      <dxl:BitmapTableScan>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="457.941664" Rows="1.000000" Width="1"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="48" Alias="ets">
+                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                          </dxl:Comparison>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+                            <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
+                              <dxl:Ident ColId="37" ColName="sym" TypeMdid="0.1043.1.0"/>
+                            </dxl:Cast>
+                            <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:And>
+                      </dxl:Filter>
+                      <dxl:RecheckCond>
+                        <dxl:And>
+                          <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
+                            <dxl:Ident ColId="36" ColName="ets" TypeMdid="0.20.1.0"/>
+                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                          </dxl:Comparison>
+                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
+                            <dxl:Ident ColId="40" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:And>
+                      </dxl:RecheckCond>
+                      <dxl:BitmapIndexProbe>
+                        <dxl:IndexCondList>
+                          <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
+                            <dxl:Ident ColId="36" ColName="ets" TypeMdid="0.20.1.0"/>
+                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                          </dxl:Comparison>
+                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
+                            <dxl:Ident ColId="40" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:IndexCondList>
+                        <dxl:IndexDescriptor Mdid="0.-1013039182.1.0" IndexName="my_tq_agg_small_ets_end_ts_ix_1_prt_p1"/>
+                      </dxl:BitmapIndexProbe>
+                      <dxl:TableDescriptor Mdid="0.-1013210182.1.1" TableName="my_tq_agg_small_prt_2">
+                        <dxl:Columns>
+                          <dxl:Column ColId="36" Attno="1" ColName="ets" TypeMdid="0.20.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="37" Attno="2" ColName="sym" TypeMdid="0.1043.1.0" ColWidth="16"/>
+                          <dxl:Column ColId="38" Attno="3" ColName="bid_price" TypeMdid="0.1700.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="39" Attno="4" ColName="ask_price" TypeMdid="0.1700.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="40" Attno="5" ColName="end_ts" TypeMdid="0.20.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="41" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                          <dxl:Column ColId="42" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="43" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="44" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="45" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="46" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="47" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:BitmapTableScan>
+                    <dxl:BitmapTableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="457.941664" Rows="1.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="48" Alias="ets">
+                          <dxl:Ident ColId="48" ColName="ets" TypeMdid="0.20.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="49" Alias="sym">
+                          <dxl:Ident ColId="49" ColName="sym" TypeMdid="0.1043.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="52" Alias="end_ts">
+                          <dxl:Ident ColId="52" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter>
+                        <dxl:And>
+                          <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
                             <dxl:Ident ColId="48" ColName="ets" TypeMdid="0.20.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="49" Alias="sym">
-                            <dxl:Ident ColId="49" ColName="sym" TypeMdid="0.1043.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="52" Alias="end_ts">
+                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                          </dxl:Comparison>
+                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
                             <dxl:Ident ColId="52" ColName="end_ts" TypeMdid="0.20.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter>
-                          <dxl:And>
-                            <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
-                              <dxl:Ident ColId="48" ColName="ets" TypeMdid="0.20.1.0"/>
-                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                            </dxl:Comparison>
-                            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-                              <dxl:Ident ColId="52" ColName="end_ts" TypeMdid="0.20.1.0"/>
-                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                            </dxl:Comparison>
-                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
-                              <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
-                                <dxl:Ident ColId="49" ColName="sym" TypeMdid="0.1043.1.0"/>
-                              </dxl:Cast>
-                              <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
-                            </dxl:Comparison>
-                          </dxl:And>
-                        </dxl:Filter>
-                        <dxl:RecheckCond>
-                          <dxl:And>
-                            <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
-                              <dxl:Ident ColId="48" ColName="ets" TypeMdid="0.20.1.0"/>
-                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                            </dxl:Comparison>
-                            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-                              <dxl:Ident ColId="52" ColName="end_ts" TypeMdid="0.20.1.0"/>
-                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                            </dxl:Comparison>
-                          </dxl:And>
-                        </dxl:RecheckCond>
-                        <dxl:BitmapIndexProbe>
-                          <dxl:IndexCondList>
-                            <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
-                              <dxl:Ident ColId="48" ColName="ets" TypeMdid="0.20.1.0"/>
-                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                            </dxl:Comparison>
-                            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-                              <dxl:Ident ColId="52" ColName="end_ts" TypeMdid="0.20.1.0"/>
-                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                            </dxl:Comparison>
-                          </dxl:IndexCondList>
-                          <dxl:IndexDescriptor Mdid="0.-1013039181.1.0" IndexName="my_tq_agg_small_ets_end_ts_ix_1_prt_p1"/>
-                        </dxl:BitmapIndexProbe>
-                        <dxl:TableDescriptor Mdid="0.-1013210181.1.1" TableName="my_tq_agg_small_prt_3">
-                          <dxl:Columns>
-                            <dxl:Column ColId="48" Attno="1" ColName="ets" TypeMdid="0.20.1.0" ColWidth="8"/>
-                            <dxl:Column ColId="49" Attno="2" ColName="sym" TypeMdid="0.1043.1.0" ColWidth="16"/>
-                            <dxl:Column ColId="50" Attno="3" ColName="bid_price" TypeMdid="0.1700.1.0" ColWidth="8"/>
-                            <dxl:Column ColId="51" Attno="4" ColName="ask_price" TypeMdid="0.1700.1.0" ColWidth="8"/>
-                            <dxl:Column ColId="52" Attno="5" ColName="end_ts" TypeMdid="0.20.1.0" ColWidth="8"/>
-                            <dxl:Column ColId="53" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                            <dxl:Column ColId="54" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="55" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="56" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="57" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="58" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="59" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:BitmapTableScan>
-                    </dxl:Append>
-                  </dxl:NestedLoopJoin>
-                </dxl:Result>
+                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                          </dxl:Comparison>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+                            <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
+                              <dxl:Ident ColId="49" ColName="sym" TypeMdid="0.1043.1.0"/>
+                            </dxl:Cast>
+                            <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:And>
+                      </dxl:Filter>
+                      <dxl:RecheckCond>
+                        <dxl:And>
+                          <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
+                            <dxl:Ident ColId="48" ColName="ets" TypeMdid="0.20.1.0"/>
+                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                          </dxl:Comparison>
+                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
+                            <dxl:Ident ColId="52" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:And>
+                      </dxl:RecheckCond>
+                      <dxl:BitmapIndexProbe>
+                        <dxl:IndexCondList>
+                          <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
+                            <dxl:Ident ColId="48" ColName="ets" TypeMdid="0.20.1.0"/>
+                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                          </dxl:Comparison>
+                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
+                            <dxl:Ident ColId="52" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:IndexCondList>
+                        <dxl:IndexDescriptor Mdid="0.-1013039181.1.0" IndexName="my_tq_agg_small_ets_end_ts_ix_1_prt_p1"/>
+                      </dxl:BitmapIndexProbe>
+                      <dxl:TableDescriptor Mdid="0.-1013210181.1.1" TableName="my_tq_agg_small_prt_3">
+                        <dxl:Columns>
+                          <dxl:Column ColId="48" Attno="1" ColName="ets" TypeMdid="0.20.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="49" Attno="2" ColName="sym" TypeMdid="0.1043.1.0" ColWidth="16"/>
+                          <dxl:Column ColId="50" Attno="3" ColName="bid_price" TypeMdid="0.1700.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="51" Attno="4" ColName="ask_price" TypeMdid="0.1700.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="52" Attno="5" ColName="end_ts" TypeMdid="0.20.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="53" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                          <dxl:Column ColId="54" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="55" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="56" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="57" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="58" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="59" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:BitmapTableScan>
+                  </dxl:Append>
+                </dxl:NestedLoopJoin>
               </dxl:RedistributeMotion>
             </dxl:Sort>
           </dxl:Aggregate>

--- a/src/backend/gporca/data/dxl/minidump/Coalesce-With-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Coalesce-With-Subquery.mdp
@@ -852,25 +852,20 @@
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2856">
-      <dxl:Result>
+    <dxl:Plan Id="0" SpaceSize="1368">
+      <dxl:Sort SortDiscardDuplicates="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="38915.798285" Rows="4.000000" Width="269"/>
+          <dxl:Cost StartupCost="0" TotalCost="6489.674275" Rows="4.000000" Width="269"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="datname">
             <dxl:Ident ColId="0" ColName="datname" TypeMdid="0.19.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="88" Alias="coalesce">
-            <dxl:Coalesce TypeMdid="0.19.1.0">
-              <dxl:Ident ColId="19" ColName="rolname" TypeMdid="0.19.1.0"/>
-              <dxl:Ident ColId="44" ColName="rolname" TypeMdid="0.19.1.0"/>
-            </dxl:Coalesce>
+            <dxl:Ident ColId="88" ColName="coalesce" TypeMdid="0.19.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="89" Alias="pg_encoding_to_char">
-            <dxl:FuncExpr FuncId="0.1597.1.0" FuncRetSet="false" TypeMdid="0.19.1.0">
-              <dxl:Ident ColId="2" ColName="encoding" TypeMdid="0.23.1.0"/>
-            </dxl:FuncExpr>
+            <dxl:Ident ColId="89" ColName="pg_encoding_to_char" TypeMdid="0.19.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="3" Alias="datistemplate">
             <dxl:Ident ColId="3" ColName="datistemplate" TypeMdid="0.16.1.0"/>
@@ -882,89 +877,102 @@
             <dxl:Ident ColId="5" ColName="datconnlimit" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="105" Alias="dattablespace">
-            <dxl:SubPlan TypeMdid="0.19.1.0" SubPlanType="ScalarSubPlan">
-              <dxl:TestExpr/>
-              <dxl:ParamList>
-                <dxl:Param ColId="8" ColName="dattablespace" TypeMdid="0.26.1.0"/>
-              </dxl:ParamList>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.001303" Rows="1.000000" Width="64"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="90" Alias="spcname">
-                    <dxl:Ident ColId="90" ColName="spcname" TypeMdid="0.19.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
-                    <dxl:Ident ColId="98" ColName="oid" TypeMdid="0.26.1.0"/>
-                    <dxl:Ident ColId="8" ColName="dattablespace" TypeMdid="0.26.1.0"/>
-                  </dxl:Comparison>
-                </dxl:Filter>
-                <dxl:TableDescriptor Mdid="0.1213.1.1" TableName="pg_tablespace">
-                  <dxl:Columns>
-                    <dxl:Column ColId="90" Attno="1" ColName="spcname" TypeMdid="0.19.1.0"/>
-                    <dxl:Column ColId="97" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="98" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="99" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="100" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="101" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="102" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="103" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="104" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-            </dxl:SubPlan>
+            <dxl:Ident ColId="105" ColName="dattablespace" TypeMdid="0.19.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:OneTimeFilter/>
-        <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+        <dxl:SortingColumnList>
+          <dxl:SortingColumn ColId="0" SortOperatorMdid="0.660.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+        </dxl:SortingColumnList>
+        <dxl:LimitCount/>
+        <dxl:LimitOffset/>
+        <dxl:HashJoin JoinType="Left">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="6920.082238" Rows="8.000000" Width="205"/>
+            <dxl:Cost StartupCost="0" TotalCost="6489.662073" Rows="4.000000" Width="269"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="datname">
               <dxl:Ident ColId="0" ColName="datname" TypeMdid="0.19.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="2" Alias="encoding">
-              <dxl:Ident ColId="2" ColName="encoding" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="88" Alias="coalesce">
+              <dxl:Ident ColId="88" ColName="coalesce" TypeMdid="0.19.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="89" Alias="pg_encoding_to_char">
+              <dxl:Ident ColId="89" ColName="pg_encoding_to_char" TypeMdid="0.19.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="3" Alias="datistemplate">
               <dxl:Ident ColId="3" ColName="datistemplate" TypeMdid="0.16.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="5" Alias="datconnlimit">
-              <dxl:Ident ColId="5" ColName="datconnlimit" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="8" Alias="dattablespace">
-              <dxl:Ident ColId="8" ColName="dattablespace" TypeMdid="0.26.1.0"/>
-            </dxl:ProjElem>
             <dxl:ProjElem ColId="10" Alias="datacl">
               <dxl:Ident ColId="10" ColName="datacl" TypeMdid="0.1034.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="19" Alias="rolname">
-              <dxl:Ident ColId="19" ColName="rolname" TypeMdid="0.19.1.0"/>
+            <dxl:ProjElem ColId="5" Alias="datconnlimit">
+              <dxl:Ident ColId="5" ColName="datconnlimit" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="44" Alias="rolname">
-              <dxl:Ident ColId="44" ColName="rolname" TypeMdid="0.19.1.0"/>
+            <dxl:ProjElem ColId="105" Alias="dattablespace">
+              <dxl:Ident ColId="105" ColName="dattablespace" TypeMdid="0.19.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:JoinFilter>
-            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-          </dxl:JoinFilter>
-          <dxl:Sort SortDiscardDuplicates="false">
+          <dxl:JoinFilter/>
+          <dxl:HashCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+              <dxl:Ident ColId="1" ColName="datdba" TypeMdid="0.26.1.0"/>
+              <dxl:Ident ColId="37" ColName="oid" TypeMdid="0.26.1.0"/>
+            </dxl:Comparison>
+          </dxl:HashCondList>
+          <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.011733" Rows="4.000000" Width="141"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.643127" Rows="3.000000" Width="209"/>
             </dxl:Properties>
             <dxl:ProjList>
+              <dxl:ProjElem ColId="89" Alias="pg_encoding_to_char">
+                <dxl:FuncExpr FuncId="0.1597.1.0" FuncRetSet="false" TypeMdid="0.19.1.0">
+                  <dxl:Ident ColId="2" ColName="encoding" TypeMdid="0.23.1.0"/>
+                </dxl:FuncExpr>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="105" Alias="dattablespace">
+                <dxl:SubPlan TypeMdid="0.19.1.0" SubPlanType="ScalarSubPlan">
+                  <dxl:TestExpr/>
+                  <dxl:ParamList>
+                    <dxl:Param ColId="8" ColName="dattablespace" TypeMdid="0.26.1.0"/>
+                  </dxl:ParamList>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000645" Rows="1.000000" Width="64"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="90" Alias="spcname">
+                        <dxl:Ident ColId="90" ColName="spcname" TypeMdid="0.19.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+                        <dxl:Ident ColId="98" ColName="oid" TypeMdid="0.26.1.0"/>
+                        <dxl:Ident ColId="8" ColName="dattablespace" TypeMdid="0.26.1.0"/>
+                      </dxl:Comparison>
+                    </dxl:Filter>
+                    <dxl:TableDescriptor Mdid="0.1213.1.1" TableName="pg_tablespace">
+                      <dxl:Columns>
+                        <dxl:Column ColId="90" Attno="1" ColName="spcname" TypeMdid="0.19.1.0"/>
+                        <dxl:Column ColId="97" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="98" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="99" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="100" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="101" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="102" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="103" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="104" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:SubPlan>
+              </dxl:ProjElem>
               <dxl:ProjElem ColId="0" Alias="datname">
                 <dxl:Ident ColId="0" ColName="datname" TypeMdid="0.19.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="2" Alias="encoding">
-                <dxl:Ident ColId="2" ColName="encoding" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="1" Alias="datdba">
+                <dxl:Ident ColId="1" ColName="datdba" TypeMdid="0.26.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="3" Alias="datistemplate">
                 <dxl:Ident ColId="3" ColName="datistemplate" TypeMdid="0.16.1.0"/>
@@ -972,29 +980,22 @@
               <dxl:ProjElem ColId="5" Alias="datconnlimit">
                 <dxl:Ident ColId="5" ColName="datconnlimit" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="8" Alias="dattablespace">
-                <dxl:Ident ColId="8" ColName="dattablespace" TypeMdid="0.26.1.0"/>
-              </dxl:ProjElem>
               <dxl:ProjElem ColId="10" Alias="datacl">
                 <dxl:Ident ColId="10" ColName="datacl" TypeMdid="0.1034.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="19" Alias="rolname">
-                <dxl:Ident ColId="19" ColName="rolname" TypeMdid="0.19.1.0"/>
-              </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList>
-              <dxl:SortingColumn ColId="0" SortOperatorMdid="0.660.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-            </dxl:SortingColumnList>
-            <dxl:LimitCount/>
-            <dxl:LimitOffset/>
-            <dxl:HashJoin JoinType="Left">
+            <dxl:OneTimeFilter/>
+            <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.005337" Rows="4.000000" Width="141"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.642200" Rows="1000.000000" Width="149"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="datname">
                   <dxl:Ident ColId="0" ColName="datname" TypeMdid="0.19.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="datdba">
+                  <dxl:Ident ColId="1" ColName="datdba" TypeMdid="0.26.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="2" Alias="encoding">
                   <dxl:Ident ColId="2" ColName="encoding" TypeMdid="0.23.1.0"/>
@@ -1011,69 +1012,68 @@
                 <dxl:ProjElem ColId="10" Alias="datacl">
                   <dxl:Ident ColId="10" ColName="datacl" TypeMdid="0.1034.1.0"/>
                 </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter>
+                <dxl:Ident ColId="4" ColName="datallowconn" TypeMdid="0.16.1.0"/>
+              </dxl:Filter>
+              <dxl:TableDescriptor Mdid="0.1262.1.1" TableName="pg_database">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="datname" TypeMdid="0.19.1.0"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="datdba" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="2" Attno="3" ColName="encoding" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="3" Attno="4" ColName="datistemplate" TypeMdid="0.16.1.0"/>
+                  <dxl:Column ColId="4" Attno="5" ColName="datallowconn" TypeMdid="0.16.1.0"/>
+                  <dxl:Column ColId="5" Attno="6" ColName="datconnlimit" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="8" Attno="9" ColName="dattablespace" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="10" Attno="11" ColName="datacl" TypeMdid="0.1034.1.0"/>
+                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="12" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:Result>
+          <dxl:Result>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="5196.012543" Rows="1.000000" Width="72"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="88" Alias="coalesce">
+                <dxl:Coalesce TypeMdid="0.19.1.0">
+                  <dxl:Ident ColId="19" ColName="rolname" TypeMdid="0.19.1.0"/>
+                  <dxl:Ident ColId="44" ColName="rolname" TypeMdid="0.19.1.0"/>
+                </dxl:Coalesce>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="37" Alias="oid">
+                <dxl:Ident ColId="37" ColName="oid" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:OneTimeFilter/>
+            <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="5196.012471" Rows="2.000000" Width="136"/>
+              </dxl:Properties>
+              <dxl:ProjList>
                 <dxl:ProjElem ColId="19" Alias="rolname">
                   <dxl:Ident ColId="19" ColName="rolname" TypeMdid="0.19.1.0"/>
                 </dxl:ProjElem>
+                <dxl:ProjElem ColId="37" Alias="oid">
+                  <dxl:Ident ColId="37" ColName="oid" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="44" Alias="rolname">
+                  <dxl:Ident ColId="44" ColName="rolname" TypeMdid="0.19.1.0"/>
+                </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:JoinFilter/>
-              <dxl:HashCondList>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
-                  <dxl:Ident ColId="1" ColName="datdba" TypeMdid="0.26.1.0"/>
-                  <dxl:Ident ColId="37" ColName="oid" TypeMdid="0.26.1.0"/>
-                </dxl:Comparison>
-              </dxl:HashCondList>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000761" Rows="3.000000" Width="81"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="datname">
-                    <dxl:Ident ColId="0" ColName="datname" TypeMdid="0.19.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="datdba">
-                    <dxl:Ident ColId="1" ColName="datdba" TypeMdid="0.26.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="2" Alias="encoding">
-                    <dxl:Ident ColId="2" ColName="encoding" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="3" Alias="datistemplate">
-                    <dxl:Ident ColId="3" ColName="datistemplate" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="5" Alias="datconnlimit">
-                    <dxl:Ident ColId="5" ColName="datconnlimit" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="8" Alias="dattablespace">
-                    <dxl:Ident ColId="8" ColName="dattablespace" TypeMdid="0.26.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="10" Alias="datacl">
-                    <dxl:Ident ColId="10" ColName="datacl" TypeMdid="0.1034.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter>
-                  <dxl:Ident ColId="4" ColName="datallowconn" TypeMdid="0.16.1.0"/>
-                </dxl:Filter>
-                <dxl:TableDescriptor Mdid="0.1262.1.1" TableName="pg_database">
-                  <dxl:Columns>
-                    <dxl:Column ColId="0" Attno="1" ColName="datname" TypeMdid="0.19.1.0"/>
-                    <dxl:Column ColId="1" Attno="2" ColName="datdba" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="2" Attno="3" ColName="encoding" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="3" Attno="4" ColName="datistemplate" TypeMdid="0.16.1.0"/>
-                    <dxl:Column ColId="4" Attno="5" ColName="datallowconn" TypeMdid="0.16.1.0"/>
-                    <dxl:Column ColId="5" Attno="6" ColName="datconnlimit" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="8" Attno="9" ColName="dattablespace" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="10" Attno="11" ColName="datacl" TypeMdid="0.1034.1.0"/>
-                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="12" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
+              <dxl:JoinFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:JoinFilter>
               <dxl:TableScan>
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="1.000000" Width="72"/>
@@ -1101,165 +1101,165 @@
                   </dxl:Columns>
                 </dxl:TableDescriptor>
               </dxl:TableScan>
-            </dxl:HashJoin>
-          </dxl:Sort>
-          <dxl:Assert ErrorCode="P0003">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="437.001650" Rows="1.000000" Width="64"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="44" Alias="rolname">
-                <dxl:Ident ColId="44" ColName="rolname" TypeMdid="0.19.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:AssertConstraintList>
-              <dxl:AssertConstraint ErrorMessage="Expected no more than one row to be returned by expression">
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-                  <dxl:Ident ColId="107" ColName="row_number" TypeMdid="0.20.1.0"/>
-                  <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                  </dxl:Cast>
-                </dxl:Comparison>
-              </dxl:AssertConstraint>
-            </dxl:AssertConstraintList>
-            <dxl:Window PartitionColumns="">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="437.001586" Rows="1.000000" Width="72"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="107" Alias="row_number">
-                  <dxl:WindowFunc Mdid="0.7000.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="44" Alias="rolname">
-                  <dxl:Ident ColId="44" ColName="rolname" TypeMdid="0.19.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:HashJoin JoinType="Inner">
+              <dxl:Assert ErrorCode="P0003">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="437.001586" Rows="1.000000" Width="64"/>
+                  <dxl:Cost StartupCost="0" TotalCost="437.001650" Rows="1.000000" Width="64"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="44" Alias="rolname">
                     <dxl:Ident ColId="44" ColName="rolname" TypeMdid="0.19.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:JoinFilter/>
-                <dxl:HashCondList>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
-                    <dxl:Ident ColId="62" ColName="oid" TypeMdid="0.26.1.0"/>
-                    <dxl:Ident ColId="70" ColName="datdba" TypeMdid="0.26.1.0"/>
-                  </dxl:Comparison>
-                </dxl:HashCondList>
-                <dxl:TableScan>
+                <dxl:AssertConstraintList>
+                  <dxl:AssertConstraint ErrorMessage="Expected no more than one row to be returned by expression">
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                      <dxl:Ident ColId="107" ColName="row_number" TypeMdid="0.20.1.0"/>
+                      <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                      </dxl:Cast>
+                    </dxl:Comparison>
+                  </dxl:AssertConstraint>
+                </dxl:AssertConstraintList>
+                <dxl:Window PartitionColumns="">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="1.000000" Width="72"/>
+                    <dxl:Cost StartupCost="0" TotalCost="437.001586" Rows="1.000000" Width="72"/>
                   </dxl:Properties>
                   <dxl:ProjList>
+                    <dxl:ProjElem ColId="107" Alias="row_number">
+                      <dxl:WindowFunc Mdid="0.7000.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
+                    </dxl:ProjElem>
                     <dxl:ProjElem ColId="44" Alias="rolname">
                       <dxl:Ident ColId="44" ColName="rolname" TypeMdid="0.19.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="62" Alias="oid">
-                      <dxl:Ident ColId="62" ColName="oid" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.1260.1.1" TableName="pg_authid">
-                    <dxl:Columns>
-                      <dxl:Column ColId="44" Attno="1" ColName="rolname" TypeMdid="0.19.1.0"/>
-                      <dxl:Column ColId="61" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="62" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="63" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="64" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="65" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="66" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="67" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="68" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-                <dxl:Assert ErrorCode="P0003">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="6.000756" Rows="1.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="70" Alias="datdba">
-                      <dxl:Ident ColId="70" ColName="datdba" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:AssertConstraintList>
-                    <dxl:AssertConstraint ErrorMessage="Expected no more than one row to be returned by expression">
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-                        <dxl:Ident ColId="106" ColName="row_number" TypeMdid="0.20.1.0"/>
-                        <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                        </dxl:Cast>
-                      </dxl:Comparison>
-                    </dxl:AssertConstraint>
-                  </dxl:AssertConstraintList>
-                  <dxl:Window PartitionColumns="">
+                  <dxl:HashJoin JoinType="Inner">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="6.000752" Rows="1.200000" Width="12"/>
+                      <dxl:Cost StartupCost="0" TotalCost="437.001586" Rows="1.000000" Width="64"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="106" Alias="row_number">
-                        <dxl:WindowFunc Mdid="0.7000.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="70" Alias="datdba">
-                        <dxl:Ident ColId="70" ColName="datdba" TypeMdid="0.26.1.0"/>
+                      <dxl:ProjElem ColId="44" Alias="rolname">
+                        <dxl:Ident ColId="44" ColName="rolname" TypeMdid="0.19.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:IndexScan IndexScanDirection="Forward">
+                    <dxl:JoinFilter/>
+                    <dxl:HashCondList>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+                        <dxl:Ident ColId="62" ColName="oid" TypeMdid="0.26.1.0"/>
+                        <dxl:Ident ColId="70" ColName="datdba" TypeMdid="0.26.1.0"/>
+                      </dxl:Comparison>
+                    </dxl:HashCondList>
+                    <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="6.000743" Rows="1.200000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="1.000000" Width="72"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="44" Alias="rolname">
+                          <dxl:Ident ColId="44" ColName="rolname" TypeMdid="0.19.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="62" Alias="oid">
+                          <dxl:Ident ColId="62" ColName="oid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="0.1260.1.1" TableName="pg_authid">
+                        <dxl:Columns>
+                          <dxl:Column ColId="44" Attno="1" ColName="rolname" TypeMdid="0.19.1.0"/>
+                          <dxl:Column ColId="61" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="62" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="63" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="64" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="65" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="66" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="67" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="68" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                    <dxl:Assert ErrorCode="P0003">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="6.000756" Rows="1.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="70" Alias="datdba">
                           <dxl:Ident ColId="70" ColName="datdba" TypeMdid="0.26.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:IndexCondList>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.93.1.0">
-                          <dxl:Ident ColId="69" ColName="datname" TypeMdid="0.19.1.0"/>
-                          <dxl:ConstValue TypeMdid="0.19.1.0" Value="dGVtcGxhdGUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#xA;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
-                        </dxl:Comparison>
-                      </dxl:IndexCondList>
-                      <dxl:IndexDescriptor Mdid="0.2671.1.0" IndexName="pg_database_datname_index"/>
-                      <dxl:TableDescriptor Mdid="0.1262.1.1" TableName="pg_database">
-                        <dxl:Columns>
-                          <dxl:Column ColId="69" Attno="1" ColName="datname" TypeMdid="0.19.1.0"/>
-                          <dxl:Column ColId="70" Attno="2" ColName="datdba" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="80" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="81" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="82" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="83" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="84" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="85" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="86" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="87" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:IndexScan>
-                    <dxl:WindowKeyList>
-                      <dxl:WindowKey>
-                        <dxl:SortingColumnList/>
-                      </dxl:WindowKey>
-                    </dxl:WindowKeyList>
-                  </dxl:Window>
-                </dxl:Assert>
-              </dxl:HashJoin>
-              <dxl:WindowKeyList>
-                <dxl:WindowKey>
-                  <dxl:SortingColumnList/>
-                </dxl:WindowKey>
-              </dxl:WindowKeyList>
-            </dxl:Window>
-          </dxl:Assert>
-        </dxl:NestedLoopJoin>
-      </dxl:Result>
+                      <dxl:AssertConstraintList>
+                        <dxl:AssertConstraint ErrorMessage="Expected no more than one row to be returned by expression">
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                            <dxl:Ident ColId="106" ColName="row_number" TypeMdid="0.20.1.0"/>
+                            <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                            </dxl:Cast>
+                          </dxl:Comparison>
+                        </dxl:AssertConstraint>
+                      </dxl:AssertConstraintList>
+                      <dxl:Window PartitionColumns="">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="6.000752" Rows="1.200000" Width="12"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="106" Alias="row_number">
+                            <dxl:WindowFunc Mdid="0.7000.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="70" Alias="datdba">
+                            <dxl:Ident ColId="70" ColName="datdba" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:IndexScan IndexScanDirection="Forward">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="6.000743" Rows="1.200000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="70" Alias="datdba">
+                              <dxl:Ident ColId="70" ColName="datdba" TypeMdid="0.26.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:IndexCondList>
+                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.93.1.0">
+                              <dxl:Ident ColId="69" ColName="datname" TypeMdid="0.19.1.0"/>
+                              <dxl:ConstValue TypeMdid="0.19.1.0" Value="dGVtcGxhdGUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#xA;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
+                            </dxl:Comparison>
+                          </dxl:IndexCondList>
+                          <dxl:IndexDescriptor Mdid="0.2671.1.0" IndexName="pg_database_datname_index"/>
+                          <dxl:TableDescriptor Mdid="0.1262.1.1" TableName="pg_database">
+                            <dxl:Columns>
+                              <dxl:Column ColId="69" Attno="1" ColName="datname" TypeMdid="0.19.1.0"/>
+                              <dxl:Column ColId="70" Attno="2" ColName="datdba" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="80" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="81" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="82" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="83" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="84" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="85" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="86" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="87" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:IndexScan>
+                        <dxl:WindowKeyList>
+                          <dxl:WindowKey>
+                            <dxl:SortingColumnList/>
+                          </dxl:WindowKey>
+                        </dxl:WindowKeyList>
+                      </dxl:Window>
+                    </dxl:Assert>
+                  </dxl:HashJoin>
+                  <dxl:WindowKeyList>
+                    <dxl:WindowKey>
+                      <dxl:SortingColumnList/>
+                    </dxl:WindowKey>
+                  </dxl:WindowKeyList>
+                </dxl:Window>
+              </dxl:Assert>
+            </dxl:NestedLoopJoin>
+          </dxl:Result>
+        </dxl:HashJoin>
+      </dxl:Sort>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/CoerceToDomain.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CoerceToDomain.mdp
@@ -1931,10 +1931,10 @@ SELECT * FROM information_schema.tables;
         </dxl:LogicalJoin>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="24">
+    <dxl:Plan Id="0" SpaceSize="80">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.080500" Rows="2.800000" Width="96"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.081610" Rows="2.800000" Width="96"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="66" Alias="table_catalog">
@@ -1943,18 +1943,10 @@ SELECT * FROM information_schema.tables;
             </dxl:CoerceToDomain>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="67" Alias="table_schema">
-            <dxl:CoerceToDomain TypeMdid="0.10689.1.0" CoercionForm="1" Location="0">
-              <dxl:FuncExpr FuncId="0.1401.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0">
-                <dxl:Ident ColId="55" ColName="nspname" TypeMdid="0.19.1.0"/>
-              </dxl:FuncExpr>
-            </dxl:CoerceToDomain>
+            <dxl:Ident ColId="67" ColName="table_schema" TypeMdid="0.10689.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="68" Alias="table_name">
-            <dxl:CoerceToDomain TypeMdid="0.10689.1.0" CoercionForm="1" Location="0">
-              <dxl:FuncExpr FuncId="0.1401.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0">
-                <dxl:Ident ColId="0" ColName="relname" TypeMdid="0.19.1.0"/>
-              </dxl:FuncExpr>
-            </dxl:CoerceToDomain>
+            <dxl:Ident ColId="68" ColName="table_name" TypeMdid="0.10689.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="69" Alias="table_type">
             <dxl:CoerceToDomain TypeMdid="0.10688.1.0" CoercionForm="1" Location="0">
@@ -2082,23 +2074,14 @@ SELECT * FROM information_schema.tables;
             </dxl:CoerceToDomain>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="77" Alias="commit_action">
-            <dxl:CoerceToDomain TypeMdid="0.10688.1.0" CoercionForm="1" Location="0">
-              <dxl:If TypeMdid="0.25.1.0">
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
-                  <dxl:Ident ColId="59" ColName="oid" TypeMdid="0.26.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.26.1.0" Value="0"/>
-                </dxl:Comparison>
-                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAADFBSRVNFUlZF" LintValue="628400934"/>
-                <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="true" LintValue="0"/>
-              </dxl:If>
-            </dxl:CoerceToDomain>
+            <dxl:Ident ColId="77" ColName="commit_action" TypeMdid="0.10688.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:OneTimeFilter/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.080231" Rows="2.800000" Width="146"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.081341" Rows="2.800000" Width="170"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="relname">
@@ -2119,6 +2102,15 @@ SELECT * FROM information_schema.tables;
             <dxl:ProjElem ColId="59" Alias="oid">
               <dxl:Ident ColId="59" ColName="oid" TypeMdid="0.26.1.0"/>
             </dxl:ProjElem>
+            <dxl:ProjElem ColId="67" Alias="table_schema">
+              <dxl:Ident ColId="67" ColName="table_schema" TypeMdid="0.10689.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="68" Alias="table_name">
+              <dxl:Ident ColId="68" ColName="table_name" TypeMdid="0.10689.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="77" Alias="commit_action">
+              <dxl:Ident ColId="77" ColName="commit_action" TypeMdid="0.10688.1.0"/>
+            </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:JoinFilter/>
@@ -2128,11 +2120,30 @@ SELECT * FROM information_schema.tables;
               <dxl:Ident ColId="1" ColName="relnamespace" TypeMdid="0.26.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:TableScan>
+          <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.001171" Rows="2.800000" Width="72"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.001418" Rows="2.800000" Width="88"/>
             </dxl:Properties>
             <dxl:ProjList>
+              <dxl:ProjElem ColId="67" Alias="table_schema">
+                <dxl:CoerceToDomain TypeMdid="0.10689.1.0" CoercionForm="1" Location="0">
+                  <dxl:FuncExpr FuncId="0.1401.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0">
+                    <dxl:Ident ColId="55" ColName="nspname" TypeMdid="0.19.1.0"/>
+                  </dxl:FuncExpr>
+                </dxl:CoerceToDomain>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="77" Alias="commit_action">
+                <dxl:CoerceToDomain TypeMdid="0.10688.1.0" CoercionForm="1" Location="0">
+                  <dxl:If TypeMdid="0.25.1.0">
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+                      <dxl:Ident ColId="59" ColName="oid" TypeMdid="0.26.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.26.1.0" Value="0"/>
+                    </dxl:Comparison>
+                    <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAADFBSRVNFUlZF" LintValue="628400934"/>
+                    <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="true" LintValue="0"/>
+                  </dxl:If>
+                </dxl:CoerceToDomain>
+              </dxl:ProjElem>
               <dxl:ProjElem ColId="55" Alias="nspname">
                 <dxl:Ident ColId="55" ColName="nspname" TypeMdid="0.19.1.0"/>
               </dxl:ProjElem>
@@ -2140,30 +2151,45 @@ SELECT * FROM information_schema.tables;
                 <dxl:Ident ColId="59" ColName="oid" TypeMdid="0.26.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter>
-              <dxl:Not>
-                <dxl:FuncExpr FuncId="0.2855.1.0" FuncRetSet="false" TypeMdid="0.16.1.0">
+            <dxl:Filter/>
+            <dxl:OneTimeFilter/>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.001171" Rows="2.800000" Width="72"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="55" Alias="nspname">
+                  <dxl:Ident ColId="55" ColName="nspname" TypeMdid="0.19.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="59" Alias="oid">
                   <dxl:Ident ColId="59" ColName="oid" TypeMdid="0.26.1.0"/>
-                </dxl:FuncExpr>
-              </dxl:Not>
-            </dxl:Filter>
-            <dxl:TableDescriptor Mdid="0.2615.1.1" TableName="pg_namespace" ExecuteAsUser="10">
-              <dxl:Columns>
-                <dxl:Column ColId="55" Attno="1" ColName="nspname" TypeMdid="0.19.1.0"/>
-                <dxl:Column ColId="58" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                <dxl:Column ColId="59" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                <dxl:Column ColId="60" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="61" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="62" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="63" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="64" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                <dxl:Column ColId="65" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:Columns>
-            </dxl:TableDescriptor>
-          </dxl:TableScan>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter>
+                <dxl:Not>
+                  <dxl:FuncExpr FuncId="0.2855.1.0" FuncRetSet="false" TypeMdid="0.16.1.0">
+                    <dxl:Ident ColId="59" ColName="oid" TypeMdid="0.26.1.0"/>
+                  </dxl:FuncExpr>
+                </dxl:Not>
+              </dxl:Filter>
+              <dxl:TableDescriptor Mdid="0.2615.1.1" TableName="pg_namespace" ExecuteAsUser="10">
+                <dxl:Columns>
+                  <dxl:Column ColId="55" Attno="1" ColName="nspname" TypeMdid="0.19.1.0"/>
+                  <dxl:Column ColId="58" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="59" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="60" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="61" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="62" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="63" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="64" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="65" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:Result>
           <dxl:HashJoin JoinType="Left">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.073278" Rows="2.000000" Width="78"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.073516" Rows="2.000000" Width="86"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="relname">
@@ -2181,6 +2207,9 @@ SELECT * FROM information_schema.tables;
               <dxl:ProjElem ColId="47" Alias="writable">
                 <dxl:Ident ColId="47" ColName="writable" TypeMdid="0.16.1.0"/>
               </dxl:ProjElem>
+              <dxl:ProjElem ColId="68" Alias="table_name">
+                <dxl:Ident ColId="68" ColName="table_name" TypeMdid="0.10689.1.0"/>
+              </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:JoinFilter/>
@@ -2190,11 +2219,18 @@ SELECT * FROM information_schema.tables;
                 <dxl:Ident ColId="38" ColName="reloid" TypeMdid="0.26.1.0"/>
               </dxl:Comparison>
             </dxl:HashCondList>
-            <dxl:TableScan>
+            <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.071749" Rows="2.000000" Width="78"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.071921" Rows="2.000000" Width="86"/>
               </dxl:Properties>
               <dxl:ProjList>
+                <dxl:ProjElem ColId="68" Alias="table_name">
+                  <dxl:CoerceToDomain TypeMdid="0.10689.1.0" CoercionForm="1" Location="0">
+                    <dxl:FuncExpr FuncId="0.1401.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0">
+                      <dxl:Ident ColId="0" ColName="relname" TypeMdid="0.19.1.0"/>
+                    </dxl:FuncExpr>
+                  </dxl:CoerceToDomain>
+                </dxl:ProjElem>
                 <dxl:ProjElem ColId="0" Alias="relname">
                   <dxl:Ident ColId="0" ColName="relname" TypeMdid="0.19.1.0"/>
                 </dxl:ProjElem>
@@ -2211,65 +2247,89 @@ SELECT * FROM information_schema.tables;
                   <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Filter>
-                <dxl:And>
-                  <dxl:ArrayComp OperatorName="=" OperatorMdid="0.92.1.0" OperatorType="Any">
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.071749" Rows="2.000000" Width="78"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="relname">
+                    <dxl:Ident ColId="0" ColName="relname" TypeMdid="0.19.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="relnamespace">
+                    <dxl:Ident ColId="1" ColName="relnamespace" TypeMdid="0.26.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="15" Alias="relkind">
                     <dxl:Ident ColId="15" ColName="relkind" TypeMdid="0.18.1.0"/>
-                    <dxl:Array ArrayType="0.1002.1.0" ElementType="0.18.1.0" MultiDimensional="false">
-                      <dxl:ConstValue TypeMdid="0.18.1.0" Value="cg=="/>
-                      <dxl:ConstValue TypeMdid="0.18.1.0" Value="dg=="/>
-                    </dxl:Array>
-                  </dxl:ArrayComp>
-                  <dxl:Or>
-                    <dxl:FuncExpr FuncId="0.2710.1.0" FuncRetSet="false" TypeMdid="0.16.1.0">
-                      <dxl:Ident ColId="3" ColName="relowner" TypeMdid="0.26.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAACVVTQUdF" LintValue="34644846"/>
-                    </dxl:FuncExpr>
-                    <dxl:FuncExpr FuncId="0.1927.1.0" FuncRetSet="false" TypeMdid="0.16.1.0">
-                      <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAClNFTEVDVA==" LintValue="194413436"/>
-                    </dxl:FuncExpr>
-                    <dxl:FuncExpr FuncId="0.1927.1.0" FuncRetSet="false" TypeMdid="0.16.1.0">
-                      <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAACklOU0VSVA==" LintValue="788693862"/>
-                    </dxl:FuncExpr>
-                    <dxl:FuncExpr FuncId="0.1927.1.0" FuncRetSet="false" TypeMdid="0.16.1.0">
-                      <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAClVQREFURQ==" LintValue="87335796"/>
-                    </dxl:FuncExpr>
-                    <dxl:FuncExpr FuncId="0.1927.1.0" FuncRetSet="false" TypeMdid="0.16.1.0">
-                      <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAACkRFTEVURQ==" LintValue="246719348"/>
-                    </dxl:FuncExpr>
-                    <dxl:FuncExpr FuncId="0.1927.1.0" FuncRetSet="false" TypeMdid="0.16.1.0">
-                      <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAADlJFRkVSRU5DRVM=" LintValue="403596270"/>
-                    </dxl:FuncExpr>
-                    <dxl:FuncExpr FuncId="0.1927.1.0" FuncRetSet="false" TypeMdid="0.16.1.0">
-                      <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAC1RSSUdHRVI=" LintValue="671499244"/>
-                    </dxl:FuncExpr>
-                  </dxl:Or>
-                </dxl:And>
-              </dxl:Filter>
-              <dxl:TableDescriptor Mdid="0.1259.1.1" TableName="pg_class" ExecuteAsUser="10">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="relname" TypeMdid="0.19.1.0"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="relnamespace" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="3" Attno="4" ColName="relowner" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="15" Attno="16" ColName="relkind" TypeMdid="0.18.1.0"/>
-                  <dxl:Column ColId="16" Attno="17" ColName="relstorage" TypeMdid="0.18.1.0"/>
-                  <dxl:Column ColId="30" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="31" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="32" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="33" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="34" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="35" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="36" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="37" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="16" Alias="relstorage">
+                    <dxl:Ident ColId="16" ColName="relstorage" TypeMdid="0.18.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="31" Alias="oid">
+                    <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter>
+                  <dxl:And>
+                    <dxl:ArrayComp OperatorName="=" OperatorMdid="0.92.1.0" OperatorType="Any">
+                      <dxl:Ident ColId="15" ColName="relkind" TypeMdid="0.18.1.0"/>
+                      <dxl:Array ArrayType="0.1002.1.0" ElementType="0.18.1.0" MultiDimensional="false">
+                        <dxl:ConstValue TypeMdid="0.18.1.0" Value="cg=="/>
+                        <dxl:ConstValue TypeMdid="0.18.1.0" Value="dg=="/>
+                      </dxl:Array>
+                    </dxl:ArrayComp>
+                    <dxl:Or>
+                      <dxl:FuncExpr FuncId="0.2710.1.0" FuncRetSet="false" TypeMdid="0.16.1.0">
+                        <dxl:Ident ColId="3" ColName="relowner" TypeMdid="0.26.1.0"/>
+                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAACVVTQUdF" LintValue="34644846"/>
+                      </dxl:FuncExpr>
+                      <dxl:FuncExpr FuncId="0.1927.1.0" FuncRetSet="false" TypeMdid="0.16.1.0">
+                        <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
+                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAClNFTEVDVA==" LintValue="194413436"/>
+                      </dxl:FuncExpr>
+                      <dxl:FuncExpr FuncId="0.1927.1.0" FuncRetSet="false" TypeMdid="0.16.1.0">
+                        <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
+                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAACklOU0VSVA==" LintValue="788693862"/>
+                      </dxl:FuncExpr>
+                      <dxl:FuncExpr FuncId="0.1927.1.0" FuncRetSet="false" TypeMdid="0.16.1.0">
+                        <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
+                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAClVQREFURQ==" LintValue="87335796"/>
+                      </dxl:FuncExpr>
+                      <dxl:FuncExpr FuncId="0.1927.1.0" FuncRetSet="false" TypeMdid="0.16.1.0">
+                        <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
+                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAACkRFTEVURQ==" LintValue="246719348"/>
+                      </dxl:FuncExpr>
+                      <dxl:FuncExpr FuncId="0.1927.1.0" FuncRetSet="false" TypeMdid="0.16.1.0">
+                        <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
+                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAADlJFRkVSRU5DRVM=" LintValue="403596270"/>
+                      </dxl:FuncExpr>
+                      <dxl:FuncExpr FuncId="0.1927.1.0" FuncRetSet="false" TypeMdid="0.16.1.0">
+                        <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
+                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAC1RSSUdHRVI=" LintValue="671499244"/>
+                      </dxl:FuncExpr>
+                    </dxl:Or>
+                  </dxl:And>
+                </dxl:Filter>
+                <dxl:TableDescriptor Mdid="0.1259.1.1" TableName="pg_class" ExecuteAsUser="10">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="relname" TypeMdid="0.19.1.0"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="relnamespace" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="3" Attno="4" ColName="relowner" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="15" Attno="16" ColName="relkind" TypeMdid="0.18.1.0"/>
+                    <dxl:Column ColId="16" Attno="17" ColName="relstorage" TypeMdid="0.18.1.0"/>
+                    <dxl:Column ColId="30" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="31" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="32" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="33" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="34" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="35" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="36" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="37" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:Result>
             <dxl:TableScan>
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.000048" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/CollapseCascadeProjects2of3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CollapseCascadeProjects2of3.mdp
@@ -250,14 +250,14 @@ select y.aProdb * y.aPlusb from (select x.a * x.b, x.aPlusb from (select a, b, a
               <dxl:Cost StartupCost="0" TotalCost="431.021890" Rows="1000.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="9" Alias="?column?">
-                <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+              <dxl:ProjElem ColId="10" Alias="?column?">
+                <dxl:OpExpr OperatorName="*" OperatorMdid="0.514.1.0" OperatorType="0.23.1.0">
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:OpExpr>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="10" Alias="?column?">
-                <dxl:OpExpr OperatorName="*" OperatorMdid="0.514.1.0" OperatorType="0.23.1.0">
+              <dxl:ProjElem ColId="9" Alias="?column?">
+                <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:OpExpr>

--- a/src/backend/gporca/data/dxl/minidump/CollapseCascadeProjects2of3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CollapseCascadeProjects2of3.mdp
@@ -250,14 +250,14 @@ select y.aProdb * y.aPlusb from (select x.a * x.b, x.aPlusb from (select a, b, a
               <dxl:Cost StartupCost="0" TotalCost="431.021890" Rows="1000.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="10" Alias="?column?">
-                <dxl:OpExpr OperatorName="*" OperatorMdid="0.514.1.0" OperatorType="0.23.1.0">
+              <dxl:ProjElem ColId="9" Alias="?column?">
+                <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:OpExpr>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="9" Alias="?column?">
-                <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+              <dxl:ProjElem ColId="10" Alias="?column?">
+                <dxl:OpExpr OperatorName="*" OperatorMdid="0.514.1.0" OperatorType="0.23.1.0">
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:OpExpr>

--- a/src/backend/gporca/data/dxl/minidump/CollapseProject-SetReturning.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CollapseProject-SetReturning.mdp
@@ -220,7 +220,7 @@ from (select regexp_split_to_table(a, ',') as c, b from t) dumb(c, b);
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000202" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000283" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="9" Alias="c">
@@ -234,34 +234,34 @@ from (select regexp_split_to_table(a, ',') as c, b from t) dumb(c, b);
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000142" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000223" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="c">
-              <dxl:Ident ColId="9" ColName="c" TypeMdid="0.25.1.0"/>
+              <dxl:FuncExpr FuncId="0.2765.1.0" FuncRetSet="true" TypeMdid="0.25.1.0">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.25.1.0"/>
+                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABSw=" LintValue="161055276"/>
+              </dxl:FuncExpr>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="10" Alias="regexp_split_to_table">
-              <dxl:FuncExpr FuncId="0.2765.1.0" FuncRetSet="true" TypeMdid="0.25.1.0">
-                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
-                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABTs=" LintValue="161178156"/>
-              </dxl:FuncExpr>
+              <dxl:Ident ColId="10" ColName="regexp_split_to_table" TypeMdid="0.25.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000103" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000185" Rows="1.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="9" Alias="c">
+              <dxl:ProjElem ColId="10" Alias="regexp_split_to_table">
                 <dxl:FuncExpr FuncId="0.2765.1.0" FuncRetSet="true" TypeMdid="0.25.1.0">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.25.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABSw=" LintValue="161055276"/>
+                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABTs=" LintValue="161178156"/>
                 </dxl:FuncExpr>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="b">
-                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.25.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>

--- a/src/backend/gporca/data/dxl/minidump/Equivalence-class-project-over-LOJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Equivalence-class-project-over-LOJ.mdp
@@ -376,10 +376,10 @@
         </dxl:UnionAll>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="10">
+    <dxl:Plan Id="0" SpaceSize="20">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.000494" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.000470" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -397,7 +397,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.000493" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.000469" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="29" Alias="ColRef_0029">
@@ -408,7 +408,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.000464" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.000439" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -424,13 +424,13 @@
             <dxl:Filter/>
             <dxl:Append IsTarget="false" IsZapped="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.000464" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.000439" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:Filter/>
               <dxl:HashJoin JoinType="Left">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.000440" Rows="2.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000416" Rows="2.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList/>
                 <dxl:Filter/>
@@ -466,7 +466,7 @@
                 </dxl:TableScan>
                 <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="9" Alias="id">
@@ -482,23 +482,18 @@
                   </dxl:HashExprList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="9" Alias="id">
                         <dxl:Ident ColId="9" ColName="id" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
-                    <dxl:Filter>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                        <dxl:Ident ColId="10" ColName="cd" TypeMdid="0.23.1.0"/>
-                        <dxl:Ident ColId="18" ColName="cd2" TypeMdid="0.23.1.0"/>
-                      </dxl:Comparison>
-                    </dxl:Filter>
+                    <dxl:Filter/>
                     <dxl:OneTimeFilter/>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="12"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="18" Alias="cd2">
@@ -506,9 +501,6 @@
                         </dxl:ProjElem>
                         <dxl:ProjElem ColId="9" Alias="id">
                           <dxl:Ident ColId="9" ColName="id" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="10" Alias="cd">
-                          <dxl:Ident ColId="10" ColName="cd" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>

--- a/src/backend/gporca/data/dxl/minidump/Equivalence-class-project-over-LOJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Equivalence-class-project-over-LOJ.mdp
@@ -379,14 +379,14 @@
     <dxl:Plan Id="0" SpaceSize="10">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.000573" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.000494" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="28" Alias="count">
             <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
               <dxl:ValuesList ParamType="aggargs">
-              <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.20.1.0"/>
+                <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.20.1.0"/>
               </dxl:ValuesList>
               <dxl:ValuesList ParamType="aggdirectargs"/>
               <dxl:ValuesList ParamType="aggorder"/>
@@ -397,7 +397,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.000572" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.000493" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="29" Alias="ColRef_0029">
@@ -408,7 +408,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.000542" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.000464" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -424,81 +424,86 @@
             <dxl:Filter/>
             <dxl:Append IsTarget="false" IsZapped="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.000542" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.000464" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:Filter/>
-              <dxl:Result>
+              <dxl:HashJoin JoinType="Left">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.000519" Rows="2.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000440" Rows="2.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList/>
                 <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:HashJoin JoinType="Left">
+                <dxl:JoinFilter/>
+                <dxl:HashCondList>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="9" ColName="id" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:HashCondList>
+                <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="862.000519" Rows="2.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="10" Alias="cd">
-                      <dxl:Ident ColId="10" ColName="cd" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="0" Alias="id">
+                      <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:JoinFilter/>
-                  <dxl:HashCondList>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                      <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+                  <dxl:TableDescriptor Mdid="0.81921.1.0" TableName="tab1">
+                    <dxl:Columns>
+                      <dxl:Column ColId="0" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="2" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="3" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="4" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="5" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="6" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="9" Alias="id">
                       <dxl:Ident ColId="9" ColName="id" TypeMdid="0.23.1.0"/>
-                    </dxl:Comparison>
-                  </dxl:HashCondList>
-                  <dxl:TableScan>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="9" ColName="id" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="0" Alias="id">
-                        <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="0.81921.1.0" TableName="tab1">
-                      <dxl:Columns>
-                        <dxl:Column ColId="0" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                        <dxl:Column ColId="2" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="3" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="4" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="5" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="6" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
-                  <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="9" Alias="id">
                         <dxl:Ident ColId="9" ColName="id" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="10" Alias="cd">
-                        <dxl:Ident ColId="10" ColName="cd" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
                     </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:HashExprList>
-                      <dxl:HashExpr>
-                        <dxl:Ident ColId="9" ColName="id" TypeMdid="0.23.1.0"/>
-                      </dxl:HashExpr>
-                    </dxl:HashExprList>
-                    <dxl:TableScan>
+                    <dxl:Filter>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                        <dxl:Ident ColId="10" ColName="cd" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="18" ColName="cd2" TypeMdid="0.23.1.0"/>
+                      </dxl:Comparison>
+                    </dxl:Filter>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="12"/>
                       </dxl:Properties>
                       <dxl:ProjList>
+                        <dxl:ProjElem ColId="18" Alias="cd2">
+                          <dxl:Ident ColId="10" ColName="cd" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="9" Alias="id">
                           <dxl:Ident ColId="9" ColName="id" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
@@ -507,24 +512,39 @@
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="0.81924.1.0" TableName="tab2">
-                        <dxl:Columns>
-                          <dxl:Column ColId="8" Attno="1" ColName="key" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="9" Attno="2" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="10" Attno="3" ColName="cd" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                          <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:RedistributeMotion>
-                </dxl:HashJoin>
-              </dxl:Result>
+                      <dxl:OneTimeFilter/>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="9" Alias="id">
+                            <dxl:Ident ColId="9" ColName="id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="10" Alias="cd">
+                            <dxl:Ident ColId="10" ColName="cd" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="0.81924.1.0" TableName="tab2">
+                          <dxl:Columns>
+                            <dxl:Column ColId="8" Attno="1" ColName="key" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="9" Attno="2" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="10" Attno="3" ColName="cd" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                            <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                    </dxl:Result>
+                  </dxl:Result>
+                </dxl:RedistributeMotion>
+              </dxl:HashJoin>
               <dxl:TableScan>
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="1"/>

--- a/src/backend/gporca/data/dxl/minidump/ExpandJoinOrder.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExpandJoinOrder.mdp
@@ -865,10 +865,10 @@
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2316">
+    <dxl:Plan Id="0" SpaceSize="134694">
       <dxl:Limit>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="31120.423435" Rows="100.000000" Width="128"/>
+          <dxl:Cost StartupCost="0" TotalCost="4315.660682" Rows="100.000000" Width="128"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="73" Alias="char_length">
@@ -970,7 +970,7 @@
         </dxl:ProjList>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="31120.410635" Rows="100.000000" Width="128"/>
+            <dxl:Cost StartupCost="0" TotalCost="4315.647882" Rows="100.000000" Width="128"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="73" Alias="char_length">
@@ -1107,7 +1107,7 @@
           </dxl:SortingColumnList>
           <dxl:Limit>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="31120.353163" Rows="100.000000" Width="128"/>
+              <dxl:Cost StartupCost="0" TotalCost="4315.590410" Rows="100.000000" Width="128"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="73" Alias="char_length">
@@ -1209,7 +1209,7 @@
             </dxl:ProjList>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="31120.346763" Rows="6147.800000" Width="128"/>
+                <dxl:Cost StartupCost="0" TotalCost="4315.584010" Rows="6147.800000" Width="128"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="73" Alias="char_length">
@@ -1346,349 +1346,241 @@
               </dxl:SortingColumnList>
               <dxl:LimitCount/>
               <dxl:LimitOffset/>
-              <dxl:Result>
+              <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="31094.499722" Rows="6147.800000" Width="128"/>
+                  <dxl:Cost StartupCost="0" TotalCost="4289.736968" Rows="6147.800000" Width="128"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="73" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="10" ColName="c913" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="73" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="74" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="30" ColName="c586" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="74" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="75" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="16" ColName="c919" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="75" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="76" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="56" ColName="c1199" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="76" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="77" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="7" ColName="c910" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="77" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="78" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="36" ColName="c592" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="78" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="79" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="34" ColName="c590" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="79" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="80" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="11" ColName="c914" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="80" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="81" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="67" ColName="c1053" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="81" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="82" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="69" ColName="c1055" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="82" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="83" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="50" ColName="c1193" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="83" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="84" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="17" ColName="c920" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="84" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="85" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="65" ColName="c1051" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="85" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="86" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="32" ColName="c588" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="86" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="87" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="61" ColName="c1047" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="87" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="88" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="40" ColName="c596" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="88" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="89" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="64" ColName="c1050" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="89" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="90" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="62" ColName="c1048" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="90" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="91" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="49" ColName="c1192" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="91" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="92" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="47" ColName="c1190" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="92" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="93" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="26" ColName="c929" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="93" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="94" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="8" ColName="c911" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="94" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="95" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="23" ColName="c926" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="95" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="96" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="15" ColName="c918" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="96" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="97" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="0" ColName="c0" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="97" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="98" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="25" ColName="c928" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="98" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="99" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="13" ColName="c916" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="99" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="100" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="1" ColName="c1" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="100" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="101" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="24" ColName="c927" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="101" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="102" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="68" ColName="c1054" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="102" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="103" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="51" ColName="c1194" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="103" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="104" Alias="char_length">
-                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="21" ColName="c924" TypeMdid="0.25.1.0"/>
-                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="104" ColName="char_length" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:HashJoin JoinType="Inner">
+                <dxl:JoinFilter>
+                  <dxl:Or>
+                    <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                      <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                        <dxl:Ident ColId="49" ColName="c1192" TypeMdid="0.25.1.0"/>
+                      </dxl:FuncExpr>
+                      <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                        <dxl:Ident ColId="53" ColName="c1196" TypeMdid="0.25.1.0"/>
+                      </dxl:FuncExpr>
+                    </dxl:Comparison>
+                    <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                      <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                        <dxl:Ident ColId="56" ColName="c1199" TypeMdid="0.25.1.0"/>
+                      </dxl:FuncExpr>
+                      <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                        <dxl:Ident ColId="40" ColName="c596" TypeMdid="0.25.1.0"/>
+                      </dxl:FuncExpr>
+                    </dxl:Comparison>
+                    <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                      <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                        <dxl:Ident ColId="21" ColName="c924" TypeMdid="0.25.1.0"/>
+                      </dxl:FuncExpr>
+                      <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                        <dxl:Ident ColId="1" ColName="c1" TypeMdid="0.25.1.0"/>
+                      </dxl:FuncExpr>
+                    </dxl:Comparison>
+                  </dxl:Or>
+                </dxl:JoinFilter>
+                <dxl:HashCondList>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                      <dxl:Ident ColId="42" ColName="c598" TypeMdid="0.25.1.0"/>
+                    </dxl:FuncExpr>
+                    <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                      <dxl:Ident ColId="17" ColName="c920" TypeMdid="0.25.1.0"/>
+                    </dxl:FuncExpr>
+                  </dxl:Comparison>
+                </dxl:HashCondList>
+                <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="31093.798873" Rows="6147.800000" Width="2274497"/>
+                    <dxl:Cost StartupCost="0" TotalCost="2622.841110" Rows="193.600000" Width="362313"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="c0">
-                      <dxl:Ident ColId="0" ColName="c0" TypeMdid="0.25.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="c1">
-                      <dxl:Ident ColId="1" ColName="c1" TypeMdid="0.25.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="7" Alias="c910">
-                      <dxl:Ident ColId="7" ColName="c910" TypeMdid="0.25.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="8" Alias="c911">
-                      <dxl:Ident ColId="8" ColName="c911" TypeMdid="0.25.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="10" Alias="c913">
-                      <dxl:Ident ColId="10" ColName="c913" TypeMdid="0.25.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="11" Alias="c914">
-                      <dxl:Ident ColId="11" ColName="c914" TypeMdid="0.25.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="13" Alias="c916">
-                      <dxl:Ident ColId="13" ColName="c916" TypeMdid="0.25.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="15" Alias="c918">
-                      <dxl:Ident ColId="15" ColName="c918" TypeMdid="0.25.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="16" Alias="c919">
-                      <dxl:Ident ColId="16" ColName="c919" TypeMdid="0.25.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="17" Alias="c920">
-                      <dxl:Ident ColId="17" ColName="c920" TypeMdid="0.25.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="21" Alias="c924">
-                      <dxl:Ident ColId="21" ColName="c924" TypeMdid="0.25.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="23" Alias="c926">
-                      <dxl:Ident ColId="23" ColName="c926" TypeMdid="0.25.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="24" Alias="c927">
-                      <dxl:Ident ColId="24" ColName="c927" TypeMdid="0.25.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="25" Alias="c928">
-                      <dxl:Ident ColId="25" ColName="c928" TypeMdid="0.25.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="26" Alias="c929">
-                      <dxl:Ident ColId="26" ColName="c929" TypeMdid="0.25.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="30" Alias="c586">
-                      <dxl:Ident ColId="30" ColName="c586" TypeMdid="0.25.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="32" Alias="c588">
-                      <dxl:Ident ColId="32" ColName="c588" TypeMdid="0.25.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="34" Alias="c590">
-                      <dxl:Ident ColId="34" ColName="c590" TypeMdid="0.25.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="36" Alias="c592">
-                      <dxl:Ident ColId="36" ColName="c592" TypeMdid="0.25.1.0"/>
-                    </dxl:ProjElem>
                     <dxl:ProjElem ColId="40" Alias="c596">
                       <dxl:Ident ColId="40" ColName="c596" TypeMdid="0.25.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="47" Alias="c1190">
-                      <dxl:Ident ColId="47" ColName="c1190" TypeMdid="0.25.1.0"/>
+                    <dxl:ProjElem ColId="42" Alias="c598">
+                      <dxl:Ident ColId="42" ColName="c598" TypeMdid="0.25.1.0"/>
                     </dxl:ProjElem>
                     <dxl:ProjElem ColId="49" Alias="c1192">
                       <dxl:Ident ColId="49" ColName="c1192" TypeMdid="0.25.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="50" Alias="c1193">
-                      <dxl:Ident ColId="50" ColName="c1193" TypeMdid="0.25.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="51" Alias="c1194">
-                      <dxl:Ident ColId="51" ColName="c1194" TypeMdid="0.25.1.0"/>
+                    <dxl:ProjElem ColId="53" Alias="c1196">
+                      <dxl:Ident ColId="53" ColName="c1196" TypeMdid="0.25.1.0"/>
                     </dxl:ProjElem>
                     <dxl:ProjElem ColId="56" Alias="c1199">
                       <dxl:Ident ColId="56" ColName="c1199" TypeMdid="0.25.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="61" Alias="c1047">
-                      <dxl:Ident ColId="61" ColName="c1047" TypeMdid="0.25.1.0"/>
+                    <dxl:ProjElem ColId="74" Alias="char_length">
+                      <dxl:Ident ColId="74" ColName="char_length" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="62" Alias="c1048">
-                      <dxl:Ident ColId="62" ColName="c1048" TypeMdid="0.25.1.0"/>
+                    <dxl:ProjElem ColId="76" Alias="char_length">
+                      <dxl:Ident ColId="76" ColName="char_length" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="64" Alias="c1050">
-                      <dxl:Ident ColId="64" ColName="c1050" TypeMdid="0.25.1.0"/>
+                    <dxl:ProjElem ColId="78" Alias="char_length">
+                      <dxl:Ident ColId="78" ColName="char_length" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="65" Alias="c1051">
-                      <dxl:Ident ColId="65" ColName="c1051" TypeMdid="0.25.1.0"/>
+                    <dxl:ProjElem ColId="79" Alias="char_length">
+                      <dxl:Ident ColId="79" ColName="char_length" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="67" Alias="c1053">
-                      <dxl:Ident ColId="67" ColName="c1053" TypeMdid="0.25.1.0"/>
+                    <dxl:ProjElem ColId="81" Alias="char_length">
+                      <dxl:Ident ColId="81" ColName="char_length" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="68" Alias="c1054">
-                      <dxl:Ident ColId="68" ColName="c1054" TypeMdid="0.25.1.0"/>
+                    <dxl:ProjElem ColId="82" Alias="char_length">
+                      <dxl:Ident ColId="82" ColName="char_length" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="69" Alias="c1055">
-                      <dxl:Ident ColId="69" ColName="c1055" TypeMdid="0.25.1.0"/>
+                    <dxl:ProjElem ColId="83" Alias="char_length">
+                      <dxl:Ident ColId="83" ColName="char_length" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="85" Alias="char_length">
+                      <dxl:Ident ColId="85" ColName="char_length" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="86" Alias="char_length">
+                      <dxl:Ident ColId="86" ColName="char_length" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="87" Alias="char_length">
+                      <dxl:Ident ColId="87" ColName="char_length" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="88" Alias="char_length">
+                      <dxl:Ident ColId="88" ColName="char_length" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="89" Alias="char_length">
+                      <dxl:Ident ColId="89" ColName="char_length" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="90" Alias="char_length">
+                      <dxl:Ident ColId="90" ColName="char_length" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="91" Alias="char_length">
+                      <dxl:Ident ColId="91" ColName="char_length" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="92" Alias="char_length">
+                      <dxl:Ident ColId="92" ColName="char_length" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="102" Alias="char_length">
+                      <dxl:Ident ColId="102" ColName="char_length" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="103" Alias="char_length">
+                      <dxl:Ident ColId="103" ColName="char_length" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:JoinFilter>
-                    <dxl:Or>
-                      <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                        <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                          <dxl:Ident ColId="49" ColName="c1192" TypeMdid="0.25.1.0"/>
-                        </dxl:FuncExpr>
-                        <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                          <dxl:Ident ColId="53" ColName="c1196" TypeMdid="0.25.1.0"/>
-                        </dxl:FuncExpr>
-                      </dxl:Comparison>
-                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                        <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                          <dxl:Ident ColId="56" ColName="c1199" TypeMdid="0.25.1.0"/>
-                        </dxl:FuncExpr>
-                        <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                          <dxl:Ident ColId="40" ColName="c596" TypeMdid="0.25.1.0"/>
-                        </dxl:FuncExpr>
-                      </dxl:Comparison>
-                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                        <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                          <dxl:Ident ColId="21" ColName="c924" TypeMdid="0.25.1.0"/>
-                        </dxl:FuncExpr>
-                        <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                          <dxl:Ident ColId="1" ColName="c1" TypeMdid="0.25.1.0"/>
-                        </dxl:FuncExpr>
-                      </dxl:Comparison>
-                    </dxl:Or>
-                  </dxl:JoinFilter>
-                  <dxl:HashCondList>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr>
                       <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
                         <dxl:Ident ColId="42" ColName="c598" TypeMdid="0.25.1.0"/>
                       </dxl:FuncExpr>
-                      <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                        <dxl:Ident ColId="17" ColName="c920" TypeMdid="0.25.1.0"/>
-                      </dxl:FuncExpr>
-                    </dxl:Comparison>
-                  </dxl:HashCondList>
-                  <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="3649.806038" Rows="193.600000" Width="1369700"/>
+                      <dxl:Cost StartupCost="0" TotalCost="2513.066068" Rows="193.600000" Width="362313"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="30" Alias="c586">
-                        <dxl:Ident ColId="30" ColName="c586" TypeMdid="0.25.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="32" Alias="c588">
-                        <dxl:Ident ColId="32" ColName="c588" TypeMdid="0.25.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="34" Alias="c590">
-                        <dxl:Ident ColId="34" ColName="c590" TypeMdid="0.25.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="36" Alias="c592">
-                        <dxl:Ident ColId="36" ColName="c592" TypeMdid="0.25.1.0"/>
-                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="40" Alias="c596">
                         <dxl:Ident ColId="40" ColName="c596" TypeMdid="0.25.1.0"/>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="42" Alias="c598">
                         <dxl:Ident ColId="42" ColName="c598" TypeMdid="0.25.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="47" Alias="c1190">
-                        <dxl:Ident ColId="47" ColName="c1190" TypeMdid="0.25.1.0"/>
-                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="49" Alias="c1192">
                         <dxl:Ident ColId="49" ColName="c1192" TypeMdid="0.25.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="50" Alias="c1193">
-                        <dxl:Ident ColId="50" ColName="c1193" TypeMdid="0.25.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="51" Alias="c1194">
-                        <dxl:Ident ColId="51" ColName="c1194" TypeMdid="0.25.1.0"/>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="53" Alias="c1196">
                         <dxl:Ident ColId="53" ColName="c1196" TypeMdid="0.25.1.0"/>
@@ -1696,127 +1588,166 @@
                       <dxl:ProjElem ColId="56" Alias="c1199">
                         <dxl:Ident ColId="56" ColName="c1199" TypeMdid="0.25.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="61" Alias="c1047">
-                        <dxl:Ident ColId="61" ColName="c1047" TypeMdid="0.25.1.0"/>
+                      <dxl:ProjElem ColId="74" Alias="char_length">
+                        <dxl:Ident ColId="74" ColName="char_length" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="62" Alias="c1048">
-                        <dxl:Ident ColId="62" ColName="c1048" TypeMdid="0.25.1.0"/>
+                      <dxl:ProjElem ColId="76" Alias="char_length">
+                        <dxl:Ident ColId="76" ColName="char_length" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="64" Alias="c1050">
-                        <dxl:Ident ColId="64" ColName="c1050" TypeMdid="0.25.1.0"/>
+                      <dxl:ProjElem ColId="78" Alias="char_length">
+                        <dxl:Ident ColId="78" ColName="char_length" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="65" Alias="c1051">
-                        <dxl:Ident ColId="65" ColName="c1051" TypeMdid="0.25.1.0"/>
+                      <dxl:ProjElem ColId="79" Alias="char_length">
+                        <dxl:Ident ColId="79" ColName="char_length" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="67" Alias="c1053">
-                        <dxl:Ident ColId="67" ColName="c1053" TypeMdid="0.25.1.0"/>
+                      <dxl:ProjElem ColId="81" Alias="char_length">
+                        <dxl:Ident ColId="81" ColName="char_length" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="68" Alias="c1054">
-                        <dxl:Ident ColId="68" ColName="c1054" TypeMdid="0.25.1.0"/>
+                      <dxl:ProjElem ColId="82" Alias="char_length">
+                        <dxl:Ident ColId="82" ColName="char_length" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="69" Alias="c1055">
-                        <dxl:Ident ColId="69" ColName="c1055" TypeMdid="0.25.1.0"/>
+                      <dxl:ProjElem ColId="83" Alias="char_length">
+                        <dxl:Ident ColId="83" ColName="char_length" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="85" Alias="char_length">
+                        <dxl:Ident ColId="85" ColName="char_length" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="86" Alias="char_length">
+                        <dxl:Ident ColId="86" ColName="char_length" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="87" Alias="char_length">
+                        <dxl:Ident ColId="87" ColName="char_length" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="88" Alias="char_length">
+                        <dxl:Ident ColId="88" ColName="char_length" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="89" Alias="char_length">
+                        <dxl:Ident ColId="89" ColName="char_length" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="90" Alias="char_length">
+                        <dxl:Ident ColId="90" ColName="char_length" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="91" Alias="char_length">
+                        <dxl:Ident ColId="91" ColName="char_length" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="92" Alias="char_length">
+                        <dxl:Ident ColId="92" ColName="char_length" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="102" Alias="char_length">
+                        <dxl:Ident ColId="102" ColName="char_length" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="103" Alias="char_length">
+                        <dxl:Ident ColId="103" ColName="char_length" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:HashExprList>
-                      <dxl:HashExpr>
+                    <dxl:JoinFilter>
+                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                         <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                          <dxl:Ident ColId="42" ColName="c598" TypeMdid="0.25.1.0"/>
+                          <dxl:Ident ColId="66" ColName="c1052" TypeMdid="0.25.1.0"/>
                         </dxl:FuncExpr>
-                      </dxl:HashExpr>
-                    </dxl:HashExprList>
+                        <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                          <dxl:Ident ColId="55" ColName="c1198" TypeMdid="0.25.1.0"/>
+                        </dxl:FuncExpr>
+                      </dxl:Comparison>
+                    </dxl:JoinFilter>
                     <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="3234.808853" Rows="193.600000" Width="1369700"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1477.629292" Rows="44.000000" Width="445556"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="30" Alias="c586">
-                          <dxl:Ident ColId="30" ColName="c586" TypeMdid="0.25.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="32" Alias="c588">
-                          <dxl:Ident ColId="32" ColName="c588" TypeMdid="0.25.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="34" Alias="c590">
-                          <dxl:Ident ColId="34" ColName="c590" TypeMdid="0.25.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="36" Alias="c592">
-                          <dxl:Ident ColId="36" ColName="c592" TypeMdid="0.25.1.0"/>
-                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="40" Alias="c596">
                           <dxl:Ident ColId="40" ColName="c596" TypeMdid="0.25.1.0"/>
                         </dxl:ProjElem>
                         <dxl:ProjElem ColId="42" Alias="c598">
                           <dxl:Ident ColId="42" ColName="c598" TypeMdid="0.25.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="47" Alias="c1190">
-                          <dxl:Ident ColId="47" ColName="c1190" TypeMdid="0.25.1.0"/>
-                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="49" Alias="c1192">
                           <dxl:Ident ColId="49" ColName="c1192" TypeMdid="0.25.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="50" Alias="c1193">
-                          <dxl:Ident ColId="50" ColName="c1193" TypeMdid="0.25.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="51" Alias="c1194">
-                          <dxl:Ident ColId="51" ColName="c1194" TypeMdid="0.25.1.0"/>
                         </dxl:ProjElem>
                         <dxl:ProjElem ColId="53" Alias="c1196">
                           <dxl:Ident ColId="53" ColName="c1196" TypeMdid="0.25.1.0"/>
                         </dxl:ProjElem>
+                        <dxl:ProjElem ColId="55" Alias="c1198">
+                          <dxl:Ident ColId="55" ColName="c1198" TypeMdid="0.25.1.0"/>
+                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="56" Alias="c1199">
                           <dxl:Ident ColId="56" ColName="c1199" TypeMdid="0.25.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="61" Alias="c1047">
-                          <dxl:Ident ColId="61" ColName="c1047" TypeMdid="0.25.1.0"/>
+                        <dxl:ProjElem ColId="74" Alias="char_length">
+                          <dxl:Ident ColId="74" ColName="char_length" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="62" Alias="c1048">
-                          <dxl:Ident ColId="62" ColName="c1048" TypeMdid="0.25.1.0"/>
+                        <dxl:ProjElem ColId="76" Alias="char_length">
+                          <dxl:Ident ColId="76" ColName="char_length" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="64" Alias="c1050">
-                          <dxl:Ident ColId="64" ColName="c1050" TypeMdid="0.25.1.0"/>
+                        <dxl:ProjElem ColId="78" Alias="char_length">
+                          <dxl:Ident ColId="78" ColName="char_length" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="65" Alias="c1051">
-                          <dxl:Ident ColId="65" ColName="c1051" TypeMdid="0.25.1.0"/>
+                        <dxl:ProjElem ColId="79" Alias="char_length">
+                          <dxl:Ident ColId="79" ColName="char_length" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="67" Alias="c1053">
-                          <dxl:Ident ColId="67" ColName="c1053" TypeMdid="0.25.1.0"/>
+                        <dxl:ProjElem ColId="83" Alias="char_length">
+                          <dxl:Ident ColId="83" ColName="char_length" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="68" Alias="c1054">
-                          <dxl:Ident ColId="68" ColName="c1054" TypeMdid="0.25.1.0"/>
+                        <dxl:ProjElem ColId="86" Alias="char_length">
+                          <dxl:Ident ColId="86" ColName="char_length" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="69" Alias="c1055">
-                          <dxl:Ident ColId="69" ColName="c1055" TypeMdid="0.25.1.0"/>
+                        <dxl:ProjElem ColId="88" Alias="char_length">
+                          <dxl:Ident ColId="88" ColName="char_length" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="91" Alias="char_length">
+                          <dxl:Ident ColId="91" ColName="char_length" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="92" Alias="char_length">
+                          <dxl:Ident ColId="92" ColName="char_length" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="103" Alias="char_length">
+                          <dxl:Ident ColId="103" ColName="char_length" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
                       <dxl:JoinFilter>
                         <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                           <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                            <dxl:Ident ColId="66" ColName="c1052" TypeMdid="0.25.1.0"/>
+                            <dxl:Ident ColId="51" ColName="c1194" TypeMdid="0.25.1.0"/>
                           </dxl:FuncExpr>
                           <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                            <dxl:Ident ColId="55" ColName="c1198" TypeMdid="0.25.1.0"/>
+                            <dxl:Ident ColId="33" ColName="c589" TypeMdid="0.25.1.0"/>
                           </dxl:FuncExpr>
                         </dxl:Comparison>
                       </dxl:JoinFilter>
-                      <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                      <dxl:Result>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1566.853456" Rows="44.000000" Width="955900"/>
+                          <dxl:Cost StartupCost="0" TotalCost="439.480988" Rows="10.000000" Width="231442"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="30" Alias="c586">
-                            <dxl:Ident ColId="30" ColName="c586" TypeMdid="0.25.1.0"/>
+                          <dxl:ProjElem ColId="74" Alias="char_length">
+                            <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                              <dxl:Ident ColId="30" ColName="c586" TypeMdid="0.25.1.0"/>
+                            </dxl:FuncExpr>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="32" Alias="c588">
-                            <dxl:Ident ColId="32" ColName="c588" TypeMdid="0.25.1.0"/>
+                          <dxl:ProjElem ColId="78" Alias="char_length">
+                            <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                              <dxl:Ident ColId="36" ColName="c592" TypeMdid="0.25.1.0"/>
+                            </dxl:FuncExpr>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="34" Alias="c590">
-                            <dxl:Ident ColId="34" ColName="c590" TypeMdid="0.25.1.0"/>
+                          <dxl:ProjElem ColId="79" Alias="char_length">
+                            <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                              <dxl:Ident ColId="34" ColName="c590" TypeMdid="0.25.1.0"/>
+                            </dxl:FuncExpr>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="36" Alias="c592">
-                            <dxl:Ident ColId="36" ColName="c592" TypeMdid="0.25.1.0"/>
+                          <dxl:ProjElem ColId="86" Alias="char_length">
+                            <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                              <dxl:Ident ColId="32" ColName="c588" TypeMdid="0.25.1.0"/>
+                            </dxl:FuncExpr>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="88" Alias="char_length">
+                            <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                              <dxl:Ident ColId="40" ColName="c596" TypeMdid="0.25.1.0"/>
+                            </dxl:FuncExpr>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="33" Alias="c589">
+                            <dxl:Ident ColId="33" ColName="c589" TypeMdid="0.25.1.0"/>
                           </dxl:ProjElem>
                           <dxl:ProjElem ColId="40" Alias="c596">
                             <dxl:Ident ColId="40" ColName="c596" TypeMdid="0.25.1.0"/>
@@ -1824,39 +1755,9 @@
                           <dxl:ProjElem ColId="42" Alias="c598">
                             <dxl:Ident ColId="42" ColName="c598" TypeMdid="0.25.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="47" Alias="c1190">
-                            <dxl:Ident ColId="47" ColName="c1190" TypeMdid="0.25.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="49" Alias="c1192">
-                            <dxl:Ident ColId="49" ColName="c1192" TypeMdid="0.25.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="50" Alias="c1193">
-                            <dxl:Ident ColId="50" ColName="c1193" TypeMdid="0.25.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="51" Alias="c1194">
-                            <dxl:Ident ColId="51" ColName="c1194" TypeMdid="0.25.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="53" Alias="c1196">
-                            <dxl:Ident ColId="53" ColName="c1196" TypeMdid="0.25.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="55" Alias="c1198">
-                            <dxl:Ident ColId="55" ColName="c1198" TypeMdid="0.25.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="56" Alias="c1199">
-                            <dxl:Ident ColId="56" ColName="c1199" TypeMdid="0.25.1.0"/>
-                          </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:JoinFilter>
-                          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                            <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                              <dxl:Ident ColId="51" ColName="c1194" TypeMdid="0.25.1.0"/>
-                            </dxl:FuncExpr>
-                            <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                              <dxl:Ident ColId="33" ColName="c589" TypeMdid="0.25.1.0"/>
-                            </dxl:FuncExpr>
-                          </dxl:Comparison>
-                        </dxl:JoinFilter>
+                        <dxl:OneTimeFilter/>
                         <dxl:TableScan>
                           <dxl:Properties>
                             <dxl:Cost StartupCost="0" TotalCost="433.748152" Rows="10.000000" Width="491949"/>
@@ -1900,19 +1801,51 @@
                             </dxl:Columns>
                           </dxl:TableDescriptor>
                         </dxl:TableScan>
-                        <dxl:Materialize Eager="false">
+                      </dxl:Result>
+                      <dxl:Materialize Eager="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="545.601600" Rows="20.000000" Width="387752"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="49" Alias="c1192">
+                            <dxl:Ident ColId="49" ColName="c1192" TypeMdid="0.25.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="51" Alias="c1194">
+                            <dxl:Ident ColId="51" ColName="c1194" TypeMdid="0.25.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="53" Alias="c1196">
+                            <dxl:Ident ColId="53" ColName="c1196" TypeMdid="0.25.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="55" Alias="c1198">
+                            <dxl:Ident ColId="55" ColName="c1198" TypeMdid="0.25.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="56" Alias="c1199">
+                            <dxl:Ident ColId="56" ColName="c1199" TypeMdid="0.25.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="76" Alias="char_length">
+                            <dxl:Ident ColId="76" ColName="char_length" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="83" Alias="char_length">
+                            <dxl:Ident ColId="83" ColName="char_length" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="91" Alias="char_length">
+                            <dxl:Ident ColId="91" ColName="char_length" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="92" Alias="char_length">
+                            <dxl:Ident ColId="92" ColName="char_length" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="103" Alias="char_length">
+                            <dxl:Ident ColId="103" ColName="char_length" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="585.388194" Rows="20.000000" Width="541297"/>
+                            <dxl:Cost StartupCost="0" TotalCost="541.724080" Rows="20.000000" Width="387752"/>
                           </dxl:Properties>
                           <dxl:ProjList>
-                            <dxl:ProjElem ColId="47" Alias="c1190">
-                              <dxl:Ident ColId="47" ColName="c1190" TypeMdid="0.25.1.0"/>
-                            </dxl:ProjElem>
                             <dxl:ProjElem ColId="49" Alias="c1192">
                               <dxl:Ident ColId="49" ColName="c1192" TypeMdid="0.25.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="50" Alias="c1193">
-                              <dxl:Ident ColId="50" ColName="c1193" TypeMdid="0.25.1.0"/>
                             </dxl:ProjElem>
                             <dxl:ProjElem ColId="51" Alias="c1194">
                               <dxl:Ident ColId="51" ColName="c1194" TypeMdid="0.25.1.0"/>
@@ -1926,21 +1859,31 @@
                             <dxl:ProjElem ColId="56" Alias="c1199">
                               <dxl:Ident ColId="56" ColName="c1199" TypeMdid="0.25.1.0"/>
                             </dxl:ProjElem>
+                            <dxl:ProjElem ColId="76" Alias="char_length">
+                              <dxl:Ident ColId="76" ColName="char_length" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="83" Alias="char_length">
+                              <dxl:Ident ColId="83" ColName="char_length" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="91" Alias="char_length">
+                              <dxl:Ident ColId="91" ColName="char_length" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="92" Alias="char_length">
+                              <dxl:Ident ColId="92" ColName="char_length" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="103" Alias="char_length">
+                              <dxl:Ident ColId="103" ColName="char_length" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                          <dxl:SortingColumnList/>
+                          <dxl:Result>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="579.975224" Rows="20.000000" Width="541297"/>
+                              <dxl:Cost StartupCost="0" TotalCost="440.229994" Rows="10.000000" Width="387752"/>
                             </dxl:Properties>
                             <dxl:ProjList>
-                              <dxl:ProjElem ColId="47" Alias="c1190">
-                                <dxl:Ident ColId="47" ColName="c1190" TypeMdid="0.25.1.0"/>
-                              </dxl:ProjElem>
                               <dxl:ProjElem ColId="49" Alias="c1192">
                                 <dxl:Ident ColId="49" ColName="c1192" TypeMdid="0.25.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="50" Alias="c1193">
-                                <dxl:Ident ColId="50" ColName="c1193" TypeMdid="0.25.1.0"/>
                               </dxl:ProjElem>
                               <dxl:ProjElem ColId="51" Alias="c1194">
                                 <dxl:Ident ColId="51" ColName="c1194" TypeMdid="0.25.1.0"/>
@@ -1954,22 +1897,56 @@
                               <dxl:ProjElem ColId="56" Alias="c1199">
                                 <dxl:Ident ColId="56" ColName="c1199" TypeMdid="0.25.1.0"/>
                               </dxl:ProjElem>
+                              <dxl:ProjElem ColId="76" Alias="char_length">
+                                <dxl:Ident ColId="76" ColName="char_length" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="83" Alias="char_length">
+                                <dxl:Ident ColId="83" ColName="char_length" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="91" Alias="char_length">
+                                <dxl:Ident ColId="91" ColName="char_length" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="92" Alias="char_length">
+                                <dxl:Ident ColId="92" ColName="char_length" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="103" Alias="char_length">
+                                <dxl:Ident ColId="103" ColName="char_length" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:Filter/>
-                            <dxl:SortingColumnList/>
-                            <dxl:TableScan>
+                            <dxl:OneTimeFilter/>
+                            <dxl:Result>
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="433.256672" Rows="10.000000" Width="541297"/>
+                                <dxl:Cost StartupCost="0" TotalCost="440.229994" Rows="10.000000" Width="387752"/>
                               </dxl:Properties>
                               <dxl:ProjList>
-                                <dxl:ProjElem ColId="47" Alias="c1190">
-                                  <dxl:Ident ColId="47" ColName="c1190" TypeMdid="0.25.1.0"/>
+                                <dxl:ProjElem ColId="76" Alias="char_length">
+                                  <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                                    <dxl:Ident ColId="56" ColName="c1199" TypeMdid="0.25.1.0"/>
+                                  </dxl:FuncExpr>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="83" Alias="char_length">
+                                  <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                                    <dxl:Ident ColId="50" ColName="c1193" TypeMdid="0.25.1.0"/>
+                                  </dxl:FuncExpr>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="91" Alias="char_length">
+                                  <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                                    <dxl:Ident ColId="49" ColName="c1192" TypeMdid="0.25.1.0"/>
+                                  </dxl:FuncExpr>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="92" Alias="char_length">
+                                  <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                                    <dxl:Ident ColId="47" ColName="c1190" TypeMdid="0.25.1.0"/>
+                                  </dxl:FuncExpr>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="103" Alias="char_length">
+                                  <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                                    <dxl:Ident ColId="51" ColName="c1194" TypeMdid="0.25.1.0"/>
+                                  </dxl:FuncExpr>
                                 </dxl:ProjElem>
                                 <dxl:ProjElem ColId="49" Alias="c1192">
                                   <dxl:Ident ColId="49" ColName="c1192" TypeMdid="0.25.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="50" Alias="c1193">
-                                  <dxl:Ident ColId="50" ColName="c1193" TypeMdid="0.25.1.0"/>
                                 </dxl:ProjElem>
                                 <dxl:ProjElem ColId="51" Alias="c1194">
                                   <dxl:Ident ColId="51" ColName="c1194" TypeMdid="0.25.1.0"/>
@@ -1985,169 +1962,325 @@
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:TableDescriptor Mdid="0.92635.1.1" TableName="t97">
-                                <dxl:Columns>
-                                  <dxl:Column ColId="47" Attno="1" ColName="c1190" TypeMdid="0.25.1.0"/>
-                                  <dxl:Column ColId="49" Attno="3" ColName="c1192" TypeMdid="0.25.1.0"/>
-                                  <dxl:Column ColId="50" Attno="4" ColName="c1193" TypeMdid="0.25.1.0"/>
-                                  <dxl:Column ColId="51" Attno="5" ColName="c1194" TypeMdid="0.25.1.0"/>
-                                  <dxl:Column ColId="53" Attno="7" ColName="c1196" TypeMdid="0.25.1.0"/>
-                                  <dxl:Column ColId="55" Attno="9" ColName="c1198" TypeMdid="0.25.1.0"/>
-                                  <dxl:Column ColId="56" Attno="10" ColName="c1199" TypeMdid="0.25.1.0"/>
-                                  <dxl:Column ColId="58" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                  <dxl:Column ColId="59" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                  <dxl:Column ColId="60" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                </dxl:Columns>
-                              </dxl:TableDescriptor>
-                            </dxl:TableScan>
-                          </dxl:BroadcastMotion>
-                        </dxl:Materialize>
-                      </dxl:NestedLoopJoin>
-                      <dxl:Materialize Eager="true">
+                              <dxl:OneTimeFilter/>
+                              <dxl:TableScan>
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="433.256672" Rows="10.000000" Width="541297"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="47" Alias="c1190">
+                                    <dxl:Ident ColId="47" ColName="c1190" TypeMdid="0.25.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="49" Alias="c1192">
+                                    <dxl:Ident ColId="49" ColName="c1192" TypeMdid="0.25.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="50" Alias="c1193">
+                                    <dxl:Ident ColId="50" ColName="c1193" TypeMdid="0.25.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="51" Alias="c1194">
+                                    <dxl:Ident ColId="51" ColName="c1194" TypeMdid="0.25.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="53" Alias="c1196">
+                                    <dxl:Ident ColId="53" ColName="c1196" TypeMdid="0.25.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="55" Alias="c1198">
+                                    <dxl:Ident ColId="55" ColName="c1198" TypeMdid="0.25.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="56" Alias="c1199">
+                                    <dxl:Ident ColId="56" ColName="c1199" TypeMdid="0.25.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:TableDescriptor Mdid="0.92635.1.1" TableName="t97">
+                                  <dxl:Columns>
+                                    <dxl:Column ColId="47" Attno="1" ColName="c1190" TypeMdid="0.25.1.0"/>
+                                    <dxl:Column ColId="49" Attno="3" ColName="c1192" TypeMdid="0.25.1.0"/>
+                                    <dxl:Column ColId="50" Attno="4" ColName="c1193" TypeMdid="0.25.1.0"/>
+                                    <dxl:Column ColId="51" Attno="5" ColName="c1194" TypeMdid="0.25.1.0"/>
+                                    <dxl:Column ColId="53" Attno="7" ColName="c1196" TypeMdid="0.25.1.0"/>
+                                    <dxl:Column ColId="55" Attno="9" ColName="c1198" TypeMdid="0.25.1.0"/>
+                                    <dxl:Column ColId="56" Attno="10" ColName="c1199" TypeMdid="0.25.1.0"/>
+                                    <dxl:Column ColId="58" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                    <dxl:Column ColId="59" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                    <dxl:Column ColId="60" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                  </dxl:Columns>
+                                </dxl:TableDescriptor>
+                              </dxl:TableScan>
+                            </dxl:Result>
+                          </dxl:Result>
+                        </dxl:BroadcastMotion>
+                      </dxl:Materialize>
+                    </dxl:NestedLoopJoin>
+                    <dxl:Materialize Eager="true">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="456.043656" Rows="20.000000" Width="65284"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="66" Alias="c1052">
+                          <dxl:Ident ColId="66" ColName="c1052" TypeMdid="0.25.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="81" Alias="char_length">
+                          <dxl:Ident ColId="81" ColName="char_length" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="82" Alias="char_length">
+                          <dxl:Ident ColId="82" ColName="char_length" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="85" Alias="char_length">
+                          <dxl:Ident ColId="85" ColName="char_length" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="87" Alias="char_length">
+                          <dxl:Ident ColId="87" ColName="char_length" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="89" Alias="char_length">
+                          <dxl:Ident ColId="89" ColName="char_length" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="90" Alias="char_length">
+                          <dxl:Ident ColId="90" ColName="char_length" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="102" Alias="char_length">
+                          <dxl:Ident ColId="102" ColName="char_length" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="590.788171" Rows="20.000000" Width="562327"/>
+                          <dxl:Cost StartupCost="0" TotalCost="455.390816" Rows="20.000000" Width="65284"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="61" Alias="c1047">
-                            <dxl:Ident ColId="61" ColName="c1047" TypeMdid="0.25.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="62" Alias="c1048">
-                            <dxl:Ident ColId="62" ColName="c1048" TypeMdid="0.25.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="64" Alias="c1050">
-                            <dxl:Ident ColId="64" ColName="c1050" TypeMdid="0.25.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="65" Alias="c1051">
-                            <dxl:Ident ColId="65" ColName="c1051" TypeMdid="0.25.1.0"/>
-                          </dxl:ProjElem>
                           <dxl:ProjElem ColId="66" Alias="c1052">
                             <dxl:Ident ColId="66" ColName="c1052" TypeMdid="0.25.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="67" Alias="c1053">
-                            <dxl:Ident ColId="67" ColName="c1053" TypeMdid="0.25.1.0"/>
+                          <dxl:ProjElem ColId="81" Alias="char_length">
+                            <dxl:Ident ColId="81" ColName="char_length" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="68" Alias="c1054">
-                            <dxl:Ident ColId="68" ColName="c1054" TypeMdid="0.25.1.0"/>
+                          <dxl:ProjElem ColId="82" Alias="char_length">
+                            <dxl:Ident ColId="82" ColName="char_length" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="69" Alias="c1055">
-                            <dxl:Ident ColId="69" ColName="c1055" TypeMdid="0.25.1.0"/>
+                          <dxl:ProjElem ColId="85" Alias="char_length">
+                            <dxl:Ident ColId="85" ColName="char_length" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="87" Alias="char_length">
+                            <dxl:Ident ColId="87" ColName="char_length" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="89" Alias="char_length">
+                            <dxl:Ident ColId="89" ColName="char_length" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="90" Alias="char_length">
+                            <dxl:Ident ColId="90" ColName="char_length" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="102" Alias="char_length">
+                            <dxl:Ident ColId="102" ColName="char_length" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                        <dxl:SortingColumnList/>
+                        <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="585.164901" Rows="20.000000" Width="562327"/>
+                            <dxl:Cost StartupCost="0" TotalCost="438.302729" Rows="10.000000" Width="65284"/>
                           </dxl:Properties>
                           <dxl:ProjList>
-                            <dxl:ProjElem ColId="61" Alias="c1047">
-                              <dxl:Ident ColId="61" ColName="c1047" TypeMdid="0.25.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="62" Alias="c1048">
-                              <dxl:Ident ColId="62" ColName="c1048" TypeMdid="0.25.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="64" Alias="c1050">
-                              <dxl:Ident ColId="64" ColName="c1050" TypeMdid="0.25.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="65" Alias="c1051">
-                              <dxl:Ident ColId="65" ColName="c1051" TypeMdid="0.25.1.0"/>
-                            </dxl:ProjElem>
                             <dxl:ProjElem ColId="66" Alias="c1052">
                               <dxl:Ident ColId="66" ColName="c1052" TypeMdid="0.25.1.0"/>
                             </dxl:ProjElem>
-                            <dxl:ProjElem ColId="67" Alias="c1053">
-                              <dxl:Ident ColId="67" ColName="c1053" TypeMdid="0.25.1.0"/>
+                            <dxl:ProjElem ColId="81" Alias="char_length">
+                              <dxl:Ident ColId="81" ColName="char_length" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
-                            <dxl:ProjElem ColId="68" Alias="c1054">
-                              <dxl:Ident ColId="68" ColName="c1054" TypeMdid="0.25.1.0"/>
+                            <dxl:ProjElem ColId="82" Alias="char_length">
+                              <dxl:Ident ColId="82" ColName="char_length" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
-                            <dxl:ProjElem ColId="69" Alias="c1055">
-                              <dxl:Ident ColId="69" ColName="c1055" TypeMdid="0.25.1.0"/>
+                            <dxl:ProjElem ColId="85" Alias="char_length">
+                              <dxl:Ident ColId="85" ColName="char_length" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="87" Alias="char_length">
+                              <dxl:Ident ColId="87" ColName="char_length" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="89" Alias="char_length">
+                              <dxl:Ident ColId="89" ColName="char_length" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="90" Alias="char_length">
+                              <dxl:Ident ColId="90" ColName="char_length" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="102" Alias="char_length">
+                              <dxl:Ident ColId="102" ColName="char_length" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:SortingColumnList/>
-                          <dxl:TableScan>
+                          <dxl:OneTimeFilter/>
+                          <dxl:Result>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="432.746168" Rows="10.000000" Width="562327"/>
+                              <dxl:Cost StartupCost="0" TotalCost="438.302729" Rows="10.000000" Width="65284"/>
                             </dxl:Properties>
                             <dxl:ProjList>
-                              <dxl:ProjElem ColId="61" Alias="c1047">
-                                <dxl:Ident ColId="61" ColName="c1047" TypeMdid="0.25.1.0"/>
+                              <dxl:ProjElem ColId="81" Alias="char_length">
+                                <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                                  <dxl:Ident ColId="67" ColName="c1053" TypeMdid="0.25.1.0"/>
+                                </dxl:FuncExpr>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="62" Alias="c1048">
-                                <dxl:Ident ColId="62" ColName="c1048" TypeMdid="0.25.1.0"/>
+                              <dxl:ProjElem ColId="82" Alias="char_length">
+                                <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                                  <dxl:Ident ColId="69" ColName="c1055" TypeMdid="0.25.1.0"/>
+                                </dxl:FuncExpr>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="64" Alias="c1050">
-                                <dxl:Ident ColId="64" ColName="c1050" TypeMdid="0.25.1.0"/>
+                              <dxl:ProjElem ColId="85" Alias="char_length">
+                                <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                                  <dxl:Ident ColId="65" ColName="c1051" TypeMdid="0.25.1.0"/>
+                                </dxl:FuncExpr>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="65" Alias="c1051">
-                                <dxl:Ident ColId="65" ColName="c1051" TypeMdid="0.25.1.0"/>
+                              <dxl:ProjElem ColId="87" Alias="char_length">
+                                <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                                  <dxl:Ident ColId="61" ColName="c1047" TypeMdid="0.25.1.0"/>
+                                </dxl:FuncExpr>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="89" Alias="char_length">
+                                <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                                  <dxl:Ident ColId="64" ColName="c1050" TypeMdid="0.25.1.0"/>
+                                </dxl:FuncExpr>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="90" Alias="char_length">
+                                <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                                  <dxl:Ident ColId="62" ColName="c1048" TypeMdid="0.25.1.0"/>
+                                </dxl:FuncExpr>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="102" Alias="char_length">
+                                <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                                  <dxl:Ident ColId="68" ColName="c1054" TypeMdid="0.25.1.0"/>
+                                </dxl:FuncExpr>
                               </dxl:ProjElem>
                               <dxl:ProjElem ColId="66" Alias="c1052">
                                 <dxl:Ident ColId="66" ColName="c1052" TypeMdid="0.25.1.0"/>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="67" Alias="c1053">
-                                <dxl:Ident ColId="67" ColName="c1053" TypeMdid="0.25.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="68" Alias="c1054">
-                                <dxl:Ident ColId="68" ColName="c1054" TypeMdid="0.25.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="69" Alias="c1055">
-                                <dxl:Ident ColId="69" ColName="c1055" TypeMdid="0.25.1.0"/>
-                              </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:Filter/>
-                            <dxl:TableDescriptor Mdid="0.92365.1.1" TableName="t86">
-                              <dxl:Columns>
-                                <dxl:Column ColId="61" Attno="1" ColName="c1047" TypeMdid="0.25.1.0"/>
-                                <dxl:Column ColId="62" Attno="2" ColName="c1048" TypeMdid="0.25.1.0"/>
-                                <dxl:Column ColId="64" Attno="4" ColName="c1050" TypeMdid="0.25.1.0"/>
-                                <dxl:Column ColId="65" Attno="5" ColName="c1051" TypeMdid="0.25.1.0"/>
-                                <dxl:Column ColId="66" Attno="6" ColName="c1052" TypeMdid="0.25.1.0"/>
-                                <dxl:Column ColId="67" Attno="7" ColName="c1053" TypeMdid="0.25.1.0"/>
-                                <dxl:Column ColId="68" Attno="8" ColName="c1054" TypeMdid="0.25.1.0"/>
-                                <dxl:Column ColId="69" Attno="9" ColName="c1055" TypeMdid="0.25.1.0"/>
-                                <dxl:Column ColId="70" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                <dxl:Column ColId="71" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                <dxl:Column ColId="72" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                              </dxl:Columns>
-                            </dxl:TableDescriptor>
-                          </dxl:TableScan>
-                        </dxl:BroadcastMotion>
-                      </dxl:Materialize>
-                    </dxl:NestedLoopJoin>
-                  </dxl:RedistributeMotion>
-                  <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                            <dxl:OneTimeFilter/>
+                            <dxl:TableScan>
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="432.746168" Rows="10.000000" Width="562327"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="61" Alias="c1047">
+                                  <dxl:Ident ColId="61" ColName="c1047" TypeMdid="0.25.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="62" Alias="c1048">
+                                  <dxl:Ident ColId="62" ColName="c1048" TypeMdid="0.25.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="64" Alias="c1050">
+                                  <dxl:Ident ColId="64" ColName="c1050" TypeMdid="0.25.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="65" Alias="c1051">
+                                  <dxl:Ident ColId="65" ColName="c1051" TypeMdid="0.25.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="66" Alias="c1052">
+                                  <dxl:Ident ColId="66" ColName="c1052" TypeMdid="0.25.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="67" Alias="c1053">
+                                  <dxl:Ident ColId="67" ColName="c1053" TypeMdid="0.25.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="68" Alias="c1054">
+                                  <dxl:Ident ColId="68" ColName="c1054" TypeMdid="0.25.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="69" Alias="c1055">
+                                  <dxl:Ident ColId="69" ColName="c1055" TypeMdid="0.25.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:TableDescriptor Mdid="0.92365.1.1" TableName="t86">
+                                <dxl:Columns>
+                                  <dxl:Column ColId="61" Attno="1" ColName="c1047" TypeMdid="0.25.1.0"/>
+                                  <dxl:Column ColId="62" Attno="2" ColName="c1048" TypeMdid="0.25.1.0"/>
+                                  <dxl:Column ColId="64" Attno="4" ColName="c1050" TypeMdid="0.25.1.0"/>
+                                  <dxl:Column ColId="65" Attno="5" ColName="c1051" TypeMdid="0.25.1.0"/>
+                                  <dxl:Column ColId="66" Attno="6" ColName="c1052" TypeMdid="0.25.1.0"/>
+                                  <dxl:Column ColId="67" Attno="7" ColName="c1053" TypeMdid="0.25.1.0"/>
+                                  <dxl:Column ColId="68" Attno="8" ColName="c1054" TypeMdid="0.25.1.0"/>
+                                  <dxl:Column ColId="69" Attno="9" ColName="c1055" TypeMdid="0.25.1.0"/>
+                                  <dxl:Column ColId="70" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  <dxl:Column ColId="71" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  <dxl:Column ColId="72" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:Columns>
+                              </dxl:TableDescriptor>
+                            </dxl:TableScan>
+                          </dxl:Result>
+                        </dxl:Result>
+                      </dxl:BroadcastMotion>
+                    </dxl:Materialize>
+                  </dxl:NestedLoopJoin>
+                </dxl:RedistributeMotion>
+                <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="1404.707980" Rows="100.000000" Width="210894"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="1" Alias="c1">
+                      <dxl:Ident ColId="1" ColName="c1" TypeMdid="0.25.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="17" Alias="c920">
+                      <dxl:Ident ColId="17" ColName="c920" TypeMdid="0.25.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="21" Alias="c924">
+                      <dxl:Ident ColId="21" ColName="c924" TypeMdid="0.25.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="73" Alias="char_length">
+                      <dxl:Ident ColId="73" ColName="char_length" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="75" Alias="char_length">
+                      <dxl:Ident ColId="75" ColName="char_length" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="77" Alias="char_length">
+                      <dxl:Ident ColId="77" ColName="char_length" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="80" Alias="char_length">
+                      <dxl:Ident ColId="80" ColName="char_length" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="84" Alias="char_length">
+                      <dxl:Ident ColId="84" ColName="char_length" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="93" Alias="char_length">
+                      <dxl:Ident ColId="93" ColName="char_length" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="94" Alias="char_length">
+                      <dxl:Ident ColId="94" ColName="char_length" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="95" Alias="char_length">
+                      <dxl:Ident ColId="95" ColName="char_length" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="96" Alias="char_length">
+                      <dxl:Ident ColId="96" ColName="char_length" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="97" Alias="char_length">
+                      <dxl:Ident ColId="97" ColName="char_length" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="98" Alias="char_length">
+                      <dxl:Ident ColId="98" ColName="char_length" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="99" Alias="char_length">
+                      <dxl:Ident ColId="99" ColName="char_length" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="100" Alias="char_length">
+                      <dxl:Ident ColId="100" ColName="char_length" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="101" Alias="char_length">
+                      <dxl:Ident ColId="101" ColName="char_length" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="104" Alias="char_length">
+                      <dxl:Ident ColId="104" ColName="char_length" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr>
+                      <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                        <dxl:Ident ColId="17" ColName="c920" TypeMdid="0.25.1.0"/>
+                      </dxl:FuncExpr>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1704.764417" Rows="100.000000" Width="1046589"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1371.703069" Rows="100.000000" Width="210894"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="0" Alias="c0">
-                        <dxl:Ident ColId="0" ColName="c0" TypeMdid="0.25.1.0"/>
-                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="1" Alias="c1">
                         <dxl:Ident ColId="1" ColName="c1" TypeMdid="0.25.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="7" Alias="c910">
-                        <dxl:Ident ColId="7" ColName="c910" TypeMdid="0.25.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="8" Alias="c911">
-                        <dxl:Ident ColId="8" ColName="c911" TypeMdid="0.25.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="10" Alias="c913">
-                        <dxl:Ident ColId="10" ColName="c913" TypeMdid="0.25.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="11" Alias="c914">
-                        <dxl:Ident ColId="11" ColName="c914" TypeMdid="0.25.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="13" Alias="c916">
-                        <dxl:Ident ColId="13" ColName="c916" TypeMdid="0.25.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="15" Alias="c918">
-                        <dxl:Ident ColId="15" ColName="c918" TypeMdid="0.25.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="16" Alias="c919">
-                        <dxl:Ident ColId="16" ColName="c919" TypeMdid="0.25.1.0"/>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="17" Alias="c920">
                         <dxl:Ident ColId="17" ColName="c920" TypeMdid="0.25.1.0"/>
@@ -2155,59 +2288,125 @@
                       <dxl:ProjElem ColId="21" Alias="c924">
                         <dxl:Ident ColId="21" ColName="c924" TypeMdid="0.25.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="23" Alias="c926">
-                        <dxl:Ident ColId="23" ColName="c926" TypeMdid="0.25.1.0"/>
+                      <dxl:ProjElem ColId="73" Alias="char_length">
+                        <dxl:Ident ColId="73" ColName="char_length" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="24" Alias="c927">
-                        <dxl:Ident ColId="24" ColName="c927" TypeMdid="0.25.1.0"/>
+                      <dxl:ProjElem ColId="75" Alias="char_length">
+                        <dxl:Ident ColId="75" ColName="char_length" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="25" Alias="c928">
-                        <dxl:Ident ColId="25" ColName="c928" TypeMdid="0.25.1.0"/>
+                      <dxl:ProjElem ColId="77" Alias="char_length">
+                        <dxl:Ident ColId="77" ColName="char_length" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="26" Alias="c929">
-                        <dxl:Ident ColId="26" ColName="c929" TypeMdid="0.25.1.0"/>
+                      <dxl:ProjElem ColId="80" Alias="char_length">
+                        <dxl:Ident ColId="80" ColName="char_length" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="84" Alias="char_length">
+                        <dxl:Ident ColId="84" ColName="char_length" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="93" Alias="char_length">
+                        <dxl:Ident ColId="93" ColName="char_length" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="94" Alias="char_length">
+                        <dxl:Ident ColId="94" ColName="char_length" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="95" Alias="char_length">
+                        <dxl:Ident ColId="95" ColName="char_length" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="96" Alias="char_length">
+                        <dxl:Ident ColId="96" ColName="char_length" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="97" Alias="char_length">
+                        <dxl:Ident ColId="97" ColName="char_length" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="98" Alias="char_length">
+                        <dxl:Ident ColId="98" ColName="char_length" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="99" Alias="char_length">
+                        <dxl:Ident ColId="99" ColName="char_length" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="100" Alias="char_length">
+                        <dxl:Ident ColId="100" ColName="char_length" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="101" Alias="char_length">
+                        <dxl:Ident ColId="101" ColName="char_length" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="104" Alias="char_length">
+                        <dxl:Ident ColId="104" ColName="char_length" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:HashExprList>
-                      <dxl:HashExpr>
-                        <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                          <dxl:Ident ColId="17" ColName="c920" TypeMdid="0.25.1.0"/>
-                        </dxl:FuncExpr>
-                      </dxl:HashExpr>
-                    </dxl:HashExprList>
-                    <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                    <dxl:JoinFilter>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:JoinFilter>
+                    <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1540.973238" Rows="100.000000" Width="1046589"/>
+                        <dxl:Cost StartupCost="0" TotalCost="444.237056" Rows="10.000000" Width="144765"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="0" Alias="c0">
-                          <dxl:Ident ColId="0" ColName="c0" TypeMdid="0.25.1.0"/>
+                        <dxl:ProjElem ColId="73" Alias="char_length">
+                          <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                            <dxl:Ident ColId="10" ColName="c913" TypeMdid="0.25.1.0"/>
+                          </dxl:FuncExpr>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="1" Alias="c1">
-                          <dxl:Ident ColId="1" ColName="c1" TypeMdid="0.25.1.0"/>
+                        <dxl:ProjElem ColId="75" Alias="char_length">
+                          <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                            <dxl:Ident ColId="16" ColName="c919" TypeMdid="0.25.1.0"/>
+                          </dxl:FuncExpr>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="7" Alias="c910">
-                          <dxl:Ident ColId="7" ColName="c910" TypeMdid="0.25.1.0"/>
+                        <dxl:ProjElem ColId="77" Alias="char_length">
+                          <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                            <dxl:Ident ColId="7" ColName="c910" TypeMdid="0.25.1.0"/>
+                          </dxl:FuncExpr>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="8" Alias="c911">
-                          <dxl:Ident ColId="8" ColName="c911" TypeMdid="0.25.1.0"/>
+                        <dxl:ProjElem ColId="80" Alias="char_length">
+                          <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                            <dxl:Ident ColId="11" ColName="c914" TypeMdid="0.25.1.0"/>
+                          </dxl:FuncExpr>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="10" Alias="c913">
-                          <dxl:Ident ColId="10" ColName="c913" TypeMdid="0.25.1.0"/>
+                        <dxl:ProjElem ColId="84" Alias="char_length">
+                          <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                            <dxl:Ident ColId="17" ColName="c920" TypeMdid="0.25.1.0"/>
+                          </dxl:FuncExpr>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="11" Alias="c914">
-                          <dxl:Ident ColId="11" ColName="c914" TypeMdid="0.25.1.0"/>
+                        <dxl:ProjElem ColId="93" Alias="char_length">
+                          <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                            <dxl:Ident ColId="26" ColName="c929" TypeMdid="0.25.1.0"/>
+                          </dxl:FuncExpr>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="13" Alias="c916">
-                          <dxl:Ident ColId="13" ColName="c916" TypeMdid="0.25.1.0"/>
+                        <dxl:ProjElem ColId="94" Alias="char_length">
+                          <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                            <dxl:Ident ColId="8" ColName="c911" TypeMdid="0.25.1.0"/>
+                          </dxl:FuncExpr>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="15" Alias="c918">
-                          <dxl:Ident ColId="15" ColName="c918" TypeMdid="0.25.1.0"/>
+                        <dxl:ProjElem ColId="95" Alias="char_length">
+                          <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                            <dxl:Ident ColId="23" ColName="c926" TypeMdid="0.25.1.0"/>
+                          </dxl:FuncExpr>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="16" Alias="c919">
-                          <dxl:Ident ColId="16" ColName="c919" TypeMdid="0.25.1.0"/>
+                        <dxl:ProjElem ColId="96" Alias="char_length">
+                          <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                            <dxl:Ident ColId="15" ColName="c918" TypeMdid="0.25.1.0"/>
+                          </dxl:FuncExpr>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="98" Alias="char_length">
+                          <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                            <dxl:Ident ColId="25" ColName="c928" TypeMdid="0.25.1.0"/>
+                          </dxl:FuncExpr>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="99" Alias="char_length">
+                          <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                            <dxl:Ident ColId="13" ColName="c916" TypeMdid="0.25.1.0"/>
+                          </dxl:FuncExpr>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="101" Alias="char_length">
+                          <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                            <dxl:Ident ColId="24" ColName="c927" TypeMdid="0.25.1.0"/>
+                          </dxl:FuncExpr>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="104" Alias="char_length">
+                          <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                            <dxl:Ident ColId="21" ColName="c924" TypeMdid="0.25.1.0"/>
+                          </dxl:FuncExpr>
                         </dxl:ProjElem>
                         <dxl:ProjElem ColId="17" Alias="c920">
                           <dxl:Ident ColId="17" ColName="c920" TypeMdid="0.25.1.0"/>
@@ -2215,23 +2414,9 @@
                         <dxl:ProjElem ColId="21" Alias="c924">
                           <dxl:Ident ColId="21" ColName="c924" TypeMdid="0.25.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="23" Alias="c926">
-                          <dxl:Ident ColId="23" ColName="c926" TypeMdid="0.25.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="24" Alias="c927">
-                          <dxl:Ident ColId="24" ColName="c927" TypeMdid="0.25.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="25" Alias="c928">
-                          <dxl:Ident ColId="25" ColName="c928" TypeMdid="0.25.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="26" Alias="c929">
-                          <dxl:Ident ColId="26" ColName="c929" TypeMdid="0.25.1.0"/>
-                        </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:JoinFilter>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:JoinFilter>
+                      <dxl:OneTimeFilter/>
                       <dxl:TableScan>
                         <dxl:Properties>
                           <dxl:Cost StartupCost="0" TotalCost="434.909012" Rows="10.000000" Width="925131"/>
@@ -2299,62 +2484,108 @@
                           </dxl:Columns>
                         </dxl:TableDescriptor>
                       </dxl:TableScan>
-                      <dxl:Materialize Eager="false">
+                    </dxl:Result>
+                    <dxl:Materialize Eager="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="451.150209" Rows="20.000000" Width="66129"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="1" Alias="c1">
+                          <dxl:Ident ColId="1" ColName="c1" TypeMdid="0.25.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="97" Alias="char_length">
+                          <dxl:Ident ColId="97" ColName="char_length" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="100" Alias="char_length">
+                          <dxl:Ident ColId="100" ColName="char_length" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="465.854720" Rows="20.000000" Width="121458"/>
+                          <dxl:Cost StartupCost="0" TotalCost="450.488919" Rows="20.000000" Width="66129"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="0" Alias="c0">
-                            <dxl:Ident ColId="0" ColName="c0" TypeMdid="0.25.1.0"/>
-                          </dxl:ProjElem>
                           <dxl:ProjElem ColId="1" Alias="c1">
                             <dxl:Ident ColId="1" ColName="c1" TypeMdid="0.25.1.0"/>
                           </dxl:ProjElem>
+                          <dxl:ProjElem ColId="97" Alias="char_length">
+                            <dxl:Ident ColId="97" ColName="char_length" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="100" Alias="char_length">
+                            <dxl:Ident ColId="100" ColName="char_length" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                        <dxl:SortingColumnList/>
+                        <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="464.640140" Rows="20.000000" Width="121458"/>
+                            <dxl:Cost StartupCost="0" TotalCost="433.179653" Rows="10.000000" Width="66129"/>
                           </dxl:Properties>
                           <dxl:ProjList>
-                            <dxl:ProjElem ColId="0" Alias="c0">
-                              <dxl:Ident ColId="0" ColName="c0" TypeMdid="0.25.1.0"/>
-                            </dxl:ProjElem>
                             <dxl:ProjElem ColId="1" Alias="c1">
                               <dxl:Ident ColId="1" ColName="c1" TypeMdid="0.25.1.0"/>
                             </dxl:ProjElem>
+                            <dxl:ProjElem ColId="97" Alias="char_length">
+                              <dxl:Ident ColId="97" ColName="char_length" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="100" Alias="char_length">
+                              <dxl:Ident ColId="100" ColName="char_length" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:SortingColumnList/>
-                          <dxl:TableScan>
+                          <dxl:OneTimeFilter/>
+                          <dxl:Result>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.718949" Rows="10.000000" Width="121458"/>
+                              <dxl:Cost StartupCost="0" TotalCost="433.179653" Rows="10.000000" Width="66129"/>
                             </dxl:Properties>
                             <dxl:ProjList>
-                              <dxl:ProjElem ColId="0" Alias="c0">
-                                <dxl:Ident ColId="0" ColName="c0" TypeMdid="0.25.1.0"/>
+                              <dxl:ProjElem ColId="97" Alias="char_length">
+                                <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                                  <dxl:Ident ColId="0" ColName="c0" TypeMdid="0.25.1.0"/>
+                                </dxl:FuncExpr>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="100" Alias="char_length">
+                                <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+                                  <dxl:Ident ColId="1" ColName="c1" TypeMdid="0.25.1.0"/>
+                                </dxl:FuncExpr>
                               </dxl:ProjElem>
                               <dxl:ProjElem ColId="1" Alias="c1">
                                 <dxl:Ident ColId="1" ColName="c1" TypeMdid="0.25.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:Filter/>
-                            <dxl:TableDescriptor Mdid="0.90124.1.1" TableName="t0">
-                              <dxl:Columns>
-                                <dxl:Column ColId="0" Attno="1" ColName="c0" TypeMdid="0.25.1.0"/>
-                                <dxl:Column ColId="1" Attno="2" ColName="c1" TypeMdid="0.25.1.0"/>
-                                <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                <dxl:Column ColId="5" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                <dxl:Column ColId="6" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                              </dxl:Columns>
-                            </dxl:TableDescriptor>
-                          </dxl:TableScan>
-                        </dxl:BroadcastMotion>
-                      </dxl:Materialize>
-                    </dxl:NestedLoopJoin>
-                  </dxl:RedistributeMotion>
-                </dxl:HashJoin>
-              </dxl:Result>
+                            <dxl:OneTimeFilter/>
+                            <dxl:TableScan>
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.718949" Rows="10.000000" Width="121458"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="0" Alias="c0">
+                                  <dxl:Ident ColId="0" ColName="c0" TypeMdid="0.25.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="1" Alias="c1">
+                                  <dxl:Ident ColId="1" ColName="c1" TypeMdid="0.25.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:TableDescriptor Mdid="0.90124.1.1" TableName="t0">
+                                <dxl:Columns>
+                                  <dxl:Column ColId="0" Attno="1" ColName="c0" TypeMdid="0.25.1.0"/>
+                                  <dxl:Column ColId="1" Attno="2" ColName="c1" TypeMdid="0.25.1.0"/>
+                                  <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  <dxl:Column ColId="5" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  <dxl:Column ColId="6" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:Columns>
+                              </dxl:TableDescriptor>
+                            </dxl:TableScan>
+                          </dxl:Result>
+                        </dxl:Result>
+                      </dxl:BroadcastMotion>
+                    </dxl:Materialize>
+                  </dxl:NestedLoopJoin>
+                </dxl:RedistributeMotion>
+              </dxl:HashJoin>
             </dxl:Sort>
             <dxl:LimitCount>
               <dxl:ConstValue TypeMdid="0.20.1.0" Value="100"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-PartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-PartTable.mdp
@@ -1742,10 +1742,10 @@ ORDER BY 1 asc ;
         </dxl:LogicalGroupBy>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="35">
+    <dxl:Plan Id="0" SpaceSize="60">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2951.636128" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="2951.652030" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="23" Alias="fivemin">
@@ -1758,7 +1758,7 @@ ORDER BY 1 asc ;
         </dxl:SortingColumnList>
         <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2951.636092" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="2951.651994" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="23" Alias="fivemin">
@@ -1773,7 +1773,7 @@ ORDER BY 1 asc ;
           <dxl:LimitOffset/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2951.636092" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="2951.651994" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="23"/>
@@ -1786,7 +1786,7 @@ ORDER BY 1 asc ;
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2951.636082" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="2951.651984" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="23" Alias="fivemin">
@@ -1801,7 +1801,7 @@ ORDER BY 1 asc ;
               <dxl:LimitOffset/>
               <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2951.636082" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="2951.651984" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="23" Alias="fivemin">
@@ -1815,39 +1815,45 @@ ORDER BY 1 asc ;
                     <dxl:Ident ColId="23" ColName="fivemin" TypeMdid="0.20.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
-                <dxl:Result>
+                <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2951.636066" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="2951.651968" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="23" Alias="fivemin">
-                      <dxl:OpExpr OperatorName="*" OperatorMdid="0.690.1.0" OperatorType="0.20.1.0">
-                        <dxl:OpExpr OperatorName="/" OperatorMdid="0.691.1.0" OperatorType="0.20.1.0">
-                          <dxl:OpExpr OperatorName="/" OperatorMdid="0.691.1.0" OperatorType="0.20.1.0">
-                            <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="100000"/>
-                          </dxl:OpExpr>
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
-                        </dxl:OpExpr>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
-                      </dxl:OpExpr>
+                      <dxl:Ident ColId="23" ColName="fivemin" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                  <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
+                  <dxl:JoinFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:JoinFilter>
+                  <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="2951.636062" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.306548" Rows="840.000000" Width="33"/>
                     </dxl:Properties>
                     <dxl:ProjList>
+                      <dxl:ProjElem ColId="23" Alias="fivemin">
+                        <dxl:OpExpr OperatorName="*" OperatorMdid="0.690.1.0" OperatorType="0.20.1.0">
+                          <dxl:OpExpr OperatorName="/" OperatorMdid="0.691.1.0" OperatorType="0.20.1.0">
+                            <dxl:OpExpr OperatorName="/" OperatorMdid="0.691.1.0" OperatorType="0.20.1.0">
+                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="100000"/>
+                            </dxl:OpExpr>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                          </dxl:OpExpr>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                        </dxl:OpExpr>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="0" Alias="symbol">
+                        <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
+                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="1" Alias="event_ts">
                         <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:JoinFilter>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:JoinFilter>
+                    <dxl:OneTimeFilter/>
                     <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                       <dxl:Properties>
                         <dxl:Cost StartupCost="0" TotalCost="431.292687" Rows="840.000000" Width="25"/>
@@ -1890,56 +1896,40 @@ ORDER BY 1 asc ;
                         </dxl:TableDescriptor>
                       </dxl:TableScan>
                     </dxl:BroadcastMotion>
-                    <dxl:Append IsTarget="false" IsZapped="false">
+                  </dxl:Result>
+                  <dxl:Append IsTarget="false" IsZapped="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="2520.336966" Rows="1.000000" Width="1"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="11" Alias="ets">
+                        <dxl:Ident ColId="11" ColName="ets" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="12" Alias="sym">
+                        <dxl:Ident ColId="12" ColName="sym" TypeMdid="0.1043.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="15" Alias="end_ts">
+                        <dxl:Ident ColId="15" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:IndexScan IndexScanDirection="Forward">
                       <dxl:Properties>
                         <dxl:Cost StartupCost="0" TotalCost="2520.336966" Rows="1.000000" Width="1"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="11" Alias="ets">
-                          <dxl:Ident ColId="11" ColName="ets" TypeMdid="0.20.1.0"/>
+                        <dxl:ProjElem ColId="24" Alias="ets">
+                          <dxl:Ident ColId="24" ColName="ets" TypeMdid="0.20.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="12" Alias="sym">
-                          <dxl:Ident ColId="12" ColName="sym" TypeMdid="0.1043.1.0"/>
+                        <dxl:ProjElem ColId="25" Alias="sym">
+                          <dxl:Ident ColId="25" ColName="sym" TypeMdid="0.1043.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="15" Alias="end_ts">
-                          <dxl:Ident ColId="15" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                        <dxl:ProjElem ColId="28" Alias="end_ts">
+                          <dxl:Ident ColId="28" ColName="end_ts" TypeMdid="0.20.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:IndexScan IndexScanDirection="Forward">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="2520.336966" Rows="1.000000" Width="1"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="24" Alias="ets">
-                            <dxl:Ident ColId="24" ColName="ets" TypeMdid="0.20.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="25" Alias="sym">
-                            <dxl:Ident ColId="25" ColName="sym" TypeMdid="0.1043.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="28" Alias="end_ts">
-                            <dxl:Ident ColId="28" ColName="end_ts" TypeMdid="0.20.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter>
-                          <dxl:And>
-                            <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
-                              <dxl:Ident ColId="24" ColName="ets" TypeMdid="0.20.1.0"/>
-                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                            </dxl:Comparison>
-                            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-                              <dxl:Ident ColId="28" ColName="end_ts" TypeMdid="0.20.1.0"/>
-                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                            </dxl:Comparison>
-                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
-                              <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
-                                <dxl:Ident ColId="25" ColName="sym" TypeMdid="0.1043.1.0"/>
-                              </dxl:Cast>
-                              <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
-                            </dxl:Comparison>
-                          </dxl:And>
-                        </dxl:Filter>
-                        <dxl:IndexCondList>
+                      <dxl:Filter>
+                        <dxl:And>
                           <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
                             <dxl:Ident ColId="24" ColName="ets" TypeMdid="0.20.1.0"/>
                             <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
@@ -1948,59 +1938,59 @@ ORDER BY 1 asc ;
                             <dxl:Ident ColId="28" ColName="end_ts" TypeMdid="0.20.1.0"/>
                             <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
                           </dxl:Comparison>
-                        </dxl:IndexCondList>
-                        <dxl:IndexDescriptor Mdid="0.-1013039183.1.0" IndexName="my_tq_agg_small_ets_end_ts_ix_1_prt_p1"/>
-                        <dxl:TableDescriptor Mdid="0.-1013210183.1.1" TableName="my_tq_agg_small_prt_1">
-                          <dxl:Columns>
-                            <dxl:Column ColId="24" Attno="1" ColName="ets" TypeMdid="0.20.1.0" ColWidth="8"/>
-                            <dxl:Column ColId="25" Attno="2" ColName="sym" TypeMdid="0.1043.1.0" ColWidth="16"/>
-                            <dxl:Column ColId="26" Attno="3" ColName="bid_price" TypeMdid="0.1700.1.0" ColWidth="8"/>
-                            <dxl:Column ColId="27" Attno="4" ColName="ask_price" TypeMdid="0.1700.1.0" ColWidth="8"/>
-                            <dxl:Column ColId="28" Attno="5" ColName="end_ts" TypeMdid="0.20.1.0" ColWidth="8"/>
-                            <dxl:Column ColId="29" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                            <dxl:Column ColId="30" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="31" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="32" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="33" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="34" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="35" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:IndexScan>
-                      <dxl:IndexScan IndexScanDirection="Forward">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="2520.336966" Rows="1.000000" Width="1"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="36" Alias="ets">
-                            <dxl:Ident ColId="36" ColName="ets" TypeMdid="0.20.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="37" Alias="sym">
-                            <dxl:Ident ColId="37" ColName="sym" TypeMdid="0.1043.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="40" Alias="end_ts">
-                            <dxl:Ident ColId="40" ColName="end_ts" TypeMdid="0.20.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter>
-                          <dxl:And>
-                            <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
-                              <dxl:Ident ColId="36" ColName="ets" TypeMdid="0.20.1.0"/>
-                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                            </dxl:Comparison>
-                            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-                              <dxl:Ident ColId="40" ColName="end_ts" TypeMdid="0.20.1.0"/>
-                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                            </dxl:Comparison>
-                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
-                              <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
-                                <dxl:Ident ColId="37" ColName="sym" TypeMdid="0.1043.1.0"/>
-                              </dxl:Cast>
-                              <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
-                            </dxl:Comparison>
-                          </dxl:And>
-                        </dxl:Filter>
-                        <dxl:IndexCondList>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+                            <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
+                              <dxl:Ident ColId="25" ColName="sym" TypeMdid="0.1043.1.0"/>
+                            </dxl:Cast>
+                            <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:And>
+                      </dxl:Filter>
+                      <dxl:IndexCondList>
+                        <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
+                          <dxl:Ident ColId="24" ColName="ets" TypeMdid="0.20.1.0"/>
+                          <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                        </dxl:Comparison>
+                        <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
+                          <dxl:Ident ColId="28" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                          <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                        </dxl:Comparison>
+                      </dxl:IndexCondList>
+                      <dxl:IndexDescriptor Mdid="0.-1013039183.1.0" IndexName="my_tq_agg_small_ets_end_ts_ix_1_prt_p1"/>
+                      <dxl:TableDescriptor Mdid="0.-1013210183.1.1" TableName="my_tq_agg_small_prt_1">
+                        <dxl:Columns>
+                          <dxl:Column ColId="24" Attno="1" ColName="ets" TypeMdid="0.20.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="25" Attno="2" ColName="sym" TypeMdid="0.1043.1.0" ColWidth="16"/>
+                          <dxl:Column ColId="26" Attno="3" ColName="bid_price" TypeMdid="0.1700.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="27" Attno="4" ColName="ask_price" TypeMdid="0.1700.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="28" Attno="5" ColName="end_ts" TypeMdid="0.20.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="29" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                          <dxl:Column ColId="30" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="31" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="32" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="33" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="34" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="35" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:IndexScan>
+                    <dxl:IndexScan IndexScanDirection="Forward">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="2520.336966" Rows="1.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="36" Alias="ets">
+                          <dxl:Ident ColId="36" ColName="ets" TypeMdid="0.20.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="37" Alias="sym">
+                          <dxl:Ident ColId="37" ColName="sym" TypeMdid="0.1043.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="40" Alias="end_ts">
+                          <dxl:Ident ColId="40" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter>
+                        <dxl:And>
                           <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
                             <dxl:Ident ColId="36" ColName="ets" TypeMdid="0.20.1.0"/>
                             <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
@@ -2009,59 +1999,59 @@ ORDER BY 1 asc ;
                             <dxl:Ident ColId="40" ColName="end_ts" TypeMdid="0.20.1.0"/>
                             <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
                           </dxl:Comparison>
-                        </dxl:IndexCondList>
-                        <dxl:IndexDescriptor Mdid="0.-1013039182.1.0" IndexName="my_tq_agg_small_ets_end_ts_ix_1_prt_p1"/>
-                        <dxl:TableDescriptor Mdid="0.-1013210182.1.1" TableName="my_tq_agg_small_prt_2">
-                          <dxl:Columns>
-                            <dxl:Column ColId="36" Attno="1" ColName="ets" TypeMdid="0.20.1.0" ColWidth="8"/>
-                            <dxl:Column ColId="37" Attno="2" ColName="sym" TypeMdid="0.1043.1.0" ColWidth="16"/>
-                            <dxl:Column ColId="38" Attno="3" ColName="bid_price" TypeMdid="0.1700.1.0" ColWidth="8"/>
-                            <dxl:Column ColId="39" Attno="4" ColName="ask_price" TypeMdid="0.1700.1.0" ColWidth="8"/>
-                            <dxl:Column ColId="40" Attno="5" ColName="end_ts" TypeMdid="0.20.1.0" ColWidth="8"/>
-                            <dxl:Column ColId="41" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                            <dxl:Column ColId="42" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="43" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="44" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="45" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="46" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="47" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:IndexScan>
-                      <dxl:IndexScan IndexScanDirection="Forward">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="2520.336966" Rows="1.000000" Width="1"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="48" Alias="ets">
-                            <dxl:Ident ColId="48" ColName="ets" TypeMdid="0.20.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="49" Alias="sym">
-                            <dxl:Ident ColId="49" ColName="sym" TypeMdid="0.1043.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="52" Alias="end_ts">
-                            <dxl:Ident ColId="52" ColName="end_ts" TypeMdid="0.20.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter>
-                          <dxl:And>
-                            <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
-                              <dxl:Ident ColId="48" ColName="ets" TypeMdid="0.20.1.0"/>
-                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                            </dxl:Comparison>
-                            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-                              <dxl:Ident ColId="52" ColName="end_ts" TypeMdid="0.20.1.0"/>
-                              <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
-                            </dxl:Comparison>
-                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
-                              <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
-                                <dxl:Ident ColId="49" ColName="sym" TypeMdid="0.1043.1.0"/>
-                              </dxl:Cast>
-                              <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
-                            </dxl:Comparison>
-                          </dxl:And>
-                        </dxl:Filter>
-                        <dxl:IndexCondList>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+                            <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
+                              <dxl:Ident ColId="37" ColName="sym" TypeMdid="0.1043.1.0"/>
+                            </dxl:Cast>
+                            <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:And>
+                      </dxl:Filter>
+                      <dxl:IndexCondList>
+                        <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
+                          <dxl:Ident ColId="36" ColName="ets" TypeMdid="0.20.1.0"/>
+                          <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                        </dxl:Comparison>
+                        <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
+                          <dxl:Ident ColId="40" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                          <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                        </dxl:Comparison>
+                      </dxl:IndexCondList>
+                      <dxl:IndexDescriptor Mdid="0.-1013039182.1.0" IndexName="my_tq_agg_small_ets_end_ts_ix_1_prt_p1"/>
+                      <dxl:TableDescriptor Mdid="0.-1013210182.1.1" TableName="my_tq_agg_small_prt_2">
+                        <dxl:Columns>
+                          <dxl:Column ColId="36" Attno="1" ColName="ets" TypeMdid="0.20.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="37" Attno="2" ColName="sym" TypeMdid="0.1043.1.0" ColWidth="16"/>
+                          <dxl:Column ColId="38" Attno="3" ColName="bid_price" TypeMdid="0.1700.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="39" Attno="4" ColName="ask_price" TypeMdid="0.1700.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="40" Attno="5" ColName="end_ts" TypeMdid="0.20.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="41" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                          <dxl:Column ColId="42" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="43" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="44" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="45" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="46" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="47" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:IndexScan>
+                    <dxl:IndexScan IndexScanDirection="Forward">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="2520.336966" Rows="1.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="48" Alias="ets">
+                          <dxl:Ident ColId="48" ColName="ets" TypeMdid="0.20.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="49" Alias="sym">
+                          <dxl:Ident ColId="49" ColName="sym" TypeMdid="0.1043.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="52" Alias="end_ts">
+                          <dxl:Ident ColId="52" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter>
+                        <dxl:And>
                           <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
                             <dxl:Ident ColId="48" ColName="ets" TypeMdid="0.20.1.0"/>
                             <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
@@ -2070,28 +2060,44 @@ ORDER BY 1 asc ;
                             <dxl:Ident ColId="52" ColName="end_ts" TypeMdid="0.20.1.0"/>
                             <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
                           </dxl:Comparison>
-                        </dxl:IndexCondList>
-                        <dxl:IndexDescriptor Mdid="0.-1013039181.1.0" IndexName="my_tq_agg_small_ets_end_ts_ix_1_prt_p1"/>
-                        <dxl:TableDescriptor Mdid="0.-1013210181.1.1" TableName="my_tq_agg_small_prt_3">
-                          <dxl:Columns>
-                            <dxl:Column ColId="48" Attno="1" ColName="ets" TypeMdid="0.20.1.0" ColWidth="8"/>
-                            <dxl:Column ColId="49" Attno="2" ColName="sym" TypeMdid="0.1043.1.0" ColWidth="16"/>
-                            <dxl:Column ColId="50" Attno="3" ColName="bid_price" TypeMdid="0.1700.1.0" ColWidth="8"/>
-                            <dxl:Column ColId="51" Attno="4" ColName="ask_price" TypeMdid="0.1700.1.0" ColWidth="8"/>
-                            <dxl:Column ColId="52" Attno="5" ColName="end_ts" TypeMdid="0.20.1.0" ColWidth="8"/>
-                            <dxl:Column ColId="53" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                            <dxl:Column ColId="54" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="55" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="56" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="57" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="58" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="59" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:IndexScan>
-                    </dxl:Append>
-                  </dxl:NestedLoopJoin>
-                </dxl:Result>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+                            <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
+                              <dxl:Ident ColId="49" ColName="sym" TypeMdid="0.1043.1.0"/>
+                            </dxl:Cast>
+                            <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:And>
+                      </dxl:Filter>
+                      <dxl:IndexCondList>
+                        <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">
+                          <dxl:Ident ColId="48" ColName="ets" TypeMdid="0.20.1.0"/>
+                          <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                        </dxl:Comparison>
+                        <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
+                          <dxl:Ident ColId="52" ColName="end_ts" TypeMdid="0.20.1.0"/>
+                          <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.20.1.0"/>
+                        </dxl:Comparison>
+                      </dxl:IndexCondList>
+                      <dxl:IndexDescriptor Mdid="0.-1013039181.1.0" IndexName="my_tq_agg_small_ets_end_ts_ix_1_prt_p1"/>
+                      <dxl:TableDescriptor Mdid="0.-1013210181.1.1" TableName="my_tq_agg_small_prt_3">
+                        <dxl:Columns>
+                          <dxl:Column ColId="48" Attno="1" ColName="ets" TypeMdid="0.20.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="49" Attno="2" ColName="sym" TypeMdid="0.1043.1.0" ColWidth="16"/>
+                          <dxl:Column ColId="50" Attno="3" ColName="bid_price" TypeMdid="0.1700.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="51" Attno="4" ColName="ask_price" TypeMdid="0.1700.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="52" Attno="5" ColName="end_ts" TypeMdid="0.20.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="53" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                          <dxl:Column ColId="54" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="55" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="56" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="57" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="58" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="59" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:IndexScan>
+                  </dxl:Append>
+                </dxl:NestedLoopJoin>
               </dxl:RedistributeMotion>
             </dxl:Sort>
           </dxl:Aggregate>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesForProcessedColumn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesForProcessedColumn.mdp
@@ -370,10 +370,10 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="552">
+    <dxl:Plan Id="0" SpaceSize="108">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.001333" Rows="1.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.001317" Rows="1.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="id">
@@ -393,7 +393,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.001244" Rows="1.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.001227" Rows="1.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="id">
@@ -414,64 +414,79 @@
           <dxl:HashCondList>
             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
               <dxl:Ident ColId="9" ColName="id" TypeMdid="0.23.1.0"/>
-              <dxl:Ident ColId="18" ColName="id" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
           <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.000570" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000568" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="id">
-                <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="name">
-                <dxl:Ident ColId="1" ColName="name" TypeMdid="0.25.1.0"/>
-              </dxl:ProjElem>
               <dxl:ProjElem ColId="9" Alias="id">
                 <dxl:Ident ColId="9" ColName="id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="27" Alias="name">
+                <dxl:Ident ColId="27" ColName="name" TypeMdid="0.25.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:JoinFilter/>
             <dxl:HashCondList>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="18" ColName="id" TypeMdid="0.23.1.0"/>
                 <dxl:Ident ColId="9" ColName="id" TypeMdid="0.23.1.0"/>
               </dxl:Comparison>
             </dxl:HashCondList>
-            <dxl:TableScan>
+            <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000078" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000090" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="id">
-                  <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="27" Alias="name">
+                  <dxl:OpExpr OperatorName="||" OperatorMdid="0.654.1.0" OperatorType="0.25.1.0">
+                    <dxl:Ident ColId="19" ColName="name" TypeMdid="0.25.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABA==" LintValue="2817148525"/>
+                  </dxl:OpExpr>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="name">
-                  <dxl:Ident ColId="1" ColName="name" TypeMdid="0.25.1.0"/>
+                <dxl:ProjElem ColId="18" Alias="id">
+                  <dxl:Ident ColId="18" ColName="id" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Filter>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
-                </dxl:Comparison>
-              </dxl:Filter>
-              <dxl:TableDescriptor Mdid="0.16384.1.0" TableName="t1">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="name" TypeMdid="0.25.1.0" ColWidth="8"/>
-                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000078" Rows="1.000000" Width="12"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="18" Alias="id">
+                    <dxl:Ident ColId="18" ColName="id" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="19" Alias="name">
+                    <dxl:Ident ColId="19" ColName="name" TypeMdid="0.25.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="18" ColName="id" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                  </dxl:Comparison>
+                </dxl:Filter>
+                <dxl:TableDescriptor Mdid="0.16396.1.0" TableName="t3">
+                  <dxl:Columns>
+                    <dxl:Column ColId="18" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="19" Attno="2" ColName="name" TypeMdid="0.25.1.0" ColWidth="8"/>
+                    <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="21" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="22" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="23" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="24" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="25" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="26" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:Result>
             <dxl:TableScan>
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="1.000000" Width="4"/>
@@ -501,56 +516,38 @@
               </dxl:TableDescriptor>
             </dxl:TableScan>
           </dxl:HashJoin>
-          <dxl:Result>
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000090" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000078" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="27" Alias="name">
-                <dxl:OpExpr OperatorName="||" OperatorMdid="0.654.1.0" OperatorType="0.25.1.0">
-                  <dxl:Ident ColId="19" ColName="name" TypeMdid="0.25.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABA==" LintValue="2817148525"/>
-                </dxl:OpExpr>
+              <dxl:ProjElem ColId="0" Alias="id">
+                <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="18" Alias="id">
-                <dxl:Ident ColId="18" ColName="id" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="1" Alias="name">
+                <dxl:Ident ColId="1" ColName="name" TypeMdid="0.25.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:OneTimeFilter/>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000078" Rows="1.000000" Width="12"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="18" Alias="id">
-                  <dxl:Ident ColId="18" ColName="id" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="19" Alias="name">
-                  <dxl:Ident ColId="19" ColName="name" TypeMdid="0.25.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="18" ColName="id" TypeMdid="0.23.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
-                </dxl:Comparison>
-              </dxl:Filter>
-              <dxl:TableDescriptor Mdid="0.16396.1.0" TableName="t3">
-                <dxl:Columns>
-                  <dxl:Column ColId="18" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="19" Attno="2" ColName="name" TypeMdid="0.25.1.0" ColWidth="8"/>
-                  <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="21" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="22" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="23" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="24" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="25" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="26" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:Result>
+            <dxl:Filter>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+              </dxl:Comparison>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.16384.1.0" TableName="t1">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="2" ColName="name" TypeMdid="0.25.1.0" ColWidth="8"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
         </dxl:HashJoin>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesForProcessedColumn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesForProcessedColumn.mdp
@@ -370,10 +370,10 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="104">
+    <dxl:Plan Id="0" SpaceSize="552">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.001317" Rows="1.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.001333" Rows="1.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="id">
@@ -393,7 +393,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.001227" Rows="1.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.001244" Rows="1.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="id">
@@ -414,111 +414,12 @@
           <dxl:HashCondList>
             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
               <dxl:Ident ColId="9" ColName="id" TypeMdid="0.23.1.0"/>
-              <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="18" ColName="id" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:Result>
+          <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.000568" Rows="1.000000" Width="12"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="27" Alias="name">
-                <dxl:OpExpr OperatorName="||" OperatorMdid="0.654.1.0" OperatorType="0.25.1.0">
-                  <dxl:Ident ColId="19" ColName="name" TypeMdid="0.25.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABA==" LintValue="2817148525"/>
-                </dxl:OpExpr>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="9" Alias="id">
-                <dxl:Ident ColId="9" ColName="id" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:OneTimeFilter/>
-            <dxl:HashJoin JoinType="Inner">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.000556" Rows="1.000000" Width="12"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="9" Alias="id">
-                  <dxl:Ident ColId="9" ColName="id" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="19" Alias="name">
-                  <dxl:Ident ColId="19" ColName="name" TypeMdid="0.25.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:JoinFilter/>
-              <dxl:HashCondList>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="18" ColName="id" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="9" ColName="id" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
-              </dxl:HashCondList>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000078" Rows="1.000000" Width="12"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="18" Alias="id">
-                    <dxl:Ident ColId="18" ColName="id" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="19" Alias="name">
-                    <dxl:Ident ColId="19" ColName="name" TypeMdid="0.25.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="18" ColName="id" TypeMdid="0.23.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
-                  </dxl:Comparison>
-                </dxl:Filter>
-                <dxl:TableDescriptor Mdid="0.16396.1.0" TableName="t3">
-                  <dxl:Columns>
-                    <dxl:Column ColId="18" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="19" Attno="2" ColName="name" TypeMdid="0.25.1.0" ColWidth="8"/>
-                    <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                    <dxl:Column ColId="21" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="22" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="23" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="24" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="25" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="26" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="1.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="9" Alias="id">
-                    <dxl:Ident ColId="9" ColName="id" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="9" ColName="id" TypeMdid="0.23.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
-                  </dxl:Comparison>
-                </dxl:Filter>
-                <dxl:TableDescriptor Mdid="0.16390.1.0" TableName="t2">
-                  <dxl:Columns>
-                    <dxl:Column ColId="9" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                    <dxl:Column ColId="12" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="13" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="14" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="15" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="16" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="17" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-            </dxl:HashJoin>
-          </dxl:Result>
-          <dxl:TableScan>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000078" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000570" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="id">
@@ -527,27 +428,129 @@
               <dxl:ProjElem ColId="1" Alias="name">
                 <dxl:Ident ColId="1" ColName="name" TypeMdid="0.25.1.0"/>
               </dxl:ProjElem>
+              <dxl:ProjElem ColId="9" Alias="id">
+                <dxl:Ident ColId="9" ColName="id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter>
+            <dxl:Filter/>
+            <dxl:JoinFilter/>
+            <dxl:HashCondList>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                 <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                <dxl:Ident ColId="9" ColName="id" TypeMdid="0.23.1.0"/>
               </dxl:Comparison>
-            </dxl:Filter>
-            <dxl:TableDescriptor Mdid="0.16384.1.0" TableName="t1">
-              <dxl:Columns>
-                <dxl:Column ColId="0" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                <dxl:Column ColId="1" Attno="2" ColName="name" TypeMdid="0.25.1.0" ColWidth="8"/>
-                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-              </dxl:Columns>
-            </dxl:TableDescriptor>
-          </dxl:TableScan>
+            </dxl:HashCondList>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000078" Rows="1.000000" Width="12"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="id">
+                  <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="name">
+                  <dxl:Ident ColId="1" ColName="name" TypeMdid="0.25.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                </dxl:Comparison>
+              </dxl:Filter>
+              <dxl:TableDescriptor Mdid="0.16384.1.0" TableName="t1">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="name" TypeMdid="0.25.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="1.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="9" Alias="id">
+                  <dxl:Ident ColId="9" ColName="id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="9" ColName="id" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                </dxl:Comparison>
+              </dxl:Filter>
+              <dxl:TableDescriptor Mdid="0.16390.1.0" TableName="t2">
+                <dxl:Columns>
+                  <dxl:Column ColId="9" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="12" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="13" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="14" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="15" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="16" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="17" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:HashJoin>
+          <dxl:Result>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000090" Rows="1.000000" Width="12"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="27" Alias="name">
+                <dxl:OpExpr OperatorName="||" OperatorMdid="0.654.1.0" OperatorType="0.25.1.0">
+                  <dxl:Ident ColId="19" ColName="name" TypeMdid="0.25.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABA==" LintValue="2817148525"/>
+                </dxl:OpExpr>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="18" Alias="id">
+                <dxl:Ident ColId="18" ColName="id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:OneTimeFilter/>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000078" Rows="1.000000" Width="12"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="18" Alias="id">
+                  <dxl:Ident ColId="18" ColName="id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="19" Alias="name">
+                  <dxl:Ident ColId="19" ColName="name" TypeMdid="0.25.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="18" ColName="id" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                </dxl:Comparison>
+              </dxl:Filter>
+              <dxl:TableDescriptor Mdid="0.16396.1.0" TableName="t3">
+                <dxl:Columns>
+                  <dxl:Column ColId="18" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="19" Attno="2" ColName="name" TypeMdid="0.25.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="21" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="22" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="23" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="24" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="25" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="26" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:Result>
         </dxl:HashJoin>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/JoinOnViewWithCastedColumn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinOnViewWithCastedColumn.mdp
@@ -1,0 +1,497 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Objective: Ensure that join on a view with a cast'd column can still be
+    considered for predicate push down. In the following scenario, the filter
+    should end up beneath the join.
+
+    Setup:
+      CREATE TABLE foo ( a text, b text);
+      CREATE TABLE bar ( c text, d text);
+      CREATE VIEW foobar AS SELECT foo.b::character varying(100) AS b, foo.a, bar.c, bar.d FROM foo JOIN bar ON foo.a = bar.c;
+      EXPLAIN SELECT * FROM foobar WHERE b = 'meh';
+
+                                                  QUERY PLAN
+      --------------------------------------------------------------------------------------------------
+       Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=32)
+         ->  Hash Join  (cost=0.00..862.00 rows=1 width=32)
+               Hash Cond: (foo.a = bar.c)
+               ->  Result  (cost=0.00..431.00 rows=1 width=16)
+                     Filter: ((("varchar"((foo.b)::character varying, 104, true)))::text = 'meh'::text)
+                     ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=16)
+               ->  Hash  (cost=431.00..431.00 rows=1 width=16)
+                     ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=16)
+       Optimizer: Pivotal Optimizer (GPORCA)
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1043.1.0" Name="varchar" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1015.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:MDCast Mdid="3.25.1.0;1043.1.0" Name="varchar" BinaryCoercible="true" SourceTypeId="0.25.1.0" DestinationTypeId="0.1043.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1009.1.0"/>
+        <dxl:MinAgg Mdid="0.2145.1.0"/>
+        <dxl:MaxAgg Mdid="0.2129.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.41158.1.0.1" Name="b" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.41158.1.0.0" Name="a" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBFunc Mdid="0.669.1.0" Name="varchar" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.1043.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:MDCast Mdid="3.25.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.25.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:MDCast Mdid="3.1043.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.1043.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:RelationStatistics Mdid="2.41158.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.41158.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.25.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.41164.1.0" Name="bar" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.41164.1.0" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="c" Attno="1" Mdid="0.25.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.41164.1.0.0" Name="c" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.98.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.25.1.0"/>
+        <dxl:RightType Mdid="0.25.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.67.1.0"/>
+        <dxl:Commutator Mdid="0.98.1.0"/>
+        <dxl:InverseOp Mdid="0.531.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7105.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1994.1.0"/>
+          <dxl:Opfamily Mdid="0.1995.1.0"/>
+          <dxl:Opfamily Mdid="0.2095.1.0"/>
+          <dxl:Opfamily Mdid="0.2229.1.0"/>
+          <dxl:Opfamily Mdid="0.4017.1.0"/>
+          <dxl:Opfamily Mdid="0.4056.1.0"/>
+          <dxl:Opfamily Mdid="0.7105.1.0"/>
+          <dxl:Opfamily Mdid="0.10018.1.0"/>
+          <dxl:Opfamily Mdid="0.10022.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="19" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="104"/>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.25.1.0"/>
+        <dxl:Ident ColId="10" ColName="c" TypeMdid="0.25.1.0"/>
+        <dxl:Ident ColId="11" ColName="d" TypeMdid="0.25.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+          <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+            <dxl:Ident ColId="19" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="104"/>
+          </dxl:Cast>
+          <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAB21laA==" LintValue="1828233457"/>
+        </dxl:Comparison>
+        <dxl:LogicalProject>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="19" Alias="b">
+              <dxl:FuncExpr FuncId="0.669.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0" TypeModifier="104">
+                <dxl:Cast TypeMdid="0.1043.1.0" FuncId="0.0.0.0">
+                  <dxl:Ident ColId="2" ColName="b" TypeMdid="0.25.1.0"/>
+                </dxl:Cast>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="104"/>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:FuncExpr>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:LogicalJoin JoinType="Inner">
+            <dxl:LogicalGet>
+              <dxl:TableDescriptor Mdid="0.41158.1.0" TableName="foo" ExecuteAsUser="10" LockMode="1">
+                <dxl:Columns>
+                  <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.25.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:LogicalGet>
+            <dxl:LogicalGet>
+              <dxl:TableDescriptor Mdid="0.41164.1.0" TableName="bar" ExecuteAsUser="10" LockMode="1">
+                <dxl:Columns>
+                  <dxl:Column ColId="10" Attno="1" ColName="c" TypeMdid="0.25.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="11" Attno="2" ColName="d" TypeMdid="0.25.1.0" ColWidth="8"/>
+                  <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="13" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="14" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="15" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="16" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="17" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="18" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:LogicalGet>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+              <dxl:Ident ColId="1" ColName="a" TypeMdid="0.25.1.0"/>
+              <dxl:Ident ColId="10" ColName="c" TypeMdid="0.25.1.0"/>
+            </dxl:Comparison>
+          </dxl:LogicalJoin>
+        </dxl:LogicalProject>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="8">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="862.001062" Rows="1.000000" Width="32"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="18" Alias="b">
+            <dxl:Ident ColId="18" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="104"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.25.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="9" Alias="c">
+            <dxl:Ident ColId="9" ColName="c" TypeMdid="0.25.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="10" Alias="d">
+            <dxl:Ident ColId="10" ColName="d" TypeMdid="0.25.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:HashJoin JoinType="Inner">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="862.000943" Rows="1.000000" Width="32"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="18" Alias="b">
+              <dxl:Ident ColId="18" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="104"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.25.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="9" Alias="c">
+              <dxl:Ident ColId="9" ColName="c" TypeMdid="0.25.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="10" Alias="d">
+              <dxl:Ident ColId="10" ColName="d" TypeMdid="0.25.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:JoinFilter/>
+          <dxl:HashCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.25.1.0"/>
+              <dxl:Ident ColId="9" ColName="c" TypeMdid="0.25.1.0"/>
+            </dxl:Comparison>
+          </dxl:HashCondList>
+          <dxl:Result>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000204" Rows="1.000000" Width="16"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.25.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="18" Alias="b">
+                <dxl:Ident ColId="18" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="104"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+                <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                  <dxl:Ident ColId="18" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="104"/>
+                </dxl:Cast>
+                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAB21laA==" LintValue="1828233457"/>
+              </dxl:Comparison>
+            </dxl:Filter>
+            <dxl:OneTimeFilter/>
+            <dxl:Result>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000171" Rows="1.000000" Width="16"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="18" Alias="b">
+                  <dxl:FuncExpr FuncId="0.669.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0" TypeModifier="104">
+                    <dxl:Cast TypeMdid="0.1043.1.0" FuncId="0.0.0.0">
+                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+                    </dxl:Cast>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="104"/>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:FuncExpr>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="0" Alias="a">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.25.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="16"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="a">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.25.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="b">
+                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.41158.1.0" TableName="foo" ExecuteAsUser="10" LockMode="1">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.25.1.0" ColWidth="8"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="8"/>
+                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:Result>
+          </dxl:Result>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="16"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="9" Alias="c">
+                <dxl:Ident ColId="9" ColName="c" TypeMdid="0.25.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="10" Alias="d">
+                <dxl:Ident ColId="10" ColName="d" TypeMdid="0.25.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="0.41164.1.0" TableName="bar" ExecuteAsUser="10" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.25.1.0" ColWidth="8"/>
+                <dxl:Column ColId="10" Attno="2" ColName="d" TypeMdid="0.25.1.0" ColWidth="8"/>
+                <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="12" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="13" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="14" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="17" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:HashJoin>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/JoinOnViewWithDisjoinCastedColumns.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinOnViewWithDisjoinCastedColumns.mdp
@@ -1,27 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Comment><![CDATA[
-    Objective: Ensure that join on a view with a cast'd column can still be
-    considered for predicate push down. In the following scenario, the filter
-    should end up beneath the join.
+    Objective: Ensure that join on a view with a project composed of 2 columns
+    from separate tables cannot be considered for predicate push down. In the
+    following scenario, the filter should end up *above* the join.
 
     Setup:
       CREATE TABLE foo (a text, b text);
       CREATE TABLE bar (c text, d text);
-      CREATE VIEW foobar AS SELECT foo.b::character varying(100) AS b, foo.a, bar.c, bar.d FROM foo JOIN bar ON foo.a = bar.c;
+      CREATE VIEW foobar AS SELECT concat(foo.b::character varying(100), d) AS b, foo.a, bar.c, bar.d FROM foo JOIN bar ON foo.a = bar.c;
       EXPLAIN SELECT * FROM foobar WHERE b = 'meh';
 
                                                   QUERY PLAN
-      --------------------------------------------------------------------------------------------------
+      ---------------------------------------------------------------------------------------------------
        Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=32)
-         ->  Hash Join  (cost=0.00..862.00 rows=1 width=32)
-               Hash Cond: (foo.a = bar.c)
-               ->  Result  (cost=0.00..431.00 rows=1 width=16)
-                     Filter: ((("varchar"((foo.b)::character varying, 104, true)))::text = 'meh'::text)
+         ->  Result  (cost=0.00..862.00 rows=1 width=32)
+               Filter: ((concat("varchar"((foo.b)::character varying, 104, true), bar.d)) = 'meh'::text)
+               ->  Hash Join  (cost=0.00..862.00 rows=1 width=32)
+                     Hash Cond: (foo.a = bar.c)
                      ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=16)
-               ->  Hash  (cost=431.00..431.00 rows=1 width=16)
-                     ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=16)
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=16)
+                           ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=16)
        Optimizer: Pivotal Optimizer (GPORCA)
+
+    Notice in the preprocessed query below that the project element stays above
+    the n-ary join. This is because the element references both "b" (1) and
+    "d" (10) which come from 2 different tables "foo" and "bar". Thus we
+    cannot push the project element above a single logical get.
+
+      +--CLogicalSelect
+         |--CLogicalProject
+         |  |--CLogicalNAryJoin
+         |  |  |--CLogicalGet "foo" ("foo"), Columns: ["a" (0), "b" (1), "ctid" (2), "xmin" (3), "cmin" (4), "xmax" (5), "cmax" (6), "tableoid" (7), "gp_segment_id" (8)] Key sets: {[2,8]}
+         |  |  |--CLogicalGet "bar" ("bar"), Columns: ["c" (9), "d" (10), "ctid" (11), "xmin" (12), "cmin" (13), "xmax" (14), "cmax" (15), "tableoid" (16), "gp_segment_id" (17)] Key sets: {[2,8]}
+         |  |  +--CScalarCmp (=)
+         |  |     |--CScalarIdent "a" (0)
+         |  |     +--CScalarIdent "c" (9)
+         |  +--CScalarProjectList
+         |     +--CScalarProjectElement "b" (18)
+         |        +--CScalarFunc (concat)
+         |           |--CScalarFunc (varchar)
+         |           |  |--CScalarCast
+         |           |  |  +--CScalarIdent "b" (1)
+         |           |  |--CScalarConst (104)
+         |           |  +--CScalarConst (1)
+         |           +--CScalarIdent "d" (10)
+         +--CScalarCmp (=)
+            |--CScalarIdent "b" (18)
+            +--CScalarConst (1828233457.000)
   ]]>
   </dxl:Comment>
   <dxl:Thread Id="0">
@@ -90,6 +116,7 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.16539.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
       <dxl:MDCast Mdid="3.25.1.0;1043.1.0" Name="varchar" BinaryCoercible="true" SourceTypeId="0.25.1.0" DestinationTypeId="0.1043.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
       <dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
         <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
@@ -108,8 +135,45 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:ColumnStatistics Mdid="1.41158.1.0.1" Name="b" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.41158.1.0.0" Name="a" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Relation Mdid="0.16539.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.25.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.16545.1.0.1" Name="d" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16545.1.0.0" Name="c" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
@@ -179,48 +243,8 @@
       <dxl:GPDBFunc Mdid="0.669.1.0" Name="varchar" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
         <dxl:ResultType Mdid="0.1043.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:MDCast Mdid="3.25.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.25.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
-      <dxl:MDCast Mdid="3.1043.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.1043.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
-      <dxl:RelationStatistics Mdid="2.41158.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
-      <dxl:Relation Mdid="0.41158.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
-        <dxl:Columns>
-          <dxl:Column Name="a" Attno="1" Mdid="0.25.1.0" Nullable="true" ColWidth="8">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="b" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="8">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-        </dxl:Columns>
-        <dxl:IndexInfoList/>
-        <dxl:Triggers/>
-        <dxl:CheckConstraints/>
-        <dxl:DistrOpfamilies>
-          <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
-        </dxl:DistrOpfamilies>
-      </dxl:Relation>
-      <dxl:RelationStatistics Mdid="2.41164.1.0" Name="bar" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
-      <dxl:Relation Mdid="0.41164.1.0" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+      <dxl:RelationStatistics Mdid="2.16545.1.0" Name="bar" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.16545.1.0" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
         <dxl:Columns>
           <dxl:Column Name="c" Attno="1" Mdid="0.25.1.0" Nullable="true" ColWidth="8">
             <dxl:DefaultValue/>
@@ -257,7 +281,9 @@
           <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:ColumnStatistics Mdid="1.41164.1.0.0" Name="c" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:MDCast Mdid="3.25.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.25.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:ColumnStatistics Mdid="1.16539.1.0.1" Name="b" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16539.1.0.0" Name="a" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:GPDBScalarOp Mdid="0.98.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.25.1.0"/>
         <dxl:RightType Mdid="0.25.1.0"/>
@@ -279,10 +305,13 @@
           <dxl:Opfamily Mdid="0.10022.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
+      <dxl:GPDBFunc Mdid="0.3058.1.0" Name="concat" ReturnsSet="false" Stability="Stable" DataAccess="NoSQL" IsStrict="false" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.25.1.0"/>
+      </dxl:GPDBFunc>
     </dxl:Metadata>
     <dxl:Query>
       <dxl:OutputColumns>
-        <dxl:Ident ColId="19" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="104"/>
+        <dxl:Ident ColId="19" ColName="b" TypeMdid="0.25.1.0"/>
         <dxl:Ident ColId="1" ColName="a" TypeMdid="0.25.1.0"/>
         <dxl:Ident ColId="10" ColName="c" TypeMdid="0.25.1.0"/>
         <dxl:Ident ColId="11" ColName="d" TypeMdid="0.25.1.0"/>
@@ -290,26 +319,27 @@
       <dxl:CTEList/>
       <dxl:LogicalSelect>
         <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
-          <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-            <dxl:Ident ColId="19" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="104"/>
-          </dxl:Cast>
+          <dxl:Ident ColId="19" ColName="b" TypeMdid="0.25.1.0"/>
           <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAB21laA==" LintValue="1828233457"/>
         </dxl:Comparison>
         <dxl:LogicalProject>
           <dxl:ProjList>
             <dxl:ProjElem ColId="19" Alias="b">
-              <dxl:FuncExpr FuncId="0.669.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0" TypeModifier="104">
-                <dxl:Cast TypeMdid="0.1043.1.0" FuncId="0.0.0.0">
-                  <dxl:Ident ColId="2" ColName="b" TypeMdid="0.25.1.0"/>
-                </dxl:Cast>
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="104"/>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              <dxl:FuncExpr FuncId="0.3058.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                <dxl:FuncExpr FuncId="0.669.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0" TypeModifier="104">
+                  <dxl:Cast TypeMdid="0.1043.1.0" FuncId="0.0.0.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.25.1.0"/>
+                  </dxl:Cast>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="104"/>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:FuncExpr>
+                <dxl:Ident ColId="11" ColName="d" TypeMdid="0.25.1.0"/>
               </dxl:FuncExpr>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:LogicalJoin JoinType="Inner">
             <dxl:LogicalGet>
-              <dxl:TableDescriptor Mdid="0.41158.1.0" TableName="foo" ExecuteAsUser="10" LockMode="1">
+              <dxl:TableDescriptor Mdid="0.16539.1.0" TableName="foo" ExecuteAsUser="10" LockMode="1">
                 <dxl:Columns>
                   <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.25.1.0" ColWidth="8"/>
                   <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="8"/>
@@ -324,7 +354,7 @@
               </dxl:TableDescriptor>
             </dxl:LogicalGet>
             <dxl:LogicalGet>
-              <dxl:TableDescriptor Mdid="0.41164.1.0" TableName="bar" ExecuteAsUser="10" LockMode="1">
+              <dxl:TableDescriptor Mdid="0.16545.1.0" TableName="bar" ExecuteAsUser="10" LockMode="1">
                 <dxl:Columns>
                   <dxl:Column ColId="10" Attno="1" ColName="c" TypeMdid="0.25.1.0" ColWidth="8"/>
                   <dxl:Column ColId="11" Attno="2" ColName="d" TypeMdid="0.25.1.0" ColWidth="8"/>
@@ -346,14 +376,14 @@
         </dxl:LogicalProject>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="8">
+    <dxl:Plan Id="0" SpaceSize="6">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.001062" Rows="1.000000" Width="32"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000968" Rows="1.000000" Width="32"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="18" Alias="b">
-            <dxl:Ident ColId="18" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="104"/>
+            <dxl:Ident ColId="18" ColName="b" TypeMdid="0.25.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="0" Alias="a">
             <dxl:Ident ColId="0" ColName="a" TypeMdid="0.25.1.0"/>
@@ -367,13 +397,13 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:HashJoin JoinType="Inner">
+        <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.000943" Rows="1.000000" Width="32"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000849" Rows="1.000000" Width="32"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="18" Alias="b">
-              <dxl:Ident ColId="18" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="104"/>
+              <dxl:Ident ColId="18" ColName="b" TypeMdid="0.25.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="0" Alias="a">
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.25.1.0"/>
@@ -385,41 +415,20 @@
               <dxl:Ident ColId="10" ColName="d" TypeMdid="0.25.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:JoinFilter/>
-          <dxl:HashCondList>
+          <dxl:Filter>
             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
-              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.25.1.0"/>
-              <dxl:Ident ColId="9" ColName="c" TypeMdid="0.25.1.0"/>
+              <dxl:Ident ColId="18" ColName="b" TypeMdid="0.25.1.0"/>
+              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAB21laA==" LintValue="1828233457"/>
             </dxl:Comparison>
-          </dxl:HashCondList>
+          </dxl:Filter>
+          <dxl:OneTimeFilter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000204" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000838" Rows="1.000000" Width="32"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="a">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.25.1.0"/>
-              </dxl:ProjElem>
               <dxl:ProjElem ColId="18" Alias="b">
-                <dxl:Ident ColId="18" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="104"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
-                <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                  <dxl:Ident ColId="18" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="104"/>
-                </dxl:Cast>
-                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAB21laA==" LintValue="1828233457"/>
-              </dxl:Comparison>
-            </dxl:Filter>
-            <dxl:OneTimeFilter/>
-            <dxl:Result>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000171" Rows="1.000000" Width="16"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="18" Alias="b">
+                <dxl:FuncExpr FuncId="0.3058.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
                   <dxl:FuncExpr FuncId="0.669.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0" TypeModifier="104">
                     <dxl:Cast TypeMdid="0.1043.1.0" FuncId="0.0.0.0">
                       <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
@@ -427,13 +436,47 @@
                     <dxl:ConstValue TypeMdid="0.23.1.0" Value="104"/>
                     <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                   </dxl:FuncExpr>
-                </dxl:ProjElem>
+                  <dxl:Ident ColId="10" ColName="d" TypeMdid="0.25.1.0"/>
+                </dxl:FuncExpr>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.25.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="9" Alias="c">
+                <dxl:Ident ColId="9" ColName="c" TypeMdid="0.25.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="10" Alias="d">
+                <dxl:Ident ColId="10" ColName="d" TypeMdid="0.25.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:OneTimeFilter/>
+            <dxl:HashJoin JoinType="Inner">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="862.000794" Rows="1.000000" Width="32"/>
+              </dxl:Properties>
+              <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.25.1.0"/>
                 </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="b">
+                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="9" Alias="c">
+                  <dxl:Ident ColId="9" ColName="c" TypeMdid="0.25.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="10" Alias="d">
+                  <dxl:Ident ColId="10" ColName="d" TypeMdid="0.25.1.0"/>
+                </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:OneTimeFilter/>
+              <dxl:JoinFilter/>
+              <dxl:HashCondList>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.25.1.0"/>
+                  <dxl:Ident ColId="9" ColName="c" TypeMdid="0.25.1.0"/>
+                </dxl:Comparison>
+              </dxl:HashCondList>
               <dxl:TableScan>
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="16"/>
@@ -447,7 +490,7 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="0.41158.1.0" TableName="foo" ExecuteAsUser="10" LockMode="1">
+                <dxl:TableDescriptor Mdid="0.16539.1.0" TableName="foo" ExecuteAsUser="10" LockMode="1">
                   <dxl:Columns>
                     <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.25.1.0" ColWidth="8"/>
                     <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="8"/>
@@ -461,36 +504,36 @@
                   </dxl:Columns>
                 </dxl:TableDescriptor>
               </dxl:TableScan>
-            </dxl:Result>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="16"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="9" Alias="c">
+                    <dxl:Ident ColId="9" ColName="c" TypeMdid="0.25.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="10" Alias="d">
+                    <dxl:Ident ColId="10" ColName="d" TypeMdid="0.25.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.16545.1.0" TableName="bar" ExecuteAsUser="10" LockMode="1">
+                  <dxl:Columns>
+                    <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.25.1.0" ColWidth="8"/>
+                    <dxl:Column ColId="10" Attno="2" ColName="d" TypeMdid="0.25.1.0" ColWidth="8"/>
+                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="12" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="13" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="14" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="15" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="16" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="17" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:HashJoin>
           </dxl:Result>
-          <dxl:TableScan>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="16"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="9" Alias="c">
-                <dxl:Ident ColId="9" ColName="c" TypeMdid="0.25.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="10" Alias="d">
-                <dxl:Ident ColId="10" ColName="d" TypeMdid="0.25.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="0.41164.1.0" TableName="bar" ExecuteAsUser="10" LockMode="1">
-              <dxl:Columns>
-                <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.25.1.0" ColWidth="8"/>
-                <dxl:Column ColId="10" Attno="2" ColName="d" TypeMdid="0.25.1.0" ColWidth="8"/>
-                <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                <dxl:Column ColId="12" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                <dxl:Column ColId="13" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                <dxl:Column ColId="14" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                <dxl:Column ColId="15" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                <dxl:Column ColId="16" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                <dxl:Column ColId="17" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-              </dxl:Columns>
-            </dxl:TableDescriptor>
-          </dxl:TableScan>
-        </dxl:HashJoin>
+        </dxl:Result>
       </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/JoinOnViewWithOverlappingCastedColumns.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinOnViewWithOverlappingCastedColumns.mdp
@@ -1,27 +1,76 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Comment><![CDATA[
-    Objective: Ensure that join on a view with a cast'd column can still be
-    considered for predicate push down. In the following scenario, the filter
-    should end up beneath the join.
+    Objective: Ensure that join on a view with a project composed of 2 columns
+    from same tables can be considered for predicate push down. In the
+    following scenario, the filter should end up below the join.
 
     Setup:
       CREATE TABLE foo (a text, b text);
       CREATE TABLE bar (c text, d text);
-      CREATE VIEW foobar AS SELECT foo.b::character varying(100) AS b, foo.a, bar.c, bar.d FROM foo JOIN bar ON foo.a = bar.c;
+      CREATE VIEW foobar AS SELECT concat(foo.b::character varying(100), a) AS b, foo.a, bar.c, bar.d FROM foo JOIN bar ON foo.a = bar.c;
       EXPLAIN SELECT * FROM foobar WHERE b = 'meh';
 
-                                                  QUERY PLAN
-      --------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN
+      ---------------------------------------------------------------------------------------------------------
        Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=32)
          ->  Hash Join  (cost=0.00..862.00 rows=1 width=32)
                Hash Cond: (foo.a = bar.c)
                ->  Result  (cost=0.00..431.00 rows=1 width=16)
-                     Filter: ((("varchar"((foo.b)::character varying, 104, true)))::text = 'meh'::text)
+                     Filter: ((concat("varchar"((foo.b)::character varying, 104, true), foo.a)) = 'meh'::text)
                      ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=16)
                ->  Hash  (cost=431.00..431.00 rows=1 width=16)
                      ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=16)
        Optimizer: Pivotal Optimizer (GPORCA)
+
+    Notice in the preprocessed query below that the project element is pushed
+    below the n-ary join. This is because even though the element references
+    both "b" (1) and "a" (0), both columns come from the same table "foo". Thus
+    we *can* push the project element above a single logical get.
+
+      Algebrized query:
+      +--CLogicalSelect
+         |--CLogicalProject
+         |  |--CLogicalNAryJoin
+         |  |  |--CLogicalGet "foo" ("foo"), Columns: ["a" (0), "b" (1), "ctid" (2), "xmin" (3), "cmin" (4), "xmax" (5), "cmax" (6), "tableoid" (7), "gp_segment_id" (8)] Key sets: {[2,8]}
+         |  |  |--CLogicalGet "bar" ("bar"), Columns: ["c" (9), "d" (10), "ctid" (11), "xmin" (12), "cmin" (13), "xmax" (14), "cmax" (15), "tableoid" (16), "gp_segment_id" (17)] Key sets: {[2,8]}
+         |  |  +--CScalarCmp (=)
+         |  |     |--CScalarIdent "a" (0)
+         |  |     +--CScalarIdent "c" (9)
+         |  +--CScalarProjectList
+         |     +--CScalarProjectElement "b" (18)
+         |        +--CScalarFunc (concat)
+         |           |--CScalarFunc (varchar)
+         |           |  |--CScalarCast
+         |           |  |  +--CScalarIdent "b" (1)
+         |           |  |--CScalarConst (104)
+         |           |  +--CScalarConst (1)
+         |           +--CScalarIdent "a" (0)
+         +--CScalarCmp (=)
+            |--CScalarIdent "b" (18)
+            +--CScalarConst (1828233457.000)
+
+      Algebrized preprocessed query:
+      +--CLogicalNAryJoin
+         |--CLogicalSelect
+         |  |--CLogicalProject
+         |  |  |--CLogicalGet "foo" ("foo"), Columns: ["a" (0), "b" (1), "ctid" (2), "xmin" (3), "cmin" (4), "xmax" (5), "cmax" (6), "tableoid" (7), "gp_segment_id" (8)] Key sets: {[2,8]}
+         |  |  +--CScalarProjectList
+         |  |     +--CScalarProjectElement "b" (18)
+         |  |        +--CScalarFunc (concat)
+         |  |           |--CScalarFunc (varchar)
+         |  |           |  |--CScalarCast
+         |  |           |  |  +--CScalarIdent "b" (1)
+         |  |           |  |--CScalarConst (104)
+         |  |           |  +--CScalarConst (1)
+         |  |           +--CScalarIdent "a" (0)
+         |  +--CScalarCmp (=)
+         |     |--CScalarIdent "b" (18)
+         |     +--CScalarConst (1828233457.000)
+         |--CLogicalGet "bar" ("bar"), Columns: ["c" (9), "d" (10), "ctid" (11), "xmin" (12), "cmin" (13), "xmax" (14), "cmax" (15), "tableoid" (16), "gp_segment_id" (17)] Key sets: {[2,8]}
+         +--CScalarCmp (=)
+            |--CScalarIdent "a" (0)
+            +--CScalarIdent "c" (9)
   ]]>
   </dxl:Comment>
   <dxl:Thread Id="0">
@@ -39,6 +88,7 @@
       <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:ColumnStatistics Mdid="1.16562.1.0.0" Name="c" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
@@ -108,8 +158,6 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:ColumnStatistics Mdid="1.41158.1.0.1" Name="b" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.41158.1.0.0" Name="a" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
@@ -179,10 +227,8 @@
       <dxl:GPDBFunc Mdid="0.669.1.0" Name="varchar" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
         <dxl:ResultType Mdid="0.1043.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:MDCast Mdid="3.25.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.25.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
-      <dxl:MDCast Mdid="3.1043.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.1043.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
-      <dxl:RelationStatistics Mdid="2.41158.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
-      <dxl:Relation Mdid="0.41158.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+      <dxl:RelationStatistics Mdid="2.16556.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.16556.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
         <dxl:Columns>
           <dxl:Column Name="a" Attno="1" Mdid="0.25.1.0" Nullable="true" ColWidth="8">
             <dxl:DefaultValue/>
@@ -219,8 +265,8 @@
           <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:RelationStatistics Mdid="2.41164.1.0" Name="bar" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
-      <dxl:Relation Mdid="0.41164.1.0" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+      <dxl:RelationStatistics Mdid="2.16562.1.0" Name="bar" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.16562.1.0" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
         <dxl:Columns>
           <dxl:Column Name="c" Attno="1" Mdid="0.25.1.0" Nullable="true" ColWidth="8">
             <dxl:DefaultValue/>
@@ -257,7 +303,7 @@
           <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:ColumnStatistics Mdid="1.41164.1.0.0" Name="c" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:MDCast Mdid="3.25.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.25.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
       <dxl:GPDBScalarOp Mdid="0.98.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.25.1.0"/>
         <dxl:RightType Mdid="0.25.1.0"/>
@@ -279,10 +325,15 @@
           <dxl:Opfamily Mdid="0.10022.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
+      <dxl:GPDBFunc Mdid="0.3058.1.0" Name="concat" ReturnsSet="false" Stability="Stable" DataAccess="NoSQL" IsStrict="false" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.25.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:ColumnStatistics Mdid="1.16556.1.0.1" Name="b" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16556.1.0.0" Name="a" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
     </dxl:Metadata>
     <dxl:Query>
       <dxl:OutputColumns>
-        <dxl:Ident ColId="19" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="104"/>
+        <dxl:Ident ColId="19" ColName="b" TypeMdid="0.25.1.0"/>
         <dxl:Ident ColId="1" ColName="a" TypeMdid="0.25.1.0"/>
         <dxl:Ident ColId="10" ColName="c" TypeMdid="0.25.1.0"/>
         <dxl:Ident ColId="11" ColName="d" TypeMdid="0.25.1.0"/>
@@ -290,26 +341,27 @@
       <dxl:CTEList/>
       <dxl:LogicalSelect>
         <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
-          <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-            <dxl:Ident ColId="19" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="104"/>
-          </dxl:Cast>
+          <dxl:Ident ColId="19" ColName="b" TypeMdid="0.25.1.0"/>
           <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAB21laA==" LintValue="1828233457"/>
         </dxl:Comparison>
         <dxl:LogicalProject>
           <dxl:ProjList>
             <dxl:ProjElem ColId="19" Alias="b">
-              <dxl:FuncExpr FuncId="0.669.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0" TypeModifier="104">
-                <dxl:Cast TypeMdid="0.1043.1.0" FuncId="0.0.0.0">
-                  <dxl:Ident ColId="2" ColName="b" TypeMdid="0.25.1.0"/>
-                </dxl:Cast>
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="104"/>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              <dxl:FuncExpr FuncId="0.3058.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                <dxl:FuncExpr FuncId="0.669.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0" TypeModifier="104">
+                  <dxl:Cast TypeMdid="0.1043.1.0" FuncId="0.0.0.0">
+                    <dxl:Ident ColId="2" ColName="b" TypeMdid="0.25.1.0"/>
+                  </dxl:Cast>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="104"/>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:FuncExpr>
+                <dxl:Ident ColId="1" ColName="a" TypeMdid="0.25.1.0"/>
               </dxl:FuncExpr>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:LogicalJoin JoinType="Inner">
             <dxl:LogicalGet>
-              <dxl:TableDescriptor Mdid="0.41158.1.0" TableName="foo" ExecuteAsUser="10" LockMode="1">
+              <dxl:TableDescriptor Mdid="0.16556.1.0" TableName="foo" ExecuteAsUser="10" LockMode="1">
                 <dxl:Columns>
                   <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.25.1.0" ColWidth="8"/>
                   <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="8"/>
@@ -324,7 +376,7 @@
               </dxl:TableDescriptor>
             </dxl:LogicalGet>
             <dxl:LogicalGet>
-              <dxl:TableDescriptor Mdid="0.41164.1.0" TableName="bar" ExecuteAsUser="10" LockMode="1">
+              <dxl:TableDescriptor Mdid="0.16562.1.0" TableName="bar" ExecuteAsUser="10" LockMode="1">
                 <dxl:Columns>
                   <dxl:Column ColId="10" Attno="1" ColName="c" TypeMdid="0.25.1.0" ColWidth="8"/>
                   <dxl:Column ColId="11" Attno="2" ColName="d" TypeMdid="0.25.1.0" ColWidth="8"/>
@@ -353,7 +405,7 @@
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="18" Alias="b">
-            <dxl:Ident ColId="18" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="104"/>
+            <dxl:Ident ColId="18" ColName="b" TypeMdid="0.25.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="0" Alias="a">
             <dxl:Ident ColId="0" ColName="a" TypeMdid="0.25.1.0"/>
@@ -373,7 +425,7 @@
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="18" Alias="b">
-              <dxl:Ident ColId="18" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="104"/>
+              <dxl:Ident ColId="18" ColName="b" TypeMdid="0.25.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="0" Alias="a">
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.25.1.0"/>
@@ -402,14 +454,12 @@
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.25.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="18" Alias="b">
-                <dxl:Ident ColId="18" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="104"/>
+                <dxl:Ident ColId="18" ColName="b" TypeMdid="0.25.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
-                <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                  <dxl:Ident ColId="18" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="104"/>
-                </dxl:Cast>
+                <dxl:Ident ColId="18" ColName="b" TypeMdid="0.25.1.0"/>
                 <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAB21laA==" LintValue="1828233457"/>
               </dxl:Comparison>
             </dxl:Filter>
@@ -420,12 +470,15 @@
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="18" Alias="b">
-                  <dxl:FuncExpr FuncId="0.669.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0" TypeModifier="104">
-                    <dxl:Cast TypeMdid="0.1043.1.0" FuncId="0.0.0.0">
-                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
-                    </dxl:Cast>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="104"/>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  <dxl:FuncExpr FuncId="0.3058.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                    <dxl:FuncExpr FuncId="0.669.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0" TypeModifier="104">
+                      <dxl:Cast TypeMdid="0.1043.1.0" FuncId="0.0.0.0">
+                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+                      </dxl:Cast>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="104"/>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:FuncExpr>
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.25.1.0"/>
                   </dxl:FuncExpr>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -447,7 +500,7 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="0.41158.1.0" TableName="foo" ExecuteAsUser="10" LockMode="1">
+                <dxl:TableDescriptor Mdid="0.16556.1.0" TableName="foo" ExecuteAsUser="10" LockMode="1">
                   <dxl:Columns>
                     <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.25.1.0" ColWidth="8"/>
                     <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="8"/>
@@ -476,7 +529,7 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="0.41164.1.0" TableName="bar" ExecuteAsUser="10" LockMode="1">
+            <dxl:TableDescriptor Mdid="0.16562.1.0" TableName="bar" ExecuteAsUser="10" LockMode="1">
               <dxl:Columns>
                 <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.25.1.0" ColWidth="8"/>
                 <dxl:Column ColId="10" Attno="2" ColName="d" TypeMdid="0.25.1.0" ColWidth="8"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Col-Const-Pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Col-Const-Pred.mdp
@@ -2110,10 +2110,10 @@
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1028">
-      <dxl:Result>
+    <dxl:Plan Id="0" SpaceSize="248">
+      <dxl:Sort SortDiscardDuplicates="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="69941.462832" Rows="896.720000" Width="238"/>
+          <dxl:Cost StartupCost="0" TotalCost="39257.229088" Rows="896.720000" Width="242"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="36" Alias="tableoid">
@@ -2138,68 +2138,7 @@
             <dxl:Ident ColId="1" ColName="relnamespace" TypeMdid="0.26.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="100" Alias="rolname">
-            <dxl:SubPlan TypeMdid="0.19.1.0" SubPlanType="ScalarSubPlan">
-              <dxl:TestExpr/>
-              <dxl:ParamList>
-                <dxl:Param ColId="3" ColName="relowner" TypeMdid="0.26.1.0"/>
-              </dxl:ParamList>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.059266" Rows="1.000000" Width="64"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="74" Alias="rolname">
-                    <dxl:Ident ColId="74" ColName="rolname" TypeMdid="0.19.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.059266" Rows="1.000000" Width="64"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="99" Alias="rolpassword">
-                      <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABWI=" LintValue="160449068"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="74" Alias="rolname">
-                      <dxl:Ident ColId="74" ColName="rolname" TypeMdid="0.19.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                  <dxl:TableScan>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.059202" Rows="1.000000" Width="64"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="74" Alias="rolname">
-                        <dxl:Ident ColId="74" ColName="rolname" TypeMdid="0.19.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
-                        <dxl:Ident ColId="92" ColName="oid" TypeMdid="0.26.1.0"/>
-                        <dxl:Ident ColId="3" ColName="relowner" TypeMdid="0.26.1.0"/>
-                      </dxl:Comparison>
-                    </dxl:Filter>
-                    <dxl:TableDescriptor Mdid="0.1260.1.1" TableName="pg_authid">
-                      <dxl:Columns>
-                        <dxl:Column ColId="74" Attno="1" ColName="rolname" TypeMdid="0.19.1.0"/>
-                        <dxl:Column ColId="91" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        <dxl:Column ColId="92" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="93" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="94" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="95" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="96" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="97" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="98" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
-                </dxl:Result>
-              </dxl:Result>
-            </dxl:SubPlan>
+            <dxl:Ident ColId="100" ColName="rolname" TypeMdid="0.19.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="18" Alias="relchecks">
             <dxl:Ident ColId="18" ColName="relchecks" TypeMdid="0.21.1.0"/>
@@ -2217,10 +2156,7 @@
             <dxl:Ident ColId="23" ColName="relhasoids" TypeMdid="0.16.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="101" Alias="relistoasted">
-            <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.608.1.0">
-              <dxl:Ident ColId="9" ColName="reltoastrelid" TypeMdid="0.26.1.0"/>
-              <dxl:ConstValue TypeMdid="0.26.1.0" Value="0"/>
-            </dxl:Comparison>
+            <dxl:Ident ColId="101" ColName="relistoasted" TypeMdid="0.16.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="42" Alias="owning_tab">
             <dxl:Ident ColId="42" ColName="refobjid" TypeMdid="0.26.1.0"/>
@@ -2229,73 +2165,34 @@
             <dxl:Ident ColId="43" ColName="refobjsubid" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="117" Alias="reltablespace">
-            <dxl:SubPlan TypeMdid="0.19.1.0" SubPlanType="ScalarSubPlan">
-              <dxl:TestExpr/>
-              <dxl:ParamList>
-                <dxl:Param ColId="6" ColName="reltablespace" TypeMdid="0.26.1.0"/>
-              </dxl:ParamList>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.131851" Rows="1.000000" Width="64"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="102" Alias="spcname">
-                    <dxl:Ident ColId="102" ColName="spcname" TypeMdid="0.19.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
-                    <dxl:Ident ColId="110" ColName="oid" TypeMdid="0.26.1.0"/>
-                    <dxl:Ident ColId="6" ColName="reltablespace" TypeMdid="0.26.1.0"/>
-                  </dxl:Comparison>
-                </dxl:Filter>
-                <dxl:TableDescriptor Mdid="0.1213.1.1" TableName="pg_tablespace">
-                  <dxl:Columns>
-                    <dxl:Column ColId="102" Attno="1" ColName="spcname" TypeMdid="0.19.1.0"/>
-                    <dxl:Column ColId="109" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="110" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="111" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="112" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="113" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="114" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="115" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="116" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-            </dxl:SubPlan>
+            <dxl:Ident ColId="117" ColName="reltablespace" TypeMdid="0.19.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="118" Alias="reloptions">
-            <dxl:FuncExpr FuncId="0.395.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
-              <dxl:Ident ColId="29" ColName="reloptions" TypeMdid="0.1009.1.0"/>
-              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABUI=" LintValue="160711212"/>
-            </dxl:FuncExpr>
+            <dxl:Ident ColId="118" ColName="reloptions" TypeMdid="0.25.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:OneTimeFilter/>
-        <dxl:Sort SortDiscardDuplicates="false">
+        <dxl:SortingColumnList>
+          <dxl:SortingColumn ColId="31" SortOperatorMdid="0.609.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+        </dxl:SortingColumnList>
+        <dxl:LimitCount/>
+        <dxl:LimitOffset/>
+        <dxl:HashJoin JoinType="Right">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="69941.159741" Rows="1000.000000" Width="241"/>
+            <dxl:Cost StartupCost="0" TotalCost="39245.160443" Rows="896.720000" Width="242"/>
           </dxl:Properties>
           <dxl:ProjList>
+            <dxl:ProjElem ColId="36" Alias="tableoid">
+              <dxl:Ident ColId="36" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="31" Alias="oid">
+              <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
+            </dxl:ProjElem>
             <dxl:ProjElem ColId="0" Alias="relname">
               <dxl:Ident ColId="0" ColName="relname" TypeMdid="0.19.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="1" Alias="relnamespace">
-              <dxl:Ident ColId="1" ColName="relnamespace" TypeMdid="0.26.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="3" Alias="relowner">
-              <dxl:Ident ColId="3" ColName="relowner" TypeMdid="0.26.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="6" Alias="reltablespace">
-              <dxl:Ident ColId="6" ColName="reltablespace" TypeMdid="0.26.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="9" Alias="reltoastrelid">
-              <dxl:Ident ColId="9" ColName="reltoastrelid" TypeMdid="0.26.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="13" Alias="relhasindex">
-              <dxl:Ident ColId="13" ColName="relhasindex" TypeMdid="0.16.1.0"/>
+            <dxl:ProjElem ColId="28" Alias="relacl">
+              <dxl:Ident ColId="28" ColName="relacl" TypeMdid="0.1034.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="15" Alias="relkind">
               <dxl:Ident ColId="15" ColName="relkind" TypeMdid="0.18.1.0"/>
@@ -2303,29 +2200,29 @@
             <dxl:ProjElem ColId="16" Alias="relstorage">
               <dxl:Ident ColId="16" ColName="relstorage" TypeMdid="0.18.1.0"/>
             </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="relnamespace">
+              <dxl:Ident ColId="1" ColName="relnamespace" TypeMdid="0.26.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="100" Alias="rolname">
+              <dxl:Ident ColId="100" ColName="rolname" TypeMdid="0.19.1.0"/>
+            </dxl:ProjElem>
             <dxl:ProjElem ColId="18" Alias="relchecks">
               <dxl:Ident ColId="18" ColName="relchecks" TypeMdid="0.21.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="19" Alias="reltriggers">
               <dxl:Ident ColId="19" ColName="reltriggers" TypeMdid="0.21.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="23" Alias="relhasoids">
-              <dxl:Ident ColId="23" ColName="relhasoids" TypeMdid="0.16.1.0"/>
+            <dxl:ProjElem ColId="13" Alias="relhasindex">
+              <dxl:Ident ColId="13" ColName="relhasindex" TypeMdid="0.16.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="25" Alias="relhasrules">
               <dxl:Ident ColId="25" ColName="relhasrules" TypeMdid="0.16.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="28" Alias="relacl">
-              <dxl:Ident ColId="28" ColName="relacl" TypeMdid="0.1034.1.0"/>
+            <dxl:ProjElem ColId="23" Alias="relhasoids">
+              <dxl:Ident ColId="23" ColName="relhasoids" TypeMdid="0.16.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="29" Alias="reloptions">
-              <dxl:Ident ColId="29" ColName="reloptions" TypeMdid="0.1009.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="31" Alias="oid">
-              <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="36" Alias="tableoid">
-              <dxl:Ident ColId="36" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:ProjElem ColId="101" Alias="relistoasted">
+              <dxl:Ident ColId="101" ColName="relistoasted" TypeMdid="0.16.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="42" Alias="refobjid">
               <dxl:Ident ColId="42" ColName="refobjid" TypeMdid="0.26.1.0"/>
@@ -2333,32 +2230,209 @@
             <dxl:ProjElem ColId="43" Alias="refobjsubid">
               <dxl:Ident ColId="43" ColName="refobjsubid" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
+            <dxl:ProjElem ColId="117" Alias="reltablespace">
+              <dxl:Ident ColId="117" ColName="reltablespace" TypeMdid="0.19.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="118" Alias="reloptions">
+              <dxl:Ident ColId="118" ColName="reloptions" TypeMdid="0.25.1.0"/>
+            </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:SortingColumnList>
-            <dxl:SortingColumn ColId="31" SortOperatorMdid="0.609.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-          </dxl:SortingColumnList>
-          <dxl:LimitCount/>
-          <dxl:LimitOffset/>
-          <dxl:HashJoin JoinType="Right">
+          <dxl:JoinFilter>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.92.1.0">
+              <dxl:Ident ColId="15" ColName="relkind" TypeMdid="0.18.1.0"/>
+              <dxl:ConstValue TypeMdid="0.18.1.0" Value="Uw=="/>
+            </dxl:Comparison>
+          </dxl:JoinFilter>
+          <dxl:HashCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+              <dxl:Ident ColId="38" ColName="classid" TypeMdid="0.26.1.0"/>
+              <dxl:Ident ColId="36" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+              <dxl:Ident ColId="39" ColName="objid" TypeMdid="0.26.1.0"/>
+              <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+              <dxl:Ident ColId="41" ColName="refclassid" TypeMdid="0.26.1.0"/>
+              <dxl:Ident ColId="36" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            </dxl:Comparison>
+          </dxl:HashCondList>
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1295.347540" Rows="896.720000" Width="145"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.642269" Rows="2240.800000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
+              <dxl:ProjElem ColId="38" Alias="classid">
+                <dxl:Ident ColId="38" ColName="classid" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="39" Alias="objid">
+                <dxl:Ident ColId="39" ColName="objid" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="41" Alias="refclassid">
+                <dxl:Ident ColId="41" ColName="refclassid" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="42" Alias="refobjid">
+                <dxl:Ident ColId="42" ColName="refobjid" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="43" Alias="refobjsubid">
+                <dxl:Ident ColId="43" ColName="refobjsubid" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:And>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="40" ColName="objsubid" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                </dxl:Comparison>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.92.1.0">
+                  <dxl:Ident ColId="44" ColName="deptype" TypeMdid="0.18.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.18.1.0" Value="YQ=="/>
+                </dxl:Comparison>
+              </dxl:And>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="0.2608.1.1" TableName="pg_depend">
+              <dxl:Columns>
+                <dxl:Column ColId="38" Attno="1" ColName="classid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="39" Attno="2" ColName="objid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="40" Attno="3" ColName="objsubid" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="41" Attno="4" ColName="refclassid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="42" Attno="5" ColName="refobjid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="43" Attno="6" ColName="refobjsubid" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="44" Attno="7" ColName="deptype" TypeMdid="0.18.1.0"/>
+                <dxl:Column ColId="45" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="46" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="47" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="48" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="49" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="50" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="51" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:Result>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="38811.557394" Rows="1.000000" Width="234"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="100" Alias="rolname">
+                <dxl:SubPlan TypeMdid="0.19.1.0" SubPlanType="ScalarSubPlan">
+                  <dxl:TestExpr/>
+                  <dxl:ParamList>
+                    <dxl:Param ColId="3" ColName="relowner" TypeMdid="0.26.1.0"/>
+                  </dxl:ParamList>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000328" Rows="1.000000" Width="64"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="74" Alias="rolname">
+                        <dxl:Ident ColId="74" ColName="rolname" TypeMdid="0.19.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000328" Rows="1.000000" Width="64"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="99" Alias="rolpassword">
+                          <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABWI=" LintValue="160449068"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="74" Alias="rolname">
+                          <dxl:Ident ColId="74" ColName="rolname" TypeMdid="0.19.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000264" Rows="1.000000" Width="64"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="74" Alias="rolname">
+                            <dxl:Ident ColId="74" ColName="rolname" TypeMdid="0.19.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+                            <dxl:Ident ColId="92" ColName="oid" TypeMdid="0.26.1.0"/>
+                            <dxl:Ident ColId="3" ColName="relowner" TypeMdid="0.26.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:Filter>
+                        <dxl:TableDescriptor Mdid="0.1260.1.1" TableName="pg_authid">
+                          <dxl:Columns>
+                            <dxl:Column ColId="74" Attno="1" ColName="rolname" TypeMdid="0.19.1.0"/>
+                            <dxl:Column ColId="91" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="92" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="93" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="94" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="95" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="96" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="97" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="98" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                    </dxl:Result>
+                  </dxl:Result>
+                </dxl:SubPlan>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="101" Alias="relistoasted">
+                <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.608.1.0">
+                  <dxl:Ident ColId="9" ColName="reltoastrelid" TypeMdid="0.26.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.26.1.0" Value="0"/>
+                </dxl:Comparison>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="117" Alias="reltablespace">
+                <dxl:SubPlan TypeMdid="0.19.1.0" SubPlanType="ScalarSubPlan">
+                  <dxl:TestExpr/>
+                  <dxl:ParamList>
+                    <dxl:Param ColId="6" ColName="reltablespace" TypeMdid="0.26.1.0"/>
+                  </dxl:ParamList>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.131851" Rows="1.000000" Width="64"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="102" Alias="spcname">
+                        <dxl:Ident ColId="102" ColName="spcname" TypeMdid="0.19.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+                        <dxl:Ident ColId="110" ColName="oid" TypeMdid="0.26.1.0"/>
+                        <dxl:Ident ColId="6" ColName="reltablespace" TypeMdid="0.26.1.0"/>
+                      </dxl:Comparison>
+                    </dxl:Filter>
+                    <dxl:TableDescriptor Mdid="0.1213.1.1" TableName="pg_tablespace">
+                      <dxl:Columns>
+                        <dxl:Column ColId="102" Attno="1" ColName="spcname" TypeMdid="0.19.1.0"/>
+                        <dxl:Column ColId="109" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="110" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="111" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="112" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="113" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="114" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="115" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="116" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:SubPlan>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="118" Alias="reloptions">
+                <dxl:FuncExpr FuncId="0.395.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                  <dxl:Ident ColId="29" ColName="reloptions" TypeMdid="0.1009.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABUI=" LintValue="160711212"/>
+                </dxl:FuncExpr>
+              </dxl:ProjElem>
               <dxl:ProjElem ColId="0" Alias="relname">
                 <dxl:Ident ColId="0" ColName="relname" TypeMdid="0.19.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="1" Alias="relnamespace">
                 <dxl:Ident ColId="1" ColName="relnamespace" TypeMdid="0.26.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="3" Alias="relowner">
-                <dxl:Ident ColId="3" ColName="relowner" TypeMdid="0.26.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="6" Alias="reltablespace">
-                <dxl:Ident ColId="6" ColName="reltablespace" TypeMdid="0.26.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="9" Alias="reltoastrelid">
-                <dxl:Ident ColId="9" ColName="reltoastrelid" TypeMdid="0.26.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="13" Alias="relhasindex">
                 <dxl:Ident ColId="13" ColName="relhasindex" TypeMdid="0.16.1.0"/>
@@ -2384,95 +2458,15 @@
               <dxl:ProjElem ColId="28" Alias="relacl">
                 <dxl:Ident ColId="28" ColName="relacl" TypeMdid="0.1034.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="29" Alias="reloptions">
-                <dxl:Ident ColId="29" ColName="reloptions" TypeMdid="0.1009.1.0"/>
-              </dxl:ProjElem>
               <dxl:ProjElem ColId="31" Alias="oid">
                 <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="36" Alias="tableoid">
                 <dxl:Ident ColId="36" ColName="tableoid" TypeMdid="0.26.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="42" Alias="refobjid">
-                <dxl:Ident ColId="42" ColName="refobjid" TypeMdid="0.26.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="43" Alias="refobjsubid">
-                <dxl:Ident ColId="43" ColName="refobjsubid" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:JoinFilter>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.92.1.0">
-                <dxl:Ident ColId="15" ColName="relkind" TypeMdid="0.18.1.0"/>
-                <dxl:ConstValue TypeMdid="0.18.1.0" Value="Uw=="/>
-              </dxl:Comparison>
-            </dxl:JoinFilter>
-            <dxl:HashCondList>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
-                <dxl:Ident ColId="38" ColName="classid" TypeMdid="0.26.1.0"/>
-                <dxl:Ident ColId="36" ColName="tableoid" TypeMdid="0.26.1.0"/>
-              </dxl:Comparison>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
-                <dxl:Ident ColId="39" ColName="objid" TypeMdid="0.26.1.0"/>
-                <dxl:Ident ColId="31" ColName="oid" TypeMdid="0.26.1.0"/>
-              </dxl:Comparison>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
-                <dxl:Ident ColId="41" ColName="refclassid" TypeMdid="0.26.1.0"/>
-                <dxl:Ident ColId="36" ColName="tableoid" TypeMdid="0.26.1.0"/>
-              </dxl:Comparison>
-            </dxl:HashCondList>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.642269" Rows="2240.800000" Width="20"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="38" Alias="classid">
-                  <dxl:Ident ColId="38" ColName="classid" TypeMdid="0.26.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="39" Alias="objid">
-                  <dxl:Ident ColId="39" ColName="objid" TypeMdid="0.26.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="41" Alias="refclassid">
-                  <dxl:Ident ColId="41" ColName="refclassid" TypeMdid="0.26.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="42" Alias="refobjid">
-                  <dxl:Ident ColId="42" ColName="refobjid" TypeMdid="0.26.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="43" Alias="refobjsubid">
-                  <dxl:Ident ColId="43" ColName="refobjsubid" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter>
-                <dxl:And>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="40" ColName="objsubid" TypeMdid="0.23.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                  </dxl:Comparison>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.92.1.0">
-                    <dxl:Ident ColId="44" ColName="deptype" TypeMdid="0.18.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.18.1.0" Value="YQ=="/>
-                  </dxl:Comparison>
-                </dxl:And>
-              </dxl:Filter>
-              <dxl:TableDescriptor Mdid="0.2608.1.1" TableName="pg_depend">
-                <dxl:Columns>
-                  <dxl:Column ColId="38" Attno="1" ColName="classid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="39" Attno="2" ColName="objid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="40" Attno="3" ColName="objsubid" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="41" Attno="4" ColName="refclassid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="42" Attno="5" ColName="refobjid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="43" Attno="6" ColName="refobjsubid" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="44" Attno="7" ColName="deptype" TypeMdid="0.18.1.0"/>
-                  <dxl:Column ColId="45" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="46" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="47" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="48" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="49" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="50" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="51" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
+            <dxl:OneTimeFilter/>
             <dxl:HashJoin JoinType="LeftAntiSemiJoinNotIn">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="862.051129" Rows="1.000000" Width="137"/>
@@ -2652,9 +2646,9 @@
                 </dxl:TableDescriptor>
               </dxl:TableScan>
             </dxl:HashJoin>
-          </dxl:HashJoin>
-        </dxl:Sort>
-      </dxl:Result>
+          </dxl:Result>
+        </dxl:HashJoin>
+      </dxl:Sort>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/MotionHazard-MaterializeUnderResult.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MotionHazard-MaterializeUnderResult.mdp
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+<dxl:Comment><![CDATA[
 create table tab1(i int , j int , k varchar(10000));
 create table tab2(i int , j int , k varchar(10000));
 create table tab3(i int , j int , k varchar(10000));
@@ -11,30 +12,26 @@ analyze tab2;
 analyze tab3;
 set optimizer_penalize_broadcast_threshold=900;
 explain select tab3.k, (select tab2.k from tab2 where tab2.i = tab1.i limit 1) as subq from tab3 left join tab1 on tab1.j = tab3.j;
-					QUERY PLAN
-
- Result  (cost=0.00..190574955.42 rows=1664667 width=16)
-   ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..190574875.52 rows=1000 width=16)
-         ->  Result  (cost=0.00..190574875.46 rows=334 width=16)
-               ->  Hash Left Join  (cost=0.00..18926.12 rows=1664667 width=1032)
-                     Hash Cond: tab3.j = tab1.j
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..443.30 rows=1665 width=1032)
-                           Hash Key: tab3.j
-                           ->  Table Scan on tab3  (cost=0.00..431.98 rows=1665 width=1032)
-                     ->  Hash  (cost=431.63..431.63 rows=334 width=8)
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.63 rows=334 width=8)
-                                 Hash Key: tab1.j
-                                 ->  Table Scan on tab1  (cost=0.00..431.59 rows=334 width=8)
+                                                        QUERY PLAN
+--------------------------------------------------------------------------------------------------------------------------
+ Hash Left Join  (cost=0.00..1638900.17 rows=5000000 width=10012)
+   Hash Cond: (tab3.j = tab1.j)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..657.71 rows=5000 width=10008)
+         ->  Seq Scan on tab3  (cost=0.00..440.21 rows=1667 width=10008)
+   ->  Hash  (cost=1463000.74..1463000.74 rows=1000 width=12)
+         ->  Result  (cost=0.00..1463000.74 rows=1000 width=12)
+               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..436.63 rows=1000 width=8)
+                     ->  Seq Scan on tab1  (cost=0.00..436.52 rows=334 width=8)
                SubPlan 1
-                 ->  Limit  (cost=0.00..164763.08 rows=1 width=1028)
-                       ->  Result  (cost=0.00..164763.08 rows=500 width=1028)
-                             Filter: tab2.i = $0
-                             ->  Materialize  (cost=0.00..460.48 rows=500 width=1032)
-                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..459.96 rows=500 width=1032)
-                                         ->  Table Scan on tab2  (cost=0.00..431.29 rows=167 width=1032) 
-Optimizer status: PQO version 2.67.0
--->
-<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+                 ->  Limit  (cost=0.00..536.93 rows=1 width=10004)
+                       ->  Result  (cost=0.00..536.92 rows=500 width=10004)
+                             Filter: (tab2.i = tab1.i)
+                             ->  Materialize  (cost=0.00..504.02 rows=500 width=10008)
+                                   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..499.01 rows=500 width=10008)
+                                         ->  Seq Scan on tab2  (cost=0.00..433.76 rows=167 width=10008)
+ Optimizer: Pivotal Optimizer (GPORCA)
+  ]]>
+  </dxl:Comment>
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
@@ -412,138 +409,44 @@ Optimizer status: PQO version 2.67.0
         </dxl:LogicalJoin>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="9">
-      <dxl:Result>
+    <dxl:Plan Id="0" SpaceSize="3">
+      <dxl:HashJoin JoinType="Left">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="166192.837038" Rows="4994000.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1898.331176" Rows="4994000.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="2" Alias="k">
             <dxl:Ident ColId="2" ColName="k" TypeMdid="0.1043.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="30" Alias="subq">
-            <dxl:SubPlan TypeMdid="0.1043.1.0" SubPlanType="ScalarSubPlan">
-              <dxl:TestExpr/>
-              <dxl:ParamList>
-                <dxl:Param ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
-              </dxl:ParamList>
-              <dxl:Limit>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="164733.638531" Rows="1.000000" Width="1"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="22" Alias="k">
-                    <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="164733.638530" Rows="500.000000" Width="1"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="22" Alias="k">
-                      <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                      <dxl:Ident ColId="20" ColName="i" TypeMdid="0.23.1.0"/>
-                      <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
-                    </dxl:Comparison>
-                  </dxl:Filter>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Materialize Eager="true">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.038530" Rows="500.000000" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="20" Alias="i">
-                        <dxl:Ident ColId="20" ColName="i" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="22" Alias="k">
-                        <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.036530" Rows="500.000000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="20" Alias="i">
-                          <dxl:Ident ColId="20" ColName="i" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="22" Alias="k">
-                          <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:TableScan>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.010450" Rows="500.000000" Width="4"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="20" Alias="i">
-                            <dxl:Ident ColId="20" ColName="i" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="22" Alias="k">
-                            <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:TableDescriptor Mdid="0.40966.1.0" TableName="tab2">
-                          <dxl:Columns>
-                            <dxl:Column ColId="20" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="22" Attno="3" ColName="k" TypeMdid="0.1043.1.0" ColWidth="0"/>
-                            <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                            <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:TableScan>
-                    </dxl:GatherMotion>
-                  </dxl:Materialize>
-                </dxl:Result>
-                <dxl:LimitCount>
-                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                </dxl:LimitCount>
-                <dxl:LimitOffset>
-                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                </dxl:LimitOffset>
-              </dxl:Limit>
-            </dxl:SubPlan>
+            <dxl:Ident ColId="30" ColName="subq" TypeMdid="0.1043.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:OneTimeFilter/>
-        <dxl:HashJoin JoinType="Left">
+        <dxl:JoinFilter/>
+        <dxl:HashCondList>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="11" ColName="j" TypeMdid="0.23.1.0"/>
+          </dxl:Comparison>
+        </dxl:HashCondList>
+        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="933.324563" Rows="4994000.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.121621" Rows="4994.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
+            <dxl:ProjElem ColId="1" Alias="j">
+              <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
             <dxl:ProjElem ColId="2" Alias="k">
               <dxl:Ident ColId="2" ColName="k" TypeMdid="0.1043.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="i">
-              <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:JoinFilter/>
-          <dxl:HashCondList>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-              <dxl:Ident ColId="11" ColName="j" TypeMdid="0.23.1.0"/>
-            </dxl:Comparison>
-          </dxl:HashCondList>
-          <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+          <dxl:SortingColumnList/>
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.121621" Rows="4994.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.034792" Rows="4994.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="j">
@@ -554,36 +457,130 @@ Optimizer status: PQO version 2.67.0
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.034792" Rows="4994.000000" Width="4"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="1" Alias="j">
-                  <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="2" Alias="k">
-                  <dxl:Ident ColId="2" ColName="k" TypeMdid="0.1043.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.40972.1.0" TableName="tab3">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="2" Attno="3" ColName="k" TypeMdid="0.1043.1.0" ColWidth="0"/>
-                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:GatherMotion>
+            <dxl:TableDescriptor Mdid="0.40972.1.0" TableName="tab3">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="3" ColName="k" TypeMdid="0.1043.1.0" ColWidth="0"/>
+                <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:GatherMotion>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1326.125033" Rows="1000.000000" Width="12"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="30" Alias="subq">
+              <dxl:SubPlan TypeMdid="0.1043.1.0" SubPlanType="ScalarSubPlan">
+                <dxl:TestExpr/>
+                <dxl:ParamList>
+                  <dxl:Param ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:ParamList>
+                <dxl:Limit>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="463.938531" Rows="1.000000" Width="1"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="22" Alias="k">
+                      <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="463.938530" Rows="500.000000" Width="1"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="22" Alias="k">
+                        <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                        <dxl:Ident ColId="20" ColName="i" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
+                      </dxl:Comparison>
+                    </dxl:Filter>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Materialize Eager="true">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.038530" Rows="500.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="20" Alias="i">
+                          <dxl:Ident ColId="20" ColName="i" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="22" Alias="k">
+                          <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.036530" Rows="500.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="20" Alias="i">
+                            <dxl:Ident ColId="20" ColName="i" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="22" Alias="k">
+                            <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.010450" Rows="500.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="20" Alias="i">
+                              <dxl:Ident ColId="20" ColName="i" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="22" Alias="k">
+                              <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="0.40966.1.0" TableName="tab2">
+                            <dxl:Columns>
+                              <dxl:Column ColId="20" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="22" Attno="3" ColName="k" TypeMdid="0.1043.1.0" ColWidth="0"/>
+                              <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                              <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:GatherMotion>
+                    </dxl:Materialize>
+                  </dxl:Result>
+                  <dxl:LimitCount>
+                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                  </dxl:LimitCount>
+                  <dxl:LimitOffset>
+                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                  </dxl:LimitOffset>
+                </dxl:Limit>
+              </dxl:SubPlan>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="11" Alias="j">
+              <dxl:Ident ColId="11" ColName="j" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
           <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.125220" Rows="1000.000000" Width="8"/>
@@ -626,8 +623,8 @@ Optimizer status: PQO version 2.67.0
               </dxl:TableDescriptor>
             </dxl:TableScan>
           </dxl:GatherMotion>
-        </dxl:HashJoin>
-      </dxl:Result>
+        </dxl:Result>
+      </dxl:HashJoin>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/MotionHazard-NoMaterializeGatherUnderResult.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MotionHazard-NoMaterializeGatherUnderResult.mdp
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+<dxl:Comment><![CDATA[
 create table tab1(i int , j int , k varchar(10000));
 create table tab2(i int , j int , k varchar(10000));
 create table tab3(i int , j int , k varchar(10000));
@@ -12,25 +13,27 @@ analyze tab3;
 set optimizer_penalize_broadcast_threshold=900;
 set optimizer_enable_motion_redistribute=off;
 explain select tab3.k, (select tab2.k from tab2 where tab2.i = tab1.i limit 1) as subq from tab3 left join tab1 on tab1.j = tab3.j;
-                                                QUERY PLAN
- Result  (cost=0.00..166192.84 rows=1664667 width=16)
-   ->  Hash Left Join  (cost=0.00..933.32 rows=1664667 width=4)
-         Hash Cond: tab3.j = tab1.j
-         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.12 rows=4994 width=4)
-               ->  Table Scan on tab3  (cost=0.00..431.03 rows=1665 width=4)
-         ->  Hash  (cost=431.13..431.13 rows=334 width=8)
-               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.13 rows=1000 width=8)
-                     ->  Table Scan on tab1  (cost=0.00..431.02 rows=334 width=8)
-   SubPlan 1
-     ->  Limit  (cost=0.00..164733.64 rows=1 width=1)
-           ->  Result  (cost=0.00..164733.64 rows=167 width=1)
-                 Filter: tab2.i = $0
-                 ->  Materialize  (cost=0.00..431.04 rows=167 width=4)
-                       ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.04 rows=500 width=4)
-                             ->  Table Scan on tab2  (cost=0.00..431.01 rows=167 width=4)
- Settings:  optimizer_penalize_broadcast_threshold=900
--->
-<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+
+                                                        QUERY PLAN
+--------------------------------------------------------------------------------------------------------------------------
+ Hash Left Join  (cost=0.00..1638900.17 rows=5000000 width=10012)
+   Hash Cond: (tab3.j = tab1.j)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..657.71 rows=5000 width=10008)
+         ->  Seq Scan on tab3  (cost=0.00..440.21 rows=1667 width=10008)
+   ->  Hash  (cost=1463000.74..1463000.74 rows=1000 width=12)
+         ->  Result  (cost=0.00..1463000.74 rows=1000 width=12)
+               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..436.63 rows=1000 width=8)
+                     ->  Seq Scan on tab1  (cost=0.00..436.52 rows=334 width=8)
+               SubPlan 1
+                 ->  Limit  (cost=0.00..536.93 rows=1 width=10004)
+                       ->  Result  (cost=0.00..536.92 rows=500 width=10004)
+                             Filter: (tab2.i = tab1.i)
+                             ->  Materialize  (cost=0.00..504.02 rows=500 width=10008)
+                                   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..499.01 rows=500 width=10008)
+                                         ->  Seq Scan on tab2  (cost=0.00..433.76 rows=167 width=10008)
+ Optimizer: Pivotal Optimizer (GPORCA)
+  ]]>
+ </dxl:Comment>
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
@@ -408,138 +411,44 @@ explain select tab3.k, (select tab2.k from tab2 where tab2.i = tab1.i limit 1) a
         </dxl:LogicalJoin>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="9">
-      <dxl:Result>
+    <dxl:Plan Id="0" SpaceSize="7">
+      <dxl:HashJoin JoinType="Left">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="166192.837038" Rows="4994000.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1898.331176" Rows="4994000.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="2" Alias="k">
             <dxl:Ident ColId="2" ColName="k" TypeMdid="0.1043.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="30" Alias="subq">
-            <dxl:SubPlan TypeMdid="0.1043.1.0" SubPlanType="ScalarSubPlan">
-              <dxl:TestExpr/>
-              <dxl:ParamList>
-                <dxl:Param ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
-              </dxl:ParamList>
-              <dxl:Limit>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="164733.638531" Rows="1.000000" Width="1"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="22" Alias="k">
-                    <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="164733.638530" Rows="500.000000" Width="1"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="22" Alias="k">
-                      <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                      <dxl:Ident ColId="20" ColName="i" TypeMdid="0.23.1.0"/>
-                      <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
-                    </dxl:Comparison>
-                  </dxl:Filter>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Materialize Eager="true">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.038530" Rows="500.000000" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="20" Alias="i">
-                        <dxl:Ident ColId="20" ColName="i" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="22" Alias="k">
-                        <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.036530" Rows="500.000000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="20" Alias="i">
-                          <dxl:Ident ColId="20" ColName="i" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="22" Alias="k">
-                          <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:TableScan>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.010450" Rows="500.000000" Width="4"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="20" Alias="i">
-                            <dxl:Ident ColId="20" ColName="i" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="22" Alias="k">
-                            <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:TableDescriptor Mdid="0.40966.1.0" TableName="tab2">
-                          <dxl:Columns>
-                            <dxl:Column ColId="20" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="22" Attno="3" ColName="k" TypeMdid="0.1043.1.0" ColWidth="0"/>
-                            <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                            <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:TableScan>
-                    </dxl:GatherMotion>
-                  </dxl:Materialize>
-                </dxl:Result>
-                <dxl:LimitCount>
-                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                </dxl:LimitCount>
-                <dxl:LimitOffset>
-                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                </dxl:LimitOffset>
-              </dxl:Limit>
-            </dxl:SubPlan>
+            <dxl:Ident ColId="30" ColName="subq" TypeMdid="0.1043.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:OneTimeFilter/>
-        <dxl:HashJoin JoinType="Left">
+        <dxl:JoinFilter/>
+        <dxl:HashCondList>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="11" ColName="j" TypeMdid="0.23.1.0"/>
+          </dxl:Comparison>
+        </dxl:HashCondList>
+        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="933.324563" Rows="4994000.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.121621" Rows="4994.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
+            <dxl:ProjElem ColId="1" Alias="j">
+              <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
             <dxl:ProjElem ColId="2" Alias="k">
               <dxl:Ident ColId="2" ColName="k" TypeMdid="0.1043.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="i">
-              <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:JoinFilter/>
-          <dxl:HashCondList>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-              <dxl:Ident ColId="11" ColName="j" TypeMdid="0.23.1.0"/>
-            </dxl:Comparison>
-          </dxl:HashCondList>
-          <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+          <dxl:SortingColumnList/>
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.121621" Rows="4994.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.034792" Rows="4994.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="j">
@@ -550,36 +459,130 @@ explain select tab3.k, (select tab2.k from tab2 where tab2.i = tab1.i limit 1) a
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.034792" Rows="4994.000000" Width="4"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="1" Alias="j">
-                  <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="2" Alias="k">
-                  <dxl:Ident ColId="2" ColName="k" TypeMdid="0.1043.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.40972.1.0" TableName="tab3">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="2" Attno="3" ColName="k" TypeMdid="0.1043.1.0" ColWidth="0"/>
-                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:GatherMotion>
+            <dxl:TableDescriptor Mdid="0.40972.1.0" TableName="tab3">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="3" ColName="k" TypeMdid="0.1043.1.0" ColWidth="0"/>
+                <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:GatherMotion>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1326.125033" Rows="1000.000000" Width="12"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="30" Alias="subq">
+              <dxl:SubPlan TypeMdid="0.1043.1.0" SubPlanType="ScalarSubPlan">
+                <dxl:TestExpr/>
+                <dxl:ParamList>
+                  <dxl:Param ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:ParamList>
+                <dxl:Limit>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="463.938531" Rows="1.000000" Width="1"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="22" Alias="k">
+                      <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="463.938530" Rows="500.000000" Width="1"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="22" Alias="k">
+                        <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                        <dxl:Ident ColId="20" ColName="i" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
+                      </dxl:Comparison>
+                    </dxl:Filter>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Materialize Eager="true">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.038530" Rows="500.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="20" Alias="i">
+                          <dxl:Ident ColId="20" ColName="i" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="22" Alias="k">
+                          <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.036530" Rows="500.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="20" Alias="i">
+                            <dxl:Ident ColId="20" ColName="i" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="22" Alias="k">
+                            <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.010450" Rows="500.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="20" Alias="i">
+                              <dxl:Ident ColId="20" ColName="i" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="22" Alias="k">
+                              <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="0.40966.1.0" TableName="tab2">
+                            <dxl:Columns>
+                              <dxl:Column ColId="20" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="22" Attno="3" ColName="k" TypeMdid="0.1043.1.0" ColWidth="0"/>
+                              <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                              <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:GatherMotion>
+                    </dxl:Materialize>
+                  </dxl:Result>
+                  <dxl:LimitCount>
+                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                  </dxl:LimitCount>
+                  <dxl:LimitOffset>
+                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                  </dxl:LimitOffset>
+                </dxl:Limit>
+              </dxl:SubPlan>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="11" Alias="j">
+              <dxl:Ident ColId="11" ColName="j" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
           <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.125220" Rows="1000.000000" Width="8"/>
@@ -622,8 +625,8 @@ explain select tab3.k, (select tab2.k from tab2 where tab2.i = tab1.i limit 1) a
               </dxl:TableDescriptor>
             </dxl:TableScan>
           </dxl:GatherMotion>
-        </dxl:HashJoin>
-      </dxl:Result>
+        </dxl:Result>
+      </dxl:HashJoin>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/MotionHazard-NoMaterializeSortUnderResult.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MotionHazard-NoMaterializeSortUnderResult.mdp
@@ -1,42 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
 create table tab1(i int , j int , k varchar(10000));
 create table tab2(i int , j int , k varchar(10000));
 create table tab3(i int , j int , k varchar(10000));
-insert into tab1 select 1, 2, repeat(‘a’,10000) from generate_series(1,1000) ;
-insert into tab2 select 1, i, repeat(‘a’,10000) from generate_series(1,500) i;
-insert into tab3 select 1, 2, repeat(‘a’,10000) from generate_series(1,5000);
+insert into tab1 select 1, 2, repeat('a',10000) from generate_series(1,1000) ;
+insert into tab2 select 1, i, repeat('a',10000) from generate_series(1,500) i;
+insert into tab3 select 1, 2, repeat('a',10000) from generate_series(1,5000);
 analyze tab1;
 analyze tab2;
 analyze tab3;
 set optimizer_penalize_broadcast_threshold=900;
 explain select tab3.k, (select tab2.k from tab2 where tab2.i = tab1.i limit 1) as subq from tab3 left join tab1 on tab1.j = tab3.j order by tab3.k;
-                                                        QUERY PLAN
- Result  (cost=0.00..170041752.00 rows=1664667 width=16)
-   ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..170041672.10 rows=1000 width=16)
-         Merge Key: tab3.k
-         ->  Result  (cost=0.00..170041672.04 rows=334 width=16)
-               ->  Sort  (cost=0.00..170041672.04 rows=334 width=16)
-                     Sort Key: tab3.k
-                     ->  Hash Left Join  (cost=0.00..886.61 rows=1664667 width=4)
-                           Hash Cond: tab3.j = tab1.j
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.08 rows=1665 width=4)
-                                 Hash Key: tab3.j
-                                 ->  Table Scan on tab3  (cost=0.00..431.03 rows=1665 width=4)
-                           ->  Hash  (cost=431.06..431.06 rows=334 width=8)
-                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.06 rows=334 width=8)
-                                       Hash Key: tab1.j
-                                       ->  Table Scan on tab1  (cost=0.00..431.02 rows=334 width=8)
-               SubPlan 1
-                 ->  Limit  (cost=0.00..164733.72 rows=1 width=1)
-                       ->  Result  (cost=0.00..164733.72 rows=500 width=1)
-                             Filter: tab2.i = $0
-                             ->  Materialize  (cost=0.00..431.12 rows=500 width=4)
-                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.12 rows=500 width=4)
-                                         ->  Table Scan on tab2  (cost=0.00..431.01 rows=167 width=4)
- Settings:  optimizer_penalize_broadcast_threshold=900
--->
-<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+                                                           QUERY PLAN
+--------------------------------------------------------------------------------------------------------------------------------
+ Sort  (cost=0.00..7955337.11 rows=5000000 width=10012)
+   Sort Key: tab3.k
+   ->  Hash Left Join  (cost=0.00..1638900.17 rows=5000000 width=10012)
+         Hash Cond: (tab3.j = tab1.j)
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..657.71 rows=5000 width=10008)
+               ->  Seq Scan on tab3  (cost=0.00..440.21 rows=1667 width=10008)
+         ->  Hash  (cost=1463000.74..1463000.74 rows=1000 width=12)
+               ->  Result  (cost=0.00..1463000.74 rows=1000 width=12)
+                     ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..436.63 rows=1000 width=8)
+                           ->  Seq Scan on tab1  (cost=0.00..436.52 rows=334 width=8)
+                     SubPlan 1
+                       ->  Limit  (cost=0.00..536.93 rows=1 width=10004)
+                             ->  Result  (cost=0.00..536.92 rows=500 width=10004)
+                                   Filter: (tab2.i = tab1.i)
+                                   ->  Materialize  (cost=0.00..504.02 rows=500 width=10008)
+                                         ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..499.01 rows=500 width=10008)
+                                               ->  Seq Scan on tab2  (cost=0.00..433.76 rows=167 width=10008)
+ Optimizer: Pivotal Optimizer (GPORCA)
+  ]]>
+  </dxl:Comment>
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
@@ -433,156 +430,63 @@ explain select tab3.k, (select tab2.k from tab2 where tab2.i = tab1.i limit 1) a
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="20">
-      <dxl:Result>
+    <dxl:Plan Id="0" SpaceSize="14">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="166193.741134" Rows="4994000.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="2542.230437" Rows="4994000.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="2" Alias="k">
             <dxl:Ident ColId="2" ColName="k" TypeMdid="0.1043.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="30" Alias="subq">
-            <dxl:SubPlan TypeMdid="0.1043.1.0" SubPlanType="ScalarSubPlan">
-              <dxl:TestExpr/>
-              <dxl:ParamList>
-                <dxl:Param ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
-              </dxl:ParamList>
-              <dxl:Limit>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="164733.638531" Rows="1.000000" Width="1"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="22" Alias="k">
-                    <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="164733.638530" Rows="500.000000" Width="1"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="22" Alias="k">
-                      <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                      <dxl:Ident ColId="20" ColName="i" TypeMdid="0.23.1.0"/>
-                      <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
-                    </dxl:Comparison>
-                  </dxl:Filter>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Materialize Eager="true">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.038530" Rows="500.000000" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="20" Alias="i">
-                        <dxl:Ident ColId="20" ColName="i" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="22" Alias="k">
-                        <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.036530" Rows="500.000000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="20" Alias="i">
-                          <dxl:Ident ColId="20" ColName="i" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="22" Alias="k">
-                          <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:TableScan>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.010450" Rows="500.000000" Width="4"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="20" Alias="i">
-                            <dxl:Ident ColId="20" ColName="i" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="22" Alias="k">
-                            <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:TableDescriptor Mdid="0.40966.1.0" TableName="tab2">
-                          <dxl:Columns>
-                            <dxl:Column ColId="20" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="22" Attno="3" ColName="k" TypeMdid="0.1043.1.0" ColWidth="0"/>
-                            <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                            <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:TableScan>
-                    </dxl:GatherMotion>
-                  </dxl:Materialize>
-                </dxl:Result>
-                <dxl:LimitCount>
-                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                </dxl:LimitCount>
-                <dxl:LimitOffset>
-                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                </dxl:LimitOffset>
-              </dxl:Limit>
-            </dxl:SubPlan>
+            <dxl:Ident ColId="30" ColName="subq" TypeMdid="0.1043.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:OneTimeFilter/>
-        <dxl:Sort SortDiscardDuplicates="false">
+        <dxl:SortingColumnList>
+          <dxl:SortingColumn ColId="2" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+        </dxl:SortingColumnList>
+        <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="166113.837134" Rows="1000.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="2393.342650" Rows="4994000.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="2" Alias="k">
               <dxl:Ident ColId="2" ColName="k" TypeMdid="0.1043.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="i">
-              <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="30" Alias="subq">
+              <dxl:Ident ColId="30" ColName="subq" TypeMdid="0.1043.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:SortingColumnList>
-            <dxl:SortingColumn ColId="2" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-          </dxl:SortingColumnList>
-          <dxl:LimitCount/>
-          <dxl:LimitOffset/>
-          <dxl:HashJoin JoinType="Left">
+          <dxl:JoinFilter>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="11" ColName="j" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:JoinFilter>
+          <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="933.324563" Rows="4994000.000000" Width="4"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.451190" Rows="4994.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
+              <dxl:ProjElem ColId="1" Alias="j">
+                <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
               <dxl:ProjElem ColId="2" Alias="k">
                 <dxl:Ident ColId="2" ColName="k" TypeMdid="0.1043.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="10" Alias="i">
-                <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:JoinFilter/>
-            <dxl:HashCondList>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-                <dxl:Ident ColId="11" ColName="j" TypeMdid="0.23.1.0"/>
-              </dxl:Comparison>
-            </dxl:HashCondList>
-            <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+            <dxl:SortingColumnList>
+              <dxl:SortingColumn ColId="2" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+            </dxl:SortingColumnList>
+            <dxl:LimitCount/>
+            <dxl:LimitOffset/>
+            <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.121621" Rows="4994.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.034792" Rows="4994.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="j">
@@ -593,81 +497,204 @@ explain select tab3.k, (select tab2.k from tab2 where tab2.i = tab1.i limit 1) a
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.034792" Rows="4994.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="1" Alias="j">
-                    <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="2" Alias="k">
-                    <dxl:Ident ColId="2" ColName="k" TypeMdid="0.1043.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="0.40972.1.0" TableName="tab3">
-                  <dxl:Columns>
-                    <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="2" Attno="3" ColName="k" TypeMdid="0.1043.1.0" ColWidth="0"/>
-                    <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                    <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-            </dxl:GatherMotion>
-            <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+              <dxl:TableDescriptor Mdid="0.40972.1.0" TableName="tab3">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="2" Attno="3" ColName="k" TypeMdid="0.1043.1.0" ColWidth="0"/>
+                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:Sort>
+          <dxl:Materialize Eager="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1326.310193" Rows="3000.000000" Width="12"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="11" Alias="j">
+                <dxl:Ident ColId="11" ColName="j" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="30" Alias="subq">
+                <dxl:Ident ColId="30" ColName="subq" TypeMdid="0.1043.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.125220" Rows="1000.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="1326.298193" Rows="3000.000000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="10" Alias="i">
-                  <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
                 <dxl:ProjElem ColId="11" Alias="j">
                   <dxl:Ident ColId="11" ColName="j" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="30" Alias="subq">
+                  <dxl:Ident ColId="30" ColName="subq" TypeMdid="0.1043.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
               <dxl:SortingColumnList/>
-              <dxl:TableScan>
+              <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.020900" Rows="1000.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1326.083393" Rows="1000.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="10" Alias="i">
-                    <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
                   <dxl:ProjElem ColId="11" Alias="j">
                     <dxl:Ident ColId="11" ColName="j" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
+                  <dxl:ProjElem ColId="30" Alias="subq">
+                    <dxl:Ident ColId="30" ColName="subq" TypeMdid="0.1043.1.0"/>
+                  </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="0.40960.1.0" TableName="tab1">
-                  <dxl:Columns>
-                    <dxl:Column ColId="10" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="11" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                    <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-            </dxl:GatherMotion>
-          </dxl:HashJoin>
-        </dxl:Sort>
-      </dxl:Result>
+                <dxl:OneTimeFilter/>
+                <dxl:Result>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="1326.083393" Rows="1000.000000" Width="12"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="30" Alias="subq">
+                      <dxl:SubPlan TypeMdid="0.1043.1.0" SubPlanType="ScalarSubPlan">
+                        <dxl:TestExpr/>
+                        <dxl:ParamList>
+                          <dxl:Param ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
+                        </dxl:ParamList>
+                        <dxl:Limit>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="464.023571" Rows="3.000000" Width="1"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="22" Alias="k">
+                              <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Result>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="464.023570" Rows="1500.000000" Width="1"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="22" Alias="k">
+                                <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter>
+                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                <dxl:Ident ColId="20" ColName="i" TypeMdid="0.23.1.0"/>
+                                <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
+                              </dxl:Comparison>
+                            </dxl:Filter>
+                            <dxl:OneTimeFilter/>
+                            <dxl:Materialize Eager="true">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.123570" Rows="1500.000000" Width="4"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="20" Alias="i">
+                                  <dxl:Ident ColId="20" ColName="i" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="22" Alias="k">
+                                  <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.121570" Rows="1500.000000" Width="4"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="20" Alias="i">
+                                    <dxl:Ident ColId="20" ColName="i" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="22" Alias="k">
+                                    <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:SortingColumnList/>
+                                <dxl:TableScan>
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.010450" Rows="500.000000" Width="4"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="20" Alias="i">
+                                      <dxl:Ident ColId="20" ColName="i" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="22" Alias="k">
+                                      <dxl:Ident ColId="22" ColName="k" TypeMdid="0.1043.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:TableDescriptor Mdid="0.40966.1.0" TableName="tab2">
+                                    <dxl:Columns>
+                                      <dxl:Column ColId="20" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="22" Attno="3" ColName="k" TypeMdid="0.1043.1.0" ColWidth="0"/>
+                                      <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                      <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                    </dxl:Columns>
+                                  </dxl:TableDescriptor>
+                                </dxl:TableScan>
+                              </dxl:BroadcastMotion>
+                            </dxl:Materialize>
+                          </dxl:Result>
+                          <dxl:LimitCount>
+                            <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                          </dxl:LimitCount>
+                          <dxl:LimitOffset>
+                            <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                          </dxl:LimitOffset>
+                        </dxl:Limit>
+                      </dxl:SubPlan>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="11" Alias="j">
+                      <dxl:Ident ColId="11" ColName="j" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:OneTimeFilter/>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="1326.079393" Rows="1000.000000" Width="12"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="10" Alias="i">
+                        <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="11" Alias="j">
+                        <dxl:Ident ColId="11" ColName="j" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.40960.1.0" TableName="tab1">
+                      <dxl:Columns>
+                        <dxl:Column ColId="10" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="11" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                        <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:Result>
+              </dxl:Result>
+            </dxl:BroadcastMotion>
+          </dxl:Materialize>
+        </dxl:NestedLoopJoin>
+      </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/Stat-Derivation-Leaf-Pattern.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Stat-Derivation-Leaf-Pattern.mdp
@@ -827,7 +827,7 @@ AND
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="604">
+    <dxl:Plan Id="0" SpaceSize="668">
       <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1373.906987" Rows="512.000000" Width="106"/>

--- a/src/backend/gporca/data/dxl/minidump/Subq2NotInWhereLOJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq2NotInWhereLOJ.mdp
@@ -676,10 +676,10 @@
         </dxl:LogicalProject>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1680">
+    <dxl:Plan Id="0" SpaceSize="4480">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1724.004114" Rows="1.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="1724.004230" Rows="1.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="30" Alias="s1">
@@ -696,7 +696,7 @@
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1724.004025" Rows="1.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="1724.004141" Rows="1.000000" Width="24"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="30"/>
@@ -717,7 +717,7 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1724.003996" Rows="1.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="1724.004112" Rows="1.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="30" Alias="s1">
@@ -740,7 +740,7 @@
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1724.003996" Rows="1.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="1724.004112" Rows="1.000000" Width="24"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="30" Alias="s1">
@@ -768,7 +768,7 @@
               </dxl:HashExprList>
               <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1724.003959" Rows="1.000000" Width="24"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1724.004075" Rows="1.000000" Width="24"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="30"/>
@@ -789,17 +789,17 @@
                 <dxl:Filter/>
                 <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1724.003938" Rows="2.000000" Width="24"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1724.004054" Rows="2.000000" Width="24"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="43" Alias="coalesce">
-                      <dxl:Ident ColId="43" ColName="coalesce" TypeMdid="0.20.1.0"/>
-                    </dxl:ProjElem>
                     <dxl:ProjElem ColId="30" Alias="s1">
                       <dxl:Ident ColId="30" ColName="s1" TypeMdid="0.1043.1.0" TypeModifier="54"/>
                     </dxl:ProjElem>
                     <dxl:ProjElem ColId="31" Alias="s2">
                       <dxl:Ident ColId="31" ColName="s2" TypeMdid="0.1043.1.0" TypeModifier="259"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="43" Alias="coalesce">
+                      <dxl:Ident ColId="43" ColName="coalesce" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
@@ -810,29 +810,36 @@
                   </dxl:SortingColumnList>
                   <dxl:LimitCount/>
                   <dxl:LimitOffset/>
-                  <dxl:Result>
+                  <dxl:HashJoin JoinType="Left">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1724.003938" Rows="2.000000" Width="24"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1724.004054" Rows="2.000000" Width="24"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="43" Alias="coalesce">
-                        <dxl:Coalesce TypeMdid="0.20.1.0">
-                          <dxl:Ident ColId="33" ColName="id3" TypeMdid="0.20.1.0"/>
-                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                        </dxl:Coalesce>
-                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="30" Alias="s1">
                         <dxl:Ident ColId="30" ColName="s1" TypeMdid="0.1043.1.0" TypeModifier="54"/>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="31" Alias="s2">
                         <dxl:Ident ColId="31" ColName="s2" TypeMdid="0.1043.1.0" TypeModifier="259"/>
                       </dxl:ProjElem>
+                      <dxl:ProjElem ColId="43" Alias="coalesce">
+                        <dxl:Ident ColId="43" ColName="coalesce" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                    <dxl:HashJoin JoinType="Left">
+                    <dxl:JoinFilter/>
+                    <dxl:HashCondList>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+                        <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                          <dxl:Ident ColId="32" ColName="s3" TypeMdid="0.1043.1.0" TypeModifier="54"/>
+                        </dxl:Cast>
+                        <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                          <dxl:Ident ColId="34" ColName="desc3" TypeMdid="0.1043.1.0" TypeModifier="54"/>
+                        </dxl:Cast>
+                      </dxl:Comparison>
+                    </dxl:HashCondList>
+                    <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1724.003922" Rows="2.000000" Width="24"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1293.002962" Rows="2.000000" Width="24"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="30" Alias="s1">
@@ -841,25 +848,20 @@
                         <dxl:ProjElem ColId="31" Alias="s2">
                           <dxl:Ident ColId="31" ColName="s2" TypeMdid="0.1043.1.0" TypeModifier="259"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="33" Alias="id3">
-                          <dxl:Ident ColId="33" ColName="id3" TypeMdid="0.20.1.0"/>
+                        <dxl:ProjElem ColId="32" Alias="s3">
+                          <dxl:Ident ColId="32" ColName="s3" TypeMdid="0.1043.1.0" TypeModifier="54"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:JoinFilter/>
-                      <dxl:HashCondList>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
-                          <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                            <dxl:Ident ColId="32" ColName="s3" TypeMdid="0.1043.1.0" TypeModifier="54"/>
-                          </dxl:Cast>
-                          <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                            <dxl:Ident ColId="34" ColName="desc3" TypeMdid="0.1043.1.0" TypeModifier="54"/>
-                          </dxl:Cast>
-                        </dxl:Comparison>
-                      </dxl:HashCondList>
-                      <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                      <dxl:SortingColumnList/>
+                      <dxl:HashExprList>
+                        <dxl:HashExpr>
+                          <dxl:Ident ColId="32" ColName="s3" TypeMdid="0.1043.1.0" TypeModifier="54"/>
+                        </dxl:HashExpr>
+                      </dxl:HashExprList>
+                      <dxl:Result>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1293.002846" Rows="2.000000" Width="24"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1293.002811" Rows="2.000000" Width="24"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="30" Alias="s1">
@@ -873,15 +875,10 @@
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:HashExprList>
-                          <dxl:HashExpr>
-                            <dxl:Ident ColId="32" ColName="s3" TypeMdid="0.1043.1.0" TypeModifier="54"/>
-                          </dxl:HashExpr>
-                        </dxl:HashExprList>
+                        <dxl:OneTimeFilter/>
                         <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1293.002695" Rows="2.000000" Width="24"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1293.002811" Rows="2.000000" Width="24"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="30" Alias="s1">
@@ -908,28 +905,18 @@
                                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                               </dxl:FuncExpr>
                             </dxl:ProjElem>
-                            <dxl:ProjElem ColId="31" Alias="s2">
-                              <dxl:FuncExpr FuncId="0.669.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0" TypeModifier="259">
-                                <dxl:Cast TypeMdid="0.1043.1.0" FuncId="0.0.0.0">
-                                  <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
-                                    <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
-                                      <dxl:Ident ColId="11" ColName="descr" TypeMdid="0.1042.1.0" TypeModifier="179"/>
-                                    </dxl:Cast>
-                                  </dxl:FuncExpr>
-                                </dxl:Cast>
-                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="259"/>
-                                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                              </dxl:FuncExpr>
-                            </dxl:ProjElem>
                             <dxl:ProjElem ColId="32" Alias="s3">
                               <dxl:ConstValue TypeMdid="0.1043.1.0" TypeModifier="54" Value="AAAABTk=" LintValue="2767856619"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="31" Alias="s2">
+                              <dxl:Ident ColId="31" ColName="s2" TypeMdid="0.1043.1.0" TypeModifier="259"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
                           <dxl:OneTimeFilter/>
                           <dxl:HashJoin JoinType="LeftAntiSemiJoinNotIn">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1293.002447" Rows="2.000000" Width="24"/>
+                              <dxl:Cost StartupCost="0" TotalCost="1293.002563" Rows="2.000000" Width="24"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="0" Alias="id">
@@ -938,8 +925,8 @@
                               <dxl:ProjElem ColId="10" Alias="id">
                                 <dxl:Ident ColId="10" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="11" Alias="descr">
-                                <dxl:Ident ColId="11" ColName="descr" TypeMdid="0.1042.1.0" TypeModifier="179"/>
+                              <dxl:ProjElem ColId="31" Alias="s2">
+                                <dxl:Ident ColId="31" ColName="s2" TypeMdid="0.1043.1.0" TypeModifier="259"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:Filter/>
@@ -956,7 +943,7 @@
                             </dxl:HashCondList>
                             <dxl:HashJoin JoinType="Left">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="862.001325" Rows="2.000000" Width="24"/>
+                                <dxl:Cost StartupCost="0" TotalCost="862.001441" Rows="2.000000" Width="24"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="0" Alias="id">
@@ -965,8 +952,8 @@
                                 <dxl:ProjElem ColId="10" Alias="id">
                                   <dxl:Ident ColId="10" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
                                 </dxl:ProjElem>
-                                <dxl:ProjElem ColId="11" Alias="descr">
-                                  <dxl:Ident ColId="11" ColName="descr" TypeMdid="0.1042.1.0" TypeModifier="179"/>
+                                <dxl:ProjElem ColId="31" Alias="s2">
+                                  <dxl:Ident ColId="31" ColName="s2" TypeMdid="0.1043.1.0" TypeModifier="259"/>
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
@@ -1060,32 +1047,33 @@
                                   </dxl:TableDescriptor>
                                 </dxl:TableScan>
                               </dxl:RedistributeMotion>
-                              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                              <dxl:Result>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000278" Rows="1.000000" Width="16"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000394" Rows="1.000000" Width="16"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
+                                  <dxl:ProjElem ColId="31" Alias="s2">
+                                    <dxl:FuncExpr FuncId="0.669.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0" TypeModifier="259">
+                                      <dxl:Cast TypeMdid="0.1043.1.0" FuncId="0.0.0.0">
+                                        <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                          <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
+                                            <dxl:Ident ColId="11" ColName="descr" TypeMdid="0.1042.1.0" TypeModifier="179"/>
+                                          </dxl:Cast>
+                                        </dxl:FuncExpr>
+                                      </dxl:Cast>
+                                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="259"/>
+                                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                    </dxl:FuncExpr>
+                                  </dxl:ProjElem>
                                   <dxl:ProjElem ColId="10" Alias="id">
                                     <dxl:Ident ColId="10" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
                                   </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="11" Alias="descr">
-                                    <dxl:Ident ColId="11" ColName="descr" TypeMdid="0.1042.1.0" TypeModifier="179"/>
-                                  </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
-                                <dxl:SortingColumnList/>
-                                <dxl:HashExprList>
-                                  <dxl:HashExpr>
-                                    <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
-                                      <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
-                                        <dxl:Ident ColId="10" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
-                                      </dxl:Cast>
-                                    </dxl:FuncExpr>
-                                  </dxl:HashExpr>
-                                </dxl:HashExprList>
-                                <dxl:TableScan>
+                                <dxl:OneTimeFilter/>
+                                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="431.000228" Rows="1.000000" Width="16"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000278" Rows="1.000000" Width="16"/>
                                   </dxl:Properties>
                                   <dxl:ProjList>
                                     <dxl:ProjElem ColId="10" Alias="id">
@@ -1095,45 +1083,69 @@
                                       <dxl:Ident ColId="11" ColName="descr" TypeMdid="0.1042.1.0" TypeModifier="179"/>
                                     </dxl:ProjElem>
                                   </dxl:ProjList>
-                                  <dxl:Filter>
-                                    <dxl:And>
-                                      <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
-                                        <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
-                                          <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
-                                            <dxl:Coalesce TypeMdid="0.1042.1.0">
-                                              <dxl:Ident ColId="12" ColName="att" TypeMdid="0.1042.1.0" TypeModifier="5"/>
-                                              <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAABA==" LintValue="3739851654"/>
-                                            </dxl:Coalesce>
-                                          </dxl:Cast>
-                                        </dxl:FuncExpr>
-                                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABVk=" LintValue="3870055082"/>
-                                      </dxl:Comparison>
-                                      <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
-                                        <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
-                                          <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
-                                            <dxl:Ident ColId="10" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
-                                          </dxl:Cast>
-                                        </dxl:FuncExpr>
-                                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABA==" LintValue="3739851654"/>
-                                      </dxl:Comparison>
-                                    </dxl:And>
-                                  </dxl:Filter>
-                                  <dxl:TableDescriptor Mdid="0.368659.1.0" TableName="t1">
-                                    <dxl:Columns>
-                                      <dxl:Column ColId="10" Attno="1" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11" ColWidth="7"/>
-                                      <dxl:Column ColId="11" Attno="2" ColName="descr" TypeMdid="0.1042.1.0" TypeModifier="179" ColWidth="175"/>
-                                      <dxl:Column ColId="12" Attno="3" ColName="att" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="1"/>
-                                      <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                      <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                    </dxl:Columns>
-                                  </dxl:TableDescriptor>
-                                </dxl:TableScan>
-                              </dxl:RedistributeMotion>
+                                  <dxl:Filter/>
+                                  <dxl:SortingColumnList/>
+                                  <dxl:HashExprList>
+                                    <dxl:HashExpr>
+                                      <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                        <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
+                                          <dxl:Ident ColId="10" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
+                                        </dxl:Cast>
+                                      </dxl:FuncExpr>
+                                    </dxl:HashExpr>
+                                  </dxl:HashExprList>
+                                  <dxl:TableScan>
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.000228" Rows="1.000000" Width="16"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="10" Alias="id">
+                                        <dxl:Ident ColId="10" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="11" Alias="descr">
+                                        <dxl:Ident ColId="11" ColName="descr" TypeMdid="0.1042.1.0" TypeModifier="179"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter>
+                                      <dxl:And>
+                                        <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
+                                          <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                            <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
+                                              <dxl:Coalesce TypeMdid="0.1042.1.0">
+                                                <dxl:Ident ColId="12" ColName="att" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+                                                <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAABA==" LintValue="3739851654"/>
+                                              </dxl:Coalesce>
+                                            </dxl:Cast>
+                                          </dxl:FuncExpr>
+                                          <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABVk=" LintValue="3870055082"/>
+                                        </dxl:Comparison>
+                                        <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
+                                          <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
+                                            <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
+                                              <dxl:Ident ColId="10" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
+                                            </dxl:Cast>
+                                          </dxl:FuncExpr>
+                                          <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABA==" LintValue="3739851654"/>
+                                        </dxl:Comparison>
+                                      </dxl:And>
+                                    </dxl:Filter>
+                                    <dxl:TableDescriptor Mdid="0.368659.1.0" TableName="t1">
+                                      <dxl:Columns>
+                                        <dxl:Column ColId="10" Attno="1" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11" ColWidth="7"/>
+                                        <dxl:Column ColId="11" Attno="2" ColName="descr" TypeMdid="0.1042.1.0" TypeModifier="179" ColWidth="175"/>
+                                        <dxl:Column ColId="12" Attno="3" ColName="att" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="1"/>
+                                        <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                        <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                      </dxl:Columns>
+                                    </dxl:TableDescriptor>
+                                  </dxl:TableScan>
+                                </dxl:RedistributeMotion>
+                              </dxl:Result>
                             </dxl:HashJoin>
                             <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                               <dxl:Properties>
@@ -1211,7 +1223,25 @@
                             </dxl:BroadcastMotion>
                           </dxl:HashJoin>
                         </dxl:Result>
-                      </dxl:RedistributeMotion>
+                      </dxl:Result>
+                    </dxl:RedistributeMotion>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000196" Rows="1.000000" Width="16"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="43" Alias="coalesce">
+                          <dxl:Coalesce TypeMdid="0.20.1.0">
+                            <dxl:Ident ColId="33" ColName="id3" TypeMdid="0.20.1.0"/>
+                            <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                          </dxl:Coalesce>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="34" Alias="desc3">
+                          <dxl:Ident ColId="34" ColName="desc3" TypeMdid="0.1043.1.0" TypeModifier="54"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
                       <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                         <dxl:Properties>
                           <dxl:Cost StartupCost="0" TotalCost="431.000180" Rows="1.000000" Width="16"/>
@@ -1265,8 +1295,8 @@
                           </dxl:TableDescriptor>
                         </dxl:TableScan>
                       </dxl:RedistributeMotion>
-                    </dxl:HashJoin>
-                  </dxl:Result>
+                    </dxl:Result>
+                  </dxl:HashJoin>
                 </dxl:Sort>
               </dxl:Aggregate>
             </dxl:RedistributeMotion>

--- a/src/backend/gporca/data/dxl/minidump/TranslateFilterWithCTEAndTableScanIntoFilterAndOneTimeFilter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TranslateFilterWithCTEAndTableScanIntoFilterAndOneTimeFilter.mdp
@@ -13,57 +13,56 @@
   analyze;
 
   In the below query, there 3 are 3 projections, each with a qual, the should get translated as below.
-  1. Projection column 1 qual: f1.b = f2.b => Contains columns not from the relational child for the filter, so it should become a One Time Filter: One-Time Filter: $0 = $1
-  2. Projection column 2 qual: f1.a=random() and f1.a=2 => Qual containing random (i.e volatile) function should get converted to a Filter, and qual f1.a = 2 should get converted to a one timer filter. i.e (One-Time Filter: $2 = 2 and Filter: $2::double precision = random())
-  3. Projection column 3 qual: b=f1.b) => It should become a Filter as it contains column b from the relational child of the filter. Filter: share0_ref3.b = $3
+  1. Projection column 1 qual: f1.b = f2.b => Contains columns not from the relational child for the filter, so it should become a One Time Filter: One-Time Filter: (foo_1.b = bar_1.b)
+
+  2. Projection column 2 qual: f1.a=random() and f1.a=2 => Qual containing random (i.e volatile) function should get converted to a Filter, and qual f1.a = 2 should get converted to a one timer filter. i.e (One-Time Filter: (foo_1.a = 2) and Filter: ((foo_1.a)::double precision = random())
+  3. Projection column 3 qual: b=f1.b) => It should become a Filter as it contains column b from the relational child of the filter. Filter: (share0_ref2.b = foo_1.b)
   pivotal=# explain with abc as (select foo.a, foo.b from foo, bar where foo.a=bar.a) select  (select 1 from abc where f1.b = f2.b limit 1), COALESCE((select 2 from abc where f1.a=random() and f1.a=2), 0), (select b from abc where b=f1.b) from foo f1, bar f2 where f1.b = f2.b;
-                                                            QUERY PLAN
-  ------------------------------------------------------------------------------------------------------------------------------
-   Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1852062876647.47 rows=11 width=12)
-     ->  Sequence  (cost=0.00..1852062876647.47 rows=4 width=12)
-           ->  Shared Scan (share slice:id 6:0)  (cost=0.00..862.00 rows=4 width=1)
-                 ->  Materialize  (cost=0.00..862.00 rows=4 width=1)
-                       ->  Hash Join  (cost=0.00..862.00 rows=4 width=8)
-                             Hash Cond: public.foo.a = public.bar.a
-                             ->  Table Scan on foo  (cost=0.00..431.00 rows=4 width=8)
-                             ->  Hash  (cost=431.00..431.00 rows=4 width=4)
-                                   ->  Table Scan on bar  (cost=0.00..431.00 rows=4 width=4)
-           ->  Result  (cost=0.00..1852062875785.47 rows=4 width=12)
-                 ->  Hash Join  (cost=0.00..862.00 rows=4 width=12)
-                       Hash Cond: public.foo.b = public.bar.b
-                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=4 width=8)
-                             Hash Key: public.foo.b
-                             ->  Table Scan on foo  (cost=0.00..431.00 rows=4 width=8)
+                                                               QUERY PLAN
+  ------------------------------------------------------------------------------------------------------------------------------------
+   Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1389270669201.79 rows=10 width=12)
+     ->  Sequence  (cost=0.00..1389270669201.78 rows=4 width=12)
+           ->  Shared Scan (share slice:id 1:0)  (cost=0.00..862.00 rows=4 width=1)
+                 ->  Hash Join  (cost=0.00..862.00 rows=4 width=8)
+                       Hash Cond: (foo.a = bar.a)
+                       ->  Seq Scan on foo  (cost=0.00..431.00 rows=4 width=8)
                        ->  Hash  (cost=431.00..431.00 rows=4 width=4)
-                             ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
-                                   Hash Key: public.bar.b
-                                   ->  Table Scan on bar  (cost=0.00..431.00 rows=4 width=4)
+                             ->  Seq Scan on bar  (cost=0.00..431.00 rows=4 width=4)
+           ->  Hash Join  (cost=0.00..1356708775.03 rows=4 width=16)
+                 Hash Cond: (foo_1.b = bar_1.b)
+                 ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1356708344.03 rows=4 width=12)
+                       Hash Key: foo_1.b
+                       ->  Seq Scan on foo foo_1  (cost=0.00..1324047.81 rows=334 width=8)
+                             SubPlan 1
+                               ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                     ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                           One-Time Filter: (foo_1.a = 2)
+                                           Filter: ((foo_1.a)::double precision = random())
+                                           ->  Materialize  (cost=0.00..431.00 rows=10 width=1)
+                                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=10 width=1)
+                                                       ->  Result  (cost=0.00..431.00 rows=4 width=1)
+                                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=4 width=1)
+                             SubPlan 2
+                               ->  Result  (cost=0.00..431.66 rows=1 width=4)
+                                     Filter: (share0_ref2.b = foo_1.b)
+                                     ->  Materialize  (cost=0.00..431.00 rows=10 width=4)
+                                           ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=10 width=4)
+                                                 ->  Result  (cost=0.00..431.00 rows=4 width=4)
+                                                       ->  Shared Scan (share slice:id 4:0)  (cost=0.00..431.00 rows=4 width=4)
+                 ->  Hash  (cost=431.00..431.00 rows=4 width=4)
+                       ->  Redistribute Motion 3:3  (slice5; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
+                             Hash Key: bar_1.b
+                             ->  Seq Scan on bar bar_1  (cost=0.00..431.00 rows=4 width=4)
                  SubPlan 3
-                   ->  Result  (cost=0.00..431.66 rows=1 width=4)
-                         Filter: share0_ref3.b = $3
-                         ->  Materialize  (cost=0.00..431.00 rows=11 width=4)
-                               ->  Broadcast Motion 3:3  (slice5; segments: 3)  (cost=0.00..431.00 rows=11 width=4)
-                                     ->  Result  (cost=0.00..431.00 rows=4 width=4)
-                                           ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=4 width=4)
-                 SubPlan 2
-                   ->  Result  (cost=0.00..431.33 rows=3 width=4)
-                         ->  Result  (cost=0.00..431.33 rows=3 width=1)
-                               One-Time Filter: $2 = 2
-                               Filter: $2::double precision = random()
-                               ->  Materialize  (cost=0.00..431.00 rows=11 width=1)
-                                     ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=11 width=1)
-                                           ->  Result  (cost=0.00..431.00 rows=4 width=1)
-                                                 ->  Shared Scan (share slice:id 4:0)  (cost=0.00..431.00 rows=4 width=1)
-                 SubPlan 1
                    ->  Result  (cost=0.00..431.01 rows=1 width=4)
                          ->  Limit  (cost=0.00..431.01 rows=1 width=1)
-                               ->  Result  (cost=0.00..431.01 rows=5 width=1)
-                                     One-Time Filter: $0 = $1
-                                     ->  Materialize  (cost=0.00..431.00 rows=11 width=1)
-                                           ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=11 width=1)
+                               ->  Result  (cost=0.00..431.01 rows=4 width=1)
+                                     One-Time Filter: (foo_1.b = bar_1.b)
+                                     ->  Materialize  (cost=0.00..431.00 rows=10 width=1)
+                                           ->  Broadcast Motion 3:3  (slice6; segments: 3)  (cost=0.00..431.00 rows=10 width=1)
                                                  ->  Result  (cost=0.00..431.00 rows=4 width=1)
-                                                       ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=4 width=1)
-   Optimizer status: PQO version 3.9.0
+                                                       ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=4 width=1)
+   Optimizer: Pivotal Optimizer (GPORCA)
   ]]>
   </dxl:Comment>
   <dxl:Thread Id="0">
@@ -612,10 +611,10 @@
         </dxl:LogicalProject>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="616">
+    <dxl:Plan Id="0" SpaceSize="2024">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1852062876647.470947" Rows="10.000001" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="1389270669202.222168" Rows="10.000001" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="55" Alias="?column?">
@@ -632,7 +631,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1852062876647.470459" Rows="10.000001" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="1389270669202.221680" Rows="10.000001" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="55" Alias="?column?">
@@ -731,7 +730,7 @@
           </dxl:CTEProducer>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1852062875785.468994" Rows="10.000001" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="1389270668340.220215" Rows="10.000001" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="55" Alias="?column?">
@@ -817,173 +816,30 @@
                 </dxl:SubPlan>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="75" Alias="coalesce">
-                <dxl:Coalesce TypeMdid="0.23.1.0">
-                  <dxl:SubPlan TypeMdid="0.23.1.0" SubPlanType="ScalarSubPlan">
-                    <dxl:TestExpr/>
-                    <dxl:ParamList>
-                      <dxl:Param ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:ParamList>
-                    <dxl:Result>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.329208" Rows="8.533334" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="74" Alias="?column?">
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:OneTimeFilter/>
-                      <dxl:Result>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.329197" Rows="8.533334" Width="1"/>
-                        </dxl:Properties>
-                        <dxl:ProjList/>
-                        <dxl:Filter>
-                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.670.1.0">
-                            <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
-                              <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
-                            </dxl:Cast>
-                            <dxl:FuncExpr FuncId="0.1598.1.0" FuncRetSet="false" TypeMdid="0.701.1.0"/>
-                          </dxl:Comparison>
-                        </dxl:Filter>
-                        <dxl:OneTimeFilter>
-                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                            <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                          </dxl:Comparison>
-                        </dxl:OneTimeFilter>
-                        <dxl:Materialize Eager="true">
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000197" Rows="30.000003" Width="1"/>
-                          </dxl:Properties>
-                          <dxl:ProjList/>
-                          <dxl:Filter/>
-                          <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000187" Rows="30.000003" Width="1"/>
-                            </dxl:Properties>
-                            <dxl:ProjList/>
-                            <dxl:Filter/>
-                            <dxl:SortingColumnList/>
-                            <dxl:Result>
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="10.000001" Width="1"/>
-                              </dxl:Properties>
-                              <dxl:ProjList/>
-                              <dxl:Filter/>
-                              <dxl:OneTimeFilter/>
-                              <dxl:CTEConsumer CTEId="0" Columns="56,57">
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="10.000001" Width="1"/>
-                                </dxl:Properties>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="56" Alias="a">
-                                    <dxl:Ident ColId="56" ColName="a" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="57" Alias="b">
-                                    <dxl:Ident ColId="57" ColName="b" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                              </dxl:CTEConsumer>
-                            </dxl:Result>
-                          </dxl:BroadcastMotion>
-                        </dxl:Materialize>
-                      </dxl:Result>
-                    </dxl:Result>
-                  </dxl:SubPlan>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                </dxl:Coalesce>
+                <dxl:Ident ColId="75" ColName="coalesce" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="94" Alias="?column?">
-                <dxl:SubPlan TypeMdid="0.23.1.0" SubPlanType="ScalarSubPlan">
-                  <dxl:TestExpr/>
-                  <dxl:ParamList>
-                    <dxl:Param ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:ParamList>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.658788" Rows="3.000000" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="77" Alias="b">
-                        <dxl:Ident ColId="77" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                        <dxl:Ident ColId="77" ColName="b" TypeMdid="0.23.1.0"/>
-                        <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:Comparison>
-                    </dxl:Filter>
-                    <dxl:OneTimeFilter/>
-                    <dxl:Materialize Eager="true">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000788" Rows="30.000003" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="77" Alias="b">
-                          <dxl:Ident ColId="77" ColName="b" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000748" Rows="30.000003" Width="4"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="77" Alias="b">
-                            <dxl:Ident ColId="77" ColName="b" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:Result>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000032" Rows="10.000001" Width="4"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="77" Alias="b">
-                              <dxl:Ident ColId="77" ColName="b" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:OneTimeFilter/>
-                          <dxl:CTEConsumer CTEId="0" Columns="76,77">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000032" Rows="10.000001" Width="4"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="76" Alias="a">
-                                <dxl:Ident ColId="76" ColName="a" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="77" Alias="b">
-                                <dxl:Ident ColId="77" ColName="b" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                          </dxl:CTEConsumer>
-                        </dxl:Result>
-                      </dxl:BroadcastMotion>
-                    </dxl:Materialize>
-                  </dxl:Result>
-                </dxl:SubPlan>
+                <dxl:Ident ColId="94" ColName="?column?" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:OneTimeFilter/>
             <dxl:HashJoin JoinType="Inner">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.001711" Rows="10.000001" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="1356708775.027694" Rows="10.000001" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="18" Alias="a">
-                  <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
                 <dxl:ProjElem ColId="19" Alias="b">
                   <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="28" Alias="b">
                   <dxl:Ident ColId="28" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="75" Alias="coalesce">
+                  <dxl:Ident ColId="75" ColName="coalesce" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="94" Alias="?column?">
+                  <dxl:Ident ColId="94" ColName="?column?" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
@@ -996,14 +852,17 @@
               </dxl:HashCondList>
               <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000203" Rows="10.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1356708344.026132" Rows="10.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="18" Alias="a">
-                    <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
                   <dxl:ProjElem ColId="19" Alias="b">
                     <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="75" Alias="coalesce">
+                    <dxl:Ident ColId="75" ColName="coalesce" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="94" Alias="?column?">
+                    <dxl:Ident ColId="94" ColName="?column?" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
@@ -1013,33 +872,215 @@
                     <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
-                <dxl:TableScan>
+                <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000070" Rows="10.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1356708344.026007" Rows="10.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="18" Alias="a">
-                      <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
                     <dxl:ProjElem ColId="19" Alias="b">
                       <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
+                    <dxl:ProjElem ColId="75" Alias="coalesce">
+                      <dxl:Ident ColId="75" ColName="coalesce" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="94" Alias="?column?">
+                      <dxl:Ident ColId="94" ColName="?column?" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="foo">
-                    <dxl:Columns>
-                      <dxl:Column ColId="18" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="19" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="1356708344.026007" Rows="10.000000" Width="12"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="75" Alias="coalesce">
+                        <dxl:Coalesce TypeMdid="0.23.1.0">
+                          <dxl:SubPlan TypeMdid="0.23.1.0" SubPlanType="ScalarSubPlan">
+                            <dxl:TestExpr/>
+                            <dxl:ParamList>
+                              <dxl:Param ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
+                            </dxl:ParamList>
+                            <dxl:Result>
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.003490" Rows="2.133332" Width="4"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="74" Alias="?column?">
+                                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:OneTimeFilter/>
+                              <dxl:Result>
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.003487" Rows="2.133332" Width="1"/>
+                                </dxl:Properties>
+                                <dxl:ProjList/>
+                                <dxl:Filter>
+                                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.670.1.0">
+                                    <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                                      <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
+                                    </dxl:Cast>
+                                    <dxl:FuncExpr FuncId="0.1598.1.0" FuncRetSet="false" TypeMdid="0.701.1.0"/>
+                                  </dxl:Comparison>
+                                </dxl:Filter>
+                                <dxl:OneTimeFilter>
+                                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                    <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
+                                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                                  </dxl:Comparison>
+                                </dxl:OneTimeFilter>
+                                <dxl:Materialize Eager="false">
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000197" Rows="30.000003" Width="1"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList/>
+                                  <dxl:Filter/>
+                                  <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.000187" Rows="30.000003" Width="1"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList/>
+                                    <dxl:Filter/>
+                                    <dxl:SortingColumnList/>
+                                    <dxl:Result>
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="10.000001" Width="1"/>
+                                      </dxl:Properties>
+                                      <dxl:ProjList/>
+                                      <dxl:Filter/>
+                                      <dxl:OneTimeFilter/>
+                                      <dxl:CTEConsumer CTEId="0" Columns="56,57">
+                                        <dxl:Properties>
+                                          <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="10.000001" Width="1"/>
+                                        </dxl:Properties>
+                                        <dxl:ProjList>
+                                          <dxl:ProjElem ColId="56" Alias="a">
+                                            <dxl:Ident ColId="56" ColName="a" TypeMdid="0.23.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="57" Alias="b">
+                                            <dxl:Ident ColId="57" ColName="b" TypeMdid="0.23.1.0"/>
+                                          </dxl:ProjElem>
+                                        </dxl:ProjList>
+                                      </dxl:CTEConsumer>
+                                    </dxl:Result>
+                                  </dxl:BroadcastMotion>
+                                </dxl:Materialize>
+                              </dxl:Result>
+                            </dxl:Result>
+                          </dxl:SubPlan>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                        </dxl:Coalesce>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="94" Alias="?column?">
+                        <dxl:SubPlan TypeMdid="0.23.1.0" SubPlanType="ScalarSubPlan">
+                          <dxl:TestExpr/>
+                          <dxl:ParamList>
+                            <dxl:Param ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ParamList>
+                          <dxl:Result>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.658788" Rows="3.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="77" Alias="b">
+                                <dxl:Ident ColId="77" ColName="b" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter>
+                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                <dxl:Ident ColId="77" ColName="b" TypeMdid="0.23.1.0"/>
+                                <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+                              </dxl:Comparison>
+                            </dxl:Filter>
+                            <dxl:OneTimeFilter/>
+                            <dxl:Materialize Eager="true">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000788" Rows="30.000003" Width="4"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="77" Alias="b">
+                                  <dxl:Ident ColId="77" ColName="b" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000748" Rows="30.000003" Width="4"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="77" Alias="b">
+                                    <dxl:Ident ColId="77" ColName="b" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:SortingColumnList/>
+                                <dxl:Result>
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000032" Rows="10.000001" Width="4"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="77" Alias="b">
+                                      <dxl:Ident ColId="77" ColName="b" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:OneTimeFilter/>
+                                  <dxl:CTEConsumer CTEId="0" Columns="76,77">
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.000032" Rows="10.000001" Width="4"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="76" Alias="a">
+                                        <dxl:Ident ColId="76" ColName="a" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="77" Alias="b">
+                                        <dxl:Ident ColId="77" ColName="b" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                  </dxl:CTEConsumer>
+                                </dxl:Result>
+                              </dxl:BroadcastMotion>
+                            </dxl:Materialize>
+                          </dxl:Result>
+                        </dxl:SubPlan>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="19" Alias="b">
+                        <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:OneTimeFilter/>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="1324047.814587" Rows="1000.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="18" Alias="a">
+                          <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="19" Alias="b">
+                          <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="foo">
+                        <dxl:Columns>
+                          <dxl:Column ColId="18" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="19" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                          <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:Result>
+                </dxl:Result>
               </dxl:RedistributeMotion>
               <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                 <dxl:Properties>

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionPreprocessor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionPreprocessor.h
@@ -13,6 +13,8 @@
 #ifndef GPOPT_CExpressionPreprocessor_H
 #define GPOPT_CExpressionPreprocessor_H
 
+#include <set>
+
 #include "gpos/base.h"
 
 #include "gpopt/base/CColumnFactory.h"
@@ -35,6 +37,18 @@ using namespace gpos;
 class CExpressionPreprocessor
 {
 private:
+	// map colref to expression
+	using ColRefToExprMap =
+		CHashMap<CColRefSet, CExpression, HashPtr<CColRefSet>,
+				 EqualPtr<CColRefSet>, CleanupNULL<CColRefSet>,
+				 CleanupNULL<CExpression>>;
+
+	// iterator for map of colref to expression
+	using ColRefToExprMapIter =
+		CHashMapIter<CColRefSet, CExpression, HashPtr<CColRefSet>,
+					 EqualPtr<CColRefSet>, CleanupNULL<CColRefSet>,
+					 CleanupNULL<CExpression>>;
+
 	// map CTE id to collected predicates
 	using CTEPredsMap =
 		CHashMap<ULONG, CExpressionArray, gpos::HashValue<ULONG>,
@@ -204,6 +218,12 @@ private:
 	static CConstraint *PcnstrFromChildPartition(const IMDRelation *partrel,
 												 CColRefArray *pdrgpcrOutput,
 												 ColRefToUlongMap *col_mapping);
+
+	// attempt to push down a project element to a corresponding logical get
+	static CExpression *PexprPushProjectElements(
+		CMemoryPool *mp, CExpression *pexpr,
+		ColRefToExprMap *mapColumnsOfProjectElement,
+		std::set<CColRefSet *> &successfulPushDownColumnSets, BOOL &inPushDown);
 
 	// private ctor
 	CExpressionPreprocessor();

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -163,7 +163,7 @@ CTAS-random-distributed-from-replicated-distributed-table
 ProjectRepeatedColumn1 ProjectRepeatedColumn2 NLJ-BC-Outer-Spool-Inner Self-Comparison Self-Comparison-Nullable
 SelectCheckConstraint ExpandJoinOrder SelectOnBpchar EqualityJoin EffectsOfJoinFilter InnerJoin-With-OuterRefs
 UDA-AnyElement-1 UDA-AnyElement-2 Project-With-NonScalar-Func SixWayDPv2 Join-Varchar-Equality NLJ-Rewindability
-NLJ-Rewindability-CTAS;
+NLJ-Rewindability-CTAS JoinOnViewWithCastedColumn;
 
 CJoinPredTest:
 MultipleDampedPredJoinCardinality MultipleIndependentPredJoinCardinality MultiDistKeyJoinCardinality

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -163,7 +163,7 @@ CTAS-random-distributed-from-replicated-distributed-table
 ProjectRepeatedColumn1 ProjectRepeatedColumn2 NLJ-BC-Outer-Spool-Inner Self-Comparison Self-Comparison-Nullable
 SelectCheckConstraint ExpandJoinOrder SelectOnBpchar EqualityJoin EffectsOfJoinFilter InnerJoin-With-OuterRefs
 UDA-AnyElement-1 UDA-AnyElement-2 Project-With-NonScalar-Func SixWayDPv2 Join-Varchar-Equality NLJ-Rewindability
-NLJ-Rewindability-CTAS JoinOnViewWithCastedColumn;
+NLJ-Rewindability-CTAS JoinOnViewWithCastedColumn JoinOnViewWithDisjoinCastedColumns JoinOnViewWithOverlappingCastedColumns;
 
 CJoinPredTest:
 MultipleDampedPredJoinCardinality MultipleIndependentPredJoinCardinality MultiDistKeyJoinCardinality

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -11112,15 +11112,17 @@ FROM   (SELECT *
  Aggregate  (cost=0.00..1293.00 rows=1 width=8)
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=4 width=1)
          ->  Append  (cost=0.00..1293.00 rows=2 width=1)
-               ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=3)
+               ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=1)
                      Hash Cond: ((tab_1.id)::text = (tab_2.id)::text)
                      ->  Seq Scan on tab_1  (cost=0.00..431.00 rows=1 width=5)
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=7)
-                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=7)
-                                 ->  Seq Scan on tab_2  (cost=0.00..431.00 rows=1 width=7)
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                       Filter: ((tab_2.cd)::text = (tab_2.cd)::text)
+                                       ->  Seq Scan on tab_2  (cost=0.00..431.00 rows=1 width=7)
                ->  Seq Scan on tab_3  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(11 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
 
 SELECT Count(*)
 FROM   (SELECT *
@@ -11436,50 +11438,50 @@ INSERT INTO onetimefilter2 SELECT i, i FROM generate_series(1,10)i;
 ANALYZE onetimefilter1;
 ANALYZE onetimefilter2;
 EXPLAIN WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM onetimefilter1, onetimefilter2 WHERE onetimefilter1.a=onetimefilter2.a) SELECT (SELECT 1 FROM abc WHERE f1.b = f2.b LIMIT 1), COALESCE((SELECT 2 FROM abc WHERE f1.a=random() AND f1.a=2), 0), (SELECT b FROM abc WHERE b=f1.b) FROM onetimefilter1 f1, onetimefilter2 f2 WHERE f1.b = f2.b;
-                                                          QUERY PLAN                                                          
-------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1852062876647.47 rows=11 width=12)
-   ->  Sequence  (cost=0.00..1852062876647.47 rows=4 width=12)
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1389270669201.79 rows=10 width=12)
+   ->  Sequence  (cost=0.00..1389270669201.78 rows=4 width=12)
          ->  Shared Scan (share slice:id 1:0)  (cost=0.00..862.00 rows=4 width=1)
                ->  Hash Join  (cost=0.00..862.00 rows=4 width=8)
                      Hash Cond: (onetimefilter1.a = onetimefilter2.a)
                      ->  Seq Scan on onetimefilter1  (cost=0.00..431.00 rows=4 width=8)
                      ->  Hash  (cost=431.00..431.00 rows=4 width=4)
                            ->  Seq Scan on onetimefilter2  (cost=0.00..431.00 rows=4 width=4)
-         ->  Hash Join  (cost=0.00..862.00 rows=4 width=12)
+         ->  Hash Join  (cost=0.00..1356708775.03 rows=4 width=16)
                Hash Cond: (onetimefilter1_1.b = onetimefilter2_1.b)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=4 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1356708344.03 rows=4 width=12)
                      Hash Key: onetimefilter1_1.b
-                     ->  Seq Scan on onetimefilter1 onetimefilter1_1  (cost=0.00..431.00 rows=4 width=8)
+                     ->  Seq Scan on onetimefilter1 onetimefilter1_1  (cost=0.00..1324047.81 rows=334 width=8)
+                           SubPlan 1
+                             ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                   ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                         One-Time Filter: (onetimefilter1_1.a = 2)
+                                         Filter: ((onetimefilter1_1.a)::double precision = random())
+                                         ->  Materialize  (cost=0.00..431.00 rows=10 width=1)
+                                               ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=10 width=1)
+                                                     ->  Result  (cost=0.00..431.00 rows=4 width=1)
+                                                           ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=4 width=1)
+                           SubPlan 2
+                             ->  Result  (cost=0.00..431.66 rows=1 width=4)
+                                   Filter: (share0_ref2.b = onetimefilter1_1.b)
+                                   ->  Materialize  (cost=0.00..431.00 rows=10 width=4)
+                                         ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=10 width=4)
+                                               ->  Result  (cost=0.00..431.00 rows=4 width=4)
+                                                     ->  Shared Scan (share slice:id 4:0)  (cost=0.00..431.00 rows=4 width=4)
                ->  Hash  (cost=431.00..431.00 rows=4 width=4)
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
+                     ->  Redistribute Motion 3:3  (slice5; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
                            Hash Key: onetimefilter2_1.b
                            ->  Seq Scan on onetimefilter2 onetimefilter2_1  (cost=0.00..431.00 rows=4 width=4)
-               SubPlan 1
+               SubPlan 3
                  ->  Result  (cost=0.00..431.01 rows=1 width=4)
                        ->  Limit  (cost=0.00..431.01 rows=1 width=1)
-                             ->  Result  (cost=0.00..431.01 rows=5 width=1)
+                             ->  Result  (cost=0.00..431.01 rows=4 width=1)
                                    One-Time Filter: (onetimefilter1_1.b = onetimefilter2_1.b)
-                                   ->  Materialize  (cost=0.00..431.00 rows=11 width=1)
-                                         ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=11 width=1)
+                                   ->  Materialize  (cost=0.00..431.00 rows=10 width=1)
+                                         ->  Broadcast Motion 3:3  (slice6; segments: 3)  (cost=0.00..431.00 rows=10 width=1)
                                                ->  Result  (cost=0.00..431.00 rows=4 width=1)
-                                                     ->  Shared Scan (share slice:id 4:0)  (cost=0.00..431.00 rows=4 width=1)
-               SubPlan 2
-                 ->  Result  (cost=0.00..431.33 rows=3 width=4)
-                       ->  Result  (cost=0.00..431.33 rows=3 width=1)
-                             One-Time Filter: (onetimefilter1_1.a = 2)
-                             Filter: ((onetimefilter1_1.a)::double precision = random())
-                             ->  Materialize  (cost=0.00..431.00 rows=11 width=1)
-                                   ->  Broadcast Motion 3:3  (slice5; segments: 3)  (cost=0.00..431.00 rows=11 width=1)
-                                         ->  Result  (cost=0.00..431.00 rows=4 width=1)
-                                               ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=4 width=1)
-               SubPlan 3
-                 ->  Result  (cost=0.00..431.66 rows=1 width=4)
-                       Filter: (share0_ref3.b = onetimefilter1_1.b)
-                       ->  Materialize  (cost=0.00..431.00 rows=11 width=4)
-                             ->  Broadcast Motion 3:3  (slice6; segments: 3)  (cost=0.00..431.00 rows=11 width=4)
-                                   ->  Result  (cost=0.00..431.00 rows=4 width=4)
-                                         ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=4 width=4)
+                                                     ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=4 width=1)
  Optimizer: Pivotal Optimizer (GPORCA)
 (43 rows)
 
@@ -11664,16 +11666,16 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO varchar_sc_array_cmp VALUES ('a'), ('b'), ('c'), ('d');
 EXPLAIN SELECT * FROM varchar_sc_array_cmp t1, varchar_sc_array_cmp t2 where t1.a = t2.a and t1.a in ('b', 'c');
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=4 width=4)
-   ->  Hash Join  (cost=0.00..862.00 rows=2 width=4)
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=16)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=16)
          Hash Cond: ((varchar_sc_array_cmp.a)::text = (varchar_sc_array_cmp_1.a)::text)
-         ->  Seq Scan on varchar_sc_array_cmp  (cost=0.00..431.00 rows=1 width=2)
-               Filter: (((a)::text = 'b'::text) OR ((a)::text = 'c'::text))
-         ->  Hash  (cost=431.00..431.00 rows=1 width=2)
-               ->  Seq Scan on varchar_sc_array_cmp varchar_sc_array_cmp_1  (cost=0.00..431.00 rows=1 width=2)
-                     Filter: (((a)::text = ANY ('{b,c}'::text[])) AND (((a)::text = 'b'::text) OR ((a)::text = 'c'::text)))
+         ->  Seq Scan on varchar_sc_array_cmp  (cost=0.00..431.00 rows=1 width=8)
+               Filter: (((a)::text = ANY ('{b,c}'::text[])) AND (a = ANY ('{b,c}'::character varying[])))
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Seq Scan on varchar_sc_array_cmp varchar_sc_array_cmp_1  (cost=0.00..431.00 rows=1 width=8)
+                     Filter: (a = ANY ('{b,c}'::character varying[]))
  Optimizer: Pivotal Optimizer (GPORCA)
 (9 rows)
 
@@ -11686,17 +11688,17 @@ SELECT * FROM varchar_sc_array_cmp t1, varchar_sc_array_cmp t2 where t1.a = t2.a
 
 SET optimizer_array_constraints=on;
 EXPLAIN SELECT * FROM varchar_sc_array_cmp t1, varchar_sc_array_cmp t2 where t1.a = t2.a and (t1.a in ('b', 'c') OR t1.a = 'a');
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=4 width=4)
-   ->  Hash Join  (cost=0.00..862.00 rows=2 width=4)
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=16)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=16)
          Hash Cond: ((varchar_sc_array_cmp.a)::text = (varchar_sc_array_cmp_1.a)::text)
-         ->  Seq Scan on varchar_sc_array_cmp  (cost=0.00..431.00 rows=1 width=2)
-               Filter: (a = ANY ('{a,b,c}'::character varying[]))
-         ->  Hash  (cost=431.00..431.00 rows=1 width=2)
-               ->  Seq Scan on varchar_sc_array_cmp varchar_sc_array_cmp_1  (cost=0.00..431.00 rows=1 width=2)
+         ->  Seq Scan on varchar_sc_array_cmp  (cost=0.00..431.00 rows=1 width=8)
+               Filter: ((((a)::text = ANY ('{b,c}'::text[])) OR ((a)::text = 'a'::text)) AND (a = ANY ('{a,b,c}'::character varying[])))
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Seq Scan on varchar_sc_array_cmp varchar_sc_array_cmp_1  (cost=0.00..431.00 rows=1 width=8)
                      Filter: (a = ANY ('{a,b,c}'::character varying[]))
- Optimizer: Pivotal Optimizer (GPORCA) version 3.65.2
+ Optimizer: Pivotal Optimizer (GPORCA)
 (9 rows)
 
 SELECT * FROM varchar_sc_array_cmp t1, varchar_sc_array_cmp t2 where t1.a = t2.a and (t1.a in ('b', 'c') OR t1.a = 'a');

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -11117,12 +11117,10 @@ FROM   (SELECT *
                      ->  Seq Scan on tab_1  (cost=0.00..431.00 rows=1 width=5)
                      ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                            ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                 ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                                       Filter: ((tab_2.cd)::text = (tab_2.cd)::text)
-                                       ->  Seq Scan on tab_2  (cost=0.00..431.00 rows=1 width=7)
+                                 ->  Seq Scan on tab_2  (cost=0.00..431.00 rows=1 width=7)
                ->  Seq Scan on tab_3  (cost=0.00..431.00 rows=1 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(11 rows)
 
 SELECT Count(*)
 FROM   (SELECT *

--- a/src/test/regress/expected/indexjoin_optimizer.out
+++ b/src/test/regress/expected/indexjoin_optimizer.out
@@ -29,25 +29,26 @@ GROUP BY 1
 ORDER BY 1 asc ;
                                                                         QUERY PLAN                                                                        
 ----------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..878.47 rows=413 width=16)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..870.29 rows=413 width=16)
    Merge Key: ((((my_tt_agg_small.event_ts / 100000) / 5) * 5))
-   ->  Finalize GroupAggregate  (cost=0.00..878.44 rows=138 width=16)
+   ->  Finalize GroupAggregate  (cost=0.00..870.27 rows=138 width=16)
          Group Key: ((((my_tt_agg_small.event_ts / 100000) / 5) * 5))
-         ->  Sort  (cost=0.00..878.44 rows=138 width=16)
+         ->  Sort  (cost=0.00..870.26 rows=138 width=16)
                Sort Key: ((((my_tt_agg_small.event_ts / 100000) / 5) * 5))
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..878.35 rows=138 width=16)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..870.18 rows=138 width=16)
                      Hash Key: ((((my_tt_agg_small.event_ts / 100000) / 5) * 5))
-                     ->  Streaming Partial HashAggregate  (cost=0.00..878.34 rows=138 width=16)
-                           Group Key: (((my_tt_agg_small.event_ts / 100000) / 5) * 5)
-                           ->  Hash Join  (cost=0.00..865.64 rows=94594 width=8)
-                                 Hash Cond: ((my_tq_agg_small.sym)::text = (my_tt_agg_small.symbol)::text)
+                     ->  Streaming Partial HashAggregate  (cost=0.00..870.17 rows=138 width=16)
+                           Group Key: ((((my_tt_agg_small.event_ts / 100000) / 5) * 5))
+                           ->  Hash Join  (cost=0.00..864.37 rows=45925 width=8)
+                                 Hash Cond: ((my_tq_agg_small.sym)::bpchar = my_tt_agg_small.symbol)
                                  Join Filter: ((my_tt_agg_small.event_ts >= my_tq_agg_small.ets) AND (my_tt_agg_small.event_ts < my_tq_agg_small.end_ts))
                                  ->  Seq Scan on my_tq_agg_small  (cost=0.00..431.02 rows=676 width=20)
-                                 ->  Hash  (cost=431.30..431.30 rows=420 width=25)
-                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.30 rows=420 width=25)
-                                             ->  Seq Scan on my_tt_agg_small  (cost=0.00..431.01 rows=140 width=25)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(18 rows)
+                                 ->  Hash  (cost=431.31..431.31 rows=420 width=33)
+                                       ->  Result  (cost=0.00..431.31 rows=420 width=33)
+                                             ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.30 rows=420 width=25)
+                                                   ->  Seq Scan on my_tt_agg_small  (cost=0.00..431.01 rows=140 width=25)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(19 rows)
 
 SELECT (tt.event_ts / 100000) / 5 * 5 as fivemin, COUNT(*)
 FROM my_tt_agg_small tt, my_tq_agg_small tq
@@ -90,25 +91,27 @@ GROUP BY 1
 ORDER BY 1 asc ;
                                                                                                       QUERY PLAN                                                                                                       
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1359.12 rows=413 width=16)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1336.17 rows=413 width=16)
    Merge Key: ((((my_tt_agg_small.event_ts / 100000) / 5) * 5))
-   ->  Finalize GroupAggregate  (cost=0.00..1359.09 rows=138 width=16)
+   ->  Finalize GroupAggregate  (cost=0.00..1336.14 rows=138 width=16)
          Group Key: ((((my_tt_agg_small.event_ts / 100000) / 5) * 5))
-         ->  Sort  (cost=0.00..1359.08 rows=138 width=16)
+         ->  Sort  (cost=0.00..1336.13 rows=138 width=16)
                Sort Key: ((((my_tt_agg_small.event_ts / 100000) / 5) * 5))
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1358.94 rows=138 width=16)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1335.99 rows=138 width=16)
                      Hash Key: ((((my_tt_agg_small.event_ts / 100000) / 5) * 5))
-                     ->  Streaming Partial HashAggregate  (cost=0.00..1358.93 rows=138 width=16)
-                           Group Key: (((my_tt_agg_small.event_ts / 100000) / 5) * 5)
-                           ->  Nested Loop  (cost=0.00..1339.87 rows=94594 width=8)
+                     ->  Partial GroupAggregate  (cost=0.00..1335.98 rows=138 width=16)
+                           Group Key: ((((my_tt_agg_small.event_ts / 100000) / 5) * 5))
+                           ->  Nested Loop  (cost=0.00..1335.42 rows=45925 width=8)
                                  Join Filter: (((my_tq_agg_small.sym)::bpchar = my_tt_agg_small.symbol) AND (my_tt_agg_small.event_ts >= my_tq_agg_small.ets) AND (my_tt_agg_small.event_ts < my_tq_agg_small.end_ts))
-                                 ->  Seq Scan on my_tt_agg_small  (cost=0.00..431.01 rows=140 width=25)
+                                 ->  Sort  (cost=0.00..431.33 rows=140 width=33)
+                                       Sort Key: ((((my_tt_agg_small.event_ts / 100000) / 5) * 5))
+                                       ->  Seq Scan on my_tt_agg_small  (cost=0.00..431.01 rows=140 width=25)
                                  ->  Materialize  (cost=0.00..431.16 rows=676 width=20)
-                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.14 rows=676 width=20)
+                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.14 rows=676 width=20)
                                              Hash Key: my_tq_agg_small.sym
                                              ->  Seq Scan on my_tq_agg_small  (cost=0.00..431.03 rows=676 width=20)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(18 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(20 rows)
 
 reset optimizer_segments;
 reset optimizer_nestloop_factor;

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -4442,20 +4442,21 @@ from (
 	group by 1,2
      ) as t1 
 group by 1, 2;
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.28 rows=1 width=12)
-   ->  GroupAggregate  (cost=0.00..1324032.28 rows=1 width=12)
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.19 rows=1 width=12)
+   ->  GroupAggregate  (cost=0.00..1324032.19 rows=1 width=12)
          Group Key: ((bar_6325.bar_6325_attr)::integer), foo_6325.foo_6325_attr
-         ->  Sort  (cost=0.00..1324032.28 rows=1 width=12)
+         ->  Sort  (cost=0.00..1324032.19 rows=1 width=12)
                Sort Key: ((bar_6325.bar_6325_attr)::integer), foo_6325.foo_6325_attr
-               ->  Nested Loop  (cost=0.00..1324032.28 rows=1 width=16)
+               ->  Nested Loop  (cost=0.00..1324032.19 rows=1 width=12)
                      Join Filter: true
-                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                           ->  Seq Scan on bar_6325  (cost=0.00..431.00 rows=1 width=8)
                      ->  Seq Scan on foo_6325  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(11 rows)
+                     ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Seq Scan on bar_6325  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
 
 -- start_ignore
 drop table qp_misc_jiras.foo_6325;

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -376,7 +376,9 @@ END
 $$
 LANGUAGE plpgSQL READS SQL DATA;
 
+SET optimizer=off;
 SELECT dtx_dispatch_f(foo.c1) FROM (SELECT c1 FROM dtx_dispatch_t WHERE c1='1' limit 1) foo;
+RESET optimizer;
 
 DROP FUNCTION dtx_dispatch_f(integer);
 DROP TABLE dtx_dispatch_t;

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -631,10 +631,12 @@ EXCEPTION
 END
 $$
 LANGUAGE plpgSQL READS SQL DATA;
+SET optimizer=off;
 SELECT dtx_dispatch_f(foo.c1) FROM (SELECT c1 FROM dtx_dispatch_t WHERE c1='1' limit 1) foo;
 ERROR:  query plan with multiple segworker groups is not supported
 HINT:  dispatching DTX commands to a busy gang
 CONTEXT:  PL/pgSQL function "dtx_dispatch_f" line 1 during statement block entry
+RESET optimizer;
 DROP FUNCTION dtx_dispatch_f(integer);
 DROP TABLE dtx_dispatch_t;
 -- Test interconnect is shut down under portal failure


### PR DESCRIPTION
Given the following setup:

   ```sql
   CREATE TABLE foo ( a text, b text);
   CREATE TABLE bar ( c text, d text);
   CREATE VIEW foobar AS SELECT foo.b::character varying(100) AS b, foo.a, bar.c, bar.d FROM foo JOIN bar ON foo.a = bar.c;

   EXPLAIN SELECT * FROM foobar WHERE b = 'meh';
   ```

ORCA was producing an inefficient plan with filter above the join:

    ```
                                             QUERY PLAN
    --------------------------------------------------------------------------------------------
     Gather Motion 3:1  (slice1; segments: 3)
       ->  Result
             Filter: ((("varchar"((foo.b)::character varying, 104, true)))::text = 'meh'::text)
             ->  Hash Join
                   Hash Cond: (foo.a = bar.c)
                   ->  Seq Scan on foo
                   ->  Hash
                         ->  Seq Scan on bar
     Optimizer: Pivotal Optimizer (GPORCA)
    (9 rows)
    ```

Issue is that given the following expression tree:

    ```
    +--CLogicalSelect
       |--CLogicalProject
       |  |--CLogicalNAryJoin
       |  |  |--CLogicalGet "foo" ("foo"), Columns: ["a" (0), "b" (1), ...
       |  |  |--CLogicalGet "bar" ("bar"), Columns: ["c" (9), "d" (10), ...
       |  |  +--CScalarCmp (=)
       |  |     |--CScalarIdent "a" (0)
       |  |     +--CScalarIdent "c" (9)
       |  +--CScalarProjectList
       |     +--CScalarProjectElement "b" (18)
       |        +--CScalarFunc (varchar)
       |           |--CScalarCast
       |           |  +--CScalarIdent "b" (1)
       |           |--CScalarConst (104)
       |           +--CScalarConst (1)
       +--CScalarCmp (=)
          |--CScalarCast
          |  +--CScalarIdent "b" (18)
          +--CScalarConst (1828233457.000)
    ```

ORCA has no way to push the CScalarCast "b" (18) below the
CLogicalNAryJoin because there are no references to "b" (18) below the
join. In order to fix this, this commit updates the preprocessor to push
any project cast down to immediately above any corresponding
CLogicalGet. For example, the previous tree would produce:

    ```
    +--CLogicalSelect
       |--CLogicalNAryJoin
       |  |--CLogicalProject
       |  |  |--CLogicalGet "foo" ("foo"), Columns: ["a" (0), "b" (1), ...
       |  |  +--CScalarProjectList
       |  |     +--CScalarProjectElement "b" (18)
       |  |        +--CScalarFunc (varchar)
       |  |           |--CScalarCast
       |  |           |  +--CScalarIdent "b" (1)
       |  |           |--CScalarConst (104)
       |  |           +--CScalarConst (1)
       |  |--CLogicalGet "bar" ("bar"), Columns: ["c" (9), "d" (10), ...
       |  +--CScalarCmp (=)
       |     |--CScalarIdent "a" (0)
       |     +--CScalarIdent "c" (9)
       +--CScalarCmp (=)
          |--CScalarCast
          |  +--CScalarIdent "b" (18)
          +--CScalarConst (1828233457.000)
    ```

After this commit ORCA is able to push down the filter below the join:

    ```
                                                QUERY PLAN
    --------------------------------------------------------------------------------------------------
     Gather Motion 3:1  (slice1; segments: 3)
       ->  Hash Join
             Hash Cond: (foo.a = bar.c)
             ->  Result
                   Filter: ((("varchar"((foo.b)::character varying, 104, true)))::text = 'meh'::text)
                   ->  Seq Scan on foo
             ->  Hash
                   ->  Seq Scan on bar
     Optimizer: Pivotal Optimizer (GPORCA)
    (9 rows)
    ```