### PR TITLE
remove gp_fastsequence entries when executing TRUNCATE AO TABLE

### DIFF
--- a/src/backend/catalog/gp_fastsequence.c
+++ b/src/backend/catalog/gp_fastsequence.c
@@ -44,8 +44,8 @@ static void insert_or_update_fastsequence(
  * only exist for lifespan of the corresponding table.
  *
  * Given those special needs, this function inserts one initial row to
- * fastsequence for segfile 0 (used for special cases like CTAS, ALTER and
- * same transaction create and insert).  Only segfile 0 can be used to insert
+ * fastsequence for segfile 0 (used for special cases like CTAS, ALTER, TRUNCATE,
+ * and same transaction create and insert).  Only segfile 0 can be used to insert
  * tuples within same transaction creating the table hence initial entry is
  * only created for these. Entries for rest of segfiles will get created with
  * frozenXids during inserts. These entries are inserted while creating the

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -55,6 +55,7 @@
 #include "catalog/storage.h"
 #include "catalog/storage_xlog.h"
 #include "catalog/toasting.h"
+#include "catalog/gp_fastsequence.h"
 #include "cdb/cdbappendonlyam.h"
 #include "cdb/cdbappendonlyxlog.h"
 #include "cdb/cdbaocsam.h"
@@ -1727,6 +1728,14 @@ ao_aux_tables_safe_truncate(Relation rel)
 	relid_set_new_relfilenode(aoseg_relid);
 	relid_set_new_relfilenode(aoblkdir_relid);
 	relid_set_new_relfilenode(aovisimap_relid);
+
+	/*
+	 * Reset existing gp_fastsequence entries for the segrel to an initial entry.
+	 * This mimics the state of the gp_fastsequence row when an empty AO/AOCS
+	 * table is created.
+	 */
+	RemoveFastSequenceEntry(aoseg_relid);
+	InsertInitialFastSequenceEntries(aoseg_relid);
 }
 
 /*

--- a/src/test/regress/input/aocs.source
+++ b/src/test/regress/input/aocs.source
@@ -688,3 +688,35 @@ select count(*) from aocs_small_and_dense_content;
 
 select gp_inject_fault('appendonly_skip_compression', 'reset', dbid)
 from gp_segment_configuration where role = 'p' and content = 0;
+
+
+-- test truncate ao table in current transaction and sub-transaction
+-- more details can look at https://github.com/greenplum-db/gpdb/issues/13699
+
+-- should success, create and truncate ao table in the same transaction;
+begin;
+create table fix_aoco_truncate_last_sequence(a int, b int) with (appendonly = true, orientation = column);
+create index index_fix_aoco_truncate_last_sequence on fix_aoco_truncate_last_sequence(b);
+insert into fix_aoco_truncate_last_sequence select i, i from generate_series(1, 5) i;
+select count(*) from fix_aoco_truncate_last_sequence;
+truncate table fix_aoco_truncate_last_sequence;
+select count(*) from fix_aoco_truncate_last_sequence;
+abort;
+
+-- should success, create and truncate ao table in the different transaction,
+-- and create index for it. 
+begin;
+create table fix_aoco_truncate_last_sequence(a int, b int) with (appendonly = true, orientation = column);
+create index index_fix_aoco_truncate_last_sequence on fix_aoco_truncate_last_sequence(b);
+insert into fix_aoco_truncate_last_sequence select i, i from generate_series(1, 5) i;
+select count(*) from fix_aoco_truncate_last_sequence;
+savepoint s1; 
+truncate table fix_aoco_truncate_last_sequence;
+insert into fix_aoco_truncate_last_sequence select 1, 1 from generate_series(1, 10);
+select count(*) from fix_aoco_truncate_last_sequence;
+rollback to s1; 
+select count(*) from fix_aoco_truncate_last_sequence;
+truncate table fix_aoco_truncate_last_sequence;
+insert into fix_aoco_truncate_last_sequence select 1, 1 from generate_series(1, 5); 
+select count(*) from fix_aoco_truncate_last_sequence;
+abort;

--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -378,8 +378,8 @@ WHERE objid IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (
 -- TRUNCATE
 TRUNCATE tenk_ao2;
 
--- Truncate changes relfilnode, as a result old pg_aoseg table is truncated but
--- gp_fastsequence remains intact.
+-- Truncate changes relfilnode, as a result old pg_aoseg table is truncated and
+-- gp_fastsequence entries are also reinitialized.
 SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END,
        objmod,
        CASE WHEN last_sequence = 0 THEN 'zero'
@@ -852,3 +852,36 @@ a.c1
 ;
 
 drop table bms_ao_bug;
+
+
+-- test truncate ao table in current transaction and sub-transaction
+-- more details can look at https://github.com/greenplum-db/gpdb/issues/13699
+
+-- should success, create and truncate ao table in the same transaction;
+begin;
+create table fix_ao_truncate_last_sequence(a int, b int) with (appendonly = true);
+create index index_fix_ao_truncate_last_sequence on fix_ao_truncate_last_sequence(b);
+insert into fix_ao_truncate_last_sequence select i, i from generate_series(1, 5) i;
+select count(*) from fix_ao_truncate_last_sequence;
+truncate table fix_ao_truncate_last_sequence;
+select count(*) from fix_ao_truncate_last_sequence;
+abort;
+
+-- should success, create and truncate ao table in the different transaction,
+-- and create index for it.
+begin;
+create table fix_ao_truncate_last_sequence(a int, b int) with (appendonly = true);
+create index index_fix_ao_truncate_last_sequence on fix_ao_truncate_last_sequence(b);
+insert into fix_ao_truncate_last_sequence select i, i from generate_series(1, 5) i;
+select count(*) from fix_ao_truncate_last_sequence;
+savepoint s1;
+truncate table fix_ao_truncate_last_sequence;
+insert into fix_ao_truncate_last_sequence select 1, 1 from generate_series(1, 10);
+select count(*) from fix_ao_truncate_last_sequence;
+rollback to s1;
+select count(*) from fix_ao_truncate_last_sequence;
+truncate table fix_ao_truncate_last_sequence;
+insert into fix_ao_truncate_last_sequence select 1, 1 from generate_series(1, 5);
+select count(*) from fix_ao_truncate_last_sequence;
+abort;
+

--- a/src/test/regress/output/aocs.source
+++ b/src/test/regress/output/aocs.source
@@ -1317,3 +1317,61 @@ from gp_segment_configuration where role = 'p' and content = 0;
  Success:
 (1 row)
 
+-- test truncate ao table in current transaction and sub-transaction
+-- more details can look at https://github.com/greenplum-db/gpdb/issues/13699
+-- should success, create and truncate ao table in the same transaction;
+begin;
+create table fix_aoco_truncate_last_sequence(a int, b int) with (appendonly = true, orientation = column);
+create index index_fix_aoco_truncate_last_sequence on fix_aoco_truncate_last_sequence(b);
+insert into fix_aoco_truncate_last_sequence select i, i from generate_series(1, 5) i;
+select count(*) from fix_aoco_truncate_last_sequence;
+ count 
+-------
+     5
+(1 row)
+
+truncate table fix_aoco_truncate_last_sequence;
+select count(*) from fix_aoco_truncate_last_sequence;
+ count 
+-------
+     0
+(1 row)
+
+abort;
+-- should success, create and truncate ao table in the different transaction,
+-- and create index for it. 
+begin;
+create table fix_aoco_truncate_last_sequence(a int, b int) with (appendonly = true, orientation = column);
+create index index_fix_aoco_truncate_last_sequence on fix_aoco_truncate_last_sequence(b);
+insert into fix_aoco_truncate_last_sequence select i, i from generate_series(1, 5) i;
+select count(*) from fix_aoco_truncate_last_sequence;
+ count 
+-------
+     5
+(1 row)
+
+savepoint s1; 
+truncate table fix_aoco_truncate_last_sequence;
+insert into fix_aoco_truncate_last_sequence select 1, 1 from generate_series(1, 10);
+select count(*) from fix_aoco_truncate_last_sequence;
+ count 
+-------
+    10
+(1 row)
+
+rollback to s1; 
+select count(*) from fix_aoco_truncate_last_sequence;
+ count 
+-------
+     5
+(1 row)
+
+truncate table fix_aoco_truncate_last_sequence;
+insert into fix_aoco_truncate_last_sequence select 1, 1 from generate_series(1, 5); 
+select count(*) from fix_aoco_truncate_last_sequence;
+ count 
+-------
+     5
+(1 row)
+
+abort;

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -740,8 +740,8 @@ WHERE objid IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (
 
 -- TRUNCATE
 TRUNCATE tenk_ao2;
--- Truncate changes relfilnode, as a result old pg_aoseg table is truncated but
--- gp_fastsequence remains intact.
+-- Truncate changes relfilnode, as a result old pg_aoseg table is truncated and
+-- gp_fastsequence entries are also reinitialized.
 SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END,
        objmod,
        CASE WHEN last_sequence = 0 THEN 'zero'
@@ -753,9 +753,9 @@ WHERE objid IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (
   SELECT oid FROM pg_class WHERE relname='tenk_ao2'));
    case    | objmod | last_sequence | gp_segment_id 
 -----------+--------+---------------+---------------
- NormalXid |      0 | >= 3300       |             1
- NormalXid |      0 | >= 3300       |             0
- NormalXid |      0 | >= 3300       |             2
+ NormalXid |      0 | zero          |             0
+ NormalXid |      0 | zero          |             2
+ NormalXid |      0 | zero          |             1
 (3 rows)
 
 -- WITH OIDS is no longer supported
@@ -1685,3 +1685,65 @@ a.c1
 (1 row)
 
 drop table bms_ao_bug;
+-- test truncate ao table in current transaction and sub-transaction
+-- more details can look at https://github.com/greenplum-db/gpdb/issues/13699
+-- should success, create and truncate ao table in the same transaction;
+begin;
+create table fix_ao_truncate_last_sequence(a int, b int) with (appendonly = true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index index_fix_ao_truncate_last_sequence on fix_ao_truncate_last_sequence(b);
+insert into fix_ao_truncate_last_sequence select i, i from generate_series(1, 5) i;
+select count(*) from fix_ao_truncate_last_sequence;
+ count 
+-------
+     5
+(1 row)
+
+truncate table fix_ao_truncate_last_sequence;
+select count(*) from fix_ao_truncate_last_sequence;
+ count 
+-------
+     0
+(1 row)
+
+abort;
+-- should success, create and truncate ao table in the different transaction,
+-- and create index for it.
+begin;
+create table fix_ao_truncate_last_sequence(a int, b int) with (appendonly = true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index index_fix_ao_truncate_last_sequence on fix_ao_truncate_last_sequence(b);
+insert into fix_ao_truncate_last_sequence select i, i from generate_series(1, 5) i;
+select count(*) from fix_ao_truncate_last_sequence;
+ count 
+-------
+     5
+(1 row)
+
+savepoint s1;
+truncate table fix_ao_truncate_last_sequence;
+insert into fix_ao_truncate_last_sequence select 1, 1 from generate_series(1, 10);
+select count(*) from fix_ao_truncate_last_sequence;
+ count 
+-------
+    10
+(1 row)
+
+rollback to s1;
+select count(*) from fix_ao_truncate_last_sequence;
+ count 
+-------
+     5
+(1 row)
+
+truncate table fix_ao_truncate_last_sequence;
+insert into fix_ao_truncate_last_sequence select 1, 1 from generate_series(1, 5);
+select count(*) from fix_ao_truncate_last_sequence;
+ count 
+-------
+     5
+(1 row)
+
+abort;


### PR DESCRIPTION
This is to fix #13699.

As we know, AO/AOCO table relies on the `last_sequence` to generate a new first row number
 to a new var block, this value will store in the heap table `gp_fastsequence`. 

Whenever we generate a new variable-length storage block, we need to obtain a continuous row 
number from the `gp_fastsequence` table as the first row number of the var block, and also as the 
unique identifier of the tuple when creating an index.

**So, the row number should not be same and not reuse deleted tuple's row number**. Therefore, 
Greenplum must ensure that row numbers are not repeated and always increment.

But sub-transaction will break it:

```sql
begin;
create table t (a int, b int) with (appendonly = true);
insert into t values (1, 1);
savepoint sub;
truncate table t;
insert into t values (2, 2);
rollback to sub;
abort;
```

After finished `truncate table t;`, the table's auxiliary table, such as `pg_aoseg.pg_aoseg_<OID>` and 
visitmap will have a new relation file node. This will lead to generating a new `last_sequence` in 
`gp_fastsequence` when we do INSERT next, and this can not rollback.

So if we want to fix this problem, we should let table `gp_fastsequence` can be rollback as other auxiliary 
tables in transaction.