### PR TITLE
Fix performance issue of syslogger_write_str() 

### DIFF
--- a/src/backend/postmaster/syslogger.c
+++ b/src/backend/postmaster/syslogger.c
@@ -135,6 +135,16 @@ static HANDLE threadHandle = 0;
 static CRITICAL_SECTION sysloggerSection;
 #endif
 
+/* GPDB: wrapper function to write to log file */
+static inline void
+syslogger_write_to_logfile(bool amsyslogger, const char *data, int len)
+{
+    if (amsyslogger)
+        write_syslogger_file_binary(data, len, LOG_DESTINATION_STDERR);
+    else
+        write(fileno(stderr), data, len);
+}
+
 static bool chunk_is_postgres_chunk(PipeProtoHeader *hdr)
 {
     return hdr->zero == 0 && hdr->pid != 0 && hdr->thid != 0 &&
@@ -1293,28 +1303,54 @@ syslogger_append_current_timestamp(bool amsyslogger)
  */
 int syslogger_write_str(const char *data, int len, bool amsyslogger, bool csv)
 {
-    int cnt = 0;
+    int cnt = 0, start = 0;
 
     /* avoid confusing an empty string with NULL */
     if (data == NULL)
         return 0;
 
+    /*   
+     * We need to process the string by two kind of modifications:
+     *
+     * 1. When terminate char ('\0') is found, finish the writing and ignore
+     *    the rest.
+     * 2. When it is CSV format and '"' is found, write an additional '"' to
+     *    implement the escape.
+     *
+     * To achieve #2, use "start" to remember the start position of previous
+     * valid substring. When it is CSV format and '"' is found, write the
+     * substring from start to current position plus an additional '"', and
+     * advance start to next position for next substring.
+     */
     while (cnt < len && data[cnt] != '\0')
     {
-        if (csv && data[cnt] == '"')
+		if(csv && data[cnt] == '"')
 		{
-			if (amsyslogger)
-				write_syslogger_file_binary("\"", 1, LOG_DESTINATION_STDERR);
-			else
-				write(fileno(stderr), "\"", 1);
-		}
-		
-		if (amsyslogger)
-			write_syslogger_file_binary(data+cnt, 1, LOG_DESTINATION_STDERR);
-		else
-			write(fileno(stderr), data+cnt, 1);
+            /* Write the substring from "start" to current position */
+            if(start <= cnt) 
+            {    
+                syslogger_write_to_logfile(amsyslogger, data + start, cnt - start + 1);
+            }    
 
-        cnt+=1;
+            /* Write an additional "\"" */
+            syslogger_write_to_logfile(amsyslogger, "\"", 1);
+
+            /* Set new start of next substring to next position */
+            start = cnt + 1;
+		}
+		cnt++;
+    }
+
+    /*
+     * Write latest substring if any
+     *
+     * Note that current pos (cnt) must have been overed the latest position
+     * of the string for now, so use (cnt - start) instead of (cnt - start + 1)
+     * as len to exclude current pos.
+     */
+    if(start < cnt)
+    {
+        syslogger_write_to_logfile(amsyslogger, data + start, cnt - start);
     }
 
     return cnt;


### PR DESCRIPTION
### Issue

In a real case CPU usage of logger process was extraordinarily high (more than 98%) and blocked other processes, 
causing seg down finally. Besides some improper settings, it's also due to a performance issue of logger code: In
`syslogger_write_str()`, `fwrite()`(or `write()`) was called per char instead of per string so it might be called for tens
of millions times when the log string is very big.

### Solution

We need to process the string by two kind of modifications (it might be the reason why existing code calls `fwrite()` 
per char instead of per string):

1. When terminate char ('\0') is found, finish the writing and ignore the rest.
2. When it is CSV format and '"' is found, write an additional '"' to implement the escape.

I was thinking about two solutions:

1. Use an extra buffer with double size (for the worst case), perform the modifications in buffer, and write the whole
 buffer. It can guarantee only one calling of `fwrite()`. However, the cost is extra memory requirement, and a lot of
memcopy in spite of how many '"' there are.
3. Go through the string, whenever hitting '"', write previous substring plus an extra '"', and continue. For the best case
(no '"' in the string), `fwrite()` is called only once. For the worst case (the entire string consist of '"'), the processing 
might fall back to "calling `fwrite()` per char", but no extra memory/memcopy is needed.

I adapted #2 since I suppose that log string containing a lot of '"' is not a common case.

### Test

I checked the log string in CSV manually. No additional test case is need because all operations writing log cover the scenario.

### Related Issues

The PR is related to another PR:

https://github.com/greenplum-db/gpdb/pull/13382

I was to fix it on GPDB7. After discussion, we agreed to remove the diff of logger between postgresql and GPDB instead of fixing the performance issue. After some investigation and consideration, I prefer to a little bit different solution: in GPDB7 we need definitely remove the diff and align to upstream, and in GPDB6 I prefer to fix the issue as-is to avoid impacting too much. The alignment is a big work, and I don't want to rewrite the logger in a stable version with much risk. So I created the PR on GPDB6, and will create another PR on GPDB7 when the alignment work is finished.