### PR TITLE
Resove GPDB_12_MERGE_FIXME in some misc files

### DIFF
--- a/src/backend/cdb/cdbhash.c
+++ b/src/backend/cdb/cdbhash.c
@@ -186,8 +186,7 @@ cdbhash(CdbHash *h, int attno, Datum datum, bool isnull)
 			uint32		hkey;
 
 			InitFunctionCallInfoData(*fcinfo, &h->hashfuncs[attno - 1], 1,
-									 /* GPDB_12_MERGE_FIXME: always use default collation. Is that OK? */
-									 DEFAULT_COLLATION_OID,
+									 DEFAULT_COLLATION_OID, /* have to specify collation for attribute of text or bpchar */
 									 NULL, NULL);
 
 			fcinfo->args[0].value = datum;

--- a/src/backend/libpq/hba.c
+++ b/src/backend/libpq/hba.c
@@ -1584,20 +1584,20 @@ parse_hba_line(TokenizedLine *tok_line, int elevel)
 			return NULL;
 		}
 
-		/* GPDB_12_MERGE_FIXME: Is this still relevant? Is there some additional GPDB 
-		 * features in LDAP authentication, or has PostgreSQL gotten them all by now? */
-#if 0
-		if ((parsedline->ldaptls || parsedline->ldapport != 0) && strncmp(parsedline->ldapserver, "ldaps://", 8) == 0)
+		/* Can't set LDAPS and StartTLS at the same time. Set ldaptls to 1 to
+		 * make the connection between database and the LDAP server use TLS
+		 * encryption. The scheme 'ldaps' makes LDAP connections over SSL.
+		 */
+		if (parsedline->ldaptls && strcmp(parsedline->ldapscheme, "ldaps") == 0)
 		{
 			ereport(LOG,
 					(errcode(ERRCODE_CONFIG_FILE_ERROR),
-					 errmsg("cannot use 'ldaptls' or 'ldapport' with 'ldapserver' start with 'ldaps://'"),
+					 errmsg("cannot use 'ldaptls' with 'ldaps' scheme or 'ldapurl' start with 'ldaps://'"),
 					 errcontext("line %d of configuration file \"%s\"",
 								line_num, HbaFileName)));
 			return NULL;
 
 		}
-#endif
 	}
 
 	if (parsedline->auth_method == uaRADIUS)


### PR DESCRIPTION
1. remove fixme in cdbhash.c: this is only used in internal to compute
the hash key value, they all use the same collation with default collation,
so it will get same result with the same value, it's ok here.

2. remove fixme in hba.c: ldapserver is used to set Names or IP addresses
of LDAP servers to connect to, the 'ldaps://' is set by ldapurl value now.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
