### PR TITLE
gpinitsystem: Making sure that host-name filed is populated with host-name

### DIFF
--- a/concourse/scripts/setup_gpadmin_user.bash
+++ b/concourse/scripts/setup_gpadmin_user.bash
@@ -63,6 +63,8 @@ create_gpadmin_if_not_existing() {
       echo "gpadmin user already exists, skipping creating again."
   else
       eval "$*"
+      # Add user to sudoers list
+      echo "gpadmin ALL = NOPASSWD : ALL" >> /etc/sudoers
   fi
 }
 

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -1278,8 +1278,7 @@ CREATE_QD_DB () {
 		BACKOUT_COMMAND "if [ -d $GP_DIR ]; then $EXPORT_LIB_PATH;export PGPORT=$GP_PORT; $PG_CTL -D $GP_DIR stop; fi"
 		BACKOUT_COMMAND "$ECHO \"Stopping Coordinator instance\""
 		LOG_MSG "[INFO]:-Completed starting the Coordinator in admin mode"
-		GP_HOSTNAME=$GP_HOSTADDRESS
-		PING_HOST $GP_HOSTNAME
+		PING_HOST $GP_HOSTADDRESS
 		RETVAL=$?
 		if [ $RETVAL -ne 0 ]; then
 			ERROR_EXIT "[FATAL]:-Could not establish connection to hostname $GP_HOSTNAME. Please check your configuration."
@@ -1325,8 +1324,7 @@ LOAD_QE_SYSTEM_DATA () {
 		do
 				SET_VAR $I
 				LOG_MSG "[INFO]:-Adding segment $GP_HOSTADDRESS to Coordinator system tables"
-				GP_HOSTNAME=$GP_HOSTADDRESS
-				PING_HOST $GP_HOSTNAME
+				PING_HOST $GP_HOSTADDRESS
 				RETVAL=$?
 				if [ $RETVAL -ne 0 ]; then
 					ERROR_EXIT "[FATAL]:-Could not establish connection to hostname $GP_HOSTNAME. Please check your configuration."

--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -317,3 +317,18 @@ Feature: gpinitsystem tests
         Then gpinitsystem should return a return code of 0
         And gpinitsystem should not print "Start Function REMOTE_EXECUTE_AND_GET_OUTPUT" to stdout
         And gpinitsystem should not print "End Function REMOTE_EXECUTE_AND_GET_OUTPUT" to stdout
+
+     Scenario: gpinitsystem creates a cluster with for multi-nic setup and populates table entries correctly
+         Given the database is not running
+         And create demo cluster config
+         #Create hosts file with new host-name
+         And backup /etc/hosts file and update hostname entry for localhost
+         And update hostlist file with updated host-address
+         And update clusterConfig file with new port and host-address
+         And update the private keys for the new host address
+         When the user runs "gpinitsystem -a -c /tmp/clusterConfigFile-1 -h /tmp/hostfile--1"
+         Then gpinitsystem should return a return code of 0
+         #Verify entries in the gp_segment_configuration as expected
+         And verify that cluster config has host-name populated correctly
+         #restore hosts file
+         And the user runs command "sudo mv -f /etc/hosts_orig /etc/hosts; rm -f /tmp/clusterConfigFile-1; rm -f /tmp/hostfile--1"


### PR DESCRIPTION
Making sure that the gpinitsystem populates correct value in gp_segment_configuration table with the right value of segment host-name for primary and mirror segments. 
Currently when creating cluster using gpinitsystem and contains host with multiple interfaces/addresses, in the segment configuration host-name field is getting populated with host-address. After this change, host-address field and host-name field will have respective values. 
Code change contains to avoid overwriting host-name field with the address. 

**Testing Done**:
Ran manual tests on ByoL cluster with mirror and standby configuration. 
Concourse pipeline is almost green. 

**Prior to change**: 
If node has multiple NIC's, and if we specify address as part of segment host list, same getting populated as host name and host-address. 
In bellow example sdw-2, sdw2-3 are the alternate address which were provided as part of host-list and are getting populated in the segment configuration in both the fields. 
Here's the sample hosts file: 
```
cat /etc/hosts
192.168.20.1 sdw1-1 sdw1
localhost :
```
Cluster Configuration we can see host name field also contains the address:
```
psql -c " select * from gp_segment_configuration" -t template1
   dbid | content | role | preferred_role | mode | status | port  | hostname | address |           datadir
------+---------+------+----------------+------+--------+-------+----------+---------+-----------------------------
    1 |      -1 | p    | p              | n    | u      | 5432 | mdw-1    | mdw-1   | /data/master/gpseg-1
    2 |       0 | p    | p              | n    | u      | 6000 | sdw1-2   | sdw1-2  | /data1/primary/gpseg0
    4 |       2 | p    | p              | n    | u      | 6000 | sdw2-3   | sdw2-3  | /data1/primary/gpseg2
    3 |       1 | p    | p              | n    | u      | 6001 | sdw1-2   | sdw1-2  | /data2/primary/gpseg1
    5 |       3 | p    | p              | n    | u      | 6001 | sdw2-3   | sdw2-3  | /data2/primary/gpseg3
```

**After the changes**
After this PR, host name is getting populated in the host-name field even when host-address (sdw1-2, sdw2-3) were provided in input host-list. 

**On a multi-node setup without mirrors**: 

```
    dbid | content | role | preferred_role | mode | status | port  | hostname | address |           datadir
------+---------+------+----------------+------+--------+-------+----------+---------+-----------------------------
   1 |      -1 | p    | p              | n    | u      |  5432 | mdw      | mdw     | /data/gpdata/master/gpseg-1
   2 |       0 | p    | p              | n    | u      | 20000 | sdw1     | sdw1-1  | /data/gpdata/primary/gpseg0
   3 |       1 | p    | p              | n    | u      | 20001 | sdw1     | sdw1-1  | /data/gpdata/primary/gpseg1
   4 |       2 | p    | p              | n    | u      | 20000 | sdw2     | sdw2-2  | /data/gpdata/primary/gpseg2
   5 |       3 | p    | p              | n    | u      | 20001 | sdw2     | sdw2-2  | /data/gpdata/primary/gpseg3
   6 |       4 | p    | p              | n    | u      | 20000 | sdw3     | sdw3-3  | /data/gpdata/primary/gpseg4
   7 |       5 | p    | p              | n    | u      | 20001 | sdw3     | sdw3-3  | /data/gpdata/primary/gpseg5
   8 |       6 | p    | p              | n    | u      | 20000 | sdw4     | sdw4-4  | /data/gpdata/primary/gpseg6
   9 |       7 | p    | p              | n    | u      | 20001 | sdw4     | sdw4-4  | /data/gpdata/primary/gpseg7

```

**On a multi-side setup with mirrors**: 
```
 dbid | content | role | preferred_role | mode | status | port  | hostname | address |           datadir
------+---------+------+----------------+------+--------+-------+----------+---------+-----------------------------
    1 |      -1 | p    | p              | n    | u      |  5432 | mdw      | mdw     | /data/gpdata/master/gpseg-1
    2 |       0 | p    | p              | s    | u      | 20000 | sdw1     | sdw1-1  | /data/gpdata/primary/gpseg0
    3 |       1 | p    | p              | s    | u      | 20001 | sdw1     | sdw1-1  | /data/gpdata/primary/gpseg1
    4 |       2 | p    | p              | s    | u      | 20000 | sdw2     | sdw2-2  | /data/gpdata/primary/gpseg2
    5 |       3 | p    | p              | s    | u      | 20001 | sdw2     | sdw2-2  | /data/gpdata/primary/gpseg3
    6 |       0 | m    | m              | s    | u      | 21000 | sdw2     | sdw2-2  | /data/gpdata/mirror/gpseg0
    7 |       1 | m    | m              | s    | u      | 21001 | sdw2     | sdw2-2  | /data/gpdata/mirror/gpseg1
    8 |       2 | m    | m              | s    | u      | 21000 | sdw1     | sdw1-1  | /data/gpdata/mirror/gpseg2
    9 |       3 | m    | m              | s    | u      | 21001 | sdw1     | sdw1-1  | /data/gpdata/mirror/gpseg3
(9 rows)
```

**After the change(and adding mirror and standby)**:
```
psql -c " select * from gp_segment_configuration" -t template1
    1 |      -1 | p    | p              | n    | u      | 5432 | mdw      | mdw     | /data/master/gpseg-1
    4 |       2 | p    | p              | s    | u      | 6000 | sdw2     | sdw2-3  | /data1/primary/gpseg2
    8 |       2 | m    | m              | s    | u      | 7000 | sdw1     | sdw1-2  | /data1/mirror/gpseg2
    2 |       0 | p    | p              | s    | u      | 6000 | sdw1     | sdw1-2  | /data1/primary/gpseg0
    6 |       0 | m    | m              | s    | u      | 7000 | sdw2     | sdw2-3  | /data1/mirror/gpseg0
    3 |       1 | p    | p              | s    | u      | 6001 | sdw1     | sdw1-2  | /data2/primary/gpseg1
    7 |       1 | m    | m              | s    | u      | 7001 | sdw2     | sdw2-3  | /data2/mirror/gpseg1
    5 |       3 | p    | p              | s    | u      | 6001 | sdw2     | sdw2-3  | /data2/primary/gpseg3
    9 |       3 | m    | m              | s    | u      | 7001 | sdw1     | sdw1-2  | /data2/mirror/gpseg3
```



## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
