### PR TITLE
Fix the wrong explain analyze results of sort

### DIFF
--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1002,7 +1002,6 @@ cdbexplain_depositStatsToNode(PlanState *planstate, CdbExplain_RecvStatCtx *ctx)
 		for (int j = 0; j < NUM_SORT_SPACE_TYPE; j++)
 		{
 			cdbexplain_depStatAcc_init0(&sortSpaceUsed[j][i]);
-			cdbexplain_depStatAcc_init0(&sortSpaceUsed[j][i]);
 		}
 	}
 
@@ -1050,14 +1049,6 @@ cdbexplain_depositStatsToNode(PlanState *planstate, CdbExplain_RecvStatCtx *ctx)
 									  (double) rsi->sortstats.spaceUsed, rsh, rsi, nsi);
 		}
 
-		Assert(rsi->sortstats.sortMethod < NUM_SORT_METHOD);
-		Assert(rsi->sortstats.spaceType < NUM_SORT_SPACE_TYPE);
-		if (rsi->sortstats.sortMethod != SORT_TYPE_STILL_IN_PROGRESS)
-		{
-			cdbexplain_depStatAcc_upd(&sortSpaceUsed[rsi->sortstats.spaceType][rsi->sortstats.sortMethod],
-									  (double) rsi->sortstats.spaceUsed, rsh, rsi, nsi);
-		}
-
 		/* Update per-slice accumulators. */
 		cdbexplain_depStatAcc_upd(&peakmemused, rsh->worker.peakmemused, rsh, rsi, nsi);
 		cdbexplain_depStatAcc_upd(&vmem_reserved, rsh->worker.vmem_reserved, rsh, rsi, nsi);
@@ -1074,7 +1065,6 @@ cdbexplain_depositStatsToNode(PlanState *planstate, CdbExplain_RecvStatCtx *ctx)
 	{
 		for (int j = 0; j < NUM_SORT_SPACE_TYPE; j++)
 		{
-			ns->sortSpaceUsed[j][i] = sortSpaceUsed[j][i].agg;
 			ns->sortSpaceUsed[j][i] = sortSpaceUsed[j][i].agg;
 		}
 	}

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -998,12 +998,8 @@ cdbexplain_depositStatsToNode(PlanState *planstate, CdbExplain_RecvStatCtx *ctx)
 	cdbexplain_depStatAcc_init0(&totalWorkfileCreated);
 	cdbexplain_depStatAcc_init0(&totalPartTableScanned);
 	for (int i = 0; i < NUM_SORT_METHOD; i++)
-	{
 		for (int j = 0; j < NUM_SORT_SPACE_TYPE; j++)
-		{
 			cdbexplain_depStatAcc_init0(&sortSpaceUsed[j][i]);
-		}
-	}
 
 	/* Initialize per-slice accumulators. */
 	cdbexplain_depStatAcc_init0(&peakmemused);
@@ -1062,12 +1058,8 @@ cdbexplain_depositStatsToNode(PlanState *planstate, CdbExplain_RecvStatCtx *ctx)
 	ns->totalWorkfileCreated = totalWorkfileCreated.agg;
 	ns->totalPartTableScanned = totalPartTableScanned.agg;
 	for (int i = 0; i < NUM_SORT_METHOD; i++)
-	{
 		for (int j = 0; j < NUM_SORT_SPACE_TYPE; j++)
-		{
 			ns->sortSpaceUsed[j][i] = sortSpaceUsed[j][i].agg;
-		}
-	}
 
 	/* Roll up summary over all nodes of slice into RecvStatCtx. */
 	ctx->workmemused_max = Max(ctx->workmemused_max, workmemused.agg.vmax);

--- a/src/test/regress/expected/partition_prune_optimizer.out
+++ b/src/test/regress/expected/partition_prune_optimizer.out
@@ -3476,7 +3476,7 @@ explain (analyze, costs off, summary off, timing off) select * from ma_test wher
    Merge Key: ma_test_p1.b
    ->  Sort (actual rows=8 loops=1)
          Sort Key: ma_test_p1.b
-         Sort Method:  quicksort  Memory: 150kB
+         Sort Method:  quicksort  Memory: 75kB
          ->  Nested Loop (actual rows=8 loops=1)
                Join Filter: (ma_test_p1.a >= (min(ma_test_p2_1.b)))
                Rows Removed by Join Filter: 3


### PR DESCRIPTION
When get the detailed **sort node's** analyzed results: an obvious mistake on its segment num
```
tpch=# explain (analyze,verbose,timing,costs,buffers) select * from nation order by n_name;
Gather Motion 3:1  (slice1; segments: 3)  ... // correct segment num:3
...
  ->  Sort  (cost=187.86..193.70 rows=2333 width=434) (actual time=2.488..2.502 rows=11 loops=1)
       // but 6 segments here
       Sort Method:  quicksort  Memory: 158kB  Max Memory: 27kB  Avg Memory: 26kb (6 segments)
...
```

Fix it is easy: just remove the duplicated code lines. I think it was introduced by mistake.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
