### PR TITLE
Close db connections properly at all places in gpcheckcat

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -200,6 +200,8 @@ def getversion():
     row = curs.getresult()[0]
     version = row[0]
 
+    db.close()
+
     logger.debug('got version %s' % version)
     return version
 
@@ -213,6 +215,8 @@ def getalldbs():
     curs = db.query('''
     select datname from pg_database where datallowconn order by datname ''')
     row = curs.getresult()
+
+    db.close()
     return row
 
 
@@ -4069,6 +4073,8 @@ def getClassOidForRelfilenode(relfilenode):
     except Exception, e:
         setError(ERROR_NOREPAIR)
         myprint('  Execution error: ' + str(e))
+    finally:
+        conn.close()
 
 
 # -------------------------------------------------------------------------------
@@ -4092,6 +4098,8 @@ def getResourceTypeOid(oid):
     except Exception, e:
         setError(ERROR_NOREPAIR)
         myprint('  Execution error: ' + str(e))
+    finally:
+        db.close()
 
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
gpcheckcat was getting stuck at aoseg_table check and taking 4 hours to complete. In master pg_logs found FATAL 'connection limit exceeded for non-superusrs' and the reason could be that db connections are not being closed properly at some places in code.

Fix:
Closed the databse connections properly at all places

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
