### PR TITLE
[doc] remove useless instruction

### DIFF
--- a/README.macOS.md
+++ b/README.macOS.md
@@ -7,7 +7,7 @@ Execute the following, this script will start by caching the `sudo` password:
 
 ```bash
 ./README.macOS.bash
-source ~/.bash_profile
+source ~/.bashrc
 ```
 
 Note: This will install Homebrew if missing


### PR DESCRIPTION
`README.macOS.bash` doesn't write to ` ~/.bash_profile` but ` ~/.bashrc`, 
so this instruction results `No such file or directory` error on a new mac environment.
Step 2 write to ` ~/.bash_profile` and sourced the `~/.bashrc`. so just remove it here.

v2

After discussed with @SmartKeyerror, we decided to change
`source ~/.bash_profile` to `source ~/.bashrc`, which guarantees
not missing source configuration files.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
