### PR TITLE
[6X_STABLE] Set the search_path correctly when CREATE EXTENSION WITH SCHEMA.

### DIFF
--- a/gpcontrib/gp_inject_fault/gp_inject_fault--1.0.sql
+++ b/gpcontrib/gp_inject_fault/gp_inject_fault--1.0.sql
@@ -3,7 +3,7 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION gp_fault_inject" to load this file. \quit
 
-CREATE FUNCTION gp_inject_fault(
+CREATE FUNCTION @extschema@.gp_inject_fault(
   faultname text,
   type text,
   ddl text,
@@ -19,7 +19,7 @@ AS 'MODULE_PATHNAME'
 LANGUAGE C VOLATILE STRICT NO SQL;
 
 -- Simpler version, without specific session id.
-CREATE FUNCTION gp_inject_fault(
+CREATE FUNCTION @extschema@.gp_inject_fault(
   faultname text,
   type text,
   ddl text,
@@ -30,58 +30,58 @@ CREATE FUNCTION gp_inject_fault(
   extra_arg int4,
   db_id int4)
 RETURNS text
-AS $$ select gp_inject_fault($1, $2, $3, $4, $5, $6, $7, $8, $9, -1) $$
+AS $$ select @extschema@.gp_inject_fault($1, $2, $3, $4, $5, $6, $7, $8, $9, -1) $$
 LANGUAGE SQL;
 
 -- Simpler version, trigger only one time, occurrence start at 1 and
 -- end at 1, no sleep and no ddl/database/tablename/sessionid.
-CREATE FUNCTION gp_inject_fault(
+CREATE FUNCTION @extschema@.gp_inject_fault(
   faultname text,
   type text,
   db_id int4)
 RETURNS text
-AS $$ select gp_inject_fault($1, $2, '', '', '', 1, 1, 0, $3, -1) $$
+AS $$ select @extschema@.gp_inject_fault($1, $2, '', '', '', 1, 1, 0, $3, -1) $$
 LANGUAGE SQL;
 
 -- Simpler version, trigger only one time, occurrence start at 1 and
 -- end at 1, no sleep and no ddl/database/tablename.
-CREATE FUNCTION gp_inject_fault(
+CREATE FUNCTION @extschema@.gp_inject_fault(
   faultname text,
   type text,
   db_id int4,
   gp_session_id int4)
 RETURNS text
-AS $$ select gp_inject_fault($1, $2, '', '', '', 1, 1, 0, $3, $4) $$
+AS $$ select @extschema@.gp_inject_fault($1, $2, '', '', '', 1, 1, 0, $3, $4) $$
 LANGUAGE SQL;
 
 -- Simpler version, always trigger until fault is reset.
-CREATE FUNCTION gp_inject_fault_infinite(
+CREATE FUNCTION @extschema@.gp_inject_fault_infinite(
   faultname text,
   type text,
   db_id int4)
 RETURNS text
-AS $$ select gp_inject_fault($1, $2, '', '', '', 1, -1, 0, $3, -1) $$
+AS $$ select @extschema@.gp_inject_fault($1, $2, '', '', '', 1, -1, 0, $3, -1) $$
 LANGUAGE SQL;
 
 -- Simpler version to avoid confusion for wait_until_triggered fault.
 -- occurrence in call below defines wait until number of times the
 -- fault hits.
-CREATE FUNCTION gp_wait_until_triggered_fault(
+CREATE FUNCTION @extschema@.gp_wait_until_triggered_fault(
   faultname text,
   numtimestriggered int4,
   db_id int4)
 RETURNS text
-AS $$ select gp_inject_fault($1, 'wait_until_triggered', '', '', '', 1, 1, $2, $3, -1) $$
+AS $$ select @extschema@.gp_inject_fault($1, 'wait_until_triggered', '', '', '', 1, 1, $2, $3, -1) $$
 LANGUAGE SQL;
 
-CREATE OR REPLACE FUNCTION insert_noop_xlog_record()
+CREATE OR REPLACE FUNCTION @extschema@.insert_noop_xlog_record()
     RETURNS VOID
 AS 'MODULE_PATHNAME',
 'insert_noop_xlog_record'
 LANGUAGE C;
 
 -- Force a mirror to have applied as much XLOG as it's primary has shipped.
-CREATE OR REPLACE FUNCTION force_mirrors_to_catch_up() RETURNS VOID AS $$
+CREATE OR REPLACE FUNCTION @extschema@.force_mirrors_to_catch_up() RETURNS VOID AS $$
 BEGIN
     -- Switch xlog to have no-op record at far distance from
     -- previously emitted xlog record. This is required due to
@@ -101,10 +101,10 @@ BEGIN
     PERFORM pg_switch_xlog();
     PERFORM pg_switch_xlog() from gp_dist_random('gp_id');
 
-    PERFORM gp_inject_fault('after_xlog_redo_noop', 'sleep', dbid) FROM gp_segment_configuration WHERE role='m';
-    PERFORM insert_noop_xlog_record();
-    PERFORM insert_noop_xlog_record() from gp_dist_random('gp_id');
-    PERFORM gp_wait_until_triggered_fault('after_xlog_redo_noop', 1, dbid) FROM gp_segment_configuration WHERE role='m';
-    PERFORM gp_inject_fault('after_xlog_redo_noop', 'reset', dbid) FROM gp_segment_configuration WHERE role='m';
+    PERFORM @extschema@.gp_inject_fault('after_xlog_redo_noop', 'sleep', dbid) FROM gp_segment_configuration WHERE role='m';
+    PERFORM @extschema@.insert_noop_xlog_record();
+    PERFORM @extschema@.insert_noop_xlog_record() from gp_dist_random('gp_id');
+    PERFORM @extschema@.gp_wait_until_triggered_fault('after_xlog_redo_noop', 1, dbid) FROM gp_segment_configuration WHERE role='m';
+    PERFORM @extschema@.gp_inject_fault('after_xlog_redo_noop', 'reset', dbid) FROM gp_segment_configuration WHERE role='m';
 END;
 $$ LANGUAGE plpgsql;

--- a/gpcontrib/gp_inject_fault/gp_inject_fault.control
+++ b/gpcontrib/gp_inject_fault/gp_inject_fault.control
@@ -2,4 +2,4 @@
 comment = 'simulate various faults for testing purposes'
 default_version = '1.0'
 module_pathname = '$libdir/gp_inject_fault'
-relocatable = true
+relocatable = false

--- a/src/test/regress/expected/create_extension_fail.out
+++ b/src/test/regress/expected/create_extension_fail.out
@@ -59,3 +59,23 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 \c
 drop table t_12713;
 drop role user_12713;
+--
+-- Another Test from Issue: https://github.com/greenplum-db/gpdb/issues/6716
+--
+drop extension if exists gp_inject_fault;
+create schema issue6716;
+create extension gp_inject_fault with schema issue6716;
+select issue6716.gp_inject_fault('issue6716', 'skip', 1);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+select issue6716.gp_inject_fault('issue6716', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+drop extension gp_inject_fault;
+drop schema issue6716;

--- a/src/test/regress/sql/create_extension_fail.sql
+++ b/src/test/regress/sql/create_extension_fail.sql
@@ -46,3 +46,14 @@ create table t_12713(a int);
 \c
 drop table t_12713;
 drop role user_12713;
+
+--
+-- Another Test from Issue: https://github.com/greenplum-db/gpdb/issues/6716
+--
+drop extension if exists gp_inject_fault;
+create schema issue6716;
+create extension gp_inject_fault with schema issue6716;
+select issue6716.gp_inject_fault('issue6716', 'skip', 1);
+select issue6716.gp_inject_fault('issue6716', 'reset', 1);
+drop extension gp_inject_fault;
+drop schema issue6716;


### PR DESCRIPTION
This commit fixes https://github.com/greenplum-db/gpdb/issues/6716.
------------------------------------------------------------------
In postgres, CREATE EXTENSION WITH SCHEMA will set up the `search_path`
to contain the target schema and required schemas before execute extension
script. Because the commands of the extension script will be dispatched to
QE, GPDB needs to set up the `search_path` on both QD and QE.

NOTE: `search_path` will be reset during transaction commit.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
