### PR TITLE
removed meaningless code line in resgroup_helper.c

### DIFF
--- a/src/backend/utils/resgroup/resgroup_helper.c
+++ b/src/backend/utils/resgroup/resgroup_helper.c
@@ -237,8 +237,6 @@ pg_resgroup_get_status(PG_FUNCTION_ARGS)
 			int ctxsize = sizeof(ResGroupStatCtx) +
 				sizeof(ResGroupStat) * (MaxResourceGroups - 1);
 
-			(void) inGroupId;
-
 			funcctx->user_fctx = palloc(ctxsize);
 			ctx = (ResGroupStatCtx *) funcctx->user_fctx;
 


### PR DESCRIPTION
There is a meaningless line in resgroup_helper.c

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
