### PR TITLE
[5X]: Fix vacuum full utility mode test

### DIFF
--- a/src/test/isolation2/expected/vacuum_full_recently_dead_tuple_due_to_distributed_snapshot.out
+++ b/src/test/isolation2/expected/vacuum_full_recently_dead_tuple_due_to_distributed_snapshot.out
@@ -43,12 +43,16 @@ count
 SET
 
 -- If gp_disable_dtx_visibility_check is set, all tuples should be vacuumed.
-delete from test_recently_dead_utility;
+create table test_recently_dead_utility2(a int, b int, c text);
+CREATE
+insert into test_recently_dead_utility2 select 1, g, 'foobar' from generate_series(1, 1000) g;
+INSERT 1000
+delete from test_recently_dead_utility2;
 DELETE 1000
 
 2U: set gp_select_invisible=1;
 SET
-2U: select count(*) from test_recently_dead_utility;
+2U: select count(*) from test_recently_dead_utility2;
 count
 -----
 1000 
@@ -58,12 +62,12 @@ SET
 
 2U: set gp_disable_dtx_visibility_check to on;
 SET
-2U: vacuum full test_recently_dead_utility;
+2U: vacuum full test_recently_dead_utility2;
 VACUUM
 
 2U: set gp_select_invisible=1;
 SET
-2U: select count(*) from test_recently_dead_utility;
+2U: select count(*) from test_recently_dead_utility2;
 count
 -----
 0    

--- a/src/test/isolation2/sql/vacuum_full_recently_dead_tuple_due_to_distributed_snapshot.sql
+++ b/src/test/isolation2/sql/vacuum_full_recently_dead_tuple_due_to_distributed_snapshot.sql
@@ -28,17 +28,19 @@ update test_recently_dead_utility set b = 1;
 2U: set gp_select_invisible=0;
 
 -- If gp_disable_dtx_visibility_check is set, all tuples should be vacuumed.
-delete from test_recently_dead_utility;
+create table test_recently_dead_utility2(a int, b int, c text);
+insert into test_recently_dead_utility2 select 1, g, 'foobar' from generate_series(1, 1000) g;
+delete from test_recently_dead_utility2;
 
 2U: set gp_select_invisible=1;
-2U: select count(*) from test_recently_dead_utility;
+2U: select count(*) from test_recently_dead_utility2;
 2U: set gp_select_invisible=0;
 
 2U: set gp_disable_dtx_visibility_check to on;
-2U: vacuum full test_recently_dead_utility;
+2U: vacuum full test_recently_dead_utility2;
 
 2U: set gp_select_invisible=1;
-2U: select count(*) from test_recently_dead_utility;
+2U: select count(*) from test_recently_dead_utility2;
 2U: set gp_select_invisible=0;
 
 -- Ensure that we ERROR out if gp_disable_dtx_visibility_check is set in


### PR DESCRIPTION
This is a follow-up to commit b1da07beba0.

With ORCA, since updates are converted to deletes and inserts in a
manner where the heap AM's update implementation is not used, we end up
with a diff in the number of tuples that could be HOT pruned (pruned
during the newly added delete after the 2 update statements):

```
*** ./expected/vacuum_full_recently_dead_tuple_due_to_distributed_snapshot.out	2022-06-23 20:43:50.048535147 +0000
--- ./results/vacuum_full_recently_dead_tuple_due_to_distributed_snapshot.out	2022-06-23 20:43:50.052535542 +0000
***************
*** 52,58 ****
  2U: select count(*) from test_recently_dead_utility;
  count
  -----
! 1000
  (1 row)
  2U: set gp_select_invisible=0;
  SET
--- 52,58 ----
  2U: select count(*) from test_recently_dead_utility;
  count
  -----
! 1280
  (1 row)
  2U: set gp_select_invisible=0;
  SET
```

So, to fix, we eliminate deletes after updates from the test setup by
using a new table to test gp_disable_dtx_visibility_check. That makes
the test more self-contained and easier to read too.

Co-authored-by: Ashwin Agrawal <aashwin@vmware.com>
