### PR TITLE
Add an Orca GUC to control fallback for replicated table

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -62,6 +62,7 @@ extern bool optimizer_enable_ctas;
 extern bool optimizer_enable_dml;
 extern bool optimizer_enable_dml_triggers;
 extern bool optimizer_enable_dml_constraints;
+extern bool optimizer_enable_replicated_table;
 extern bool optimizer_enable_multiple_distinct_aggs;
 
 // OIDs of variants of LEAD window function
@@ -3288,6 +3289,15 @@ CTranslatorQueryToDXL::NoteDistributionPolicyOpclasses(const RangeTblEntry *rte)
 		{
 			gpdb::CloseRelation(rel);
 			return;
+		}
+
+		if (!optimizer_enable_replicated_table &&
+			policy->ptype == POLICYTYPE_REPLICATED)
+		{
+			GPOS_RAISE(
+				gpdxl::ExmaMD, gpdxl::ExmiMDObjUnsupported,
+				GPOS_WSZ_LIT(
+					"Use optimizer_enable_replicated_table to enable replicated tables"));
 		}
 
 		int policy_nattrs = policy->nattrs;

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -362,7 +362,7 @@ bool		optimizer_enable_mergejoin;
 bool		optimizer_prune_unused_columns;
 bool		optimizer_enable_redistribute_nestloop_loj_inner_child;
 bool		optimizer_force_comprehensive_join_implementation;
-
+bool		optimizer_enable_replicated_table;
 
 /* Optimizer plan enumeration related GUCs */
 bool		optimizer_enumerate_plans;
@@ -3204,6 +3204,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 		false,
 		NULL, NULL, NULL
 	},
+	{
+		{"optimizer_enable_replicated_table", PGC_USERSET, DEVELOPER_OPTIONS,
+		 gettext_noop("Enable replicated tables."),
+		 NULL,
+		 GUC_NOT_IN_SAMPLE
+		 },
+		 &optimizer_enable_replicated_table,
+		 true,
+		 NULL, NULL, NULL
+	},
+
 
 	{
 		{"gp_log_resqueue_priority_sleep_time", PGC_USERSET, RESOURCES_MGM,

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -494,6 +494,7 @@ extern bool optimizer_enable_mergejoin;
 extern bool optimizer_prune_unused_columns;
 extern bool optimizer_enable_redistribute_nestloop_loj_inner_child;
 extern bool optimizer_force_comprehensive_join_implementation;
+extern bool optimizer_enable_replicated_table;
 
 /* Optimizer plan enumeration related GUCs */
 extern bool optimizer_enumerate_plans;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -391,6 +391,7 @@
 		"optimizer_enable_tablescan",
 		"optimizer_enable_redistribute_nestloop_loj_inner_child",
 		"optimizer_force_comprehensive_join_implementation",
+		"optimizer_enable_replicated_table",
 		"optimizer_enforce_subplans",
 		"optimizer_enumerate_plans",
 		"optimizer_expand_fulljoin",

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -1241,6 +1241,27 @@ select c from rep_tab where c in (select distinct d from rand_tab);
  2
 (2 rows)
 
+-- test for optimizer_enable_replicated_table
+explain (costs off) select * from rep_tab;
+                QUERY PLAN
+------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on rep_tab
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+set optimizer_enable_replicated_table=off;
+set optimizer_trace_fallback=on;
+explain (costs off) select * from rep_tab;
+                QUERY PLAN
+------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on rep_tab
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+reset optimizer_trace_fallback;
+reset optimizer_enable_replicated_table;
 -- start_ignore
 drop schema rpt cascade;
 NOTICE:  drop cascades to 13 other objects

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -1226,6 +1226,30 @@ select c from rep_tab where c in (select distinct d from rand_tab);
  2
 (2 rows)
 
+-- test for optimizer_enable_replicated_table
+explain (costs off) select * from rep_tab;
+                QUERY PLAN
+------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on rep_tab
+ Optimizer: Pivotal Optimizer (GPORCA)
+(3 rows)
+
+set optimizer_enable_replicated_table=off;
+set optimizer_trace_fallback=on;
+explain (costs off) select * from rep_tab;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Use optimizer_enable_replicated_table to enable replicated tables
+WARNING:  relcache reference leak: relation "rep_tab" not closed
+                QUERY PLAN
+------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on rep_tab
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+reset optimizer_trace_fallback;
+reset optimizer_enable_replicated_table;
 -- start_ignore
 drop schema rpt cascade;
 NOTICE:  drop cascades to 13 other objects

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -500,6 +500,14 @@ select c from rep_tab where c in (select distinct a from dist_tab);
 explain select c from rep_tab where c in (select distinct d from rand_tab);
 select c from rep_tab where c in (select distinct d from rand_tab);
 
+-- test for optimizer_enable_replicated_table
+explain (costs off) select * from rep_tab;
+set optimizer_enable_replicated_table=off;
+set optimizer_trace_fallback=on;
+explain (costs off) select * from rep_tab;
+reset optimizer_trace_fallback;
+reset optimizer_enable_replicated_table;
+
 -- start_ignore
 drop schema rpt cascade;
 -- end_ignore


### PR DESCRIPTION
This adds a GUC optimizer_enable_replicated_table, which defaults any DML
operation on a replicated table to fall back to Postgres planner.
optimizer_enable_replicated_table is on by default.
