### PR TITLE
[clang-tidy] Add readability braces around statements

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,7 +9,7 @@ Checks: |
   modernize-use-nullptr,
   modernize-use-default-member-init,
   modernize-use-bool-literals,
-  modernize-use-using
+  modernize-use-using,
   readability-make-member-function-const,
   readability-non-const-parameter,
   readability-static-accessed-through-instance,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,7 @@ Checks: |
   modernize-use-default-member-init,
   modernize-use-bool-literals,
   modernize-use-using,
+  readability-braces-around-statements,
   readability-make-member-function-const,
   readability-non-const-parameter,
   readability-static-accessed-through-instance,

--- a/src/backend/gpopt/CGPOptimizer.cpp
+++ b/src/backend/gpopt/CGPOptimizer.cpp
@@ -133,7 +133,9 @@ CGPOptimizer::GPOPTOptimizedPlan(
 				errmsg(
 					"GPORCA failed to produce a plan, falling back to planner");
 				if (serialized_error_msg)
+				{
 					errdetail("%s", serialized_error_msg);
+				}
 				errfinish(ex.Filename(), ex.Line(), nullptr);
 			}
 		}
@@ -141,7 +143,9 @@ CGPOptimizer::GPOPTOptimizedPlan(
 		*had_unexpected_failure = gpopt_context.m_is_unexpected_failure;
 
 		if (serialized_error_msg)
+		{
 			pfree(serialized_error_msg);
+		}
 	}
 	GPOS_CATCH_END;
 	return plStmt;

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -473,7 +473,9 @@ gpdb::TypeCollation(Oid type)
 		if (OidIsValid(typcollation))
 		{
 			if (type == NAMEOID)
+			{
 				return typcollation;  // As of v12, this is C_COLLATION_OID
+			}
 			return DEFAULT_COLLATION_OID;
 		}
 		return collation;
@@ -1661,7 +1663,9 @@ gpdb::GpdbEreportImpl(int xerrcode, int severitylevel, const char *xerrmsg,
 			errcode(xerrcode);
 			errmsg("%s", xerrmsg);
 			if (xerrhint)
+			{
 				errhint("%s", xerrhint);
+			}
 			errfinish(filename, lineno, funcname);
 		}
 	}
@@ -2633,7 +2637,9 @@ gpdb::MDCacheNeedsReset(void)
 			mdcache_invalidation_counter_registered = true;
 		}
 		if (last_mdcache_invalidation_counter == mdcache_invalidation_counter)
+		{
 			return false;
+		}
 		else
 		{
 			last_mdcache_invalidation_counter = mdcache_invalidation_counter;

--- a/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
@@ -524,8 +524,10 @@ CContextDXLToPlStmt::GetStaticPruneResult(ULONG scanId)
 	// GPDB_12_MERGE_FIXME: we haven't seen the scan id yet, this scan id is likely for dynamic pruning.
 	// When we can, remove this check
 	if ((scanId - 1) >= m_static_prune_results.size())
+	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion,
 				   GPOS_WSZ_LIT("dynamic pruning"));
+	}
 	return m_static_prune_results[scanId - 1];
 }
 void

--- a/src/backend/gpopt/translate/CQueryMutators.cpp
+++ b/src/backend/gpopt/translate/CQueryMutators.cpp
@@ -836,11 +836,15 @@ CQueryMutators::MakeVarInDerivedTable(Node *node,
 	const ULONG attno = gpdb::ListLength(context->m_lower_table_tlist) + 1;
 	TargetEntry *tle = nullptr;
 	if (IsA(node, Aggref) || IsA(node, GroupingFunc))
+	{
 		tle = GetTargetEntryForAggExpr(context->m_mp, context->m_mda, node,
 									   attno);
+	}
 	else if (IsA(node, Var))
+	{
 		tle = gpdb::MakeTargetEntry((Expr *) node, (AttrNumber) attno, nullptr,
 									false);
+	}
 
 	context->m_lower_table_tlist =
 		gpdb::LAppend(context->m_lower_table_tlist, tle);

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -2871,19 +2871,33 @@ CTranslatorDXLToPlStmt::TranslateDXLWindow(
 					win_frame_leading_dxlnode->GetOperator())
 					->ParseDXLFrameBoundary();
 			if (lead_boundary_type == EdxlfbUnboundedPreceding)
+			{
 				window->frameOptions |= FRAMEOPTION_END_UNBOUNDED_PRECEDING;
+			}
 			if (lead_boundary_type == EdxlfbBoundedPreceding)
+			{
 				window->frameOptions |= FRAMEOPTION_END_OFFSET_PRECEDING;
+			}
 			if (lead_boundary_type == EdxlfbCurrentRow)
+			{
 				window->frameOptions |= FRAMEOPTION_END_CURRENT_ROW;
+			}
 			if (lead_boundary_type == EdxlfbBoundedFollowing)
+			{
 				window->frameOptions |= FRAMEOPTION_END_OFFSET_FOLLOWING;
+			}
 			if (lead_boundary_type == EdxlfbUnboundedFollowing)
+			{
 				window->frameOptions |= FRAMEOPTION_END_UNBOUNDED_FOLLOWING;
+			}
 			if (lead_boundary_type == EdxlfbDelayedBoundedPreceding)
+			{
 				window->frameOptions |= FRAMEOPTION_END_OFFSET_PRECEDING;
+			}
 			if (lead_boundary_type == EdxlfbDelayedBoundedFollowing)
+			{
 				window->frameOptions |= FRAMEOPTION_END_OFFSET_FOLLOWING;
+			}
 			if (0 != win_frame_leading_dxlnode->Arity())
 			{
 				window->endOffset =
@@ -2899,19 +2913,33 @@ CTranslatorDXLToPlStmt::TranslateDXLWindow(
 					win_frame_trailing_dxlnode->GetOperator())
 					->ParseDXLFrameBoundary();
 			if (trail_boundary_type == EdxlfbUnboundedPreceding)
+			{
 				window->frameOptions |= FRAMEOPTION_START_UNBOUNDED_PRECEDING;
+			}
 			if (trail_boundary_type == EdxlfbBoundedPreceding)
+			{
 				window->frameOptions |= FRAMEOPTION_START_OFFSET_PRECEDING;
+			}
 			if (trail_boundary_type == EdxlfbCurrentRow)
+			{
 				window->frameOptions |= FRAMEOPTION_START_CURRENT_ROW;
+			}
 			if (trail_boundary_type == EdxlfbBoundedFollowing)
+			{
 				window->frameOptions |= FRAMEOPTION_START_OFFSET_FOLLOWING;
+			}
 			if (trail_boundary_type == EdxlfbUnboundedFollowing)
+			{
 				window->frameOptions |= FRAMEOPTION_START_UNBOUNDED_FOLLOWING;
+			}
 			if (trail_boundary_type == EdxlfbDelayedBoundedPreceding)
+			{
 				window->frameOptions |= FRAMEOPTION_START_OFFSET_PRECEDING;
+			}
 			if (trail_boundary_type == EdxlfbDelayedBoundedFollowing)
+			{
 				window->frameOptions |= FRAMEOPTION_START_OFFSET_FOLLOWING;
+			}
 			if (0 != win_frame_trailing_dxlnode->Arity())
 			{
 				window->startOffset =
@@ -2923,7 +2951,9 @@ CTranslatorDXLToPlStmt::TranslateDXLWindow(
 			child_contexts->Release();
 		}
 		else
+		{
 			window->frameOptions = FRAMEOPTION_DEFAULTS;
+		}
 	}
 
 	SetParamIds(plan);
@@ -3128,7 +3158,9 @@ ContainsSetReturningFuncOrOp(const CDXLNode *project_list_dxlnode,
 		{
 			case EdxlopScalarFuncExpr:
 				if (CDXLScalarFuncExpr::Cast(op)->ReturnsSet())
+				{
 					return true;
+				}
 				break;
 			case EdxlopScalarOpExpr:
 			{
@@ -3137,7 +3169,9 @@ ContainsSetReturningFuncOrOp(const CDXLNode *project_list_dxlnode,
 				const IMDFunction *md_func =
 					md_accessor->RetrieveFunc(md_sclar_op->FuncMdId());
 				if (md_func->ReturnsSet())
+				{
 					return true;
+				}
 				break;
 			}
 			default:
@@ -3161,16 +3195,24 @@ SanityCheckProjectSetTargetList(List *targetlist)
 			(IsA(expr, OpExpr) && ((OpExpr *) expr)->opretset))
 		{
 			if (IsA(expr, FuncExpr))
+			{
 				args = ((FuncExpr *) expr)->args;
+			}
 			else
+			{
 				args = ((OpExpr *) expr)->args;
+			}
 			if (gpdb::ExpressionReturnsSet((Node *) args))
+			{
 				return false;
+			}
 			continue;
 		}
 
 		if (gpdb::ExpressionReturnsSet((Node *) expr))
+		{
 			return false;
+		}
 	}
 	return true;
 }
@@ -3185,9 +3227,11 @@ CTranslatorDXLToPlStmt::TranslateDXLProjectSet(
 	// GPDB_12_MERGE_FIXME: had we generated a DXLProjectSet in ORCA we wouldn't
 	// have needed to be defensive here...
 	if ((*result_dxlnode)[EdxlresultIndexFilter]->Arity() > 0)
+	{
 		GPOS_RAISE(
 			gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
 			GPOS_WSZ_LIT("Unsupported one-time filter in ProjectSet node"));
+	}
 
 	// create project set (nee result) plan node
 	ProjectSet *project_set = MakeNode(ProjectSet);
@@ -3241,9 +3285,11 @@ CTranslatorDXLToPlStmt::TranslateDXLProjectSet(
 	// double check the targetlist is kosher
 	// we are only doing this because ORCA didn't do it...
 	if (!SanityCheckProjectSetTargetList(plan->targetlist))
+	{
 		GPOS_RAISE(
 			gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
 			GPOS_WSZ_LIT("Unexpected target list entries in ProjectSet node"));
+	}
 
 	return (Plan *) project_set;
 }
@@ -3267,8 +3313,10 @@ CTranslatorDXLToPlStmt::TranslateDXLResult(
 	// actual result node
 	if (ContainsSetReturningFuncOrOp((*result_dxlnode)[EdxlresultIndexProjList],
 									 m_md_accessor))
+	{
 		return TranslateDXLProjectSet(result_dxlnode, output_context,
 									  ctxt_translation_prev_siblings);
+	}
 
 	// create result plan node
 	Result *result = MakeNode(Result);
@@ -3331,9 +3379,11 @@ CTranslatorDXLToPlStmt::TranslateDXLResult(
 	// double check the targetlist is kosher
 	// we are only doing this because ORCA didn't do it...
 	if (!SanityCheckProjectSetTargetList(plan->targetlist))
+	{
 		GPOS_RAISE(
 			gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
 			GPOS_WSZ_LIT("Unexpected target list entries in ProjectSet node"));
+	}
 
 	return (Plan *) result;
 }
@@ -3974,9 +4024,11 @@ CTranslatorDXLToPlStmt::TranslateDXLDml(
 	// partition Oid in the child's target list, but we don't use it for
 	// anything in GPDB.
 	if (m_cmd_type == CMD_UPDATE)
+	{
 		(void) AddJunkTargetEntryForColId(&dml_target_list, &child_context,
 										  phy_dml_dxlop->ActionColId(),
 										  "DMLAction");
+	}
 
 	if (m_cmd_type == CMD_UPDATE || m_cmd_type == CMD_DELETE)
 	{
@@ -3987,8 +4039,10 @@ CTranslatorDXLToPlStmt::TranslateDXLDml(
 								   "gp_segment_id");
 	}
 	if (m_cmd_type == CMD_UPDATE && phy_dml_dxlop->IsOidsPreserved())
+	{
 		AddJunkTargetEntryForColId(&dml_target_list, &child_context,
 								   phy_dml_dxlop->GetTupleOid(), "oid");
+	}
 
 	// Add a Result node on top of the child plan, to coerce the target
 	// list to match the exact physical layout of the target table,
@@ -4020,7 +4074,9 @@ CTranslatorDXLToPlStmt::TranslateDXLDml(
 
 	// ORCA plans all updates as split updates
 	if (m_cmd_type == CMD_UPDATE)
+	{
 		dml->isSplitUpdates = ListMake1Int((int) true);
+	}
 
 	plan->targetlist = NIL;
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -730,8 +730,10 @@ CTranslatorDXLToScalar::TranslateDXLScalarWindowRefToScalar(
 	window_func->winagg = dxlop->IsSimpleAgg();
 
 	if (dxlop->GetDxlWinStage() != EdxlwinstageImmediate)
+	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLError,
 				   GPOS_WSZ_LIT("Unsupported window function stage"));
+	}
 
 	// translate the arguments of the window function
 	window_func->args = TranslateScalarChildren(window_func->args,

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -155,9 +155,13 @@ CTranslatorQueryToDXL::CTranslatorQueryToDXL(
 	// If this is a subquery, make a copy of the parent's mapping, otherwise
 	// initialize a new, empty, mapping.
 	if (var_colid_mapping)
+	{
 		m_var_to_colid_map = var_colid_mapping->CopyMapColId(m_mp);
+	}
 	else
+	{
 		m_var_to_colid_map = GPOS_NEW(m_mp) CMappingVarColId(m_mp);
+	}
 
 	m_query_level_to_cte_map = GPOS_NEW(m_mp) HMUlCTEListEntry(m_mp);
 	m_dxl_cte_producers = GPOS_NEW(m_mp) CDXLNodeArray(m_mp);
@@ -266,7 +270,9 @@ CTranslatorQueryToDXL::~CTranslatorQueryToDXL()
 	CRefCount::SafeRelease(m_dxl_query_output_cols);
 
 	if (m_query_level == 0)
+	{
 		GPOS_DELETE(m_context);
+	}
 }
 
 //---------------------------------------------------------------------------
@@ -521,13 +527,17 @@ CTranslatorQueryToDXL::TranslateSelectQueryToDXL()
 
 	// RETURNING is not supported yet.
 	if (m_query->returningList)
+	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
 				   GPOS_WSZ_LIT("RETURNING clause"));
+	}
 
 	// ON CONFLICT is not supported yet.
 	if (m_query->onConflict)
+	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
 				   GPOS_WSZ_LIT("ON CONFLICT clause"));
+	}
 
 	CDXLNode *child_dxlnode = nullptr;
 	IntToUlongMap *sort_group_attno_to_colid_mapping =
@@ -3321,9 +3331,13 @@ CTranslatorQueryToDXL::NoteDistributionPolicyOpclasses(const RangeTblEntry *rte)
 					gpdb::GetDefaultDistributionOpclassForType(typeoid);
 
 				if (opclasses[i] == default_opclass)
+				{
 					contains_default_hashops = true;
+				}
 				else
+				{
 					contains_nondefault_hashops = true;
+				}
 			}
 		}
 
@@ -3340,10 +3354,12 @@ CTranslatorQueryToDXL::NoteDistributionPolicyOpclasses(const RangeTblEntry *rte)
 		{
 			if (m_context->m_distribution_hashops !=
 				DistrHashOpsNotDeterminedYet)
+			{
 				GPOS_RAISE(
 					gpdxl::ExmaMD, gpdxl::ExmiMDObjUnsupported,
 					GPOS_WSZ_LIT(
 						"Query contains relations with a mix of default and legacy hash opclasses"));
+			}
 			m_context->m_distribution_hashops = DistrUseDefaultHashOps;
 		}
 		if (contains_legacy_hashops &&
@@ -3351,10 +3367,12 @@ CTranslatorQueryToDXL::NoteDistributionPolicyOpclasses(const RangeTblEntry *rte)
 		{
 			if (m_context->m_distribution_hashops !=
 				DistrHashOpsNotDeterminedYet)
+			{
 				GPOS_RAISE(
 					gpdxl::ExmaMD, gpdxl::ExmiMDObjUnsupported,
 					GPOS_WSZ_LIT(
 						"Query contains relations with a mix of default and legacy hash opclasses"));
+			}
 			m_context->m_distribution_hashops = DistrUseLegacyHashOps;
 		}
 	}
@@ -3912,7 +3930,9 @@ CTranslatorQueryToDXL::TranslateJoinExprInFromToDXL(JoinExpr *join_expr)
 		Node *join_alias_node = (Node *) lfirst(lc_node);
 		// rte->joinaliasvars may contain NULL ptrs which indicates dropped columns
 		if (!join_alias_node)
+		{
 			continue;
+		}
 		GPOS_ASSERT(IsA(join_alias_node, Var) ||
 					IsA(join_alias_node, CoalesceExpr));
 		Value *value = (Value *) lfirst(lc_col_name);

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -503,8 +503,10 @@ CTranslatorRelcacheToDXL::RetrieveRelColumns(CMemoryPool *mp,
 		// FIXME: XXX in hindsight, we can fallback less often.
 		//  We _really_ should only fallback on DML, not *all the time*
 		if (rel->rd_att->attrs[ul].attgenerated)
+		{
 			GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDObjUnsupported,
 					   GPOS_WSZ_LIT("column has GENERATED default value"));
+		}
 	}
 
 	for (ULONG ul = 0; ul < (ULONG) rel->rd_att->natts; ul++)
@@ -1278,8 +1280,10 @@ CTranslatorRelcacheToDXL::LookupFuncProps(
 	*access = GetEFuncDataAccess(gpdb::FuncDataAccess(func_oid));
 
 	if (gpdb::FuncExecLocation(func_oid) != PROEXECLOCATION_ANY)
+	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
 				   GPOS_WSZ_LIT("unsupported exec location"));
+	}
 
 	*returns_set = gpdb::GetFuncRetset(func_oid);
 	*is_strict = gpdb::FuncStrict(func_oid);
@@ -1620,7 +1624,9 @@ CTranslatorRelcacheToDXL::RetrieveAggIntermediateResultType(CMemoryPool *mp,
 	 * right datatype.
 	 */
 	if (intermediate_type_oid == INTERNALOID)
+	{
 		intermediate_type_oid = BYTEAOID;
+	}
 
 	return GPOS_NEW(mp) CMDIdGPDB(intermediate_type_oid);
 }
@@ -2445,9 +2451,13 @@ CTranslatorRelcacheToDXL::RetrieveRelStorageType(Relation rel)
 				rel_storage_type = IMDRelation::ErelstorageCompositeType;
 			}
 			else if (rel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE)
+			{
 				rel_storage_type = RetrieveStorageTypeForPartitionedTable(rel);
+			}
 			else if (gpdb::RelIsExternalTable(rel->rd_id))
+			{
 				rel_storage_type = IMDRelation::ErelstorageExternal;
+			}
 			else
 			{
 				// GPORCA does not support foreign data wrappers
@@ -2682,7 +2692,9 @@ CTranslatorRelcacheToDXL::IsIndexSupported(Relation index_rel)
 
 	// covering index -- it has INCLUDE (...) columns
 	if (index_rel->rd_index->indnatts > index_rel->rd_index->indnkeyatts)
+	{
 		return false;
+	}
 
 	// index expressions and index constraints not supported
 	return gpdb::HeapAttIsNull(tup, Anum_pg_index_indexprs) &&

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -2500,7 +2500,9 @@ CTranslatorUtils::IsCompositeConst(CMemoryPool *mp, CMDAccessor *md_accessor,
 								   const RangeTblFunction *rtfunc)
 {
 	if (!IsA(rtfunc->funcexpr, Const))
+	{
 		return false;
+	}
 
 	Const *constExpr = (Const *) rtfunc->funcexpr;
 

--- a/src/backend/gpopt/utils/RelationWrapper.cpp
+++ b/src/backend/gpopt/utils/RelationWrapper.cpp
@@ -11,7 +11,9 @@ namespace gpdb
 RelationWrapper::~RelationWrapper() noexcept(false)
 {
 	if (m_relation)
+	{
 		CloseRelation(m_relation);
+	}
 }
 
 void

--- a/src/backend/gporca/libgpdbcost/src/CCostModelParamsGPDB.cpp
+++ b/src/backend/gporca/libgpdbcost/src/CCostModelParamsGPDB.cpp
@@ -579,12 +579,16 @@ CCostModelParamsGPDB::Equals(ICostModelParams *pcm) const
 {
 	CCostModelParamsGPDB *pcmgOther = dynamic_cast<CCostModelParamsGPDB *>(pcm);
 	if (nullptr == pcmgOther)
+	{
 		return false;
+	}
 
 	for (ULONG ul = 0U; ul < GPOS_ARRAY_SIZE(m_rgpcp); ul++)
 	{
 		if (!m_rgpcp[ul]->Equals(pcmgOther->m_rgpcp[ul]))
+		{
 			return false;
+		}
 	}
 
 	return true;

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CKHeap.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CKHeap.h
@@ -73,13 +73,17 @@ private:
 		ULONG min_element_ix = ix;
 
 		if (exists(left_child_ix) && cost(left_child_ix) < cost(ix))
+		{
 			// left child is better than parent, it becomes the new candidate
 			min_element_ix = left_child_ix;
+		}
 
 		if (exists(right_child_ix) &&
 			cost(right_child_ix) < cost(min_element_ix))
+		{
 			// right child is better than min(parent, left child)
 			min_element_ix = right_child_ix;
+		}
 
 		if (min_element_ix != ix)
 		{
@@ -96,7 +100,9 @@ private:
 		ULONG parent_ix = parent(ix);
 
 		if (!exists(parent_ix))
+		{
 			return;
+		}
 
 		if (cost(ix) < cost(parent_ix))
 		{
@@ -116,7 +122,9 @@ private:
 
 		// now work our way up to the root, calling HeapifyDown
 		for (ULONG ix = start_ix; exists(ix); ix--)
+		{
 			HeapifyDown(ix);
+		}
 
 		m_is_heapified = true;
 	}
@@ -174,7 +182,9 @@ public:
 		}
 
 		if (!m_is_heapified)
+		{
 			Heapify();
+		}
 
 		// we want to remove and return the root of the tree, which is the best element
 

--- a/src/backend/gporca/libgpopt/include/gpopt/search/CSearchStage.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/search/CSearchStage.h
@@ -73,7 +73,9 @@ public:
 	RestartTimer()
 	{
 		if (m_time_threshold != gpos::ulong_max)
+		{
 			m_timer.Restart();
+		}
 	}
 
 	// is search stage timed-out?
@@ -83,7 +85,9 @@ public:
 	FTimedOut() const
 	{
 		if (m_time_threshold == gpos::ulong_max)
+		{
 			return false;
+		}
 		return m_timer.ElapsedMS() > m_time_threshold;
 	}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformImplementIndexApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformImplementIndexApply.h
@@ -96,11 +96,15 @@ public:
 		CPhysicalNLJoin *pop = nullptr;
 
 		if (CLogicalIndexApply::PopConvert(pexpr->Pop())->FouterJoin())
+		{
 			pop = GPOS_NEW(mp) CPhysicalLeftOuterIndexNLJoin(
 				mp, colref_array, indexApply->OrigJoinPred());
+		}
 		else
+		{
 			pop = GPOS_NEW(mp) CPhysicalInnerIndexNLJoin(
 				mp, colref_array, indexApply->OrigJoinPred());
+		}
 
 		CExpression *pexprResult = GPOS_NEW(mp)
 			CExpression(mp, pop, pexprOuter, pexprInner, pexprScalar);

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecHashed.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecHashed.cpp
@@ -438,7 +438,9 @@ CDistributionSpecHashed::HashValue() const
 {
 	CDistributionSpecHashed *equiv_spec = this->PdshashedEquiv();
 	if (nullptr != equiv_spec)
+	{
 		return equiv_spec->HashValue();
+	}
 
 	ULONG ulHash = (ULONG) Edt();
 
@@ -525,7 +527,9 @@ CDistributionSpecHashed::FMatchHashedDistribution(
 		CExpressionArrays *all_equiv_exprs = pdshashed->HashSpecEquivExprs();
 		CExpressionArray *equiv_distribution_exprs = nullptr;
 		if (nullptr != all_equiv_exprs && all_equiv_exprs->Size() > 0)
+		{
 			equiv_distribution_exprs = (*all_equiv_exprs)[ul];
+		}
 		CExpression *pexprLeft = (*(pdshashed->m_pdrgpexpr))[ul];
 		CExpression *pexprRight = (*m_pdrgpexpr)[ul];
 		BOOL fSuccess = CUtils::Equals(pexprLeft, pexprRight);
@@ -586,7 +590,9 @@ CDistributionSpecHashed::Equals(const CDistributionSpec *input_spec) const
 	GPOS_CHECK_STACK_SIZE;
 
 	if (input_spec->Edt() != Edt())
+	{
 		return false;
+	}
 
 	const CDistributionSpecHashed *other_spec =
 		CDistributionSpecHashed::PdsConvert(input_spec);
@@ -596,7 +602,9 @@ CDistributionSpecHashed::Equals(const CDistributionSpec *input_spec) const
 	// if one of the spec has equivalent spec and other doesn't, they are not equal
 	if ((spec_equiv != nullptr && other_spec_equiv == nullptr) ||
 		(spec_equiv == nullptr && other_spec_equiv != nullptr))
+	{
 		return false;
+	}
 
 	BOOL equals = true;
 	// if both the specs has equivalent specs, compare them
@@ -606,7 +614,9 @@ CDistributionSpecHashed::Equals(const CDistributionSpec *input_spec) const
 	}
 	// if the equivalent spec are not equal, the spec objects are not equal
 	if (!equals)
+	{
 		return false;
+	}
 
 	if (!CUtils::Equals(m_opfamilies, other_spec->m_opfamilies))
 	{
@@ -620,7 +630,9 @@ CDistributionSpecHashed::Equals(const CDistributionSpec *input_spec) const
 		CUtils::Equals(m_pdrgpexpr, other_spec->m_pdrgpexpr);
 
 	if (!matches)
+	{
 		return false;
+	}
 
 	// compare the equivalent expression arrays
 	CExpressionArrays *spec_equiv_exprs = m_equiv_hash_exprs;

--- a/src/backend/gporca/libgpopt/src/base/CFunctionalDependency.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CFunctionalDependency.cpp
@@ -159,16 +159,22 @@ CFunctionalDependency::Equals(const CFunctionalDependencyArray *pdrgpfdFst,
 							  const CFunctionalDependencyArray *pdrgpfdSnd)
 {
 	if (nullptr == pdrgpfdFst && nullptr == pdrgpfdSnd)
+	{
 		return true; /* both empty */
+	}
 
 	if (nullptr == pdrgpfdFst || nullptr == pdrgpfdSnd)
+	{
 		return false; /* one is empty, the other is not */
+	}
 
 	const ULONG ulLenFst = pdrgpfdFst->Size();
 	const ULONG ulLenSnd = pdrgpfdSnd->Size();
 
 	if (ulLenFst != ulLenSnd)
+	{
 		return false;
+	}
 
 	BOOL fEqual = true;
 	for (ULONG ulFst = 0; fEqual && ulFst < ulLenFst; ulFst++)

--- a/src/backend/gporca/libgpopt/src/base/CUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CUtils.cpp
@@ -621,7 +621,9 @@ CUtils::GetPercentileAggMDId(CMemoryPool *mp, CExpression *pexprAggFn)
 	OID return_oid = 0;
 
 	if (popScAggFunc->FHasAmbiguousReturnType())
+	{
 		return_oid = GPDB_GP_PERCENTILE_DISC;
+	}
 	else
 	{
 		switch (oid_arg_type)
@@ -4234,7 +4236,9 @@ CUtils::FEquivalanceClassesEqual(CMemoryPool *mp, CColRefSetArray *pdrgpcrsFst,
 	const ULONG ulLenSecond = pdrgpcrsSnd->Size();
 
 	if (ulLenFrst != ulLenSecond)
+	{
 		return false;
+	}
 
 	ColRefToColRefSetMap *phmcscrs = GPOS_NEW(mp) ColRefToColRefSetMap(mp);
 	for (ULONG ulFst = 0; ulFst < ulLenFrst; ulFst++)
@@ -4473,7 +4477,9 @@ CUtils::FExprHasAnyCrFromCrs(CExpression *pexpr, CColRefSet *pcrs)
 				CScalarProjectElement::PopConvert(pexpr->Pop());
 			colref = (CColRef *) popScalarProjectElement->Pcr();
 			if (pcrs->FMember(colref))
+			{
 				return true;
+			}
 			break;
 		}
 		case COperator::EopScalarIdent:
@@ -4482,7 +4488,9 @@ CUtils::FExprHasAnyCrFromCrs(CExpression *pexpr, CColRefSet *pcrs)
 			CScalarIdent *popScalarOp = CScalarIdent::PopConvert(pexpr->Pop());
 			colref = (CColRef *) popScalarOp->Pcr();
 			if (pcrs->FMember(colref))
+			{
 				return true;
+			}
 			break;
 		}
 		default:
@@ -4494,7 +4502,9 @@ CUtils::FExprHasAnyCrFromCrs(CExpression *pexpr, CColRefSet *pcrs)
 	for (ULONG ul = 0; ul < arity; ul++)
 	{
 		if (FExprHasAnyCrFromCrs((*pexpr)[ul], pcrs))
+		{
 			return true;
+		}
 	}
 
 	return false;
@@ -4549,7 +4559,9 @@ CUtils::FCrossJoin(CExpression *pexpr)
 		GPOS_ASSERT(3 == pexpr->Arity());
 		CExpression *pexprPred = (*pexpr)[2];
 		if (CUtils::FScalarConstTrue(pexprPred))
+		{
 			fCrossJoin = true;
+		}
 	}
 	return fCrossJoin;
 }
@@ -4749,7 +4761,9 @@ CUtils::PexprMatchEqualityOrINDF(
 	}
 
 	if (nullptr != pexprMatching)
+	{
 		return CCastUtils::PexprWithoutBinaryCoercibleCasts(pexprMatching);
+	}
 	return pexprMatching;
 }
 

--- a/src/backend/gporca/libgpopt/src/mdcache/CMDAccessor.cpp
+++ b/src/backend/gporca/libgpopt/src/mdcache/CMDAccessor.cpp
@@ -1248,7 +1248,9 @@ CMDAccessor::Serialize(COstream &oos)
 	// Now that we're done iterating and no longer hold the lock,
 	// serialize the entries.
 	for (ul = 0; ul < nentries; ul++)
+	{
 		oos << cacheEntries[ul]->GetStrRepr()->GetBuffer();
+	}
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogical.cpp
@@ -162,7 +162,9 @@ CLogical::PosFromIndex(CMemoryPool *mp, const IMDIndex *pmdindex,
 	if (pmdindex->IndexType() == IMDIndex::EmdindGist ||
 		pmdindex->IndexType() == IMDIndex::EmdindGin ||
 		pmdindex->IndexType() == IMDIndex::EmdindBrin)
+	{
 		return pos;
+	}
 
 	const ULONG ulLenKeys = pmdindex->Keys();
 

--- a/src/backend/gporca/libgpopt/src/operators/COrderedAggPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/COrderedAggPreprocessor.cpp
@@ -179,7 +179,9 @@ COrderedAggPreprocessor::SplitPrjList(
 				}
 			}
 			if (skip)
+			{
 				continue;
+			}
 			if (0 < ul)
 			{
 				pexprRemappedAggConsumer->AddRef();
@@ -560,10 +562,12 @@ COrderedAggPreprocessor::PexprInputAggPrj2Join(CMemoryPool *mp,
 							 ->UlCTEId();
 	ULONG ulCTEIdEnd = ulCTEIdStart;
 	if (has_nlj_ontop)
+	{
 		ulCTEIdEnd =
 			CLogicalCTEConsumer::PopConvert(
 				(*(*(*(*(*pexprOrderedAgg)[arity - 2])[0])[0])[1])[0]->Pop())
 				->UlCTEId();
+	}
 	CExpression *pexpResult = pexprFinalJoin;
 	for (ULONG ul = ulCTEIdEnd; ul > ulCTEIdStart; ul--)
 	{

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalHashJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalHashJoin.cpp
@@ -339,7 +339,9 @@ CPhysicalHashJoin::PdshashedMatching(
 		CExpression *pexprDlvrd = (*pdrgpexprDist)[ulDlvrdIdx];
 		CExpressionArray *equiv_distribution_exprs = nullptr;
 		if (nullptr != all_equiv_exprs && all_equiv_exprs->Size() > 0)
+		{
 			equiv_distribution_exprs = (*all_equiv_exprs)[ulDlvrdIdx];
+		}
 		for (ULONG idx = 0; idx < ulSourceSize; idx++)
 		{
 			BOOL fSuccess = false;

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalInnerNLJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalInnerNLJoin.cpp
@@ -130,7 +130,9 @@ CPhysicalInnerNLJoin::Ped(CMemoryPool *mp, CExpressionHandle &exprhdl,
 				CPhysicalJoin::PedInnerHashedFromOuterHashed(
 					mp, exprhdl, dmatch, (*pdrgpdpCtxt)[0]);
 			if (pEnfdHashedDistribution)
+			{
 				return pEnfdHashedDistribution;
+			}
 		}
 		return CPhysicalJoin::Ped(mp, exprhdl, prppInput, child_index,
 								  pdrgpdpCtxt, ulOptReq);

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalJoin.cpp
@@ -294,7 +294,9 @@ CPhysicalJoin::Ped(CMemoryPool *mp, CExpressionHandle &exprhdl,
 				CPhysicalJoin::PedInnerHashedFromOuterHashed(
 					mp, exprhdl, dmatch, (*pdrgpdpCtxt)[0]);
 			if (pEnfdHashedDistribution)
+			{
 				return pEnfdHashedDistribution;
+			}
 		}
 
 

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalTVF.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalTVF.cpp
@@ -49,9 +49,13 @@ CPhysicalTVF::CPhysicalTVF(CMemoryPool *mp, IMDId *mdid_func,
 
 	CMDAccessor *md_accessor = COptCtxt::PoctxtFromTLS()->Pmda();
 	if (m_func_mdid->IsValid())
+	{
 		m_pmdfunc = md_accessor->RetrieveFunc(m_func_mdid);
+	}
 	else
+	{
 		m_pmdfunc = nullptr;
+	}
 }
 
 

--- a/src/backend/gporca/libgpopt/src/operators/CPredicateUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPredicateUtils.cpp
@@ -1505,7 +1505,9 @@ CPredicateUtils::FNotNullCheckOnColumn(CExpression *pexpr, CColRef *colref)
 	GPOS_ASSERT(nullptr != colref);
 
 	if (0 == pexpr->Arity())
+	{
 		return false;
+	}
 
 	return (FNullCheckOnColumn(pexpr, colref) && FNot(pexpr));
 }

--- a/src/backend/gporca/libgpopt/src/search/CGroupExpression.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CGroupExpression.cpp
@@ -1117,7 +1117,9 @@ CGroupExpression::ContainsCircularDependencies()
 	{
 		CGroup *child_group = (*child_groups)[ul];
 		if (child_group->FScalar())
+		{
 			continue;
+		}
 		CGroup *child_duplicate_group = child_group->PgroupDuplicate();
 		if (child_duplicate_group != nullptr)
 		{

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -545,7 +545,9 @@ CTranslatorDXLToExpr::PexprLogicalTVF(const CDXLNode *dxlnode)
 									popTVF->PdrgpcrOutput());
 
 	if (!popTVF->FuncMdId()->IsValid())
+	{
 		return pexpr;
+	}
 
 	const IMDFunction *pmdfunc = m_pmda->RetrieveFunc(mdid_func);
 

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXLUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXLUtils.cpp
@@ -1805,7 +1805,9 @@ CTranslatorExprToDXLUtils::FMotionHazard(CMemoryPool *mp, CDXLNode *dxlnode,
 	// non-streaming operator/Gather motion neutralizes any motion hazard that its subtree imposes
 	// hence stop recursing further
 	if (FMotionHazardSafeOp(dxlnode))
+	{
 		return false;
+	}
 
 	if (FDXLOpExists(dxlnode->GetOperator(), peopid, ulOps))
 	{
@@ -1866,7 +1868,9 @@ CTranslatorExprToDXLUtils::FMotionHazardSafeOp(CDXLNode *dxlnode)
 			CDXLPhysicalAgg *pdxlnPhysicalAgg =
 				CDXLPhysicalAgg::Cast(dxlnode->GetOperator());
 			if (pdxlnPhysicalAgg->GetAggStrategy() == EdxlaggstrategyHashed)
+			{
 				fMotionHazardSafeOp = true;
+			}
 		}
 		break;
 

--- a/src/backend/gporca/libgpopt/src/xforms/CJoinOrder.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CJoinOrder.cpp
@@ -462,9 +462,13 @@ CJoinOrder::PcompCombine(SComponent *comp1, SComponent *comp2)
 			CExpression *pexpr = pedge->m_pexpr;
 			pexpr->AddRef();
 			if (0 < pedge->m_loj_num)
+			{
 				loj_conjuncts->Append(pexpr);
+			}
 			else
+			{
 				other_conjuncts->Append(pexpr);
+			}
 		}
 	}
 

--- a/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDPv2.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CJoinOrderDPv2.cpp
@@ -1945,33 +1945,43 @@ CJoinOrderDPv2::OsPrintProperty(IOstream &os, SExpressionProperties &props)
 		if (props.Satisfies(EJoinOrderMincard))
 		{
 			if (!is_first)
+			{
 				os << ", ";
+			}
 			os << "Mincard";
 			is_first = false;
 		}
 		if (props.Satisfies(EJoinOrderGreedyAvoidXProd))
 		{
 			if (!is_first)
+			{
 				os << ", ";
+			}
 			os << "GreedyAvoidXProd";
 			is_first = false;
 		}
 		if (props.Satisfies(EJoinOrderHasPS))
 		{
 			if (!is_first)
+			{
 				os << ", ";
+			}
 			os << "HasPS";
 		}
 		if (props.Satisfies(EJoinOrderStats))
 		{
 			if (!is_first)
+			{
 				os << ", ";
+			}
 			os << "Stats";
 		}
 		if (props.Satisfies(EJoinOrderDP))
 		{
 			if (!is_first)
+			{
 				os << ", ";
+			}
 			os << "DP";
 		}
 	}

--- a/src/backend/gporca/libgpopt/src/xforms/CSubqueryHandler.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CSubqueryHandler.cpp
@@ -1682,9 +1682,11 @@ CSubqueryHandler::FRemoveAllSubquery(CExpression *pexprOuter,
 			const IMDFunction *pmdFunc =
 				md_accessor->RetrieveFunc(pmdOp->FuncMdId());
 			if (IMDFunction::EfsVolatile == pmdFunc->GetFuncStability())
+			{
 				// the non-correlated plan would evaluate the comparison operation twice
 				// per outer row, that is not a good idea when the operation is volatile
 				fUseCorrelated = true;
+			}
 		}
 
 		CExpression *pexprInnerSelect = PexprInnerSelect(

--- a/src/backend/gporca/libgpopt/src/xforms/CXformJoin2IndexApplyGeneric.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformJoin2IndexApplyGeneric.cpp
@@ -33,9 +33,13 @@ CXformJoin2IndexApplyGeneric::FCanLeftOuterIndexApply(
 	IMDRelation::Ereldistrpolicy ereldist = ptabDesc->GetRelDistribution();
 
 	if (ereldist == IMDRelation::EreldistrRandom)
+	{
 		return false;
+	}
 	else if (ereldist == IMDRelation::EreldistrMasterOnly)
+	{
 		return true;
+	}
 
 	// now consider hash distributed table
 	CColRefSet *pcrsInnerOutput = pexprInner->DeriveOutputColumns();

--- a/src/backend/gporca/libgpos/include/gpos/common/CSyncList.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CSyncList.h
@@ -67,7 +67,9 @@ public:
 	Pop()
 	{
 		if (!m_list.IsEmpty())
+		{
 			return m_list.RemoveHead();
+		}
 		return nullptr;
 	}
 

--- a/src/backend/gporca/libgpos/server/include/unittest/gpos/common/CSyncHashtableTest.h
+++ b/src/backend/gporca/libgpos/server/include/unittest/gpos/common/CSyncHashtableTest.h
@@ -37,16 +37,16 @@ class CSyncHashtableTest
 
 private:
 	// types used by testing functions
-	typedef CSyncHashtable<SElem, ULONG> SElemHashtable;
+	using SElemHashtable = CSyncHashtable<SElem, ULONG>;
 
-	typedef CSyncHashtableAccessByKey<SElem, ULONG> SElemHashtableAccessor;
+	using SElemHashtableAccessor = CSyncHashtableAccessByKey<SElem, ULONG>;
 
-	typedef CSyncHashtableIter<SElem, ULONG> SElemHashtableIter;
+	using SElemHashtableIter = CSyncHashtableIter<SElem, ULONG>;
 
-	typedef CSyncHashtableAccessByIter<SElem, ULONG> SElemHashtableIterAccessor;
+	using SElemHashtableIterAccessor = CSyncHashtableAccessByIter<SElem, ULONG>;
 
 	// function pointer to a hash table task
-	typedef void *(*pfuncHashtableTask)(void *);
+	using pfuncHashtableTask = void *(*) (void *);
 
 	//---------------------------------------------------------------------------
 	//	@class:

--- a/src/backend/gporca/libgpos/server/include/unittest/gpos/memory/CCacheTest.h
+++ b/src/backend/gporca/libgpos/server/include/unittest/gpos/memory/CCacheTest.h
@@ -112,7 +112,7 @@ private:
 		CList<SDeepObjectEntry> m_list;
 
 	public:
-		typedef CList<SDeepObjectEntry> CDeepObjectList;
+		using CDeepObjectList = CList<SDeepObjectEntry>;
 
 		// ctor
 		CDeepObject()
@@ -141,12 +141,12 @@ private:
 
 
 	// accessors type definitions
-	typedef CCacheAccessor<SSimpleObject *, ULONG *> CSimpleObjectCacheAccessor;
-	typedef CCacheAccessor<CDeepObject *, CDeepObject::CDeepObjectList *>
-		CDeepObjectCacheAccessor;
+	using CSimpleObjectCacheAccessor = CCacheAccessor<SSimpleObject *, ULONG *>;
+	using CDeepObjectCacheAccessor =
+		CCacheAccessor<CDeepObject *, CDeepObject::CDeepObjectList *>;
 
 	// cache task function pointer
-	typedef void *(*TaskFuncPtr)(void *);
+	using TaskFuncPtr = void *(*) (void *);
 
 public:
 	// unittests

--- a/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CDynamicPtrArrayTest.cpp
+++ b/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CDynamicPtrArrayTest.cpp
@@ -64,8 +64,8 @@ CDynamicPtrArrayTest::EresUnittest_Basic()
 					  "wert", "dfg", "xcv", "zxc"};
 	const CHAR *szMissingElem = "missing";
 
-	CDynamicPtrArray<CHAR, CleanupNULL<CHAR> > *pdrg =
-		GPOS_NEW(mp) CDynamicPtrArray<CHAR, CleanupNULL<CHAR> >(mp, 2);
+	CDynamicPtrArray<CHAR, CleanupNULL<CHAR>> *pdrg =
+		GPOS_NEW(mp) CDynamicPtrArray<CHAR, CleanupNULL<CHAR>>(mp, 2);
 
 	// add elements incl trigger resize of array
 	for (ULONG i = 0; i < 9; i++)
@@ -101,7 +101,7 @@ CDynamicPtrArrayTest::EresUnittest_Basic()
 
 	// test with ULONG array
 
-	typedef CDynamicPtrArray<ULONG, CleanupNULL<ULONG> > UlongArray;
+	using UlongArray = CDynamicPtrArray<ULONG, CleanupNULL<ULONG>>;
 	UlongArray *pdrgULONG = GPOS_NEW(mp) UlongArray(mp, 1);
 	ULONG c = 256;
 
@@ -149,7 +149,7 @@ CDynamicPtrArrayTest::EresUnittest_Ownership()
 
 	// test with ULONGs
 
-	typedef CDynamicPtrArray<ULONG, CleanupDelete<ULONG> > UlongArray;
+	using UlongArray = CDynamicPtrArray<ULONG, CleanupDelete<ULONG>>;
 	UlongArray *pdrgULONG = GPOS_NEW(mp) UlongArray(mp, 1);
 
 	// add elements incl trigger resize of array
@@ -164,7 +164,7 @@ CDynamicPtrArrayTest::EresUnittest_Ownership()
 
 	// test with CHAR array
 
-	typedef CDynamicPtrArray<CHAR, CleanupDeleteArray<CHAR> > CharArray;
+	using CharArray = CDynamicPtrArray<CHAR, CleanupDeleteArray<CHAR>>;
 	CharArray *pdrgCHAR = GPOS_NEW(mp) CharArray(mp, 2);
 
 	// add elements incl trigger resize of array
@@ -200,7 +200,7 @@ CDynamicPtrArrayTest::EresUnittest_ArrayAppend()
 	CAutoMemoryPool amp;
 	CMemoryPool *mp = amp.Pmp();
 
-	typedef CDynamicPtrArray<ULONG, CleanupNULL<ULONG> > UlongArray;
+	using UlongArray = CDynamicPtrArray<ULONG, CleanupNULL<ULONG>>;
 
 	ULONG cVal = 0;
 
@@ -249,7 +249,7 @@ CDynamicPtrArrayTest::EresUnittest_ArrayAppendExactFit()
 	CAutoMemoryPool amp;
 	CMemoryPool *mp = amp.Pmp();
 
-	typedef CDynamicPtrArray<ULONG, CleanupNULL<ULONG> > UlongArray;
+	using UlongArray = CDynamicPtrArray<ULONG, CleanupNULL<ULONG>>;
 
 	ULONG cVal = 0;
 
@@ -298,7 +298,7 @@ CDynamicPtrArrayTest::EresUnittest_ArrayAppendExactFit()
 GPOS_RESULT
 CDynamicPtrArrayTest::EresUnittest_PdrgpulSubsequenceIndexes()
 {
-	typedef CDynamicPtrArray<ULONG, CleanupNULL<ULONG> > UlongArray;
+	using UlongArray = CDynamicPtrArray<ULONG, CleanupNULL<ULONG>>;
 
 	CAutoMemoryPool amp;
 	CMemoryPool *mp = amp.Pmp();

--- a/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CEnumSetTest.cpp
+++ b/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CEnumSetTest.cpp
@@ -52,8 +52,8 @@ CEnumSetTest::EresUnittest_Basics()
 	CAutoMemoryPool amp;
 	CMemoryPool *mp = amp.Pmp();
 
-	typedef CEnumSet<eTest, eTestSentinel> CETestSet;
-	typedef CEnumSetIter<eTest, eTestSentinel> CETestIter;
+	using CETestSet = CEnumSet<eTest, eTestSentinel>;
+	using CETestIter = CEnumSetIter<eTest, eTestSentinel>;
 
 	CETestSet *enum_set = GPOS_NEW(mp) CETestSet(mp);
 

--- a/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CHashMapIterTest.cpp
+++ b/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CHashMapIterTest.cpp
@@ -57,13 +57,12 @@ CHashMapIterTest::EresUnittest_Basic()
 	ULONG rgul[] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
 	const ULONG ulCnt = GPOS_ARRAY_SIZE(rgul);
 
-	typedef CHashMap<ULONG, ULONG, HashPtr<ULONG>, gpos::Equals<ULONG>,
-					 CleanupNULL<ULONG>, CleanupNULL<ULONG> >
-		Map;
+	using Map = CHashMap<ULONG, ULONG, HashPtr<ULONG>, gpos::Equals<ULONG>,
+						 CleanupNULL<ULONG>, CleanupNULL<ULONG>>;
 
-	typedef CHashMapIter<ULONG, ULONG, HashPtr<ULONG>, gpos::Equals<ULONG>,
-						 CleanupNULL<ULONG>, CleanupNULL<ULONG> >
-		MapIter;
+	using MapIter =
+		CHashMapIter<ULONG, ULONG, HashPtr<ULONG>, gpos::Equals<ULONG>,
+					 CleanupNULL<ULONG>, CleanupNULL<ULONG>>;
 
 
 	// using N - 2 slots guarantees collisions
@@ -77,7 +76,7 @@ CHashMapIterTest::EresUnittest_Basic()
 
 #endif	// GPOS_DEBUG
 
-	typedef CDynamicPtrArray<const ULONG, CleanupNULL> ULongPtrArray;
+	using ULongPtrArray = CDynamicPtrArray<const ULONG, CleanupNULL>;
 	CAutoRef<ULongPtrArray> pdrgpulKeys(GPOS_NEW(mp) ULongPtrArray(mp)),
 		pdrgpulValues(GPOS_NEW(mp) ULongPtrArray(mp));
 	// load map and iterate over it after each step

--- a/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CHashMapTest.cpp
+++ b/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CHashMapTest.cpp
@@ -61,10 +61,9 @@ CHashMapTest::EresUnittest_Basic()
 	GPOS_ASSERT(GPOS_ARRAY_SIZE(rgul) == GPOS_ARRAY_SIZE(rgsz));
 	const ULONG ulCnt = GPOS_ARRAY_SIZE(rgul);
 
-	typedef CHashMap<ULONG_PTR, CHAR, HashPtr<ULONG_PTR>,
-					 gpos::Equals<ULONG_PTR>, CleanupNULL<ULONG_PTR>,
-					 CleanupNULL<CHAR> >
-		UlongPtrToCharMap;
+	using UlongPtrToCharMap =
+		CHashMap<ULONG_PTR, CHAR, HashPtr<ULONG_PTR>, gpos::Equals<ULONG_PTR>,
+				 CleanupNULL<ULONG_PTR>, CleanupNULL<CHAR>>;
 
 	UlongPtrToCharMap *phm = GPOS_NEW(mp) UlongPtrToCharMap(mp, 128);
 	for (ULONG i = 0; i < ulCnt; ++i)
@@ -104,9 +103,9 @@ CHashMapTest::EresUnittest_Basic()
 	phm->Release();
 
 	// test replacing values and triggering their release
-	typedef CHashMap<ULONG, ULONG, HashValue<ULONG>, gpos::Equals<ULONG>,
-					 CleanupDelete<ULONG>, CleanupDelete<ULONG> >
-		UlongToUlongMap;
+	using UlongToUlongMap =
+		CHashMap<ULONG, ULONG, HashValue<ULONG>, gpos::Equals<ULONG>,
+				 CleanupDelete<ULONG>, CleanupDelete<ULONG>>;
 	UlongToUlongMap *phm2 = GPOS_NEW(mp) UlongToUlongMap(mp, 128);
 
 	ULONG *pulKey = GPOS_NEW(mp) ULONG(1);
@@ -156,10 +155,9 @@ CHashMapTest::EresUnittest_Ownership()
 
 	ULONG ulCnt = 256;
 
-	typedef CHashMap<ULONG_PTR, CHAR, HashPtr<ULONG_PTR>,
-					 gpos::Equals<ULONG_PTR>, CleanupDelete<ULONG_PTR>,
-					 CleanupDeleteArray<CHAR> >
-		UlongPtrToCharMap;
+	using UlongPtrToCharMap =
+		CHashMap<ULONG_PTR, CHAR, HashPtr<ULONG_PTR>, gpos::Equals<ULONG_PTR>,
+				 CleanupDelete<ULONG_PTR>, CleanupDeleteArray<CHAR>>;
 
 	UlongPtrToCharMap *phm = GPOS_NEW(mp) UlongPtrToCharMap(mp, 32);
 	for (ULONG i = 0; i < ulCnt; ++i)

--- a/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CHashSetIterTest.cpp
+++ b/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CHashSetIterTest.cpp
@@ -35,13 +35,12 @@ CHashSetIterTest::EresUnittest_Basic()
 	ULONG rgul[] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
 	const ULONG ulCnt = GPOS_ARRAY_SIZE(rgul);
 
-	typedef CHashSet<ULONG, HashValue<ULONG>, gpos::Equals<ULONG>,
-					 CleanupNULL<ULONG> >
-		UlongHashSet;
+	using UlongHashSet = CHashSet<ULONG, HashValue<ULONG>, gpos::Equals<ULONG>,
+								  CleanupNULL<ULONG>>;
 
-	typedef CHashSetIter<ULONG, HashValue<ULONG>, gpos::Equals<ULONG>,
-						 CleanupNULL<ULONG> >
-		UlongHashSetIter;
+	using UlongHashSetIter =
+		CHashSetIter<ULONG, HashValue<ULONG>, gpos::Equals<ULONG>,
+					 CleanupNULL<ULONG>>;
 
 	// using N - 2 slots guarantees collisions
 	UlongHashSet *ps = GPOS_NEW(mp) UlongHashSet(mp, ulCnt - 2);
@@ -54,7 +53,7 @@ CHashSetIterTest::EresUnittest_Basic()
 
 #endif	// GPOS_DEBUG
 
-	typedef CDynamicPtrArray<const ULONG, CleanupNULL> ULongPtrArray;
+	using ULongPtrArray = CDynamicPtrArray<const ULONG, CleanupNULL>;
 	CAutoRef<ULongPtrArray> pdrgpulValues(GPOS_NEW(mp) ULongPtrArray(mp));
 	// load map and iterate over it after each step
 	for (ULONG ul = 0; ul < ulCnt; ++ul)

--- a/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CHashSetTest.cpp
+++ b/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CHashSetTest.cpp
@@ -65,9 +65,8 @@ CHashSetTest::EresUnittest_Basic()
 
 	const ULONG ulCnt = GPOS_ARRAY_SIZE(rgul);
 
-	typedef CHashSet<ULONG_PTR, HashPtr<ULONG_PTR>, Equals<ULONG_PTR>,
-					 CleanupNULL<ULONG_PTR> >
-		UlongPtrHashSet;
+	using UlongPtrHashSet = CHashSet<ULONG_PTR, HashPtr<ULONG_PTR>,
+									 Equals<ULONG_PTR>, CleanupNULL<ULONG_PTR>>;
 
 	UlongPtrHashSet *phs = GPOS_NEW(mp) UlongPtrHashSet(mp, 128);
 	for (ULONG ul = 0; ul < ulCnt; ul++)
@@ -105,9 +104,9 @@ CHashSetTest::EresUnittest_Ownership()
 
 	ULONG ulCnt = 256;
 
-	typedef CHashSet<ULONG_PTR, HashPtr<ULONG_PTR>, Equals<ULONG_PTR>,
-					 CleanupDelete<ULONG_PTR> >
-		UlongPtrHashSet;
+	using UlongPtrHashSet =
+		CHashSet<ULONG_PTR, HashPtr<ULONG_PTR>, Equals<ULONG_PTR>,
+				 CleanupDelete<ULONG_PTR>>;
 
 	UlongPtrHashSet *phs = GPOS_NEW(mp) UlongPtrHashSet(mp, 32);
 	for (ULONG ul = 0; ul < ulCnt; ul++)

--- a/src/backend/gporca/libgpos/src/common/CBitSet.cpp
+++ b/src/backend/gporca/libgpos/src/common/CBitSet.cpp
@@ -351,7 +351,7 @@ CBitSet::Union(const CBitSet *pbsOther)
 	CBitSetLink *bsl_other = nullptr;
 
 	// dynamic array of CBitSetLink
-	typedef CDynamicPtrArray<CBitSetLink, CleanupNULL> CBitSetLinkArray;
+	using CBitSetLinkArray = CDynamicPtrArray<CBitSetLink, CleanupNULL>;
 
 	CAutoRef<CBitSetLinkArray> a_drgpbsl;
 	a_drgpbsl = GPOS_NEW(m_mp) CBitSetLinkArray(m_mp);

--- a/src/backend/gporca/libgpos/src/error/CErrorContext.cpp
+++ b/src/backend/gporca/libgpos/src/error/CErrorContext.cpp
@@ -90,7 +90,9 @@ void
 CErrorContext::Record(CException &exc, VA_LIST vl)
 {
 	if (m_serializing)
+	{
 		return;
+	}
 
 #ifdef GPOS_DEBUG
 	if (m_pending)
@@ -187,7 +189,9 @@ void
 CErrorContext::Serialize()
 {
 	if (m_serializing)
+	{
 		return;
+	}
 
 	if (nullptr == m_mini_dumper_handle ||
 		m_serializable_objects_list.IsEmpty())

--- a/src/backend/gporca/libgpos/src/io/COstream.cpp
+++ b/src/backend/gporca/libgpos/src/io/COstream.cpp
@@ -280,7 +280,7 @@ COstream::operator<<(WOSTREAM &(*func_ptr)(WOSTREAM &) __attribute__((unused)))
 // standard-library implementations that may implement std::endl as a template.
 // It is enabled only for GNU libstdc++, where it is known to work.
 #if defined(GPOS_DEBUG) && defined(__GLIBCXX__)
-	typedef WOSTREAM &(*TManip)(WOSTREAM &);
+	using TManip = WOSTREAM &(*) (WOSTREAM &);
 	TManip tmf = func_ptr;
 	GPOS_ASSERT(tmf == static_cast<TManip>(std::endl) &&
 				"Only std::endl allowed");

--- a/src/backend/gporca/libgpos/src/task/CTaskLocalStorage.cpp
+++ b/src/backend/gporca/libgpos/src/task/CTaskLocalStorage.cpp
@@ -18,9 +18,8 @@ using namespace gpos;
 
 
 // shorthand for HT accessor
-typedef CSyncHashtableAccessByKey<CTaskLocalStorageObject,
-								  CTaskLocalStorage::Etlsidx>
-	HashTableAccessor;
+using HashTableAccessor = CSyncHashtableAccessByKey<CTaskLocalStorageObject,
+													CTaskLocalStorage::Etlsidx>;
 
 
 // invalid idx

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLScalarSortGroupClause.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLScalarSortGroupClause.h
@@ -30,8 +30,8 @@ class CXMLSerializer;
 class CDXLScalarSortGroupClause;
 
 // arrays of column references
-typedef CDynamicPtrArray<CDXLScalarSortGroupClause, CleanupRelease>
-	CDXLScalarSortGroupClauseArray;
+using CDXLScalarSortGroupClauseArray =
+	CDynamicPtrArray<CDXLScalarSortGroupClause, CleanupRelease>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/backend/gporca/libnaucrates/src/base/IDatum.cpp
+++ b/src/backend/gporca/libnaucrates/src/base/IDatum.cpp
@@ -213,7 +213,9 @@ IDatum::StatsAreComparable(const IDatum *datum) const
 			CMDTypeGenericGPDB::IsTimeRelatedType(this->MDId()) &&
 			CMDTypeGenericGPDB::IsTimeRelatedType(datum->MDId());
 		if (is_time_comparison)
+		{
 			return false;
+		}
 	}
 	// datums can be compared based on either LINT or Doubles or BYTEA values
 	BOOL is_double_comparison =

--- a/src/backend/gporca/libnaucrates/src/md/CMDPartConstraintGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDPartConstraintGPDB.cpp
@@ -129,7 +129,9 @@ CMDPartConstraintGPDB::Serialize(CXMLSerializer *xml_serializer) const
 
 	// serialize the scalar expression
 	if (nullptr != m_dxl_node)
+	{
 		m_dxl_node->SerializeToDXL(xml_serializer);
+	}
 
 	xml_serializer->CloseElement(
 		CDXLTokens::GetDXLTokenStr(EdxltokenNamespacePrefix),

--- a/src/backend/gporca/libnaucrates/src/md/CMDRelationGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDRelationGPDB.cpp
@@ -784,7 +784,9 @@ CMDRelationGPDB::Serialize(CXMLSerializer *xml_serializer) const
 
 		// serialize the scalar expression
 		if (nullptr != m_mdpart_constraint)
+		{
 			m_mdpart_constraint->SerializeToDXL(xml_serializer);
+		}
 
 		xml_serializer->CloseElement(
 			CDXLTokens::GetDXLTokenStr(EdxltokenNamespacePrefix),

--- a/src/backend/gporca/server/src/unittest/gpopt/engine/CBindingTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/engine/CBindingTest.cpp
@@ -140,7 +140,9 @@ CBindingTest::EresUnittest_Basic()
 	GPOS_RESULT eres = GPOS_FAILED;
 
 	if (bindings_for_xform == EXPECTED_BINDING)
+	{
 		eres = GPOS_OK;
+	}
 
 	// clean up
 	pexprPlan->Release();

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -27,15 +27,15 @@ extern "C" {
 #include "gpos/types.h"
 
 // fwd declarations
-typedef struct SysScanDescData *SysScanDesc;
+using SysScanDesc = struct SysScanDescData *;
 struct TypeCacheEntry;
-typedef struct NumericData *Numeric;
-typedef struct HeapTupleData *HeapTuple;
-typedef struct RelationData *Relation;
+using Numeric = struct NumericData *;
+using HeapTuple = struct HeapTupleData *;
+using Relation = struct RelationData *;
 struct Value;
-typedef struct TupleDescData *TupleDesc;
+using TupleDesc = struct TupleDescData *;
 struct Query;
-typedef struct ScanKeyData *ScanKey;
+using ScanKey = struct ScanKeyData *;
 struct Bitmapset;
 struct Plan;
 struct ListCell;
@@ -46,7 +46,7 @@ struct ForeignScan;
 struct Uri;
 struct CdbComponentDatabases;
 struct StringInfoData;
-typedef StringInfoData *StringInfo;
+using StringInfo = StringInfoData *;
 struct LogicalIndexes;
 struct ParseState;
 struct DefElem;

--- a/src/include/gpopt/translate/CCTEListEntry.h
+++ b/src/include/gpopt/translate/CCTEListEntry.h
@@ -73,9 +73,8 @@ private:
 	};
 
 	// hash maps mapping CHAR *->SCTEProducerInfo
-	typedef CHashMap<CHAR, SCTEProducerInfo, HashStr, StrEqual, CleanupNULL,
-					 CleanupDelete>
-		HMSzCTEInfo;
+	using HMSzCTEInfo = CHashMap<CHAR, SCTEProducerInfo, HashStr, StrEqual,
+								 CleanupNULL, CleanupDelete>;
 
 	// query level where the CTEs are defined
 	ULONG m_query_level;
@@ -117,14 +116,14 @@ public:
 };
 
 // hash maps mapping ULONG -> CCTEListEntry
-typedef CHashMap<ULONG, CCTEListEntry, gpos::HashValue<ULONG>,
-				 gpos::Equals<ULONG>, CleanupDelete<ULONG>, CleanupRelease>
-	HMUlCTEListEntry;
+using HMUlCTEListEntry =
+	CHashMap<ULONG, CCTEListEntry, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+			 CleanupDelete<ULONG>, CleanupRelease>;
 
 // iterator
-typedef CHashMapIter<ULONG, CCTEListEntry, gpos::HashValue<ULONG>,
-					 gpos::Equals<ULONG>, CleanupDelete<ULONG>, CleanupRelease>
-	HMIterUlCTEListEntry;
+using HMIterUlCTEListEntry =
+	CHashMapIter<ULONG, CCTEListEntry, gpos::HashValue<ULONG>,
+				 gpos::Equals<ULONG>, CleanupDelete<ULONG>, CleanupRelease>;
 
 }  // namespace gpdxl
 #endif	// !GPDXL_CCTEListEntry_H

--- a/src/include/gpopt/translate/CContextDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CContextDXLToPlStmt.h
@@ -38,10 +38,10 @@ namespace gpdxl
 // fwd decl
 class CDXLTranslateContext;
 
-typedef CHashMap<ULONG, CDXLTranslateContext, gpos::HashValue<ULONG>,
-				 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-				 CleanupDelete<CDXLTranslateContext> >
-	HMUlDxltrctx;
+using HMUlDxltrctx =
+	CHashMap<ULONG, CDXLTranslateContext, gpos::HashValue<ULONG>,
+			 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
+			 CleanupDelete<CDXLTranslateContext>>;
 
 //---------------------------------------------------------------------------
 //	@class:
@@ -82,10 +82,10 @@ private:
 	};
 
 	// hash maps mapping ULONG -> SCTEConsumerInfo
-	typedef CHashMap<ULONG, SCTEConsumerInfo, gpos::HashValue<ULONG>,
-					 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-					 CleanupDelete<SCTEConsumerInfo> >
-		HMUlCTEConsumerInfo;
+	using HMUlCTEConsumerInfo =
+		CHashMap<ULONG, SCTEConsumerInfo, gpos::HashValue<ULONG>,
+				 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
+				 CleanupDelete<SCTEConsumerInfo>>;
 
 	CMemoryPool *m_mp;
 

--- a/src/include/gpopt/translate/CDXLTranslateContext.h
+++ b/src/include/gpopt/translate/CDXLTranslateContext.h
@@ -32,20 +32,19 @@ namespace gpdxl
 using namespace gpos;
 
 // hash maps mapping ULONG -> TargetEntry
-typedef CHashMap<ULONG, TargetEntry, gpos::HashValue<ULONG>,
-				 gpos::Equals<ULONG>, CleanupDelete<ULONG>, CleanupNULL>
-	ULongToTargetEntryMap;
-
+using ULongToTargetEntryMap =
+	CHashMap<ULONG, TargetEntry, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+			 CleanupDelete<ULONG>, CleanupNULL>;
 // hash maps mapping ULONG -> CMappingElementColIdParamId
-typedef CHashMap<ULONG, CMappingElementColIdParamId, gpos::HashValue<ULONG>,
-				 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-				 CleanupRelease<CMappingElementColIdParamId> >
-	ULongToColParamMap;
+using ULongToColParamMap =
+	CHashMap<ULONG, CMappingElementColIdParamId, gpos::HashValue<ULONG>,
+			 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
+			 CleanupRelease<CMappingElementColIdParamId>>;
 
-typedef CHashMapIter<ULONG, CMappingElementColIdParamId, gpos::HashValue<ULONG>,
-					 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
-					 CleanupRelease<CMappingElementColIdParamId> >
-	ULongToColParamMapIter;
+using ULongToColParamMapIter =
+	CHashMapIter<ULONG, CMappingElementColIdParamId, gpos::HashValue<ULONG>,
+				 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
+				 CleanupRelease<CMappingElementColIdParamId>>;
 
 
 //---------------------------------------------------------------------------
@@ -116,8 +115,8 @@ public:
 
 
 // array of dxl translation context
-typedef CDynamicPtrArray<const CDXLTranslateContext, CleanupNULL>
-	CDXLTranslationContextArray;
+using CDXLTranslationContextArray =
+	CDynamicPtrArray<const CDXLTranslateContext, CleanupNULL>;
 }  // namespace gpdxl
 
 #endif	// !GPDXL_CDXLTranslateContext_H

--- a/src/include/gpopt/translate/CDXLTranslateContextBaseTable.h
+++ b/src/include/gpopt/translate/CDXLTranslateContextBaseTable.h
@@ -45,10 +45,9 @@ using namespace gpos;
 class CDXLTranslateContextBaseTable
 {
 	// hash maps mapping ULONG -> INT
-	typedef CHashMap<ULONG, INT, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
-					 CleanupDelete<ULONG>, CleanupDelete<INT> >
-		UlongToIntMap;
-
+	using UlongToIntMap =
+		CHashMap<ULONG, INT, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+				 CleanupDelete<ULONG>, CleanupDelete<INT>>;
 
 private:
 	CMemoryPool *m_mp;

--- a/src/include/gpopt/translate/CIndexQualInfo.h
+++ b/src/include/gpopt/translate/CIndexQualInfo.h
@@ -82,7 +82,7 @@ public:
 	}
 };
 // array of index qual info
-typedef CDynamicPtrArray<CIndexQualInfo, CleanupDelete> CIndexQualInfoArray;
+using CIndexQualInfoArray = CDynamicPtrArray<CIndexQualInfo, CleanupDelete>;
 }  // namespace gpdxl
 
 #endif	// !GPDXL_CIndexQualInfo_H

--- a/src/include/gpopt/translate/CMappingVarColId.h
+++ b/src/include/gpopt/translate/CMappingVarColId.h
@@ -80,14 +80,15 @@ private:
 	CMemoryPool *m_mp;
 
 	// hash map structure to store gpdb att -> opt col information
-	typedef CHashMap<CGPDBAttInfo, CGPDBAttOptCol, HashGPDBAttInfo,
-					 EqualGPDBAttInfo, CleanupRelease, CleanupRelease>
-		GPDBAttOptColHashMap;
+	using GPDBAttOptColHashMap =
+		CHashMap<CGPDBAttInfo, CGPDBAttOptCol, HashGPDBAttInfo,
+				 EqualGPDBAttInfo, CleanupRelease, CleanupRelease>;
 
 	// iterator
-	typedef CHashMapIter<CGPDBAttInfo, CGPDBAttOptCol, HashGPDBAttInfo,
-						 EqualGPDBAttInfo, CleanupRelease, CleanupRelease>
-		GPDBAttOptColHashMapIter;
+	using GPDBAttOptColHashMapIter =
+		CHashMapIter<CGPDBAttInfo, CGPDBAttOptCol, HashGPDBAttInfo,
+					 EqualGPDBAttInfo, CleanupRelease, CleanupRelease>;
+
 
 	// map from gpdb att to optimizer col
 	GPDBAttOptColHashMap *m_gpdb_att_opt_col_mapping;

--- a/src/include/gpopt/translate/CQueryMutators.h
+++ b/src/include/gpopt/translate/CQueryMutators.h
@@ -50,10 +50,10 @@ namespace gpdxl
 //---------------------------------------------------------------------------
 class CQueryMutators
 {
-	typedef Node *(*MutatorWalkerFn)();
-	typedef BOOL (*ExprWalkerFn)();
+	using MutatorWalkerFn = Node *(*) ();
+	using ExprWalkerFn = BOOL (*)();
 
-	typedef struct SContextGrpbyPlMutator
+	using CContextGrpbyPlMutator = struct SContextGrpbyPlMutator
 	{
 	public:
 		// memory pool
@@ -92,10 +92,9 @@ class CQueryMutators
 
 		// dtor
 		~SContextGrpbyPlMutator() = default;
+	};
 
-	} CContextGrpbyPlMutator;
-
-	typedef struct SContextIncLevelsupMutator
+	using CContextIncLevelsupMutator = struct SContextIncLevelsupMutator
 	{
 	public:
 		// the current query level
@@ -115,11 +114,10 @@ class CQueryMutators
 
 		// dtor
 		~SContextIncLevelsupMutator() = default;
-
-	} CContextIncLevelsupMutator;
+	};
 
 	// context for walker that iterates over the expression in the target entry
-	typedef struct SContextTLWalker
+	using CContextTLWalker = struct SContextTLWalker
 	{
 	public:
 		// list of target list entries in the query
@@ -136,8 +134,7 @@ class CQueryMutators
 
 		// dtor
 		~SContextTLWalker() = default;
-
-	} CContextTLWalker;
+	};
 
 public:
 	// fall back during since the target list refers to a attribute which algebrizer at this point cannot resolve

--- a/src/include/gpopt/translate/CTranslatorQueryToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorQueryToDXL.h
@@ -44,13 +44,13 @@ namespace gpdxl
 using namespace gpos;
 using namespace gpopt;
 
-typedef CHashMap<ULONG, BOOL, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
-				 CleanupDelete<ULONG>, CleanupDelete<BOOL> >
-	UlongBoolHashMap;
+using UlongBoolHashMap =
+	CHashMap<ULONG, BOOL, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+			 CleanupDelete<ULONG>, CleanupDelete<BOOL>>;
 
-typedef CHashMapIter<INT, ULONG, gpos::HashValue<INT>, gpos::Equals<INT>,
-					 CleanupDelete<INT>, CleanupDelete<ULONG> >
-	IntUlongHashmapIter;
+using IntUlongHashmapIter =
+	CHashMapIter<INT, ULONG, gpos::HashValue<INT>, gpos::Equals<INT>,
+				 CleanupDelete<INT>, CleanupDelete<ULONG>>;
 
 //---------------------------------------------------------------------------
 //	@class:

--- a/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
@@ -46,7 +46,7 @@ extern "C" {
 
 // fwd decl
 struct RelationData;
-typedef struct RelationData *Relation;
+using Relation = struct RelationData *;
 struct LogicalIndexes;
 
 namespace gpdxl

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -48,7 +48,7 @@ namespace gpopt
 class CMDAccessor;
 
 // dynamic array of bitsets
-typedef CDynamicPtrArray<CBitSet, CleanupRelease> CBitSetArray;
+using CBitSetArray = CDynamicPtrArray<CBitSet, CleanupRelease>;
 }  // namespace gpopt
 
 namespace gpdxl

--- a/src/include/gpopt/utils/RelationWrapper.h
+++ b/src/include/gpopt/utils/RelationWrapper.h
@@ -7,7 +7,7 @@
 
 #include <cstddef>
 
-typedef struct RelationData *Relation;
+using Relation = struct RelationData *;
 
 namespace gpdb
 {


### PR DESCRIPTION
Enable config "readability-braces-around-statements" [1].  Also, commit
d045742784c had config syntax error that unintentionally disabled tidy checks.
Auto fix up the files after fixing that mistake.

[1] https://releases.llvm.org/11.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/readability-braces-around-statements.html