### PR TITLE
[6X] Enhance ORCA to generate performant plans for ordered-set aggs with skewed data

### DIFF
--- a/gpcontrib/gp_percentile_agg/expected/gp_percentile_agg_optimizer.out
+++ b/gpcontrib/gp_percentile_agg/expected/gp_percentile_agg_optimizer.out
@@ -52,47 +52,59 @@ from  (select * from generate_series(1, 99) i ) a ;
 set optimizer_enable_orderedagg=on;
 explain select percentile_cont(0.5) within group (order by a),
 	median(a), percentile_disc(0.5) within group(order by a) from perct;
-                                                                        QUERY PLAN                                                                         
------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice8; segments: 3)  (cost=0.00..2712065311.58 rows=1 width=20)
-   ->  Sequence  (cost=0.00..2712065311.58 rows=1 width=20)
-         ->  Shared Scan (share slice:id 8:0)  (cost=0.00..431.00 rows=34 width=1)
-               ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
-                     ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=34)
-         ->  Redistribute Motion 1:3  (slice7)  (cost=0.00..2712064880.58 rows=1 width=20)
-               ->  Nested Loop  (cost=0.00..2712064880.58 rows=1 width=20)
-                     Join Filter: true
-                     ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=16)
-                           ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
-                                 ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
-                                       Merge Key: share0_ref4.a
-                                       ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
-                                             Sort Key: share0_ref4.a
-                                             ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
+                                                                              QUERY PLAN                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice8; segments: 3)  (cost=0.00..2712071156.19 rows=1 width=20)
+   ->  Sequence  (cost=0.00..2712071156.19 rows=1 width=20)
+         ->  Shared Scan (share slice:id 8:0)  (cost=0.00..431.01 rows=34 width=1)
+               ->  Materialize  (cost=0.00..431.01 rows=34 width=1)
+                     ->  GroupAggregate  (cost=0.00..431.01 rows=34 width=12)
+                           Group Key: perct_1.a
+                           ->  Sort  (cost=0.00..431.00 rows=34 width=4)
+                                 Sort Key: perct_1.a
+                                 ->  Seq Scan on perct perct_1  (cost=0.00..431.00 rows=34 width=4)
+         ->  Sequence  (cost=0.00..2712070725.18 rows=1 width=20)
+               ->  Shared Scan (share slice:id 8:1)  (cost=0.00..431.01 rows=34 width=1)
+                     ->  Materialize  (cost=0.00..431.01 rows=34 width=1)
+                           ->  GroupAggregate  (cost=0.00..431.01 rows=34 width=12)
+                                 Group Key: perct.a
+                                 ->  Sort  (cost=0.00..431.00 rows=34 width=4)
+                                       Sort Key: perct.a
+                                       ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=4)
+               ->  Redistribute Motion 1:3  (slice7)  (cost=0.00..2712070294.18 rows=1 width=20)
+                     ->  Nested Loop  (cost=0.00..2712070294.18 rows=1 width=20)
+                           Join Filter: true
+                           ->  Aggregate  (cost=0.00..1324037.57 rows=1 width=16)
+                                 ->  Limit  (cost=0.00..1324037.57 rows=34 width=20)
+                                       ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1324037.57 rows=100 width=20)
+                                             Merge Key: share0_ref3.a
+                                             ->  Nested Loop  (cost=0.00..1324037.56 rows=34 width=20)
                                                    Join Filter: true
-                                                   ->  Broadcast Motion 1:3  (slice5)  (cost=0.00..431.00 rows=3 width=8)
-                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                               ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=34 width=12)
+                                                   ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Broadcast Motion 1:3  (slice5)  (cost=0.00..431.00 rows=3 width=8)
                                                                      ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                           ->  Shared Scan (share slice:id 4:0)  (cost=0.00..431.00 rows=34 width=4)
-                                                   ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=34 width=4)
-                     ->  Materialize  (cost=0.00..1324034.93 rows=1 width=4)
-                           ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=4)
-                                 ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
-                                       ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
-                                             Merge Key: share0_ref2.a
-                                             ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
-                                                   Sort Key: share0_ref2.a
-                                                   ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
+                                                                           ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                       ->  Shared Scan (share slice:id 4:0)  (cost=0.00..431.00 rows=34 width=8)
+                           ->  Materialize  (cost=0.00..1324037.57 rows=1 width=4)
+                                 ->  Aggregate  (cost=0.00..1324037.57 rows=1 width=4)
+                                       ->  Limit  (cost=0.00..1324037.57 rows=34 width=20)
+                                             ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324037.57 rows=100 width=20)
+                                                   Merge Key: share1_ref3.a
+                                                   ->  Nested Loop  (cost=0.00..1324037.56 rows=34 width=20)
                                                          Join Filter: true
-                                                         ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
-                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Shared Scan (share slice:id 3:1)  (cost=0.00..431.00 rows=34 width=12)
+                                                         ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                                     ->  Result  (cost=0.00..431.00 rows=1 width=8)
                                                                            ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                                 ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=4)
-                                                         ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                                                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                             ->  Shared Scan (share slice:id 1:1)  (cost=0.00..431.00 rows=34 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(38 rows)
+(50 rows)
 
 select percentile_cont(0.5) within group (order by a),
 	median(a), percentile_disc(0.5) within group(order by a) from perct;
@@ -135,23 +147,26 @@ select b, percentile_cont(0.5) within group (order by a),
 (11 rows)
 
 explain select percentile_cont(0.2) within group (order by a) from generate_series(1, 100)a;
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
- Sequence  (cost=0.00..1324105.78 rows=1 width=8)
-   ->  Shared Scan (share slice:id -1:0)  (cost=0.00..0.01 rows=334 width=1)
-         ->  Materialize  (cost=0.00..0.01 rows=334 width=1)
-               ->  Function Scan on generate_series  (cost=0.00..0.00 rows=334 width=4)
-   ->  Aggregate  (cost=0.00..1324105.78 rows=1 width=8)
-         ->  Limit  (cost=0.00..1324105.78 rows=334 width=12)
-               ->  Sort  (cost=0.00..1324105.76 rows=334 width=12)
-                     Sort Key: share0_ref2.generate_series
-                     ->  Nested Loop  (cost=0.00..1324105.09 rows=334 width=12)
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Sequence  (cost=0.00..1324182.58 rows=1 width=8)
+   ->  Shared Scan (share slice:id -1:0)  (cost=0.00..0.13 rows=334 width=1)
+         ->  Materialize  (cost=0.00..0.13 rows=334 width=1)
+               ->  HashAggregate  (cost=0.00..0.13 rows=334 width=12)
+                     Group Key: generate_series.generate_series
+                     ->  Function Scan on generate_series  (cost=0.00..0.00 rows=334 width=4)
+   ->  Aggregate  (cost=0.00..1324182.45 rows=1 width=8)
+         ->  Limit  (cost=0.00..1324182.44 rows=334 width=20)
+               ->  Sort  (cost=0.00..1324182.42 rows=334 width=20)
+                     Sort Key: share0_ref3.generate_series
+                     ->  Nested Loop  (cost=0.00..1324181.29 rows=334 width=20)
                            Join Filter: true
-                           ->  Aggregate  (cost=0.00..431.01 rows=1 width=8)
-                                 ->  Shared Scan (share slice:id -1:0)  (cost=0.00..431.01 rows=334 width=4)
-                           ->  Shared Scan (share slice:id -1:0)  (cost=0.00..431.01 rows=334 width=4)
+                           ->  Shared Scan (share slice:id -1:0)  (cost=0.00..431.03 rows=334 width=12)
+                           ->  Result  (cost=0.00..431.02 rows=1 width=8)
+                                 ->  Aggregate  (cost=0.00..431.02 rows=1 width=8)
+                                       ->  Shared Scan (share slice:id -1:0)  (cost=0.00..431.02 rows=334 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+(17 rows)
 
 select percentile_cont(0.2) within group (order by a) from generate_series(1, 100)a;
  percentile_cont 
@@ -258,37 +273,41 @@ select percentile_cont(0.1) within group (order by a), count(*), sum(a) from per
 (11 rows)
 
 explain select percentile_cont(0.6) within group (order by a), count(*), sum(a) from perct;
-                                                                        QUERY PLAN                                                                         
------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1356694888.30 rows=1 width=24)
-   ->  Sequence  (cost=0.00..1356694888.30 rows=1 width=24)
-         ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=34 width=1)
-               ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
-                     ->  Seq Scan on perct perct_1  (cost=0.00..431.00 rows=34 width=34)
-         ->  Redistribute Motion 1:3  (slice5)  (cost=0.00..1356694457.29 rows=1 width=24)
-               ->  Nested Loop  (cost=0.00..1356694457.29 rows=1 width=24)
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1356697594.89 rows=1 width=24)
+   ->  Sequence  (cost=0.00..1356697594.89 rows=1 width=24)
+         ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.01 rows=34 width=1)
+               ->  Materialize  (cost=0.00..431.01 rows=34 width=1)
+                     ->  GroupAggregate  (cost=0.00..431.01 rows=34 width=12)
+                           Group Key: perct_1.a
+                           ->  Sort  (cost=0.00..431.00 rows=34 width=4)
+                                 Sort Key: perct_1.a
+                                 ->  Seq Scan on perct perct_1  (cost=0.00..431.00 rows=34 width=4)
+         ->  Redistribute Motion 1:3  (slice5)  (cost=0.00..1356697163.89 rows=1 width=24)
+               ->  Nested Loop  (cost=0.00..1356697163.89 rows=1 width=24)
                      Join Filter: true
                      ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
                            ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
                                  ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
                                        ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=4)
-                     ->  Materialize  (cost=0.00..1324034.93 rows=1 width=8)
-                           ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=8)
-                                 ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
-                                       ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
-                                             Merge Key: share0_ref2.a
-                                             ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
-                                                   Sort Key: share0_ref2.a
-                                                   ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
-                                                         Join Filter: true
+                     ->  Materialize  (cost=0.00..1324037.57 rows=1 width=8)
+                           ->  Aggregate  (cost=0.00..1324037.57 rows=1 width=8)
+                                 ->  Limit  (cost=0.00..1324037.57 rows=34 width=20)
+                                       ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324037.57 rows=100 width=20)
+                                             Merge Key: share0_ref3.a
+                                             ->  Nested Loop  (cost=0.00..1324037.56 rows=34 width=20)
+                                                   Join Filter: true
+                                                   ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=12)
+                                                   ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
                                                          ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
-                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                                                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                                 ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=4)
-                                                         ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                               ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                       ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(28 rows)
+(32 rows)
 
 select percentile_cont(0.6) within group (order by a), count(*), sum(a) from perct;
  percentile_cont | count | sum  
@@ -452,30 +471,36 @@ select count(*), median(b+1) from perct group by b+2
 (11 rows)
 
 explain select median(a) from perct2;
-                                                                  QUERY PLAN                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324468.39 rows=1 width=8)
-   ->  Sequence  (cost=0.00..1324468.39 rows=1 width=8)
-         ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.01 rows=67 width=1)
-               ->  Materialize  (cost=0.00..431.01 rows=67 width=1)
-                     ->  Seq Scan on perct2  (cost=0.00..431.00 rows=67 width=34)
-         ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324037.39 rows=1 width=8)
-               ->  Aggregate  (cost=0.00..1324037.39 rows=1 width=8)
-                     ->  Limit  (cost=0.00..1324037.39 rows=67 width=12)
-                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324037.38 rows=200 width=12)
-                                 Merge Key: share0_ref2.a
-                                 ->  Sort  (cost=0.00..1324037.38 rows=67 width=12)
-                                       Sort Key: share0_ref2.a
-                                       ->  Nested Loop  (cost=0.00..1324037.35 rows=67 width=12)
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1324468.60 rows=1 width=8)
+   ->  Sequence  (cost=0.00..1324468.60 rows=1 width=8)
+         ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.01 rows=34 width=1)
+               ->  Materialize  (cost=0.00..431.01 rows=34 width=1)
+                     ->  HashAggregate  (cost=0.00..431.01 rows=34 width=12)
+                           Group Key: perct2.a
+                           ->  Redistribute Motion 3:3  (slice5; segments: 3)  (cost=0.00..431.00 rows=67 width=4)
+                                 Hash Key: perct2.a
+                                 ->  Seq Scan on perct2  (cost=0.00..431.00 rows=67 width=4)
+         ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324037.59 rows=1 width=8)
+               ->  Aggregate  (cost=0.00..1324037.59 rows=1 width=8)
+                     ->  Limit  (cost=0.00..1324037.59 rows=34 width=20)
+                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324037.59 rows=100 width=20)
+                                 Merge Key: share0_ref3.a
+                                 ->  Sort  (cost=0.00..1324037.58 rows=34 width=20)
+                                       Sort Key: share0_ref3.a
+                                       ->  Nested Loop  (cost=0.00..1324037.56 rows=34 width=20)
                                              Join Filter: true
-                                             ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
-                                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=12)
+                                             ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
                                                                ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                     ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=67 width=4)
-                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=67 width=4)
+                                                                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                 ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+(27 rows)
 
 select median(a) from perct2;
  median 
@@ -584,47 +609,65 @@ from perct group by b+1 order by b+1;
 (11 rows)
 
 explain select median(a), median(c) from perct4;
-                                                                        QUERY PLAN                                                                         
------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice8; segments: 3)  (cost=0.00..2712066833.06 rows=1 width=16)
-   ->  Sequence  (cost=0.00..2712066833.06 rows=1 width=16)
-         ->  Shared Scan (share slice:id 8:0)  (cost=0.00..431.00 rows=34 width=1)
-               ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
-                     ->  Seq Scan on perct4  (cost=0.00..431.00 rows=34 width=42)
-         ->  Redistribute Motion 1:3  (slice7)  (cost=0.00..2712066402.06 rows=1 width=16)
-               ->  Nested Loop  (cost=0.00..2712066402.06 rows=1 width=16)
-                     Join Filter: true
-                     ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=8)
-                           ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
-                                 ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
-                                       Merge Key: share0_ref4.a
-                                       ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
-                                             Sort Key: share0_ref4.a
-                                             ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice9; segments: 3)  (cost=0.00..2712065060.98 rows=1 width=16)
+   ->  Sequence  (cost=0.00..2712065060.98 rows=1 width=16)
+         ->  Shared Scan (share slice:id 9:0)  (cost=0.00..431.01 rows=28 width=1)
+               ->  Materialize  (cost=0.00..431.01 rows=28 width=1)
+                     ->  GroupAggregate  (cost=0.00..431.01 rows=28 width=12)
+                           Group Key: perct4_1.a
+                           ->  Sort  (cost=0.00..431.01 rows=34 width=4)
+                                 Sort Key: perct4_1.a
+                                 ->  Redistribute Motion 3:3  (slice8; segments: 3)  (cost=0.00..431.00 rows=34 width=4)
+                                       Hash Key: perct4_1.a
+                                       ->  Seq Scan on perct4 perct4_1  (cost=0.00..431.00 rows=34 width=4)
+         ->  Sequence  (cost=0.00..2712064629.97 rows=1 width=16)
+               ->  Shared Scan (share slice:id 9:1)  (cost=0.00..431.01 rows=1 width=1)
+                     ->  Materialize  (cost=0.00..431.01 rows=1 width=1)
+                           ->  GroupAggregate  (cost=0.00..431.01 rows=1 width=16)
+                                 Group Key: perct4.c
+                                 ->  Sort  (cost=0.00..431.01 rows=1 width=16)
+                                       Sort Key: perct4.c
+                                       ->  Redistribute Motion 3:3  (slice7; segments: 3)  (cost=0.00..431.01 rows=1 width=16)
+                                             Hash Key: perct4.c
+                                             ->  Result  (cost=0.00..431.01 rows=1 width=16)
+                                                   ->  HashAggregate  (cost=0.00..431.01 rows=1 width=16)
+                                                         Group Key: perct4.c
+                                                         ->  Seq Scan on perct4  (cost=0.00..431.00 rows=34 width=8)
+               ->  Redistribute Motion 1:3  (slice6)  (cost=0.00..2712064198.97 rows=1 width=16)
+                     ->  Nested Loop  (cost=0.00..2712064198.97 rows=1 width=16)
+                           Join Filter: true
+                           ->  Aggregate  (cost=0.00..1324036.68 rows=1 width=8)
+                                 ->  Limit  (cost=0.00..1324036.68 rows=28 width=20)
+                                       ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324036.67 rows=82 width=20)
+                                             Merge Key: share0_ref3.a
+                                             ->  Nested Loop  (cost=0.00..1324036.67 rows=28 width=20)
                                                    Join Filter: true
-                                                   ->  Broadcast Motion 1:3  (slice5)  (cost=0.00..431.00 rows=3 width=8)
-                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                               ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=28 width=12)
+                                                   ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Broadcast Motion 1:3  (slice4)  (cost=0.00..431.00 rows=3 width=8)
                                                                      ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                           ->  Shared Scan (share slice:id 4:0)  (cost=0.00..431.00 rows=34 width=4)
-                                                   ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=34 width=4)
-                     ->  Materialize  (cost=0.00..1324036.42 rows=1 width=8)
-                           ->  Aggregate  (cost=0.00..1324036.42 rows=1 width=8)
-                                 ->  Limit  (cost=0.00..1324036.42 rows=34 width=16)
-                                       ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324036.41 rows=100 width=16)
-                                             Merge Key: share0_ref2.c
-                                             ->  Sort  (cost=0.00..1324036.41 rows=34 width=16)
-                                                   Sort Key: share0_ref2.c
-                                                   ->  Nested Loop  (cost=0.00..1324036.39 rows=34 width=16)
-                                                         Join Filter: true
-                                                         ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
-                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                                                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                                 ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=8)
-                                                         ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=8)
+                                                                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                       ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=28 width=8)
+                           ->  Aggregate  (cost=0.00..1324032.52 rows=1 width=8)
+                                 ->  Limit  (cost=0.00..1324032.52 rows=1 width=24)
+                                       ->  Sort  (cost=0.00..1324032.52 rows=1 width=24)
+                                             Sort Key: share1_ref2.c
+                                             ->  Nested Loop  (cost=0.00..1324032.52 rows=1 width=24)
+                                                   Join Filter: true
+                                                   ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Shared Scan (share slice:id 2:1)  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Materialize  (cost=0.00..431.00 rows=1 width=16)
+                                                         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+                                                               ->  Shared Scan (share slice:id 1:1)  (cost=0.00..431.00 rows=1 width=16)
  Optimizer: Pivotal Optimizer (GPORCA)
-(38 rows)
+(56 rows)
 
 select median(a), median(c) from perct4;
  median | median 
@@ -732,30 +775,34 @@ select sum(median(a)) over (partition by b) from perct group by b order by b;
 (11 rows)
 
 explain select percentile_disc(0) within group (order by a) from perct;
-                                                                  QUERY PLAN                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324465.93 rows=1 width=4)
-   ->  Sequence  (cost=0.00..1324465.93 rows=1 width=4)
-         ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=34 width=1)
-               ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
-                     ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=34)
-         ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324034.93 rows=1 width=4)
-               ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=4)
-                     ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
-                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
-                                 Merge Key: share0_ref2.a
-                                 ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
-                                       Sort Key: share0_ref2.a
-                                       ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
-                                             Join Filter: true
-                                             ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
-                                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                     ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=4)
-                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324468.58 rows=1 width=4)
+   ->  Sequence  (cost=0.00..1324468.58 rows=1 width=4)
+         ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.01 rows=34 width=1)
+               ->  Materialize  (cost=0.00..431.01 rows=34 width=1)
+                     ->  GroupAggregate  (cost=0.00..431.01 rows=34 width=12)
+                           Group Key: perct.a
+                           ->  Sort  (cost=0.00..431.00 rows=34 width=4)
+                                 Sort Key: perct.a
+                                 ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=4)
+         ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324037.57 rows=1 width=4)
+               ->  Aggregate  (cost=0.00..1324037.57 rows=1 width=4)
+                     ->  Limit  (cost=0.00..1324037.57 rows=34 width=20)
+                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324037.57 rows=100 width=20)
+                                 Merge Key: share0_ref3.a
+                                 ->  Nested Loop  (cost=0.00..1324037.56 rows=34 width=20)
+                                       Join Filter: true
+                                       ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=12)
+                                       ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+(25 rows)
 
 select percentile_disc(0) within group (order by a) from perct;
  percentile_disc 
@@ -799,37 +846,41 @@ execute p(0.8);
 
 deallocate p;
 explain select sum((select median(a) from perct)) from perct;
-                                                                                 QUERY PLAN                                                                                  
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..1357135807.06 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1357135807.06 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..1357135807.06 rows=1 width=8)
-               ->  Nested Loop Left Join  (cost=0.00..1357135807.06 rows=67 width=8)
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..1357138415.08 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1357138415.08 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..1357138415.08 rows=1 width=8)
+               ->  Nested Loop Left Join  (cost=0.00..1357138415.08 rows=67 width=8)
                      Join Filter: true
                      ->  Seq Scan on perct perct_1  (cost=0.00..431.00 rows=34 width=1)
-                     ->  Materialize  (cost=0.00..1324465.93 rows=1 width=8)
-                           ->  Broadcast Motion 3:3  (slice5; segments: 3)  (cost=0.00..1324465.93 rows=1 width=8)
-                                 ->  Sequence  (cost=0.00..1324465.93 rows=1 width=8)
-                                       ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=34 width=1)
-                                             ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
-                                                   ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=34)
-                                       ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324034.93 rows=1 width=8)
-                                             ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=8)
-                                                   ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
-                                                         ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
-                                                               Merge Key: share0_ref2.a
-                                                               ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
-                                                                     Sort Key: share0_ref2.a
-                                                                     ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
+                     ->  Materialize  (cost=0.00..1324468.48 rows=1 width=8)
+                           ->  Broadcast Motion 3:3  (slice5; segments: 3)  (cost=0.00..1324468.48 rows=1 width=8)
+                                 ->  Sequence  (cost=0.00..1324468.48 rows=1 width=8)
+                                       ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.01 rows=34 width=1)
+                                             ->  Materialize  (cost=0.00..431.01 rows=34 width=1)
+                                                   ->  GroupAggregate  (cost=0.00..431.01 rows=34 width=12)
+                                                         Group Key: perct.a
+                                                         ->  Sort  (cost=0.00..431.00 rows=34 width=4)
+                                                               Sort Key: perct.a
+                                                               ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=4)
+                                       ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324037.47 rows=1 width=8)
+                                             ->  Aggregate  (cost=0.00..1324037.47 rows=1 width=8)
+                                                   ->  Result  (cost=0.00..1324037.47 rows=34 width=20)
+                                                         ->  Limit  (cost=0.00..1324037.46 rows=34 width=20)
+                                                               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324037.46 rows=100 width=20)
+                                                                     Merge Key: share0_ref3.a
+                                                                     ->  Nested Loop  (cost=0.00..1324037.45 rows=34 width=20)
                                                                            Join Filter: true
-                                                                           ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
-                                                                                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                                       ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                                                                             ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                                                   ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=4)
-                                                                           ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                                           ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=12)
+                                                                           ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                                                                 ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                             ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                                         ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(28 rows)
+(32 rows)
 
 select sum((select median(a) from perct)) from perct;
  sum  
@@ -838,30 +889,34 @@ select sum((select median(a) from perct)) from perct;
 (1 row)
 
 explain select percentile_cont(null) within group (order by a) from perct;
-                                                                  QUERY PLAN                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324465.93 rows=1 width=8)
-   ->  Sequence  (cost=0.00..1324465.93 rows=1 width=8)
-         ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=34 width=1)
-               ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
-                     ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=34)
-         ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324034.93 rows=1 width=8)
-               ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=8)
-                     ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
-                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
-                                 Merge Key: share0_ref2.a
-                                 ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
-                                       Sort Key: share0_ref2.a
-                                       ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
-                                             Join Filter: true
-                                             ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
-                                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                     ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=4)
-                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324468.58 rows=1 width=8)
+   ->  Sequence  (cost=0.00..1324468.58 rows=1 width=8)
+         ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.01 rows=34 width=1)
+               ->  Materialize  (cost=0.00..431.01 rows=34 width=1)
+                     ->  GroupAggregate  (cost=0.00..431.01 rows=34 width=12)
+                           Group Key: perct.a
+                           ->  Sort  (cost=0.00..431.00 rows=34 width=4)
+                                 Sort Key: perct.a
+                                 ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=4)
+         ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324037.57 rows=1 width=8)
+               ->  Aggregate  (cost=0.00..1324037.57 rows=1 width=8)
+                     ->  Limit  (cost=0.00..1324037.57 rows=34 width=20)
+                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324037.57 rows=100 width=20)
+                                 Merge Key: share0_ref3.a
+                                 ->  Nested Loop  (cost=0.00..1324037.56 rows=34 width=20)
+                                       Join Filter: true
+                                       ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=12)
+                                       ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+(25 rows)
 
 select percentile_cont(null) within group (order by a) from perct;
  percentile_cont 
@@ -963,26 +1018,33 @@ from percts group by b order by b;
 
 explain select percentile_cont(1.0/86400) within group (order by a) from percts
 	where c between 1 and 2;
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
- Sequence  (cost=0.00..1324463.26 rows=1 width=8)
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Sequence  (cost=0.00..1324463.47 rows=1 width=8)
    ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=1)
          ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
-               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=42)
-                     ->  Seq Scan on percts  (cost=0.00..431.00 rows=1 width=42)
-                           Filter: ((c >= 1) AND (c <= 2))
-   ->  Aggregate  (cost=0.00..1324032.25 rows=1 width=8)
-         ->  Limit  (cost=0.00..1324032.25 rows=1 width=16)
-               ->  Sort  (cost=0.00..1324032.25 rows=1 width=16)
+               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=3 width=16)
+                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
+                           Group Key: percts.a
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                                 Sort Key: percts.a
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                       Hash Key: percts.a
+                                       ->  Seq Scan on percts  (cost=0.00..431.00 rows=1 width=8)
+                                             Filter: ((c >= 1) AND (c <= 2))
+   ->  Aggregate  (cost=0.00..1324032.47 rows=1 width=8)
+         ->  Limit  (cost=0.00..1324032.47 rows=1 width=24)
+               ->  Sort  (cost=0.00..1324032.47 rows=1 width=24)
                      Sort Key: share0_ref3.a
-                     ->  Nested Loop  (cost=0.00..1324032.25 rows=1 width=16)
+                     ->  Nested Loop  (cost=0.00..1324032.47 rows=1 width=24)
                            Join Filter: true
-                           ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=16)
                            ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
-                                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                       ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(24 rows)
 
 select percentile_cont(1.0/86400) within group (order by a) from percts
 	where c between 1 and 2;
@@ -993,47 +1055,63 @@ select percentile_cont(1.0/86400) within group (order by a) from percts
 
 explain select percentile_cont(0.1) within group (order by a),
        percentile_cont(0.9) within group (order by a desc) from percts;
-                                                                        QUERY PLAN                                                                         
------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice8; segments: 3)  (cost=0.00..2712068354.83 rows=1 width=16)
-   ->  Sequence  (cost=0.00..2712068354.83 rows=1 width=16)
-         ->  Shared Scan (share slice:id 8:0)  (cost=0.00..431.00 rows=34 width=1)
-               ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
-                     ->  Seq Scan on percts  (cost=0.00..431.00 rows=34 width=38)
-         ->  Redistribute Motion 1:3  (slice7)  (cost=0.00..2712067923.83 rows=1 width=16)
-               ->  Nested Loop  (cost=0.00..2712067923.83 rows=1 width=16)
-                     Join Filter: true
-                     ->  Aggregate  (cost=0.00..1324036.42 rows=1 width=8)
-                           ->  Limit  (cost=0.00..1324036.42 rows=34 width=16)
-                                 ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1324036.41 rows=100 width=16)
-                                       Merge Key: share0_ref4.a
-                                       ->  Sort  (cost=0.00..1324036.41 rows=34 width=16)
-                                             Sort Key: share0_ref4.a
-                                             ->  Nested Loop  (cost=0.00..1324036.39 rows=34 width=16)
-                                                   Join Filter: true
-                                                   ->  Broadcast Motion 1:3  (slice5)  (cost=0.00..431.00 rows=3 width=8)
-                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                               ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                           ->  Shared Scan (share slice:id 4:0)  (cost=0.00..431.00 rows=34 width=8)
-                                                   ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=34 width=8)
-                     ->  Materialize  (cost=0.00..1324036.42 rows=1 width=8)
-                           ->  Aggregate  (cost=0.00..1324036.42 rows=1 width=8)
-                                 ->  Limit  (cost=0.00..1324036.42 rows=34 width=16)
-                                       ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324036.41 rows=100 width=16)
-                                             Merge Key: share0_ref2.a
-                                             ->  Sort  (cost=0.00..1324036.41 rows=34 width=16)
-                                                   Sort Key: share0_ref2.a
-                                                   ->  Nested Loop  (cost=0.00..1324036.39 rows=34 width=16)
+                                                                                 QUERY PLAN                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice10; segments: 3)  (cost=0.00..2712073029.49 rows=1 width=16)
+   ->  Sequence  (cost=0.00..2712073029.49 rows=1 width=16)
+         ->  Shared Scan (share slice:id 10:0)  (cost=0.00..431.01 rows=34 width=1)
+               ->  Materialize  (cost=0.00..431.01 rows=34 width=1)
+                     ->  HashAggregate  (cost=0.00..431.01 rows=34 width=16)
+                           Group Key: percts_1.a
+                           ->  Redistribute Motion 3:3  (slice9; segments: 3)  (cost=0.00..431.00 rows=34 width=8)
+                                 Hash Key: percts_1.a
+                                 ->  Seq Scan on percts percts_1  (cost=0.00..431.00 rows=34 width=8)
+         ->  Sequence  (cost=0.00..2712072598.48 rows=1 width=16)
+               ->  Shared Scan (share slice:id 10:1)  (cost=0.00..431.01 rows=34 width=1)
+                     ->  Materialize  (cost=0.00..431.01 rows=34 width=1)
+                           ->  HashAggregate  (cost=0.00..431.01 rows=34 width=16)
+                                 Group Key: percts.a
+                                 ->  Redistribute Motion 3:3  (slice8; segments: 3)  (cost=0.00..431.00 rows=34 width=8)
+                                       Hash Key: percts.a
+                                       ->  Seq Scan on percts  (cost=0.00..431.00 rows=34 width=8)
+               ->  Redistribute Motion 1:3  (slice7)  (cost=0.00..2712072167.47 rows=1 width=16)
+                     ->  Nested Loop  (cost=0.00..2712072167.47 rows=1 width=16)
+                           Join Filter: true
+                           ->  Aggregate  (cost=0.00..1324038.49 rows=1 width=8)
+                                 ->  Limit  (cost=0.00..1324038.49 rows=34 width=24)
+                                       ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1324038.48 rows=100 width=24)
+                                             Merge Key: share0_ref3.a
+                                             ->  Sort  (cost=0.00..1324038.48 rows=34 width=24)
+                                                   Sort Key: share0_ref3.a
+                                                   ->  Nested Loop  (cost=0.00..1324038.45 rows=34 width=24)
                                                          Join Filter: true
-                                                         ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
-                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=34 width=16)
+                                                         ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Broadcast Motion 1:3  (slice5)  (cost=0.00..431.00 rows=3 width=8)
                                                                            ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                                 ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=8)
-                                                         ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=8)
+                                                                                 ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                             ->  Shared Scan (share slice:id 4:0)  (cost=0.00..431.00 rows=34 width=8)
+                           ->  Materialize  (cost=0.00..1324038.49 rows=1 width=8)
+                                 ->  Aggregate  (cost=0.00..1324038.49 rows=1 width=8)
+                                       ->  Limit  (cost=0.00..1324038.49 rows=34 width=24)
+                                             ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324038.48 rows=100 width=24)
+                                                   Merge Key: share1_ref3.a
+                                                   ->  Sort  (cost=0.00..1324038.48 rows=34 width=24)
+                                                         Sort Key: share1_ref3.a
+                                                         ->  Nested Loop  (cost=0.00..1324038.45 rows=34 width=24)
+                                                               Join Filter: true
+                                                               ->  Shared Scan (share slice:id 3:1)  (cost=0.00..431.00 rows=34 width=16)
+                                                               ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                                           ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                                                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                       ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                                             ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                                   ->  Shared Scan (share slice:id 1:1)  (cost=0.00..431.00 rows=34 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(38 rows)
+(54 rows)
 
 select percentile_cont(0.1) within group (order by a),
        percentile_cont(0.9) within group (order by a desc) from percts;
@@ -1044,30 +1122,36 @@ select percentile_cont(0.1) within group (order by a),
 
 explain select percentile_cont(0.1) within group (order by a),
        percentile_cont(0.2) within group (order by a) from perctsz;
-                                                                  QUERY PLAN                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324467.42 rows=1 width=16)
-   ->  Sequence  (cost=0.00..1324467.42 rows=1 width=16)
-         ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=34 width=1)
-               ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
-                     ->  Seq Scan on perctsz  (cost=0.00..431.00 rows=34 width=38)
-         ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324036.42 rows=1 width=16)
-               ->  Aggregate  (cost=0.00..1324036.42 rows=1 width=16)
-                     ->  Limit  (cost=0.00..1324036.42 rows=34 width=16)
-                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324036.41 rows=100 width=16)
-                                 Merge Key: share0_ref2.a
-                                 ->  Sort  (cost=0.00..1324036.41 rows=34 width=16)
-                                       Sort Key: share0_ref2.a
-                                       ->  Nested Loop  (cost=0.00..1324036.39 rows=34 width=16)
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1324469.50 rows=1 width=16)
+   ->  Sequence  (cost=0.00..1324469.50 rows=1 width=16)
+         ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.01 rows=34 width=1)
+               ->  Materialize  (cost=0.00..431.01 rows=34 width=1)
+                     ->  HashAggregate  (cost=0.00..431.01 rows=34 width=16)
+                           Group Key: perctsz.a
+                           ->  Redistribute Motion 3:3  (slice5; segments: 3)  (cost=0.00..431.00 rows=34 width=8)
+                                 Hash Key: perctsz.a
+                                 ->  Seq Scan on perctsz  (cost=0.00..431.00 rows=34 width=8)
+         ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324038.49 rows=1 width=16)
+               ->  Aggregate  (cost=0.00..1324038.49 rows=1 width=16)
+                     ->  Limit  (cost=0.00..1324038.49 rows=34 width=24)
+                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324038.48 rows=100 width=24)
+                                 Merge Key: share0_ref3.a
+                                 ->  Sort  (cost=0.00..1324038.48 rows=34 width=24)
+                                       Sort Key: share0_ref3.a
+                                       ->  Nested Loop  (cost=0.00..1324038.45 rows=34 width=24)
                                              Join Filter: true
-                                             ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
-                                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=16)
+                                             ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
                                                                ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                     ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=8)
-                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=8)
+                                                                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                 ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+(27 rows)
 
 select percentile_cont(0.1) within group (order by a),
        percentile_cont(0.2) within group (order by a) from perctsz;
@@ -1131,32 +1215,36 @@ select median(a), b from perct group by b order by b desc;
 (11 rows)
 
 explain select count(*) from(select median(a) from perct group by ())s;
-                                                                        QUERY PLAN                                                                         
------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..1324465.93 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324465.93 rows=1 width=1)
-         ->  Sequence  (cost=0.00..1324465.93 rows=1 width=1)
-               ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=34 width=1)
-                     ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
-                           ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=34)
-               ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324034.93 rows=1 width=1)
-                     ->  Result  (cost=0.00..1324034.93 rows=1 width=1)
-                           ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=1)
-                                 ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
-                                       ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
-                                             Merge Key: share0_ref2.a
-                                             ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
-                                                   Sort Key: share0_ref2.a
-                                                   ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
-                                                         Join Filter: true
-                                                         ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
-                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                                                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                                 ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=4)
-                                                         ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..1324468.58 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324468.58 rows=1 width=1)
+         ->  Sequence  (cost=0.00..1324468.58 rows=1 width=1)
+               ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.01 rows=34 width=1)
+                     ->  Materialize  (cost=0.00..431.01 rows=34 width=1)
+                           ->  GroupAggregate  (cost=0.00..431.01 rows=34 width=12)
+                                 Group Key: perct.a
+                                 ->  Sort  (cost=0.00..431.00 rows=34 width=4)
+                                       Sort Key: perct.a
+                                       ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=4)
+               ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324037.57 rows=1 width=1)
+                     ->  Result  (cost=0.00..1324037.57 rows=1 width=1)
+                           ->  Aggregate  (cost=0.00..1324037.57 rows=1 width=1)
+                                 ->  Limit  (cost=0.00..1324037.57 rows=34 width=20)
+                                       ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324037.57 rows=100 width=20)
+                                             Merge Key: share0_ref3.a
+                                             ->  Nested Loop  (cost=0.00..1324037.56 rows=34 width=20)
+                                                   Join Filter: true
+                                                   ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=12)
+                                                   ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                       ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(23 rows)
+(27 rows)
 
 select count(*) from(select median(a) from perct group by ())s;
  count 
@@ -1197,37 +1285,41 @@ select median(a) from perct group by grouping sets((b)) order by b;
 (11 rows)
 
 explain select distinct median(a), count(*) from perct;
-                                                                     QUERY PLAN                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1356694888.00 rows=1 width=16)
-   ->  Sequence  (cost=0.00..1356694888.00 rows=1 width=16)
-         ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=34 width=1)
-               ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
-                     ->  Seq Scan on perct perct_1  (cost=0.00..431.00 rows=34 width=34)
-         ->  Redistribute Motion 1:3  (slice5)  (cost=0.00..1356694457.00 rows=1 width=16)
-               ->  Nested Loop  (cost=0.00..1356694457.00 rows=1 width=16)
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1356697594.60 rows=1 width=16)
+   ->  Sequence  (cost=0.00..1356697594.60 rows=1 width=16)
+         ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.01 rows=34 width=1)
+               ->  Materialize  (cost=0.00..431.01 rows=34 width=1)
+                     ->  GroupAggregate  (cost=0.00..431.01 rows=34 width=12)
+                           Group Key: perct_1.a
+                           ->  Sort  (cost=0.00..431.00 rows=34 width=4)
+                                 Sort Key: perct_1.a
+                                 ->  Seq Scan on perct perct_1  (cost=0.00..431.00 rows=34 width=4)
+         ->  Redistribute Motion 1:3  (slice5)  (cost=0.00..1356697163.60 rows=1 width=16)
+               ->  Nested Loop  (cost=0.00..1356697163.60 rows=1 width=16)
                      Join Filter: true
-                     ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=8)
-                           ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
-                                 ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
-                                       Merge Key: share0_ref2.a
-                                       ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
-                                             Sort Key: share0_ref2.a
-                                             ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
-                                                   Join Filter: true
+                     ->  Aggregate  (cost=0.00..1324037.57 rows=1 width=8)
+                           ->  Limit  (cost=0.00..1324037.57 rows=34 width=20)
+                                 ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1324037.57 rows=100 width=20)
+                                       Merge Key: share0_ref3.a
+                                       ->  Nested Loop  (cost=0.00..1324037.56 rows=34 width=20)
+                                             Join Filter: true
+                                             ->  Shared Scan (share slice:id 4:0)  (cost=0.00..431.00 rows=34 width=12)
+                                             ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
                                                    ->  Broadcast Motion 1:3  (slice3)  (cost=0.00..431.00 rows=3 width=8)
-                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                           ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.00 rows=34 width=4)
-                                                   ->  Shared Scan (share slice:id 4:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                         ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                 ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.00 rows=34 width=8)
                      ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
                            ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
                                  ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
                                        ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
                                              ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(28 rows)
+(32 rows)
 
 select distinct median(a), count(*) from perct;
  median | count 
@@ -1306,30 +1398,36 @@ select median(a - '2011-12-31 00:00:00 UTC'::timestamptz) from perctsz group by 
 
 --numeric types
 explain select percentile_cont(0.95) within group( order by c) from perctnum;
-                                                                  QUERY PLAN                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324467.05 rows=1 width=8)
-   ->  Sequence  (cost=0.00..1324467.05 rows=1 width=8)
-         ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=34 width=1)
-               ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
-                     ->  Seq Scan on perctnum  (cost=0.00..431.00 rows=34 width=37)
-         ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324036.04 rows=1 width=8)
-               ->  Aggregate  (cost=0.00..1324036.04 rows=1 width=8)
-                     ->  Limit  (cost=0.00..1324036.04 rows=34 width=15)
-                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324036.04 rows=100 width=15)
-                                 Merge Key: share0_ref2.c
-                                 ->  Sort  (cost=0.00..1324036.04 rows=34 width=15)
-                                       Sort Key: share0_ref2.c
-                                       ->  Nested Loop  (cost=0.00..1324036.02 rows=34 width=15)
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1324469.27 rows=1 width=8)
+   ->  Sequence  (cost=0.00..1324469.27 rows=1 width=8)
+         ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.01 rows=34 width=1)
+               ->  Materialize  (cost=0.00..431.01 rows=34 width=1)
+                     ->  HashAggregate  (cost=0.00..431.01 rows=34 width=15)
+                           Group Key: perctnum.c
+                           ->  Redistribute Motion 3:3  (slice5; segments: 3)  (cost=0.00..431.00 rows=34 width=7)
+                                 Hash Key: perctnum.c
+                                 ->  Seq Scan on perctnum  (cost=0.00..431.00 rows=34 width=7)
+         ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324038.26 rows=1 width=8)
+               ->  Aggregate  (cost=0.00..1324038.26 rows=1 width=8)
+                     ->  Limit  (cost=0.00..1324038.26 rows=34 width=23)
+                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324038.26 rows=100 width=23)
+                                 Merge Key: share0_ref3.c
+                                 ->  Sort  (cost=0.00..1324038.25 rows=34 width=23)
+                                       Sort Key: share0_ref3.c
+                                       ->  Nested Loop  (cost=0.00..1324038.23 rows=34 width=23)
                                              Join Filter: true
-                                             ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
-                                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=15)
+                                             ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
                                                                ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                     ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=7)
-                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=7)
+                                                                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                 ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+(27 rows)
 
 select percentile_cont(0.95) within group( order by c) from perctnum;
  percentile_cont 
@@ -1443,30 +1541,34 @@ select percentile_cont((select 0.1 from gp_id)) within group (order by a) from p
 
 -- volatile argument
 explain select percentile_cont(floor(random()*0.1)+0.5) within group (order by a) from perct;
-                                                                  QUERY PLAN                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324465.93 rows=1 width=8)
-   ->  Sequence  (cost=0.00..1324465.93 rows=1 width=8)
-         ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=34 width=1)
-               ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
-                     ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=34)
-         ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324034.93 rows=1 width=8)
-               ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=8)
-                     ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
-                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
-                                 Merge Key: share0_ref2.a
-                                 ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
-                                       Sort Key: share0_ref2.a
-                                       ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
-                                             Join Filter: true
-                                             ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
-                                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                     ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=4)
-                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324468.58 rows=1 width=8)
+   ->  Sequence  (cost=0.00..1324468.58 rows=1 width=8)
+         ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.01 rows=34 width=1)
+               ->  Materialize  (cost=0.00..431.01 rows=34 width=1)
+                     ->  GroupAggregate  (cost=0.00..431.01 rows=34 width=12)
+                           Group Key: perct.a
+                           ->  Sort  (cost=0.00..431.00 rows=34 width=4)
+                                 Sort Key: perct.a
+                                 ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=4)
+         ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324037.57 rows=1 width=8)
+               ->  Aggregate  (cost=0.00..1324037.57 rows=1 width=8)
+                     ->  Limit  (cost=0.00..1324037.57 rows=34 width=20)
+                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324037.57 rows=100 width=20)
+                                 Merge Key: share0_ref3.a
+                                 ->  Nested Loop  (cost=0.00..1324037.56 rows=34 width=20)
+                                       Join Filter: true
+                                       ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=12)
+                                       ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+(25 rows)
 
 select percentile_cont(floor(random()*0.1)+0.5) within group (order by a) from perct;
  percentile_cont 
@@ -1476,58 +1578,66 @@ select percentile_cont(floor(random()*0.1)+0.5) within group (order by a) from p
 
 -- out of range
 explain select percentile_cont(-0.1) within group (order by a) from perct;
-                                                                  QUERY PLAN                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324465.93 rows=1 width=8)
-   ->  Sequence  (cost=0.00..1324465.93 rows=1 width=8)
-         ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=34 width=1)
-               ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
-                     ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=34)
-         ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324034.93 rows=1 width=8)
-               ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=8)
-                     ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
-                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
-                                 Merge Key: share0_ref2.a
-                                 ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
-                                       Sort Key: share0_ref2.a
-                                       ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
-                                             Join Filter: true
-                                             ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
-                                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                     ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=4)
-                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324468.58 rows=1 width=8)
+   ->  Sequence  (cost=0.00..1324468.58 rows=1 width=8)
+         ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.01 rows=34 width=1)
+               ->  Materialize  (cost=0.00..431.01 rows=34 width=1)
+                     ->  GroupAggregate  (cost=0.00..431.01 rows=34 width=12)
+                           Group Key: perct.a
+                           ->  Sort  (cost=0.00..431.00 rows=34 width=4)
+                                 Sort Key: perct.a
+                                 ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=4)
+         ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324037.57 rows=1 width=8)
+               ->  Aggregate  (cost=0.00..1324037.57 rows=1 width=8)
+                     ->  Limit  (cost=0.00..1324037.57 rows=34 width=20)
+                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324037.57 rows=100 width=20)
+                                 Merge Key: share0_ref3.a
+                                 ->  Nested Loop  (cost=0.00..1324037.56 rows=34 width=20)
+                                       Join Filter: true
+                                       ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=12)
+                                       ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+(25 rows)
 
 select percentile_cont(-0.1) within group (order by a) from perct;
 ERROR:  percentile value -0.1 is not between 0 and 1
 explain select percentile_cont(1.00000001) within group (order by a) from perct;
-                                                                  QUERY PLAN                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324465.93 rows=1 width=8)
-   ->  Sequence  (cost=0.00..1324465.93 rows=1 width=8)
-         ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=34 width=1)
-               ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
-                     ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=34)
-         ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324034.93 rows=1 width=8)
-               ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=8)
-                     ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
-                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
-                                 Merge Key: share0_ref2.a
-                                 ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
-                                       Sort Key: share0_ref2.a
-                                       ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
-                                             Join Filter: true
-                                             ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
-                                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                     ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=4)
-                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324468.58 rows=1 width=8)
+   ->  Sequence  (cost=0.00..1324468.58 rows=1 width=8)
+         ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.01 rows=34 width=1)
+               ->  Materialize  (cost=0.00..431.01 rows=34 width=1)
+                     ->  GroupAggregate  (cost=0.00..431.01 rows=34 width=12)
+                           Group Key: perct.a
+                           ->  Sort  (cost=0.00..431.00 rows=34 width=4)
+                                 Sort Key: perct.a
+                                 ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=4)
+         ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324037.57 rows=1 width=8)
+               ->  Aggregate  (cost=0.00..1324037.57 rows=1 width=8)
+                     ->  Limit  (cost=0.00..1324037.57 rows=34 width=20)
+                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324037.57 rows=100 width=20)
+                                 Merge Key: share0_ref3.a
+                                 ->  Nested Loop  (cost=0.00..1324037.56 rows=34 width=20)
+                                       Join Filter: true
+                                       ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=12)
+                                       ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+(25 rows)
 
 select percentile_cont(1.00000001) within group (order by a) from perct;
 ERROR:  percentile value 1 is not between 0 and 1
@@ -1568,31 +1678,35 @@ LINE 1: select percentile_cont(0.8) within group (order by a, a + 1,...
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 -- set-returning
 explain select generate_series(1, 2), median(a) from perct;
-                                                                     QUERY PLAN                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324465.93 rows=1 width=12)
-   ->  Result  (cost=0.00..1324465.93 rows=1 width=12)
-         ->  Sequence  (cost=0.00..1324465.93 rows=1 width=8)
-               ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.00 rows=34 width=1)
-                     ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
-                           ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=34)
-               ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324034.93 rows=1 width=8)
-                     ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=8)
-                           ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
-                                 ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
-                                       Merge Key: share0_ref2.a
-                                       ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
-                                             Sort Key: share0_ref2.a
-                                             ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
-                                                   Join Filter: true
-                                                   ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
-                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                           ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=4)
-                                                   ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1324468.58 rows=1 width=12)
+   ->  Result  (cost=0.00..1324468.58 rows=1 width=12)
+         ->  Sequence  (cost=0.00..1324468.58 rows=1 width=8)
+               ->  Shared Scan (share slice:id 5:0)  (cost=0.00..431.01 rows=34 width=1)
+                     ->  Materialize  (cost=0.00..431.01 rows=34 width=1)
+                           ->  GroupAggregate  (cost=0.00..431.01 rows=34 width=12)
+                                 Group Key: perct.a
+                                 ->  Sort  (cost=0.00..431.00 rows=34 width=4)
+                                       Sort Key: perct.a
+                                       ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=4)
+               ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324037.57 rows=1 width=8)
+                     ->  Aggregate  (cost=0.00..1324037.57 rows=1 width=8)
+                           ->  Limit  (cost=0.00..1324037.57 rows=34 width=20)
+                                 ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324037.57 rows=100 width=20)
+                                       Merge Key: share0_ref3.a
+                                       ->  Nested Loop  (cost=0.00..1324037.56 rows=34 width=20)
+                                             Join Filter: true
+                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=12)
+                                             ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                 ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(22 rows)
+(26 rows)
 
 select generate_series(1, 2), median(a) from perct;
  generate_series | median 
@@ -1603,14 +1717,14 @@ select generate_series(1, 2), median(a) from perct;
 
 -- GROUPING SETS
 explain select median(a) from perct group by grouping sets((), (b));
-                                                                           QUERY PLAN                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1325327.94 rows=12 width=8)
-   ->  Sequence  (cost=0.00..1325327.94 rows=4 width=8)
+                                                                              QUERY PLAN                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1325330.59 rows=12 width=8)
+   ->  Sequence  (cost=0.00..1325330.59 rows=4 width=8)
          ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=34 width=1)
                ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
                      ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=8)
-         ->  Append  (cost=0.00..1324896.94 rows=4 width=8)
+         ->  Append  (cost=0.00..1324899.59 rows=4 width=8)
                ->  Result  (cost=0.00..431.01 rows=4 width=8)
                      ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=8)
                            Group Key: share0_ref2.b
@@ -1619,28 +1733,32 @@ explain select median(a) from perct group by grouping sets((), (b));
                                  ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=8)
                                        Hash Key: share0_ref2.b
                                        ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=8)
-               ->  Result  (cost=0.00..1324465.93 rows=1 width=8)
-                     ->  Sequence  (cost=0.00..1324465.93 rows=1 width=8)
+               ->  Result  (cost=0.00..1324468.58 rows=1 width=8)
+                     ->  Sequence  (cost=0.00..1324468.58 rows=1 width=8)
                            ->  Shared Scan (share slice:id 6:1)  (cost=0.00..431.00 rows=34 width=1)
                                  ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
-                                       ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=34 width=8)
-                           ->  Redistribute Motion 1:3  (slice5)  (cost=0.00..1324034.93 rows=1 width=8)
-                                 ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=8)
-                                       ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
-                                             ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
-                                                   Merge Key: share1_ref2.a
-                                                   ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
-                                                         Sort Key: share1_ref2.a
-                                                         ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
-                                                               Join Filter: true
-                                                               ->  Broadcast Motion 1:3  (slice3)  (cost=0.00..431.00 rows=3 width=8)
-                                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                           ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                                                                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                                       ->  Shared Scan (share slice:id 2:1)  (cost=0.00..431.00 rows=34 width=4)
-                                                               ->  Shared Scan (share slice:id 4:1)  (cost=0.00..431.00 rows=34 width=4)
+                                       ->  GroupAggregate  (cost=0.00..431.00 rows=34 width=12)
+                                             Group Key: share0_ref3.a
+                                             ->  Sort  (cost=0.00..431.00 rows=34 width=4)
+                                                   Sort Key: share0_ref3.a
+                                                   ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=34 width=4)
+                           ->  Redistribute Motion 1:3  (slice5)  (cost=0.00..1324037.57 rows=1 width=8)
+                                 ->  Aggregate  (cost=0.00..1324037.57 rows=1 width=8)
+                                       ->  Limit  (cost=0.00..1324037.57 rows=34 width=20)
+                                             ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1324037.57 rows=100 width=20)
+                                                   Merge Key: share1_ref3.a
+                                                   ->  Nested Loop  (cost=0.00..1324037.56 rows=34 width=20)
+                                                         Join Filter: true
+                                                         ->  Shared Scan (share slice:id 4:1)  (cost=0.00..431.00 rows=34 width=12)
+                                                         ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Broadcast Motion 1:3  (slice3)  (cost=0.00..431.00 rows=3 width=8)
+                                                                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                 ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                             ->  Shared Scan (share slice:id 2:1)  (cost=0.00..431.00 rows=34 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(35 rows)
+(39 rows)
 
 select median(a) from perct group by grouping sets((), (b));
  median 
@@ -1676,37 +1794,41 @@ LINE 1: select percentile_cont(0.5) within group (order by point(0,0...
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 -- outer references
 explain select (select a from perct where median(t.a) = 5) from perct t;
-                                                                                     QUERY PLAN                                                                                      
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1357135822.46 rows=1 width=4)
-   ->  Result  (cost=0.00..1357135822.46 rows=1 width=4)
-         ->  Sequence  (cost=0.00..1324465.93 rows=1 width=8)
-               ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=34 width=1)
-                     ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
-                           ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=34)
-               ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324034.93 rows=1 width=8)
-                     ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=8)
-                           ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
-                                 ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
-                                       Merge Key: share0_ref2.a
-                                       ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
-                                             Sort Key: share0_ref2.a
-                                             ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
-                                                   Join Filter: true
-                                                   ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
-                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                           ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=4)
-                                                   ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                                                                           QUERY PLAN                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1357138531.43 rows=1 width=4)
+   ->  Result  (cost=0.00..1357138531.43 rows=1 width=4)
+         ->  Sequence  (cost=0.00..1324468.58 rows=1 width=8)
+               ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.01 rows=34 width=1)
+                     ->  Materialize  (cost=0.00..431.01 rows=34 width=1)
+                           ->  GroupAggregate  (cost=0.00..431.01 rows=34 width=12)
+                                 Group Key: perct.a
+                                 ->  Sort  (cost=0.00..431.00 rows=34 width=4)
+                                       Sort Key: perct.a
+                                       ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=4)
+               ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324037.57 rows=1 width=8)
+                     ->  Aggregate  (cost=0.00..1324037.57 rows=1 width=8)
+                           ->  Limit  (cost=0.00..1324037.57 rows=34 width=20)
+                                 ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324037.57 rows=100 width=20)
+                                       Merge Key: share0_ref3.a
+                                       ->  Nested Loop  (cost=0.00..1324037.56 rows=34 width=20)
+                                             Join Filter: true
+                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=12)
+                                             ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                 ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=8)
          SubPlan 1  (slice6; segments: 3)
            ->  Result  (cost=0.00..431.01 rows=40 width=4)
-                 One-Time Filter: ((gp_percentile_cont((share0_ref2.a)::double precision, 0.5::double precision, (count((count(share0_ref3.a)))), 1::bigint)) = 5::double precision)
+                 One-Time Filter: ((gp_percentile_cont((share0_ref3.a)::double precision, 0.5::double precision, (int8((pg_catalog.sum((sum(share0_ref2."ColRef_0020")))))), share0_ref3."ColRef_0020")) = 5::double precision)
                  ->  Materialize  (cost=0.00..431.01 rows=100 width=4)
                        ->  Broadcast Motion 3:3  (slice5; segments: 3)  (cost=0.00..431.01 rows=100 width=4)
                              ->  Seq Scan on perct perct_1  (cost=0.00..431.00 rows=34 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(28 rows)
+(32 rows)
 
 select (select a from perct where median(t.a) = 5) from perct t;
  a 
@@ -1715,38 +1837,42 @@ select (select a from perct where median(t.a) = 5) from perct t;
 (1 row)
 
 explain select (select array_agg(a ORDER BY a) from perct where median(t.a) = 50.5) from (select * from perct t order by a offset 0) as t;
-                                                                                          QUERY PLAN                                                                                          
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1357135829.77 rows=1 width=8)
-   ->  Result  (cost=0.00..1357135829.77 rows=1 width=8)
-         ->  Sequence  (cost=0.00..1324465.93 rows=1 width=8)
-               ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=34 width=1)
-                     ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
-                           ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=34)
-               ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324034.93 rows=1 width=8)
-                     ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=8)
-                           ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
-                                 ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
-                                       Merge Key: share0_ref2.a
-                                       ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
-                                             Sort Key: share0_ref2.a
-                                             ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
-                                                   Join Filter: true
-                                                   ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
-                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                                                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                           ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=4)
-                                                   ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                                                                               QUERY PLAN                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1357138538.74 rows=1 width=8)
+   ->  Result  (cost=0.00..1357138538.74 rows=1 width=8)
+         ->  Sequence  (cost=0.00..1324468.58 rows=1 width=8)
+               ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.01 rows=34 width=1)
+                     ->  Materialize  (cost=0.00..431.01 rows=34 width=1)
+                           ->  GroupAggregate  (cost=0.00..431.01 rows=34 width=12)
+                                 Group Key: perct.a
+                                 ->  Sort  (cost=0.00..431.00 rows=34 width=4)
+                                       Sort Key: perct.a
+                                       ->  Seq Scan on perct  (cost=0.00..431.00 rows=34 width=4)
+               ->  Redistribute Motion 1:3  (slice4)  (cost=0.00..1324037.57 rows=1 width=8)
+                     ->  Aggregate  (cost=0.00..1324037.57 rows=1 width=8)
+                           ->  Limit  (cost=0.00..1324037.57 rows=34 width=20)
+                                 ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324037.57 rows=100 width=20)
+                                       Merge Key: share0_ref3.a
+                                       ->  Nested Loop  (cost=0.00..1324037.56 rows=34 width=20)
+                                             Join Filter: true
+                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=12)
+                                             ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=8)
+                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                 ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=8)
          SubPlan 1  (slice6; segments: 3)
            ->  Aggregate  (cost=0.00..431.01 rows=1 width=8)
                  ->  Result  (cost=0.00..431.01 rows=40 width=4)
-                       One-Time Filter: ((gp_percentile_cont((share0_ref2.a)::double precision, 0.5::double precision, (count((count(share0_ref3.a)))), 1::bigint)) = 50.5::double precision)
+                       One-Time Filter: ((gp_percentile_cont((share0_ref3.a)::double precision, 0.5::double precision, (int8((pg_catalog.sum((sum(share0_ref2."ColRef_0021")))))), share0_ref3."ColRef_0021")) = 50.5::double precision)
                        ->  Materialize  (cost=0.00..431.01 rows=100 width=4)
                              ->  Broadcast Motion 3:3  (slice5; segments: 3)  (cost=0.00..431.01 rows=100 width=4)
                                    ->  Seq Scan on perct perct_1  (cost=0.00..431.00 rows=34 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(29 rows)
+(33 rows)
 
 select (select array_agg(a ORDER BY a) from perct where median(t.a) = 50.5) from (select * from perct t order by a offset 0) as t;
                                                                                                                                                array_agg                                                                                                                                               

--- a/gpcontrib/gp_percentile_agg/gp_percentile_agg--1.0.0.sql
+++ b/gpcontrib/gp_percentile_agg/gp_percentile_agg--1.0.0.sql
@@ -16,32 +16,32 @@
 CREATE FUNCTION gp_percentile_cont_float8_transition(float8, float8, float8, int8, int8)
     RETURNS float8
 AS '$libdir/gp_percentile_agg'
-   LANGUAGE C IMMUTABLE STRICT;
+   LANGUAGE C IMMUTABLE;
 
 CREATE FUNCTION gp_percentile_cont_interval_transition(interval, interval, float8, int8, int8)
     RETURNS interval
 AS '$libdir/gp_percentile_agg'
-   LANGUAGE C IMMUTABLE STRICT;
+   LANGUAGE C IMMUTABLE;
 
 CREATE FUNCTION gp_percentile_cont_timestamp_transition(timestamp, timestamp, float8, int8, int8)
     RETURNS timestamp
 AS '$libdir/gp_percentile_agg'
-   LANGUAGE C IMMUTABLE STRICT;
+   LANGUAGE C IMMUTABLE;
 
 CREATE FUNCTION gp_percentile_cont_timestamptz_transition(timestamptz, timestamptz, float8, int8, int8)
     RETURNS timestamptz
 AS '$libdir/gp_percentile_agg'
-   LANGUAGE C IMMUTABLE STRICT;
+   LANGUAGE C IMMUTABLE;
 
 CREATE FUNCTION gp_percentile_disc_transition(anyelement, anyelement, float8, int8, int8)
     RETURNS anyelement
 AS '$libdir/gp_percentile_agg'
-   LANGUAGE C IMMUTABLE STRICT;
+   LANGUAGE C IMMUTABLE;
 
 CREATE FUNCTION gp_percentile_final(anyelement)
     RETURNS anyelement
 AS '$libdir/gp_percentile_agg'
-   LANGUAGE C IMMUTABLE STRICT;
+   LANGUAGE C IMMUTABLE;
 
 -- Creating aggregate functions
 CREATE AGGREGATE gp_percentile_cont(float8, float8, int8, int8)

--- a/gpcontrib/gp_percentile_agg/gp_percentile_agg.c
+++ b/gpcontrib/gp_percentile_agg/gp_percentile_agg.c
@@ -60,6 +60,10 @@ gp_percentile_cont_transition(FunctionCallInfo fcinfo,
 	int64        first_row;
 	int64        second_row;
 
+	/* Return state for NULL inputs of val*/
+	if (PG_ARGISNULL(1) && !PG_ARGISNULL(0))
+		PG_RETURN_DATUM(PG_GETARG_DATUM(0));
+
 	/* Ignore NULL inputs for val, percent and total_count*/
 	if (PG_ARGISNULL(1) || PG_ARGISNULL(2) || PG_ARGISNULL(3))
 		PG_RETURN_NULL();
@@ -75,8 +79,9 @@ gp_percentile_cont_transition(FunctionCallInfo fcinfo,
 	Datum val = PG_GETARG_DATUM(1);
 	Datum return_state = prev_state;
 	int64 total_rows = PG_GETARG_INT64(3);
-	first_row = (int64) floor(percentile * (total_rows - 1));
-	second_row = (int64) ceil(percentile * (total_rows - 1));
+	int64 peer_count = PG_GETARG_INT64(4);
+	first_row = (int64) floor(percentile * (total_rows - 1) + 1);
+	second_row = (int64) ceil(percentile * (total_rows - 1) + 1);
 	double proportion = (percentile * (total_rows - 1)) - floor(percentile * (total_rows - 1));
 	int64 *cnt;
 
@@ -94,17 +99,17 @@ gp_percentile_cont_transition(FunctionCallInfo fcinfo,
 		cnt = (int64 *) fcinfo->flinfo->fn_extra;
 	}
 
-	if(*cnt == first_row)
+	if(*cnt <= first_row && first_row < *cnt + peer_count)
 	{
 		return_state = val;
 	}
-	else if(*cnt == second_row)
+	else if(*cnt <= second_row && second_row < *cnt + peer_count)
 	{
 		return_state = lerpfunc(prev_state, val, proportion);
 	}
-	*cnt = *cnt + 1;
+	*cnt = *cnt + peer_count;
 
-	if(*cnt >= total_rows)
+	if(*cnt > total_rows)
 	{
 		/* Clean up, so the next group can see NULL for fn_extra */
 		pfree(cnt);
@@ -159,6 +164,10 @@ gp_percentile_disc_transition(PG_FUNCTION_ARGS)
 {
 	int64        rownum;
 
+	/* Return state for NULL inputs of val*/
+	if (PG_ARGISNULL(1) && !PG_ARGISNULL(0))
+		PG_RETURN_DATUM(PG_GETARG_DATUM(0));
+
 	/* Ignore NULL inputs for val, percent and total_count*/
 	if (PG_ARGISNULL(1) || PG_ARGISNULL(2) || PG_ARGISNULL(3))
 			PG_RETURN_NULL();
@@ -173,6 +182,7 @@ gp_percentile_disc_transition(PG_FUNCTION_ARGS)
 	Datum val = PG_GETARG_DATUM(1);
 	Datum return_state = prev_state;
 	int64 total_rows = PG_GETARG_INT64(3);
+	int64 peer_count = PG_GETARG_INT64(4);
 	rownum = (int64) ceil(percentile * (total_rows));
 	int64 *cnt;
 
@@ -181,20 +191,22 @@ gp_percentile_disc_transition(PG_FUNCTION_ARGS)
 		cnt = (int64 *) MemoryContextAllocZero(fcinfo->flinfo->fn_mcxt, sizeof(int64));
 		*cnt = 1;
 		fcinfo->flinfo->fn_extra = cnt;
+		if (percentile == 0.0)
+			rownum = 1;
 	}
 	else
 	{
 		cnt = (int64 *) fcinfo->flinfo->fn_extra;
 	}
 
-	if(*cnt == rownum - 1)
+	if(*cnt <= rownum && rownum < *cnt + peer_count)
 	{
 		return_state = val;
 	}
 
-	*cnt = *cnt + 1;
+	*cnt = *cnt + peer_count;
 
-	if(*cnt >= total_rows)
+	if(*cnt > total_rows)
 	{
 		/* Clean up, so the next group can see NULL for fn_extra */
 		pfree(cnt);

--- a/src/backend/gporca/data/dxl/minidump/CTAS_OrderedAgg_multiple_cols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS_OrderedAgg_multiple_cols.mdp
@@ -19,63 +19,87 @@ EXPLAIN CREATE TABLE test AS
 
                                                    QUERY PLAN
  Result  (cost=0.00..0.00 rows=0 width=0)
-   ->  Result  (cost=0.00..2778510692279.12 rows=1 width=24)
-         ->  Result  (cost=0.00..2778510692279.08 rows=1 width=24)
-               ->  Sequence  (cost=0.00..2778510692279.08 rows=1 width=72)
-                     ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=34 width=1)
-                           ->  Materialize  (cost=0.00..431.00 rows=34 width=1)
-                                 ->  Seq Scan on foo1  (cost=0.00..431.00 rows=34 width=42)
-                     ->  Redistribute Motion 1:3  (slice10; segments: 1)  (cost=0.00..2778510691848.08 rows=1 width=72)
-                           ->  Nested Loop  (cost=0.00..2778510691848.08 rows=1 width=72)
-                                 Join Filter: true
-                                 ->  Nested Loop  (cost=0.00..2712064881.58 rows=1 width=48)
-                                       Join Filter: true
-                                       ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=24)
-                                             ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
-                                                   ->  Gather Motion 3:1  (slice9; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
-                                                         Merge Key: share0_ref6.b
-                                                         ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
-                                                               Sort Key: share0_ref6.b
-                                                               ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
-                                                                     Join Filter: true
-                                                                     ->  Broadcast Motion 1:3  (slice8; segments: 1)  (cost=0.00..431.00 rows=3 width=8)
-                                                                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                                 ->  Gather Motion 3:1  (slice7; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                                                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                                             ->  Shared Scan (share slice:id 7:0)  (cost=0.00..431.00 rows=34 width=4)
-                                                                     ->  Shared Scan (share slice:id 9:0)  (cost=0.00..431.00 rows=34 width=4)
-                                       ->  Materialize  (cost=0.00..1324034.93 rows=1 width=24)
-                                             ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=24)
-                                                   ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
-                                                         ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
-                                                               Merge Key: share0_ref4.a
-                                                               ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
-                                                                     Sort Key: share0_ref4.a
-                                                                     ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
+   ->  Result  (cost=0.00..2778516240645.43 rows=1 width=24)
+         ->  Result  (cost=0.00..2778516240645.39 rows=1 width=24)
+               ->  Sequence  (cost=0.00..2778516240645.39 rows=1 width=72)
+                     ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.01 rows=34 width=1)
+                           ->  Materialize  (cost=0.00..431.01 rows=34 width=1)
+                                 ->  GroupAggregate  (cost=0.00..431.01 rows=34 width=12)
+                                       Group Key: foo1_2.a
+                                       ->  Sort  (cost=0.00..431.00 rows=34 width=4)
+                                             Sort Key: foo1_2.a
+                                             ->  Seq Scan on foo1 foo1_2  (cost=0.00..431.00 rows=34 width=4)
+                     ->  Sequence  (cost=0.00..2778516240214.39 rows=1 width=72)
+                           ->  Shared Scan (share slice:id 0:1)  (cost=0.00..431.01 rows=34 width=1)
+                                 ->  Materialize  (cost=0.00..431.01 rows=34 width=1)
+                                       ->  GroupAggregate  (cost=0.00..431.01 rows=34 width=12)
+                                             Group Key: foo1_1.b
+                                             ->  Sort  (cost=0.00..431.01 rows=34 width=4)
+                                                   Sort Key: foo1_1.b
+                                                   ->  Redistribute Motion 3:3  (slice12; segments: 3)  (cost=0.00..431.00 rows=34 width=4)
+                                                         Hash Key: foo1_1.b
+                                                         ->  Seq Scan on foo1 foo1_1  (cost=0.00..431.00 rows=34 width=4)
+                           ->  Sequence  (cost=0.00..2778516239783.38 rows=1 width=72)
+                                 ->  Shared Scan (share slice:id 0:2)  (cost=0.00..431.01 rows=34 width=1)
+                                       ->  Materialize  (cost=0.00..431.01 rows=34 width=1)
+                                             ->  GroupAggregate  (cost=0.00..431.01 rows=34 width=12)
+                                                   Group Key: foo1.c
+                                                   ->  Sort  (cost=0.00..431.01 rows=34 width=4)
+                                                         Sort Key: foo1.c
+                                                         ->  Redistribute Motion 3:3  (slice11; segments: 3)  (cost=0.00..431.00 rows=34 width=4)
+                                                               Hash Key: foo1.c
+                                                               ->  Seq Scan on foo1  (cost=0.00..431.00 rows=34 width=4)
+                                 ->  Redistribute Motion 1:3  (slice10; segments: 1)  (cost=0.00..2778516239352.37 rows=1 width=72)
+                                       ->  Nested Loop  (cost=0.00..2778516239352.37 rows=1 width=72)
+                                             Join Filter: true
+                                             ->  Nested Loop  (cost=0.00..2712070296.42 rows=1 width=48)
+                                                   Join Filter: true
+                                                   ->  Aggregate  (cost=0.00..1324037.57 rows=1 width=24)
+                                                         ->  Limit  (cost=0.00..1324037.57 rows=34 width=20)
+                                                               ->  Gather Motion 3:1  (slice9; segments: 3)  (cost=0.00..1324037.57 rows=100 width=20)
+                                                                     Merge Key: share1_ref3.b
+                                                                     ->  Nested Loop  (cost=0.00..1324037.56 rows=34 width=20)
                                                                            Join Filter: true
-                                                                           ->  Broadcast Motion 1:3  (slice5; segments: 1)  (cost=0.00..431.00 rows=3 width=8)
-                                                                                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                                       ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                           ->  Shared Scan (share slice:id 9:1)  (cost=0.00..431.00 rows=34 width=12)
+                                                                           ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                                                                 ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                                                       ->  Broadcast Motion 1:3  (slice8; segments: 1)  (cost=0.00..431.00 rows=3 width=8)
                                                                                              ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                                                   ->  Shared Scan (share slice:id 4:0)  (cost=0.00..431.00 rows=34 width=4)
-                                                                           ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=34 width=4)
-                                 ->  Materialize  (cost=0.00..1324034.93 rows=1 width=24)
-                                       ->  Aggregate  (cost=0.00..1324034.93 rows=1 width=24)
-                                             ->  Limit  (cost=0.00..1324034.93 rows=34 width=12)
-                                                   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324034.93 rows=100 width=12)
-                                                         Merge Key: share0_ref2.c
-                                                         ->  Sort  (cost=0.00..1324034.92 rows=34 width=12)
-                                                               Sort Key: share0_ref2.c
-                                                               ->  Nested Loop  (cost=0.00..1324034.91 rows=34 width=12)
-                                                                     Join Filter: true
-                                                                     ->  Broadcast Motion 1:3  (slice2; segments: 1)  (cost=0.00..431.00 rows=3 width=8)
-                                                                           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                                                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                                                                             ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=34 width=4)
-                                                                     ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=34 width=4)
+                                                                                                   ->  Gather Motion 3:1  (slice7; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                                               ->  Shared Scan (share slice:id 7:1)  (cost=0.00..431.00 rows=34 width=8)
+                                                   ->  Materialize  (cost=0.00..1324037.57 rows=1 width=24)
+                                                         ->  Aggregate  (cost=0.00..1324037.57 rows=1 width=24)
+                                                               ->  Limit  (cost=0.00..1324037.57 rows=34 width=20)
+                                                                     ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1324037.57 rows=100 width=20)
+                                                                           Merge Key: share0_ref3.a
+                                                                           ->  Nested Loop  (cost=0.00..1324037.56 rows=34 width=20)
+                                                                                 Join Filter: true
+                                                                                 ->  Shared Scan (share slice:id 6:0)  (cost=0.00..431.00 rows=34 width=12)
+                                                                                 ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                                                                       ->  Broadcast Motion 1:3  (slice5; segments: 1)  (cost=0.00..431.00 rows=3 width=8)
+                                                                                             ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                                                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                                         ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                                                     ->  Shared Scan (share slice:id 4:0)  (cost=0.00..431.00 rows=34 width=8)
+                                             ->  Materialize  (cost=0.00..1324037.57 rows=1 width=24)
+                                                   ->  Aggregate  (cost=0.00..1324037.57 rows=1 width=24)
+                                                         ->  Limit  (cost=0.00..1324037.57 rows=34 width=20)
+                                                               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324037.57 rows=100 width=20)
+                                                                     Merge Key: share2_ref3.c
+                                                                     ->  Nested Loop  (cost=0.00..1324037.56 rows=34 width=20)
+                                                                           Join Filter: true
+                                                                           ->  Shared Scan (share slice:id 3:2)  (cost=0.00..431.00 rows=34 width=12)
+                                                                           ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                                                                 ->  Broadcast Motion 1:3  (slice2; segments: 1)  (cost=0.00..431.00 rows=3 width=8)
+                                                                                       ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                                                             ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                                   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                                                                               ->  Shared Scan (share slice:id 1:2)  (cost=0.00..431.00 rows=34 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(57 rows)
+(81 rows)
 -->
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
@@ -97,10 +121,421 @@ EXPLAIN CREATE TABLE test AS
         <dxl:ResultType Mdid="0.701.1.0"/>
         <dxl:IntermediateResultType Mdid="0.17.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:GPDBAgg Mdid="0.327945.1.0" Name="gp_percentile_cont" IsSplittable="false" HashAggCapable="false">
-        <dxl:ResultType Mdid="0.701.1.0"/>
-        <dxl:IntermediateResultType Mdid="0.701.1.0"/>
-      </dxl:GPDBAgg>
+      <dxl:ColumnStatistics Mdid="1.132001.1.0.2" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="52"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="58"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="82"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="92"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Type Mdid="0.17.1.0" Name="bytea" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2223.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7107.1.0"/>
+        <dxl:EqualityOp Mdid="0.1955.1.0"/>
+        <dxl:InequalityOp Mdid="0.1956.1.0"/>
+        <dxl:LessThanOp Mdid="0.1957.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1958.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1959.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1960.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1954.1.0"/>
+        <dxl:ArrayType Mdid="0.1001.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
@@ -152,404 +587,6 @@ EXPLAIN CREATE TABLE test AS
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:ColumnStatistics Mdid="1.164167.1.0.2" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="52"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="58"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="82"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="92"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
-        </dxl:StatsBucket>
-      </dxl:ColumnStatistics>
       <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
@@ -584,6 +621,10 @@ EXPLAIN CREATE TABLE test AS
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.131996.1.0" Name="gp_percentile_cont" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBAgg>
       <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
         <dxl:EqualityOp Mdid="0.385.1.0"/>
@@ -628,840 +669,8 @@ EXPLAIN CREATE TABLE test AS
           <dxl:Opfamily Mdid="0.7024.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:CTASRelation Mdid="5.1.1.0" Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" VarTypeModList="-1,-1,-1" DistributionPolicy="Random">
-        <dxl:Columns>
-          <dxl:Column Name="first_quartile" Attno="1" Mdid="0.1022.1.0" Nullable="true">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="median_quartile" Attno="2" Mdid="0.1022.1.0" Nullable="true">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="third_quartile" Attno="3" Mdid="0.1022.1.0" Nullable="true">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-        </dxl:Columns>
-        <dxl:CTASOptions OnCommitAction="NOOP"/>
-        <dxl:DistrOpfamilies/>
-        <dxl:DistrOpclasses/>
-      </dxl:CTASRelation>
-      <dxl:ColumnStatistics Mdid="1.164167.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="52"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="58"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="82"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="92"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
-        </dxl:StatsBucket>
-      </dxl:ColumnStatistics>
-      <dxl:ColumnStatistics Mdid="1.164167.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="52"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="58"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="82"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="92"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
-        </dxl:StatsBucket>
-      </dxl:ColumnStatistics>
-      <dxl:GPDBFunc Mdid="0.316.1.0" Name="float8" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
-        <dxl:ResultType Mdid="0.701.1.0"/>
-      </dxl:GPDBFunc>
-      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
-        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
-        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
-        <dxl:EqualityOp Mdid="0.670.1.0"/>
-        <dxl:InequalityOp Mdid="0.671.1.0"/>
-        <dxl:LessThanOp Mdid="0.672.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
-        <dxl:ComparisonOp Mdid="0.355.1.0"/>
-        <dxl:ArrayType Mdid="0.1022.1.0"/>
-        <dxl:MinAgg Mdid="0.2136.1.0"/>
-        <dxl:MaxAgg Mdid="0.2120.1.0"/>
-        <dxl:AvgAgg Mdid="0.2105.1.0"/>
-        <dxl:SumAgg Mdid="0.2111.1.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:RelationStatistics Mdid="2.164167.1.0" Name="foo1" Rows="100.000000" RelPages="3" RelAllVisible="0" EmptyRelation="false"/>
-      <dxl:Relation Mdid="0.164167.1.0" Name="foo1" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+      <dxl:RelationStatistics Mdid="2.132001.1.0" Name="foo1" Rows="100.000000" RelPages="3" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.132001.1.0" Name="foo1" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
         <dxl:Columns>
           <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
@@ -1501,6 +710,859 @@ EXPLAIN CREATE TABLE test AS
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
+      <dxl:Type Mdid="0.1700.1.0" Name="numeric" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1998.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7103.1.0"/>
+        <dxl:EqualityOp Mdid="0.1752.1.0"/>
+        <dxl:InequalityOp Mdid="0.1753.1.0"/>
+        <dxl:LessThanOp Mdid="0.1754.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1755.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1756.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1757.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1769.1.0"/>
+        <dxl:ArrayType Mdid="0.1231.1.0"/>
+        <dxl:MinAgg Mdid="0.2146.1.0"/>
+        <dxl:MaxAgg Mdid="0.2130.1.0"/>
+        <dxl:AvgAgg Mdid="0.2103.1.0"/>
+        <dxl:SumAgg Mdid="0.2114.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.132001.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="52"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="58"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="82"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="92"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.132001.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="21"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="21"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="52"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="58"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="65"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="65"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="82"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="87"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="92"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010101" DistinctValues="1.010101">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:CTASRelation Mdid="5.1.1.0" Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" VarTypeModList="-1,-1,-1" DistributionPolicy="Random">
+        <dxl:Columns>
+          <dxl:Column Name="first_quartile" Attno="1" Mdid="0.1022.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="median_quartile" Attno="2" Mdid="0.1022.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="third_quartile" Attno="3" Mdid="0.1022.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:CTASOptions OnCommitAction="NOOP"/>
+        <dxl:DistrOpfamilies/>
+        <dxl:DistrOpclasses/>
+      </dxl:CTASRelation>
+      <dxl:GPDBAgg Mdid="0.2107.1.0" Name="sum" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.1700.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.17.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:GPDBFunc Mdid="0.316.1.0" Name="float8" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
+        <dxl:EqualityOp Mdid="0.670.1.0"/>
+        <dxl:InequalityOp Mdid="0.671.1.0"/>
+        <dxl:LessThanOp Mdid="0.672.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
+        <dxl:ComparisonOp Mdid="0.355.1.0"/>
+        <dxl:ArrayType Mdid="0.1022.1.0"/>
+        <dxl:MinAgg Mdid="0.2136.1.0"/>
+        <dxl:MaxAgg Mdid="0.2120.1.0"/>
+        <dxl:AvgAgg Mdid="0.2105.1.0"/>
+        <dxl:SumAgg Mdid="0.2111.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
       <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.23.1.0"/>
         <dxl:RightType Mdid="0.23.1.0"/>
@@ -1517,6 +1579,9 @@ EXPLAIN CREATE TABLE test AS
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
+      <dxl:GPDBFunc Mdid="0.1779.1.0" Name="int8" ReturnsSet="false" Stability="Immutable" DataAccess="ContainsSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBFunc>
       <dxl:MDCast Mdid="3.23.1.0;701.1.0" Name="float8" BinaryCoercible="false" SourceTypeId="0.23.1.0" DestinationTypeId="0.701.1.0" CastFuncId="0.316.1.0" CoercePathType="1"/>
       <dxl:Type Mdid="0.1022.1.0" Name="_float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
         <dxl:DistrOpfamily Mdid="0.627.1.0"/>
@@ -1579,7 +1644,7 @@ EXPLAIN CREATE TABLE test AS
             <dxl:GroupingColumns/>
             <dxl:ProjList>
               <dxl:ProjElem ColId="11" Alias="percentile_cont">
-                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.327945.1.0">
+                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.131996.1.0">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
                       <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
@@ -1595,7 +1660,7 @@ EXPLAIN CREATE TABLE test AS
                 </dxl:AggFunc>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="12" Alias="percentile_cont">
-                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.327945.1.0">
+                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.131996.1.0">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
                       <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
@@ -1611,7 +1676,7 @@ EXPLAIN CREATE TABLE test AS
                 </dxl:AggFunc>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="13" Alias="percentile_cont">
-                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.327945.1.0">
+                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.131996.1.0">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
                       <dxl:Ident ColId="3" ColName="c" TypeMdid="0.23.1.0"/>
@@ -1627,7 +1692,7 @@ EXPLAIN CREATE TABLE test AS
                 </dxl:AggFunc>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="14" Alias="percentile_cont">
-                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.327945.1.0">
+                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.131996.1.0">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
                       <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
@@ -1643,7 +1708,7 @@ EXPLAIN CREATE TABLE test AS
                 </dxl:AggFunc>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="15" Alias="percentile_cont">
-                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.327945.1.0">
+                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.131996.1.0">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
                       <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
@@ -1659,7 +1724,7 @@ EXPLAIN CREATE TABLE test AS
                 </dxl:AggFunc>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="16" Alias="percentile_cont">
-                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.327945.1.0">
+                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.131996.1.0">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
                       <dxl:Ident ColId="3" ColName="c" TypeMdid="0.23.1.0"/>
@@ -1675,7 +1740,7 @@ EXPLAIN CREATE TABLE test AS
                 </dxl:AggFunc>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="17" Alias="percentile_cont">
-                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.327945.1.0">
+                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.131996.1.0">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
                       <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
@@ -1691,7 +1756,7 @@ EXPLAIN CREATE TABLE test AS
                 </dxl:AggFunc>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="18" Alias="percentile_cont">
-                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.327945.1.0">
+                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.131996.1.0">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
                       <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
@@ -1707,7 +1772,7 @@ EXPLAIN CREATE TABLE test AS
                 </dxl:AggFunc>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="19" Alias="percentile_cont">
-                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.327945.1.0">
+                <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.131996.1.0">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
                       <dxl:Ident ColId="3" ColName="c" TypeMdid="0.23.1.0"/>
@@ -1724,7 +1789,7 @@ EXPLAIN CREATE TABLE test AS
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:LogicalGet>
-              <dxl:TableDescriptor Mdid="0.164167.1.0" TableName="foo1">
+              <dxl:TableDescriptor Mdid="0.132001.1.0" TableName="foo1">
                 <dxl:Columns>
                   <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                   <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -1743,16 +1808,16 @@ EXPLAIN CREATE TABLE test AS
         </dxl:LogicalProject>
       </dxl:LogicalCTAS>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="506989368">
+    <dxl:Plan Id="0" SpaceSize="16799099328000">
       <dxl:PhysicalCTAS Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" DistributionPolicy="Random" InsertColumns="19,20,21" VarTypeModList="-1,-1,-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2778510692279.118164" Rows="1.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="2778516240645.427246" Rows="1.000000" Width="24"/>
         </dxl:Properties>
         <dxl:DistrOpclasses/>
         <dxl:Columns>
-          <dxl:Column ColId="49" Attno="1" ColName="first_quartile" TypeMdid="0.1022.1.0"/>
-          <dxl:Column ColId="50" Attno="2" ColName="median_quartile" TypeMdid="0.1022.1.0"/>
-          <dxl:Column ColId="51" Attno="3" ColName="third_quartile" TypeMdid="0.1022.1.0"/>
+          <dxl:Column ColId="131" Attno="1" ColName="first_quartile" TypeMdid="0.1022.1.0"/>
+          <dxl:Column ColId="132" Attno="2" ColName="median_quartile" TypeMdid="0.1022.1.0"/>
+          <dxl:Column ColId="133" Attno="3" ColName="third_quartile" TypeMdid="0.1022.1.0"/>
         </dxl:Columns>
         <dxl:CTASOptions OnCommitAction="NOOP"/>
         <dxl:ProjList>
@@ -1768,7 +1833,7 @@ EXPLAIN CREATE TABLE test AS
         </dxl:ProjList>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2778510692279.081543" Rows="1.000000" Width="28"/>
+            <dxl:Cost StartupCost="0" TotalCost="2778516240645.390625" Rows="1.000000" Width="28"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="19" Alias="first_quartile">
@@ -1780,7 +1845,7 @@ EXPLAIN CREATE TABLE test AS
             <dxl:ProjElem ColId="21" Alias="third_quartile">
               <dxl:Ident ColId="21" ColName="third_quartile" TypeMdid="0.1022.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="48" Alias="ColRef_0048">
+            <dxl:ProjElem ColId="130" Alias="ColRef_0130">
               <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
             </dxl:ProjElem>
           </dxl:ProjList>
@@ -1788,7 +1853,7 @@ EXPLAIN CREATE TABLE test AS
           <dxl:OneTimeFilter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2778510692279.081543" Rows="1.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="2778516240645.390625" Rows="1.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="19" Alias="first_quartile">
@@ -1817,7 +1882,7 @@ EXPLAIN CREATE TABLE test AS
             <dxl:OneTimeFilter/>
             <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2778510692279.081543" Rows="1.000000" Width="72"/>
+                <dxl:Cost StartupCost="0" TotalCost="2778516240645.390625" Rows="1.000000" Width="72"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="percentile_cont">
@@ -1848,98 +1913,87 @@ EXPLAIN CREATE TABLE test AS
                   <dxl:Ident ColId="18" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:CTEProducer CTEId="0" Columns="22,23,24,25,26,27,28,29,30,31">
+              <dxl:CTEProducer CTEId="0" Columns="23,24">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.003407" Rows="100.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.005234" Rows="99.999999" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="22" Alias="a">
-                    <dxl:Ident ColId="22" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="23" Alias="a">
+                    <dxl:Ident ColId="23" ColName="a" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="23" Alias="b">
-                    <dxl:Ident ColId="23" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="24" Alias="c">
-                    <dxl:Ident ColId="24" ColName="c" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="25" Alias="ctid">
-                    <dxl:Ident ColId="25" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="26" Alias="xmin">
-                    <dxl:Ident ColId="26" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="27" Alias="cmin">
-                    <dxl:Ident ColId="27" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="28" Alias="xmax">
-                    <dxl:Ident ColId="28" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="29" Alias="cmax">
-                    <dxl:Ident ColId="29" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="30" Alias="tableoid">
-                    <dxl:Ident ColId="30" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="31" Alias="gp_segment_id">
-                    <dxl:Ident ColId="31" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="24" Alias="ColRef_0022">
+                    <dxl:Ident ColId="24" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:TableScan>
+                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000770" Rows="100.000000" Width="42"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.005200" Rows="99.999999" Width="12"/>
                   </dxl:Properties>
+                  <dxl:GroupingColumns>
+                    <dxl:GroupingColumn ColId="23"/>
+                  </dxl:GroupingColumns>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="22" Alias="a">
-                      <dxl:Ident ColId="22" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="23" Alias="a">
+                      <dxl:Ident ColId="23" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="23" Alias="b">
-                      <dxl:Ident ColId="23" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="24" Alias="c">
-                      <dxl:Ident ColId="24" ColName="c" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="25" Alias="ctid">
-                      <dxl:Ident ColId="25" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="26" Alias="xmin">
-                      <dxl:Ident ColId="26" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="27" Alias="cmin">
-                      <dxl:Ident ColId="27" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="28" Alias="xmax">
-                      <dxl:Ident ColId="28" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="29" Alias="cmax">
-                      <dxl:Ident ColId="29" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="30" Alias="tableoid">
-                      <dxl:Ident ColId="30" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="31" Alias="gp_segment_id">
-                      <dxl:Ident ColId="31" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="24" Alias="ColRef_0022">
+                      <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                        <dxl:ValuesList ParamType="aggargs">
+                          <dxl:Ident ColId="23" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ValuesList>
+                        <dxl:ValuesList ParamType="aggdirectargs"/>
+                        <dxl:ValuesList ParamType="aggorder"/>
+                        <dxl:ValuesList ParamType="aggdistinct"/>
+                      </dxl:AggFunc>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.164167.1.0" TableName="foo1">
-                    <dxl:Columns>
-                      <dxl:Column ColId="22" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="23" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="24" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="26" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="27" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="28" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="29" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="30" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="31" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
+                  <dxl:Sort SortDiscardDuplicates="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.004843" Rows="100.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="23" Alias="a">
+                        <dxl:Ident ColId="23" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList>
+                      <dxl:SortingColumn ColId="23" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                    </dxl:SortingColumnList>
+                    <dxl:LimitCount/>
+                    <dxl:LimitOffset/>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000770" Rows="100.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="23" Alias="a">
+                          <dxl:Ident ColId="23" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="0.132001.1.0" TableName="foo1">
+                        <dxl:Columns>
+                          <dxl:Column ColId="23" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="25" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="26" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="27" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                          <dxl:Column ColId="28" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="29" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="30" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="31" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="32" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="33" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:Sort>
+                </dxl:Aggregate>
               </dxl:CTEProducer>
-              <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2">
+              <dxl:Sequence>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2778510691848.078125" Rows="1.000000" Width="72"/>
+                  <dxl:Cost StartupCost="0" TotalCost="2778516240214.385254" Rows="1.000000" Width="72"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="10" Alias="percentile_cont">
@@ -1970,11 +2024,104 @@ EXPLAIN CREATE TABLE test AS
                     <dxl:Ident ColId="18" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                <dxl:CTEProducer CTEId="1" Columns="57,58">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2778510691848.078125" Rows="1.000000" Width="72"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.005651" Rows="99.999999" Width="1"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="57" Alias="b">
+                      <dxl:Ident ColId="57" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="58" Alias="ColRef_0056">
+                      <dxl:Ident ColId="58" ColName="ColRef_0056" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.005618" Rows="99.999999" Width="12"/>
+                    </dxl:Properties>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="57"/>
+                    </dxl:GroupingColumns>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="57" Alias="b">
+                        <dxl:Ident ColId="57" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="58" Alias="ColRef_0056">
+                        <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                          <dxl:ValuesList ParamType="aggargs">
+                            <dxl:Ident ColId="57" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ValuesList>
+                          <dxl:ValuesList ParamType="aggdirectargs"/>
+                          <dxl:ValuesList ParamType="aggorder"/>
+                          <dxl:ValuesList ParamType="aggdistinct"/>
+                        </dxl:AggFunc>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:Sort SortDiscardDuplicates="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.005260" Rows="100.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="57" Alias="b">
+                          <dxl:Ident ColId="57" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList>
+                        <dxl:SortingColumn ColId="57" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      </dxl:SortingColumnList>
+                      <dxl:LimitCount/>
+                      <dxl:LimitOffset/>
+                      <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.001435" Rows="100.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="57" Alias="b">
+                            <dxl:Ident ColId="57" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:HashExprList>
+                          <dxl:HashExpr Opfamily="0.1977.1.0">
+                            <dxl:Ident ColId="57" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:HashExpr>
+                        </dxl:HashExprList>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000770" Rows="100.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="57" Alias="b">
+                              <dxl:Ident ColId="57" ColName="b" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="0.132001.1.0" TableName="foo1">
+                            <dxl:Columns>
+                              <dxl:Column ColId="59" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="57" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="60" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="61" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                              <dxl:Column ColId="62" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="63" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="64" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="65" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="66" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="67" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:RedistributeMotion>
+                    </dxl:Sort>
+                  </dxl:Aggregate>
+                </dxl:CTEProducer>
+                <dxl:Sequence>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="2778516239783.379395" Rows="1.000000" Width="72"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="10" Alias="percentile_cont">
@@ -2005,13 +2152,104 @@ EXPLAIN CREATE TABLE test AS
                       <dxl:Ident ColId="18" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:JoinFilter>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:JoinFilter>
-                  <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                  <dxl:CTEProducer CTEId="2" Columns="91,92">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="2712064881.577200" Rows="1.000000" Width="48"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.005651" Rows="99.999999" Width="1"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="91" Alias="c">
+                        <dxl:Ident ColId="91" ColName="c" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="92" Alias="ColRef_0090">
+                        <dxl:Ident ColId="92" ColName="ColRef_0090" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.005618" Rows="99.999999" Width="12"/>
+                      </dxl:Properties>
+                      <dxl:GroupingColumns>
+                        <dxl:GroupingColumn ColId="91"/>
+                      </dxl:GroupingColumns>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="91" Alias="c">
+                          <dxl:Ident ColId="91" ColName="c" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="92" Alias="ColRef_0090">
+                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Ident ColId="91" ColName="c" TypeMdid="0.23.1.0"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:Sort SortDiscardDuplicates="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.005260" Rows="100.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="91" Alias="c">
+                            <dxl:Ident ColId="91" ColName="c" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList>
+                          <dxl:SortingColumn ColId="91" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        </dxl:SortingColumnList>
+                        <dxl:LimitCount/>
+                        <dxl:LimitOffset/>
+                        <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.001435" Rows="100.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="91" Alias="c">
+                              <dxl:Ident ColId="91" ColName="c" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList/>
+                          <dxl:HashExprList>
+                            <dxl:HashExpr Opfamily="0.1977.1.0">
+                              <dxl:Ident ColId="91" ColName="c" TypeMdid="0.23.1.0"/>
+                            </dxl:HashExpr>
+                          </dxl:HashExprList>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000770" Rows="100.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="91" Alias="c">
+                                <dxl:Ident ColId="91" ColName="c" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="0.132001.1.0" TableName="foo1">
+                              <dxl:Columns>
+                                <dxl:Column ColId="93" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="94" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="91" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="95" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                <dxl:Column ColId="96" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="97" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="98" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="99" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="100" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="101" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:RedistributeMotion>
+                      </dxl:Sort>
+                    </dxl:Aggregate>
+                  </dxl:CTEProducer>
+                  <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="2778516239352.373535" Rows="1.000000" Width="72"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="10" Alias="percentile_cont">
@@ -2020,11 +2258,17 @@ EXPLAIN CREATE TABLE test AS
                       <dxl:ProjElem ColId="11" Alias="percentile_cont">
                         <dxl:Ident ColId="11" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
                       </dxl:ProjElem>
+                      <dxl:ProjElem ColId="12" Alias="percentile_cont">
+                        <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="13" Alias="percentile_cont">
                         <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="14" Alias="percentile_cont">
                         <dxl:Ident ColId="14" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="15" Alias="percentile_cont">
+                        <dxl:Ident ColId="15" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="16" Alias="percentile_cont">
                         <dxl:Ident ColId="16" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
@@ -2032,454 +2276,240 @@ EXPLAIN CREATE TABLE test AS
                       <dxl:ProjElem ColId="17" Alias="percentile_cont">
                         <dxl:Ident ColId="17" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
                       </dxl:ProjElem>
+                      <dxl:ProjElem ColId="18" Alias="percentile_cont">
+                        <dxl:Ident ColId="18" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:JoinFilter>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:JoinFilter>
-                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                    <dxl:SortingColumnList/>
+                    <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1324034.930325" Rows="1.000000" Width="24"/>
-                      </dxl:Properties>
-                      <dxl:GroupingColumns/>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="11" Alias="percentile_cont">
-                          <dxl:AggFunc AggMdid="0.327945.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                            <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
-                                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                              </dxl:Cast>
-                              <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA0D8=" DoubleValue="0.250000"/>
-                              <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                            </dxl:ValuesList>
-                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                            <dxl:ValuesList ParamType="aggorder"/>
-                            <dxl:ValuesList ParamType="aggdistinct"/>
-                          </dxl:AggFunc>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="14" Alias="percentile_cont">
-                          <dxl:AggFunc AggMdid="0.327945.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                            <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
-                                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                              </dxl:Cast>
-                              <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
-                              <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                            </dxl:ValuesList>
-                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                            <dxl:ValuesList ParamType="aggorder"/>
-                            <dxl:ValuesList ParamType="aggdistinct"/>
-                          </dxl:AggFunc>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="17" Alias="percentile_cont">
-                          <dxl:AggFunc AggMdid="0.327945.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                            <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
-                                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                              </dxl:Cast>
-                              <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA6D8=" DoubleValue="0.750000"/>
-                              <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                            </dxl:ValuesList>
-                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                            <dxl:ValuesList ParamType="aggorder"/>
-                            <dxl:ValuesList ParamType="aggdistinct"/>
-                          </dxl:AggFunc>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:Limit>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1324034.929519" Rows="100.000000" Width="12"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="1" Alias="b">
-                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="43" Alias="ColRef_0043">
-                            <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1324034.928319" Rows="100.000000" Width="12"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="1" Alias="b">
-                              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="43" Alias="ColRef_0043">
-                              <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:SortingColumnList>
-                            <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                          </dxl:SortingColumnList>
-                          <dxl:Sort SortDiscardDuplicates="false">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1324034.923847" Rows="100.000000" Width="12"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="1" Alias="b">
-                                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="43" Alias="ColRef_0043">
-                                <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:SortingColumnList>
-                              <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                            </dxl:SortingColumnList>
-                            <dxl:LimitCount/>
-                            <dxl:LimitOffset/>
-                            <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="1324034.912373" Rows="100.000000" Width="12"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="1" Alias="b">
-                                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="43" Alias="ColRef_0043">
-                                  <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:JoinFilter>
-                                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                              </dxl:JoinFilter>
-                              <dxl:BroadcastMotion InputSegments="0" OutputSegments="0,1,2">
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000797" Rows="3.000000" Width="8"/>
-                                </dxl:Properties>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="43" Alias="ColRef_0043">
-                                    <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                                <dxl:Filter/>
-                                <dxl:SortingColumnList/>
-                                <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-                                  <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="431.000367" Rows="1.000000" Width="8"/>
-                                  </dxl:Properties>
-                                  <dxl:GroupingColumns/>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="43" Alias="ColRef_0043">
-                                      <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
-                                        <dxl:ValuesList ParamType="aggargs">
-                                          <dxl:Ident ColId="46" ColName="ColRef_0046" TypeMdid="0.20.1.0"/>
-                                        </dxl:ValuesList>
-                                        <dxl:ValuesList ParamType="aggdirectargs"/>
-                                        <dxl:ValuesList ParamType="aggorder"/>
-                                        <dxl:ValuesList ParamType="aggdistinct"/>
-                                      </dxl:AggFunc>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
-                                  <dxl:Filter/>
-                                  <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
-                                    <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="431.000366" Rows="1.000000" Width="8"/>
-                                    </dxl:Properties>
-                                    <dxl:ProjList>
-                                      <dxl:ProjElem ColId="46" Alias="ColRef_0046">
-                                        <dxl:Ident ColId="46" ColName="ColRef_0046" TypeMdid="0.20.1.0"/>
-                                      </dxl:ProjElem>
-                                    </dxl:ProjList>
-                                    <dxl:Filter/>
-                                    <dxl:SortingColumnList/>
-                                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-                                      <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="431.000336" Rows="1.000000" Width="8"/>
-                                      </dxl:Properties>
-                                      <dxl:GroupingColumns/>
-                                      <dxl:ProjList>
-                                        <dxl:ProjElem ColId="46" Alias="ColRef_0046">
-                                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
-                                            <dxl:ValuesList ParamType="aggargs">
-                                              <dxl:Ident ColId="33" ColName="b" TypeMdid="0.23.1.0"/>
-                                            </dxl:ValuesList>
-                                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                                            <dxl:ValuesList ParamType="aggorder"/>
-                                            <dxl:ValuesList ParamType="aggdistinct"/>
-                                          </dxl:AggFunc>
-                                        </dxl:ProjElem>
-                                      </dxl:ProjList>
-                                      <dxl:Filter/>
-                                      <dxl:CTEConsumer CTEId="0" Columns="32,33,34,35,36,37,38,39,40,41">
-                                        <dxl:Properties>
-                                          <dxl:Cost StartupCost="0" TotalCost="431.000321" Rows="100.000000" Width="4"/>
-                                        </dxl:Properties>
-                                        <dxl:ProjList>
-                                          <dxl:ProjElem ColId="32" Alias="a">
-                                            <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>
-                                          </dxl:ProjElem>
-                                          <dxl:ProjElem ColId="33" Alias="b">
-                                            <dxl:Ident ColId="33" ColName="b" TypeMdid="0.23.1.0"/>
-                                          </dxl:ProjElem>
-                                          <dxl:ProjElem ColId="34" Alias="c">
-                                            <dxl:Ident ColId="34" ColName="c" TypeMdid="0.23.1.0"/>
-                                          </dxl:ProjElem>
-                                          <dxl:ProjElem ColId="35" Alias="ctid">
-                                            <dxl:Ident ColId="35" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                          </dxl:ProjElem>
-                                          <dxl:ProjElem ColId="36" Alias="xmin">
-                                            <dxl:Ident ColId="36" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                          </dxl:ProjElem>
-                                          <dxl:ProjElem ColId="37" Alias="cmin">
-                                            <dxl:Ident ColId="37" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                          </dxl:ProjElem>
-                                          <dxl:ProjElem ColId="38" Alias="xmax">
-                                            <dxl:Ident ColId="38" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                          </dxl:ProjElem>
-                                          <dxl:ProjElem ColId="39" Alias="cmax">
-                                            <dxl:Ident ColId="39" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                          </dxl:ProjElem>
-                                          <dxl:ProjElem ColId="40" Alias="tableoid">
-                                            <dxl:Ident ColId="40" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                          </dxl:ProjElem>
-                                          <dxl:ProjElem ColId="41" Alias="gp_segment_id">
-                                            <dxl:Ident ColId="41" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                          </dxl:ProjElem>
-                                        </dxl:ProjList>
-                                      </dxl:CTEConsumer>
-                                    </dxl:Aggregate>
-                                  </dxl:GatherMotion>
-                                </dxl:Aggregate>
-                              </dxl:BroadcastMotion>
-                              <dxl:CTEConsumer CTEId="0" Columns="0,1,2,3,4,5,6,7,8,9">
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000321" Rows="100.000000" Width="4"/>
-                                </dxl:Properties>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="0" Alias="a">
-                                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="1" Alias="b">
-                                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="2" Alias="c">
-                                    <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="3" Alias="ctid">
-                                    <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="4" Alias="xmin">
-                                    <dxl:Ident ColId="4" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="5" Alias="cmin">
-                                    <dxl:Ident ColId="5" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="6" Alias="xmax">
-                                    <dxl:Ident ColId="6" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="7" Alias="cmax">
-                                    <dxl:Ident ColId="7" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="8" Alias="tableoid">
-                                    <dxl:Ident ColId="8" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                                    <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                              </dxl:CTEConsumer>
-                            </dxl:NestedLoopJoin>
-                          </dxl:Sort>
-                        </dxl:GatherMotion>
-                        <dxl:LimitCount>
-                          <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
-                        </dxl:LimitCount>
-                        <dxl:LimitOffset>
-                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                        </dxl:LimitOffset>
-                      </dxl:Limit>
-                    </dxl:Aggregate>
-                    <dxl:Materialize Eager="true">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1324034.930349" Rows="1.000000" Width="24"/>
+                        <dxl:Cost StartupCost="0" TotalCost="2778516239352.373535" Rows="1.000000" Width="72"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="10" Alias="percentile_cont">
                           <dxl:Ident ColId="10" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
                         </dxl:ProjElem>
+                        <dxl:ProjElem ColId="11" Alias="percentile_cont">
+                          <dxl:Ident ColId="11" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="12" Alias="percentile_cont">
+                          <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="13" Alias="percentile_cont">
                           <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="14" Alias="percentile_cont">
+                          <dxl:Ident ColId="14" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="15" Alias="percentile_cont">
+                          <dxl:Ident ColId="15" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
                         </dxl:ProjElem>
                         <dxl:ProjElem ColId="16" Alias="percentile_cont">
                           <dxl:Ident ColId="16" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
                         </dxl:ProjElem>
+                        <dxl:ProjElem ColId="17" Alias="percentile_cont">
+                          <dxl:Ident ColId="17" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="18" Alias="percentile_cont">
+                          <dxl:Ident ColId="18" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                        </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                      <dxl:JoinFilter>
+                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                      </dxl:JoinFilter>
+                      <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1324034.930325" Rows="1.000000" Width="24"/>
+                          <dxl:Cost StartupCost="0" TotalCost="2712070296.417899" Rows="1.000000" Width="48"/>
                         </dxl:Properties>
-                        <dxl:GroupingColumns/>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="10" Alias="percentile_cont">
-                            <dxl:AggFunc AggMdid="0.327945.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                              <dxl:ValuesList ParamType="aggargs">
-                                <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
-                                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                                </dxl:Cast>
-                                <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA0D8=" DoubleValue="0.250000"/>
-                                <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                              </dxl:ValuesList>
-                              <dxl:ValuesList ParamType="aggdirectargs"/>
-                              <dxl:ValuesList ParamType="aggorder"/>
-                              <dxl:ValuesList ParamType="aggdistinct"/>
-                            </dxl:AggFunc>
+                            <dxl:Ident ColId="10" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="11" Alias="percentile_cont">
+                            <dxl:Ident ColId="11" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
                           </dxl:ProjElem>
                           <dxl:ProjElem ColId="13" Alias="percentile_cont">
-                            <dxl:AggFunc AggMdid="0.327945.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                              <dxl:ValuesList ParamType="aggargs">
-                                <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
-                                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                                </dxl:Cast>
-                                <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
-                                <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                              </dxl:ValuesList>
-                              <dxl:ValuesList ParamType="aggdirectargs"/>
-                              <dxl:ValuesList ParamType="aggorder"/>
-                              <dxl:ValuesList ParamType="aggdistinct"/>
-                            </dxl:AggFunc>
+                            <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="14" Alias="percentile_cont">
+                            <dxl:Ident ColId="14" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
                           </dxl:ProjElem>
                           <dxl:ProjElem ColId="16" Alias="percentile_cont">
-                            <dxl:AggFunc AggMdid="0.327945.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                              <dxl:ValuesList ParamType="aggargs">
-                                <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
-                                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                                </dxl:Cast>
-                                <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA6D8=" DoubleValue="0.750000"/>
-                                <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                              </dxl:ValuesList>
-                              <dxl:ValuesList ParamType="aggdirectargs"/>
-                              <dxl:ValuesList ParamType="aggorder"/>
-                              <dxl:ValuesList ParamType="aggdistinct"/>
-                            </dxl:AggFunc>
+                            <dxl:Ident ColId="16" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="17" Alias="percentile_cont">
+                            <dxl:Ident ColId="17" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:Limit>
+                        <dxl:JoinFilter>
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:JoinFilter>
+                        <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1324034.929519" Rows="100.000000" Width="12"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1324037.574291" Rows="1.000000" Width="24"/>
                           </dxl:Properties>
+                          <dxl:GroupingColumns/>
                           <dxl:ProjList>
-                            <dxl:ProjElem ColId="0" Alias="a">
-                              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                            <dxl:ProjElem ColId="11" Alias="percentile_cont">
+                              <dxl:AggFunc AggMdid="0.131996.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                                <dxl:ValuesList ParamType="aggargs">
+                                  <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                                  </dxl:Cast>
+                                  <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA0D8=" DoubleValue="0.250000"/>
+                                  <dxl:Ident ColId="89" ColName="ColRef_0089" TypeMdid="0.20.1.0"/>
+                                  <dxl:Ident ColId="56" ColName="ColRef_0056" TypeMdid="0.20.1.0"/>
+                                </dxl:ValuesList>
+                                <dxl:ValuesList ParamType="aggdirectargs"/>
+                                <dxl:ValuesList ParamType="aggorder"/>
+                                <dxl:ValuesList ParamType="aggdistinct"/>
+                              </dxl:AggFunc>
                             </dxl:ProjElem>
-                            <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                              <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                            <dxl:ProjElem ColId="14" Alias="percentile_cont">
+                              <dxl:AggFunc AggMdid="0.131996.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                                <dxl:ValuesList ParamType="aggargs">
+                                  <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                                  </dxl:Cast>
+                                  <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+                                  <dxl:Ident ColId="89" ColName="ColRef_0089" TypeMdid="0.20.1.0"/>
+                                  <dxl:Ident ColId="56" ColName="ColRef_0056" TypeMdid="0.20.1.0"/>
+                                </dxl:ValuesList>
+                                <dxl:ValuesList ParamType="aggdirectargs"/>
+                                <dxl:ValuesList ParamType="aggorder"/>
+                                <dxl:ValuesList ParamType="aggdistinct"/>
+                              </dxl:AggFunc>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="17" Alias="percentile_cont">
+                              <dxl:AggFunc AggMdid="0.131996.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                                <dxl:ValuesList ParamType="aggargs">
+                                  <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                                  </dxl:Cast>
+                                  <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA6D8=" DoubleValue="0.750000"/>
+                                  <dxl:Ident ColId="89" ColName="ColRef_0089" TypeMdid="0.20.1.0"/>
+                                  <dxl:Ident ColId="56" ColName="ColRef_0056" TypeMdid="0.20.1.0"/>
+                                </dxl:ValuesList>
+                                <dxl:ValuesList ParamType="aggdirectargs"/>
+                                <dxl:ValuesList ParamType="aggorder"/>
+                                <dxl:ValuesList ParamType="aggdistinct"/>
+                              </dxl:AggFunc>
                             </dxl:ProjElem>
                           </dxl:ProjList>
-                          <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                          <dxl:Filter/>
+                          <dxl:Limit>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1324034.928319" Rows="100.000000" Width="12"/>
+                              <dxl:Cost StartupCost="0" TotalCost="1324037.572275" Rows="99.999999" Width="20"/>
                             </dxl:Properties>
                             <dxl:ProjList>
-                              <dxl:ProjElem ColId="0" Alias="a">
-                                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                              <dxl:ProjElem ColId="1" Alias="b">
+                                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                                <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                              <dxl:ProjElem ColId="56" Alias="ColRef_0056">
+                                <dxl:Ident ColId="56" ColName="ColRef_0056" TypeMdid="0.20.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="89" Alias="ColRef_0089">
+                                <dxl:Ident ColId="89" ColName="ColRef_0089" TypeMdid="0.20.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:SortingColumnList>
-                              <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                            </dxl:SortingColumnList>
-                            <dxl:Sort SortDiscardDuplicates="false">
+                            <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="1324034.923847" Rows="100.000000" Width="12"/>
+                                <dxl:Cost StartupCost="0" TotalCost="1324037.570275" Rows="99.999999" Width="20"/>
                               </dxl:Properties>
                               <dxl:ProjList>
-                                <dxl:ProjElem ColId="0" Alias="a">
-                                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                                <dxl:ProjElem ColId="1" Alias="b">
+                                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                                 </dxl:ProjElem>
-                                <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                                  <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                                <dxl:ProjElem ColId="56" Alias="ColRef_0056">
+                                  <dxl:Ident ColId="56" ColName="ColRef_0056" TypeMdid="0.20.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="89" Alias="ColRef_0089">
+                                  <dxl:Ident ColId="89" ColName="ColRef_0089" TypeMdid="0.20.1.0"/>
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
                               <dxl:SortingColumnList>
-                                <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                               </dxl:SortingColumnList>
-                              <dxl:LimitCount/>
-                              <dxl:LimitOffset/>
                               <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="1324034.912373" Rows="100.000000" Width="12"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="1324037.562821" Rows="99.999999" Width="20"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
-                                  <dxl:ProjElem ColId="0" Alias="a">
-                                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                                  <dxl:ProjElem ColId="1" Alias="b">
+                                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                                   </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                                    <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                                  <dxl:ProjElem ColId="56" Alias="ColRef_0056">
+                                    <dxl:Ident ColId="56" ColName="ColRef_0056" TypeMdid="0.20.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="89" Alias="ColRef_0089">
+                                    <dxl:Ident ColId="89" ColName="ColRef_0089" TypeMdid="0.20.1.0"/>
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
                                 <dxl:JoinFilter>
                                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                                 </dxl:JoinFilter>
-                                <dxl:BroadcastMotion InputSegments="0" OutputSegments="0,1,2">
+                                <dxl:CTEConsumer CTEId="1" Columns="1,56">
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="431.000797" Rows="3.000000" Width="8"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000964" Rows="99.999999" Width="12"/>
                                   </dxl:Properties>
                                   <dxl:ProjList>
-                                    <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                                      <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                                    <dxl:ProjElem ColId="1" Alias="b">
+                                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="56" Alias="ColRef_0056">
+                                      <dxl:Ident ColId="56" ColName="ColRef_0056" TypeMdid="0.20.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                </dxl:CTEConsumer>
+                                <dxl:Materialize Eager="false">
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.001249" Rows="3.000000" Width="8"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="89" Alias="ColRef_0089">
+                                      <dxl:Ident ColId="89" ColName="ColRef_0089" TypeMdid="0.20.1.0"/>
                                     </dxl:ProjElem>
                                   </dxl:ProjList>
                                   <dxl:Filter/>
-                                  <dxl:SortingColumnList/>
-                                  <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                                  <dxl:Result>
                                     <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="431.000367" Rows="1.000000" Width="8"/>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.001241" Rows="3.000000" Width="8"/>
                                     </dxl:Properties>
-                                    <dxl:GroupingColumns/>
                                     <dxl:ProjList>
-                                      <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                                        <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
-                                          <dxl:ValuesList ParamType="aggargs">
-                                            <dxl:Ident ColId="47" ColName="ColRef_0047" TypeMdid="0.20.1.0"/>
-                                          </dxl:ValuesList>
-                                          <dxl:ValuesList ParamType="aggdirectargs"/>
-                                          <dxl:ValuesList ParamType="aggorder"/>
-                                          <dxl:ValuesList ParamType="aggdistinct"/>
-                                        </dxl:AggFunc>
+                                      <dxl:ProjElem ColId="89" Alias="ColRef_0089">
+                                        <dxl:FuncExpr FuncId="0.1779.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
+                                          <dxl:Ident ColId="88" ColName="ColRef_0088" TypeMdid="0.1700.1.0"/>
+                                        </dxl:FuncExpr>
                                       </dxl:ProjElem>
                                     </dxl:ProjList>
                                     <dxl:Filter/>
-                                    <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                                    <dxl:OneTimeFilter/>
+                                    <dxl:BroadcastMotion InputSegments="0" OutputSegments="0,1,2">
                                       <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="431.000366" Rows="1.000000" Width="8"/>
+                                        <dxl:Cost StartupCost="0" TotalCost="431.001133" Rows="3.000000" Width="8"/>
                                       </dxl:Properties>
                                       <dxl:ProjList>
-                                        <dxl:ProjElem ColId="47" Alias="ColRef_0047">
-                                          <dxl:Ident ColId="47" ColName="ColRef_0047" TypeMdid="0.20.1.0"/>
+                                        <dxl:ProjElem ColId="88" Alias="ColRef_0088">
+                                          <dxl:Ident ColId="88" ColName="ColRef_0088" TypeMdid="0.1700.1.0"/>
                                         </dxl:ProjElem>
                                       </dxl:ProjList>
                                       <dxl:Filter/>
                                       <dxl:SortingColumnList/>
                                       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                                         <dxl:Properties>
-                                          <dxl:Cost StartupCost="0" TotalCost="431.000336" Rows="1.000000" Width="8"/>
+                                          <dxl:Cost StartupCost="0" TotalCost="431.000703" Rows="1.000000" Width="8"/>
                                         </dxl:Properties>
                                         <dxl:GroupingColumns/>
                                         <dxl:ProjList>
-                                          <dxl:ProjElem ColId="47" Alias="ColRef_0047">
-                                            <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
+                                          <dxl:ProjElem ColId="88" Alias="ColRef_0088">
+                                            <dxl:AggFunc AggMdid="0.2107.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
                                               <dxl:ValuesList ParamType="aggargs">
-                                                <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>
+                                                <dxl:Ident ColId="125" ColName="ColRef_0125" TypeMdid="0.17.1.0"/>
                                               </dxl:ValuesList>
                                               <dxl:ValuesList ParamType="aggdirectargs"/>
                                               <dxl:ValuesList ParamType="aggorder"/>
@@ -2488,378 +2518,561 @@ EXPLAIN CREATE TABLE test AS
                                           </dxl:ProjElem>
                                         </dxl:ProjList>
                                         <dxl:Filter/>
-                                        <dxl:CTEConsumer CTEId="0" Columns="32,33,34,35,36,37,38,39,40,41">
+                                        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
                                           <dxl:Properties>
-                                            <dxl:Cost StartupCost="0" TotalCost="431.000321" Rows="100.000000" Width="4"/>
+                                            <dxl:Cost StartupCost="0" TotalCost="431.000702" Rows="1.000000" Width="8"/>
                                           </dxl:Properties>
                                           <dxl:ProjList>
-                                            <dxl:ProjElem ColId="32" Alias="a">
-                                              <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>
-                                            </dxl:ProjElem>
-                                            <dxl:ProjElem ColId="33" Alias="b">
-                                              <dxl:Ident ColId="33" ColName="b" TypeMdid="0.23.1.0"/>
-                                            </dxl:ProjElem>
-                                            <dxl:ProjElem ColId="34" Alias="c">
-                                              <dxl:Ident ColId="34" ColName="c" TypeMdid="0.23.1.0"/>
-                                            </dxl:ProjElem>
-                                            <dxl:ProjElem ColId="35" Alias="ctid">
-                                              <dxl:Ident ColId="35" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                            </dxl:ProjElem>
-                                            <dxl:ProjElem ColId="36" Alias="xmin">
-                                              <dxl:Ident ColId="36" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                            </dxl:ProjElem>
-                                            <dxl:ProjElem ColId="37" Alias="cmin">
-                                              <dxl:Ident ColId="37" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                            </dxl:ProjElem>
-                                            <dxl:ProjElem ColId="38" Alias="xmax">
-                                              <dxl:Ident ColId="38" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                            </dxl:ProjElem>
-                                            <dxl:ProjElem ColId="39" Alias="cmax">
-                                              <dxl:Ident ColId="39" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                            </dxl:ProjElem>
-                                            <dxl:ProjElem ColId="40" Alias="tableoid">
-                                              <dxl:Ident ColId="40" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                            </dxl:ProjElem>
-                                            <dxl:ProjElem ColId="41" Alias="gp_segment_id">
-                                              <dxl:Ident ColId="41" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                            <dxl:ProjElem ColId="125" Alias="ColRef_0125">
+                                              <dxl:Ident ColId="125" ColName="ColRef_0125" TypeMdid="0.17.1.0"/>
                                             </dxl:ProjElem>
                                           </dxl:ProjList>
-                                        </dxl:CTEConsumer>
+                                          <dxl:Filter/>
+                                          <dxl:SortingColumnList/>
+                                          <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                                            <dxl:Properties>
+                                              <dxl:Cost StartupCost="0" TotalCost="431.000673" Rows="1.000000" Width="8"/>
+                                            </dxl:Properties>
+                                            <dxl:GroupingColumns/>
+                                            <dxl:ProjList>
+                                              <dxl:ProjElem ColId="125" Alias="ColRef_0125">
+                                                <dxl:AggFunc AggMdid="0.2107.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
+                                                  <dxl:ValuesList ParamType="aggargs">
+                                                    <dxl:Ident ColId="69" ColName="ColRef_0056" TypeMdid="0.20.1.0"/>
+                                                  </dxl:ValuesList>
+                                                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                                                  <dxl:ValuesList ParamType="aggorder"/>
+                                                  <dxl:ValuesList ParamType="aggdistinct"/>
+                                                </dxl:AggFunc>
+                                              </dxl:ProjElem>
+                                            </dxl:ProjList>
+                                            <dxl:Filter/>
+                                            <dxl:CTEConsumer CTEId="1" Columns="68,69">
+                                              <dxl:Properties>
+                                                <dxl:Cost StartupCost="0" TotalCost="431.000643" Rows="99.999999" Width="8"/>
+                                              </dxl:Properties>
+                                              <dxl:ProjList>
+                                                <dxl:ProjElem ColId="68" Alias="b">
+                                                  <dxl:Ident ColId="68" ColName="b" TypeMdid="0.23.1.0"/>
+                                                </dxl:ProjElem>
+                                                <dxl:ProjElem ColId="69" Alias="ColRef_0056">
+                                                  <dxl:Ident ColId="69" ColName="ColRef_0056" TypeMdid="0.20.1.0"/>
+                                                </dxl:ProjElem>
+                                              </dxl:ProjList>
+                                            </dxl:CTEConsumer>
+                                          </dxl:Aggregate>
+                                        </dxl:GatherMotion>
                                       </dxl:Aggregate>
-                                    </dxl:GatherMotion>
-                                  </dxl:Aggregate>
-                                </dxl:BroadcastMotion>
-                                <dxl:CTEConsumer CTEId="0" Columns="0,1,2,3,4,5,6,7,8,9">
-                                  <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="431.000321" Rows="100.000000" Width="4"/>
-                                  </dxl:Properties>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="0" Alias="a">
-                                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                                    </dxl:ProjElem>
-                                    <dxl:ProjElem ColId="1" Alias="b">
-                                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                                    </dxl:ProjElem>
-                                    <dxl:ProjElem ColId="2" Alias="c">
-                                      <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                                    </dxl:ProjElem>
-                                    <dxl:ProjElem ColId="3" Alias="ctid">
-                                      <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                    </dxl:ProjElem>
-                                    <dxl:ProjElem ColId="4" Alias="xmin">
-                                      <dxl:Ident ColId="4" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                    </dxl:ProjElem>
-                                    <dxl:ProjElem ColId="5" Alias="cmin">
-                                      <dxl:Ident ColId="5" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                    </dxl:ProjElem>
-                                    <dxl:ProjElem ColId="6" Alias="xmax">
-                                      <dxl:Ident ColId="6" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                    </dxl:ProjElem>
-                                    <dxl:ProjElem ColId="7" Alias="cmax">
-                                      <dxl:Ident ColId="7" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                    </dxl:ProjElem>
-                                    <dxl:ProjElem ColId="8" Alias="tableoid">
-                                      <dxl:Ident ColId="8" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                    </dxl:ProjElem>
-                                    <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                                      <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
-                                </dxl:CTEConsumer>
+                                    </dxl:BroadcastMotion>
+                                  </dxl:Result>
+                                </dxl:Materialize>
                               </dxl:NestedLoopJoin>
-                            </dxl:Sort>
-                          </dxl:GatherMotion>
-                          <dxl:LimitCount>
-                            <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
-                          </dxl:LimitCount>
-                          <dxl:LimitOffset>
-                            <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                          </dxl:LimitOffset>
-                        </dxl:Limit>
-                      </dxl:Aggregate>
-                    </dxl:Materialize>
-                  </dxl:NestedLoopJoin>
-                  <dxl:Materialize Eager="true">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324034.930349" Rows="1.000000" Width="24"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="12" Alias="percentile_cont">
-                        <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="15" Alias="percentile_cont">
-                        <dxl:Ident ColId="15" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="18" Alias="percentile_cont">
-                        <dxl:Ident ColId="18" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1324034.930325" Rows="1.000000" Width="24"/>
-                      </dxl:Properties>
-                      <dxl:GroupingColumns/>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="12" Alias="percentile_cont">
-                          <dxl:AggFunc AggMdid="0.327945.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                            <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
-                                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                              </dxl:Cast>
-                              <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA0D8=" DoubleValue="0.250000"/>
-                              <dxl:Ident ColId="44" ColName="ColRef_0044" TypeMdid="0.20.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                            </dxl:ValuesList>
-                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                            <dxl:ValuesList ParamType="aggorder"/>
-                            <dxl:ValuesList ParamType="aggdistinct"/>
-                          </dxl:AggFunc>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="15" Alias="percentile_cont">
-                          <dxl:AggFunc AggMdid="0.327945.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                            <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
-                                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                              </dxl:Cast>
-                              <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
-                              <dxl:Ident ColId="44" ColName="ColRef_0044" TypeMdid="0.20.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                            </dxl:ValuesList>
-                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                            <dxl:ValuesList ParamType="aggorder"/>
-                            <dxl:ValuesList ParamType="aggdistinct"/>
-                          </dxl:AggFunc>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="18" Alias="percentile_cont">
-                          <dxl:AggFunc AggMdid="0.327945.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                            <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
-                                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                              </dxl:Cast>
-                              <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA6D8=" DoubleValue="0.750000"/>
-                              <dxl:Ident ColId="44" ColName="ColRef_0044" TypeMdid="0.20.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                            </dxl:ValuesList>
-                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                            <dxl:ValuesList ParamType="aggorder"/>
-                            <dxl:ValuesList ParamType="aggdistinct"/>
-                          </dxl:AggFunc>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:Limit>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1324034.929519" Rows="100.000000" Width="12"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="2" Alias="c">
-                            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="44" Alias="ColRef_0044">
-                            <dxl:Ident ColId="44" ColName="ColRef_0044" TypeMdid="0.20.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                            </dxl:GatherMotion>
+                            <dxl:LimitCount>
+                              <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
+                            </dxl:LimitCount>
+                            <dxl:LimitOffset>
+                              <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                            </dxl:LimitOffset>
+                          </dxl:Limit>
+                        </dxl:Aggregate>
+                        <dxl:Materialize Eager="true">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1324034.928319" Rows="100.000000" Width="12"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1324037.574315" Rows="1.000000" Width="24"/>
                           </dxl:Properties>
                           <dxl:ProjList>
-                            <dxl:ProjElem ColId="2" Alias="c">
-                              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                            <dxl:ProjElem ColId="10" Alias="percentile_cont">
+                              <dxl:Ident ColId="10" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
                             </dxl:ProjElem>
-                            <dxl:ProjElem ColId="44" Alias="ColRef_0044">
-                              <dxl:Ident ColId="44" ColName="ColRef_0044" TypeMdid="0.20.1.0"/>
+                            <dxl:ProjElem ColId="13" Alias="percentile_cont">
+                              <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="16" Alias="percentile_cont">
+                              <dxl:Ident ColId="16" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:SortingColumnList>
-                            <dxl:SortingColumn ColId="2" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                          </dxl:SortingColumnList>
-                          <dxl:Sort SortDiscardDuplicates="false">
+                          <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1324034.923847" Rows="100.000000" Width="12"/>
+                              <dxl:Cost StartupCost="0" TotalCost="1324037.574291" Rows="1.000000" Width="24"/>
                             </dxl:Properties>
+                            <dxl:GroupingColumns/>
                             <dxl:ProjList>
-                              <dxl:ProjElem ColId="2" Alias="c">
-                                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                              <dxl:ProjElem ColId="10" Alias="percentile_cont">
+                                <dxl:AggFunc AggMdid="0.131996.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                                  <dxl:ValuesList ParamType="aggargs">
+                                    <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                                    </dxl:Cast>
+                                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA0D8=" DoubleValue="0.250000"/>
+                                    <dxl:Ident ColId="55" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
+                                    <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
+                                  </dxl:ValuesList>
+                                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                                  <dxl:ValuesList ParamType="aggorder"/>
+                                  <dxl:ValuesList ParamType="aggdistinct"/>
+                                </dxl:AggFunc>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="44" Alias="ColRef_0044">
-                                <dxl:Ident ColId="44" ColName="ColRef_0044" TypeMdid="0.20.1.0"/>
+                              <dxl:ProjElem ColId="13" Alias="percentile_cont">
+                                <dxl:AggFunc AggMdid="0.131996.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                                  <dxl:ValuesList ParamType="aggargs">
+                                    <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                                    </dxl:Cast>
+                                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+                                    <dxl:Ident ColId="55" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
+                                    <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
+                                  </dxl:ValuesList>
+                                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                                  <dxl:ValuesList ParamType="aggorder"/>
+                                  <dxl:ValuesList ParamType="aggdistinct"/>
+                                </dxl:AggFunc>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="16" Alias="percentile_cont">
+                                <dxl:AggFunc AggMdid="0.131996.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                                  <dxl:ValuesList ParamType="aggargs">
+                                    <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                                    </dxl:Cast>
+                                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA6D8=" DoubleValue="0.750000"/>
+                                    <dxl:Ident ColId="55" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
+                                    <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
+                                  </dxl:ValuesList>
+                                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                                  <dxl:ValuesList ParamType="aggorder"/>
+                                  <dxl:ValuesList ParamType="aggdistinct"/>
+                                </dxl:AggFunc>
                               </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:Filter/>
-                            <dxl:SortingColumnList>
-                              <dxl:SortingColumn ColId="2" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                            </dxl:SortingColumnList>
-                            <dxl:LimitCount/>
-                            <dxl:LimitOffset/>
-                            <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                            <dxl:Limit>
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="1324034.912373" Rows="100.000000" Width="12"/>
+                                <dxl:Cost StartupCost="0" TotalCost="1324037.572275" Rows="99.999999" Width="20"/>
                               </dxl:Properties>
                               <dxl:ProjList>
-                                <dxl:ProjElem ColId="2" Alias="c">
-                                  <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                                <dxl:ProjElem ColId="0" Alias="a">
+                                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                                 </dxl:ProjElem>
-                                <dxl:ProjElem ColId="44" Alias="ColRef_0044">
-                                  <dxl:Ident ColId="44" ColName="ColRef_0044" TypeMdid="0.20.1.0"/>
+                                <dxl:ProjElem ColId="22" Alias="ColRef_0022">
+                                  <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="55" Alias="ColRef_0055">
+                                  <dxl:Ident ColId="55" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
                                 </dxl:ProjElem>
                               </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:JoinFilter>
-                                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                              </dxl:JoinFilter>
-                              <dxl:BroadcastMotion InputSegments="0" OutputSegments="0,1,2">
+                              <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000797" Rows="3.000000" Width="8"/>
-                                </dxl:Properties>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="44" Alias="ColRef_0044">
-                                    <dxl:Ident ColId="44" ColName="ColRef_0044" TypeMdid="0.20.1.0"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                                <dxl:Filter/>
-                                <dxl:SortingColumnList/>
-                                <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-                                  <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="431.000367" Rows="1.000000" Width="8"/>
-                                  </dxl:Properties>
-                                  <dxl:GroupingColumns/>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="44" Alias="ColRef_0044">
-                                      <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
-                                        <dxl:ValuesList ParamType="aggargs">
-                                          <dxl:Ident ColId="45" ColName="ColRef_0045" TypeMdid="0.20.1.0"/>
-                                        </dxl:ValuesList>
-                                        <dxl:ValuesList ParamType="aggdirectargs"/>
-                                        <dxl:ValuesList ParamType="aggorder"/>
-                                        <dxl:ValuesList ParamType="aggdistinct"/>
-                                      </dxl:AggFunc>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
-                                  <dxl:Filter/>
-                                  <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
-                                    <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="431.000366" Rows="1.000000" Width="8"/>
-                                    </dxl:Properties>
-                                    <dxl:ProjList>
-                                      <dxl:ProjElem ColId="45" Alias="ColRef_0045">
-                                        <dxl:Ident ColId="45" ColName="ColRef_0045" TypeMdid="0.20.1.0"/>
-                                      </dxl:ProjElem>
-                                    </dxl:ProjList>
-                                    <dxl:Filter/>
-                                    <dxl:SortingColumnList/>
-                                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-                                      <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="431.000336" Rows="1.000000" Width="8"/>
-                                      </dxl:Properties>
-                                      <dxl:GroupingColumns/>
-                                      <dxl:ProjList>
-                                        <dxl:ProjElem ColId="45" Alias="ColRef_0045">
-                                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
-                                            <dxl:ValuesList ParamType="aggargs">
-                                              <dxl:Ident ColId="34" ColName="c" TypeMdid="0.23.1.0"/>
-                                            </dxl:ValuesList>
-                                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                                            <dxl:ValuesList ParamType="aggorder"/>
-                                            <dxl:ValuesList ParamType="aggdistinct"/>
-                                          </dxl:AggFunc>
-                                        </dxl:ProjElem>
-                                      </dxl:ProjList>
-                                      <dxl:Filter/>
-                                      <dxl:CTEConsumer CTEId="0" Columns="32,33,34,35,36,37,38,39,40,41">
-                                        <dxl:Properties>
-                                          <dxl:Cost StartupCost="0" TotalCost="431.000321" Rows="100.000000" Width="4"/>
-                                        </dxl:Properties>
-                                        <dxl:ProjList>
-                                          <dxl:ProjElem ColId="32" Alias="a">
-                                            <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>
-                                          </dxl:ProjElem>
-                                          <dxl:ProjElem ColId="33" Alias="b">
-                                            <dxl:Ident ColId="33" ColName="b" TypeMdid="0.23.1.0"/>
-                                          </dxl:ProjElem>
-                                          <dxl:ProjElem ColId="34" Alias="c">
-                                            <dxl:Ident ColId="34" ColName="c" TypeMdid="0.23.1.0"/>
-                                          </dxl:ProjElem>
-                                          <dxl:ProjElem ColId="35" Alias="ctid">
-                                            <dxl:Ident ColId="35" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                          </dxl:ProjElem>
-                                          <dxl:ProjElem ColId="36" Alias="xmin">
-                                            <dxl:Ident ColId="36" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                          </dxl:ProjElem>
-                                          <dxl:ProjElem ColId="37" Alias="cmin">
-                                            <dxl:Ident ColId="37" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                          </dxl:ProjElem>
-                                          <dxl:ProjElem ColId="38" Alias="xmax">
-                                            <dxl:Ident ColId="38" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                          </dxl:ProjElem>
-                                          <dxl:ProjElem ColId="39" Alias="cmax">
-                                            <dxl:Ident ColId="39" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                          </dxl:ProjElem>
-                                          <dxl:ProjElem ColId="40" Alias="tableoid">
-                                            <dxl:Ident ColId="40" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                          </dxl:ProjElem>
-                                          <dxl:ProjElem ColId="41" Alias="gp_segment_id">
-                                            <dxl:Ident ColId="41" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                          </dxl:ProjElem>
-                                        </dxl:ProjList>
-                                      </dxl:CTEConsumer>
-                                    </dxl:Aggregate>
-                                  </dxl:GatherMotion>
-                                </dxl:Aggregate>
-                              </dxl:BroadcastMotion>
-                              <dxl:CTEConsumer CTEId="0" Columns="0,1,2,3,4,5,6,7,8,9">
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000321" Rows="100.000000" Width="4"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="1324037.570275" Rows="99.999999" Width="20"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="0" Alias="a">
                                     <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                                   </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="1" Alias="b">
-                                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                                  <dxl:ProjElem ColId="22" Alias="ColRef_0022">
+                                    <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
                                   </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="55" Alias="ColRef_0055">
+                                    <dxl:Ident ColId="55" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:SortingColumnList>
+                                  <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                </dxl:SortingColumnList>
+                                <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="1324037.562821" Rows="99.999999" Width="20"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="0" Alias="a">
+                                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="22" Alias="ColRef_0022">
+                                      <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="55" Alias="ColRef_0055">
+                                      <dxl:Ident ColId="55" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:JoinFilter>
+                                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                  </dxl:JoinFilter>
+                                  <dxl:CTEConsumer CTEId="0" Columns="0,22">
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.000964" Rows="99.999999" Width="12"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="0" Alias="a">
+                                        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="22" Alias="ColRef_0022">
+                                        <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                  </dxl:CTEConsumer>
+                                  <dxl:Materialize Eager="false">
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.001249" Rows="3.000000" Width="8"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="55" Alias="ColRef_0055">
+                                        <dxl:Ident ColId="55" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:BroadcastMotion InputSegments="0" OutputSegments="0,1,2">
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="431.001241" Rows="3.000000" Width="8"/>
+                                      </dxl:Properties>
+                                      <dxl:ProjList>
+                                        <dxl:ProjElem ColId="55" Alias="ColRef_0055">
+                                          <dxl:Ident ColId="55" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
+                                        </dxl:ProjElem>
+                                      </dxl:ProjList>
+                                      <dxl:Filter/>
+                                      <dxl:SortingColumnList/>
+                                      <dxl:Result>
+                                        <dxl:Properties>
+                                          <dxl:Cost StartupCost="0" TotalCost="431.000811" Rows="1.000000" Width="8"/>
+                                        </dxl:Properties>
+                                        <dxl:ProjList>
+                                          <dxl:ProjElem ColId="55" Alias="ColRef_0055">
+                                            <dxl:FuncExpr FuncId="0.1779.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
+                                              <dxl:Ident ColId="54" ColName="ColRef_0054" TypeMdid="0.1700.1.0"/>
+                                            </dxl:FuncExpr>
+                                          </dxl:ProjElem>
+                                        </dxl:ProjList>
+                                        <dxl:Filter/>
+                                        <dxl:OneTimeFilter/>
+                                        <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                                          <dxl:Properties>
+                                            <dxl:Cost StartupCost="0" TotalCost="431.000703" Rows="1.000000" Width="8"/>
+                                          </dxl:Properties>
+                                          <dxl:GroupingColumns/>
+                                          <dxl:ProjList>
+                                            <dxl:ProjElem ColId="54" Alias="ColRef_0054">
+                                              <dxl:AggFunc AggMdid="0.2107.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
+                                                <dxl:ValuesList ParamType="aggargs">
+                                                  <dxl:Ident ColId="126" ColName="ColRef_0126" TypeMdid="0.17.1.0"/>
+                                                </dxl:ValuesList>
+                                                <dxl:ValuesList ParamType="aggdirectargs"/>
+                                                <dxl:ValuesList ParamType="aggorder"/>
+                                                <dxl:ValuesList ParamType="aggdistinct"/>
+                                              </dxl:AggFunc>
+                                            </dxl:ProjElem>
+                                          </dxl:ProjList>
+                                          <dxl:Filter/>
+                                          <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                                            <dxl:Properties>
+                                              <dxl:Cost StartupCost="0" TotalCost="431.000702" Rows="1.000000" Width="8"/>
+                                            </dxl:Properties>
+                                            <dxl:ProjList>
+                                              <dxl:ProjElem ColId="126" Alias="ColRef_0126">
+                                                <dxl:Ident ColId="126" ColName="ColRef_0126" TypeMdid="0.17.1.0"/>
+                                              </dxl:ProjElem>
+                                            </dxl:ProjList>
+                                            <dxl:Filter/>
+                                            <dxl:SortingColumnList/>
+                                            <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                                              <dxl:Properties>
+                                                <dxl:Cost StartupCost="0" TotalCost="431.000673" Rows="1.000000" Width="8"/>
+                                              </dxl:Properties>
+                                              <dxl:GroupingColumns/>
+                                              <dxl:ProjList>
+                                                <dxl:ProjElem ColId="126" Alias="ColRef_0126">
+                                                  <dxl:AggFunc AggMdid="0.2107.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
+                                                    <dxl:ValuesList ParamType="aggargs">
+                                                      <dxl:Ident ColId="35" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
+                                                    </dxl:ValuesList>
+                                                    <dxl:ValuesList ParamType="aggdirectargs"/>
+                                                    <dxl:ValuesList ParamType="aggorder"/>
+                                                    <dxl:ValuesList ParamType="aggdistinct"/>
+                                                  </dxl:AggFunc>
+                                                </dxl:ProjElem>
+                                              </dxl:ProjList>
+                                              <dxl:Filter/>
+                                              <dxl:CTEConsumer CTEId="0" Columns="34,35">
+                                                <dxl:Properties>
+                                                  <dxl:Cost StartupCost="0" TotalCost="431.000643" Rows="99.999999" Width="8"/>
+                                                </dxl:Properties>
+                                                <dxl:ProjList>
+                                                  <dxl:ProjElem ColId="34" Alias="a">
+                                                    <dxl:Ident ColId="34" ColName="a" TypeMdid="0.23.1.0"/>
+                                                  </dxl:ProjElem>
+                                                  <dxl:ProjElem ColId="35" Alias="ColRef_0022">
+                                                    <dxl:Ident ColId="35" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
+                                                  </dxl:ProjElem>
+                                                </dxl:ProjList>
+                                              </dxl:CTEConsumer>
+                                            </dxl:Aggregate>
+                                          </dxl:GatherMotion>
+                                        </dxl:Aggregate>
+                                      </dxl:Result>
+                                    </dxl:BroadcastMotion>
+                                  </dxl:Materialize>
+                                </dxl:NestedLoopJoin>
+                              </dxl:GatherMotion>
+                              <dxl:LimitCount>
+                                <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
+                              </dxl:LimitCount>
+                              <dxl:LimitOffset>
+                                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                              </dxl:LimitOffset>
+                            </dxl:Limit>
+                          </dxl:Aggregate>
+                        </dxl:Materialize>
+                      </dxl:NestedLoopJoin>
+                      <dxl:Materialize Eager="true">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="1324037.574315" Rows="1.000000" Width="24"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="12" Alias="percentile_cont">
+                            <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="15" Alias="percentile_cont">
+                            <dxl:Ident ColId="15" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="18" Alias="percentile_cont">
+                            <dxl:Ident ColId="18" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="1324037.574291" Rows="1.000000" Width="24"/>
+                          </dxl:Properties>
+                          <dxl:GroupingColumns/>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="12" Alias="percentile_cont">
+                              <dxl:AggFunc AggMdid="0.131996.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                                <dxl:ValuesList ParamType="aggargs">
+                                  <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                                    <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                                  </dxl:Cast>
+                                  <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA0D8=" DoubleValue="0.250000"/>
+                                  <dxl:Ident ColId="123" ColName="ColRef_0123" TypeMdid="0.20.1.0"/>
+                                  <dxl:Ident ColId="90" ColName="ColRef_0090" TypeMdid="0.20.1.0"/>
+                                </dxl:ValuesList>
+                                <dxl:ValuesList ParamType="aggdirectargs"/>
+                                <dxl:ValuesList ParamType="aggorder"/>
+                                <dxl:ValuesList ParamType="aggdistinct"/>
+                              </dxl:AggFunc>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="15" Alias="percentile_cont">
+                              <dxl:AggFunc AggMdid="0.131996.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                                <dxl:ValuesList ParamType="aggargs">
+                                  <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                                    <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                                  </dxl:Cast>
+                                  <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+                                  <dxl:Ident ColId="123" ColName="ColRef_0123" TypeMdid="0.20.1.0"/>
+                                  <dxl:Ident ColId="90" ColName="ColRef_0090" TypeMdid="0.20.1.0"/>
+                                </dxl:ValuesList>
+                                <dxl:ValuesList ParamType="aggdirectargs"/>
+                                <dxl:ValuesList ParamType="aggorder"/>
+                                <dxl:ValuesList ParamType="aggdistinct"/>
+                              </dxl:AggFunc>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="18" Alias="percentile_cont">
+                              <dxl:AggFunc AggMdid="0.131996.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                                <dxl:ValuesList ParamType="aggargs">
+                                  <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                                    <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                                  </dxl:Cast>
+                                  <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA6D8=" DoubleValue="0.750000"/>
+                                  <dxl:Ident ColId="123" ColName="ColRef_0123" TypeMdid="0.20.1.0"/>
+                                  <dxl:Ident ColId="90" ColName="ColRef_0090" TypeMdid="0.20.1.0"/>
+                                </dxl:ValuesList>
+                                <dxl:ValuesList ParamType="aggdirectargs"/>
+                                <dxl:ValuesList ParamType="aggorder"/>
+                                <dxl:ValuesList ParamType="aggdistinct"/>
+                              </dxl:AggFunc>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:Limit>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="1324037.572275" Rows="99.999999" Width="20"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="2" Alias="c">
+                                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="90" Alias="ColRef_0090">
+                                <dxl:Ident ColId="90" ColName="ColRef_0090" TypeMdid="0.20.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="123" Alias="ColRef_0123">
+                                <dxl:Ident ColId="123" ColName="ColRef_0123" TypeMdid="0.20.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="1324037.570275" Rows="99.999999" Width="20"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="2" Alias="c">
+                                  <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="90" Alias="ColRef_0090">
+                                  <dxl:Ident ColId="90" ColName="ColRef_0090" TypeMdid="0.20.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="123" Alias="ColRef_0123">
+                                  <dxl:Ident ColId="123" ColName="ColRef_0123" TypeMdid="0.20.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:SortingColumnList>
+                                <dxl:SortingColumn ColId="2" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                              </dxl:SortingColumnList>
+                              <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="1324037.562821" Rows="99.999999" Width="20"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
                                   <dxl:ProjElem ColId="2" Alias="c">
                                     <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
                                   </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="3" Alias="ctid">
-                                    <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  <dxl:ProjElem ColId="90" Alias="ColRef_0090">
+                                    <dxl:Ident ColId="90" ColName="ColRef_0090" TypeMdid="0.20.1.0"/>
                                   </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="4" Alias="xmin">
-                                    <dxl:Ident ColId="4" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="5" Alias="cmin">
-                                    <dxl:Ident ColId="5" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="6" Alias="xmax">
-                                    <dxl:Ident ColId="6" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="7" Alias="cmax">
-                                    <dxl:Ident ColId="7" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="8" Alias="tableoid">
-                                    <dxl:Ident ColId="8" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                                    <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                  <dxl:ProjElem ColId="123" Alias="ColRef_0123">
+                                    <dxl:Ident ColId="123" ColName="ColRef_0123" TypeMdid="0.20.1.0"/>
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
-                              </dxl:CTEConsumer>
-                            </dxl:NestedLoopJoin>
-                          </dxl:Sort>
-                        </dxl:GatherMotion>
-                        <dxl:LimitCount>
-                          <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
-                        </dxl:LimitCount>
-                        <dxl:LimitOffset>
-                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                        </dxl:LimitOffset>
-                      </dxl:Limit>
-                    </dxl:Aggregate>
-                  </dxl:Materialize>
-                </dxl:NestedLoopJoin>
-              </dxl:RandomMotion>
+                                <dxl:Filter/>
+                                <dxl:JoinFilter>
+                                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                </dxl:JoinFilter>
+                                <dxl:CTEConsumer CTEId="2" Columns="2,90">
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000964" Rows="99.999999" Width="12"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="2" Alias="c">
+                                      <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="90" Alias="ColRef_0090">
+                                      <dxl:Ident ColId="90" ColName="ColRef_0090" TypeMdid="0.20.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                </dxl:CTEConsumer>
+                                <dxl:Materialize Eager="false">
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.001249" Rows="3.000000" Width="8"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="123" Alias="ColRef_0123">
+                                      <dxl:Ident ColId="123" ColName="ColRef_0123" TypeMdid="0.20.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:BroadcastMotion InputSegments="0" OutputSegments="0,1,2">
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.001241" Rows="3.000000" Width="8"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="123" Alias="ColRef_0123">
+                                        <dxl:Ident ColId="123" ColName="ColRef_0123" TypeMdid="0.20.1.0"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:SortingColumnList/>
+                                    <dxl:Result>
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="431.000811" Rows="1.000000" Width="8"/>
+                                      </dxl:Properties>
+                                      <dxl:ProjList>
+                                        <dxl:ProjElem ColId="123" Alias="ColRef_0123">
+                                          <dxl:FuncExpr FuncId="0.1779.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
+                                            <dxl:Ident ColId="122" ColName="ColRef_0122" TypeMdid="0.1700.1.0"/>
+                                          </dxl:FuncExpr>
+                                        </dxl:ProjElem>
+                                      </dxl:ProjList>
+                                      <dxl:Filter/>
+                                      <dxl:OneTimeFilter/>
+                                      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                                        <dxl:Properties>
+                                          <dxl:Cost StartupCost="0" TotalCost="431.000703" Rows="1.000000" Width="8"/>
+                                        </dxl:Properties>
+                                        <dxl:GroupingColumns/>
+                                        <dxl:ProjList>
+                                          <dxl:ProjElem ColId="122" Alias="ColRef_0122">
+                                            <dxl:AggFunc AggMdid="0.2107.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
+                                              <dxl:ValuesList ParamType="aggargs">
+                                                <dxl:Ident ColId="124" ColName="ColRef_0124" TypeMdid="0.17.1.0"/>
+                                              </dxl:ValuesList>
+                                              <dxl:ValuesList ParamType="aggdirectargs"/>
+                                              <dxl:ValuesList ParamType="aggorder"/>
+                                              <dxl:ValuesList ParamType="aggdistinct"/>
+                                            </dxl:AggFunc>
+                                          </dxl:ProjElem>
+                                        </dxl:ProjList>
+                                        <dxl:Filter/>
+                                        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                                          <dxl:Properties>
+                                            <dxl:Cost StartupCost="0" TotalCost="431.000702" Rows="1.000000" Width="8"/>
+                                          </dxl:Properties>
+                                          <dxl:ProjList>
+                                            <dxl:ProjElem ColId="124" Alias="ColRef_0124">
+                                              <dxl:Ident ColId="124" ColName="ColRef_0124" TypeMdid="0.17.1.0"/>
+                                            </dxl:ProjElem>
+                                          </dxl:ProjList>
+                                          <dxl:Filter/>
+                                          <dxl:SortingColumnList/>
+                                          <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                                            <dxl:Properties>
+                                              <dxl:Cost StartupCost="0" TotalCost="431.000673" Rows="1.000000" Width="8"/>
+                                            </dxl:Properties>
+                                            <dxl:GroupingColumns/>
+                                            <dxl:ProjList>
+                                              <dxl:ProjElem ColId="124" Alias="ColRef_0124">
+                                                <dxl:AggFunc AggMdid="0.2107.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
+                                                  <dxl:ValuesList ParamType="aggargs">
+                                                    <dxl:Ident ColId="103" ColName="ColRef_0090" TypeMdid="0.20.1.0"/>
+                                                  </dxl:ValuesList>
+                                                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                                                  <dxl:ValuesList ParamType="aggorder"/>
+                                                  <dxl:ValuesList ParamType="aggdistinct"/>
+                                                </dxl:AggFunc>
+                                              </dxl:ProjElem>
+                                            </dxl:ProjList>
+                                            <dxl:Filter/>
+                                            <dxl:CTEConsumer CTEId="2" Columns="102,103">
+                                              <dxl:Properties>
+                                                <dxl:Cost StartupCost="0" TotalCost="431.000643" Rows="99.999999" Width="8"/>
+                                              </dxl:Properties>
+                                              <dxl:ProjList>
+                                                <dxl:ProjElem ColId="102" Alias="c">
+                                                  <dxl:Ident ColId="102" ColName="c" TypeMdid="0.23.1.0"/>
+                                                </dxl:ProjElem>
+                                                <dxl:ProjElem ColId="103" Alias="ColRef_0090">
+                                                  <dxl:Ident ColId="103" ColName="ColRef_0090" TypeMdid="0.20.1.0"/>
+                                                </dxl:ProjElem>
+                                              </dxl:ProjList>
+                                            </dxl:CTEConsumer>
+                                          </dxl:Aggregate>
+                                        </dxl:GatherMotion>
+                                      </dxl:Aggregate>
+                                    </dxl:Result>
+                                  </dxl:BroadcastMotion>
+                                </dxl:Materialize>
+                              </dxl:NestedLoopJoin>
+                            </dxl:GatherMotion>
+                            <dxl:LimitCount>
+                              <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
+                            </dxl:LimitCount>
+                            <dxl:LimitOffset>
+                              <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                            </dxl:LimitOffset>
+                          </dxl:Limit>
+                        </dxl:Aggregate>
+                      </dxl:Materialize>
+                    </dxl:NestedLoopJoin>
+                  </dxl:RandomMotion>
+                </dxl:Sequence>
+              </dxl:Sequence>
             </dxl:Sequence>
           </dxl:Result>
         </dxl:Result>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_diffcol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_diffcol.mdp
@@ -11,34 +11,52 @@ CREATE TABLE foo(a1 int, a2 double precision, a3 interval, a4 timestamp, a5 time
 EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_cont(0.5) WITHIN GROUP(ORDER BY a2) FROM foo;
 
                                                    QUERY PLAN
- Sequence  (cost=0.00..2712059529.06 rows=1 width=16)
+ Sequence  (cost=0.00..2712060318.28 rows=1 width=16)
    ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=1)
          ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
-               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=42)
-                     ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=42)
-   ->  Nested Loop  (cost=0.00..2712059098.06 rows=1 width=16)
-         Join Filter: true
-         ->  Aggregate  (cost=0.00..1324032.08 rows=1 width=8)
-               ->  Limit  (cost=0.00..1324032.08 rows=1 width=12)
-                     ->  Sort  (cost=0.00..1324032.08 rows=1 width=12)
-                           Sort Key: share0_ref4.a1
-                           ->  Nested Loop  (cost=0.00..1324032.08 rows=1 width=12)
-                                 Join Filter: true
-                                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                       ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=4)
-                                 ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
-                                       ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=4)
-         ->  Aggregate  (cost=0.00..1324032.13 rows=1 width=8)
-               ->  Limit  (cost=0.00..1324032.13 rows=1 width=16)
-                     ->  Sort  (cost=0.00..1324032.13 rows=1 width=16)
-                           Sort Key: share0_ref3.a2
-                           ->  Nested Loop  (cost=0.00..1324032.13 rows=1 width=16)
-                                 Join Filter: true
-                                 ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
-                                 ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
-                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                             ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                           Group Key: foo_1.a1
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                                 Sort Key: foo_1.a1
+                                 ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=4)
+   ->  Sequence  (cost=0.00..2712059887.28 rows=1 width=16)
+         ->  Shared Scan (share slice:id 0:1)  (cost=0.00..431.00 rows=1 width=1)
+               ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+                     ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
+                                 Group Key: foo.a2
+                                 ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                                       Sort Key: foo.a2
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                             Hash Key: foo.a2
+                                             ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+         ->  Nested Loop  (cost=0.00..2712059456.28 rows=1 width=16)
+               Join Filter: true
+               ->  Aggregate  (cost=0.00..1324032.27 rows=1 width=8)
+                     ->  Limit  (cost=0.00..1324032.27 rows=1 width=20)
+                           ->  Sort  (cost=0.00..1324032.27 rows=1 width=20)
+                                 Sort Key: share0_ref3.a1
+                                 ->  Nested Loop  (cost=0.00..1324032.27 rows=1 width=20)
+                                       Join Filter: true
+                                       ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=12)
+                                       ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+               ->  Aggregate  (cost=0.00..1324032.29 rows=1 width=8)
+                     ->  Limit  (cost=0.00..1324032.29 rows=1 width=24)
+                           ->  Sort  (cost=0.00..1324032.29 rows=1 width=24)
+                                 Sort Key: share1_ref3.a2
+                                 ->  Nested Loop  (cost=0.00..1324032.29 rows=1 width=24)
+                                       Join Filter: true
+                                       ->  Shared Scan (share slice:id 0:1)  (cost=0.00..431.00 rows=1 width=16)
+                                       ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Shared Scan (share slice:id 0:1)  (cost=0.00..431.00 rows=1 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
+(45 rows)
 -->
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
@@ -60,6 +78,25 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_cont(0
         <dxl:ResultType Mdid="0.701.1.0"/>
         <dxl:IntermediateResultType Mdid="0.17.1.0"/>
       </dxl:GPDBAgg>
+      <dxl:ColumnStatistics Mdid="1.132004.1.0.1" Name="a2" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.132004.1.0.0" Name="a1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.17.1.0" Name="bytea" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2223.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7107.1.0"/>
+        <dxl:EqualityOp Mdid="0.1955.1.0"/>
+        <dxl:InequalityOp Mdid="0.1956.1.0"/>
+        <dxl:LessThanOp Mdid="0.1957.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1958.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1959.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1960.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1954.1.0"/>
+        <dxl:ArrayType Mdid="0.1001.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
@@ -145,6 +182,10 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_cont(0
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.131996.1.0" Name="gp_percentile_cont" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBAgg>
       <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
         <dxl:EqualityOp Mdid="0.385.1.0"/>
@@ -223,34 +264,25 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_cont(0
         <dxl:SumAgg Mdid="0.2113.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:ColumnStatistics Mdid="1.164182.1.0.1" Name="a2" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.164182.1.0.0" Name="a1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:GPDBFunc Mdid="0.316.1.0" Name="float8" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
-        <dxl:ResultType Mdid="0.701.1.0"/>
-      </dxl:GPDBFunc>
-      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
-        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
-        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
-        <dxl:EqualityOp Mdid="0.670.1.0"/>
-        <dxl:InequalityOp Mdid="0.671.1.0"/>
-        <dxl:LessThanOp Mdid="0.672.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
-        <dxl:ComparisonOp Mdid="0.355.1.0"/>
-        <dxl:ArrayType Mdid="0.1022.1.0"/>
-        <dxl:MinAgg Mdid="0.2136.1.0"/>
-        <dxl:MaxAgg Mdid="0.2120.1.0"/>
-        <dxl:AvgAgg Mdid="0.2105.1.0"/>
-        <dxl:SumAgg Mdid="0.2111.1.0"/>
+      <dxl:Type Mdid="0.1700.1.0" Name="numeric" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1998.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7103.1.0"/>
+        <dxl:EqualityOp Mdid="0.1752.1.0"/>
+        <dxl:InequalityOp Mdid="0.1753.1.0"/>
+        <dxl:LessThanOp Mdid="0.1754.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1755.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1756.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1757.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1769.1.0"/>
+        <dxl:ArrayType Mdid="0.1231.1.0"/>
+        <dxl:MinAgg Mdid="0.2146.1.0"/>
+        <dxl:MaxAgg Mdid="0.2130.1.0"/>
+        <dxl:AvgAgg Mdid="0.2103.1.0"/>
+        <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:GPDBAgg Mdid="0.164162.1.0" Name="gp_percentile_cont" IsSplittable="false" HashAggCapable="false">
-        <dxl:ResultType Mdid="0.701.1.0"/>
-        <dxl:IntermediateResultType Mdid="0.701.1.0"/>
-      </dxl:GPDBAgg>
-      <dxl:RelationStatistics Mdid="2.164182.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
-      <dxl:Relation Mdid="0.164182.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="11,5" NumberLeafPartitions="0">
+      <dxl:RelationStatistics Mdid="2.132004.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.132004.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="11,5" NumberLeafPartitions="0">
         <dxl:Columns>
           <dxl:Column Name="a1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
@@ -296,6 +328,30 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_cont(0
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
+      <dxl:GPDBAgg Mdid="0.2107.1.0" Name="sum" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.1700.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.17.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:GPDBFunc Mdid="0.316.1.0" Name="float8" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
+        <dxl:EqualityOp Mdid="0.670.1.0"/>
+        <dxl:InequalityOp Mdid="0.671.1.0"/>
+        <dxl:LessThanOp Mdid="0.672.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
+        <dxl:ComparisonOp Mdid="0.355.1.0"/>
+        <dxl:ArrayType Mdid="0.1022.1.0"/>
+        <dxl:MinAgg Mdid="0.2136.1.0"/>
+        <dxl:MaxAgg Mdid="0.2120.1.0"/>
+        <dxl:AvgAgg Mdid="0.2105.1.0"/>
+        <dxl:SumAgg Mdid="0.2111.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
       <dxl:Type Mdid="0.1114.1.0" Name="timestamp" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2040.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7111.1.0"/>
@@ -329,6 +385,9 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_cont(0
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
+      <dxl:GPDBFunc Mdid="0.1779.1.0" Name="int8" ReturnsSet="false" Stability="Immutable" DataAccess="ContainsSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBFunc>
       <dxl:MDCast Mdid="3.23.1.0;701.1.0" Name="float8" BinaryCoercible="false" SourceTypeId="0.23.1.0" DestinationTypeId="0.701.1.0" CastFuncId="0.316.1.0" CoercePathType="1"/>
     </dxl:Metadata>
     <dxl:Query>
@@ -341,7 +400,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_cont(0
         <dxl:GroupingColumns/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="13" Alias="percentile_cont">
-            <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.164162.1.0">
+            <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.131996.1.0">
               <dxl:ValuesList ParamType="aggargs">
                 <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
                   <dxl:Ident ColId="1" ColName="a1" TypeMdid="0.23.1.0"/>
@@ -357,7 +416,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_cont(0
             </dxl:AggFunc>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="14" Alias="percentile_cont">
-            <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.164162.1.0">
+            <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.131996.1.0">
               <dxl:ValuesList ParamType="aggargs">
                 <dxl:Ident ColId="2" ColName="a2" TypeMdid="0.701.1.0"/>
               </dxl:ValuesList>
@@ -372,7 +431,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_cont(0
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
+          <dxl:TableDescriptor Mdid="0.132004.1.0" TableName="foo">
             <dxl:Columns>
               <dxl:Column ColId="1" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="2" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
@@ -391,10 +450,10 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_cont(0
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="244">
+    <dxl:Plan Id="0" SpaceSize="39440">
       <dxl:Sequence>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2712059529.061808" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="2712060318.276298" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="12" Alias="percentile_cont">
@@ -404,130 +463,104 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_cont(0
             <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
-        <dxl:CTEProducer CTEId="0" Columns="14,15,16,17,18,19,20,21,22">
+        <dxl:CTEProducer CTEId="0" Columns="15,16">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000197" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000100" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="14" Alias="a1">
-              <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="15" Alias="a1">
+              <dxl:Ident ColId="15" ColName="a1" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="15" Alias="a2">
-              <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="16" Alias="ctid">
-              <dxl:Ident ColId="16" ColName="ctid" TypeMdid="0.27.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="17" Alias="xmin">
-              <dxl:Ident ColId="17" ColName="xmin" TypeMdid="0.28.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="18" Alias="cmin">
-              <dxl:Ident ColId="18" ColName="cmin" TypeMdid="0.29.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="19" Alias="xmax">
-              <dxl:Ident ColId="19" ColName="xmax" TypeMdid="0.28.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="20" Alias="cmax">
-              <dxl:Ident ColId="20" ColName="cmax" TypeMdid="0.29.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="21" Alias="tableoid">
-              <dxl:Ident ColId="21" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="22" Alias="gp_segment_id">
-              <dxl:Ident ColId="22" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="16" Alias="ColRef_0014">
+              <dxl:Ident ColId="16" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000196" Rows="1.000000" Width="42"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000099" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="14" Alias="a1">
-                <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="15" Alias="a1">
+                <dxl:Ident ColId="15" ColName="a1" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="15" Alias="a2">
-                <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="16" Alias="ctid">
-                <dxl:Ident ColId="16" ColName="ctid" TypeMdid="0.27.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="17" Alias="xmin">
-                <dxl:Ident ColId="17" ColName="xmin" TypeMdid="0.28.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="18" Alias="cmin">
-                <dxl:Ident ColId="18" ColName="cmin" TypeMdid="0.29.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="19" Alias="xmax">
-                <dxl:Ident ColId="19" ColName="xmax" TypeMdid="0.28.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="20" Alias="cmax">
-                <dxl:Ident ColId="20" ColName="cmax" TypeMdid="0.29.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="21" Alias="tableoid">
-                <dxl:Ident ColId="21" ColName="tableoid" TypeMdid="0.26.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="22" Alias="gp_segment_id">
-                <dxl:Ident ColId="22" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="16" Alias="ColRef_0014">
+                <dxl:Ident ColId="16" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:SortingColumnList/>
-            <dxl:TableScan>
+            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="42"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="12"/>
               </dxl:Properties>
+              <dxl:GroupingColumns>
+                <dxl:GroupingColumn ColId="15"/>
+              </dxl:GroupingColumns>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="14" Alias="a1">
-                  <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="15" Alias="a1">
+                  <dxl:Ident ColId="15" ColName="a1" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="15" Alias="a2">
-                  <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="16" Alias="ctid">
-                  <dxl:Ident ColId="16" ColName="ctid" TypeMdid="0.27.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="17" Alias="xmin">
-                  <dxl:Ident ColId="17" ColName="xmin" TypeMdid="0.28.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="18" Alias="cmin">
-                  <dxl:Ident ColId="18" ColName="cmin" TypeMdid="0.29.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="19" Alias="xmax">
-                  <dxl:Ident ColId="19" ColName="xmax" TypeMdid="0.28.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="20" Alias="cmax">
-                  <dxl:Ident ColId="20" ColName="cmax" TypeMdid="0.29.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="21" Alias="tableoid">
-                  <dxl:Ident ColId="21" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="22" Alias="gp_segment_id">
-                  <dxl:Ident ColId="22" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="16" Alias="ColRef_0014">
+                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                    <dxl:ValuesList ParamType="aggargs">
+                      <dxl:Ident ColId="15" ColName="a1" TypeMdid="0.23.1.0"/>
+                    </dxl:ValuesList>
+                    <dxl:ValuesList ParamType="aggdirectargs"/>
+                    <dxl:ValuesList ParamType="aggorder"/>
+                    <dxl:ValuesList ParamType="aggdistinct"/>
+                  </dxl:AggFunc>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
-                <dxl:Columns>
-                  <dxl:Column ColId="14" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="15" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
-                  <dxl:Column ColId="23" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
-                  <dxl:Column ColId="24" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
-                  <dxl:Column ColId="25" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
-                  <dxl:Column ColId="16" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="17" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="18" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="19" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="20" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
+              <dxl:Sort SortDiscardDuplicates="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000048" Rows="1.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="15" Alias="a1">
+                    <dxl:Ident ColId="15" ColName="a1" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="15" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000041" Rows="1.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="15" Alias="a1">
+                      <dxl:Ident ColId="15" ColName="a1" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.132004.1.0" TableName="foo">
+                    <dxl:Columns>
+                      <dxl:Column ColId="15" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="17" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
+                      <dxl:Column ColId="18" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
+                      <dxl:Column ColId="19" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
+                      <dxl:Column ColId="20" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
+                      <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="22" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="23" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="24" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="25" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:Sort>
+            </dxl:Aggregate>
           </dxl:GatherMotion>
         </dxl:CTEProducer>
-        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+        <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2712059098.061594" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="2712059887.276181" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="12" Alias="percentile_cont">
@@ -537,387 +570,450 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_cont(0
               <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:JoinFilter>
-            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-          </dxl:JoinFilter>
-          <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+          <dxl:CTEProducer CTEId="1" Columns="55,56">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324032.082180" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000103" Rows="1.000000" Width="1"/>
             </dxl:Properties>
-            <dxl:GroupingColumns/>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="55" Alias="a2">
+                <dxl:Ident ColId="55" ColName="a2" TypeMdid="0.701.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="56" Alias="ColRef_0054">
+                <dxl:Ident ColId="56" ColName="ColRef_0054" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000102" Rows="1.000000" Width="16"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="55" Alias="a2">
+                  <dxl:Ident ColId="55" ColName="a2" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="56" Alias="ColRef_0054">
+                  <dxl:Ident ColId="56" ColName="ColRef_0054" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="1.000000" Width="16"/>
+                </dxl:Properties>
+                <dxl:GroupingColumns>
+                  <dxl:GroupingColumn ColId="55"/>
+                </dxl:GroupingColumns>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="55" Alias="a2">
+                    <dxl:Ident ColId="55" ColName="a2" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="56" Alias="ColRef_0054">
+                    <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                      <dxl:ValuesList ParamType="aggargs">
+                        <dxl:Ident ColId="55" ColName="a2" TypeMdid="0.701.1.0"/>
+                      </dxl:ValuesList>
+                      <dxl:ValuesList ParamType="aggdirectargs"/>
+                      <dxl:ValuesList ParamType="aggorder"/>
+                      <dxl:ValuesList ParamType="aggdistinct"/>
+                    </dxl:AggFunc>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:Sort SortDiscardDuplicates="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000031" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="55" Alias="a2">
+                      <dxl:Ident ColId="55" ColName="a2" TypeMdid="0.701.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="55" SortOperatorMdid="0.672.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  </dxl:SortingColumnList>
+                  <dxl:LimitCount/>
+                  <dxl:LimitOffset/>
+                  <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000031" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="55" Alias="a2">
+                        <dxl:Ident ColId="55" ColName="a2" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList/>
+                    <dxl:HashExprList>
+                      <dxl:HashExpr Opfamily="0.1971.1.0">
+                        <dxl:Ident ColId="55" ColName="a2" TypeMdid="0.701.1.0"/>
+                      </dxl:HashExpr>
+                    </dxl:HashExprList>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="55" Alias="a2">
+                          <dxl:Ident ColId="55" ColName="a2" TypeMdid="0.701.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="0.132004.1.0" TableName="foo">
+                        <dxl:Columns>
+                          <dxl:Column ColId="57" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="55" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="58" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
+                          <dxl:Column ColId="59" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="60" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="61" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                          <dxl:Column ColId="62" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="63" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="64" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="65" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="66" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="67" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:RedistributeMotion>
+                </dxl:Sort>
+              </dxl:Aggregate>
+            </dxl:GatherMotion>
+          </dxl:CTEProducer>
+          <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="2712059456.276062" Rows="1.000000" Width="16"/>
+            </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="12" Alias="percentile_cont">
-                <dxl:AggFunc AggMdid="0.164162.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                  <dxl:ValuesList ParamType="aggargs">
-                    <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
-                      <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
-                    </dxl:Cast>
-                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
-                    <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                  </dxl:ValuesList>
-                  <dxl:ValuesList ParamType="aggdirectargs"/>
-                  <dxl:ValuesList ParamType="aggorder"/>
-                  <dxl:ValuesList ParamType="aggdistinct"/>
-                </dxl:AggFunc>
+                <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="13" Alias="percentile_cont">
+                <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:Limit>
+            <dxl:JoinFilter>
+              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+            </dxl:JoinFilter>
+            <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324032.082178" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.267991" Rows="1.000000" Width="8"/>
               </dxl:Properties>
+              <dxl:GroupingColumns/>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="a1">
-                  <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                  <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                <dxl:ProjElem ColId="12" Alias="percentile_cont">
+                  <dxl:AggFunc AggMdid="0.131996.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                    <dxl:ValuesList ParamType="aggargs">
+                      <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                        <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                      </dxl:Cast>
+                      <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+                      <dxl:Ident ColId="53" ColName="ColRef_0053" TypeMdid="0.20.1.0"/>
+                      <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
+                    </dxl:ValuesList>
+                    <dxl:ValuesList ParamType="aggdirectargs"/>
+                    <dxl:ValuesList ParamType="aggorder"/>
+                    <dxl:ValuesList ParamType="aggdistinct"/>
+                  </dxl:AggFunc>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Sort SortDiscardDuplicates="false">
+              <dxl:Filter/>
+              <dxl:Limit>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324032.082166" Rows="1.000000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324032.267984" Rows="1.000000" Width="20"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a1">
                     <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                    <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                  <dxl:ProjElem ColId="14" Alias="ColRef_0014">
+                    <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="53" Alias="ColRef_0053">
+                    <dxl:Ident ColId="53" ColName="ColRef_0053" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList>
-                  <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                </dxl:SortingColumnList>
-                <dxl:LimitCount/>
-                <dxl:LimitOffset/>
-                <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324032.082166" Rows="1.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324032.267964" Rows="1.000000" Width="20"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a1">
                       <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                      <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="14" Alias="ColRef_0014">
+                      <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="53" Alias="ColRef_0053">
+                      <dxl:Ident ColId="53" ColName="ColRef_0053" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:JoinFilter>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:JoinFilter>
-                  <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  </dxl:SortingColumnList>
+                  <dxl:LimitCount/>
+                  <dxl:LimitOffset/>
+                  <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="8"/>
-                    </dxl:Properties>
-                    <dxl:GroupingColumns/>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                        <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                          <dxl:ValuesList ParamType="aggargs">
-                            <dxl:Ident ColId="26" ColName="a1" TypeMdid="0.23.1.0"/>
-                          </dxl:ValuesList>
-                          <dxl:ValuesList ParamType="aggdirectargs"/>
-                          <dxl:ValuesList ParamType="aggorder"/>
-                          <dxl:ValuesList ParamType="aggdistinct"/>
-                        </dxl:AggFunc>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:CTEConsumer CTEId="0" Columns="26,27,28,29,30,31,32,33,34">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="26" Alias="a1">
-                          <dxl:Ident ColId="26" ColName="a1" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="27" Alias="a2">
-                          <dxl:Ident ColId="27" ColName="a2" TypeMdid="0.701.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="28" Alias="ctid">
-                          <dxl:Ident ColId="28" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="29" Alias="xmin">
-                          <dxl:Ident ColId="29" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="30" Alias="cmin">
-                          <dxl:Ident ColId="30" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="31" Alias="xmax">
-                          <dxl:Ident ColId="31" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="32" Alias="cmax">
-                          <dxl:Ident ColId="32" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="33" Alias="tableoid">
-                          <dxl:Ident ColId="33" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="34" Alias="gp_segment_id">
-                          <dxl:Ident ColId="34" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                    </dxl:CTEConsumer>
-                  </dxl:Aggregate>
-                  <dxl:Materialize Eager="true">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1324032.267964" Rows="1.000000" Width="20"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="a1">
                         <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="1" Alias="a2">
-                        <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                      <dxl:ProjElem ColId="14" Alias="ColRef_0014">
+                        <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="5" Alias="ctid">
-                        <dxl:Ident ColId="5" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="6" Alias="xmin">
-                        <dxl:Ident ColId="6" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="7" Alias="cmin">
-                        <dxl:Ident ColId="7" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="8" Alias="xmax">
-                        <dxl:Ident ColId="8" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="9" Alias="cmax">
-                        <dxl:Ident ColId="9" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="10" Alias="tableoid">
-                        <dxl:Ident ColId="10" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="11" Alias="gp_segment_id">
-                        <dxl:Ident ColId="11" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="53" Alias="ColRef_0053">
+                        <dxl:Ident ColId="53" ColName="ColRef_0053" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:CTEConsumer CTEId="0" Columns="0,1,5,6,7,8,9,10,11">
+                    <dxl:JoinFilter>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:JoinFilter>
+                    <dxl:CTEConsumer CTEId="0" Columns="0,14">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000029" Rows="1.000000" Width="12"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="0" Alias="a1">
                           <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="1" Alias="a2">
-                          <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="5" Alias="ctid">
-                          <dxl:Ident ColId="5" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="6" Alias="xmin">
-                          <dxl:Ident ColId="6" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="7" Alias="cmin">
-                          <dxl:Ident ColId="7" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="8" Alias="xmax">
-                          <dxl:Ident ColId="8" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="9" Alias="cmax">
-                          <dxl:Ident ColId="9" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="10" Alias="tableoid">
-                          <dxl:Ident ColId="10" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="11" Alias="gp_segment_id">
-                          <dxl:Ident ColId="11" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="14" Alias="ColRef_0014">
+                          <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                     </dxl:CTEConsumer>
-                  </dxl:Materialize>
-                </dxl:NestedLoopJoin>
-              </dxl:Sort>
-              <dxl:LimitCount>
-                <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
-              </dxl:LimitCount>
-              <dxl:LimitOffset>
-                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-              </dxl:LimitOffset>
-            </dxl:Limit>
-          </dxl:Aggregate>
-          <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324032.130690" Rows="1.000000" Width="8"/>
-            </dxl:Properties>
-            <dxl:GroupingColumns/>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="13" Alias="percentile_cont">
-                <dxl:AggFunc AggMdid="0.164162.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                  <dxl:ValuesList ParamType="aggargs">
-                    <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
-                    <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                  </dxl:ValuesList>
-                  <dxl:ValuesList ParamType="aggdirectargs"/>
-                  <dxl:ValuesList ParamType="aggorder"/>
-                  <dxl:ValuesList ParamType="aggdistinct"/>
-                </dxl:AggFunc>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:Limit>
+                    <dxl:Materialize Eager="true">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000136" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="53" Alias="ColRef_0053">
+                          <dxl:Ident ColId="53" ColName="ColRef_0053" TypeMdid="0.20.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:Result>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000128" Rows="1.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="53" Alias="ColRef_0053">
+                            <dxl:FuncExpr FuncId="0.1779.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
+                              <dxl:Ident ColId="52" ColName="ColRef_0052" TypeMdid="0.1700.1.0"/>
+                            </dxl:FuncExpr>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:OneTimeFilter/>
+                        <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
+                          </dxl:Properties>
+                          <dxl:GroupingColumns/>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="52" Alias="ColRef_0052">
+                              <dxl:AggFunc AggMdid="0.2107.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                                <dxl:ValuesList ParamType="aggargs">
+                                  <dxl:Ident ColId="29" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
+                                </dxl:ValuesList>
+                                <dxl:ValuesList ParamType="aggdirectargs"/>
+                                <dxl:ValuesList ParamType="aggorder"/>
+                                <dxl:ValuesList ParamType="aggdistinct"/>
+                              </dxl:AggFunc>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:CTEConsumer CTEId="0" Columns="28,29">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="28" Alias="a1">
+                                <dxl:Ident ColId="28" ColName="a1" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="29" Alias="ColRef_0014">
+                                <dxl:Ident ColId="29" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                          </dxl:CTEConsumer>
+                        </dxl:Aggregate>
+                      </dxl:Result>
+                    </dxl:Materialize>
+                  </dxl:NestedLoopJoin>
+                </dxl:Sort>
+                <dxl:LimitCount>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
+                </dxl:LimitCount>
+                <dxl:LimitOffset>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                </dxl:LimitOffset>
+              </dxl:Limit>
+            </dxl:Aggregate>
+            <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324032.130687" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.294698" Rows="1.000000" Width="8"/>
               </dxl:Properties>
+              <dxl:GroupingColumns/>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="1" Alias="a2">
-                  <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                  <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                <dxl:ProjElem ColId="13" Alias="percentile_cont">
+                  <dxl:AggFunc AggMdid="0.131996.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                    <dxl:ValuesList ParamType="aggargs">
+                      <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+                      <dxl:Ident ColId="93" ColName="ColRef_0093" TypeMdid="0.20.1.0"/>
+                      <dxl:Ident ColId="54" ColName="ColRef_0054" TypeMdid="0.20.1.0"/>
+                    </dxl:ValuesList>
+                    <dxl:ValuesList ParamType="aggdirectargs"/>
+                    <dxl:ValuesList ParamType="aggorder"/>
+                    <dxl:ValuesList ParamType="aggdistinct"/>
+                  </dxl:AggFunc>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Sort SortDiscardDuplicates="false">
+              <dxl:Filter/>
+              <dxl:Limit>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324032.294690" Rows="1.000000" Width="24"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="a2">
                     <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                    <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                  <dxl:ProjElem ColId="54" Alias="ColRef_0054">
+                    <dxl:Ident ColId="54" ColName="ColRef_0054" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="93" Alias="ColRef_0093">
+                    <dxl:Ident ColId="93" ColName="ColRef_0093" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList>
-                  <dxl:SortingColumn ColId="1" SortOperatorMdid="0.672.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                </dxl:SortingColumnList>
-                <dxl:LimitCount/>
-                <dxl:LimitOffset/>
-                <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324032.294666" Rows="1.000000" Width="24"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="1" Alias="a2">
                       <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                      <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="54" Alias="ColRef_0054">
+                      <dxl:Ident ColId="54" ColName="ColRef_0054" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="93" Alias="ColRef_0093">
+                      <dxl:Ident ColId="93" ColName="ColRef_0093" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:JoinFilter>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:JoinFilter>
-                  <dxl:CTEConsumer CTEId="0" Columns="0,1,5,6,7,8,9,10,11">
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="1" SortOperatorMdid="0.672.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  </dxl:SortingColumnList>
+                  <dxl:LimitCount/>
+                  <dxl:LimitOffset/>
+                  <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1324032.294666" Rows="1.000000" Width="24"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="0" Alias="a1">
-                        <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="1" Alias="a2">
                         <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="5" Alias="ctid">
-                        <dxl:Ident ColId="5" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:ProjElem ColId="54" Alias="ColRef_0054">
+                        <dxl:Ident ColId="54" ColName="ColRef_0054" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="6" Alias="xmin">
-                        <dxl:Ident ColId="6" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="7" Alias="cmin">
-                        <dxl:Ident ColId="7" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="8" Alias="xmax">
-                        <dxl:Ident ColId="8" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="9" Alias="cmax">
-                        <dxl:Ident ColId="9" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="10" Alias="tableoid">
-                        <dxl:Ident ColId="10" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="11" Alias="gp_segment_id">
-                        <dxl:Ident ColId="11" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                  </dxl:CTEConsumer>
-                  <dxl:Materialize Eager="true">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                        <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                      <dxl:ProjElem ColId="93" Alias="ColRef_0093">
+                        <dxl:Ident ColId="93" ColName="ColRef_0093" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                    <dxl:JoinFilter>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:JoinFilter>
+                    <dxl:CTEConsumer CTEId="1" Columns="1,54">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="16"/>
                       </dxl:Properties>
-                      <dxl:GroupingColumns/>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                            <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Ident ColId="27" ColName="a2" TypeMdid="0.701.1.0"/>
-                            </dxl:ValuesList>
-                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                            <dxl:ValuesList ParamType="aggorder"/>
-                            <dxl:ValuesList ParamType="aggdistinct"/>
-                          </dxl:AggFunc>
+                        <dxl:ProjElem ColId="1" Alias="a2">
+                          <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="54" Alias="ColRef_0054">
+                          <dxl:Ident ColId="54" ColName="ColRef_0054" TypeMdid="0.20.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                    </dxl:CTEConsumer>
+                    <dxl:Materialize Eager="true">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000136" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="93" Alias="ColRef_0093">
+                          <dxl:Ident ColId="93" ColName="ColRef_0093" TypeMdid="0.20.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:CTEConsumer CTEId="0" Columns="26,27,28,29,30,31,32,33,34">
+                      <dxl:Result>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000128" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="26" Alias="a1">
-                            <dxl:Ident ColId="26" ColName="a1" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="27" Alias="a2">
-                            <dxl:Ident ColId="27" ColName="a2" TypeMdid="0.701.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="28" Alias="ctid">
-                            <dxl:Ident ColId="28" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="29" Alias="xmin">
-                            <dxl:Ident ColId="29" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="30" Alias="cmin">
-                            <dxl:Ident ColId="30" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="31" Alias="xmax">
-                            <dxl:Ident ColId="31" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="32" Alias="cmax">
-                            <dxl:Ident ColId="32" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="33" Alias="tableoid">
-                            <dxl:Ident ColId="33" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="34" Alias="gp_segment_id">
-                            <dxl:Ident ColId="34" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="93" Alias="ColRef_0093">
+                            <dxl:FuncExpr FuncId="0.1779.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
+                              <dxl:Ident ColId="92" ColName="ColRef_0092" TypeMdid="0.1700.1.0"/>
+                            </dxl:FuncExpr>
                           </dxl:ProjElem>
                         </dxl:ProjList>
-                      </dxl:CTEConsumer>
-                    </dxl:Aggregate>
-                  </dxl:Materialize>
-                </dxl:NestedLoopJoin>
-              </dxl:Sort>
-              <dxl:LimitCount>
-                <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
-              </dxl:LimitCount>
-              <dxl:LimitOffset>
-                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-              </dxl:LimitOffset>
-            </dxl:Limit>
-          </dxl:Aggregate>
-        </dxl:NestedLoopJoin>
+                        <dxl:Filter/>
+                        <dxl:OneTimeFilter/>
+                        <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
+                          </dxl:Properties>
+                          <dxl:GroupingColumns/>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="92" Alias="ColRef_0092">
+                              <dxl:AggFunc AggMdid="0.2107.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                                <dxl:ValuesList ParamType="aggargs">
+                                  <dxl:Ident ColId="69" ColName="ColRef_0054" TypeMdid="0.20.1.0"/>
+                                </dxl:ValuesList>
+                                <dxl:ValuesList ParamType="aggdirectargs"/>
+                                <dxl:ValuesList ParamType="aggorder"/>
+                                <dxl:ValuesList ParamType="aggdistinct"/>
+                              </dxl:AggFunc>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:CTEConsumer CTEId="1" Columns="68,69">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="68" Alias="a2">
+                                <dxl:Ident ColId="68" ColName="a2" TypeMdid="0.701.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="69" Alias="ColRef_0054">
+                                <dxl:Ident ColId="69" ColName="ColRef_0054" TypeMdid="0.20.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                          </dxl:CTEConsumer>
+                        </dxl:Aggregate>
+                      </dxl:Result>
+                    </dxl:Materialize>
+                  </dxl:NestedLoopJoin>
+                </dxl:Sort>
+                <dxl:LimitCount>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
+                </dxl:LimitCount>
+                <dxl:LimitOffset>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                </dxl:LimitOffset>
+              </dxl:Limit>
+            </dxl:Aggregate>
+          </dxl:NestedLoopJoin>
+        </dxl:Sequence>
       </dxl:Sequence>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_samecol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_samecol.mdp
@@ -12,23 +12,30 @@ CREATE TABLE foo(a1 int, a2 double precision, a3 interval, a4 timestamp, a5 time
 EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_disc(0.5) WITHIN GROUP(ORDER BY a2) FROM foo;
 
                                                    QUERY PLAN
- Sequence  (cost=0.00..1324463.13 rows=1 width=16)
+ Sequence  (cost=0.00..1324463.29 rows=1 width=16)
    ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=1)
          ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
-               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=42)
-                     ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=42)
-   ->  Aggregate  (cost=0.00..1324032.13 rows=1 width=16)
-         ->  Limit  (cost=0.00..1324032.13 rows=1 width=16)
-               ->  Sort  (cost=0.00..1324032.13 rows=1 width=16)
+               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
+                           Group Key: foo.a2
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                                 Sort Key: foo.a2
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                       Hash Key: foo.a2
+                                       ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+   ->  Aggregate  (cost=0.00..1324032.29 rows=1 width=16)
+         ->  Limit  (cost=0.00..1324032.29 rows=1 width=24)
+               ->  Sort  (cost=0.00..1324032.29 rows=1 width=24)
                      Sort Key: share0_ref3.a2
-                     ->  Nested Loop  (cost=0.00..1324032.13 rows=1 width=16)
+                     ->  Nested Loop  (cost=0.00..1324032.29 rows=1 width=24)
                            Join Filter: true
-                           ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=16)
                            ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
-                                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                       ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(16 rows)
+(23 rows)
 -->
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
@@ -54,6 +61,25 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_disc(0
         <dxl:ResultType Mdid="0.701.1.0"/>
         <dxl:IntermediateResultType Mdid="0.17.1.0"/>
       </dxl:GPDBAgg>
+      <dxl:ColumnStatistics Mdid="1.132004.1.0.0" Name="a1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.132004.1.0.1" Name="a2" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.17.1.0" Name="bytea" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2223.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7107.1.0"/>
+        <dxl:EqualityOp Mdid="0.1955.1.0"/>
+        <dxl:InequalityOp Mdid="0.1956.1.0"/>
+        <dxl:LessThanOp Mdid="0.1957.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1958.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1959.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1960.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1954.1.0"/>
+        <dxl:ArrayType Mdid="0.1001.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
@@ -139,6 +165,10 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_disc(0
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.131996.1.0" Name="gp_percentile_cont" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBAgg>
       <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
         <dxl:EqualityOp Mdid="0.385.1.0"/>
@@ -171,6 +201,10 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_disc(0
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.132000.1.0" Name="gp_percentile_disc" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.2283.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.2283.1.0"/>
+      </dxl:GPDBAgg>
       <dxl:GPDBScalarOp Mdid="0.672.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.701.1.0"/>
         <dxl:RightType Mdid="0.701.1.0"/>
@@ -217,35 +251,25 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_disc(0
         <dxl:SumAgg Mdid="0.2113.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:ColumnStatistics Mdid="1.164182.1.0.1" Name="a2" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.164182.1.0.0" Name="a1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
-        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
-        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
-        <dxl:EqualityOp Mdid="0.670.1.0"/>
-        <dxl:InequalityOp Mdid="0.671.1.0"/>
-        <dxl:LessThanOp Mdid="0.672.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
-        <dxl:ComparisonOp Mdid="0.355.1.0"/>
-        <dxl:ArrayType Mdid="0.1022.1.0"/>
-        <dxl:MinAgg Mdid="0.2136.1.0"/>
-        <dxl:MaxAgg Mdid="0.2120.1.0"/>
-        <dxl:AvgAgg Mdid="0.2105.1.0"/>
-        <dxl:SumAgg Mdid="0.2111.1.0"/>
+      <dxl:Type Mdid="0.1700.1.0" Name="numeric" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1998.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7103.1.0"/>
+        <dxl:EqualityOp Mdid="0.1752.1.0"/>
+        <dxl:InequalityOp Mdid="0.1753.1.0"/>
+        <dxl:LessThanOp Mdid="0.1754.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1755.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1756.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1757.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1769.1.0"/>
+        <dxl:ArrayType Mdid="0.1231.1.0"/>
+        <dxl:MinAgg Mdid="0.2146.1.0"/>
+        <dxl:MaxAgg Mdid="0.2130.1.0"/>
+        <dxl:AvgAgg Mdid="0.2103.1.0"/>
+        <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:GPDBAgg Mdid="0.164166.1.0" Name="gp_percentile_disc" IsSplittable="false" HashAggCapable="false">
-        <dxl:ResultType Mdid="0.2283.1.0"/>
-        <dxl:IntermediateResultType Mdid="0.2283.1.0"/>
-      </dxl:GPDBAgg>
-      <dxl:GPDBAgg Mdid="0.164162.1.0" Name="gp_percentile_cont" IsSplittable="false" HashAggCapable="false">
-        <dxl:ResultType Mdid="0.701.1.0"/>
-        <dxl:IntermediateResultType Mdid="0.701.1.0"/>
-      </dxl:GPDBAgg>
-      <dxl:RelationStatistics Mdid="2.164182.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
-      <dxl:Relation Mdid="0.164182.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="11,5" NumberLeafPartitions="0">
+      <dxl:RelationStatistics Mdid="2.132004.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.132004.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="11,5" NumberLeafPartitions="0">
         <dxl:Columns>
           <dxl:Column Name="a1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
@@ -291,6 +315,27 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_disc(0
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
+      <dxl:GPDBAgg Mdid="0.2107.1.0" Name="sum" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.1700.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.17.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
+        <dxl:EqualityOp Mdid="0.670.1.0"/>
+        <dxl:InequalityOp Mdid="0.671.1.0"/>
+        <dxl:LessThanOp Mdid="0.672.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
+        <dxl:ComparisonOp Mdid="0.355.1.0"/>
+        <dxl:ArrayType Mdid="0.1022.1.0"/>
+        <dxl:MinAgg Mdid="0.2136.1.0"/>
+        <dxl:MaxAgg Mdid="0.2120.1.0"/>
+        <dxl:AvgAgg Mdid="0.2105.1.0"/>
+        <dxl:SumAgg Mdid="0.2111.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
       <dxl:Type Mdid="0.1114.1.0" Name="timestamp" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2040.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7111.1.0"/>
@@ -327,6 +372,9 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_disc(0
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
+      <dxl:GPDBFunc Mdid="0.1779.1.0" Name="int8" ReturnsSet="false" Stability="Immutable" DataAccess="ContainsSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBFunc>
     </dxl:Metadata>
     <dxl:Query>
       <dxl:OutputColumns>
@@ -338,7 +386,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_disc(0
         <dxl:GroupingColumns/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="13" Alias="percentile_cont">
-            <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.164162.1.0">
+            <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.131996.1.0">
               <dxl:ValuesList ParamType="aggargs">
                 <dxl:Ident ColId="2" ColName="a2" TypeMdid="0.701.1.0"/>
               </dxl:ValuesList>
@@ -352,7 +400,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_disc(0
             </dxl:AggFunc>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="14" Alias="percentile_disc">
-            <dxl:AggFunc AggMdid="0.3972.1.0" AggDistinct="false" AggStage="Normal" TypeMdid="0.701.1.0" AggKind="o" GpAggMdid="0.164166.1.0">
+            <dxl:AggFunc AggMdid="0.3972.1.0" AggDistinct="false" AggStage="Normal" TypeMdid="0.701.1.0" AggKind="o" GpAggMdid="0.132000.1.0">
               <dxl:ValuesList ParamType="aggargs">
                 <dxl:Ident ColId="2" ColName="a2" TypeMdid="0.701.1.0"/>
               </dxl:ValuesList>
@@ -367,7 +415,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_disc(0
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
+          <dxl:TableDescriptor Mdid="0.132004.1.0" TableName="foo">
             <dxl:Columns>
               <dxl:Column ColId="1" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="2" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
@@ -386,10 +434,10 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_disc(0
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="10">
+    <dxl:Plan Id="0" SpaceSize="190">
       <dxl:Sequence>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324463.130907" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324463.294825" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="12" Alias="percentile_cont">
@@ -399,140 +447,131 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_disc(0
             <dxl:Ident ColId="13" ColName="percentile_disc" TypeMdid="0.701.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
-        <dxl:CTEProducer CTEId="0" Columns="14,15,16,17,18,19,20,21,22">
+        <dxl:CTEProducer CTEId="0" Columns="15,16">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000197" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000103" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="14" Alias="a1">
-              <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
             <dxl:ProjElem ColId="15" Alias="a2">
               <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="16" Alias="ctid">
-              <dxl:Ident ColId="16" ColName="ctid" TypeMdid="0.27.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="17" Alias="xmin">
-              <dxl:Ident ColId="17" ColName="xmin" TypeMdid="0.28.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="18" Alias="cmin">
-              <dxl:Ident ColId="18" ColName="cmin" TypeMdid="0.29.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="19" Alias="xmax">
-              <dxl:Ident ColId="19" ColName="xmax" TypeMdid="0.28.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="20" Alias="cmax">
-              <dxl:Ident ColId="20" ColName="cmax" TypeMdid="0.29.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="21" Alias="tableoid">
-              <dxl:Ident ColId="21" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="22" Alias="gp_segment_id">
-              <dxl:Ident ColId="22" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="16" Alias="ColRef_0014">
+              <dxl:Ident ColId="16" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000196" Rows="1.000000" Width="42"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000102" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="14" Alias="a1">
-                <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
               <dxl:ProjElem ColId="15" Alias="a2">
                 <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="16" Alias="ctid">
-                <dxl:Ident ColId="16" ColName="ctid" TypeMdid="0.27.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="17" Alias="xmin">
-                <dxl:Ident ColId="17" ColName="xmin" TypeMdid="0.28.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="18" Alias="cmin">
-                <dxl:Ident ColId="18" ColName="cmin" TypeMdid="0.29.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="19" Alias="xmax">
-                <dxl:Ident ColId="19" ColName="xmax" TypeMdid="0.28.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="20" Alias="cmax">
-                <dxl:Ident ColId="20" ColName="cmax" TypeMdid="0.29.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="21" Alias="tableoid">
-                <dxl:Ident ColId="21" ColName="tableoid" TypeMdid="0.26.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="22" Alias="gp_segment_id">
-                <dxl:Ident ColId="22" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="16" Alias="ColRef_0014">
+                <dxl:Ident ColId="16" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:SortingColumnList/>
-            <dxl:TableScan>
+            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="42"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="1.000000" Width="16"/>
               </dxl:Properties>
+              <dxl:GroupingColumns>
+                <dxl:GroupingColumn ColId="15"/>
+              </dxl:GroupingColumns>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="14" Alias="a1">
-                  <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
                 <dxl:ProjElem ColId="15" Alias="a2">
                   <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="16" Alias="ctid">
-                  <dxl:Ident ColId="16" ColName="ctid" TypeMdid="0.27.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="17" Alias="xmin">
-                  <dxl:Ident ColId="17" ColName="xmin" TypeMdid="0.28.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="18" Alias="cmin">
-                  <dxl:Ident ColId="18" ColName="cmin" TypeMdid="0.29.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="19" Alias="xmax">
-                  <dxl:Ident ColId="19" ColName="xmax" TypeMdid="0.28.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="20" Alias="cmax">
-                  <dxl:Ident ColId="20" ColName="cmax" TypeMdid="0.29.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="21" Alias="tableoid">
-                  <dxl:Ident ColId="21" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="22" Alias="gp_segment_id">
-                  <dxl:Ident ColId="22" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="16" Alias="ColRef_0014">
+                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                    <dxl:ValuesList ParamType="aggargs">
+                      <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
+                    </dxl:ValuesList>
+                    <dxl:ValuesList ParamType="aggdirectargs"/>
+                    <dxl:ValuesList ParamType="aggorder"/>
+                    <dxl:ValuesList ParamType="aggdistinct"/>
+                  </dxl:AggFunc>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
-                <dxl:Columns>
-                  <dxl:Column ColId="14" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="15" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
-                  <dxl:Column ColId="23" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
-                  <dxl:Column ColId="24" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
-                  <dxl:Column ColId="25" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
-                  <dxl:Column ColId="16" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="17" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="18" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="19" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="20" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
+              <dxl:Sort SortDiscardDuplicates="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000031" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="15" Alias="a2">
+                    <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="15" SortOperatorMdid="0.672.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000031" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="15" Alias="a2">
+                      <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr Opfamily="0.1971.1.0">
+                      <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="15" Alias="a2">
+                        <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.132004.1.0" TableName="foo">
+                      <dxl:Columns>
+                        <dxl:Column ColId="17" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="15" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
+                        <dxl:Column ColId="18" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
+                        <dxl:Column ColId="19" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
+                        <dxl:Column ColId="20" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
+                        <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                        <dxl:Column ColId="22" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="23" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="24" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="25" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:RedistributeMotion>
+              </dxl:Sort>
+            </dxl:Aggregate>
           </dxl:GatherMotion>
         </dxl:CTEProducer>
         <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324032.130694" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324032.294706" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:GroupingColumns/>
           <dxl:ProjList>
             <dxl:ProjElem ColId="12" Alias="percentile_cont">
-              <dxl:AggFunc AggMdid="0.164162.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+              <dxl:AggFunc AggMdid="0.131996.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
                 <dxl:ValuesList ParamType="aggargs">
                   <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
                   <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
-                  <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                  <dxl:Ident ColId="53" ColName="ColRef_0053" TypeMdid="0.20.1.0"/>
+                  <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
                 </dxl:ValuesList>
                 <dxl:ValuesList ParamType="aggdirectargs"/>
                 <dxl:ValuesList ParamType="aggorder"/>
@@ -540,12 +579,12 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_disc(0
               </dxl:AggFunc>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="13" Alias="percentile_disc">
-              <dxl:AggFunc AggMdid="0.164166.1.0" AggDistinct="false" AggStage="Normal" TypeMdid="0.701.1.0" AggKind="n">
+              <dxl:AggFunc AggMdid="0.132000.1.0" AggDistinct="false" AggStage="Normal" TypeMdid="0.701.1.0" AggKind="n">
                 <dxl:ValuesList ParamType="aggargs">
                   <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
                   <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
-                  <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                  <dxl:Ident ColId="53" ColName="ColRef_0053" TypeMdid="0.20.1.0"/>
+                  <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
                 </dxl:ValuesList>
                 <dxl:ValuesList ParamType="aggdirectargs"/>
                 <dxl:ValuesList ParamType="aggorder"/>
@@ -556,26 +595,32 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_disc(0
           <dxl:Filter/>
           <dxl:Limit>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324032.130687" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.294690" Rows="1.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="a2">
                 <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+              <dxl:ProjElem ColId="14" Alias="ColRef_0014">
+                <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="53" Alias="ColRef_0053">
+                <dxl:Ident ColId="53" ColName="ColRef_0053" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.294666" Rows="1.000000" Width="24"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="a2">
                   <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                  <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                <dxl:ProjElem ColId="14" Alias="ColRef_0014">
+                  <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="53" Alias="ColRef_0053">
+                  <dxl:Ident ColId="53" ColName="ColRef_0053" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
@@ -586,117 +631,92 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_disc(0
               <dxl:LimitOffset/>
               <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324032.294666" Rows="1.000000" Width="24"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="a2">
                     <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                    <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                  <dxl:ProjElem ColId="14" Alias="ColRef_0014">
+                    <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="53" Alias="ColRef_0053">
+                    <dxl:Ident ColId="53" ColName="ColRef_0053" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
                 <dxl:JoinFilter>
                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                 </dxl:JoinFilter>
-                <dxl:CTEConsumer CTEId="0" Columns="0,1,5,6,7,8,9,10,11">
+                <dxl:CTEConsumer CTEId="0" Columns="1,14">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="a1">
-                      <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
                     <dxl:ProjElem ColId="1" Alias="a2">
                       <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="5" Alias="ctid">
-                      <dxl:Ident ColId="5" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="6" Alias="xmin">
-                      <dxl:Ident ColId="6" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="7" Alias="cmin">
-                      <dxl:Ident ColId="7" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="8" Alias="xmax">
-                      <dxl:Ident ColId="8" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="9" Alias="cmax">
-                      <dxl:Ident ColId="9" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="10" Alias="tableoid">
-                      <dxl:Ident ColId="10" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="11" Alias="gp_segment_id">
-                      <dxl:Ident ColId="11" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="14" Alias="ColRef_0014">
+                      <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                 </dxl:CTEConsumer>
                 <dxl:Materialize Eager="true">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000136" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                      <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="53" Alias="ColRef_0053">
+                      <dxl:Ident ColId="53" ColName="ColRef_0053" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                  <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000128" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
-                    <dxl:GroupingColumns/>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                        <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                          <dxl:ValuesList ParamType="aggargs">
-                            <dxl:Ident ColId="27" ColName="a2" TypeMdid="0.701.1.0"/>
-                          </dxl:ValuesList>
-                          <dxl:ValuesList ParamType="aggdirectargs"/>
-                          <dxl:ValuesList ParamType="aggorder"/>
-                          <dxl:ValuesList ParamType="aggdistinct"/>
-                        </dxl:AggFunc>
+                      <dxl:ProjElem ColId="53" Alias="ColRef_0053">
+                        <dxl:FuncExpr FuncId="0.1779.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
+                          <dxl:Ident ColId="52" ColName="ColRef_0052" TypeMdid="0.1700.1.0"/>
+                        </dxl:FuncExpr>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:CTEConsumer CTEId="0" Columns="26,27,28,29,30,31,32,33,34">
+                    <dxl:OneTimeFilter/>
+                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
+                      <dxl:GroupingColumns/>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="26" Alias="a1">
-                          <dxl:Ident ColId="26" ColName="a1" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="27" Alias="a2">
-                          <dxl:Ident ColId="27" ColName="a2" TypeMdid="0.701.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="28" Alias="ctid">
-                          <dxl:Ident ColId="28" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="29" Alias="xmin">
-                          <dxl:Ident ColId="29" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="30" Alias="cmin">
-                          <dxl:Ident ColId="30" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="31" Alias="xmax">
-                          <dxl:Ident ColId="31" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="32" Alias="cmax">
-                          <dxl:Ident ColId="32" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="33" Alias="tableoid">
-                          <dxl:Ident ColId="33" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="34" Alias="gp_segment_id">
-                          <dxl:Ident ColId="34" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="52" Alias="ColRef_0052">
+                          <dxl:AggFunc AggMdid="0.2107.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Ident ColId="29" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
                         </dxl:ProjElem>
                       </dxl:ProjList>
-                    </dxl:CTEConsumer>
-                  </dxl:Aggregate>
+                      <dxl:Filter/>
+                      <dxl:CTEConsumer CTEId="0" Columns="28,29">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="28" Alias="a2">
+                            <dxl:Ident ColId="28" ColName="a2" TypeMdid="0.701.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="29" Alias="ColRef_0014">
+                            <dxl:Ident ColId="29" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                      </dxl:CTEConsumer>
+                    </dxl:Aggregate>
+                  </dxl:Result>
                 </dxl:Materialize>
               </dxl:NestedLoopJoin>
             </dxl:Sort>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_samecol_difforderespec.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_samecol_difforderespec.mdp
@@ -11,35 +11,54 @@ CREATE TABLE foo(a1 int, a2 double precision, a3 interval, a4 timestamp, a5 time
 EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_cont(0.5) WITHIN GROUP(ORDER BY a2 desc) FROM foo;
 
                                                       QUERY PLAN
- Sequence  (cost=0.00..2712059578.74 rows=1 width=16)
+ Sequence  (cost=0.00..2712060345.62 rows=1 width=16)
    ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=1)
          ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
-               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=42)
-                     ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=42)
-   ->  Nested Loop  (cost=0.00..2712059147.74 rows=1 width=16)
-         Join Filter: true
-         ->  Aggregate  (cost=0.00..1324032.13 rows=1 width=8)
-               ->  Limit  (cost=0.00..1324032.13 rows=1 width=16)
-                     ->  Sort  (cost=0.00..1324032.13 rows=1 width=16)
-                           Sort Key: share0_ref5.a2
-                           ->  Nested Loop  (cost=0.00..1324032.13 rows=1 width=16)
-                                 Join Filter: true
-                                 ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
-                                 ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
-                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                             ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..1324032.13 rows=1 width=8)
-               ->  Limit  (cost=0.00..1324032.13 rows=1 width=16)
-                     ->  Sort  (cost=0.00..1324032.13 rows=1 width=16)
-                           Sort Key: share0_ref3.a2
-                           ->  Nested Loop  (cost=0.00..1324032.13 rows=1 width=16)
-                                 Join Filter: true
-                                 ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
-                                 ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
-                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                             ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+               ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
+                           Group Key: foo_1.a2
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                                 Sort Key: foo_1.a2
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                       Hash Key: foo_1.a2
+                                       ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=8)
+   ->  Sequence  (cost=0.00..2712059914.62 rows=1 width=16)
+         ->  Shared Scan (share slice:id 0:1)  (cost=0.00..431.00 rows=1 width=1)
+               ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+                     ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
+                                 Group Key: foo.a2
+                                 ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                                       Sort Key: foo.a2
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                             Hash Key: foo.a2
+                                             ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+         ->  Nested Loop  (cost=0.00..2712059483.62 rows=1 width=16)
+               Join Filter: true
+               ->  Aggregate  (cost=0.00..1324032.29 rows=1 width=8)
+                     ->  Limit  (cost=0.00..1324032.29 rows=1 width=24)
+                           ->  Sort  (cost=0.00..1324032.29 rows=1 width=24)
+                                 Sort Key: share0_ref3.a2
+                                 ->  Nested Loop  (cost=0.00..1324032.29 rows=1 width=24)
+                                       Join Filter: true
+                                       ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=16)
+                                       ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+               ->  Aggregate  (cost=0.00..1324032.29 rows=1 width=8)
+                     ->  Limit  (cost=0.00..1324032.29 rows=1 width=24)
+                           ->  Sort  (cost=0.00..1324032.29 rows=1 width=24)
+                                 Sort Key: share1_ref3.a2
+                                 ->  Nested Loop  (cost=0.00..1324032.29 rows=1 width=24)
+                                       Join Filter: true
+                                       ->  Shared Scan (share slice:id 0:1)  (cost=0.00..431.00 rows=1 width=16)
+                                       ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Shared Scan (share slice:id 0:1)  (cost=0.00..431.00 rows=1 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(28 rows)
+(47 rows)
 -->
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
@@ -61,6 +80,25 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_cont(0
         <dxl:ResultType Mdid="0.701.1.0"/>
         <dxl:IntermediateResultType Mdid="0.17.1.0"/>
       </dxl:GPDBAgg>
+      <dxl:ColumnStatistics Mdid="1.132004.1.0.0" Name="a1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.132004.1.0.1" Name="a2" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.17.1.0" Name="bytea" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2223.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7107.1.0"/>
+        <dxl:EqualityOp Mdid="0.1955.1.0"/>
+        <dxl:InequalityOp Mdid="0.1956.1.0"/>
+        <dxl:LessThanOp Mdid="0.1957.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1958.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1959.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1960.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1954.1.0"/>
+        <dxl:ArrayType Mdid="0.1001.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
@@ -146,6 +184,10 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_cont(0
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.131996.1.0" Name="gp_percentile_cont" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBAgg>
       <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
         <dxl:EqualityOp Mdid="0.385.1.0"/>
@@ -236,31 +278,25 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_cont(0
         <dxl:SumAgg Mdid="0.2113.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:ColumnStatistics Mdid="1.164182.1.0.1" Name="a2" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.164182.1.0.0" Name="a1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
-        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
-        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
-        <dxl:EqualityOp Mdid="0.670.1.0"/>
-        <dxl:InequalityOp Mdid="0.671.1.0"/>
-        <dxl:LessThanOp Mdid="0.672.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
-        <dxl:ComparisonOp Mdid="0.355.1.0"/>
-        <dxl:ArrayType Mdid="0.1022.1.0"/>
-        <dxl:MinAgg Mdid="0.2136.1.0"/>
-        <dxl:MaxAgg Mdid="0.2120.1.0"/>
-        <dxl:AvgAgg Mdid="0.2105.1.0"/>
-        <dxl:SumAgg Mdid="0.2111.1.0"/>
+      <dxl:Type Mdid="0.1700.1.0" Name="numeric" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1998.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7103.1.0"/>
+        <dxl:EqualityOp Mdid="0.1752.1.0"/>
+        <dxl:InequalityOp Mdid="0.1753.1.0"/>
+        <dxl:LessThanOp Mdid="0.1754.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1755.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1756.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1757.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1769.1.0"/>
+        <dxl:ArrayType Mdid="0.1231.1.0"/>
+        <dxl:MinAgg Mdid="0.2146.1.0"/>
+        <dxl:MaxAgg Mdid="0.2130.1.0"/>
+        <dxl:AvgAgg Mdid="0.2103.1.0"/>
+        <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:GPDBAgg Mdid="0.164162.1.0" Name="gp_percentile_cont" IsSplittable="false" HashAggCapable="false">
-        <dxl:ResultType Mdid="0.701.1.0"/>
-        <dxl:IntermediateResultType Mdid="0.701.1.0"/>
-      </dxl:GPDBAgg>
-      <dxl:RelationStatistics Mdid="2.164182.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
-      <dxl:Relation Mdid="0.164182.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="11,5" NumberLeafPartitions="0">
+      <dxl:RelationStatistics Mdid="2.132004.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.132004.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="11,5" NumberLeafPartitions="0">
         <dxl:Columns>
           <dxl:Column Name="a1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
@@ -306,6 +342,27 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_cont(0
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
+      <dxl:GPDBAgg Mdid="0.2107.1.0" Name="sum" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.1700.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.17.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
+        <dxl:EqualityOp Mdid="0.670.1.0"/>
+        <dxl:InequalityOp Mdid="0.671.1.0"/>
+        <dxl:LessThanOp Mdid="0.672.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
+        <dxl:ComparisonOp Mdid="0.355.1.0"/>
+        <dxl:ArrayType Mdid="0.1022.1.0"/>
+        <dxl:MinAgg Mdid="0.2136.1.0"/>
+        <dxl:MaxAgg Mdid="0.2120.1.0"/>
+        <dxl:AvgAgg Mdid="0.2105.1.0"/>
+        <dxl:SumAgg Mdid="0.2111.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
       <dxl:Type Mdid="0.1114.1.0" Name="timestamp" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2040.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7111.1.0"/>
@@ -327,6 +384,9 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_cont(0
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
+      <dxl:GPDBFunc Mdid="0.1779.1.0" Name="int8" ReturnsSet="false" Stability="Immutable" DataAccess="ContainsSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBFunc>
     </dxl:Metadata>
     <dxl:Query>
       <dxl:OutputColumns>
@@ -338,7 +398,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_cont(0
         <dxl:GroupingColumns/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="13" Alias="percentile_cont">
-            <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.164162.1.0">
+            <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.131996.1.0">
               <dxl:ValuesList ParamType="aggargs">
                 <dxl:Ident ColId="2" ColName="a2" TypeMdid="0.701.1.0"/>
               </dxl:ValuesList>
@@ -352,7 +412,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_cont(0
             </dxl:AggFunc>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="14" Alias="percentile_cont">
-            <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.164162.1.0">
+            <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.131996.1.0">
               <dxl:ValuesList ParamType="aggargs">
                 <dxl:Ident ColId="2" ColName="a2" TypeMdid="0.701.1.0"/>
               </dxl:ValuesList>
@@ -367,7 +427,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_cont(0
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
+          <dxl:TableDescriptor Mdid="0.132004.1.0" TableName="foo">
             <dxl:Columns>
               <dxl:Column ColId="1" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="2" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
@@ -386,10 +446,10 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_cont(0
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="244">
+    <dxl:Plan Id="0" SpaceSize="197200">
       <dxl:Sequence>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2712059578.735769" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="2712060345.624441" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="12" Alias="percentile_cont">
@@ -399,130 +459,121 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_cont(0
             <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
-        <dxl:CTEProducer CTEId="0" Columns="14,15,16,17,18,19,20,21,22">
+        <dxl:CTEProducer CTEId="0" Columns="15,16">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000197" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000103" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="14" Alias="a1">
-              <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
             <dxl:ProjElem ColId="15" Alias="a2">
               <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="16" Alias="ctid">
-              <dxl:Ident ColId="16" ColName="ctid" TypeMdid="0.27.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="17" Alias="xmin">
-              <dxl:Ident ColId="17" ColName="xmin" TypeMdid="0.28.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="18" Alias="cmin">
-              <dxl:Ident ColId="18" ColName="cmin" TypeMdid="0.29.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="19" Alias="xmax">
-              <dxl:Ident ColId="19" ColName="xmax" TypeMdid="0.28.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="20" Alias="cmax">
-              <dxl:Ident ColId="20" ColName="cmax" TypeMdid="0.29.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="21" Alias="tableoid">
-              <dxl:Ident ColId="21" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="22" Alias="gp_segment_id">
-              <dxl:Ident ColId="22" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="16" Alias="ColRef_0014">
+              <dxl:Ident ColId="16" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000196" Rows="1.000000" Width="42"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000102" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="14" Alias="a1">
-                <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
               <dxl:ProjElem ColId="15" Alias="a2">
                 <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="16" Alias="ctid">
-                <dxl:Ident ColId="16" ColName="ctid" TypeMdid="0.27.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="17" Alias="xmin">
-                <dxl:Ident ColId="17" ColName="xmin" TypeMdid="0.28.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="18" Alias="cmin">
-                <dxl:Ident ColId="18" ColName="cmin" TypeMdid="0.29.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="19" Alias="xmax">
-                <dxl:Ident ColId="19" ColName="xmax" TypeMdid="0.28.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="20" Alias="cmax">
-                <dxl:Ident ColId="20" ColName="cmax" TypeMdid="0.29.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="21" Alias="tableoid">
-                <dxl:Ident ColId="21" ColName="tableoid" TypeMdid="0.26.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="22" Alias="gp_segment_id">
-                <dxl:Ident ColId="22" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="16" Alias="ColRef_0014">
+                <dxl:Ident ColId="16" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:SortingColumnList/>
-            <dxl:TableScan>
+            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="42"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="1.000000" Width="16"/>
               </dxl:Properties>
+              <dxl:GroupingColumns>
+                <dxl:GroupingColumn ColId="15"/>
+              </dxl:GroupingColumns>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="14" Alias="a1">
-                  <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
                 <dxl:ProjElem ColId="15" Alias="a2">
                   <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="16" Alias="ctid">
-                  <dxl:Ident ColId="16" ColName="ctid" TypeMdid="0.27.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="17" Alias="xmin">
-                  <dxl:Ident ColId="17" ColName="xmin" TypeMdid="0.28.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="18" Alias="cmin">
-                  <dxl:Ident ColId="18" ColName="cmin" TypeMdid="0.29.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="19" Alias="xmax">
-                  <dxl:Ident ColId="19" ColName="xmax" TypeMdid="0.28.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="20" Alias="cmax">
-                  <dxl:Ident ColId="20" ColName="cmax" TypeMdid="0.29.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="21" Alias="tableoid">
-                  <dxl:Ident ColId="21" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="22" Alias="gp_segment_id">
-                  <dxl:Ident ColId="22" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="16" Alias="ColRef_0014">
+                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                    <dxl:ValuesList ParamType="aggargs">
+                      <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
+                    </dxl:ValuesList>
+                    <dxl:ValuesList ParamType="aggdirectargs"/>
+                    <dxl:ValuesList ParamType="aggorder"/>
+                    <dxl:ValuesList ParamType="aggdistinct"/>
+                  </dxl:AggFunc>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
-                <dxl:Columns>
-                  <dxl:Column ColId="14" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="15" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
-                  <dxl:Column ColId="23" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
-                  <dxl:Column ColId="24" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
-                  <dxl:Column ColId="25" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
-                  <dxl:Column ColId="16" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="17" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="18" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="19" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="20" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
+              <dxl:Sort SortDiscardDuplicates="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000031" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="15" Alias="a2">
+                    <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="15" SortOperatorMdid="0.672.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000031" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="15" Alias="a2">
+                      <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr Opfamily="0.1971.1.0">
+                      <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="15" Alias="a2">
+                        <dxl:Ident ColId="15" ColName="a2" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.132004.1.0" TableName="foo">
+                      <dxl:Columns>
+                        <dxl:Column ColId="17" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="15" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
+                        <dxl:Column ColId="18" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
+                        <dxl:Column ColId="19" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
+                        <dxl:Column ColId="20" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
+                        <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                        <dxl:Column ColId="22" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="23" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="24" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="25" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:RedistributeMotion>
+              </dxl:Sort>
+            </dxl:Aggregate>
           </dxl:GatherMotion>
         </dxl:CTEProducer>
-        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+        <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2712059147.735556" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="2712059914.624321" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="12" Alias="percentile_cont">
@@ -532,361 +583,448 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_cont(0
               <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:JoinFilter>
-            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-          </dxl:JoinFilter>
-          <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+          <dxl:CTEProducer CTEId="1" Columns="55,56">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324032.130690" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000103" Rows="1.000000" Width="1"/>
             </dxl:Properties>
-            <dxl:GroupingColumns/>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="55" Alias="a2">
+                <dxl:Ident ColId="55" ColName="a2" TypeMdid="0.701.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="56" Alias="ColRef_0054">
+                <dxl:Ident ColId="56" ColName="ColRef_0054" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000102" Rows="1.000000" Width="16"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="55" Alias="a2">
+                  <dxl:Ident ColId="55" ColName="a2" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="56" Alias="ColRef_0054">
+                  <dxl:Ident ColId="56" ColName="ColRef_0054" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="1.000000" Width="16"/>
+                </dxl:Properties>
+                <dxl:GroupingColumns>
+                  <dxl:GroupingColumn ColId="55"/>
+                </dxl:GroupingColumns>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="55" Alias="a2">
+                    <dxl:Ident ColId="55" ColName="a2" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="56" Alias="ColRef_0054">
+                    <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                      <dxl:ValuesList ParamType="aggargs">
+                        <dxl:Ident ColId="55" ColName="a2" TypeMdid="0.701.1.0"/>
+                      </dxl:ValuesList>
+                      <dxl:ValuesList ParamType="aggdirectargs"/>
+                      <dxl:ValuesList ParamType="aggorder"/>
+                      <dxl:ValuesList ParamType="aggdistinct"/>
+                    </dxl:AggFunc>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:Sort SortDiscardDuplicates="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000031" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="55" Alias="a2">
+                      <dxl:Ident ColId="55" ColName="a2" TypeMdid="0.701.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="55" SortOperatorMdid="0.672.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  </dxl:SortingColumnList>
+                  <dxl:LimitCount/>
+                  <dxl:LimitOffset/>
+                  <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000031" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="55" Alias="a2">
+                        <dxl:Ident ColId="55" ColName="a2" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList/>
+                    <dxl:HashExprList>
+                      <dxl:HashExpr Opfamily="0.1971.1.0">
+                        <dxl:Ident ColId="55" ColName="a2" TypeMdid="0.701.1.0"/>
+                      </dxl:HashExpr>
+                    </dxl:HashExprList>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="55" Alias="a2">
+                          <dxl:Ident ColId="55" ColName="a2" TypeMdid="0.701.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="0.132004.1.0" TableName="foo">
+                        <dxl:Columns>
+                          <dxl:Column ColId="57" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="55" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="58" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
+                          <dxl:Column ColId="59" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="60" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="61" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                          <dxl:Column ColId="62" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="63" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="64" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="65" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="66" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="67" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:RedistributeMotion>
+                </dxl:Sort>
+              </dxl:Aggregate>
+            </dxl:GatherMotion>
+          </dxl:CTEProducer>
+          <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="2712059483.624202" Rows="1.000000" Width="16"/>
+            </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="12" Alias="percentile_cont">
-                <dxl:AggFunc AggMdid="0.164162.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                  <dxl:ValuesList ParamType="aggargs">
-                    <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
-                    <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                  </dxl:ValuesList>
-                  <dxl:ValuesList ParamType="aggdirectargs"/>
-                  <dxl:ValuesList ParamType="aggorder"/>
-                  <dxl:ValuesList ParamType="aggdistinct"/>
-                </dxl:AggFunc>
+                <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
               </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:Limit>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324032.130687" Rows="1.000000" Width="16"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="1" Alias="a2">
-                  <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                  <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Sort SortDiscardDuplicates="false">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="1" Alias="a2">
-                    <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                    <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList>
-                  <dxl:SortingColumn ColId="1" SortOperatorMdid="0.672.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                </dxl:SortingColumnList>
-                <dxl:LimitCount/>
-                <dxl:LimitOffset/>
-                <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="1" Alias="a2">
-                      <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                      <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:JoinFilter>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:JoinFilter>
-                  <dxl:CTEConsumer CTEId="0" Columns="0,1,5,6,7,8,9,10,11">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="0" Alias="a1">
-                        <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="1" Alias="a2">
-                        <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="5" Alias="ctid">
-                        <dxl:Ident ColId="5" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="6" Alias="xmin">
-                        <dxl:Ident ColId="6" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="7" Alias="cmin">
-                        <dxl:Ident ColId="7" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="8" Alias="xmax">
-                        <dxl:Ident ColId="8" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="9" Alias="cmax">
-                        <dxl:Ident ColId="9" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="10" Alias="tableoid">
-                        <dxl:Ident ColId="10" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="11" Alias="gp_segment_id">
-                        <dxl:Ident ColId="11" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                  </dxl:CTEConsumer>
-                  <dxl:Materialize Eager="true">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                        <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
-                      </dxl:Properties>
-                      <dxl:GroupingColumns/>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                            <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Ident ColId="27" ColName="a2" TypeMdid="0.701.1.0"/>
-                            </dxl:ValuesList>
-                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                            <dxl:ValuesList ParamType="aggorder"/>
-                            <dxl:ValuesList ParamType="aggdistinct"/>
-                          </dxl:AggFunc>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:CTEConsumer CTEId="0" Columns="26,27,28,29,30,31,32,33,34">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="26" Alias="a1">
-                            <dxl:Ident ColId="26" ColName="a1" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="27" Alias="a2">
-                            <dxl:Ident ColId="27" ColName="a2" TypeMdid="0.701.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="28" Alias="ctid">
-                            <dxl:Ident ColId="28" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="29" Alias="xmin">
-                            <dxl:Ident ColId="29" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="30" Alias="cmin">
-                            <dxl:Ident ColId="30" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="31" Alias="xmax">
-                            <dxl:Ident ColId="31" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="32" Alias="cmax">
-                            <dxl:Ident ColId="32" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="33" Alias="tableoid">
-                            <dxl:Ident ColId="33" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="34" Alias="gp_segment_id">
-                            <dxl:Ident ColId="34" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                      </dxl:CTEConsumer>
-                    </dxl:Aggregate>
-                  </dxl:Materialize>
-                </dxl:NestedLoopJoin>
-              </dxl:Sort>
-              <dxl:LimitCount>
-                <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
-              </dxl:LimitCount>
-              <dxl:LimitOffset>
-                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-              </dxl:LimitOffset>
-            </dxl:Limit>
-          </dxl:Aggregate>
-          <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324032.130690" Rows="1.000000" Width="8"/>
-            </dxl:Properties>
-            <dxl:GroupingColumns/>
-            <dxl:ProjList>
               <dxl:ProjElem ColId="13" Alias="percentile_cont">
-                <dxl:AggFunc AggMdid="0.164162.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                  <dxl:ValuesList ParamType="aggargs">
-                    <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
-                    <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                  </dxl:ValuesList>
-                  <dxl:ValuesList ParamType="aggdirectargs"/>
-                  <dxl:ValuesList ParamType="aggorder"/>
-                  <dxl:ValuesList ParamType="aggdistinct"/>
-                </dxl:AggFunc>
+                <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:Limit>
+            <dxl:JoinFilter>
+              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+            </dxl:JoinFilter>
+            <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324032.130687" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.294698" Rows="1.000000" Width="8"/>
               </dxl:Properties>
+              <dxl:GroupingColumns/>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="1" Alias="a2">
-                  <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                  <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                <dxl:ProjElem ColId="12" Alias="percentile_cont">
+                  <dxl:AggFunc AggMdid="0.131996.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                    <dxl:ValuesList ParamType="aggargs">
+                      <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+                      <dxl:Ident ColId="53" ColName="ColRef_0053" TypeMdid="0.20.1.0"/>
+                      <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
+                    </dxl:ValuesList>
+                    <dxl:ValuesList ParamType="aggdirectargs"/>
+                    <dxl:ValuesList ParamType="aggorder"/>
+                    <dxl:ValuesList ParamType="aggdistinct"/>
+                  </dxl:AggFunc>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Sort SortDiscardDuplicates="false">
+              <dxl:Filter/>
+              <dxl:Limit>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324032.294690" Rows="1.000000" Width="24"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="a2">
                     <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                    <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                  <dxl:ProjElem ColId="14" Alias="ColRef_0014">
+                    <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="53" Alias="ColRef_0053">
+                    <dxl:Ident ColId="53" ColName="ColRef_0053" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList>
-                  <dxl:SortingColumn ColId="1" SortOperatorMdid="0.674.1.0" SortOperatorName="&gt;" SortNullsFirst="true"/>
-                </dxl:SortingColumnList>
-                <dxl:LimitCount/>
-                <dxl:LimitOffset/>
-                <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324032.294666" Rows="1.000000" Width="24"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="1" Alias="a2">
                       <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                      <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="14" Alias="ColRef_0014">
+                      <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="53" Alias="ColRef_0053">
+                      <dxl:Ident ColId="53" ColName="ColRef_0053" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:JoinFilter>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:JoinFilter>
-                  <dxl:CTEConsumer CTEId="0" Columns="0,1,5,6,7,8,9,10,11">
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="1" SortOperatorMdid="0.672.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  </dxl:SortingColumnList>
+                  <dxl:LimitCount/>
+                  <dxl:LimitOffset/>
+                  <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1324032.294666" Rows="1.000000" Width="24"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="0" Alias="a1">
-                        <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="1" Alias="a2">
                         <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="5" Alias="ctid">
-                        <dxl:Ident ColId="5" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:ProjElem ColId="14" Alias="ColRef_0014">
+                        <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="6" Alias="xmin">
-                        <dxl:Ident ColId="6" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="7" Alias="cmin">
-                        <dxl:Ident ColId="7" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="8" Alias="xmax">
-                        <dxl:Ident ColId="8" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="9" Alias="cmax">
-                        <dxl:Ident ColId="9" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="10" Alias="tableoid">
-                        <dxl:Ident ColId="10" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="11" Alias="gp_segment_id">
-                        <dxl:Ident ColId="11" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                  </dxl:CTEConsumer>
-                  <dxl:Materialize Eager="true">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                        <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                      <dxl:ProjElem ColId="53" Alias="ColRef_0053">
+                        <dxl:Ident ColId="53" ColName="ColRef_0053" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                    <dxl:JoinFilter>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:JoinFilter>
+                    <dxl:CTEConsumer CTEId="0" Columns="1,14">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="16"/>
                       </dxl:Properties>
-                      <dxl:GroupingColumns/>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                            <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Ident ColId="27" ColName="a2" TypeMdid="0.701.1.0"/>
-                            </dxl:ValuesList>
-                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                            <dxl:ValuesList ParamType="aggorder"/>
-                            <dxl:ValuesList ParamType="aggdistinct"/>
-                          </dxl:AggFunc>
+                        <dxl:ProjElem ColId="1" Alias="a2">
+                          <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="14" Alias="ColRef_0014">
+                          <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                    </dxl:CTEConsumer>
+                    <dxl:Materialize Eager="true">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000136" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="53" Alias="ColRef_0053">
+                          <dxl:Ident ColId="53" ColName="ColRef_0053" TypeMdid="0.20.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:CTEConsumer CTEId="0" Columns="26,27,28,29,30,31,32,33,34">
+                      <dxl:Result>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000128" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="26" Alias="a1">
-                            <dxl:Ident ColId="26" ColName="a1" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="27" Alias="a2">
-                            <dxl:Ident ColId="27" ColName="a2" TypeMdid="0.701.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="28" Alias="ctid">
-                            <dxl:Ident ColId="28" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="29" Alias="xmin">
-                            <dxl:Ident ColId="29" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="30" Alias="cmin">
-                            <dxl:Ident ColId="30" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="31" Alias="xmax">
-                            <dxl:Ident ColId="31" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="32" Alias="cmax">
-                            <dxl:Ident ColId="32" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="33" Alias="tableoid">
-                            <dxl:Ident ColId="33" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="34" Alias="gp_segment_id">
-                            <dxl:Ident ColId="34" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="53" Alias="ColRef_0053">
+                            <dxl:FuncExpr FuncId="0.1779.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
+                              <dxl:Ident ColId="52" ColName="ColRef_0052" TypeMdid="0.1700.1.0"/>
+                            </dxl:FuncExpr>
                           </dxl:ProjElem>
                         </dxl:ProjList>
-                      </dxl:CTEConsumer>
-                    </dxl:Aggregate>
-                  </dxl:Materialize>
-                </dxl:NestedLoopJoin>
-              </dxl:Sort>
-              <dxl:LimitCount>
-                <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
-              </dxl:LimitCount>
-              <dxl:LimitOffset>
-                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-              </dxl:LimitOffset>
-            </dxl:Limit>
-          </dxl:Aggregate>
-        </dxl:NestedLoopJoin>
+                        <dxl:Filter/>
+                        <dxl:OneTimeFilter/>
+                        <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
+                          </dxl:Properties>
+                          <dxl:GroupingColumns/>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="52" Alias="ColRef_0052">
+                              <dxl:AggFunc AggMdid="0.2107.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                                <dxl:ValuesList ParamType="aggargs">
+                                  <dxl:Ident ColId="29" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
+                                </dxl:ValuesList>
+                                <dxl:ValuesList ParamType="aggdirectargs"/>
+                                <dxl:ValuesList ParamType="aggorder"/>
+                                <dxl:ValuesList ParamType="aggdistinct"/>
+                              </dxl:AggFunc>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:CTEConsumer CTEId="0" Columns="28,29">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="28" Alias="a2">
+                                <dxl:Ident ColId="28" ColName="a2" TypeMdid="0.701.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="29" Alias="ColRef_0014">
+                                <dxl:Ident ColId="29" ColName="ColRef_0014" TypeMdid="0.20.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                          </dxl:CTEConsumer>
+                        </dxl:Aggregate>
+                      </dxl:Result>
+                    </dxl:Materialize>
+                  </dxl:NestedLoopJoin>
+                </dxl:Sort>
+                <dxl:LimitCount>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
+                </dxl:LimitCount>
+                <dxl:LimitOffset>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                </dxl:LimitOffset>
+              </dxl:Limit>
+            </dxl:Aggregate>
+            <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.294698" Rows="1.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:GroupingColumns/>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="13" Alias="percentile_cont">
+                  <dxl:AggFunc AggMdid="0.131996.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                    <dxl:ValuesList ParamType="aggargs">
+                      <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+                      <dxl:Ident ColId="93" ColName="ColRef_0093" TypeMdid="0.20.1.0"/>
+                      <dxl:Ident ColId="54" ColName="ColRef_0054" TypeMdid="0.20.1.0"/>
+                    </dxl:ValuesList>
+                    <dxl:ValuesList ParamType="aggdirectargs"/>
+                    <dxl:ValuesList ParamType="aggorder"/>
+                    <dxl:ValuesList ParamType="aggdistinct"/>
+                  </dxl:AggFunc>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:Limit>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1324032.294690" Rows="1.000000" Width="24"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="1" Alias="a2">
+                    <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="54" Alias="ColRef_0054">
+                    <dxl:Ident ColId="54" ColName="ColRef_0054" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="93" Alias="ColRef_0093">
+                    <dxl:Ident ColId="93" ColName="ColRef_0093" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Sort SortDiscardDuplicates="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="1324032.294666" Rows="1.000000" Width="24"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="1" Alias="a2">
+                      <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="54" Alias="ColRef_0054">
+                      <dxl:Ident ColId="54" ColName="ColRef_0054" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="93" Alias="ColRef_0093">
+                      <dxl:Ident ColId="93" ColName="ColRef_0093" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="1" SortOperatorMdid="0.674.1.0" SortOperatorName="&gt;" SortNullsFirst="true"/>
+                  </dxl:SortingColumnList>
+                  <dxl:LimitCount/>
+                  <dxl:LimitOffset/>
+                  <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="1324032.294666" Rows="1.000000" Width="24"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="1" Alias="a2">
+                        <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="54" Alias="ColRef_0054">
+                        <dxl:Ident ColId="54" ColName="ColRef_0054" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="93" Alias="ColRef_0093">
+                        <dxl:Ident ColId="93" ColName="ColRef_0093" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:JoinFilter>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:JoinFilter>
+                    <dxl:CTEConsumer CTEId="1" Columns="1,54">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="16"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="1" Alias="a2">
+                          <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="54" Alias="ColRef_0054">
+                          <dxl:Ident ColId="54" ColName="ColRef_0054" TypeMdid="0.20.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                    </dxl:CTEConsumer>
+                    <dxl:Materialize Eager="true">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000136" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="93" Alias="ColRef_0093">
+                          <dxl:Ident ColId="93" ColName="ColRef_0093" TypeMdid="0.20.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:Result>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000128" Rows="1.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="93" Alias="ColRef_0093">
+                            <dxl:FuncExpr FuncId="0.1779.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
+                              <dxl:Ident ColId="92" ColName="ColRef_0092" TypeMdid="0.1700.1.0"/>
+                            </dxl:FuncExpr>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:OneTimeFilter/>
+                        <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
+                          </dxl:Properties>
+                          <dxl:GroupingColumns/>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="92" Alias="ColRef_0092">
+                              <dxl:AggFunc AggMdid="0.2107.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                                <dxl:ValuesList ParamType="aggargs">
+                                  <dxl:Ident ColId="69" ColName="ColRef_0054" TypeMdid="0.20.1.0"/>
+                                </dxl:ValuesList>
+                                <dxl:ValuesList ParamType="aggdirectargs"/>
+                                <dxl:ValuesList ParamType="aggorder"/>
+                                <dxl:ValuesList ParamType="aggdistinct"/>
+                              </dxl:AggFunc>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:CTEConsumer CTEId="1" Columns="68,69">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="68" Alias="a2">
+                                <dxl:Ident ColId="68" ColName="a2" TypeMdid="0.701.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="69" Alias="ColRef_0054">
+                                <dxl:Ident ColId="69" ColName="ColRef_0054" TypeMdid="0.20.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                          </dxl:CTEConsumer>
+                        </dxl:Aggregate>
+                      </dxl:Result>
+                    </dxl:Materialize>
+                  </dxl:NestedLoopJoin>
+                </dxl:Sort>
+                <dxl:LimitCount>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
+                </dxl:LimitCount>
+                <dxl:LimitOffset>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                </dxl:LimitOffset>
+              </dxl:Limit>
+            </dxl:Aggregate>
+          </dxl:NestedLoopJoin>
+        </dxl:Sequence>
       </dxl:Sequence>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_single.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_single.mdp
@@ -11,23 +11,30 @@ CREATE TABLE foo(a1 int, a2 double precision, a3 interval, a4 timestamp, a5 time
 EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2) FROM foo;
 
                                                    QUERY PLAN
- Sequence  (cost=0.00..1324463.13 rows=1 width=8)
+ Sequence  (cost=0.00..1324463.29 rows=1 width=8)
    ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=1)
          ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
-               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=42)
-                     ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=42)
-   ->  Aggregate  (cost=0.00..1324032.13 rows=1 width=8)
-         ->  Limit  (cost=0.00..1324032.13 rows=1 width=16)
-               ->  Sort  (cost=0.00..1324032.13 rows=1 width=16)
+               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
+                           Group Key: foo.a2
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                                 Sort Key: foo.a2
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                       Hash Key: foo.a2
+                                       ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+   ->  Aggregate  (cost=0.00..1324032.29 rows=1 width=8)
+         ->  Limit  (cost=0.00..1324032.29 rows=1 width=24)
+               ->  Sort  (cost=0.00..1324032.29 rows=1 width=24)
                      Sort Key: share0_ref3.a2
-                     ->  Nested Loop  (cost=0.00..1324032.13 rows=1 width=16)
+                     ->  Nested Loop  (cost=0.00..1324032.29 rows=1 width=24)
                            Join Filter: true
-                           ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=16)
                            ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
-                                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                       ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(16 rows)
+(23 rows)
 -->
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
@@ -49,6 +56,25 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2) FROM foo;
         <dxl:ResultType Mdid="0.701.1.0"/>
         <dxl:IntermediateResultType Mdid="0.17.1.0"/>
       </dxl:GPDBAgg>
+      <dxl:ColumnStatistics Mdid="1.132004.1.0.0" Name="a1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.132004.1.0.1" Name="a2" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.17.1.0" Name="bytea" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2223.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7107.1.0"/>
+        <dxl:EqualityOp Mdid="0.1955.1.0"/>
+        <dxl:InequalityOp Mdid="0.1956.1.0"/>
+        <dxl:LessThanOp Mdid="0.1957.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1958.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1959.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1960.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1954.1.0"/>
+        <dxl:ArrayType Mdid="0.1001.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
@@ -134,6 +160,10 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2) FROM foo;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.131996.1.0" Name="gp_percentile_cont" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBAgg>
       <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
         <dxl:EqualityOp Mdid="0.385.1.0"/>
@@ -212,31 +242,25 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2) FROM foo;
         <dxl:SumAgg Mdid="0.2113.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:ColumnStatistics Mdid="1.164182.1.0.1" Name="a2" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.164182.1.0.0" Name="a1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
-        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
-        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
-        <dxl:EqualityOp Mdid="0.670.1.0"/>
-        <dxl:InequalityOp Mdid="0.671.1.0"/>
-        <dxl:LessThanOp Mdid="0.672.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
-        <dxl:ComparisonOp Mdid="0.355.1.0"/>
-        <dxl:ArrayType Mdid="0.1022.1.0"/>
-        <dxl:MinAgg Mdid="0.2136.1.0"/>
-        <dxl:MaxAgg Mdid="0.2120.1.0"/>
-        <dxl:AvgAgg Mdid="0.2105.1.0"/>
-        <dxl:SumAgg Mdid="0.2111.1.0"/>
+      <dxl:Type Mdid="0.1700.1.0" Name="numeric" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1998.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7103.1.0"/>
+        <dxl:EqualityOp Mdid="0.1752.1.0"/>
+        <dxl:InequalityOp Mdid="0.1753.1.0"/>
+        <dxl:LessThanOp Mdid="0.1754.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1755.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1756.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1757.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1769.1.0"/>
+        <dxl:ArrayType Mdid="0.1231.1.0"/>
+        <dxl:MinAgg Mdid="0.2146.1.0"/>
+        <dxl:MaxAgg Mdid="0.2130.1.0"/>
+        <dxl:AvgAgg Mdid="0.2103.1.0"/>
+        <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:GPDBAgg Mdid="0.164162.1.0" Name="gp_percentile_cont" IsSplittable="false" HashAggCapable="false">
-        <dxl:ResultType Mdid="0.701.1.0"/>
-        <dxl:IntermediateResultType Mdid="0.701.1.0"/>
-      </dxl:GPDBAgg>
-      <dxl:RelationStatistics Mdid="2.164182.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
-      <dxl:Relation Mdid="0.164182.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="11,5" NumberLeafPartitions="0">
+      <dxl:RelationStatistics Mdid="2.132004.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.132004.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="11,5" NumberLeafPartitions="0">
         <dxl:Columns>
           <dxl:Column Name="a1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
@@ -282,6 +306,27 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2) FROM foo;
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
+      <dxl:GPDBAgg Mdid="0.2107.1.0" Name="sum" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.1700.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.17.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
+        <dxl:EqualityOp Mdid="0.670.1.0"/>
+        <dxl:InequalityOp Mdid="0.671.1.0"/>
+        <dxl:LessThanOp Mdid="0.672.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
+        <dxl:ComparisonOp Mdid="0.355.1.0"/>
+        <dxl:ArrayType Mdid="0.1022.1.0"/>
+        <dxl:MinAgg Mdid="0.2136.1.0"/>
+        <dxl:MaxAgg Mdid="0.2120.1.0"/>
+        <dxl:AvgAgg Mdid="0.2105.1.0"/>
+        <dxl:SumAgg Mdid="0.2111.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
       <dxl:Type Mdid="0.1114.1.0" Name="timestamp" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2040.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7111.1.0"/>
@@ -303,6 +348,9 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2) FROM foo;
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
+      <dxl:GPDBFunc Mdid="0.1779.1.0" Name="int8" ReturnsSet="false" Stability="Immutable" DataAccess="ContainsSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBFunc>
     </dxl:Metadata>
     <dxl:Query>
       <dxl:OutputColumns>
@@ -313,7 +361,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2) FROM foo;
         <dxl:GroupingColumns/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="13" Alias="percentile_cont">
-            <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.164162.1.0">
+            <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.131996.1.0">
               <dxl:ValuesList ParamType="aggargs">
                 <dxl:Ident ColId="2" ColName="a2" TypeMdid="0.701.1.0"/>
               </dxl:ValuesList>
@@ -328,7 +376,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2) FROM foo;
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
+          <dxl:TableDescriptor Mdid="0.132004.1.0" TableName="foo">
             <dxl:Columns>
               <dxl:Column ColId="1" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="2" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
@@ -347,150 +395,141 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2) FROM foo;
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="10">
+    <dxl:Plan Id="0" SpaceSize="190">
       <dxl:Sequence>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324463.130895" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324463.294809" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="12" Alias="percentile_cont">
             <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
-        <dxl:CTEProducer CTEId="0" Columns="13,14,15,16,17,18,19,20,21">
+        <dxl:CTEProducer CTEId="0" Columns="14,15">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000197" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000103" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="13" Alias="a1">
-              <dxl:Ident ColId="13" ColName="a1" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
             <dxl:ProjElem ColId="14" Alias="a2">
               <dxl:Ident ColId="14" ColName="a2" TypeMdid="0.701.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="15" Alias="ctid">
-              <dxl:Ident ColId="15" ColName="ctid" TypeMdid="0.27.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="16" Alias="xmin">
-              <dxl:Ident ColId="16" ColName="xmin" TypeMdid="0.28.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="17" Alias="cmin">
-              <dxl:Ident ColId="17" ColName="cmin" TypeMdid="0.29.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="18" Alias="xmax">
-              <dxl:Ident ColId="18" ColName="xmax" TypeMdid="0.28.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="19" Alias="cmax">
-              <dxl:Ident ColId="19" ColName="cmax" TypeMdid="0.29.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="20" Alias="tableoid">
-              <dxl:Ident ColId="20" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="21" Alias="gp_segment_id">
-              <dxl:Ident ColId="21" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="15" Alias="ColRef_0013">
+              <dxl:Ident ColId="15" ColName="ColRef_0013" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000196" Rows="1.000000" Width="42"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000102" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="13" Alias="a1">
-                <dxl:Ident ColId="13" ColName="a1" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
               <dxl:ProjElem ColId="14" Alias="a2">
                 <dxl:Ident ColId="14" ColName="a2" TypeMdid="0.701.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="15" Alias="ctid">
-                <dxl:Ident ColId="15" ColName="ctid" TypeMdid="0.27.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="16" Alias="xmin">
-                <dxl:Ident ColId="16" ColName="xmin" TypeMdid="0.28.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="17" Alias="cmin">
-                <dxl:Ident ColId="17" ColName="cmin" TypeMdid="0.29.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="18" Alias="xmax">
-                <dxl:Ident ColId="18" ColName="xmax" TypeMdid="0.28.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="19" Alias="cmax">
-                <dxl:Ident ColId="19" ColName="cmax" TypeMdid="0.29.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="20" Alias="tableoid">
-                <dxl:Ident ColId="20" ColName="tableoid" TypeMdid="0.26.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="21" Alias="gp_segment_id">
-                <dxl:Ident ColId="21" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="15" Alias="ColRef_0013">
+                <dxl:Ident ColId="15" ColName="ColRef_0013" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:SortingColumnList/>
-            <dxl:TableScan>
+            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="42"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="1.000000" Width="16"/>
               </dxl:Properties>
+              <dxl:GroupingColumns>
+                <dxl:GroupingColumn ColId="14"/>
+              </dxl:GroupingColumns>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="13" Alias="a1">
-                  <dxl:Ident ColId="13" ColName="a1" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
                 <dxl:ProjElem ColId="14" Alias="a2">
                   <dxl:Ident ColId="14" ColName="a2" TypeMdid="0.701.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="15" Alias="ctid">
-                  <dxl:Ident ColId="15" ColName="ctid" TypeMdid="0.27.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="16" Alias="xmin">
-                  <dxl:Ident ColId="16" ColName="xmin" TypeMdid="0.28.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="17" Alias="cmin">
-                  <dxl:Ident ColId="17" ColName="cmin" TypeMdid="0.29.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="18" Alias="xmax">
-                  <dxl:Ident ColId="18" ColName="xmax" TypeMdid="0.28.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="19" Alias="cmax">
-                  <dxl:Ident ColId="19" ColName="cmax" TypeMdid="0.29.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="20" Alias="tableoid">
-                  <dxl:Ident ColId="20" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="21" Alias="gp_segment_id">
-                  <dxl:Ident ColId="21" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="15" Alias="ColRef_0013">
+                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                    <dxl:ValuesList ParamType="aggargs">
+                      <dxl:Ident ColId="14" ColName="a2" TypeMdid="0.701.1.0"/>
+                    </dxl:ValuesList>
+                    <dxl:ValuesList ParamType="aggdirectargs"/>
+                    <dxl:ValuesList ParamType="aggorder"/>
+                    <dxl:ValuesList ParamType="aggdistinct"/>
+                  </dxl:AggFunc>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
-                <dxl:Columns>
-                  <dxl:Column ColId="13" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="14" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
-                  <dxl:Column ColId="22" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
-                  <dxl:Column ColId="23" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
-                  <dxl:Column ColId="24" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
-                  <dxl:Column ColId="15" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="16" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="17" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="18" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="19" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="20" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="21" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
+              <dxl:Sort SortDiscardDuplicates="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000031" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="14" Alias="a2">
+                    <dxl:Ident ColId="14" ColName="a2" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="14" SortOperatorMdid="0.672.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000031" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="14" Alias="a2">
+                      <dxl:Ident ColId="14" ColName="a2" TypeMdid="0.701.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr Opfamily="0.1971.1.0">
+                      <dxl:Ident ColId="14" ColName="a2" TypeMdid="0.701.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="14" Alias="a2">
+                        <dxl:Ident ColId="14" ColName="a2" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.132004.1.0" TableName="foo">
+                      <dxl:Columns>
+                        <dxl:Column ColId="16" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="14" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
+                        <dxl:Column ColId="17" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
+                        <dxl:Column ColId="18" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
+                        <dxl:Column ColId="19" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
+                        <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                        <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:RedistributeMotion>
+              </dxl:Sort>
+            </dxl:Aggregate>
           </dxl:GatherMotion>
         </dxl:CTEProducer>
         <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324032.130690" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324032.294698" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:GroupingColumns/>
           <dxl:ProjList>
             <dxl:ProjElem ColId="12" Alias="percentile_cont">
-              <dxl:AggFunc AggMdid="0.164162.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+              <dxl:AggFunc AggMdid="0.131996.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
                 <dxl:ValuesList ParamType="aggargs">
                   <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
                   <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
-                  <dxl:Ident ColId="40" ColName="ColRef_0040" TypeMdid="0.20.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                  <dxl:Ident ColId="52" ColName="ColRef_0052" TypeMdid="0.20.1.0"/>
+                  <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.20.1.0"/>
                 </dxl:ValuesList>
                 <dxl:ValuesList ParamType="aggdirectargs"/>
                 <dxl:ValuesList ParamType="aggorder"/>
@@ -501,26 +540,32 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2) FROM foo;
           <dxl:Filter/>
           <dxl:Limit>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324032.130687" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.294690" Rows="1.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="a2">
                 <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="40" Alias="ColRef_0040">
-                <dxl:Ident ColId="40" ColName="ColRef_0040" TypeMdid="0.20.1.0"/>
+              <dxl:ProjElem ColId="13" Alias="ColRef_0013">
+                <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="52" Alias="ColRef_0052">
+                <dxl:Ident ColId="52" ColName="ColRef_0052" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.294666" Rows="1.000000" Width="24"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="a2">
                   <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="40" Alias="ColRef_0040">
-                  <dxl:Ident ColId="40" ColName="ColRef_0040" TypeMdid="0.20.1.0"/>
+                <dxl:ProjElem ColId="13" Alias="ColRef_0013">
+                  <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="52" Alias="ColRef_0052">
+                  <dxl:Ident ColId="52" ColName="ColRef_0052" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
@@ -531,117 +576,92 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2) FROM foo;
               <dxl:LimitOffset/>
               <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324032.294666" Rows="1.000000" Width="24"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="a2">
                     <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="40" Alias="ColRef_0040">
-                    <dxl:Ident ColId="40" ColName="ColRef_0040" TypeMdid="0.20.1.0"/>
+                  <dxl:ProjElem ColId="13" Alias="ColRef_0013">
+                    <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="52" Alias="ColRef_0052">
+                    <dxl:Ident ColId="52" ColName="ColRef_0052" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
                 <dxl:JoinFilter>
                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                 </dxl:JoinFilter>
-                <dxl:CTEConsumer CTEId="0" Columns="0,1,5,6,7,8,9,10,11">
+                <dxl:CTEConsumer CTEId="0" Columns="1,13">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="a1">
-                      <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
                     <dxl:ProjElem ColId="1" Alias="a2">
                       <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="5" Alias="ctid">
-                      <dxl:Ident ColId="5" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="6" Alias="xmin">
-                      <dxl:Ident ColId="6" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="7" Alias="cmin">
-                      <dxl:Ident ColId="7" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="8" Alias="xmax">
-                      <dxl:Ident ColId="8" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="9" Alias="cmax">
-                      <dxl:Ident ColId="9" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="10" Alias="tableoid">
-                      <dxl:Ident ColId="10" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="11" Alias="gp_segment_id">
-                      <dxl:Ident ColId="11" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="13" Alias="ColRef_0013">
+                      <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                 </dxl:CTEConsumer>
                 <dxl:Materialize Eager="true">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000136" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="40" Alias="ColRef_0040">
-                      <dxl:Ident ColId="40" ColName="ColRef_0040" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="52" Alias="ColRef_0052">
+                      <dxl:Ident ColId="52" ColName="ColRef_0052" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                  <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000128" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
-                    <dxl:GroupingColumns/>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="40" Alias="ColRef_0040">
-                        <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                          <dxl:ValuesList ParamType="aggargs">
-                            <dxl:Ident ColId="26" ColName="a2" TypeMdid="0.701.1.0"/>
-                          </dxl:ValuesList>
-                          <dxl:ValuesList ParamType="aggdirectargs"/>
-                          <dxl:ValuesList ParamType="aggorder"/>
-                          <dxl:ValuesList ParamType="aggdistinct"/>
-                        </dxl:AggFunc>
+                      <dxl:ProjElem ColId="52" Alias="ColRef_0052">
+                        <dxl:FuncExpr FuncId="0.1779.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
+                          <dxl:Ident ColId="51" ColName="ColRef_0051" TypeMdid="0.1700.1.0"/>
+                        </dxl:FuncExpr>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:CTEConsumer CTEId="0" Columns="25,26,27,28,29,30,31,32,33">
+                    <dxl:OneTimeFilter/>
+                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
+                      <dxl:GroupingColumns/>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="25" Alias="a1">
-                          <dxl:Ident ColId="25" ColName="a1" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="26" Alias="a2">
-                          <dxl:Ident ColId="26" ColName="a2" TypeMdid="0.701.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="27" Alias="ctid">
-                          <dxl:Ident ColId="27" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="28" Alias="xmin">
-                          <dxl:Ident ColId="28" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="29" Alias="cmin">
-                          <dxl:Ident ColId="29" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="30" Alias="xmax">
-                          <dxl:Ident ColId="30" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="31" Alias="cmax">
-                          <dxl:Ident ColId="31" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="32" Alias="tableoid">
-                          <dxl:Ident ColId="32" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="33" Alias="gp_segment_id">
-                          <dxl:Ident ColId="33" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="51" Alias="ColRef_0051">
+                          <dxl:AggFunc AggMdid="0.2107.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Ident ColId="28" ColName="ColRef_0013" TypeMdid="0.20.1.0"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
                         </dxl:ProjElem>
                       </dxl:ProjList>
-                    </dxl:CTEConsumer>
-                  </dxl:Aggregate>
+                      <dxl:Filter/>
+                      <dxl:CTEConsumer CTEId="0" Columns="27,28">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="27" Alias="a2">
+                            <dxl:Ident ColId="27" ColName="a2" TypeMdid="0.701.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="28" Alias="ColRef_0013">
+                            <dxl:Ident ColId="28" ColName="ColRef_0013" TypeMdid="0.20.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                      </dxl:CTEConsumer>
+                    </dxl:Aggregate>
+                  </dxl:Result>
                 </dxl:Materialize>
               </dxl:NestedLoopJoin>
             </dxl:Sort>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_skewed_data.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_skewed_data.mdp
@@ -1,29 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 Objective:
-Test pre-processing step converts multiple ordered-set aggs with non ScalarConst
-fraction into a NLJ joining GbAgg expression containing ordered aggs split to
-gp_percentile aggs
+Test pre-processing step converts ordered-set agg on skewed dataset
+into a NLJ joining total_count GbAgg and CTEConsumer on deduped data.
+The deduplication of data ensure better performance
 
 CREATE EXTENSION gp_percentile_agg;
 SET optimizer_enable_orderedagg=on;
-CREATE TABLE foo(a1 int, a2 double precision, a3 interval, a4 timestamp, a5 timestamptz);
-EXPLAIN SELECT percentile_cont(floor(random()*0.1)+0.5) WITHIN GROUP(ORDER BY a1) FROM foo;
+CREATE TABLE t AS SELECT 1 a FROM generate_series(1, 10000000) DISTRIBUTED BY (a);
+ANALYZE t;
+EXPLAIN ANALYZE SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a ASC nulls first) FROM t;
+(Better execution time as compared to commit d7de477)
 
-                                                QUERY PLAN
- Sequence  (cost=0.00..1324463.27 rows=1 width=8)
-   ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=1)
-         ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
-               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
-                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
-                           Group Key: foo.a1
-                           ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                 Sort Key: foo.a1
-                                 ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=4)
+                                                             QUERY PLAN
+ Sequence  (cost=0.00..1325244.23 rows=1 width=8)
+   ->  Shared Scan (share slice:id 0:0)  (cost=0.00..1211.96 rows=1 width=1)
+         ->  Materialize  (cost=0.00..1211.96 rows=1 width=1)
+               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1211.96 rows=1 width=12)
+                     ->  GroupAggregate  (cost=0.00..1211.96 rows=1 width=12)
+                           Group Key: t.a
+                           ->  Sort  (cost=0.00..1211.96 rows=1 width=12)
+                                 Sort Key: t.a
+                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1211.96 rows=1 width=12)
+                                       Hash Key: t.a
+                                       ->  Result  (cost=0.00..1211.96 rows=1 width=12)
+                                             ->  HashAggregate  (cost=0.00..1211.96 rows=1 width=12)
+                                                   Group Key: t.a
+                                                   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..796.26 rows=3333306 width=4)
+                                                         ->  Seq Scan on t  (cost=0.00..618.00 rows=3333306 width=4)
    ->  Aggregate  (cost=0.00..1324032.27 rows=1 width=8)
          ->  Limit  (cost=0.00..1324032.27 rows=1 width=20)
                ->  Sort  (cost=0.00..1324032.27 rows=1 width=20)
-                     Sort Key: share0_ref3.a1
+                     Sort Key: share0_ref3.a
                      ->  Nested Loop  (cost=0.00..1324032.27 rows=1 width=20)
                            Join Filter: true
                            ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=12)
@@ -32,7 +40,7 @@ EXPLAIN SELECT percentile_cont(floor(random()*0.1)+0.5) WITHIN GROUP(ORDER BY a1
                                        ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
                                              ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+(27 rows)
 -->
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
@@ -50,14 +58,10 @@ EXPLAIN SELECT percentile_cont(floor(random()*0.1)+0.5) WITHIN GROUP(ORDER BY a1
       <dxl:TraceFlags Value="102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,103043,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:GPDBFunc Mdid="0.2309.1.0" Name="floor" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
-        <dxl:ResultType Mdid="0.701.1.0"/>
-      </dxl:GPDBFunc>
       <dxl:GPDBAgg Mdid="0.3974.1.0" Name="percentile_cont" IsOrdered="true" IsSplittable="false" HashAggCapable="false">
         <dxl:ResultType Mdid="0.701.1.0"/>
         <dxl:IntermediateResultType Mdid="0.17.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:ColumnStatistics Mdid="1.132004.1.0.0" Name="a1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:Type Mdid="0.17.1.0" Name="bytea" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
         <dxl:DistrOpfamily Mdid="0.2223.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7107.1.0"/>
@@ -126,6 +130,12 @@ EXPLAIN SELECT percentile_cont(floor(random()*0.1)+0.5) WITHIN GROUP(ORDER BY a1
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.132007.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
       <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
@@ -208,40 +218,6 @@ EXPLAIN SELECT percentile_cont(floor(random()*0.1)+0.5) WITHIN GROUP(ORDER BY a1
           <dxl:Opfamily Mdid="0.7024.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Type Mdid="0.1184.1.0" Name="timestamptz" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
-        <dxl:DistrOpfamily Mdid="0.1999.1.0"/>
-        <dxl:LegacyDistrOpfamily Mdid="0.7112.1.0"/>
-        <dxl:EqualityOp Mdid="0.1320.1.0"/>
-        <dxl:InequalityOp Mdid="0.1321.1.0"/>
-        <dxl:LessThanOp Mdid="0.1322.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.1323.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.1324.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.1325.1.0"/>
-        <dxl:ComparisonOp Mdid="0.1314.1.0"/>
-        <dxl:ArrayType Mdid="0.1185.1.0"/>
-        <dxl:MinAgg Mdid="0.2143.1.0"/>
-        <dxl:MaxAgg Mdid="0.2127.1.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
-      <dxl:Type Mdid="0.1186.1.0" Name="interval" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="16" PassByValue="false">
-        <dxl:DistrOpfamily Mdid="0.1983.1.0"/>
-        <dxl:LegacyDistrOpfamily Mdid="0.7116.1.0"/>
-        <dxl:EqualityOp Mdid="0.1330.1.0"/>
-        <dxl:InequalityOp Mdid="0.1331.1.0"/>
-        <dxl:LessThanOp Mdid="0.1332.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.1333.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.1334.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.1335.1.0"/>
-        <dxl:ComparisonOp Mdid="0.1315.1.0"/>
-        <dxl:ArrayType Mdid="0.1187.1.0"/>
-        <dxl:MinAgg Mdid="0.2144.1.0"/>
-        <dxl:MaxAgg Mdid="0.2128.1.0"/>
-        <dxl:AvgAgg Mdid="0.2106.1.0"/>
-        <dxl:SumAgg Mdid="0.2113.1.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
       <dxl:Type Mdid="0.1700.1.0" Name="numeric" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
         <dxl:DistrOpfamily Mdid="0.1998.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7103.1.0"/>
@@ -259,22 +235,10 @@ EXPLAIN SELECT percentile_cont(floor(random()*0.1)+0.5) WITHIN GROUP(ORDER BY a1
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:RelationStatistics Mdid="2.132004.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
-      <dxl:Relation Mdid="0.132004.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="11,5" NumberLeafPartitions="0">
+      <dxl:RelationStatistics Mdid="2.132007.1.0" Name="t" Rows="9999918.000000" RelPages="11002" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.132007.1.0" Name="t" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
         <dxl:Columns>
-          <dxl:Column Name="a1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="a2" Attno="2" Mdid="0.701.1.0" Nullable="true" ColWidth="8">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="a3" Attno="3" Mdid="0.1186.1.0" Nullable="true" ColWidth="16">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="a4" Attno="4" Mdid="0.1114.1.0" Nullable="true" ColWidth="8">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="a5" Attno="5" Mdid="0.1184.1.0" Nullable="true" ColWidth="8">
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
           <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
@@ -330,40 +294,6 @@ EXPLAIN SELECT percentile_cont(floor(random()*0.1)+0.5) WITHIN GROUP(ORDER BY a1
         <dxl:SumAgg Mdid="0.2111.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:GPDBFunc Mdid="0.1598.1.0" Name="random" ReturnsSet="false" Stability="Volatile" DataAccess="ContainsSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
-        <dxl:ResultType Mdid="0.701.1.0"/>
-      </dxl:GPDBFunc>
-      <dxl:GPDBScalarOp Mdid="0.591.1.0" Name="+" ComparisonType="Other" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
-        <dxl:LeftType Mdid="0.701.1.0"/>
-        <dxl:RightType Mdid="0.701.1.0"/>
-        <dxl:ResultType Mdid="0.701.1.0"/>
-        <dxl:OpFunc Mdid="0.218.1.0"/>
-        <dxl:Commutator Mdid="0.591.1.0"/>
-      </dxl:GPDBScalarOp>
-      <dxl:GPDBScalarOp Mdid="0.594.1.0" Name="*" ComparisonType="Other" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
-        <dxl:LeftType Mdid="0.701.1.0"/>
-        <dxl:RightType Mdid="0.701.1.0"/>
-        <dxl:ResultType Mdid="0.701.1.0"/>
-        <dxl:OpFunc Mdid="0.216.1.0"/>
-        <dxl:Commutator Mdid="0.594.1.0"/>
-      </dxl:GPDBScalarOp>
-      <dxl:Type Mdid="0.1114.1.0" Name="timestamp" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
-        <dxl:DistrOpfamily Mdid="0.2040.1.0"/>
-        <dxl:LegacyDistrOpfamily Mdid="0.7111.1.0"/>
-        <dxl:EqualityOp Mdid="0.2060.1.0"/>
-        <dxl:InequalityOp Mdid="0.2061.1.0"/>
-        <dxl:LessThanOp Mdid="0.2062.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.2063.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.2064.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.2065.1.0"/>
-        <dxl:ComparisonOp Mdid="0.2045.1.0"/>
-        <dxl:ArrayType Mdid="0.1115.1.0"/>
-        <dxl:MinAgg Mdid="0.2142.1.0"/>
-        <dxl:MaxAgg Mdid="0.2126.1.0"/>
-        <dxl:AvgAgg Mdid="0.0.0.0"/>
-        <dxl:SumAgg Mdid="0.0.0.0"/>
-        <dxl:CountAgg Mdid="0.2147.1.0"/>
-      </dxl:Type>
       <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.23.1.0"/>
         <dxl:RightType Mdid="0.23.1.0"/>
@@ -384,112 +314,99 @@ EXPLAIN SELECT percentile_cont(floor(random()*0.1)+0.5) WITHIN GROUP(ORDER BY a1
         <dxl:ResultType Mdid="0.20.1.0"/>
       </dxl:GPDBFunc>
       <dxl:MDCast Mdid="3.23.1.0;701.1.0" Name="float8" BinaryCoercible="false" SourceTypeId="0.23.1.0" DestinationTypeId="0.701.1.0" CastFuncId="0.316.1.0" CoercePathType="1"/>
-      <dxl:MDCast Mdid="3.701.1.0;701.1.0" Name="float8" BinaryCoercible="true" SourceTypeId="0.701.1.0" DestinationTypeId="0.701.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
     </dxl:Metadata>
     <dxl:Query>
       <dxl:OutputColumns>
-        <dxl:Ident ColId="13" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+        <dxl:Ident ColId="9" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
       </dxl:OutputColumns>
       <dxl:CTEList/>
       <dxl:LogicalGroupBy>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
-          <dxl:ProjElem ColId="13" Alias="percentile_cont">
+          <dxl:ProjElem ColId="9" Alias="percentile_cont">
             <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.131996.1.0">
               <dxl:ValuesList ParamType="aggargs">
                 <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
-                  <dxl:Ident ColId="1" ColName="a1" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:FuncExpr>
               </dxl:ValuesList>
               <dxl:ValuesList ParamType="aggdirectargs">
-                <dxl:OpExpr OperatorName="+" OperatorMdid="0.591.1.0" OperatorType="0.701.1.0">
-                  <dxl:FuncExpr FuncId="0.2309.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
-                    <dxl:OpExpr OperatorName="*" OperatorMdid="0.594.1.0" OperatorType="0.701.1.0">
-                      <dxl:FuncExpr FuncId="0.1598.1.0" FuncRetSet="false" TypeMdid="0.701.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.701.1.0" Value="mpmZmZmZuT8=" DoubleValue="0.100000"/>
-                    </dxl:OpExpr>
-                  </dxl:FuncExpr>
-                  <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
-                </dxl:OpExpr>
+                <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA0D8=" DoubleValue="0.250000"/>
               </dxl:ValuesList>
               <dxl:ValuesList ParamType="aggorder">
-                <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="672" SortNullsFirst="false" IsHashable="true"/>
+                <dxl:SortGroupClause Index="0" EqualityOp="670" SortOperatorMdid="672" SortNullsFirst="true" IsHashable="true"/>
               </dxl:ValuesList>
               <dxl:ValuesList ParamType="aggdistinct"/>
             </dxl:AggFunc>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="0.132004.1.0" TableName="foo">
+          <dxl:TableDescriptor Mdid="0.132007.1.0" TableName="t">
             <dxl:Columns>
-              <dxl:Column ColId="1" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
-              <dxl:Column ColId="2" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
-              <dxl:Column ColId="3" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
-              <dxl:Column ColId="4" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
-              <dxl:Column ColId="5" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
-              <dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-              <dxl:Column ColId="7" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-              <dxl:Column ColId="8" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-              <dxl:Column ColId="9" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-              <dxl:Column ColId="10" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-              <dxl:Column ColId="11" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-              <dxl:Column ColId="12" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
             </dxl:Columns>
           </dxl:TableDescriptor>
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="38">
+    <dxl:Plan Id="0" SpaceSize="190">
       <dxl:Sequence>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324463.268099" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1325244.228342" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
-          <dxl:ProjElem ColId="12" Alias="percentile_cont">
-            <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+          <dxl:ProjElem ColId="8" Alias="percentile_cont">
+            <dxl:Ident ColId="8" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
-        <dxl:CTEProducer CTEId="0" Columns="14,15">
+        <dxl:CTEProducer CTEId="0" Columns="10,11">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000100" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="1211.960343" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="14" Alias="a1">
-              <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="10" Alias="a">
+              <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="15" Alias="ColRef_0013">
-              <dxl:Ident ColId="15" ColName="ColRef_0013" TypeMdid="0.20.1.0"/>
+            <dxl:ProjElem ColId="11" Alias="ColRef_0009">
+              <dxl:Ident ColId="11" ColName="ColRef_0009" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000099" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="1211.960342" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="14" Alias="a1">
-                <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="10" Alias="a">
+                <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="15" Alias="ColRef_0013">
-                <dxl:Ident ColId="15" ColName="ColRef_0013" TypeMdid="0.20.1.0"/>
+              <dxl:ProjElem ColId="11" Alias="ColRef_0009">
+                <dxl:Ident ColId="11" ColName="ColRef_0009" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="1211.960297" Rows="1.000000" Width="12"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
-                <dxl:GroupingColumn ColId="14"/>
+                <dxl:GroupingColumn ColId="10"/>
               </dxl:GroupingColumns>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="14" Alias="a1">
-                  <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="10" Alias="a">
+                  <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="15" Alias="ColRef_0013">
-                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                <dxl:ProjElem ColId="11" Alias="ColRef_0009">
+                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
                     <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="38" ColName="ColRef_0038" TypeMdid="0.20.1.0"/>
                     </dxl:ValuesList>
                     <dxl:ValuesList ParamType="aggdirectargs"/>
                     <dxl:ValuesList ParamType="aggorder"/>
@@ -500,46 +417,116 @@ EXPLAIN SELECT percentile_cont(floor(random()*0.1)+0.5) WITHIN GROUP(ORDER BY a1
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000048" Rows="1.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1211.960283" Rows="1.000000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="14" Alias="a1">
-                    <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="10" Alias="a">
+                    <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="38" Alias="ColRef_0038">
+                    <dxl:Ident ColId="38" ColName="ColRef_0038" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
                 <dxl:SortingColumnList>
-                  <dxl:SortingColumn ColId="14" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  <dxl:SortingColumn ColId="10" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                 </dxl:SortingColumnList>
                 <dxl:LimitCount/>
                 <dxl:LimitOffset/>
-                <dxl:TableScan>
+                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000041" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1211.960283" Rows="1.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="14" Alias="a1">
-                      <dxl:Ident ColId="14" ColName="a1" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="10" Alias="a">
+                      <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="38" Alias="ColRef_0038">
+                      <dxl:Ident ColId="38" ColName="ColRef_0038" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.132004.1.0" TableName="foo">
-                    <dxl:Columns>
-                      <dxl:Column ColId="14" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="16" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
-                      <dxl:Column ColId="17" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
-                      <dxl:Column ColId="18" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
-                      <dxl:Column ColId="19" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
-                      <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr Opfamily="0.1977.1.0">
+                      <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="1211.960264" Rows="1.000000" Width="12"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="10" Alias="a">
+                        <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="38" Alias="ColRef_0038">
+                        <dxl:Ident ColId="38" ColName="ColRef_0038" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="1211.960264" Rows="1.000000" Width="12"/>
+                      </dxl:Properties>
+                      <dxl:GroupingColumns>
+                        <dxl:GroupingColumn ColId="10"/>
+                      </dxl:GroupingColumns>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="38" Alias="ColRef_0038">
+                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="10" Alias="a">
+                          <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:RandomMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="796.263671" Rows="9999918.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="10" Alias="a">
+                            <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="617.998467" Rows="9999918.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="10" Alias="a">
+                              <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="0.132007.1.0" TableName="t">
+                            <dxl:Columns>
+                              <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                              <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:RandomMotion>
+                    </dxl:Aggregate>
+                  </dxl:Result>
+                </dxl:RedistributeMotion>
               </dxl:Sort>
             </dxl:Aggregate>
           </dxl:GatherMotion>
@@ -550,23 +537,15 @@ EXPLAIN SELECT percentile_cont(floor(random()*0.1)+0.5) WITHIN GROUP(ORDER BY a1
           </dxl:Properties>
           <dxl:GroupingColumns/>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="12" Alias="percentile_cont">
+            <dxl:ProjElem ColId="8" Alias="percentile_cont">
               <dxl:AggFunc AggMdid="0.131996.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
                 <dxl:ValuesList ParamType="aggargs">
                   <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
-                    <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                   </dxl:Cast>
-                  <dxl:OpExpr OperatorName="+" OperatorMdid="0.591.1.0" OperatorType="0.701.1.0">
-                    <dxl:FuncExpr FuncId="0.2309.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
-                      <dxl:OpExpr OperatorName="*" OperatorMdid="0.594.1.0" OperatorType="0.701.1.0">
-                        <dxl:FuncExpr FuncId="0.1598.1.0" FuncRetSet="false" TypeMdid="0.701.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.701.1.0" Value="mpmZmZmZuT8=" DoubleValue="0.100000"/>
-                      </dxl:OpExpr>
-                    </dxl:FuncExpr>
-                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
-                  </dxl:OpExpr>
-                  <dxl:Ident ColId="52" ColName="ColRef_0052" TypeMdid="0.20.1.0"/>
-                  <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.20.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA0D8=" DoubleValue="0.250000"/>
+                  <dxl:Ident ColId="36" ColName="ColRef_0036" TypeMdid="0.20.1.0"/>
+                  <dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.20.1.0"/>
                 </dxl:ValuesList>
                 <dxl:ValuesList ParamType="aggdirectargs"/>
                 <dxl:ValuesList ParamType="aggorder"/>
@@ -580,14 +559,14 @@ EXPLAIN SELECT percentile_cont(floor(random()*0.1)+0.5) WITHIN GROUP(ORDER BY a1
               <dxl:Cost StartupCost="0" TotalCost="1324032.267984" Rows="1.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="a1">
-                <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="13" Alias="ColRef_0013">
-                <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.20.1.0"/>
+              <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+                <dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="52" Alias="ColRef_0052">
-                <dxl:Ident ColId="52" ColName="ColRef_0052" TypeMdid="0.20.1.0"/>
+              <dxl:ProjElem ColId="36" Alias="ColRef_0036">
+                <dxl:Ident ColId="36" ColName="ColRef_0036" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Sort SortDiscardDuplicates="false">
@@ -595,19 +574,19 @@ EXPLAIN SELECT percentile_cont(floor(random()*0.1)+0.5) WITHIN GROUP(ORDER BY a1
                 <dxl:Cost StartupCost="0" TotalCost="1324032.267964" Rows="1.000000" Width="20"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="a1">
-                  <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="0" Alias="a">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="13" Alias="ColRef_0013">
-                  <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.20.1.0"/>
+                <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+                  <dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="52" Alias="ColRef_0052">
-                  <dxl:Ident ColId="52" ColName="ColRef_0052" TypeMdid="0.20.1.0"/>
+                <dxl:ProjElem ColId="36" Alias="ColRef_0036">
+                  <dxl:Ident ColId="36" ColName="ColRef_0036" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
               <dxl:SortingColumnList>
-                <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="true"/>
               </dxl:SortingColumnList>
               <dxl:LimitCount/>
               <dxl:LimitOffset/>
@@ -616,30 +595,30 @@ EXPLAIN SELECT percentile_cont(floor(random()*0.1)+0.5) WITHIN GROUP(ORDER BY a1
                   <dxl:Cost StartupCost="0" TotalCost="1324032.267964" Rows="1.000000" Width="20"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="a1">
-                    <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="0" Alias="a">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="13" Alias="ColRef_0013">
-                    <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.20.1.0"/>
+                  <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+                    <dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="52" Alias="ColRef_0052">
-                    <dxl:Ident ColId="52" ColName="ColRef_0052" TypeMdid="0.20.1.0"/>
+                  <dxl:ProjElem ColId="36" Alias="ColRef_0036">
+                    <dxl:Ident ColId="36" ColName="ColRef_0036" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
                 <dxl:JoinFilter>
                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                 </dxl:JoinFilter>
-                <dxl:CTEConsumer CTEId="0" Columns="0,13">
+                <dxl:CTEConsumer CTEId="0" Columns="0,9">
                   <dxl:Properties>
                     <dxl:Cost StartupCost="0" TotalCost="431.000029" Rows="1.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="a1">
-                      <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="0" Alias="a">
+                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="13" Alias="ColRef_0013">
-                      <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+                      <dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                 </dxl:CTEConsumer>
@@ -648,8 +627,8 @@ EXPLAIN SELECT percentile_cont(floor(random()*0.1)+0.5) WITHIN GROUP(ORDER BY a1
                     <dxl:Cost StartupCost="0" TotalCost="431.000136" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="52" Alias="ColRef_0052">
-                      <dxl:Ident ColId="52" ColName="ColRef_0052" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="36" Alias="ColRef_0036">
+                      <dxl:Ident ColId="36" ColName="ColRef_0036" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
@@ -658,9 +637,9 @@ EXPLAIN SELECT percentile_cont(floor(random()*0.1)+0.5) WITHIN GROUP(ORDER BY a1
                       <dxl:Cost StartupCost="0" TotalCost="431.000128" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="52" Alias="ColRef_0052">
+                      <dxl:ProjElem ColId="36" Alias="ColRef_0036">
                         <dxl:FuncExpr FuncId="0.1779.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
-                          <dxl:Ident ColId="51" ColName="ColRef_0051" TypeMdid="0.1700.1.0"/>
+                          <dxl:Ident ColId="35" ColName="ColRef_0035" TypeMdid="0.1700.1.0"/>
                         </dxl:FuncExpr>
                       </dxl:ProjElem>
                     </dxl:ProjList>
@@ -672,10 +651,10 @@ EXPLAIN SELECT percentile_cont(floor(random()*0.1)+0.5) WITHIN GROUP(ORDER BY a1
                       </dxl:Properties>
                       <dxl:GroupingColumns/>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="51" Alias="ColRef_0051">
+                        <dxl:ProjElem ColId="35" Alias="ColRef_0035">
                           <dxl:AggFunc AggMdid="0.2107.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
                             <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Ident ColId="28" ColName="ColRef_0013" TypeMdid="0.20.1.0"/>
+                              <dxl:Ident ColId="20" ColName="ColRef_0009" TypeMdid="0.20.1.0"/>
                             </dxl:ValuesList>
                             <dxl:ValuesList ParamType="aggdirectargs"/>
                             <dxl:ValuesList ParamType="aggorder"/>
@@ -684,16 +663,16 @@ EXPLAIN SELECT percentile_cont(floor(random()*0.1)+0.5) WITHIN GROUP(ORDER BY a1
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:CTEConsumer CTEId="0" Columns="27,28">
+                      <dxl:CTEConsumer CTEId="0" Columns="19,20">
                         <dxl:Properties>
                           <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="27" Alias="a1">
-                            <dxl:Ident ColId="27" ColName="a1" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="19" Alias="a">
+                            <dxl:Ident ColId="19" ColName="a" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="28" Alias="ColRef_0013">
-                            <dxl:Ident ColId="28" ColName="ColRef_0013" TypeMdid="0.20.1.0"/>
+                          <dxl:ProjElem ColId="20" Alias="ColRef_0009">
+                            <dxl:Ident ColId="20" ColName="ColRef_0009" TypeMdid="0.20.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                       </dxl:CTEConsumer>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_with_nonOrderedAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_with_nonOrderedAgg.mdp
@@ -10,40 +10,57 @@ CREATE TABLE foo(a1 int, a2 double precision, a3 interval, a4 timestamp, a5 time
 EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_disc(0.5) WITHIN GROUP(ORDER BY a2 desc), count(*) FROM foo;
 
                                                       QUERY PLAN
- Sequence  (cost=0.00..1390608387896.22 rows=1 width=24)
+ Sequence  (cost=0.00..1390608583331.79 rows=1 width=24)
    ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=1)
          ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
-               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=42)
-                     ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=42)
-   ->  Nested Loop  (cost=0.00..1390608387465.22 rows=1 width=24)
-         Join Filter: true
-         ->  Nested Loop  (cost=0.00..1356691540.25 rows=1 width=16)
+               ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                           Group Key: foo_2.a1
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                                 Sort Key: foo_2.a1
+                                 ->  Seq Scan on foo foo_2  (cost=0.00..431.00 rows=1 width=4)
+   ->  Sequence  (cost=0.00..1390608582900.79 rows=1 width=24)
+         ->  Shared Scan (share slice:id 0:1)  (cost=0.00..431.00 rows=1 width=1)
+               ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
+                                 Group Key: foo_1.a2
+                                 ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                                       Sort Key: foo_1.a2
+                                       ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                             Hash Key: foo_1.a2
+                                             ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=8)
+         ->  Nested Loop  (cost=0.00..1390608582469.79 rows=1 width=24)
                Join Filter: true
-               ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
-                           ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=1)
-               ->  Aggregate  (cost=0.00..1324032.08 rows=1 width=8)
-                     ->  Limit  (cost=0.00..1324032.08 rows=1 width=12)
-                           ->  Sort  (cost=0.00..1324032.08 rows=1 width=12)
-                                 Sort Key: share0_ref4.a1
-                                 ->  Nested Loop  (cost=0.00..1324032.08 rows=1 width=12)
+               ->  Nested Loop  (cost=0.00..1356691730.52 rows=1 width=16)
+                     Join Filter: true
+                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                                 ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=1)
+                     ->  Aggregate  (cost=0.00..1324032.27 rows=1 width=8)
+                           ->  Limit  (cost=0.00..1324032.27 rows=1 width=20)
+                                 ->  Sort  (cost=0.00..1324032.27 rows=1 width=20)
+                                       Sort Key: share0_ref3.a1
+                                       ->  Nested Loop  (cost=0.00..1324032.27 rows=1 width=20)
+                                             Join Filter: true
+                                             ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=12)
+                                             ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                               ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+               ->  Aggregate  (cost=0.00..1324032.29 rows=1 width=8)
+                     ->  Limit  (cost=0.00..1324032.29 rows=1 width=24)
+                           ->  Sort  (cost=0.00..1324032.29 rows=1 width=24)
+                                 Sort Key: share1_ref3.a2
+                                 ->  Nested Loop  (cost=0.00..1324032.29 rows=1 width=24)
                                        Join Filter: true
-                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                             ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=4)
-                                       ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
-                                             ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=4)
-         ->  Aggregate  (cost=0.00..1324032.13 rows=1 width=8)
-               ->  Limit  (cost=0.00..1324032.13 rows=1 width=16)
-                     ->  Sort  (cost=0.00..1324032.13 rows=1 width=16)
-                           Sort Key: share0_ref3.a2
-                           ->  Nested Loop  (cost=0.00..1324032.13 rows=1 width=16)
-                                 Join Filter: true
-                                 ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
-                                 ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
-                                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                                             ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Shared Scan (share slice:id 0:1)  (cost=0.00..431.00 rows=1 width=16)
+                                       ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                                         ->  Shared Scan (share slice:id 0:1)  (cost=0.00..431.00 rows=1 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(33 rows)
+(50 rows)
 -->
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
@@ -69,6 +86,25 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_disc(0
         <dxl:ResultType Mdid="0.701.1.0"/>
         <dxl:IntermediateResultType Mdid="0.17.1.0"/>
       </dxl:GPDBAgg>
+      <dxl:ColumnStatistics Mdid="1.132004.1.0.1" Name="a2" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.132004.1.0.0" Name="a1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.17.1.0" Name="bytea" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2223.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7107.1.0"/>
+        <dxl:EqualityOp Mdid="0.1955.1.0"/>
+        <dxl:InequalityOp Mdid="0.1956.1.0"/>
+        <dxl:LessThanOp Mdid="0.1957.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1958.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1959.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1960.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1954.1.0"/>
+        <dxl:ArrayType Mdid="0.1001.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
@@ -154,6 +190,10 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_disc(0
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.131996.1.0" Name="gp_percentile_cont" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBAgg>
       <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
         <dxl:EqualityOp Mdid="0.385.1.0"/>
@@ -186,6 +226,10 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_disc(0
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.132000.1.0" Name="gp_percentile_disc" IsSplittable="false" HashAggCapable="false">
+        <dxl:ResultType Mdid="0.2283.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.2283.1.0"/>
+      </dxl:GPDBAgg>
       <dxl:GPDBScalarOp Mdid="0.672.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.701.1.0"/>
         <dxl:RightType Mdid="0.701.1.0"/>
@@ -244,38 +288,25 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_disc(0
         <dxl:SumAgg Mdid="0.2113.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:ColumnStatistics Mdid="1.164182.1.0.1" Name="a2" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.164182.1.0.0" Name="a1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:GPDBFunc Mdid="0.316.1.0" Name="float8" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
-        <dxl:ResultType Mdid="0.701.1.0"/>
-      </dxl:GPDBFunc>
-      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
-        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
-        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
-        <dxl:EqualityOp Mdid="0.670.1.0"/>
-        <dxl:InequalityOp Mdid="0.671.1.0"/>
-        <dxl:LessThanOp Mdid="0.672.1.0"/>
-        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
-        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
-        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
-        <dxl:ComparisonOp Mdid="0.355.1.0"/>
-        <dxl:ArrayType Mdid="0.1022.1.0"/>
-        <dxl:MinAgg Mdid="0.2136.1.0"/>
-        <dxl:MaxAgg Mdid="0.2120.1.0"/>
-        <dxl:AvgAgg Mdid="0.2105.1.0"/>
-        <dxl:SumAgg Mdid="0.2111.1.0"/>
+      <dxl:Type Mdid="0.1700.1.0" Name="numeric" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1998.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7103.1.0"/>
+        <dxl:EqualityOp Mdid="0.1752.1.0"/>
+        <dxl:InequalityOp Mdid="0.1753.1.0"/>
+        <dxl:LessThanOp Mdid="0.1754.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1755.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1756.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1757.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1769.1.0"/>
+        <dxl:ArrayType Mdid="0.1231.1.0"/>
+        <dxl:MinAgg Mdid="0.2146.1.0"/>
+        <dxl:MaxAgg Mdid="0.2130.1.0"/>
+        <dxl:AvgAgg Mdid="0.2103.1.0"/>
+        <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:GPDBAgg Mdid="0.164166.1.0" Name="gp_percentile_disc" IsSplittable="false" HashAggCapable="false">
-        <dxl:ResultType Mdid="0.2283.1.0"/>
-        <dxl:IntermediateResultType Mdid="0.2283.1.0"/>
-      </dxl:GPDBAgg>
-      <dxl:GPDBAgg Mdid="0.164162.1.0" Name="gp_percentile_cont" IsSplittable="false" HashAggCapable="false">
-        <dxl:ResultType Mdid="0.701.1.0"/>
-        <dxl:IntermediateResultType Mdid="0.701.1.0"/>
-      </dxl:GPDBAgg>
-      <dxl:RelationStatistics Mdid="2.164182.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
-      <dxl:Relation Mdid="0.164182.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="11,5" NumberLeafPartitions="0">
+      <dxl:RelationStatistics Mdid="2.132004.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.132004.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="11,5" NumberLeafPartitions="0">
         <dxl:Columns>
           <dxl:Column Name="a1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
@@ -321,6 +352,30 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_disc(0
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
+      <dxl:GPDBAgg Mdid="0.2107.1.0" Name="sum" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.1700.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.17.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:GPDBFunc Mdid="0.316.1.0" Name="float8" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1971.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7102.1.0"/>
+        <dxl:EqualityOp Mdid="0.670.1.0"/>
+        <dxl:InequalityOp Mdid="0.671.1.0"/>
+        <dxl:LessThanOp Mdid="0.672.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
+        <dxl:ComparisonOp Mdid="0.355.1.0"/>
+        <dxl:ArrayType Mdid="0.1022.1.0"/>
+        <dxl:MinAgg Mdid="0.2136.1.0"/>
+        <dxl:MaxAgg Mdid="0.2120.1.0"/>
+        <dxl:AvgAgg Mdid="0.2105.1.0"/>
+        <dxl:SumAgg Mdid="0.2111.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
       <dxl:Type Mdid="0.1114.1.0" Name="timestamp" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2040.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7111.1.0"/>
@@ -369,6 +424,9 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_disc(0
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
+      <dxl:GPDBFunc Mdid="0.1779.1.0" Name="int8" ReturnsSet="false" Stability="Immutable" DataAccess="ContainsSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBFunc>
       <dxl:GPDBAgg Mdid="0.2803.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
@@ -386,7 +444,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_disc(0
         <dxl:GroupingColumns/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="13" Alias="percentile_cont">
-            <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.164162.1.0">
+            <dxl:AggFunc AggMdid="0.3974.1.0" AggDistinct="false" AggStage="Normal" AggKind="o" GpAggMdid="0.131996.1.0">
               <dxl:ValuesList ParamType="aggargs">
                 <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
                   <dxl:Ident ColId="1" ColName="a1" TypeMdid="0.23.1.0"/>
@@ -402,7 +460,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_disc(0
             </dxl:AggFunc>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="14" Alias="percentile_disc">
-            <dxl:AggFunc AggMdid="0.3972.1.0" AggDistinct="false" AggStage="Normal" TypeMdid="0.701.1.0" AggKind="o" GpAggMdid="0.164166.1.0">
+            <dxl:AggFunc AggMdid="0.3972.1.0" AggDistinct="false" AggStage="Normal" TypeMdid="0.701.1.0" AggKind="o" GpAggMdid="0.132000.1.0">
               <dxl:ValuesList ParamType="aggargs">
                 <dxl:Ident ColId="2" ColName="a2" TypeMdid="0.701.1.0"/>
               </dxl:ValuesList>
@@ -425,7 +483,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_disc(0
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
+          <dxl:TableDescriptor Mdid="0.132004.1.0" TableName="foo">
             <dxl:Columns>
               <dxl:Column ColId="1" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="2" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
@@ -444,10 +502,10 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_disc(0
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6318">
+    <dxl:Plan Id="0" SpaceSize="1086480">
       <dxl:Sequence>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1390608387896.216797" Rows="1.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="1390608583331.788818" Rows="1.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="12" Alias="percentile_cont">
@@ -460,130 +518,104 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_disc(0
             <dxl:Ident ColId="14" ColName="count" TypeMdid="0.20.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
-        <dxl:CTEProducer CTEId="0" Columns="15,16,17,18,19,20,21,22,23">
+        <dxl:CTEProducer CTEId="0" Columns="16,17">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000197" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000100" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="15" Alias="a1">
-              <dxl:Ident ColId="15" ColName="a1" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="16" Alias="a1">
+              <dxl:Ident ColId="16" ColName="a1" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="16" Alias="a2">
-              <dxl:Ident ColId="16" ColName="a2" TypeMdid="0.701.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="17" Alias="ctid">
-              <dxl:Ident ColId="17" ColName="ctid" TypeMdid="0.27.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="18" Alias="xmin">
-              <dxl:Ident ColId="18" ColName="xmin" TypeMdid="0.28.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="19" Alias="cmin">
-              <dxl:Ident ColId="19" ColName="cmin" TypeMdid="0.29.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="20" Alias="xmax">
-              <dxl:Ident ColId="20" ColName="xmax" TypeMdid="0.28.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="21" Alias="cmax">
-              <dxl:Ident ColId="21" ColName="cmax" TypeMdid="0.29.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="22" Alias="tableoid">
-              <dxl:Ident ColId="22" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="23" Alias="gp_segment_id">
-              <dxl:Ident ColId="23" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="17" Alias="ColRef_0015">
+              <dxl:Ident ColId="17" ColName="ColRef_0015" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000196" Rows="1.000000" Width="42"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000099" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="15" Alias="a1">
-                <dxl:Ident ColId="15" ColName="a1" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="16" Alias="a1">
+                <dxl:Ident ColId="16" ColName="a1" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="16" Alias="a2">
-                <dxl:Ident ColId="16" ColName="a2" TypeMdid="0.701.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="17" Alias="ctid">
-                <dxl:Ident ColId="17" ColName="ctid" TypeMdid="0.27.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="18" Alias="xmin">
-                <dxl:Ident ColId="18" ColName="xmin" TypeMdid="0.28.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="19" Alias="cmin">
-                <dxl:Ident ColId="19" ColName="cmin" TypeMdid="0.29.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="20" Alias="xmax">
-                <dxl:Ident ColId="20" ColName="xmax" TypeMdid="0.28.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="21" Alias="cmax">
-                <dxl:Ident ColId="21" ColName="cmax" TypeMdid="0.29.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="22" Alias="tableoid">
-                <dxl:Ident ColId="22" ColName="tableoid" TypeMdid="0.26.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="23" Alias="gp_segment_id">
-                <dxl:Ident ColId="23" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="17" Alias="ColRef_0015">
+                <dxl:Ident ColId="17" ColName="ColRef_0015" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:SortingColumnList/>
-            <dxl:TableScan>
+            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="42"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="12"/>
               </dxl:Properties>
+              <dxl:GroupingColumns>
+                <dxl:GroupingColumn ColId="16"/>
+              </dxl:GroupingColumns>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="15" Alias="a1">
-                  <dxl:Ident ColId="15" ColName="a1" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="16" Alias="a1">
+                  <dxl:Ident ColId="16" ColName="a1" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="16" Alias="a2">
-                  <dxl:Ident ColId="16" ColName="a2" TypeMdid="0.701.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="17" Alias="ctid">
-                  <dxl:Ident ColId="17" ColName="ctid" TypeMdid="0.27.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="18" Alias="xmin">
-                  <dxl:Ident ColId="18" ColName="xmin" TypeMdid="0.28.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="19" Alias="cmin">
-                  <dxl:Ident ColId="19" ColName="cmin" TypeMdid="0.29.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="20" Alias="xmax">
-                  <dxl:Ident ColId="20" ColName="xmax" TypeMdid="0.28.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="21" Alias="cmax">
-                  <dxl:Ident ColId="21" ColName="cmax" TypeMdid="0.29.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="22" Alias="tableoid">
-                  <dxl:Ident ColId="22" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="23" Alias="gp_segment_id">
-                  <dxl:Ident ColId="23" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="17" Alias="ColRef_0015">
+                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                    <dxl:ValuesList ParamType="aggargs">
+                      <dxl:Ident ColId="16" ColName="a1" TypeMdid="0.23.1.0"/>
+                    </dxl:ValuesList>
+                    <dxl:ValuesList ParamType="aggdirectargs"/>
+                    <dxl:ValuesList ParamType="aggorder"/>
+                    <dxl:ValuesList ParamType="aggdistinct"/>
+                  </dxl:AggFunc>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
-                <dxl:Columns>
-                  <dxl:Column ColId="15" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="16" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
-                  <dxl:Column ColId="24" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
-                  <dxl:Column ColId="25" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
-                  <dxl:Column ColId="26" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
-                  <dxl:Column ColId="17" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="18" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="19" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="20" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="21" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="22" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="23" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
+              <dxl:Sort SortDiscardDuplicates="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000048" Rows="1.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="16" Alias="a1">
+                    <dxl:Ident ColId="16" ColName="a1" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="16" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000041" Rows="1.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="16" Alias="a1">
+                      <dxl:Ident ColId="16" ColName="a1" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.132004.1.0" TableName="foo">
+                    <dxl:Columns>
+                      <dxl:Column ColId="16" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="18" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
+                      <dxl:Column ColId="19" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
+                      <dxl:Column ColId="20" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
+                      <dxl:Column ColId="21" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
+                      <dxl:Column ColId="22" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="23" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="24" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="25" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="26" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="27" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="28" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:Sort>
+            </dxl:Aggregate>
           </dxl:GatherMotion>
         </dxl:CTEProducer>
-        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+        <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1390608387465.216553" Rows="1.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="1390608582900.788818" Rows="1.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="12" Alias="percentile_cont">
@@ -596,17 +628,128 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_disc(0
               <dxl:Ident ColId="14" ColName="count" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:JoinFilter>
-            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-          </dxl:JoinFilter>
+          <dxl:CTEProducer CTEId="1" Columns="56,57">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000103" Rows="1.000000" Width="1"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="56" Alias="a2">
+                <dxl:Ident ColId="56" ColName="a2" TypeMdid="0.701.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="57" Alias="ColRef_0055">
+                <dxl:Ident ColId="57" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000102" Rows="1.000000" Width="16"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="56" Alias="a2">
+                  <dxl:Ident ColId="56" ColName="a2" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="57" Alias="ColRef_0055">
+                  <dxl:Ident ColId="57" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="1.000000" Width="16"/>
+                </dxl:Properties>
+                <dxl:GroupingColumns>
+                  <dxl:GroupingColumn ColId="56"/>
+                </dxl:GroupingColumns>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="56" Alias="a2">
+                    <dxl:Ident ColId="56" ColName="a2" TypeMdid="0.701.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="57" Alias="ColRef_0055">
+                    <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                      <dxl:ValuesList ParamType="aggargs">
+                        <dxl:Ident ColId="56" ColName="a2" TypeMdid="0.701.1.0"/>
+                      </dxl:ValuesList>
+                      <dxl:ValuesList ParamType="aggdirectargs"/>
+                      <dxl:ValuesList ParamType="aggorder"/>
+                      <dxl:ValuesList ParamType="aggdistinct"/>
+                    </dxl:AggFunc>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:Sort SortDiscardDuplicates="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000031" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="56" Alias="a2">
+                      <dxl:Ident ColId="56" ColName="a2" TypeMdid="0.701.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="56" SortOperatorMdid="0.672.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  </dxl:SortingColumnList>
+                  <dxl:LimitCount/>
+                  <dxl:LimitOffset/>
+                  <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000031" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="56" Alias="a2">
+                        <dxl:Ident ColId="56" ColName="a2" TypeMdid="0.701.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList/>
+                    <dxl:HashExprList>
+                      <dxl:HashExpr Opfamily="0.1971.1.0">
+                        <dxl:Ident ColId="56" ColName="a2" TypeMdid="0.701.1.0"/>
+                      </dxl:HashExpr>
+                    </dxl:HashExprList>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="56" Alias="a2">
+                          <dxl:Ident ColId="56" ColName="a2" TypeMdid="0.701.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="0.132004.1.0" TableName="foo">
+                        <dxl:Columns>
+                          <dxl:Column ColId="58" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="56" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="59" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
+                          <dxl:Column ColId="60" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="61" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
+                          <dxl:Column ColId="62" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                          <dxl:Column ColId="63" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="64" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="65" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="66" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="67" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="68" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:RedistributeMotion>
+                </dxl:Sort>
+              </dxl:Aggregate>
+            </dxl:GatherMotion>
+          </dxl:CTEProducer>
           <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1356691540.253197" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1390608582469.788818" Rows="1.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="12" Alias="percentile_cont">
                 <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="13" Alias="percentile_disc">
+                <dxl:Ident ColId="13" ColName="percentile_disc" TypeMdid="0.701.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="14" Alias="count">
                 <dxl:Ident ColId="14" ColName="count" TypeMdid="0.20.1.0"/>
@@ -616,66 +759,239 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_disc(0
             <dxl:JoinFilter>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:JoinFilter>
-            <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+            <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="1356691730.523342" Rows="1.000000" Width="16"/>
               </dxl:Properties>
-              <dxl:GroupingColumns/>
               <dxl:ProjList>
+                <dxl:ProjElem ColId="12" Alias="percentile_cont">
+                  <dxl:Ident ColId="12" ColName="percentile_cont" TypeMdid="0.701.1.0"/>
+                </dxl:ProjElem>
                 <dxl:ProjElem ColId="14" Alias="count">
-                  <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                    <dxl:ValuesList ParamType="aggargs"/>
-                    <dxl:ValuesList ParamType="aggdirectargs"/>
-                    <dxl:ValuesList ParamType="aggorder"/>
-                    <dxl:ValuesList ParamType="aggdistinct"/>
-                  </dxl:AggFunc>
+                  <dxl:Ident ColId="14" ColName="count" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+              <dxl:JoinFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:JoinFilter>
+              <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
-                <dxl:ProjList/>
+                <dxl:GroupingColumns/>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="14" Alias="count">
+                    <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                      <dxl:ValuesList ParamType="aggargs"/>
+                      <dxl:ValuesList ParamType="aggdirectargs"/>
+                      <dxl:ValuesList ParamType="aggorder"/>
+                      <dxl:ValuesList ParamType="aggdistinct"/>
+                    </dxl:AggFunc>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:TableScan>
+                <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList/>
                   <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.164182.1.0" TableName="foo">
-                    <dxl:Columns>
-                      <dxl:Column ColId="0" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="1" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
-                      <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="6" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="7" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="8" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="9" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="10" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="11" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:GatherMotion>
-            </dxl:Aggregate>
+                  <dxl:SortingColumnList/>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="1"/>
+                    </dxl:Properties>
+                    <dxl:ProjList/>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.132004.1.0" TableName="foo">
+                      <dxl:Columns>
+                        <dxl:Column ColId="0" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="1" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
+                        <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                        <dxl:Column ColId="6" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="7" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="8" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="9" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="10" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="11" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:GatherMotion>
+              </dxl:Aggregate>
+              <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1324032.267991" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:GroupingColumns/>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="12" Alias="percentile_cont">
+                    <dxl:AggFunc AggMdid="0.131996.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                      <dxl:ValuesList ParamType="aggargs">
+                        <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
+                          <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                        </dxl:Cast>
+                        <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
+                        <dxl:Ident ColId="54" ColName="ColRef_0054" TypeMdid="0.20.1.0"/>
+                        <dxl:Ident ColId="15" ColName="ColRef_0015" TypeMdid="0.20.1.0"/>
+                      </dxl:ValuesList>
+                      <dxl:ValuesList ParamType="aggdirectargs"/>
+                      <dxl:ValuesList ParamType="aggorder"/>
+                      <dxl:ValuesList ParamType="aggdistinct"/>
+                    </dxl:AggFunc>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:Limit>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="1324032.267984" Rows="1.000000" Width="20"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="a1">
+                      <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="15" Alias="ColRef_0015">
+                      <dxl:Ident ColId="15" ColName="ColRef_0015" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="54" Alias="ColRef_0054">
+                      <dxl:Ident ColId="54" ColName="ColRef_0054" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Sort SortDiscardDuplicates="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="1324032.267964" Rows="1.000000" Width="20"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="a1">
+                        <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="15" Alias="ColRef_0015">
+                        <dxl:Ident ColId="15" ColName="ColRef_0015" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="54" Alias="ColRef_0054">
+                        <dxl:Ident ColId="54" ColName="ColRef_0054" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList>
+                      <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                    </dxl:SortingColumnList>
+                    <dxl:LimitCount/>
+                    <dxl:LimitOffset/>
+                    <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="1324032.267964" Rows="1.000000" Width="20"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="0" Alias="a1">
+                          <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="15" Alias="ColRef_0015">
+                          <dxl:Ident ColId="15" ColName="ColRef_0015" TypeMdid="0.20.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="54" Alias="ColRef_0054">
+                          <dxl:Ident ColId="54" ColName="ColRef_0054" TypeMdid="0.20.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:JoinFilter>
+                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                      </dxl:JoinFilter>
+                      <dxl:CTEConsumer CTEId="0" Columns="0,15">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000029" Rows="1.000000" Width="12"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="0" Alias="a1">
+                            <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="15" Alias="ColRef_0015">
+                            <dxl:Ident ColId="15" ColName="ColRef_0015" TypeMdid="0.20.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                      </dxl:CTEConsumer>
+                      <dxl:Materialize Eager="true">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000136" Rows="1.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="54" Alias="ColRef_0054">
+                            <dxl:Ident ColId="54" ColName="ColRef_0054" TypeMdid="0.20.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:Result>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000128" Rows="1.000000" Width="8"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="54" Alias="ColRef_0054">
+                              <dxl:FuncExpr FuncId="0.1779.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
+                                <dxl:Ident ColId="53" ColName="ColRef_0053" TypeMdid="0.1700.1.0"/>
+                              </dxl:FuncExpr>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:OneTimeFilter/>
+                          <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
+                            </dxl:Properties>
+                            <dxl:GroupingColumns/>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="53" Alias="ColRef_0053">
+                                <dxl:AggFunc AggMdid="0.2107.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                                  <dxl:ValuesList ParamType="aggargs">
+                                    <dxl:Ident ColId="30" ColName="ColRef_0015" TypeMdid="0.20.1.0"/>
+                                  </dxl:ValuesList>
+                                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                                  <dxl:ValuesList ParamType="aggorder"/>
+                                  <dxl:ValuesList ParamType="aggdistinct"/>
+                                </dxl:AggFunc>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:CTEConsumer CTEId="0" Columns="29,30">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="29" Alias="a1">
+                                  <dxl:Ident ColId="29" ColName="a1" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="30" Alias="ColRef_0015">
+                                  <dxl:Ident ColId="30" ColName="ColRef_0015" TypeMdid="0.20.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                            </dxl:CTEConsumer>
+                          </dxl:Aggregate>
+                        </dxl:Result>
+                      </dxl:Materialize>
+                    </dxl:NestedLoopJoin>
+                  </dxl:Sort>
+                  <dxl:LimitCount>
+                    <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
+                  </dxl:LimitCount>
+                  <dxl:LimitOffset>
+                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                  </dxl:LimitOffset>
+                </dxl:Limit>
+              </dxl:Aggregate>
+            </dxl:NestedLoopJoin>
             <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324032.082180" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.294698" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:GroupingColumns/>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="12" Alias="percentile_cont">
-                  <dxl:AggFunc AggMdid="0.164162.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                <dxl:ProjElem ColId="13" Alias="percentile_disc">
+                  <dxl:AggFunc AggMdid="0.132000.1.0" AggDistinct="false" AggStage="Normal" TypeMdid="0.701.1.0" AggKind="n">
                     <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
-                        <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
-                      </dxl:Cast>
+                      <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
                       <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
-                      <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                      <dxl:Ident ColId="94" ColName="ColRef_0094" TypeMdid="0.20.1.0"/>
+                      <dxl:Ident ColId="55" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
                     </dxl:ValuesList>
                     <dxl:ValuesList ParamType="aggdirectargs"/>
                     <dxl:ValuesList ParamType="aggorder"/>
@@ -686,171 +1002,128 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_disc(0
               <dxl:Filter/>
               <dxl:Limit>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324032.082178" Rows="1.000000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324032.294690" Rows="1.000000" Width="24"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="a1">
-                    <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="1" Alias="a2">
+                    <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                    <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                  <dxl:ProjElem ColId="55" Alias="ColRef_0055">
+                    <dxl:Ident ColId="55" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="94" Alias="ColRef_0094">
+                    <dxl:Ident ColId="94" ColName="ColRef_0094" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324032.082166" Rows="1.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324032.294666" Rows="1.000000" Width="24"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="a1">
-                      <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="1" Alias="a2">
+                      <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                      <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="55" Alias="ColRef_0055">
+                      <dxl:Ident ColId="55" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="94" Alias="ColRef_0094">
+                      <dxl:Ident ColId="94" ColName="ColRef_0094" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:SortingColumnList>
-                    <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                    <dxl:SortingColumn ColId="1" SortOperatorMdid="0.674.1.0" SortOperatorName="&gt;" SortNullsFirst="true"/>
                   </dxl:SortingColumnList>
                   <dxl:LimitCount/>
                   <dxl:LimitOffset/>
                   <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324032.082166" Rows="1.000000" Width="12"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1324032.294666" Rows="1.000000" Width="24"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="0" Alias="a1">
-                        <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="1" Alias="a2">
+                        <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                        <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                      <dxl:ProjElem ColId="55" Alias="ColRef_0055">
+                        <dxl:Ident ColId="55" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="94" Alias="ColRef_0094">
+                        <dxl:Ident ColId="94" ColName="ColRef_0094" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
                     <dxl:JoinFilter>
                       <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                     </dxl:JoinFilter>
-                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                    <dxl:CTEConsumer CTEId="1" Columns="1,55">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="8"/>
-                      </dxl:Properties>
-                      <dxl:GroupingColumns/>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                            <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Ident ColId="27" ColName="a1" TypeMdid="0.23.1.0"/>
-                            </dxl:ValuesList>
-                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                            <dxl:ValuesList ParamType="aggorder"/>
-                            <dxl:ValuesList ParamType="aggdistinct"/>
-                          </dxl:AggFunc>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:CTEConsumer CTEId="0" Columns="27,28,29,30,31,32,33,34,35">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="27" Alias="a1">
-                            <dxl:Ident ColId="27" ColName="a1" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="28" Alias="a2">
-                            <dxl:Ident ColId="28" ColName="a2" TypeMdid="0.701.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="29" Alias="ctid">
-                            <dxl:Ident ColId="29" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="30" Alias="xmin">
-                            <dxl:Ident ColId="30" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="31" Alias="cmin">
-                            <dxl:Ident ColId="31" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="32" Alias="xmax">
-                            <dxl:Ident ColId="32" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="33" Alias="cmax">
-                            <dxl:Ident ColId="33" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="34" Alias="tableoid">
-                            <dxl:Ident ColId="34" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="35" Alias="gp_segment_id">
-                            <dxl:Ident ColId="35" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                      </dxl:CTEConsumer>
-                    </dxl:Aggregate>
-                    <dxl:Materialize Eager="true">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="16"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="0" Alias="a1">
-                          <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="1" Alias="a2">
                           <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="5" Alias="ctid">
-                          <dxl:Ident ColId="5" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:ProjElem ColId="55" Alias="ColRef_0055">
+                          <dxl:Ident ColId="55" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="6" Alias="xmin">
-                          <dxl:Ident ColId="6" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="7" Alias="cmin">
-                          <dxl:Ident ColId="7" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="8" Alias="xmax">
-                          <dxl:Ident ColId="8" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="9" Alias="cmax">
-                          <dxl:Ident ColId="9" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="10" Alias="tableoid">
-                          <dxl:Ident ColId="10" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="11" Alias="gp_segment_id">
-                          <dxl:Ident ColId="11" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjList>
+                    </dxl:CTEConsumer>
+                    <dxl:Materialize Eager="true">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000136" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="94" Alias="ColRef_0094">
+                          <dxl:Ident ColId="94" ColName="ColRef_0094" TypeMdid="0.20.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:CTEConsumer CTEId="0" Columns="0,1,5,6,7,8,9,10,11">
+                      <dxl:Result>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="4"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000128" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="0" Alias="a1">
-                            <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="1" Alias="a2">
-                            <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="5" Alias="ctid">
-                            <dxl:Ident ColId="5" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="6" Alias="xmin">
-                            <dxl:Ident ColId="6" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="7" Alias="cmin">
-                            <dxl:Ident ColId="7" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="8" Alias="xmax">
-                            <dxl:Ident ColId="8" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="9" Alias="cmax">
-                            <dxl:Ident ColId="9" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="10" Alias="tableoid">
-                            <dxl:Ident ColId="10" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="11" Alias="gp_segment_id">
-                            <dxl:Ident ColId="11" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="94" Alias="ColRef_0094">
+                            <dxl:FuncExpr FuncId="0.1779.1.0" FuncRetSet="false" TypeMdid="0.20.1.0">
+                              <dxl:Ident ColId="93" ColName="ColRef_0093" TypeMdid="0.1700.1.0"/>
+                            </dxl:FuncExpr>
                           </dxl:ProjElem>
                         </dxl:ProjList>
-                      </dxl:CTEConsumer>
+                        <dxl:Filter/>
+                        <dxl:OneTimeFilter/>
+                        <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
+                          </dxl:Properties>
+                          <dxl:GroupingColumns/>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="93" Alias="ColRef_0093">
+                              <dxl:AggFunc AggMdid="0.2107.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                                <dxl:ValuesList ParamType="aggargs">
+                                  <dxl:Ident ColId="70" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
+                                </dxl:ValuesList>
+                                <dxl:ValuesList ParamType="aggdirectargs"/>
+                                <dxl:ValuesList ParamType="aggorder"/>
+                                <dxl:ValuesList ParamType="aggdistinct"/>
+                              </dxl:AggFunc>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:CTEConsumer CTEId="1" Columns="69,70">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="69" Alias="a2">
+                                <dxl:Ident ColId="69" ColName="a2" TypeMdid="0.701.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="70" Alias="ColRef_0055">
+                                <dxl:Ident ColId="70" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                          </dxl:CTEConsumer>
+                        </dxl:Aggregate>
+                      </dxl:Result>
                     </dxl:Materialize>
                   </dxl:NestedLoopJoin>
                 </dxl:Sort>
@@ -863,182 +1136,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_disc(0
               </dxl:Limit>
             </dxl:Aggregate>
           </dxl:NestedLoopJoin>
-          <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324032.130690" Rows="1.000000" Width="8"/>
-            </dxl:Properties>
-            <dxl:GroupingColumns/>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="13" Alias="percentile_disc">
-                <dxl:AggFunc AggMdid="0.164166.1.0" AggDistinct="false" AggStage="Normal" TypeMdid="0.701.1.0" AggKind="n">
-                  <dxl:ValuesList ParamType="aggargs">
-                    <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.701.1.0" Value="AAAAAAAA4D8=" DoubleValue="0.500000"/>
-                    <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                  </dxl:ValuesList>
-                  <dxl:ValuesList ParamType="aggdirectargs"/>
-                  <dxl:ValuesList ParamType="aggorder"/>
-                  <dxl:ValuesList ParamType="aggdistinct"/>
-                </dxl:AggFunc>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:Limit>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324032.130687" Rows="1.000000" Width="16"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="1" Alias="a2">
-                  <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="43" Alias="ColRef_0043">
-                  <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Sort SortDiscardDuplicates="false">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="1" Alias="a2">
-                    <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="43" Alias="ColRef_0043">
-                    <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList>
-                  <dxl:SortingColumn ColId="1" SortOperatorMdid="0.674.1.0" SortOperatorName="&gt;" SortNullsFirst="true"/>
-                </dxl:SortingColumnList>
-                <dxl:LimitCount/>
-                <dxl:LimitOffset/>
-                <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324032.130671" Rows="1.000000" Width="16"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="1" Alias="a2">
-                      <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="43" Alias="ColRef_0043">
-                      <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:JoinFilter>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:JoinFilter>
-                  <dxl:CTEConsumer CTEId="0" Columns="0,1,5,6,7,8,9,10,11">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="0" Alias="a1">
-                        <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="1" Alias="a2">
-                        <dxl:Ident ColId="1" ColName="a2" TypeMdid="0.701.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="5" Alias="ctid">
-                        <dxl:Ident ColId="5" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="6" Alias="xmin">
-                        <dxl:Ident ColId="6" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="7" Alias="cmin">
-                        <dxl:Ident ColId="7" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="8" Alias="xmax">
-                        <dxl:Ident ColId="8" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="9" Alias="cmax">
-                        <dxl:Ident ColId="9" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="10" Alias="tableoid">
-                        <dxl:Ident ColId="10" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="11" Alias="gp_segment_id">
-                        <dxl:Ident ColId="11" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                  </dxl:CTEConsumer>
-                  <dxl:Materialize Eager="true">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="43" Alias="ColRef_0043">
-                        <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="8"/>
-                      </dxl:Properties>
-                      <dxl:GroupingColumns/>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="43" Alias="ColRef_0043">
-                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                            <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Ident ColId="28" ColName="a2" TypeMdid="0.701.1.0"/>
-                            </dxl:ValuesList>
-                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                            <dxl:ValuesList ParamType="aggorder"/>
-                            <dxl:ValuesList ParamType="aggdistinct"/>
-                          </dxl:AggFunc>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:CTEConsumer CTEId="0" Columns="27,28,29,30,31,32,33,34,35">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="27" Alias="a1">
-                            <dxl:Ident ColId="27" ColName="a1" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="28" Alias="a2">
-                            <dxl:Ident ColId="28" ColName="a2" TypeMdid="0.701.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="29" Alias="ctid">
-                            <dxl:Ident ColId="29" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="30" Alias="xmin">
-                            <dxl:Ident ColId="30" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="31" Alias="cmin">
-                            <dxl:Ident ColId="31" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="32" Alias="xmax">
-                            <dxl:Ident ColId="32" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="33" Alias="cmax">
-                            <dxl:Ident ColId="33" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="34" Alias="tableoid">
-                            <dxl:Ident ColId="34" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="35" Alias="gp_segment_id">
-                            <dxl:Ident ColId="35" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                      </dxl:CTEConsumer>
-                    </dxl:Aggregate>
-                  </dxl:Materialize>
-                </dxl:NestedLoopJoin>
-              </dxl:Sort>
-              <dxl:LimitCount>
-                <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
-              </dxl:LimitCount>
-              <dxl:LimitOffset>
-                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-              </dxl:LimitOffset>
-            </dxl:Limit>
-          </dxl:Aggregate>
-        </dxl:NestedLoopJoin>
+        </dxl:Sequence>
       </dxl:Sequence>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/COrderedAggPreprocessor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/COrderedAggPreprocessor.h
@@ -57,7 +57,8 @@ private:
 	static CExpression *PexprFinalAgg(CMemoryPool *mp,
 									  CExpression *pexprAggFunc,
 									  CColRef *arg_col_ref,
-									  CColRef *total_count_colref);
+									  CColRef *total_count_colref,
+									  CColRef *peer_count_colref);
 
 	// transform sequence project expression into an inner join expression
 	static CExpression *PexprInputAggPrj2Join(CMemoryPool *mp,

--- a/src/backend/gporca/libgpopt/src/operators/COrderedAggPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/COrderedAggPreprocessor.cpp
@@ -61,11 +61,6 @@ COrderedAggPreprocessor::SplitPrjList(
 		GPOS_NEW(mp) CExpressionArray(mp);
 
 	CExpressionArray *pdrgpexprOtherPrEl = GPOS_NEW(mp) CExpressionArray(mp);
-	// create CTE using SeqPrj child expression
-	CExpression *pexprRemappedAggConsumer = NULL;
-	CExpression *pexprAggConsumer = NULL;
-	CreateCTE(mp, pexprInputAggPrj, &pexprRemappedAggConsumer,
-			  &pexprAggConsumer);
 
 	// iterate over project list and split project elements between
 	// Ordered Aggs list, and Other aggs list
@@ -105,7 +100,7 @@ COrderedAggPreprocessor::SplitPrjList(
 					 uidx++)
 				{
 					// For multiple ordered-set aggs on the same ORDERING column and ORDERING SPEC(ASC/DESC), we optimize
-					// to add the new aggregate as a ProjectiElement to the ProjectList of an existing JOIN, instead of
+					// to add the new aggregate as a ProjectElement to the ProjectList of an existing JOIN, instead of
 					// creating a new JOIN for doing the same SORT.
 					// Eg. SELECT percentile_cont(0.25) WITHIN GROUP(ORDER BY a), percentile_cont(0.5) WITHIN GROUP(ORDER BY a) from tab;
 					// Currently, to check if colref's SORT ORDER Spec(Asc/Desc) is same, we match only the SortOp and NullFirst
@@ -138,10 +133,14 @@ COrderedAggPreprocessor::SplitPrjList(
 						const CColRef *total_count_colref =
 							CCastUtils::PcrExtractFromScIdOrCastScId(
 								(*(*pCurrExprAggFunc)[0])[2]);
+						const CColRef *peer_count_colref =
+							CCastUtils::PcrExtractFromScIdOrCastScId(
+								(*(*pCurrExprAggFunc)[0])[3]);
 
 						CExpression *pexprNewAggFunc = PexprFinalAgg(
 							mp, pexprAggFunc, pcrPrjElem,
-							const_cast<CColRef *>(total_count_colref));
+							const_cast<CColRef *>(total_count_colref),
+							const_cast<CColRef *>(peer_count_colref));
 						CExpression *pexprAddPrjElem =
 							CUtils::PexprScalarProjectElement(mp, pcrPrjElem,
 															  pexprNewAggFunc);
@@ -176,37 +175,75 @@ COrderedAggPreprocessor::SplitPrjList(
 				}
 			}
 			if (skip)
-				continue;
-			if (0 < ul)
 			{
-				pexprRemappedAggConsumer->AddRef();
-				pexprAggConsumer->AddRef();
+				continue;
 			}
-			// CREATE total count aggregate
+
+			/*
+			 * This preprocessor step, splits the percentile_cont() function into the following pattern
+			 * Sequence
+			 * |
+			 * |_____ CTEProducer (SELECT col, count(col) peer_count FROM table GROUP BY col)
+			 * |      |
+			 * |      |______ Scan (table)
+			 * |
+			 * |______ CLogicalGbAgg (gp_percentile agg(col, percentile_fraction, total_cnt, peer_count))
+			 *         |____NLJ
+			 *              |
+			 *              |_______ CLogicalGbAgg (count total rows => SELECT SUM(peer_count) total_cnt FROM CTE)
+			 *              |        |
+			 *              |        |_____ CTEConsumer
+			 *              |
+			 *              |_______ CTEConsumer
+			 * */
+
+			// STEP 1: CREATE Aggregate for peer_count
 			CColumnFactory *col_factory = COptCtxt::PoctxtFromTLS()->Pcf();
 			CMDAccessor *md_accessor = COptCtxt::PoctxtFromTLS()->Pmda();
 			CExpression *pexprAgg = CUtils::PexprAgg(
 				mp, md_accessor, IMDType::EaggCount, colref, false);
-			CColRef *total_count_colref = col_factory->PcrCreate(
+			CColRef *peer_count_colref = col_factory->PcrCreate(
 				md_accessor->RetrieveType(
 					CScalarAggFunc::PopConvert(pexprAgg->Pop())->MdidType()),
 				CScalarAggFunc::PopConvert(pexprAgg->Pop())->TypeModifier());
 			CExpression *pexprNewPrjElem = CUtils::PexprScalarProjectElement(
-				mp, total_count_colref, pexprAgg);
+				mp, peer_count_colref, pexprAgg);
 			CExpression *pexprCountAggPrjList = GPOS_NEW(mp) CExpression(
 				mp, GPOS_NEW(mp) CScalarProjectList(mp), pexprNewPrjElem);
+			CColRefArray *pc = GPOS_NEW(mp) CColRefArray(mp);
+			pc->Append(const_cast<CColRef *>(colref));
 			(*pexprInputAggPrj)[0]->AddRef();
+			CExpression *pexprPeerCountAgg = CUtils::PexprLogicalGbAggGlobal(
+				mp, pc, (*pexprInputAggPrj)[0], pexprCountAggPrjList);
+
+			// STEP 1(a): CREATE CTE for the peer_count
+			CExpression *pexprRemappedPCConsumer = NULL;
+			CExpression *pexprPCConsumer = NULL;
+			CreateCTE(mp, pexprPeerCountAgg, &pexprRemappedPCConsumer,
+					  &pexprPCConsumer);
+
+			// STEP 2: Create Aggregate for calculating total_count SUM(peer_count)
+			CExpression *pexprSumAgg = CUtils::PexprAgg(
+				mp, md_accessor, IMDType::EaggSum, peer_count_colref, false);
+			CColRef *total_count_colref = col_factory->PcrCreate(
+				md_accessor->RetrieveType(
+					CScalarAggFunc::PopConvert(pexprSumAgg->Pop())->MdidType()),
+				CScalarAggFunc::PopConvert(pexprSumAgg->Pop())->TypeModifier());
+			CExpression *pexprSumPrjElem = CUtils::PexprScalarProjectElement(
+				mp, total_count_colref, pexprSumAgg);
+			CExpression *pexprSumAggPrjList = GPOS_NEW(mp) CExpression(
+				mp, GPOS_NEW(mp) CScalarProjectList(mp), pexprSumPrjElem);
 			CExpression *pexprTotalCountAgg = CUtils::PexprLogicalGbAggGlobal(
-				mp, GPOS_NEW(mp) CColRefArray(mp), (*pexprInputAggPrj)[0],
-				pexprCountAggPrjList);
+				mp, GPOS_NEW(mp) CColRefArray(mp), pexprPeerCountAgg,
+				pexprSumAggPrjList);
 
 			// to match requested columns upstream, we have to re-use the same computed
 			// columns that define the aggregates, we avoid recreating new columns during
 			// expression copy by passing must_exist as false
 			CColRefArray *pdrgpcrChildOutput =
-				pexprAggConsumer->DeriveOutputColumns()->Pdrgpcr(mp);
+				pexprPCConsumer->DeriveOutputColumns()->Pdrgpcr(mp);
 			CColRefArray *pdrgpcrConsumerOutput =
-				CLogicalCTEConsumer::PopConvert(pexprRemappedAggConsumer->Pop())
+				CLogicalCTEConsumer::PopConvert(pexprRemappedPCConsumer->Pop())
 					->Pdrgpcr();
 			UlongToColRefMap *colref_mapping = CUtils::PhmulcrMapping(
 				mp, pdrgpcrChildOutput, pdrgpcrConsumerOutput);
@@ -217,24 +254,50 @@ COrderedAggPreprocessor::SplitPrjList(
 			pdrgpcrChildOutput->Release();
 			pexprTotalCountAgg->Release();
 
-			// finalize total count agg expression by replacing its child with CTE consumer
+			// finalize total_count agg expression by replacing its child with CTE consumer
 			pexprTotalCountAggRemapped->Pop()->AddRef();
 			(*pexprTotalCountAggRemapped)[1]->AddRef();
 			CExpression *pexprFinalGbAgg = GPOS_NEW(mp) CExpression(
-				mp, pexprTotalCountAggRemapped->Pop(), pexprRemappedAggConsumer,
+				mp, pexprTotalCountAggRemapped->Pop(), pexprRemappedPCConsumer,
 				(*pexprTotalCountAggRemapped)[1]);
 			pexprTotalCountAggRemapped->Release();
-
 
 			CExpression *pexprJoinCondition =
 				CUtils::PexprScalarConstBool(mp, true /*value*/);
 
-			// create a join between expanded total count and CTE Consumer expressions
+			// STEP 3: CREATE a join between expanded total_count and CTEConsumer expressions
+			const CColRef *pcrSum = CScalarProjectElement::PopConvert(
+										(*(*pexprFinalGbAgg)[1])[0]->Pop())
+										->Pcr();
+			CExpression *pexprScalarIdentSum =
+				CUtils::PexprScalarIdent(mp, pcrSum);
+
+			// STEP 3(a): Explicit Cast total_count to bigint.
+			// Since count() returns bigint, sum(count()) returns numeric and gp_percentile agg's
+			// expect the total_count as bigint, therefore adding an explicit cast on top
+			IMDId *mdid_func = GPOS_NEW(mp) CMDIdGPDB(GPDB_INT8_CAST);
+			const IMDFunction *cast_func = md_accessor->RetrieveFunc(mdid_func);
+			const CWStringConst *pstrFunc = GPOS_NEW(mp) CWStringConst(
+				mp, (cast_func->Mdname().GetMDName())->GetBuffer());
+			mdid_func->AddRef();
+			cast_func->GetResultTypeMdid()->AddRef();
+			CScalarFunc *popCastScalarFunc = GPOS_NEW(mp) CScalarFunc(
+				mp, mdid_func, cast_func->GetResultTypeMdid(), -1, pstrFunc);
+			CExpression *pexprCastScalarIdent = GPOS_NEW(mp)
+				CExpression(mp, popCastScalarFunc, pexprScalarIdentSum);
+			CExpressionArray *colref_array1 = GPOS_NEW(mp) CExpressionArray(mp);
+			colref_array1->Append(pexprCastScalarIdent);
+			CExpression *pexprProjected = CUtils::PexprAddProjection(
+				mp, pexprFinalGbAgg, colref_array1, false);
+			CColRef *new_total_count_ref =
+				CUtils::PcrFromProjElem((*(*pexprProjected)[1])[0]);
 			CExpression *pexprJoin =
 				CUtils::PexprLogicalJoin<CLogicalInnerJoin>(
-					mp, pexprAggConsumer, pexprFinalGbAgg, pexprJoinCondition);
+					mp, pexprPCConsumer, pexprProjected, pexprJoinCondition);
+			colref_array1->Release();
+			mdid_func->Release();
 
-			// create ordered spec for the Join to merge on the colref passed in as part
+			// STEP 4: CREATE ordered spec for the Join to merge on the colref passed in as part
 			// of the ordered agg's WITHIN(ORDER BY) clause
 			COrderSpec *pos = GPOS_NEW(mp) COrderSpec(mp);
 			IMDId *mdid_curr_sortop =
@@ -263,9 +326,10 @@ COrderedAggPreprocessor::SplitPrjList(
 			CExpression *pexprJoinLimit = GPOS_NEW(mp) CExpression(
 				mp, popLimit, pexprJoin, pexprLimitOffset, pexprLimitCount);
 
-			// Create the final gp_percentile agg on top
+			// STEP 5: CREATE the final gp_percentile agg on top
 			CExpression *pexprNewAggFunc =
-				PexprFinalAgg(mp, pexprAggFunc, pcrPrjElem, total_count_colref);
+				PexprFinalAgg(mp, pexprAggFunc, pcrPrjElem, new_total_count_ref,
+							  peer_count_colref);
 			CExpression *pexprExistingPrjElem =
 				CUtils::PexprScalarProjectElement(mp, pcrPrjElem,
 												  pexprNewAggFunc);
@@ -376,17 +440,14 @@ COrderedAggPreprocessor::SplitOrderedAggsPrj(
 //
 //---------------------------------------------------------------------------
 void
-COrderedAggPreprocessor::CreateCTE(CMemoryPool *mp,
-								   CExpression *pexprInputAggPrj,
+COrderedAggPreprocessor::CreateCTE(CMemoryPool *mp, CExpression *pexprChild,
 								   CExpression **ppexprFirstConsumer,
 								   CExpression **ppexprSecondConsumer)
 {
-	GPOS_ASSERT(NULL != pexprInputAggPrj);
-	GPOS_ASSERT(COperator::EopLogicalGbAgg == pexprInputAggPrj->Pop()->Eopid());
+	GPOS_ASSERT(NULL != pexprChild);
 	GPOS_ASSERT(NULL != ppexprFirstConsumer);
 	GPOS_ASSERT(NULL != ppexprSecondConsumer);
 
-	CExpression *pexprChild = (*pexprInputAggPrj)[0];
 	CColRefSet *pcrsChildOutput = pexprChild->DeriveOutputColumns();
 	CColRefArray *pdrgpcrChildOutput = pcrsChildOutput->Pdrgpcr(mp);
 
@@ -398,7 +459,7 @@ COrderedAggPreprocessor::CreateCTE(CMemoryPool *mp,
 	CColRefArray *pdrgpcrProducerOutput =
 		pexprCTEProd->DeriveOutputColumns()->Pdrgpcr(mp);
 
-	//	 first consumer creates new output columns to be used later as input to GbAgg expression
+	// first consumer creates new output columns to be used later as input to GbAgg expression
 	*ppexprFirstConsumer = GPOS_NEW(mp) CExpression(
 		mp, GPOS_NEW(mp) CLogicalCTEConsumer(
 				mp, ulCTEId, CUtils::PdrgpcrCopy(mp, pdrgpcrProducerOutput)));
@@ -429,8 +490,14 @@ CExpression *
 COrderedAggPreprocessor::PexprFinalAgg(CMemoryPool *mp,
 									   CExpression *pexprAggFunc,
 									   CColRef *arg_col_ref,
-									   CColRef *total_count_colref)
+									   CColRef *total_count_colref,
+									   CColRef *peer_count_colref)
 {
+	GPOS_ASSERT(NULL != pexprAggFunc);
+	GPOS_ASSERT(NULL != arg_col_ref);
+	GPOS_ASSERT(NULL != total_count_colref);
+	GPOS_ASSERT(NULL != peer_count_colref);
+
 	CScalarAggFunc *popScAggFunc =
 		CScalarAggFunc::PopConvert(pexprAggFunc->Pop());
 	CExpressionArray *pdrgpexpr = GPOS_NEW(mp) CExpressionArray(mp);
@@ -447,11 +514,10 @@ COrderedAggPreprocessor::PexprFinalAgg(CMemoryPool *mp,
 	pexprAggFuncDirectArg->AddRef();
 	pdrgpexprChildren->Append(pexprAggFuncDirectArg);
 	pdrgpexprChildren->Append(CUtils::PexprScalarIdent(mp, total_count_colref));
-	// Currently passing dummy peer_count as 1 always. Will pass along the
-	// calculated peer_count col_ref once we dedup data for handling skew
-	CExpression *pexprDummyPeerCount =
-		CUtils::PexprScalarConstInt8(mp, 1 /*val*/);
-	pdrgpexprChildren->Append(pexprDummyPeerCount);
+	// Passing along the calculated peer_count col_ref for handling skew
+	CExpression *pexprPeerCount =
+		CUtils::PexprScalarIdent(mp, peer_count_colref);
+	pdrgpexprChildren->Append(pexprPeerCount);
 
 	pdrgpexpr->Append(
 		GPOS_NEW(mp) CExpression(mp, popScalarValuesList, pdrgpexprChildren));
@@ -536,14 +602,15 @@ COrderedAggPreprocessor::PexprInputAggPrj2Join(CMemoryPool *mp,
 		pexprTopmostCTE = (*pexprTopmostCTE)[0];
 	}
 	ULONG ulCTEIdStart = CLogicalCTEConsumer::PopConvert(
-							 (*(*(*(*pexprTopmostCTE)[0])[0])[1])[0]->Pop())
+							 (*(*(*pexprTopmostCTE)[0])[0])[0]->Pop())
 							 ->UlCTEId();
 	ULONG ulCTEIdEnd = ulCTEIdStart;
 	if (has_nlj_ontop)
-		ulCTEIdEnd =
-			CLogicalCTEConsumer::PopConvert(
-				(*(*(*(*(*pexprOrderedAgg)[arity - 2])[0])[0])[1])[0]->Pop())
-				->UlCTEId();
+	{
+		ulCTEIdEnd = CLogicalCTEConsumer::PopConvert(
+						 (*(*(*(*pexprOrderedAgg)[arity - 2])[0])[0])[0]->Pop())
+						 ->UlCTEId();
+	}
 	CExpression *pexpResult = pexprFinalJoin;
 	for (ULONG ul = ulCTEIdEnd; ul > ulCTEIdStart; ul--)
 	{

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/gpdb_types.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/gpdb_types.h
@@ -65,6 +65,7 @@ typedef ULONG OID;
 #define GPDB_COUNT_ANY OID(2147)   // count(Any)
 #define GPDB_UUID OID(2950)
 #define GPDB_ANY OID(2283)
+#define GPDB_INT8_CAST OID(1779)  // int8(numeric)
 #define GPDB_PERCENTILE_DISC \
 	OID(3972)  // percentile_disc(fraction) group within(ANYELEMENT)
 #define GPDB_PERCENTILE_CONT_FLOAT8 \

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -364,6 +364,7 @@ COrderedAggTest:
 CTAS_OrderedAgg_multiple_cols OrderedAgg_multiple_diffcol OrderedAgg_with_groupby OrderedAgg_computed_col
 OrderedAggUsingGroupColumnInDirectArg OrderedAgg_multiple_samecol OrderedAgg_with_nonOrderedAgg OrderedAgg_single
 OrderedAgg_array_fraction OrderedAgg_multiple_samecol_difforderespec OrderedAgg_with_nonconst_fraction
+OrderedAgg_skewed_data
 ")
 
 set(mdp_dir "../data/dxl/minidump/")


### PR DESCRIPTION
This is a backport of https://github.com/greenplum-db/gpdb/pull/13740 to 6X

This is an extension to the original PR https://github.com/greenplum-db/gpdb/pull/13596
As part of the original PR, the plan ORCA generated for ordered-set aggs were of the following shape:
```
GbAgg (New aggregate: gp_percentile_cont(a, 0.5, total_cnt)) 
+----- Gather (output: a, 0.5, total_cnt)
            (merge key = a)
            +----- Sort (Gather Merge on coordinator)  --- parallelized on segments
                        +----- NLJ (output: a, 0.5, total_cnt)
                                  +----- GbAgg (count(a) as total_cnt)  --- parallelized on segments
                                  +----- Scan t
```
This would be MPP-efficient for non-skewed data scenarios, where there is no duplicate data and would read the entire table. But for skewed data (with duplicates), reading the entire data would lead to slower execution.
Example:
```
CREATE TABLE t AS SELECT 1 a FROM generate_series(1, 10000000) DISTRIBUTED BY (a);
ANALYZE t;
EXPLAIN ANALYZE SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a ASC nulls first) FROM t;
```
This PR, enhances the preprocessing step to deduplicate data and pass along the peer_count along with the
```
CTEProducer
 +----- GbAgg (a, count(a) as peer_count from t group by a)
             +----- Scan t

GbAgg (New aggregate: gp_percentile_cont(a, 0.5, total_cnt, peer_count)) 
+----- Gather (output: a, 0.5, total_cnt)
            (merge key = a)
            +----- Sort (Gather Merge on coordinator)  --- parallelized on segments
                        +----- NLJ (output: a, 0.5, total_cnt)
                                   +----- GbAgg (sum(peer_count) as total_cnt)  --- parallelized on segments
                                               +----- CTEConsumer
                                   +----- CTEConsumer
```
Deduplicating data, helps optimize the execution time.
With this PR, for the above example query previously the execution time would be ~25 sec which is now reduced to ~6 sec.

Additionally, this PR adds the following:

- Changes to the underlying gp_percentile_agg contrib's C function that would now consider peer_count for calculation
- Convert the gp_percentile_agg contrib's transition functions to non-strict and handle NULL inputs.
- Update Tests