### PR TITLE
docs - add disk i/o sched policy recommends for diff storage types

### DIFF
--- a/gpdb-doc/markdown/install_guide/prep_os.html.md
+++ b/gpdb-doc/markdown/install_guide/prep_os.html.md
@@ -382,8 +382,7 @@ The XFS options can also be set in the `/etc/fstab` file. This example entry fro
     | Solid-State Drives (SSD) | RHEL 7 | `noop` |
     |                          | RHEL 8</br>Ubuntu | `none` |
     | Other | RHEL 7 | `deadline` |
-    |       | RHEL 8 | `mq-deadline` |
-    |       | Ubuntu | `mq-deadline` or `bfq` |
+    |       | RHEL 8</br>Ubuntu| `mq-deadline` |
     <br>
     You can configure the disk scheduler as described in this RedHat Enterprise Linux documentation for [RHEL 7](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/performance_tuning_guide/sect-red_hat_enterprise_linux-performance_tuning_guide-storage_and_file_systems-configuration_tools#sect-Red_Hat_Enterprise_Linux-Performance_Tuning_Guide-Configuration_tools-Setting_the_default_IO_scheduler) or [RHEL 8](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/monitoring_and_managing_system_status_and_performance/setting-the-disk-scheduler_monitoring-and-managing-system-status-and-performance). The Ubuntu wiki [IOSchedulers](https://wiki.ubuntu.com/Kernel/Reference/IOSchedulers) topic describes the I/O schedulers available on Ubuntu systems.
 

--- a/gpdb-doc/markdown/install_guide/prep_os.html.md
+++ b/gpdb-doc/markdown/install_guide/prep_os.html.md
@@ -383,10 +383,39 @@ The XFS options can also be set in the `/etc/fstab` file. This example entry fro
     |                          | RHEL 8</br>Ubuntu | `none` |
     | Other | RHEL 7 | `deadline` |
     |       | RHEL 8</br>Ubuntu| `mq-deadline` |
-    <br>
-    You can configure the disk scheduler as described in this RedHat Enterprise Linux documentation for [RHEL 7](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/performance_tuning_guide/sect-red_hat_enterprise_linux-performance_tuning_guide-storage_and_file_systems-configuration_tools#sect-Red_Hat_Enterprise_Linux-Performance_Tuning_Guide-Configuration_tools-Setting_the_default_IO_scheduler) or [RHEL 8](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/monitoring_and_managing_system_status_and_performance/setting-the-disk-scheduler_monitoring-and-managing-system-status-and-performance). The Ubuntu wiki [IOSchedulers](https://wiki.ubuntu.com/Kernel/Reference/IOSchedulers) topic describes the I/O schedulers available on Ubuntu systems.
+    </br>
+    To specify a scheduler until the next system reboot, run the following:
 
-    (If you used the `grubby` command to configure the disk scheduler on a RHEL or CentOS 7.x system and it does not update the kernels, see the [Note](#grubby_note) at the end of the section.)
+    ```
+    # echo schedulername > /sys/block/<devname>/queue/scheduler
+    ```
+
+    For example:
+
+    ```
+    # echo deadline > /sys/block/sbd/queue/scheduler
+    ```
+
+    **Note:** Using the `echo` command to set the disk I/O scheduler policy is not persistent; you must ensure that you run the command whenever the system reboots. How to run the command will vary based on your system.
+
+    To specify the I/O scheduler at boot time on systems that use `grub2` such as RHEL 7.x or CentOS 7.x, use the system utility `grubby`. This command adds the parameter when run as `root`:
+
+    ```
+    # grubby --update-kernel=ALL --args="elevator=deadline"
+    ```
+
+    After adding the parameter, reboot the system.
+
+    This `grubby` command displays kernel parameter settings:
+
+    ```
+    # grubby --info=ALL
+    ```
+
+    Refer to your operating system documentation for more information about the `grubby` utility. If you used the `grubby` command to configure the disk scheduler on a RHEL or CentOS 7.x system and it does not update the kernels, see the [Note](#grubby_note) at the end of the section.
+
+    For additional information about configuring the disk scheduler, refer to the RedHat Enterprise Linux documentation for [RHEL 7](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/performance_tuning_guide/sect-red_hat_enterprise_linux-performance_tuning_guide-storage_and_file_systems-configuration_tools#sect-Red_Hat_Enterprise_Linux-Performance_Tuning_Guide-Configuration_tools-Setting_the_default_IO_scheduler) or [RHEL 8](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/monitoring_and_managing_system_status_and_performance/setting-the-disk-scheduler_monitoring-and-managing-system-status-and-performance). The Ubuntu wiki [IOSchedulers](https://wiki.ubuntu.com/Kernel/Reference/IOSchedulers) topic describes the I/O schedulers available on Ubuntu systems.
+
 
 ### <a id="networking"></a>Networking
 
@@ -483,9 +512,9 @@ Restart the SSH daemon after you update `MaxStartups` and `MaxSessions`. For exa
 # service sshd restart
 ```
 
-<a id="grubby_note"></a>
-
 For detailed information about SSH configuration options, refer to the SSH documentation for your Linux distribution.
+
+<a id="grubby_note"></a>
 
 **Note:** If the `grubby` command does not update the kernels of a RHEL 7.x or CentOS 7.x system, you can manually update all kernels on the system. For example, to add the parameter `transparent_hugepage=never` to all kernels on a system.
 

--- a/gpdb-doc/markdown/install_guide/prep_os.html.md
+++ b/gpdb-doc/markdown/install_guide/prep_os.html.md
@@ -376,14 +376,41 @@ The XFS options can also be set in the `/etc/fstab` file. This example entry fro
 
     A typical Linux disk I/O scheduler supports multiple access policies. The optimal policy selection depends on the underlying storage infrastructure. The recommended scheduler policy settings for Greenplum Database systems for specific OSs and storage device types follow:
 
-    | Storage Device Type | OS | Recommended Scheduler Policy |
-    |-------------------|---------------|-------|
-    | Non-Volatile Memory Express (NVMe) | RHEL 7</br>RHEL 8</br>Ubuntu | `none` |
-    | Solid-State Drives (SSD) | RHEL 7 | `noop` |
-    |                          | RHEL 8</br>Ubuntu | `none` |
-    | Other | RHEL 7 | `deadline` |
-    |       | RHEL 8</br>Ubuntu| `mq-deadline` |
-    </br>
+    <table>
+      <thead>
+        <tr>
+          <th>Storage Device Type</th>
+          <th>OS</th>
+          <th>Recommended Scheduler Policy</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Non-Volatile Memory Express (NVMe)</td>
+          <td>RHEL 7</br>RHEL 8</br>Ubuntu</td>
+          <td><code>none</code></td>
+        </tr>
+        <tr>
+          <td rowspan="2">Solid-State Drives (SSD)</td>
+          <td>RHEL 7</td>
+          <td><code>noop</code></td>
+        </tr>
+        <tr>
+          <td>RHEL 8</br>Ubuntu</td>
+          <td><code>none</code></td>
+        </tr>
+        <tr>
+          <td rowspan="2">Other</td>
+          <td>RHEL 7</td>
+          <td><code>deadline</code></td>
+        </tr>
+        <tr>
+          <td>RHEL 8</br>Ubuntu</td>
+          <td><code>mq-deadline</code></td>
+        </tr>
+      </tbody>
+    </table>
+
     To specify a scheduler until the next system reboot, run the following:
 
     ```

--- a/gpdb-doc/markdown/install_guide/prep_os.html.md
+++ b/gpdb-doc/markdown/install_guide/prep_os.html.md
@@ -372,46 +372,22 @@ The XFS options can also be set in the `/etc/fstab` file. This example entry fro
 
 -   Disk I/O scheduler
 
-    The Linux disk I/O scheduler for disk access supports different policies, such as `CFQ`, `AS`, and `deadline`.
+    The Linux disk scheduler orders the I/O requests submitted to a storage device, controlling the way the kernel commits reads and writes to disk.
 
-    The `deadline` scheduler option is recommended. To specify a scheduler until the next system reboot, run the following:
+    A typical Linux disk I/O scheduler supports multiple access policies. The optimal policy selection depends on the underlying storage infrastructure. The recommended scheduler policy settings for Greenplum Database systems for specific OSs and storage device types follow:
 
-    ```
-    # echo schedulername > /sys/block/<devname>/queue/scheduler
-    ```
+    | Storage Device Type | OS | Recommended Scheduler Policy |
+    |-------------------|---------------|-------|
+    | Non-Volatile Memory Express (NVMe) | RHEL 7</br>RHEL 8</br>Ubuntu | `none` |
+    | Solid-State Drives (SSD) | RHEL 7 | `noop` |
+    |                          | RHEL 8</br>Ubuntu | `none` |
+    | Other | RHEL 7 | `deadline` |
+    |       | RHEL 8 | `mq-deadline` |
+    |       | Ubuntu | `mq-deadline` or `bfq` |
+    <br>
+    You can configure the disk scheduler as described in this RedHat Enterprise Linux documentation for [RHEL 7](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/performance_tuning_guide/sect-red_hat_enterprise_linux-performance_tuning_guide-storage_and_file_systems-configuration_tools#sect-Red_Hat_Enterprise_Linux-Performance_Tuning_Guide-Configuration_tools-Setting_the_default_IO_scheduler) or [RHEL 8](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/monitoring_and_managing_system_status_and_performance/setting-the-disk-scheduler_monitoring-and-managing-system-status-and-performance). The Ubuntu wiki [IOSchedulers](https://wiki.ubuntu.com/Kernel/Reference/IOSchedulers) topic describes the I/O schedulers available on Ubuntu systems.
 
-    For example:
-
-    ```
-    # echo deadline > /sys/block/sbd/queue/scheduler
-    ```
-
-    **Note:** Using the `echo` command to set the disk I/O scheduler policy is not persistent, therefore you must ensure the command is run whenever the system reboots. How to run the command will vary based on your system.
-
-    One method to set the I/O scheduler policy at boot time is with the `elevator` kernel parameter. Add the parameter `elevator=deadline` to the kernel command in the file `/boot/grub/grub.conf`, the GRUB boot loader configuration file. This is an example kernel command from a `grub.conf` file on RHEL 6.x or CentOS 6.x. The command is on multiple lines for readability.
-
-    ```
-    kernel /vmlinuz-2.6.18-274.3.1.el5 ro root=LABEL=/
-                     elevator=deadline crashkernel=128M@16M  quiet console=tty1
-                     console=ttyS1,115200 panic=30 transparent_hugepage=never 
-                     initrd /initrd-2.6.18-274.3.1.el5.img
-    ```
-
-    To specify the I/O scheduler at boot time on systems that use `grub2` such as RHEL 7.x or CentOS 7.x, use the system utility `grubby`. This command adds the parameter when run as root.
-
-    ```
-    # grubby --update-kernel=ALL --args="elevator=deadline"
-    ```
-
-    After adding the parameter, reboot the system.
-
-    This `grubby` command displays kernel parameter settings.
-
-    ```
-    # grubby --info=ALL
-    ```
-
-    For more information about the `grubby` utility, see your operating system documentation. If the `grubby` command does not update the kernels, see the [Note](#grubby_note) at the end of the section.
+    (If you used the `grubby` command to configure the disk scheduler on a RHEL or CentOS 7.x system and it does not update the kernels, see the [Note](#grubby_note) at the end of the section.)
 
 ### <a id="networking"></a>Networking
 
@@ -507,6 +483,8 @@ Restart the SSH daemon after you update `MaxStartups` and `MaxSessions`. For exa
 ```
 # service sshd restart
 ```
+
+<a id="grubby_note"></a>
 
 For detailed information about SSH configuration options, refer to the SSH documentation for your Linux distribution.
 


### PR DESCRIPTION
clarify the disk schedule docs.  in this PR:
- add a storagetype/os/scheduler table
- remove some specifics about setting the scheduler and replace with links to rhel and ubuntu documentation

QUESTION:  i pulled the ubuntu settings from the referenced link.  can someone please confirm/verify these settings?

attached is a screen cap of the html.
![disksched2](https://user-images.githubusercontent.com/19785845/176781970-d9f4d50d-4956-4864-bf74-717a222cdcfe.png)

