### PR TITLE
Add comment explaining AT SET ACCESS METHOD flow

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -5718,6 +5718,21 @@ ATRewriteTables(AlterTableStmt *parsetree, List **wqueue, LOCKMODE lockmode)
 			 * AO/AOCO tables, and should not be set, pass in
 			 * InvalidTransactionId instead of RecentXmin.
 			 */
+
+			/*
+			 * Example workflow of changing access method from a
+			 * Heap table (Oid:a) to an AO table:
+			 * - Create transient AO table (Oid:b) and its AO aux tables in
+			 * 	 make_new_heap
+			 * - Copy table data into the transient table
+			 * - Swap Oids in the pg_appendonly entry so that newly generated
+			 * 	 aux tables are mapped to Oid a in ATAOEntries
+			 * - Swap attributes in pg_class entry between the two tables
+			 * 	 (such as relfilenode, relam, ...)
+			 * - Now dropping the transient table will use the heap AM and
+			 *   delete the original heap relation file.
+			 */
+
 			if (NewAccessMethod == AO_ROW_TABLE_AM_OID || NewAccessMethod == AO_COLUMN_TABLE_AM_OID)
 				relfrozenxid = InvalidTransactionId;
 			else


### PR DESCRIPTION
While performing an AT for access method changes
such as Heap table (Oid:a) to AO table Workflow:
- Create transient AO table (Oid:b) and its AO aux tables in
  make_new_heap
- Copy table data into the transient table
- Swap Oids in the pg_appendonly entry so that newly generated aux
  tables are mapped to Oid a in ATAOEntries
- Swap attributes in pg_class entry between the two tables (such as
  relfilenode, relam, ...)
- Reindex the relation
- Now that pg_class has Oid a pointing to transient table, drop the heap
  table
