### PR TITLE
disallow truncating ao table in different (sub)transaction levels

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -2183,6 +2183,13 @@ ExecuteTruncateGuts(List *explicit_rels, List *relids, List *relids_logged,
 		}
 		else
 		{
+
+			if (RelationIsAppendOptimized(rel) && rel->rd_createSubid != InvalidSubTransactionId)
+				ereport(ERROR, 
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("Can not truncate AO/AOCO table in (sub)transaction "
+								"which is not created by current (sub)transaction or previous committed transaction.")));
+
 			Oid			heap_relid;
 			Oid			toast_relid;
 

--- a/src/test/regress/expected/distributed_transactions.out
+++ b/src/test/regress/expected/distributed_transactions.out
@@ -741,34 +741,6 @@ select count(*) = 0 as passed from subt_reindex_ao
  t
 (1 row)
 
--- truncate cases
-savepoint sp7; -- child of sp2
-truncate subt_reindex_heap;
-truncate subt_reindex_ao;
-savepoint sp8; -- child of sp7
-truncate subt_reindex_co;
-select count(*) = 0 as passed from subt_reindex_heap where i < 7;
- passed 
---------
- t
-(1 row)
-
-select count(*) = 0 as passed from subt_reindex_ao where i < 6;
- passed 
---------
- t
-(1 row)
-
-select count(*) = 0 as passed from subt_reindex_co where i < 6;
- passed 
---------
- t
-(1 row)
-
-rollback to sp8;
-update subt_reindex_co set x = 'CO sp8', b = '((1,1),(8,8))'
- where i = 2;
-release savepoint sp7; -- commit sp7
 -- Test rollback of truncate in a committed subtransaction.
 rollback to sp2;
 COMMIT;

--- a/src/test/regress/input/aocs.source
+++ b/src/test/regress/input/aocs.source
@@ -688,3 +688,29 @@ select count(*) from aocs_small_and_dense_content;
 
 select gp_inject_fault('appendonly_skip_compression', 'reset', dbid)
 from gp_segment_configuration where role = 'p' and content = 0;
+
+
+-- test truncate aoco table in current transaction and sub-transaction
+-- more details can look at https://github.com/greenplum-db/gpdb/issues/13699
+
+-- should success, create and truncate ao table in the same transaction;
+begin;
+create table aoco_13699(a int, b int) with (appendonly = true, orientation = column); 
+insert into aoco_13699 select i, i from generate_series(1, 100) i;
+select count(*) from aoco_13699;
+truncate table aoco_13699;
+select count(*) from aoco_13699;
+abort;
+
+-- should fail, create and truncate aoco table in the different transaction;
+begin;
+create table aoco_13699(a int, b int) with (appendonly = true, orientation = column);
+insert into aoco_13699 select i, i from generate_series(1, 100) i;
+select count(*) from aoco_13699;
+savepoint s1;
+-- should error
+truncate table aoco_13699;
+-- should error too
+rollback to s1;
+truncate table aoco_13699;
+abort;

--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -817,6 +817,32 @@ select * from ao_inh_p1;
 select * from ao_inh_p4;
 
 
+-- test truncate ao table in current transaction and sub-transaction
+-- more details can look at https://github.com/greenplum-db/gpdb/issues/13699
+
+-- should success, create and truncate ao table in the same transaction;
+begin;
+create table ao_13699(a int, b int) with (appendonly = true); 
+insert into ao_13699 select i, i from generate_series(1, 100) i;
+select count(*) from ao_13699;
+truncate table ao_13699;
+select count(*) from ao_13699;
+abort;
+
+-- should fail, create and truncate ao table in the different transaction;
+begin;
+create table ao_13699(a int, b int) with (appendonly = true); 
+insert into ao_13699 select i, i from generate_series(1, 100) i;
+select count(*) from ao_13699;
+savepoint s1;
+-- should error
+truncate table ao_13699;
+-- should error too
+rollback to s1;
+truncate table ao_13699;
+abort;
+
+
 --------------------------------------------------------------------------------
 -- Finally check to detect if any dangling gp_fastsequence entries are left
 -- behind by this SQL file

--- a/src/test/regress/output/aocs.source
+++ b/src/test/regress/output/aocs.source
@@ -1317,3 +1317,42 @@ from gp_segment_configuration where role = 'p' and content = 0;
  Success:
 (1 row)
 
+-- test truncate aoco table in current transaction and sub-transaction
+-- more details can look at https://github.com/greenplum-db/gpdb/issues/13699
+-- should success, create and truncate ao table in the same transaction;
+begin;
+create table aoco_13699(a int, b int) with (appendonly = true, orientation = column); 
+insert into aoco_13699 select i, i from generate_series(1, 100) i;
+select count(*) from aoco_13699;
+ count 
+-------
+   100
+(1 row)
+
+truncate table aoco_13699;
+select count(*) from aoco_13699;
+ count 
+-------
+     0
+(1 row)
+
+abort;
+-- should fail, create and truncate aoco table in the different transaction;
+begin;
+create table aoco_13699(a int, b int) with (appendonly = true, orientation = column);
+insert into aoco_13699 select i, i from generate_series(1, 100) i;
+select count(*) from aoco_13699;
+ count 
+-------
+   100
+(1 row)
+
+savepoint s1;
+-- should error
+truncate table aoco_13699;
+ERROR:  Can not truncate AO/AOCO table in (sub)transaction which is not created by current (sub)transaction or previous committed transaction.
+-- should error too
+rollback to s1;
+truncate table aoco_13699;
+ERROR:  Can not truncate AO/AOCO table in (sub)transaction which is not created by current (sub)transaction or previous committed transaction.
+abort;

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -1646,6 +1646,49 @@ select * from ao_inh_p4;
  16 | 16 | 15
 (6 rows)
 
+-- test truncate ao table in current transaction and sub-transaction
+-- more details can look at https://github.com/greenplum-db/gpdb/issues/13699
+-- should success, create and truncate ao table in the same transaction;
+begin;
+create table ao_13699(a int, b int) with (appendonly = true); 
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into ao_13699 select i, i from generate_series(1, 100) i;
+select count(*) from ao_13699;
+ count 
+-------
+   100
+(1 row)
+
+truncate table ao_13699;
+select count(*) from ao_13699;
+ count 
+-------
+     0
+(1 row)
+
+abort;
+-- should fail, create and truncate ao table in the different transaction;
+begin;
+create table ao_13699(a int, b int) with (appendonly = true); 
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into ao_13699 select i, i from generate_series(1, 100) i;
+select count(*) from ao_13699;
+ count 
+-------
+   100
+(1 row)
+
+savepoint s1;
+-- should error
+truncate table ao_13699;
+ERROR:  Can not truncate AO/AOCO table in (sub)transaction which is not created by current (sub)transaction or previous committed transaction.
+-- should error too
+rollback to s1;
+truncate table ao_13699;
+ERROR:  Can not truncate AO/AOCO table in (sub)transaction which is not created by current (sub)transaction or previous committed transaction.
+abort;
 --------------------------------------------------------------------------------
 -- Finally check to detect if any dangling gp_fastsequence entries are left
 -- behind by this SQL file

--- a/src/test/regress/sql/distributed_transactions.sql
+++ b/src/test/regress/sql/distributed_transactions.sql
@@ -519,20 +519,6 @@ select count(*) = 5 as passed from subt_reindex_co
 select count(*) = 0 as passed from subt_reindex_ao
  where x = 'AO sp4';
 
--- truncate cases
-savepoint sp7; -- child of sp2
-truncate subt_reindex_heap;
-truncate subt_reindex_ao;
-savepoint sp8; -- child of sp7
-truncate subt_reindex_co;
-select count(*) = 0 as passed from subt_reindex_heap where i < 7;
-select count(*) = 0 as passed from subt_reindex_ao where i < 6;
-select count(*) = 0 as passed from subt_reindex_co where i < 6;
-rollback to sp8;
-update subt_reindex_co set x = 'CO sp8', b = '((1,1),(8,8))'
- where i = 2;
-release savepoint sp7; -- commit sp7
-
 -- Test rollback of truncate in a committed subtransaction.
 rollback to sp2;
 


### PR DESCRIPTION
This is to fix #13255.

As we know, AO/AOCO table relies on the `last_sequence` to generate a new first row number
 to a new var block, this value will store in the heap table `gp_fastsequence`. 

Whenever we generate a new variable-length storage block, we need to obtain a continuous row 
number from the `gp_fastsequence` table as the first row number of the var block, and also as the 
unique identifier of the tuple when creating an index.

**So, the row number should not be same and not reuse deleted tuple's row number**. Therefore, 
Greenplum must ensure that row numbers are not repeated and always increment.

But sub-transaction will break it:

```sql
begin;
create table t (a int, b int) with (appendonly = true);
insert into t values (1, 1);
savepoint sub;
truncate table t;
insert into t values (2, 2);
rollback to sub;
abort;
```

After the `truncate table t;` statement, table `gp_fastsequence` will have a new relation file node 
(this is what `truncate table` works) and all subsequent operations on AO table `t` will depend on 
the new file node, but the new file is empty, so the `gp_fastsequence.last_sequence` will be 0, will
less than the original `last_sequence`.

To avoid this, we should disallow truncating ao table in different (sub)transaction levels, just allow only 
following 2 situations:

1. truncate the AO table in another transaction
```
create table t (a int, b int) with (appendonly = true);

begin;
truncate table t;    -- allow this
insert into t values (2, 2);
commit;
```

2. create and truncate AO table in the same transaction

```
begin;
create table t (a int, b int) with (appendonly = true);
insert into t values (2, 2);
truncate table t;    -- allow this
commit;
```

