### PR TITLE
[backport] added cluster health check for gpexpand

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -40,6 +40,7 @@ try:
     from gppylib.heapchecksum import HeapChecksum
     from gppylib.commands.pg import PgBaseBackup
     from gppylib.mainUtils import ExceptionNoStackTraceNeeded
+    from contextlib import closing
 
 except ImportError, e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
@@ -257,6 +258,17 @@ def gpexpand_status_file_exists(master_data_directory):
     """Checks if gpexpand.pid exists"""
     return os.path.exists(master_data_directory + '/gpexpand.status')
 
+
+def is_cluster_up_and_balanced(dburl):
+    count = -1
+    sql = "select count(*) from gp_segment_configuration where status <> 'u' or preferred_role <> role;"
+    try:
+        with closing(dbconn.connect(dburl, encoding='UTF8')) as conn:
+            count = dbconn.execSQLForSingleton(conn, sql)
+    except Exception as e:
+        raise Exception("failed to query cluster role check: %s" % str(e))
+
+    return count == 0
 
 # -------------------------------------------------------------------------
 # expansion schema
@@ -2473,6 +2485,10 @@ def main(options, args, parser):
             except ExpansionError, e:
                 logger.error(e)
                 sys.exit(1)
+
+        # check if the cluster is in good health
+        if gpexpand_file_status is None and gpexpand_db_status is None and not is_cluster_up_and_balanced(dburl):
+            logger.warning('One or more segments are either down or not in preferred role.')
 
         if gpexpand_db_status == 'SETUP DONE' or gpexpand_db_status == 'EXPANSION STOPPED':
             if not _gp_expand.validate_max_connections():

--- a/gpMgmt/bin/gppylib/gparray.py
+++ b/gpMgmt/bin/gppylib/gparray.py
@@ -1254,54 +1254,66 @@ class GpArray:
         return len(self.segmentPairs)
 
     # --------------------------------------------------------------------
+    def get_primary_port_list(self):
+        primary_ports = []
+        for segPair in self.segmentPairs:
+            primary = segPair.primaryDB
+            mirror = segPair.mirrorDB
+
+            if primary.preferred_role == primary.role:
+                primary_ports.append(primary.port)
+            else:
+                primary_ports.append(mirror.port)
+
+        if len(primary_ports) == 0:
+            raise Exception("No primary ports found in array.")
+
+        return primary_ports
+    # --------------------------------------------------------------------
+
+    def get_mirror_port_list(self):
+
+        if self.get_mirroring_enabled() is False:
+            raise Exception('Mirroring is not enabled')
+
+        mirror_ports = []
+        for segPair in self.segmentPairs:
+            primary = segPair.primaryDB
+            mirror = segPair.mirrorDB
+
+            if mirror.preferred_role == mirror.role:
+                mirror_ports.append(mirror.port)
+            else:
+                mirror_ports.append(primary.port)
+
+        if len(mirror_ports) == 0:
+            raise Exception("No mirror ports found in array.")
+
+        return mirror_ports
+
+    # --------------------------------------------------------------------
     def get_min_primary_port(self):
         """Returns the minimum primary segment db port"""
-        min_primary_port = self.segmentPairs[0].primaryDB.port
-        for segPair in self.segmentPairs:
-            if segPair.primaryDB.port < min_primary_port:
-                min_primary_port = segPair.primaryDB.port
-
-        return min_primary_port
+        primary_ports = self.get_primary_port_list()
+        return min(primary_ports)
 
     # --------------------------------------------------------------------
     def get_max_primary_port(self):
         """Returns the maximum primary segment db port"""
-        max_primary_port = self.segmentPairs[0].primaryDB.port
-        for segPair in self.segmentPairs:
-            if segPair.primaryDB.port > max_primary_port:
-                max_primary_port = segPair.primaryDB.port
-
-        return max_primary_port
+        primary_ports = self.get_primary_port_list()
+        return max(primary_ports)
 
     # --------------------------------------------------------------------
     def get_min_mirror_port(self):
         """Returns the minimum mirror segment db port"""
-        if self.get_mirroring_enabled() is False:
-            raise Exception('Mirroring is not enabled')
-
-        min_mirror_port = self.segmentPairs[0].mirrorDB.port
-
-        for segPair in self.segmentPairs:
-            mirror = segPair.mirrorDB
-            if mirror and mirror.port < min_mirror_port:
-                min_mirror_port = mirror.port
-
-        return min_mirror_port
+        mirror_ports = self.get_mirror_port_list()
+        return min(mirror_ports)
 
     # --------------------------------------------------------------------
     def get_max_mirror_port(self):
         """Returns the maximum mirror segment db port"""
-        if self.get_mirroring_enabled() is False:
-            raise Exception('Mirroring is not enabled')
-
-        max_mirror_port = self.segmentPairs[0].mirrorDB.port
-
-        for segPair in self.segmentPairs:
-            mirror = segPair.mirrorDB
-            if mirror and mirror.port > max_mirror_port:
-                max_mirror_port = mirror.port
-
-        return max_mirror_port
+        mirror_ports = self.get_mirror_port_list()
+        return max(mirror_ports)
 
     # --------------------------------------------------------------------
     def get_interface_numbers(self):

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gparray.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gparray.py
@@ -190,7 +190,7 @@ class GpArrayTestCase(GpTestCase):
                     port = 5432,
                     datadir = '/masterdir')
         allrows = []
-        allrows.append(master)                 
+        allrows.append(master)
         rows =  createSegmentRows(hostlist, interface_list, primary_list, primary_portbase, mirror_type,
                                   mirror_list, mirror_portbase, dir_prefix)
         
@@ -256,11 +256,132 @@ class GpArrayTestCase(GpTestCase):
         with self.assertRaisesRegexp(Exception, 'Cannot connect to GPDB version 5 from installed version 6'):
             GpArray.initFromCatalog(None)
 
+    def test_get_min_primary_port_when_cluster_balanced(self):
+        self.gpArray = self._createBalancedGpArrayWith2Primary2Mirrors()
+        expected = 6000
+        actual = GpArray.get_min_primary_port(self.gpArray)
+        self.assertEqual(expected, actual)
+
+    def test_get_min_primary_port_when_cluster_not_balanced(self):
+        self.gpArray = self._createUnBalancedGpArrayWith2Primary2Mirrors()
+        expected = 6000
+        actual = GpArray.get_min_primary_port(self.gpArray)
+        self.assertEqual(expected, actual)
+
+    def test_get_max_primary_port_when_cluster_balanced(self):
+        self.gpArray = self._createBalancedGpArrayWith2Primary2Mirrors()
+        expected = 6001
+        actual = GpArray.get_max_primary_port(self.gpArray)
+        self.assertEqual(expected, actual)
+
+    def test_get_max_primary_port_when_cluster_not_balanced(self):
+        self.gpArray = self._createUnBalancedGpArrayWith2Primary2Mirrors()
+        expected = 6001
+        actual = GpArray.get_max_primary_port(self.gpArray)
+        self.assertEqual(expected, actual)
+
+    def test_get_min_mirror_port_when_cluster_balanced(self):
+        self.gpArray = self._createBalancedGpArrayWith2Primary2Mirrors()
+        expected = 7000
+        actual = GpArray.get_min_mirror_port(self.gpArray)
+        self.assertEqual(expected, actual)
+
+    def test_get_min_mirror_port_when_cluster_not_balanced(self):
+        self.gpArray = self._createUnBalancedGpArrayWith2Primary2Mirrors()
+        expected = 7000
+        actual = GpArray.get_min_mirror_port(self.gpArray)
+        self.assertEqual(expected, actual)
+
+    def test_get_max_mirror_port_when_cluster_balanced(self):
+        self.gpArray = self._createBalancedGpArrayWith2Primary2Mirrors()
+        expected = 7001
+        actual = GpArray.get_max_mirror_port(self.gpArray)
+        self.assertEqual(expected, actual)
+
+    def test_get_max_mirror_port_when_cluster_not_balanced(self):
+        self.gpArray = self._createUnBalancedGpArrayWith2Primary2Mirrors()
+        expected = 7001
+        actual = GpArray.get_max_mirror_port(self.gpArray)
+        self.assertEqual(expected, actual)
+
+    def test_get_primary_port_list_when_cluster_balanced(self):
+        self.gpArray = self._createBalancedGpArrayWith2Primary2Mirrors()
+        expected = [6000, 6001]
+        actual = GpArray.get_primary_port_list(self.gpArray)
+        self.assertEqual(expected, actual)
+
+    def test_get_primary_port_list_when_cluster_not_balanced(self):
+        self.gpArray = self._createUnBalancedGpArrayWith2Primary2Mirrors()
+        expected = [6000, 6001]
+        actual = GpArray.get_primary_port_list(self.gpArray)
+        self.assertEqual(expected, actual)
+
+    def test_get_primary_port_list_len_exception(self):
+        self.gpArray = self._createBalancedGpArrayWith2Primary2Mirrors()
+        self.gpArray.segmentPairs = []
+        with self.assertRaisesRegexp(Exception, 'No primary ports found in array.'):
+            GpArray.get_primary_port_list(self.gpArray)
+
+    def test_get_mirror_port_list_when_cluster_balanced(self):
+        self.gpArray = self._createBalancedGpArrayWith2Primary2Mirrors()
+        expected = [7000, 7001]
+        actual = GpArray.get_mirror_port_list(self.gpArray)
+        self.assertEqual(expected, actual)
+
+    def test_get_mirror_port_list_when_cluster_not_balanced(self):
+        self.gpArray = self._createUnBalancedGpArrayWith2Primary2Mirrors()
+        expected = [7000, 7001]
+        actual = GpArray.get_mirror_port_list(self.gpArray)
+        self.assertEqual(expected, actual)
+
+    @patch('gppylib.gparray.GpArray.get_mirroring_enabled', return_value=False)
+    def test_get_mirror_port_list_no_mirror_exception(self,mock1):
+        self.gpArray = self._createBalancedGpArrayWith2Primary2Mirrors()
+        with self.assertRaisesRegexp(Exception, 'Mirroring is not enabled'):
+            GpArray.get_mirror_port_list(self.gpArray)
+
+    @patch('gppylib.gparray.GpArray.get_mirroring_enabled', return_value=True)
+    def test_get_mirror_port_list_len_exception(self, mock1):
+        self.gpArray = self._createBalancedGpArrayWith2Primary2Mirrors()
+        self.gpArray.segmentPairs = []
+        with self.assertRaisesRegexp(Exception, 'No mirror ports found in array.'):
+            GpArray.get_mirror_port_list(self.gpArray)
+
+    def _createBalancedGpArrayWith2Primary2Mirrors(self):
+        self.coordinator = Segment.initFromString(
+            "1|-1|p|p|s|u|cdw|cdw|6432|/data/coordinator")
+        self.primary0 = Segment.initFromString(
+            "2|0|p|p|s|u|sdw1|sdw1|6000|/data/primary0")
+        self.primary1 = Segment.initFromString(
+            "3|1|p|p|s|u|sdw2|sdw2|6001|/data/primary1")
+        self.mirror0 = Segment.initFromString(
+            "4|0|m|m|s|u|sdw2|sdw2|7000|/data/mirror0")
+        self.mirror1 = Segment.initFromString(
+            "5|1|m|m|s|u|sdw1|sdw1|7001|/data/mirror1")
+        self.standby = Segment.initFromString(
+            "6|-1|m|m|s|u|sdw3|sdw3|6432|/data/standby")
+        return GpArray([self.coordinator, self.standby, self.primary0, self.primary1, self.mirror0, self.mirror1])
+
+    def _createUnBalancedGpArrayWith2Primary2Mirrors(self):
+        self.coordinator = Segment.initFromString(
+            "1|-1|p|p|s|u|cdw|cdw|6432|/data/coordinator")
+        self.primary0 = Segment.initFromString(
+            "2|0|m|p|s|u|sdw1|sdw1|6000|/data/primary0")
+        self.primary1 = Segment.initFromString(
+            "3|1|m|p|s|u|sdw2|sdw2|6001|/data/primary1")
+        self.mirror0 = Segment.initFromString(
+            "4|0|p|m|s|u|sdw2|sdw2|7000|/data/mirror0")
+        self.mirror1 = Segment.initFromString(
+            "5|1|p|m|s|u|sdw1|sdw1|7001|/data/mirror1")
+        self.standby = Segment.initFromString(
+            "6|-1|m|m|s|u|sdw3|sdw3|6432|/data/standby")
+        return GpArray([self.coordinator, self.standby, self.primary0, self.primary1, self.mirror0, self.mirror1])
+
 def convert_bool(val):
     if val == 't':
         return True
     else:
-        return False   
+        return False
 
 #------------------------------- Mainline --------------------------------
 if __name__ == '__main__':

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpexpand.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpexpand.py
@@ -9,6 +9,7 @@ from gppylib.db import catalog
 from gppylib.gplog import *
 from gppylib.system.configurationInterface import GpConfigurationProvider
 from gppylib.system.environment import GpMasterEnvironment
+from gppylib.db import dbconn
 import io
 import sys
 
@@ -71,8 +72,8 @@ class GpExpand(GpTestCase):
         sys.argv = self.old_sys_argv
         super(GpExpand, self).tearDown()
 
-    # @patch('gpexpand.PgControlData.return_value.get_value', side_effect=[1, 1, 0])
-    def test_validate_heap_checksums_aborts_when_cluster_inconsistent(self):
+    @patch('gpexpand.is_cluster_up_and_balanced', return_value=True)
+    def test_validate_heap_checksums_aborts_when_cluster_inconsistent(self, mock1):
         self.options.filename = '/tmp/doesnotexist' # Replacement of the sys.argv
 
         self.mock_heap_checksum.return_value.get_segments_checksum_settings.return_value = ([1], [0])
@@ -94,8 +95,8 @@ class GpExpand(GpTestCase):
 
     @patch('gpexpand.FileDirExists.return_value.filedir_exists', return_value=True)
     @patch('gpexpand.FileDirExists', return_value=Mock())
-    # @patch('gpexpand.HeapChecksum.PgControlData.return_value.get_value', side_effect=[1, 1, 1])
-    def test_validate_heap_checksums_completes_when_cluster_consistent(self, mock1, mock2):
+    @patch('gpexpand.is_cluster_up_and_balanced', return_value=True)
+    def test_validate_heap_checksums_completes_when_cluster_consistent(self, mock1, mock2, mock3):
         """
         If all the segment checksums match the checksum at the master, then the cluster is consistent.
         This is essentially making sure that the validate_heap_checksums() internal method has not detected any
@@ -127,6 +128,33 @@ class GpExpand(GpTestCase):
             self.assertIn('The current system appears to be non-standard.', mock_stdout.getvalue())
 
         self.subject.logger.info.assert_any_call("User Aborted. Exiting...")
+
+    @patch('gppylib.db.dbconn.execSQLForSingleton', return_value=0)
+    def test_unit_cluster_up_and_balanced_true(self, mock1):
+        expected = True
+        actual = self.subject.is_cluster_up_and_balanced(dbconn.DbURL())
+        self.assertEqual(actual, expected)
+
+    @patch('gppylib.db.dbconn.execSQLForSingleton', return_value=2)
+    def test_unit_cluster_up_and_balanced_false(self, mock):
+        expected = False
+        actual = self.subject.is_cluster_up_and_balanced(dbconn.DbURL())
+        self.assertEqual(actual, expected)
+
+    @patch('gppylib.db.dbconn.execSQLForSingleton', side_effect=Exception())
+    def test_unit_cluster_up_and_balanced_exception(self, mock1):
+        with self.assertRaises(Exception) as ex:
+            self.subject.is_cluster_up_and_balanced(dbconn.DbURL())
+
+        self.assertTrue('failed to query cluster role check' in str(ex.exception))
+
+    @patch('gppylib.db.dbconn.connect', side_effect=Exception())
+    def test_unit_cluster_up_and_balanced_conn_exception(self, mock1):
+        with self.assertRaises(Exception) as ex:
+            self.subject.is_cluster_up_and_balanced(dbconn.DbURL())
+
+        self.assertTrue('failed to query cluster role check' in str(ex.exception))
+
     #
     # end tests for interview_setup()
     #


### PR DESCRIPTION
**Issue:** when one or more cluster is down or not in their preferred role, the assignment of port on expanded nodes are going wrong. the reason behind that the calculation of port using function get_max_primary_port() and get_max_mirror_port(). The idea to exit from gpexpand when the cluster is not in balanced state was blocking customer to expand if they found difficulty to make the system in balance state.  

**Fix:** updated the function to work in imbalance cluster state scenario. we are collecting all the port for primary and mirror based on preferred role of the segment, and if the role is switched we are considering segmentPairs.mirrorDB for primary port and segmentPairs.primaryDB for mirror port. in this we are collecting the port which is based on the preferred role.

Added warning in gpexpand when the cluster is in imbalance state. 

Added unit test cases for the positive/negative and exception scenario for the newly added functions. Updated feature test case where we are converting error to warning. 


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
