### PR TITLE
Fix non-default collation fallbacks

### DIFF
--- a/contrib/auto_explain/expected/auto_explain_optimizer.out
+++ b/contrib/auto_explain/expected/auto_explain_optimizer.out
@@ -31,12 +31,9 @@ SET auto_explain.log_timing = FALSE;
 LOG:  statement: SET auto_explain.log_timing = FALSE;
 SET auto_explain.log_verbose = FALSE;
 LOG:  statement: SET auto_explain.log_verbose = FALSE;
--- start_ignore
--- GPDB_12_MERGE_FIXME: Non default collations
--- end_ignore
 SELECT relname FROM pg_class WHERE relname='pg_class';
 LOG:  statement: SELECT relname FROM pg_class WHERE relname='pg_class';
-"Feature not supported: Non-default collation",
+"Feature not supported: Queries on master-only tables",
 LOG:  duration: 0.026 ms  plan:
 Query Text: SELECT relname FROM pg_class WHERE relname='pg_class';
 Index Only Scan using pg_class_relname_nsp_index on pg_class  (cost=0.15..4.17 rows=1 width=64) (actual rows=1 loops=1)
@@ -77,12 +74,9 @@ LOG:  statement: SET auto_explain.log_triggers = FALSE;
 SET auto_explain.log_verbose = TRUE;
 LOG:  statement: SET auto_explain.log_verbose = TRUE;
 -- this select should not dump execution plan
--- start_ignore
--- GPDB_12_MERGE_FIXME: Non default collation
--- end_ignore
 SELECT relname FROM pg_class WHERE relname='pg_class';
 LOG:  statement: SELECT relname FROM pg_class WHERE relname='pg_class';
-"Feature not supported: Non-default collation",
+"Feature not supported: Queries on master-only tables",
  relname  
 ----------
  pg_class

--- a/contrib/btree_gin/expected/name_optimizer.out
+++ b/contrib/btree_gin/expected/name_optimizer.out
@@ -1,0 +1,114 @@
+set enable_seqscan=off;
+CREATE TABLE test_name (
+	i name
+);
+INSERT INTO test_name VALUES ('a'),('ab'),('abc'),('abb'),('axy'),('xyz');
+CREATE INDEX idx_name ON test_name USING gin (i);
+SELECT * FROM test_name WHERE i<'abc' ORDER BY i;
+  i  
+-----
+ a
+ ab
+ abb
+(3 rows)
+
+SELECT * FROM test_name WHERE i<='abc' ORDER BY i;
+  i  
+-----
+ a
+ ab
+ abb
+ abc
+(4 rows)
+
+SELECT * FROM test_name WHERE i='abc' ORDER BY i;
+  i  
+-----
+ abc
+(1 row)
+
+SELECT * FROM test_name WHERE i>='abc' ORDER BY i;
+  i  
+-----
+ abc
+ axy
+ xyz
+(3 rows)
+
+SELECT * FROM test_name WHERE i>'abc' ORDER BY i;
+  i  
+-----
+ axy
+ xyz
+(2 rows)
+
+EXPLAIN (COSTS OFF) SELECT * FROM test_name WHERE i<'abc' ORDER BY i;
+                    QUERY PLAN                     
+---------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: i
+   ->  Sort
+         Sort Key: i
+         ->  Bitmap Heap Scan on test_name
+               Recheck Cond: (i < 'abc'::name)
+               ->  Bitmap Index Scan on idx_name
+                     Index Cond: (i < 'abc'::name)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+EXPLAIN (COSTS OFF) SELECT * FROM test_name WHERE i<='abc' ORDER BY i;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: i
+   ->  Sort
+         Sort Key: i
+         ->  Bitmap Heap Scan on test_name
+               Recheck Cond: (i <= 'abc'::name)
+               ->  Bitmap Index Scan on idx_name
+                     Index Cond: (i <= 'abc'::name)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+EXPLAIN (COSTS OFF) SELECT * FROM test_name WHERE i='abc' ORDER BY i;
+                 QUERY PLAN                  
+---------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   Merge Key: i
+   ->  Sort
+         Sort Key: i
+         ->  Bitmap Heap Scan on test_name
+               Recheck Cond: (i = 'abc'::name)
+               ->  Bitmap Index Scan on idx_name
+                     Index Cond: (i = 'abc'::name)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+EXPLAIN (COSTS OFF) SELECT * FROM test_name WHERE i>='abc' ORDER BY i;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: i
+   ->  Sort
+         Sort Key: i
+         ->  Bitmap Heap Scan on test_name
+               Recheck Cond: (i >= 'abc'::name)
+               ->  Bitmap Index Scan on idx_name
+                     Index Cond: (i >= 'abc'::name)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+EXPLAIN (COSTS OFF) SELECT * FROM test_name WHERE i>'abc' ORDER BY i;
+                    QUERY PLAN                     
+---------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: i
+   ->  Sort
+         Sort Key: i
+         ->  Bitmap Heap Scan on test_name
+               Recheck Cond: (i > 'abc'::name)
+               ->  Bitmap Index Scan on idx_name
+                     Index Cond: (i > 'abc'::name)
+ Optimizer: Postgres query optimizer
+(9 rows)
+

--- a/src/backend/optimizer/util/walkers.c
+++ b/src/backend/optimizer/util/walkers.c
@@ -884,9 +884,11 @@ check_collation_walker(Node *node, check_collation_context *context)
 	switch (nodeTag(node))
 	{
 		case T_Var:
-			type = (castNode(Var, node))->vartype;
+		case T_Const:
+		case T_OpExpr:
+			type = exprType((node));
 			collation = exprCollation(node);
-			if (type == NAMEOID)
+			if (type == NAMEOID || type == NAMEARRAYOID)
 			{
 				if (collation != C_COLLATION_OID)
 					context->foundNonDefaultCollation = 1;
@@ -896,8 +898,6 @@ check_collation_walker(Node *node, check_collation_context *context)
 				context->foundNonDefaultCollation = 1;
 			}
 			break;
-		case T_Const:
-		case T_OpExpr:
 		case T_ScalarArrayOpExpr:
 		case T_DistinctExpr:
 		case T_BoolExpr:

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -1934,7 +1934,7 @@ select pg_get_viewdef('aggordview1');
 
 select * from aggordview1 order by ten;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+DETAIL:  Feature not supported: Aggregate functions with FILTER
  ten | p50 | px  | rank 
 -----+-----+-----+------
    0 | 490 |     |  101
@@ -2375,7 +2375,7 @@ select pg_get_viewdef('aggordview1');
 
 select * from aggordview1 order by ten;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+DETAIL:  Feature not supported: Aggregate functions with FILTER
  ten | p50 | px  | rank 
 -----+-----+-----+------
    0 | 490 |     |  101
@@ -3108,7 +3108,7 @@ drop table agg_hash_4;
 -- fix github issue #12061 numsegments of general locus is not -1 on create_minmaxagg_path
 explain analyze select count(*) from pg_class,  (select count(*) >0 from  (select count(*) from pg_class where relname like 't%')x)y;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+DETAIL:  Feature not supported: Queries on master-only tables
                                                       QUERY PLAN                                                       
 -----------------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=10000000017.74..10000000017.75 rows=1 width=8) (actual time=0.142..0.142 rows=1 loops=1)

--- a/src/test/regress/expected/autostats.out
+++ b/src/test/regress/expected/autostats.out
@@ -5,7 +5,7 @@
 -- s/tableoid \d+/tableoid XXXXX/
 -- end_matchsubs
 -- start_matchignore
--- m/^LOG: .*Feature not supported: Non-default collation./
+-- m/^LOG: .*Feature not supported: Queries on master-only tables./
 -- m/^LOG:.*ERROR,"PG exception raised"/
 -- end_matchignore
 set gp_autostats_mode=on_change;

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -23,31 +23,35 @@ create index bfv_tab1_idx1 on bfv_tab1 using btree(unique1);
 -- GPDB_12_MERGE_FIXME: Non default collation
 explain select * from bfv_tab1, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i, j)
     WHERE bfv_tab1.unique1 = v.i and bfv_tab1.stringu1 = v.j;
-                                                    QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.06..279.08 rows=14 width=280)
-   ->  Hash Join  (cost=0.06..278.81 rows=5 width=280)
-         Hash Cond: ((bfv_tab1.unique1 = "*VALUES*".column1) AND (bfv_tab1.stringu1 = ("*VALUES*".column2)::text))
-         ->  Seq Scan on bfv_tab1  (cost=0.00..219.00 rows=3967 width=244)
-         ->  Hash  (cost=0.03..0.03 rows=1 width=36)
-               ->  Values Scan on "*VALUES*"  (cost=0.00..0.03 rows=1 width=36)
- Optimizer: Postgres query optimizer
-(7 rows)
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..12.00 rows=1 width=256)
+   ->  Nested Loop  (cost=0.00..12.00 rows=1 width=256)
+         Join Filter: true
+         ->  Result  (cost=0.00..0.00 rows=1 width=12)
+               ->  Values Scan on "Values"  (cost=0.00..0.00 rows=1 width=12)
+         ->  Index Scan using bfv_tab1_idx1 on bfv_tab1  (cost=0.00..12.00 rows=1 width=244)
+               Index Cond: (unique1 = "Values".column1)
+               Filter: (stringu1 = "Values".column2)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
 
 set gp_enable_relsize_collection=on;
 -- GPDB_12_MERGE_FIXME: Non default collation
 explain select * from bfv_tab1, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i, j)
     WHERE bfv_tab1.unique1 = v.i and bfv_tab1.stringu1 = v.j;
-                                                    QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.01..0.15 rows=4 width=280)
-   ->  Hash Join  (cost=0.01..0.09 rows=2 width=280)
-         Hash Cond: (("*VALUES*".column1 = bfv_tab1.unique1) AND (("*VALUES*".column2)::text = bfv_tab1.stringu1))
-         ->  Values Scan on "*VALUES*"  (cost=0.00..0.03 rows=1 width=36)
-         ->  Hash  (cost=0.00..0.00 rows=1 width=244)
-               ->  Seq Scan on bfv_tab1  (cost=0.00..0.00 rows=1 width=244)
- Optimizer: Postgres query optimizer
-(7 rows)
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..12.00 rows=1 width=256)
+   ->  Nested Loop  (cost=0.00..12.00 rows=1 width=256)
+         Join Filter: true
+         ->  Result  (cost=0.00..0.00 rows=1 width=12)
+               ->  Values Scan on "Values"  (cost=0.00..0.00 rows=1 width=12)
+         ->  Index Scan using bfv_tab1_idx1 on bfv_tab1  (cost=0.00..12.00 rows=1 width=244)
+               Index Cond: (unique1 = "Values".column1)
+               Filter: (stringu1 = "Values".column2)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
 
 -- Test that we do not choose to perform an index scan if indisvalid=false.
 create table bfv_tab1_with_invalid_index (like bfv_tab1 including indexes);

--- a/src/test/regress/expected/brin_ao_optimizer.out
+++ b/src/test/regress/expected/brin_ao_optimizer.out
@@ -418,11 +418,6 @@ WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>,inet,0.0.0
 WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>=,inet,0.0.0.0,125)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (lsncol,IS,pg_lsn,,25)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (lsncol,"IS NOT",pg_lsn,,100)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,<,name,ZZAAAA,100)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,<=,name,ZZAAAA,100)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,=,name,MAAAAA,2)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,>,name,AAAAAA,100)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,>=,name,AAAAAA,100)
 -- Note: ORCA does not support all of the above operators:
 --       - standard comparison operators on inet and cidr columns
 --         because ORCA does not look at the second occurrence of a column in an index,

--- a/src/test/regress/expected/brin_aocs_optimizer.out
+++ b/src/test/regress/expected/brin_aocs_optimizer.out
@@ -418,11 +418,6 @@ WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>,inet,0.0.0
 WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>=,inet,0.0.0.0,125)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (lsncol,IS,pg_lsn,,25)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (lsncol,"IS NOT",pg_lsn,,100)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,<,name,ZZAAAA,100)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,<=,name,ZZAAAA,100)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,=,name,MAAAAA,2)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,>,name,AAAAAA,100)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,>=,name,AAAAAA,100)
 -- Note: ORCA does not support all of the above operators:
 --       - standard comparison operators on inet and cidr columns
 --         because ORCA does not look at the second occurrence of a column in an index,

--- a/src/test/regress/expected/brin_optimizer.out
+++ b/src/test/regress/expected/brin_optimizer.out
@@ -406,11 +406,6 @@ WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>,inet,0.0.0
 WARNING:  ORCA did not produce a bitmap indexscan plan for (inetcol,>=,inet,0.0.0.0,125)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (lsncol,IS,pg_lsn,,25)
 WARNING:  ORCA did not produce a bitmap indexscan plan for (lsncol,"IS NOT",pg_lsn,,100)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,<,name,ZZAAAA,100)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,<=,name,ZZAAAA,100)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,=,name,MAAAAA,2)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,>,name,AAAAAA,100)
-WARNING:  ORCA did not produce a bitmap indexscan plan for (namecol,>=,name,AAAAAA,100)
 -- Note: ORCA does not support all of the above operators:
 --       - standard comparison operators on inet and cidr columns
 --         because ORCA does not look at the second occurrence of a column in an index,

--- a/src/test/regress/expected/gp_array_agg_optimizer.out
+++ b/src/test/regress/expected/gp_array_agg_optimizer.out
@@ -324,14 +324,10 @@ INSERT INTO arrtest (a, b[1:2][1:2][1:2], c, d, e, f, g)
 VALUES ('{1,2}', '{{{0,0},{1,2}},{{3,4},{5,6}}}', '{"foo"}',
         '{{"elt1", "elt2"}}', '{1.1, 2.2}',
         '{"abc","abcde"}', '{"abc","abcde"}');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
 INSERT INTO arrtest (a, b[1:2][1:2][1:2], c, d, e, f, g)
 VALUES ('{1,2}', '{{{7,8},{9,10}},{{11,12},{13,14}}}', '{"bar"}',
         '{{"elt1", "elt2"}}', '{"3.3", "4.4"}',
         '{"abc","abcde"}', '{"abc","abcde"}');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
 SELECT $query$
 select
   array_agg(a) agg_a,

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -8134,35 +8134,21 @@ string4 name
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'unique1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into orca.onek values (931,1,1,3,1,11,1,31,131,431,931,2,3,'VJAAAA','BAAAAA','HHHHxx');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
 insert into orca.onek values (714,2,0,2,4,14,4,14,114,214,714,8,9,'MBAAAA','CAAAAA','OOOOxx');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
 insert into orca.onek values (711,3,1,3,1,11,1,11,111,211,711,2,3,'JBAAAA','DAAAAA','VVVVxx');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
 insert into orca.onek values (883,4,1,3,3,3,3,83,83,383,883,6,7,'ZHAAAA','EAAAAA','AAAAxx');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
 insert into orca.onek values (439,5,1,3,9,19,9,39,39,439,439,18,19,'XQAAAA','FAAAAA','HHHHxx');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
 insert into orca.onek values (670,6,0,2,0,10,0,70,70,170,670,0,1,'UZAAAA','GAAAAA','OOOOxx');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
 insert into orca.onek values (543,7,1,3,3,3,3,43,143,43,543,6,7,'XUAAAA','HAAAAA','VVVVxx');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
 select ten, sum(distinct four) from orca.onek a
 group by ten
 having exists (select 1 from orca.onek b where sum(distinct a.four) = b.four);
  ten | sum 
 -----+-----
    0 |   2
-   4 |   2
    1 |   3
    3 |   3
+   4 |   2
    9 |   3
 (5 rows)
 
@@ -9235,7 +9221,7 @@ WITH (appendonly=true, compresstype=zlib) DISTRIBUTED BY (uid136);
  SET
          relpages = 30915::int, reltuples = 7.28661e+07::real WHERE relname = 'tmp_verd_s_pp_provtabs_agt_0015_extract1' AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'xvclin');
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
+DETAIL:  DXL-to-PlStmt Translation: Assert not supported
 insert into pg_statistic
 values (
   'orca.tmp_verd_s_pp_provtabs_agt_0015_extract1'::regclass,
@@ -9756,8 +9742,6 @@ create table orca.arrtest (
  ) DISTRIBUTED RANDOMLY;
 insert into orca.arrtest (a[1:5], b[1:1][1:2][1:2], c, d)
 values ('{1,2,3,4,5}', '{{{0,0},{1,2}}}', '{}', '{}');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Non-default collation
 select a[1:3], b[1][2][1], c[1], d[1][1] FROM orca.arrtest order by 1,2,3,4;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Non-default collation

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -3336,34 +3336,39 @@ where t1.unique2 < 42 and t1.stringu1 > t2.stringu2;
                                         QUERY PLAN                                        
 ------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Nested Loop
-         ->  Broadcast Motion 1:3  (slice2; segments: 1)
-               ->  Seq Scan on int4_tbl i1
-                     Filter: (f1 = 0)
-         ->  Materialize
-               ->  Hash Join
-                     Hash Cond: ((11) = t1.unique2)
-                     Join Filter: (t1.stringu1 > t2.stringu2)
-                     ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                           ->  Nested Loop
-                                 Join Filter: (11 < 42)
-                                 ->  Broadcast Motion 3:3  (slice4; segments: 3)
-                                       ->  Seq Scan on onerow
-                                 ->  Materialize
-                                       ->  Hash Join
-                                             Hash Cond: (t2.unique1 = (3))
-                                             ->  Seq Scan on tenk1 t2
-                                             ->  Hash
-                                                   ->  Redistribute Motion 3:3  (slice5; segments: 3)
-                                                         Hash Key: (3)
-                                                         ->  Seq Scan on onerow onerow_1
-                     ->  Hash
-                           ->  Bitmap Heap Scan on tenk1 t1
-                                 Recheck Cond: (unique2 < 42)
-                                 ->  Bitmap Index Scan on tenk1_unique2
-                                       Index Cond: (unique2 < 42)
- Optimizer: Postgres query optimizer
-(28 rows)
+   ->  Hash Join
+         Hash Cond: (tenk1.unique1 = (3))
+         Join Filter: (tenk1_1.stringu1 > tenk1.stringu2)
+         ->  Seq Scan on tenk1
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: (3)
+                     ->  Hash Join
+                           Hash Cond: ((0) = int4_tbl.f1)
+                           ->  Hash Join
+                                 Hash Cond: (tenk1_1.unique2 = (11))
+                                 ->  Index Scan using tenk1_unique2 on tenk1 tenk1_1
+                                       Index Cond: ((unique2 < 42) AND (unique2 = 11))
+                                 ->  Hash
+                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                             ->  Result
+                                                   Filter: (((11) < 42) AND ((11) = 11))
+                                                   ->  Hash Left Join
+                                                         Hash Cond: ((1) = (1))
+                                                         ->  Result
+                                                               Filter: ((0) = 0)
+                                                               ->  Seq Scan on onerow
+                                                         ->  Hash
+                                                               ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                                                     ->  Result
+                                                                           Filter: ((1) = 1)
+                                                                           ->  Seq Scan on onerow onerow_1
+                           ->  Hash
+                                 ->  Broadcast Motion 3:3  (slice5; segments: 3)
+                                       ->  Seq Scan on int4_tbl
+                                             Filter: (f1 = 0)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(33 rows)
 
 --end_ignore
 select t1.unique2, t1.stringu1, t2.unique1, t2.stringu2 from
@@ -3417,28 +3422,35 @@ select t1.unique2, t1.stringu1, t2.unique1, t2.stringu2 from
   left join tenk1 t2
   on (subq1.y1 = t2.unique1)
 where t1.unique2 < 42 and t1.stringu1 > t2.stringu2;
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Hash Join
-         Hash Cond: (t2.unique1 = (3))
-         Join Filter: (t1.stringu1 > t2.stringu2)
-         ->  Seq Scan on tenk1 t2
-         ->  Hash
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: (3)
-                     ->  Hash Join
-                           Hash Cond: (t1.unique2 = (11))
-                           ->  Bitmap Heap Scan on tenk1 t1
-                                 Recheck Cond: (unique2 < 42)
-                                 ->  Bitmap Index Scan on tenk1_unique2
-                                       Index Cond: (unique2 < 42)
-                           ->  Hash
-                                 ->  Broadcast Motion 1:3  (slice3; segments: 1)
-                                       ->  Seq Scan on int4_tbl i1
-                                             Filter: ((11 < 42) AND (f1 = 0))
- Optimizer: Postgres query optimizer
-(19 rows)
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Hash Join
+   Hash Cond: ((11) = tenk1_1.unique2)
+   Join Filter: (tenk1_1.stringu1 > tenk1.stringu2)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Hash Join
+               Hash Cond: ((0) = int4_tbl.f1)
+               ->  Nested Loop
+                     Join Filter: true
+                     ->  Result
+                           ->  Result
+                                 Filter: ((11) < 42)
+                                 ->  Hash Left Join
+                                       Hash Cond: ((1) = (1))
+                                       ->  Result
+                                       ->  Hash
+                                             ->  Result
+                     ->  Index Scan using tenk1_unique1 on tenk1
+                           Index Cond: (unique1 = (3))
+               ->  Hash
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                           ->  Seq Scan on int4_tbl
+   ->  Hash
+         ->  Gather Motion 3:1  (slice3; segments: 3)
+               ->  Index Scan using tenk1_unique2 on tenk1 tenk1_1
+                     Index Cond: ((unique2 < 42) AND (unique2 = 11))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(26 rows)
 
 select t1.unique2, t1.stringu1, t2.unique1, t2.stringu2 from
   tenk1 t1
@@ -4911,19 +4923,26 @@ where ss.stringu2 !~* ss.case1;
 --------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
-         Hash Cond: (CASE t1.ten WHEN 0 THEN 'doh!'::text ELSE NULL::text END = t0.f1)
-         ->  Hash Join
-               Hash Cond: (t1.unique2 = i4.f1)
-               ->  Seq Scan on tenk1 t1
-                     Filter: (stringu2 !~* CASE ten WHEN 0 THEN 'doh!'::text ELSE NULL::text END)
-               ->  Hash
-                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                           ->  Seq Scan on int4_tbl i4
+         Hash Cond: ((CASE tenk1.ten WHEN 0 THEN 'doh!'::text ELSE NULL::text END) = text_tbl.f1)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: (CASE tenk1.ten WHEN 0 THEN 'doh!'::text ELSE NULL::text END)
+               ->  Result
+                     Filter: (tenk1.stringu2 !~* (CASE tenk1.ten WHEN 0 THEN 'doh!'::text ELSE NULL::text END))
+                     ->  Hash Left Join
+                           Hash Cond: (tenk1.string4 = (uniquetbl.f1)::name)
+                           ->  Nested Loop
+                                 Join Filter: true
+                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                       ->  Seq Scan on int4_tbl
+                                 ->  Index Scan using tenk1_unique2 on tenk1
+                                       Index Cond: (unique2 = int4_tbl.f1)
+                           ->  Hash
+                                 ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                       ->  Seq Scan on uniquetbl
          ->  Hash
-               ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                     ->  Seq Scan on text_tbl t0
- Optimizer: Postgres query optimizer
-(14 rows)
+               ->  Seq Scan on text_tbl
+ Optimizer: Pivotal Optimizer (GPORCA)
+(21 rows)
 
 select t0.*
 from

--- a/src/test/regress/expected/portals_optimizer.out
+++ b/src/test/regress/expected/portals_optimizer.out
@@ -980,10 +980,10 @@ DECLARE c1 CURSOR FOR SELECT stringu1 FROM onek WHERE stringu1 = 'DZAAAA';
                       QUERY PLAN                       
 -------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Only Scan using onek_stringu1 on onek
+   ->  Index Scan using onek_stringu1 on onek
          Index Cond: (stringu1 = 'DZAAAA'::name)
- Optimizer: Postgres query optimizer
-(6 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
 
 DECLARE c1 CURSOR FOR SELECT stringu1 FROM onek WHERE stringu1 = 'DZAAAA';
 FETCH FROM c1;

--- a/src/test/regress/expected/select.out
+++ b/src/test/regress/expected/select.out
@@ -292,6 +292,7 @@ SELECT onek2.unique1, onek2.stringu1 FROM onek2
 RESET enable_seqscan;
 RESET enable_bitmapscan;
 RESET enable_sort;
+RESET optimizer_enable_tablescan;
 SELECT two, stringu1, ten, string4
    INTO TABLE tmp
    FROM onek;
@@ -738,6 +739,7 @@ SELECT * FROM foo ORDER BY f1 DESC NULLS LAST;
 --
 -- partial index is usable
 SET enable_seqscan TO off;
+SET optimizer_enable_tablescan TO off;
 explain (costs off)
 select * from onek2 where unique2 = 11 and stringu1 = 'ATAAAA';
                   QUERY PLAN                   

--- a/src/test/regress/expected/select_optimizer.out
+++ b/src/test/regress/expected/select_optimizer.out
@@ -292,6 +292,7 @@ SELECT onek2.unique1, onek2.stringu1 FROM onek2
 RESET enable_seqscan;
 RESET enable_bitmapscan;
 RESET enable_sort;
+RESET optimizer_enable_tablescan;
 SELECT two, stringu1, ten, string4
    INTO TABLE tmp
    FROM onek;
@@ -739,10 +740,11 @@ SELECT * FROM foo ORDER BY f1 DESC NULLS LAST;
 --
 -- partial index is usable
 SET enable_seqscan TO off;
+SET optimizer_enable_tablescan TO off;
 explain (costs off)
 select * from onek2 where unique2 = 11 and stringu1 = 'ATAAAA';
-                  QUERY PLAN                   
------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Index Scan using onek2_u2_prtl on onek2
          Index Cond: (unique2 = 11)
@@ -759,8 +761,8 @@ select * from onek2 where unique2 = 11 and stringu1 = 'ATAAAA';
 -- actually run the query with an analyze to use the partial index
 explain (costs off, analyze on, timing off, summary off)
 select * from onek2 where unique2 = 11 and stringu1 = 'ATAAAA';
-                              QUERY PLAN                               
------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=1 loops=1)
    ->  Index Scan using onek2_u2_prtl on onek2 (actual rows=1 loops=1)
          Index Cond: (unique2 = 11)
@@ -770,8 +772,8 @@ select * from onek2 where unique2 = 11 and stringu1 = 'ATAAAA';
 
 explain (costs off)
 select unique2 from onek2 where unique2 = 11 and stringu1 = 'ATAAAA';
-                  QUERY PLAN                   
------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Index Scan using onek2_u2_prtl on onek2
          Index Cond: (unique2 = 11)

--- a/src/test/regress/expected/select_parallel_optimizer.out
+++ b/src/test/regress/expected/select_parallel_optimizer.out
@@ -1063,19 +1063,28 @@ explain (costs off)
 ---------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
-         Hash Cond: (a.two = b.two)
-         ->  Seq Scan on tenk1 a
+         Hash Cond: (tenk1.two = tenk1_1.two)
+         ->  Seq Scan on tenk1
          ->  Hash
-               ->  Broadcast Motion 1:3  (slice2; segments: 1)
-                     ->  HashAggregate
-                           Group Key: b.two
-                           ->  Limit
-                                 ->  Gather Motion 3:1  (slice3; segments: 3)
-                                       ->  Limit
-                                             ->  Seq Scan on tenk1 b
-                                                   Filter: (stringu1 ~~ '%AAAA'::text)
- Optimizer: Postgres query optimizer
-(14 rows)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     ->  GroupAggregate
+                           Group Key: tenk1_1.two
+                           ->  Sort
+                                 Sort Key: tenk1_1.two
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                       Hash Key: tenk1_1.two
+                                       ->  GroupAggregate
+                                             Group Key: tenk1_1.two
+                                             ->  Sort
+                                                   Sort Key: tenk1_1.two
+                                                   ->  Redistribute Motion 1:3  (slice4)
+                                                         ->  Limit
+                                                               ->  Gather Motion 3:1  (slice5; segments: 3)
+                                                                     ->  Limit
+                                                                           ->  Seq Scan on tenk1 tenk1_1
+                                                                                 Filter: (stringu1 ~~ '%AAAA'::text)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(23 rows)
 
 -- to increase the parallel query test coverage
 SAVEPOINT settings;

--- a/src/test/regress/sql/autostats.sql
+++ b/src/test/regress/sql/autostats.sql
@@ -5,7 +5,7 @@
 -- s/tableoid \d+/tableoid XXXXX/
 -- end_matchsubs
 -- start_matchignore
--- m/^LOG: .*Feature not supported: Non-default collation./
+-- m/^LOG: .*Feature not supported: Queries on master-only tables./
 -- m/^LOG:.*ERROR,"PG exception raised"/
 -- end_matchignore
 set gp_autostats_mode=on_change;

--- a/src/test/regress/sql/select.sql
+++ b/src/test/regress/sql/select.sql
@@ -89,6 +89,7 @@ SELECT onek2.unique1, onek2.stringu1 FROM onek2
 RESET enable_seqscan;
 RESET enable_bitmapscan;
 RESET enable_sort;
+RESET optimizer_enable_tablescan;
 
 
 SELECT two, stringu1, ten, string4
@@ -192,6 +193,7 @@ SELECT * FROM foo ORDER BY f1 DESC NULLS LAST;
 --
 -- partial index is usable
 SET enable_seqscan TO off;
+SET optimizer_enable_tablescan TO off;
 explain (costs off)
 select * from onek2 where unique2 = 11 and stringu1 = 'ATAAAA';
 select * from onek2 where unique2 = 11 and stringu1 = 'ATAAAA';


### PR DESCRIPTION
For type NAMEOID, the default collation is C. Make sure various nodetypes are
aware of it.  Earlier only VAR node type took care of it. Extend it CONST and
OPEXPR.

A note about test case change in `select` ICG test. The test cases are supposed
to test for index scan on partial indexes. Earlier ORCA would fall back to
planner. After this fix, ORCA started to give sequential scan which was flaky
with explain analyze. So just like planner, we have turned off tablescan for
these tests. They are falling back to Planner for now.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
