### PR TITLE
Resolve GPDB_12_MERGE_FIXME in sync.h and instrument.h

### DIFF
--- a/src/include/executor/instrument.h
+++ b/src/include/executor/instrument.h
@@ -67,8 +67,6 @@ typedef struct Instrumentation
 	double		startup;		/* Total startup time (in seconds) */
 	double		total;			/* Total total time (in seconds) */
 	uint64		ntuples;		/* Total tuples produced */
-	// GPDB_12_MERGE_FIXME: we had changed 'ntuples' and 'nloops' to uint64. Do the same
-	// for 'ntuples2', or?
 	double		ntuples2;		/* Secondary node-specific tuple counter */
 	uint64		nloops;			/* # of run cycles for this node */
 	double		nfiltered1;		/* # tuples removed by scanqual or joinqual */

--- a/src/include/storage/sync.h
+++ b/src/include/storage/sync.h
@@ -49,24 +49,6 @@ typedef struct FileTag
 	int16		forknum;		/* ForkNumber, saving space */
 	RelFileNode rnode;
 	uint32		segno;
-	/*
-	 * GPDB_12_MERGE_FIXME: Should the "is this AO table?" flag be put here?
-	 * Do we need to keep track of whether this file backs an AO table? GPDB 6
-	 * has logic in md/smgr layer to optimize operations on AO tables.
-	 *
-	 * For example:
-	 *   1. delaying fsync on AO tables
-	 *      (commit 6bd76f70450)
-	 *   2. skipping heap specific functions like ForgetRelationFsyncRequests()
-	 *      and DropRelFileNodeBuffers() when operating on AO tables
-	 *      (commit 85fee7365d2)
-	 *   3. efficient unlinking of AO tables
-	 *      (commit 8838ac983c6)
-	 *
-	 * Seems like these features should come through the tableam interface.
-	 * Let's try to do that and delete this diff from upstream.
-	 */
-	/*bool		is_ao_segno;*/
 } FileTag;
 
 #define INIT_FILETAG(a,xx_rnode,xx_forknum,xx_segno,xx_handler)	\


### PR DESCRIPTION
This pr contains the following changes:
- Remove GPDB_12_MERGE_FIXME in instrument.h
    `ntuples` was changed in https://github.com/greenplum-db/gpdb/pull/4317/commits/c3a9ed28aad53951d9eca162c0eae14414c7f036 for performance reason. It's not necessary to do the same for `ntuples2`, so just remove GPDB_12_MERGE_FIXME flag and align with upstream.
- Resolve GPDB_12_MERGE_FXIME in sync.h
    We no longer need "is the AO table" flag in struct `FileTag` since upstream introduced a new function table `SyncOps syncsw[]` for sync handlers in https://github.com/postgres/postgres/commit/3eb77eba5a51780d5cf52cd66a9844cd4d26feb0. The difference of handling sync and unlink requests of ao and heap is hidden by the SyncOps api.
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
