### PR TITLE
Support for changing ACCESS METHOD from AO to heap

### DIFF
--- a/src/backend/catalog/pg_appendonly.c
+++ b/src/backend/catalog/pg_appendonly.c
@@ -34,7 +34,7 @@
 #include "utils/fmgroids.h"
 #include "utils/guc.h"
 
-static void ATAOEntriesHeapToAO(Oid heaprelid, Oid aorelid);
+static void TransferAppendonlyEntries(Oid fromrelid, Oid torelid);
 static void SwapAppendonlyEntries(Oid entryRelId1, Oid entryRelId2);
 
 /*
@@ -424,6 +424,11 @@ RemoveAppendonlyEntry(Oid relid)
 	table_close(pg_appendonly_rel, NoLock);
 }
 
+/*
+ * Does 2 things:
+ * 	Sever existing dependencies: oid -> *
+ * 	Create a new dependency: oid -> baseOid
+ */
 static void
 TransferDependencyLink(
 	Oid baseOid, 
@@ -524,14 +529,22 @@ GetAppendEntryForMove(
 }
 
 /*
- * This function acts as a controller of catalog actions that must be performed
- * when we:
- * 1. perform an ALTER TABLE on an existing AO/AOCO table that does not change
- * the access method (refer to SwapAppendOnlyEntries()).
- * 2. change the access method from/to AO/AOCO
- * (refer to individual * ATAOEntriesXXXToYYY() functions)
+ * This function acts as a controller of catalog actions that needs to be
+ * performed when we have an AT involving AO/AOCO table, where the original
+ * table could be rewritten.
+ *
+ * Parameters:
+ * relform1: original table that is the target of the AT operation.
+ * relform2: newly created temp table that rows have been CTASed into.
+ *
+ * The actions vary on a case-by-case basis:
+ * 1. If we are not changing the table's AM, we need to swap the pg_appendonly
+ *	entries between the temp table and the original table and rewire aux
+ *	table dependencies.
+ * 2. If we are changing the table's AM, we need to transfer the pg_appendonly
+ *	entry of one table to the other and rewire aux table dependencies. See
+ *	individual case bodies for more details.
  */
-
 void
 ATAOEntries(Form_pg_class relform1, Form_pg_class relform2)
 {
@@ -541,7 +554,16 @@ ATAOEntries(Form_pg_class relform1, Form_pg_class relform2)
 			switch(relform2->relam)
 			{
 				case AO_ROW_TABLE_AM_OID:
-					ATAOEntriesHeapToAO(relform1->oid, relform2->oid);
+					/*
+					 * Since the newly created AO table temp relid will be
+					 * dropped from the catalog (later on in finish_heap_swap()),
+					 * we ensure that the:
+					 * 1. newly created pg_appendonly row carries the original
+					 * 		heap relid.
+					 * 2. newly created AO aux tables depend on the original
+					 * 		heap relid.
+					 */
+					TransferAppendonlyEntries(relform2->oid, relform1->oid);
 					break;
 				case AO_COLUMN_TABLE_AM_OID:
 					ereport(ERROR,
@@ -557,9 +579,19 @@ ATAOEntries(Form_pg_class relform1, Form_pg_class relform2)
 			switch(relform2->relam)
 			{
 				case HEAP_TABLE_AM_OID:
-					ereport(ERROR,
-							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								errmsg("alter table does not support switch from AO to Heap")));
+					/*
+					 * Since the newly created heap table temp relid will be
+					 * dropped from the catalog (later on in finish_heap_swap()),
+					 * we ensure that the:
+					 * 1. original AO table's pg_appendonly row carries the heap
+					 * 		temp table's relid.
+					 * 2. original AO table's AO aux tables now depend on the
+					 * 		heap temp table's relid.
+					 * This way when the heap temp table relid is dropped from
+					 * the catalog, the pg_appendonly row and aux tables also
+					 * follow suit.
+					 */
+					TransferAppendonlyEntries(relform1->oid, relform2->oid);
 					break;
 				case AO_ROW_TABLE_AM_OID:
 					SwapAppendonlyEntries(relform1->oid, relform2->oid);
@@ -600,8 +632,17 @@ ATAOEntries(Form_pg_class relform1, Form_pg_class relform2)
 	}
 }
 
+/*
+ * Transfer the pg_appendonly_entry of the relation identified by fromrelid to
+ * the relation identified by torelid.
+ *
+ * This is done by simply overwriting the relid field of the pg_appendonly row
+ * for fromrelid with value = torelid.
+ *
+ * For completeness, also rewire the aux table dependencies to point to torelid.
+ */
 static void
-ATAOEntriesHeapToAO(Oid heaprelid, Oid aorelid)
+TransferAppendonlyEntries(Oid fromrelid, Oid torelid)
 {
 	Relation	pg_appendonly_rel;
 	TupleDesc	pg_appendonly_dsc;
@@ -619,7 +660,7 @@ ATAOEntriesHeapToAO(Oid heaprelid, Oid aorelid)
 	pg_appendonly_tuple = GetAppendEntryForMove(
 		pg_appendonly_rel,
 		pg_appendonly_dsc,
-		aorelid,
+		fromrelid,
 		&aosegrelid,
 		&aoblkdirrelid,
 		&aovisimaprelid);
@@ -629,7 +670,7 @@ ATAOEntriesHeapToAO(Oid heaprelid, Oid aorelid)
 	replace = palloc0(pg_appendonly_dsc->natts * sizeof(bool));
 
 	replace[Anum_pg_appendonly_relid - 1] = true;
-	newValues[Anum_pg_appendonly_relid - 1] = heaprelid;
+	newValues[Anum_pg_appendonly_relid - 1] = torelid;
 
 	pg_appendonly_tuple = heap_modify_tuple(pg_appendonly_tuple, pg_appendonly_dsc,
 								   newValues, newNulls, replace);
@@ -645,15 +686,15 @@ ATAOEntriesHeapToAO(Oid heaprelid, Oid aorelid)
 	pfree(replace);
 
 	if (OidIsValid(aosegrelid))
-		TransferDependencyLink(heaprelid, aosegrelid, "aoseg");
+		TransferDependencyLink(torelid, aosegrelid, "aoseg");
 	if (OidIsValid(aoblkdirrelid))
-		TransferDependencyLink(heaprelid, aoblkdirrelid, "aoblkdir");
+		TransferDependencyLink(torelid, aoblkdirrelid, "aoblkdir");
 	if (OidIsValid(aovisimaprelid))
-		TransferDependencyLink(heaprelid, aovisimaprelid, "aovisimap");
+		TransferDependencyLink(torelid, aovisimaprelid, "aovisimap");
 }
 
 /*
- * Swap pg_appendonly entries between tables.
+ * Swap pg_appendonly entries between tables and transfer aux table dependencies.
  */
 static void
 SwapAppendonlyEntries(Oid entryRelId1, Oid entryRelId2)

--- a/src/test/regress/expected/alter_table_set_am.out
+++ b/src/test/regress/expected/alter_table_set_am.out
@@ -285,34 +285,48 @@ ERROR:  'child2' is not an append-only row relation  (seg0 slice1 127.0.0.1:7002
 SELECT * FROM gp_toolkit.__gp_aovisimap('child2');
 ERROR:  function not supported on relation
 -- Scenario 3: AO to Heap
+SET gp_default_storage_options = 'blocksize=65536, compresstype=zlib, compresslevel=5, checksum=true';
 CREATE TABLE ao2heap(a int, b int) WITH (appendonly=true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE ao2heap2(a int, b int) WITH (appendonly=true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE INDEX aoi ON ao2heap(b);
 INSERT INTO ao2heap SELECT i,i FROM generate_series(1,5) i;
--- Check once that the AO table has the custom reloptions 
-SELECT reloptions FROM pg_class WHERE relname = 'ao2heap';
-            reloptions             
------------------------------------
- {blocksize=65536,compresslevel=5}
-(1 row)
+INSERT INTO ao2heap2 SELECT i,i FROM generate_series(1,5) i;
+-- Check once that the AO tables have the custom reloptions 
+SELECT relname, reloptions FROM pg_class WHERE relname LIKE 'ao2heap%';
+ relname  |            reloptions             
+----------+-----------------------------------
+ ao2heap  | {blocksize=65536,compresslevel=5}
+ ao2heap2 | {blocksize=65536,compresslevel=5}
+(2 rows)
 
--- Check once that the AO table has relfrozenxid = 0
-SELECT relfrozenxid FROM pg_class WHERE relname = 'ao2heap';
- relfrozenxid 
---------------
-            0
-(1 row)
+-- Check once that the AO tables have relfrozenxid = 0
+SELECT relname, relfrozenxid FROM pg_class WHERE relname LIKE 'ao2heap%';
+ relname  | relfrozenxid 
+----------+--------------
+ ao2heap  |            0
+ ao2heap2 |            0
+(2 rows)
 
 CREATE TEMP TABLE relfilebeforeao2heap AS
-    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('ao2heap', 'aoi')
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('ao2heap', 'ao2heap2', 'aoi')
     UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
-    WHERE relname in ('ao2heap', 'aoi') ORDER BY segid;
+    WHERE relname in ('ao2heap', 'ao2heap2', 'aoi') ORDER BY segid;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- Altering AO to heap
 ALTER TABLE ao2heap SET ACCESS METHOD heap;
+ALTER TABLE ao2heap2 SET WITH (appendoptimized=false);
 -- The tables and indexes should have been rewritten (should have different relfilenodes)
 CREATE TEMP TABLE relfileafterao2heap AS
-    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('ao2heap', 'aoi')
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('ao2heap', 'ao2heap2', 'aoi')
     UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
-    WHERE relname in ('ao2heap', 'aoi') ORDER BY segid;
+    WHERE relname in ('ao2heap', 'ao2heap2', 'aoi') ORDER BY segid;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 SELECT * FROM relfilebeforeao2heap INTERSECT SELECT * FROM relfileafterao2heap;
  segid | relfilenode 
 -------+-------------
@@ -322,30 +336,47 @@ SELECT * FROM relfilebeforeao2heap INTERSECT SELECT * FROM relfileafterao2heap;
 SELECT * FROM ao2heap;
  a | b 
 ---+---
- 1 | 1
  2 | 2
  3 | 3
  4 | 4
+ 1 | 1
+ 5 | 5
+(5 rows)
+
+SELECT * FROM ao2heap2;
+ a | b 
+---+---
+ 2 | 2
+ 3 | 3
+ 4 | 4
+ 1 | 1
  5 | 5
 (5 rows)
 
 -- No AO aux tables should be left
 SELECT * FROM gp_toolkit.__gp_aoseg('ao2heap');
-ERROR:  'ao2heap' is not an append-only row relation
+ERROR:  'ao2heap' is not an append-only row relation  (seg0 slice1 127.0.1.1:7002 pid=6817)
 SELECT * FROM gp_toolkit.__gp_aovisimap('ao2heap');
 ERROR:  function not supported on relation
--- The new heap table shouldn't have the old AO table's reloptions
-SELECT reloptions FROM pg_class WHERE relname = 'ao2heap';
- reloptions 
-------------
- 
-(1 row)
+SELECT * FROM gp_toolkit.__gp_aoseg('ao2heap2');
+ERROR:  'ao2heap2' is not an append-only row relation  (seg0 slice1 127.0.1.1:7002 pid=6817)
+SELECT * FROM gp_toolkit.__gp_aovisimap('ao2heap2');
+ERROR:  function not supported on relation
+-- The new heap tables shouldn't have the old AO table's reloptions
+SELECT relname, reloptions FROM pg_class WHERE relname LIKE 'ao2heap%';
+ relname  | reloptions 
+----------+------------
+ ao2heap  | 
+ ao2heap2 | 
+(2 rows)
 
--- The new heap table should have a valid relfrozenxid
-SELECT relfrozenxid <> '0' FROM pg_class WHERE relname = 'ao2heap';
- ?column? 
-----------
- t
-(1 row)
+-- The new heap tables should have a valid relfrozenxid
+SELECT relname, relfrozenxid <> '0' FROM pg_class WHERE relname LIKE 'ao2heap%';
+ relname  | ?column? 
+----------+----------
+ ao2heap  | t
+ ao2heap2 | t
+(2 rows)
 
 DROP TABLE ao2heap;
+DROP TABLE ao2heap2;

--- a/src/test/regress/expected/alter_table_set_am.out
+++ b/src/test/regress/expected/alter_table_set_am.out
@@ -284,3 +284,68 @@ SELECT * FROM gp_toolkit.__gp_aoseg('child2');
 ERROR:  'child2' is not an append-only row relation  (seg0 slice1 127.0.0.1:7002 pid=29947)
 SELECT * FROM gp_toolkit.__gp_aovisimap('child2');
 ERROR:  function not supported on relation
+-- Scenario 3: AO to Heap
+CREATE TABLE ao2heap(a int, b int) WITH (appendonly=true);
+CREATE INDEX aoi ON ao2heap(b);
+INSERT INTO ao2heap SELECT i,i FROM generate_series(1,5) i;
+-- Check once that the AO table has the custom reloptions 
+SELECT reloptions FROM pg_class WHERE relname = 'ao2heap';
+            reloptions             
+-----------------------------------
+ {blocksize=65536,compresslevel=5}
+(1 row)
+
+-- Check once that the AO table has relfrozenxid = 0
+SELECT relfrozenxid FROM pg_class WHERE relname = 'ao2heap';
+ relfrozenxid 
+--------------
+            0
+(1 row)
+
+CREATE TEMP TABLE relfilebeforeao2heap AS
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('ao2heap', 'aoi')
+    UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname in ('ao2heap', 'aoi') ORDER BY segid;
+-- Altering AO to heap
+ALTER TABLE ao2heap SET ACCESS METHOD heap;
+-- The tables and indexes should have been rewritten (should have different relfilenodes)
+CREATE TEMP TABLE relfileafterao2heap AS
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('ao2heap', 'aoi')
+    UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname in ('ao2heap', 'aoi') ORDER BY segid;
+SELECT * FROM relfilebeforeao2heap INTERSECT SELECT * FROM relfileafterao2heap;
+ segid | relfilenode 
+-------+-------------
+(0 rows)
+
+-- Check data is intact
+SELECT * FROM ao2heap;
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+ 3 | 3
+ 4 | 4
+ 5 | 5
+(5 rows)
+
+-- No AO aux tables should be left
+SELECT * FROM gp_toolkit.__gp_aoseg('ao2heap');
+ERROR:  'ao2heap' is not an append-only row relation
+SELECT * FROM gp_toolkit.__gp_aovisimap('ao2heap');
+ERROR:  function not supported on relation
+-- The new heap table shouldn't have the old AO table's reloptions
+SELECT reloptions FROM pg_class WHERE relname = 'ao2heap';
+ reloptions 
+------------
+ 
+(1 row)
+
+-- The new heap table should have a valid relfrozenxid
+SELECT relfrozenxid <> '0' FROM pg_class WHERE relname = 'ao2heap';
+ ?column? 
+----------
+ t
+(1 row)
+
+DROP TABLE ao2heap;

--- a/src/test/regress/expected/alter_table_set_am.out
+++ b/src/test/regress/expected/alter_table_set_am.out
@@ -51,7 +51,15 @@ SET gp_default_storage_options = 'blocksize=65536, compresstype=zlib, compressle
 -- Alter table heap to AO should work
 ALTER TABLE heap2ao SET ACCESS METHOD ao_row;
 ALTER TABLE heap2ao2 SET WITH (appendoptimized=true);
--- The altered table should inherit storage options from gp_default_storage_options
+-- The altered tables should have AO AM
+SELECT c.relname, a.amname FROM pg_class c JOIN pg_am a ON c.relam = a.oid WHERE c.relname LIKE 'heap2ao%';
+ relname  | amname 
+----------+--------
+ heap2ao  | ao_row
+ heap2ao2 | ao_row
+(2 rows)
+
+-- The altered tables should inherit storage options from gp_default_storage_options
 SELECT blocksize,compresslevel,checksum,compresstype,columnstore
 FROM pg_appendonly WHERE relid in ('heap2ao'::regclass::oid, 'heap2ao2'::regclass::oid);
  blocksize | compresslevel | checksum | compresstype | columnstore 
@@ -132,17 +140,17 @@ SELECT * FROM gp_toolkit.__gp_aovisimap('heap2ao2');
 CREATE TABLE heapbase (a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-CREATE TABLE child (c int) INHERITS (heapbase);
+CREATE TABLE heapchild (c int) INHERITS (heapbase);
 NOTICE:  table has parent, setting distribution columns to match parent table
 CREATE TABLE heapbase2 (a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-CREATE TABLE child2 (c int) INHERITS (heapbase2);
+CREATE TABLE heapchild2 (c int) INHERITS (heapbase2);
 NOTICE:  table has parent, setting distribution columns to match parent table
 INSERT INTO heapbase SELECT i,i FROM generate_series(1,5) i;
-INSERT INTO child SELECT i,i,i FROM generate_series(1,5) i;
+INSERT INTO heapchild SELECT i,i,i FROM generate_series(1,5) i;
 INSERT INTO heapbase2 SELECT i,i FROM generate_series(1,5) i;
-INSERT INTO child2 SELECT i,i,i FROM generate_series(1,5) i;
+INSERT INTO heapchild2 SELECT i,i,i FROM generate_series(1,5) i;
 CREATE TEMP TABLE inheritrelfilebefore AS
     SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heapbase', 'heapbase2')
     UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
@@ -150,14 +158,14 @@ CREATE TEMP TABLE inheritrelfilebefore AS
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TEMP TABLE inheritchildrelfilebefore AS
-    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('child', 'child2')
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heapchild', 'heapchild2')
     UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
-    WHERE relname in ('child', 'child2') ORDER BY segid;
+    WHERE relname in ('heapchild', 'heapchild2') ORDER BY segid;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ALTER TABLE heapbase SET ACCESS METHOD ao_row;
 ALTER TABLE heapbase2 SET WITH (appendoptimized=true);
--- The altered table should inherit storage options from gp_default_storage_options
+-- The altered tables should inherit storage options from gp_default_storage_options
 show gp_default_storage_options;
                    gp_default_storage_options                    
 -----------------------------------------------------------------
@@ -180,17 +188,27 @@ SELECT reloptions from pg_class where relname in ('heapbase','heapbase2');
 (2 rows)
 
 SELECT blocksize,compresslevel,checksum,compresstype,columnstore
-FROM pg_appendonly WHERE relid in ('child'::regclass::oid, 'child2'::regclass::oid);
+FROM pg_appendonly WHERE relid in ('heapchild'::regclass::oid, 'heapchild2'::regclass::oid);
  blocksize | compresslevel | checksum | compresstype | columnstore 
 -----------+---------------+----------+--------------+-------------
 (0 rows)
 
-SELECT reloptions from pg_class where relname in ('child','child2');
+SELECT reloptions from pg_class where relname in ('heapchild','heapchild2');
  reloptions 
 ------------
  
  
 (2 rows)
+
+-- The altered parent tables should have AO AM but child tables are still heap
+SELECT c.relname, a.amname FROM pg_class c JOIN pg_am a ON c.relam = a.oid WHERE c.relname LIKE 'heapbase%' OR c.relname LIKE 'heapchild%';
+  relname   | amname 
+------------+--------
+ heapbase   | ao_row
+ heapbase2  | ao_row
+ heapchild  | heap
+ heapchild2 | heap
+(4 rows)
 
 -- Check data is intact
 SELECT * FROM heapbase;
@@ -237,9 +255,9 @@ SELECT * FROM inheritrelfilebefore INTERSECT SELECT * FROM inheritrelfileafter;
 
 -- relfile node should not change for child table
 CREATE TEMP TABLE inheritchildrelfileafter AS
-    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('child', 'child2')
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heapchild', 'heapchild2')
     UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
-    WHERE relname in ('child', 'child2') ORDER BY segid;
+    WHERE relname in ('heapchild', 'heapchild2') ORDER BY segid;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 SELECT count(*) FROM (SELECT * FROM inheritchildrelfilebefore UNION SELECT * FROM inheritchildrelfileafter)a;
@@ -276,13 +294,13 @@ SELECT * FROM gp_toolkit.__gp_aovisimap('heapbase2');
 (0 rows)
 
 -- aux tables are not created for child table
-SELECT * FROM gp_toolkit.__gp_aoseg('child');
-ERROR:  'child' is not an append-only row relation  (seg0 slice1 127.0.0.1:7002 pid=29947)
-SELECT * FROM gp_toolkit.__gp_aovisimap('child');
+SELECT * FROM gp_toolkit.__gp_aoseg('heapchild');
+ERROR:  'heapchild' is not an append-only row relation  (seg0 slice1 127.0.0.1:7002 pid=29947)
+SELECT * FROM gp_toolkit.__gp_aovisimap('heapchild');
 ERROR:  function not supported on relation
-SELECT * FROM gp_toolkit.__gp_aoseg('child2');
-ERROR:  'child2' is not an append-only row relation  (seg0 slice1 127.0.0.1:7002 pid=29947)
-SELECT * FROM gp_toolkit.__gp_aovisimap('child2');
+SELECT * FROM gp_toolkit.__gp_aoseg('heapchild2');
+ERROR:  'heapchild2' is not an append-only row relation  (seg0 slice1 127.0.0.1:7002 pid=29947)
+SELECT * FROM gp_toolkit.__gp_aovisimap('heapchild2');
 ERROR:  function not supported on relation
 -- Scenario 3: AO to Heap
 SET gp_default_storage_options = 'blocksize=65536, compresstype=zlib, compresslevel=5, checksum=true';
@@ -362,6 +380,14 @@ SELECT * FROM gp_toolkit.__gp_aoseg('ao2heap2');
 ERROR:  'ao2heap2' is not an append-only row relation  (seg0 slice1 127.0.1.1:7002 pid=6817)
 SELECT * FROM gp_toolkit.__gp_aovisimap('ao2heap2');
 ERROR:  function not supported on relation
+-- The altered tabless should have heap AM.
+SELECT c.relname, a.amname FROM pg_class c JOIN pg_am a ON c.relam = a.oid WHERE c.relname LIKE 'ao2heap%';
+ relname  | amname 
+----------+--------
+ ao2heap  | heap
+ ao2heap2 | heap
+(2 rows)
+
 -- The new heap tables shouldn't have the old AO table's reloptions
 SELECT relname, reloptions FROM pg_class WHERE relname LIKE 'ao2heap%';
  relname  | reloptions 

--- a/src/test/regress/sql/alter_table_set_am.sql
+++ b/src/test/regress/sql/alter_table_set_am.sql
@@ -143,3 +143,46 @@ SELECT * FROM gp_toolkit.__gp_aoseg('child');
 SELECT * FROM gp_toolkit.__gp_aovisimap('child');
 SELECT * FROM gp_toolkit.__gp_aoseg('child2');
 SELECT * FROM gp_toolkit.__gp_aovisimap('child2');
+
+-- Scenario 3: AO to Heap
+CREATE TABLE ao2heap(a int, b int) WITH (appendonly=true);
+CREATE INDEX aoi ON ao2heap(b);
+
+INSERT INTO ao2heap SELECT i,i FROM generate_series(1,5) i;
+
+-- Check once that the AO table has the custom reloptions 
+SELECT reloptions FROM pg_class WHERE relname = 'ao2heap';
+
+-- Check once that the AO table has relfrozenxid = 0
+SELECT relfrozenxid FROM pg_class WHERE relname = 'ao2heap';
+
+CREATE TEMP TABLE relfilebeforeao2heap AS
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('ao2heap', 'aoi')
+    UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname in ('ao2heap', 'aoi') ORDER BY segid;
+
+-- Altering AO to heap
+ALTER TABLE ao2heap SET ACCESS METHOD heap;
+
+-- The tables and indexes should have been rewritten (should have different relfilenodes)
+CREATE TEMP TABLE relfileafterao2heap AS
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('ao2heap', 'aoi')
+    UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname in ('ao2heap', 'aoi') ORDER BY segid;
+
+SELECT * FROM relfilebeforeao2heap INTERSECT SELECT * FROM relfileafterao2heap;
+
+-- Check data is intact
+SELECT * FROM ao2heap;
+
+-- No AO aux tables should be left
+SELECT * FROM gp_toolkit.__gp_aoseg('ao2heap');
+SELECT * FROM gp_toolkit.__gp_aovisimap('ao2heap');
+
+-- The new heap table shouldn't have the old AO table's reloptions
+SELECT reloptions FROM pg_class WHERE relname = 'ao2heap';
+
+-- The new heap table should have a valid relfrozenxid
+SELECT relfrozenxid <> '0' FROM pg_class WHERE relname = 'ao2heap';
+
+DROP TABLE ao2heap;


### PR DESCRIPTION
Reference:
* Heap to AO: https://github.com/greenplum-db/gpdb/pull/13571
* Comments about the general WF of ATAM from/to AO/AOCO tables: https://github.com/greenplum-db/gpdb/pull/13744

-------------

Main considerations of changes:
* Dropping pg_appendonly entries and AO aux tables:
  * We rely on the existing AT framework to drop those since it needs to cleanup the intermediate temporary table in the end. The only thing we need to do is to transfer the AO entry for the original AO table to the temporary heap table and also link the AO aux table dependencies to it too. 
  * So, we can reuse the existing `ATAOEntriesHeapToAO()` function but rename it accordingly.
  * Added more comment for `ATAOEntries` too.
* Reloptions from the old AO are not applicable to new heap table, discard them
* The new heap table should have valid pg_class.relfrozenxid

For `ALTER TABLE SET WITH` from AO to Heap tables, it's trivially supported since the syntax is there. Just adding tests.