### PR TITLE
Docs: Update mirrorless support note.

### DIFF
--- a/gpdb-doc/markdown/admin_guide/highavail/topics/g-enabling-high-availability-features.html.md
+++ b/gpdb-doc/markdown/admin_guide/highavail/topics/g-enabling-high-availability-features.html.md
@@ -6,7 +6,7 @@ The fault tolerance and the high-availability features of Greenplum Database can
 
 **Important:** When data loss is not acceptable for a Greenplum Database cluster, Greenplum master and segment mirroring is recommended. If mirroring is not enabled then Greenplum stores only one copy of the data, so the underlying storage media provides the only guarantee for data availability and correctness in the event of a hardware failure.
 
-Kubernetes enables quick recovery from both pod and host failures, and Kubernetes storage services provide a high level of availability for the underlying data. Furthermore, virtualized environments make it difficult to ensure the anti-affinity guarantees required for Greenplum mirroring solutions. For these reasons, mirrorless deployments are fully supported with VMware Tanzu Greenplum for Kubernetes. Other deployment environments are generally not supported for production use unless both Greenplum master and segment mirroring are enabled.
+Because VMware vSphere enables quick recovery from host failures and high availability for the underlying data, mirrorless deployments of Tanzu Greenplum are fully supported on certain configurations of VMware vSphere. See [Supported Platforms for VMware vSphere with Greenplum](/gpvirtual/supported-platforms.html). Other deployment environments are generally not supported for production use unless both Greenplum master and segment mirroring are enabled.
 
 For information about the utilities that are used to enable high availability, see the *Greenplum Database Utility Guide*.
 

--- a/gpdb-doc/markdown/admin_guide/intro/about_ha.html.md
+++ b/gpdb-doc/markdown/admin_guide/intro/about_ha.html.md
@@ -8,7 +8,7 @@ You can deploy Greenplum Database without a single point of failure by mirroring
 
 **Important:** When data loss is not acceptable for a Greenplum Database cluster, Greenplum master and segment mirroring is recommended. If mirroring is not enabled then Greenplum stores only one copy of the data, so the underlying storage media provides the only guarantee for data availability and correctness in the event of a hardware failure.
 
-Kubernetes enables quick recovery from both pod and host failures, and Kubernetes storage services provide a high level of availability for the underlying data. Furthermore, virtualized environments make it difficult to ensure the anti-affinity guarantees required for Greenplum mirroring solutions. For these reasons, mirrorless deployments are fully supported with VMware Tanzu Greenplum for Kubernetes. Other deployment environments are generally not supported for production use unless both Greenplum master and segment mirroring are enabled.
+Because VMware vSphere enables quick recovery from host failures and high availability for the underlying data, mirrorless deployments of Tanzu Greenplum are fully supported on certain configurations of VMware vSphere. See [Supported Platforms for VMware vSphere with Greenplum](/gpvirtual/supported-platforms.html). Other deployment environments are generally not supported for production use unless both Greenplum master and segment mirroring are enabled.
 
 ## <a id="segment_mirroring"></a>About Segment Mirroring 
 

--- a/gpdb-doc/markdown/admin_guide/workload_mgmt_resgroups.html.md
+++ b/gpdb-doc/markdown/admin_guide/workload_mgmt_resgroups.html.md
@@ -42,7 +42,7 @@ Within a resource group for roles, transactions are evaluated on a first in, fir
 
 You can also use resource groups to manage the CPU and memory resources of external components such as PL/Container. Resource groups for external components use Linux cgroups to manage both the total CPU and total memory resources for the component.
 
-**Note:** Containerized deployments of Greenplum Database, such as Greenplum for Kubernetes, might create a hierarchical set of nested cgroups to manage host system resources. The nesting of cgroups affects the Greenplum Database resource group limits for CPU percentage, CPU cores, and memory \(except for Greenplum Database external components\). The Greenplum Database resource group system resource limit is based on the quota for the parent group.
+**Note:** Containerized deployments of Greenplum Database might create a hierarchical set of nested cgroups to manage host system resources. The nesting of cgroups affects the Greenplum Database resource group limits for CPU percentage, CPU cores, and memory \(except for Greenplum Database external components\). The Greenplum Database resource group system resource limit is based on the quota for the parent group.
 
 For example, Greenplum Database is running in a cgroup demo, and the Greenplum Database cgroup is nested in the cgroup demo. If the cgroup demo is configured with a CPU limit of 60% of system CPU resources and the Greenplum Database resource group CPU limit is set 90%, the Greenplum Database limit of host system CPU resources is 54% \(0.6 x 0.9\).
 

--- a/gpdb-doc/markdown/install_guide/prep_os.html.md
+++ b/gpdb-doc/markdown/install_guide/prep_os.html.md
@@ -23,7 +23,7 @@ For information about running Tanzu Greenplum Database in the cloud see *Cloud S
 
 **Important:** When data loss is not acceptable for a Greenplum Database cluster, Greenplum coordinator and segment mirroring is recommended. If mirroring is not enabled then Greenplum stores only one copy of the data, so the underlying storage media provides the only guarantee for data availability and correctness in the event of a hardware failure.
 
-Kubernetes enables quick recovery from both pod and host failures, and Kubernetes storage services provide a high level of availability for the underlying data. Furthermore, virtualized environments make it difficult to ensure the anti-affinity guarantees required for Greenplum mirroring solutions. For these reasons, mirrorless deployments are fully supported with Greenplum for Kubernetes. Other deployment environments are generally not supported for production use unless both Greenplum coordinator and segment mirroring are enabled.
+Because VMware vSphere enables quick recovery from host failures and high availability for the underlying data, mirrorless deployments of Tanzu Greenplum are fully supported on certain configurations of VMware vSphere. See [Supported Platforms for VMware vSphere with Greenplum](/gpvirtual/supported-platforms.html). Other deployment environments are generally not supported for production use unless both Greenplum master and segment mirroring are enabled.
 
 **Note:** For information about upgrading Tanzu Greenplum from a previous version, see the *Tanzu Greenplum Database Release Notes* for the release that you are installing.
 


### PR DESCRIPTION
Re-purposes mirrorless notes to mention vSphere rather than gpdb for k8s, which is no longer available.

