### PR TITLE
Enable index only scan on ao/aocs table.

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -1594,7 +1594,52 @@ aocs_fetch_finish(AOCSFetchDesc aocsFetchDesc)
 	AppendOnlyVisimap_Finish(&aocsFetchDesc->visibilityMap, AccessShareLock);
 }
 
+AOCSIndexOnlyDesc
+aocs_index_only_init(Relation relation, Snapshot snapshot)
+{
+	AOCSIndexOnlyDesc indexonlydesc = (AOCSIndexOnlyDesc) palloc0(sizeof(AppendOnlyIndexOnlyDescData));
 
+	/* initialize the block directory */
+	indexonlydesc->blockDirectory = palloc0(sizeof(AppendOnlyBlockDirectory));
+	AppendOnlyBlockDirectory_Init_forIndexOnlyScan(indexonlydesc->blockDirectory,
+												   relation,
+												   relation->rd_att->natts, /* numColGroups */
+												   snapshot);
+
+	/* initialize the visimap */
+	indexonlydesc->visimap = palloc0(sizeof(AppendOnlyVisimap));
+	AppendOnlyVisimap_Init_forIndexOnlyScan(indexonlydesc->visimap,
+											relation,
+											snapshot);
+	return indexonlydesc;										
+}
+
+bool
+aocs_index_only_check(AOCSIndexOnlyDesc indexonlydesc, AOTupleId *aotid, Snapshot snapshot)
+{
+	if (!AppendOnlyBlockDirectory_CoversTuple(indexonlydesc->blockDirectory, aotid))
+		return false;
+
+	/* check SnapshotAny for the case when gp_select_invisible is on */
+	if (snapshot != SnapshotAny && !AppendOnlyVisimap_IsVisible(indexonlydesc->visimap, aotid))
+		return false;
+	
+	return true;
+}
+
+void
+aocs_index_only_finish(AOCSIndexOnlyDesc indexonlydesc)
+{
+	/* clean up the block directory */
+	AppendOnlyBlockDirectory_End_forIndexOnlyScan(indexonlydesc->blockDirectory);
+	pfree(indexonlydesc->blockDirectory);
+	indexonlydesc->blockDirectory = NULL;
+
+	/* clean up the visimap */
+	AppendOnlyVisimap_Finish_forIndexOnlyScan(indexonlydesc->visimap);
+	pfree(indexonlydesc->visimap);
+	indexonlydesc->visimap = NULL;
+}
 
 /*
  * appendonly_delete_init

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -741,6 +741,13 @@ aoco_index_fetch_end(IndexFetchTableData *scan)
 		aocoscan->aocofetch = NULL;
 	}
 
+	if (aocoscan->indexonlydesc)
+	{
+		aocs_index_only_finish(aocoscan->indexonlydesc);
+		pfree(aocoscan->indexonlydesc);
+		aocoscan->indexonlydesc = NULL;
+	}
+
 	if (aocoscan->proj)
 	{
 		pfree(aocoscan->proj);
@@ -921,6 +928,33 @@ aoco_index_unique_check(Relation rel,
 				(!TransactionIdIsValid(snapshot->xmin) && !TransactionIdIsValid(snapshot->xmax)));
 
 	return visible;
+}
+
+static bool
+aocs_index_fetch_tuple_visible(struct IndexFetchTableData *scan,
+							   ItemPointer tid,
+							   Snapshot snapshot)
+{
+	IndexFetchAOCOData *aocoscan = (IndexFetchAOCOData *) scan;
+
+	if (!aocoscan->indexonlydesc)
+	{
+		Snapshot	appendOnlyMetaDataSnapshot = snapshot;
+
+		if (appendOnlyMetaDataSnapshot == SnapshotAny)
+		{
+			/*
+			 * the append-only meta data should never be fetched with
+			 * SnapshotAny as bogus results are returned.
+			 */
+			appendOnlyMetaDataSnapshot = GetTransactionSnapshot();
+		}
+
+		aocoscan->indexonlydesc = aocs_index_only_init(aocoscan->xs_base.rel,
+											  		   appendOnlyMetaDataSnapshot);
+	}
+
+	return aocs_index_only_check(aocoscan->indexonlydesc, (AOTupleId *) tid, snapshot);
 }
 
 static void
@@ -2000,15 +2034,22 @@ aoco_relation_needs_toast_table(Relation rel)
  */
 static void
 aoco_estimate_rel_size(Relation rel, int32 *attr_widths,
-                             BlockNumber *pages, double *tuples,
-                             double *allvisfrac)
+					   BlockNumber *pages, double *tuples,
+					   double *allvisfrac)
 {
 	FileSegTotals  *fileSegTotals;
 	Snapshot		snapshot;
 
 	*pages = 1;
 	*tuples = 1;
-	*allvisfrac = 0;
+
+	/*
+	 * Indirectly, allvisfrac is the fraction of pages for which we don't need
+	 * to scan the full table during an index only scan.
+	 * For AO/CO tables, we never have to scan the underlying table. This is
+	 * why we set this to 1.
+	 */
+	*allvisfrac = 1;
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 		return;
@@ -2210,6 +2251,7 @@ static const TableAmRoutine ao_column_methods = {
 	.index_fetch_reset = aoco_index_fetch_reset,
 	.index_fetch_end = aoco_index_fetch_end,
 	.index_fetch_tuple = aoco_index_fetch_tuple,
+	.index_fetch_tuple_visible = aocs_index_fetch_tuple_visible,
 	.index_unique_check = aoco_index_unique_check,
 
 	.dml_init = aoco_dml_init,

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -839,7 +839,7 @@ aoco_index_fetch_tuple(struct IndexFetchTableData *scan,
  * true and have the xwait machinery kick in.
  */
 static bool
-aoco_index_fetch_tuple_exists(Relation rel,
+aoco_index_unique_check(Relation rel,
 							  ItemPointer tid,
 							  Snapshot snapshot,
 							  bool *all_dead)
@@ -2210,7 +2210,7 @@ static const TableAmRoutine ao_column_methods = {
 	.index_fetch_reset = aoco_index_fetch_reset,
 	.index_fetch_end = aoco_index_fetch_end,
 	.index_fetch_tuple = aoco_index_fetch_tuple,
-	.index_fetch_tuple_exists = aoco_index_fetch_tuple_exists,
+	.index_unique_check = aoco_index_unique_check,
 
 	.dml_init = aoco_dml_init,
 	.dml_finish = aoco_dml_finish,

--- a/src/backend/access/appendonly/README.md
+++ b/src/backend/access/appendonly/README.md
@@ -222,7 +222,7 @@ degradation in the worst case) in setting up and tearing down scan descriptors
 for AO/CO tables, we avoid the scanbegin..fetch..scanend construct in
 table_index_fetch_tuple_check().
 
-So, a new tableam API index_fetch_tuple_exists() is used, which is implemented
+So, a new tableam API index_unique_check() is used, which is implemented
 only for AO/CO tables. Here, we fetch a UniqueCheckDesc, which stores all the
 in-memory state to help us perform a unique index check. This descriptor is
 attached to the DMLState structs. The descriptor holds a block directory struct

--- a/src/backend/access/appendonly/README.md
+++ b/src/backend/access/appendonly/README.md
@@ -259,3 +259,50 @@ index, and hence there are no uniqueness checks triggered (see
 ExecInsertIndexTuples()). Also during partial unique index builds, keys that
 don't satisfy the partial index predicate are never inserted into the index
 (see *_index_build_range_scan()).
+
+# Index only scan
+
+Index scan has been disabled on append-optimized tables is mainly because index
+fetch tuples in random I/O pattern is not friendly to append-optimized varblock
+lookups. Not only it depends on additional auxiliary tables (such as AO block
+directory, visibility map) lookups in random order, it also needs to extract the
+tuple from uncompressed target varblock, which could yield to extremely poor
+performance in a typical case that the fetching tuples sparsely distributed in
+different varblocks.
+
+Index only scan could save cycles from no access of append-optimized varblocks,
+but only randomly reads auxiliary Heap tables. Hence it is more performant than
+index scan. Based on this theory, we enable index only scan on append-optimized
+tables to serve satisfied queries that no need to fetch tuples from physical
+append-optimized data files.
+
+Index only scan functionality is based on the target tuple visibility check.
+In past (before removing aoblkdir hole filling mechanism [1]), pg_aoseg/pg_aocsseg
+stored EOF (or checking physical file for tuple presence) was the only source to
+perform transaction visibility checks for append-optimized tables (block directory
+was only used for optimization).
+
+With the change made by removing aoblkdir hole filling mechanism to align block
+directory reflect the reality of block information on-disk, now the design is:
+
+- for non-indexed append-optimized tables EOF acts as source (along with visimap)
+- for indexed append-optimized tables block directory acts as source (along with visimap)
+
+So to perform the visibility check, we rely on the block directory to see if the tid
+is covered by a block directory entry. If no, the tid is not visible to the index only
+scan. If yes, we check if the tid is deleted in the visimap and if it isn't we declare
+that the tid is visible to the index only scan. This mechanism is very similar to unique
+index checks, except that we use a regular MVCC snapshot (and not SNAPSHOT_DIRTY).
+
+A note about upgrades:
+given the commit of removing aoblkdir hole filling mechanism was introduced from GP7,
+old block directory may still contain gaps in the case of tables in-place upgrade.
+To make index only scan work properly on append-optimized tables, we introduced
+"version" column into pg_appendonly catalog [2] to be as a factor to determine whether
+selecting index only path or not during planning stage. The strategy is, if the version
+is not less than AORelationVersion_GP7, index only scan is selectable; otherwise, it is
+disabled because we are still working with a gapped block directory which can't be used
+as a source of tuple visibility determination.
+
+[1] https://github.com/greenplum-db/gpdb/commit/258ec966b26929430fc5dc9f6e6fe09854644302
+[2] https://github.com/greenplum-db/gpdb/commit/9d7cfbf62d06cf4825de6589b321c11d7596a947

--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -374,7 +374,6 @@ GetAllFileSegInfo(Relation parentrel,
 	return result;
 }
 
-
 /*
  * The comparison routine that sorts an array of FileSegInfos
  * in the ascending order of the segment number.

--- a/src/backend/access/appendonly/appendonly_visimap.c
+++ b/src/backend/access/appendonly/appendonly_visimap.c
@@ -878,7 +878,7 @@ AppendOnlyVisimapDelete_Finish(
  * uniqueness checks.
  *
  * Note: we defer setting up the appendOnlyMetaDataSnapshot for the visibility
- * map to the index_fetch_tuple_exists() table AM call. This is because
+ * map to the index_unique_check() table AM call. This is because
  * snapshots used for unique index lookups are special and don't follow the
  * usual allocation or registration mechanism. They may be stack-allocated and a
  * new snapshot object may be passed to every unique index check (this happens

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -606,7 +606,7 @@ appendonly_index_fetch_tuple(struct IndexFetchTableData *scan,
  * true and have the xwait machinery kick in.
  */
 static bool
-appendonly_index_fetch_tuple_exists(Relation rel,
+appendonly_index_unique_check(Relation rel,
 									ItemPointer tid,
 									Snapshot snapshot,
 									bool *all_dead)
@@ -1995,7 +1995,7 @@ static const TableAmRoutine ao_row_methods = {
 	.index_fetch_reset = appendonly_index_fetch_reset,
 	.index_fetch_end = appendonly_index_fetch_end,
 	.index_fetch_tuple = appendonly_index_fetch_tuple,
-	.index_fetch_tuple_exists = appendonly_index_fetch_tuple_exists,
+	.index_unique_check = appendonly_index_unique_check,
 
 	.dml_init = appendonly_dml_init,
 	.dml_finish = appendonly_dml_finish,

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -528,6 +528,13 @@ appendonly_index_fetch_end(IndexFetchTableData *scan)
 		aoscan->aofetch = NULL;
 	}
 
+	if (aoscan->indexonlydesc)
+	{
+		appendonly_index_only_finish(aoscan->indexonlydesc);
+		pfree(aoscan->indexonlydesc);
+		aoscan->indexonlydesc = NULL;
+	}
+
 	pfree(aoscan);
 }
 
@@ -690,6 +697,32 @@ appendonly_index_unique_check(Relation rel,
 	return visible;
 }
 
+static bool
+appendonly_index_fetch_tuple_visible(struct IndexFetchTableData *scan,
+									 ItemPointer tid,
+									 Snapshot snapshot)
+{
+	IndexFetchAppendOnlyData *aoscan = (IndexFetchAppendOnlyData *) scan;
+
+	if (!aoscan->indexonlydesc)
+	{
+		Snapshot	appendOnlyMetaDataSnapshot = snapshot;
+
+		if (appendOnlyMetaDataSnapshot == SnapshotAny)
+		{
+			/*
+			 * the append-only meta data should never be fetched with
+			 * SnapshotAny as bogus results are returned.
+			 */
+			appendOnlyMetaDataSnapshot = GetTransactionSnapshot();
+		}
+
+		aoscan->indexonlydesc = appendonly_index_only_init(aoscan->xs_base.rel,
+														   appendOnlyMetaDataSnapshot);
+	}
+
+	return appendonly_index_only_check(aoscan->indexonlydesc, (AOTupleId *) tid, snapshot);
+}
 
 /* ------------------------------------------------------------------------
  * Callbacks for non-modifying operations on individual tuples for
@@ -1801,15 +1834,22 @@ appendonly_relation_needs_toast_table(Relation rel)
  */
 static void
 appendonly_estimate_rel_size(Relation rel, int32 *attr_widths,
-						 BlockNumber *pages, double *tuples,
-						 double *allvisfrac)
+							 BlockNumber *pages, double *tuples,
+							 double *allvisfrac)
 {
 	FileSegTotals  *fileSegTotals;
 	Snapshot		snapshot;
 
 	*pages = 1;
 	*tuples = 1;
-	*allvisfrac = 0;
+
+	/*
+	 * Indirectly, allvisfrac is the fraction of pages for which we don't need
+	 * to scan the full table during an index only scan.
+	 * For AO/CO tables, we never have to scan the underlying table. This is
+	 * why we set this to 1.
+	 */
+	*allvisfrac = 1;
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 		return;
@@ -1995,6 +2035,7 @@ static const TableAmRoutine ao_row_methods = {
 	.index_fetch_reset = appendonly_index_fetch_reset,
 	.index_fetch_end = appendonly_index_fetch_end,
 	.index_fetch_tuple = appendonly_index_fetch_tuple,
+	.index_fetch_tuple_visible = appendonly_index_fetch_tuple_visible,
 	.index_unique_check = appendonly_index_unique_check,
 
 	.dml_init = appendonly_dml_init,

--- a/src/backend/access/appendonly/appendonlyblockdirectory.c
+++ b/src/backend/access/appendonly/appendonlyblockdirectory.c
@@ -230,7 +230,7 @@ AppendOnlyBlockDirectory_Init_forSearch(
  * itself and will not involve the physical AO relation.
  *
  * Note: we defer setting up the appendOnlyMetaDataSnapshot for the block
- * directory to the index_fetch_tuple_exists() table AM call. This is because
+ * directory to the index_unique_check() table AM call. This is because
  * snapshots used for unique index lookups are special and don't follow the
  * usual allocation or registration mechanism. They may be stack-allocated and a
  * new snapshot object may be passed to every unique index check (this happens

--- a/src/backend/access/table/tableam.c
+++ b/src/backend/access/table/tableam.c
@@ -207,10 +207,10 @@ table_index_fetch_tuple_check(Relation rel,
 	/*
 	 * Optimized path for AO/CO relations as the aforementioned per-tuple
 	 * overhead is significant for AO/CO relations. For details, please refer to
-	 * table_index_fetch_tuple_exists().
+	 * table_index_unique_check().
 	 */
 	if (RelationIsAppendOptimized(rel))
-		return table_index_fetch_tuple_exists(rel, tid, snapshot, all_dead);
+		return table_index_unique_check(rel, tid, snapshot, all_dead);
 
 	slot = table_slot_create(rel, NULL);
 	scan = table_index_fetch_begin(rel);

--- a/src/backend/executor/nodeIndexonlyscan.c
+++ b/src/backend/executor/nodeIndexonlyscan.c
@@ -124,6 +124,19 @@ IndexOnlyNext(IndexOnlyScanState *node)
 
 		CHECK_FOR_INTERRUPTS();
 
+		if (RelationAMIsAO(scandesc->xs_heapfetch->rel))
+		{
+			if (!table_index_fetch_tuple_visible(scandesc->xs_heapfetch,
+												 tid,
+												 scandesc->xs_snapshot))
+				continue;
+			else
+			{
+				/* visible, we can now fill the scan tuple slot */
+			}
+		}
+		/* Else branch for heap tables follows under comment block. */
+
 		/*
 		 * We can skip the heap fetch if the TID references a heap page on
 		 * which all tuples are known visible to everybody.  In any case,
@@ -158,9 +171,9 @@ IndexOnlyNext(IndexOnlyScanState *node)
 		 * It's worth going through this complexity to avoid needing to lock
 		 * the VM buffer, which could cause significant contention.
 		 */
-		if (!VM_ALL_VISIBLE(scandesc->heapRelation,
-							ItemPointerGetBlockNumber(tid),
-							&node->ioss_VMBuffer))
+		else if (!VM_ALL_VISIBLE(scandesc->heapRelation,
+								 ItemPointerGetBlockNumber(tid),
+								 &node->ioss_VMBuffer))
 		{
 			/*
 			 * Rats, we have to visit the heap to check visibility.

--- a/src/backend/optimizer/path/indxpath.c
+++ b/src/backend/optimizer/path/indxpath.c
@@ -804,15 +804,12 @@ get_index_paths(PlannerInfo *root, RelOptInfo *rel,
 		 * the last decompressed block between fetch calls.
 		 * Index scan path on GPDB's bitmap index should works the same as bitmap paths.
 		 *
-		 * GPDB_12_MERGE_FIXME: Also there is no code in place in order to be
-		 * able to use index only scans on AO/AOCO relations. However it is
-		 * suboptimal to have to expose the relation's access method here. There
-		 * are no straight forward solutions though.
+		 * Enable index only scan on AO here, but the index scan is still disabled.
 		 */
 		if (index->amhasgettuple &&
-				((rel->relam != AO_ROW_TABLE_AM_OID &&
-				 rel->relam != AO_COLUMN_TABLE_AM_OID) ||
-				 index->amcostestimate == bmcostestimate))
+				((!IsAccessMethodAO(rel->relam) ||
+				 index->amcostestimate == bmcostestimate ||
+				 ipath->path.pathtype == T_IndexOnlyScan)))
 			add_path(rel, (Path *) ipath);
 
 		if (index->amhasgetbitmap &&

--- a/src/include/access/appendonly_visimap.h
+++ b/src/include/access/appendonly_visimap.h
@@ -144,6 +144,14 @@ extern void AppendOnlyVisimap_Init_forUniqueCheck(
 extern void AppendOnlyVisimap_Finish_forUniquenessChecks(
 												   AppendOnlyVisimap *visiMap);
 
+extern void AppendOnlyVisimap_Init_forIndexOnlyScan(
+									   AppendOnlyVisimap *visiMap,
+									   Relation aoRel,
+									   Snapshot snapshot);
+
+extern void AppendOnlyVisimap_Finish_forIndexOnlyScan(
+												   AppendOnlyVisimap *visiMap);
+
 bool AppendOnlyVisimapScan_GetNextInvisible(
 									   AppendOnlyVisimapScan *visiMapScan,
 									   AOTupleId *tupleId);

--- a/src/include/access/tableam.h
+++ b/src/include/access/tableam.h
@@ -356,8 +356,8 @@ typedef struct TableAmRoutine
 									  TupleTableSlot *slot,
 									  bool *call_again, bool *all_dead);
 
-	/* See table_index_fetch_tuple_exists() for details */
-	bool		(*index_fetch_tuple_exists) (Relation rel,
+	/* See table_index_unique_check() for details */
+	bool		(*index_unique_check) (Relation rel,
 											 ItemPointer tid,
 											 Snapshot snapshot,
 											 bool *all_dead);
@@ -1147,12 +1147,12 @@ extern bool table_index_fetch_tuple_check(Relation rel,
  * This has to have an identical signature to table_index_fetch_tuple_check().
  */
 static inline bool
-table_index_fetch_tuple_exists(Relation rel,
+table_index_unique_check(Relation rel,
 							   ItemPointer tid,
 							   Snapshot snapshot,
 							   bool *all_dead)
 {
-	return rel->rd_tableam->index_fetch_tuple_exists(rel, tid, snapshot,
+	return rel->rd_tableam->index_unique_check(rel, tid, snapshot,
 														   all_dead);
 }
 

--- a/src/include/catalog/pg_am.h
+++ b/src/include/catalog/pg_am.h
@@ -21,6 +21,10 @@
 #include "catalog/genbki.h"
 #include "catalog/pg_am_d.h"
 
+/* GPDB: convenient macro for checking AO AMs */
+#define IsAccessMethodAO(am_oid) \
+	((am_oid) == AO_ROW_TABLE_AM_OID || (am_oid) == AO_COLUMN_TABLE_AM_OID)
+
 /* ----------------
  *		pg_am definition.  cpp turns this into
  *		typedef struct FormData_pg_am

--- a/src/include/cdb/cdbaocsam.h
+++ b/src/include/cdb/cdbaocsam.h
@@ -274,14 +274,22 @@ typedef struct AOCSUniqueCheckDescData
 
 typedef struct AOCSUniqueCheckDescData *AOCSUniqueCheckDesc;
 
+typedef struct AOCSIndexOnlyDescData
+{
+	AppendOnlyBlockDirectory *blockDirectory;
+	AppendOnlyVisimap 		 *visimap;
+} AOCSIndexOnlyDescData, *AOCSIndexOnlyDesc;
+
 /*
  * Descriptor for fetches from table via an index.
  */
 typedef struct IndexFetchAOCOData
 {
-	IndexFetchTableData xs_base;	/* AM independent part of the descriptor */
+	IndexFetchTableData xs_base;		/* AM independent part of the descriptor */
 
-	AOCSFetchDesc       aocofetch;
+	AOCSFetchDesc       aocofetch;		/* used only for index scans */
+
+	AOCSIndexOnlyDesc	indexonlydesc;	/* used only for index only scans */
 
 	bool                *proj;
 } IndexFetchAOCOData;
@@ -354,6 +362,12 @@ extern bool aocs_fetch(AOCSFetchDesc aocsFetchDesc,
 					   AOTupleId *aoTupleId,
 					   TupleTableSlot *slot);
 extern void aocs_fetch_finish(AOCSFetchDesc aocsFetchDesc);
+extern AOCSIndexOnlyDesc aocs_index_only_init(Relation relation,
+											  Snapshot snapshot);
+extern bool aocs_index_only_check(AOCSIndexOnlyDesc indexonlydesc,
+								  AOTupleId *aotid,
+								  Snapshot snapshot);
+extern void aocs_index_only_finish(AOCSIndexOnlyDesc indexonlydesc);
 extern AOCSDeleteDesc aocs_delete_init(Relation rel);
 extern TM_Result aocs_delete(AOCSDeleteDesc desc, 
 		AOTupleId *aoTupleId);

--- a/src/include/cdb/cdbappendonlyam.h
+++ b/src/include/cdb/cdbappendonlyam.h
@@ -391,14 +391,23 @@ typedef struct AppendOnlyUniqueCheckDescData
 } AppendOnlyUniqueCheckDescData;
 
 typedef struct AppendOnlyUniqueCheckDescData *AppendOnlyUniqueCheckDesc;
+
+typedef struct AppendOnlyIndexOnlyDescData
+{
+	AppendOnlyBlockDirectory *blockDirectory;
+	AppendOnlyVisimap 		 *visimap;
+} AppendOnlyIndexOnlyDescData, *AppendOnlyIndexOnlyDesc;
+
 /*
  * Descriptor for fetches from table via an index.
  */
 typedef struct IndexFetchAppendOnlyData
 {
-	IndexFetchTableData xs_base;	/* AM independent part of the descriptor */
+	IndexFetchTableData xs_base;			/* AM independent part of the descriptor */
 
-	AppendOnlyFetchDesc aofetch;
+	AppendOnlyFetchDesc aofetch;			/* used only for index scans */
+
+	AppendOnlyIndexOnlyDesc indexonlydesc;	/* used only for index only scans */
 } IndexFetchAppendOnlyData;
 
 /* ----------------
@@ -433,6 +442,12 @@ extern bool appendonly_fetch(
 	AOTupleId *aoTid,
 	TupleTableSlot *slot);
 extern void appendonly_fetch_finish(AppendOnlyFetchDesc aoFetchDesc);
+extern AppendOnlyIndexOnlyDesc appendonly_index_only_init(Relation relation,
+														  Snapshot snapshot);
+extern bool appendonly_index_only_check(AppendOnlyIndexOnlyDesc indexonlydesc,
+										AOTupleId *aotid,
+										Snapshot snapshot);
+extern void appendonly_index_only_finish(AppendOnlyIndexOnlyDesc indexonlydesc);
 extern void appendonly_dml_init(Relation relation);
 extern AppendOnlyInsertDesc appendonly_insert_init(Relation rel,
 												   int segno,

--- a/src/include/cdb/cdbappendonlyblockdirectory.h
+++ b/src/include/cdb/cdbappendonlyblockdirectory.h
@@ -110,7 +110,7 @@ typedef struct AppendOnlyBlockDirectory
 	bool *proj; /* projected columns, used only if isAOCol = TRUE */
 
 	MemoryContext memoryContext;
-	
+
 	int				totalSegfiles;
 	FileSegInfo 	**segmentFileInfo;
 
@@ -220,6 +220,10 @@ extern void AppendOnlyBlockDirectory_Init_forUniqueChecks(AppendOnlyBlockDirecto
 														  Relation aoRel,
 														  int numColumnGroups,
 														  Snapshot snapshot);
+extern void AppendOnlyBlockDirectory_Init_forIndexOnlyScan(AppendOnlyBlockDirectory *blockDirectory,
+														   Relation aoRel,
+														   int numColumnGroups,
+														   Snapshot snapshot);
 extern void AppendOnlyBlockDirectory_Init_addCol(
 	AppendOnlyBlockDirectory *blockDirectory,
 	Snapshot appendOnlyMetaDataSnapshot,
@@ -247,6 +251,8 @@ extern void AppendOnlyBlockDirectory_DeleteSegmentFile(
 		int segno,
 		int columnGroupNo);
 extern void AppendOnlyBlockDirectory_End_forUniqueChecks(
+	AppendOnlyBlockDirectory *blockDirectory);
+extern void AppendOnlyBlockDirectory_End_forIndexOnlyScan(
 	AppendOnlyBlockDirectory *blockDirectory);
 
 extern void AppendOnlyBlockDirectory_InsertPlaceholder(AppendOnlyBlockDirectory *blockDirectory,

--- a/src/include/commands/tablecmds.h
+++ b/src/include/commands/tablecmds.h
@@ -29,10 +29,6 @@
 #include "storage/lock.h"
 #include "utils/relcache.h"
 
-/* Convenient macro for checking AO AMs */
-#define IsAccessMethodAO(am_oid) \
-	(am_oid == AO_ROW_TABLE_AM_OID || am_oid == AO_COLUMN_TABLE_AM_OID)
-
 extern const char *synthetic_sql;
 
 extern void	DefineExternalRelation(CreateExternalStmt *stmt);

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -463,6 +463,15 @@ typedef struct ViewOptions
 		relation->rd_rel->relkind != RELKIND_PARTITIONED_TABLE)
 
 /*
+ * Convenient macro for checking AO AMs
+ *
+ * RelationAMIsAO
+ * 		True iff relam is ao_row or or ao_column.
+ */
+#define RelationAMIsAO(relation) \
+	IsAccessMethodAO((relation)->rd_rel->relam)
+
+/*
  * RelationIsBitmapIndex
  *      True iff relation is a bitmap index
  */

--- a/src/test/isolation2/input/uao/index_only_scan.source
+++ b/src/test/isolation2/input/uao/index_only_scan.source
@@ -1,0 +1,42 @@
+-- This test file verifies the correctness of Index Only Scans for AO/CO tables.
+
+SET enable_seqscan TO off;
+SET optimizer TO off;
+
+CREATE TABLE uao_index_only_scan_@amname@(i int, j int) USING @amname@;
+CREATE INDEX ON uao_index_only_scan_@amname@(i);
+
+-- Set 1: Insert (and commit) some rows
+INSERT INTO uao_index_only_scan_@amname@ SELECT i, 0 FROM generate_series(1, 3)i;
+
+-- Establish a transaction with repeatable read isolation and take a snapshot
+-- early
+1: SET enable_seqscan TO off;
+1: SET optimizer TO off;
+1: BEGIN ISOLATION LEVEL REPEATABLE READ;
+1: EXPLAIN SELECT i FROM uao_index_only_scan_@amname@;
+-- We should see the rows from Set 1.
+1: SELECT i FROM uao_index_only_scan_@amname@;
+
+-- Set 2: Insert and then delete some rows
+INSERT INTO uao_index_only_scan_@amname@ SELECT i, 0 FROM generate_series(4, 6)i;
+DELETE FROM uao_index_only_scan_@amname@ WHERE i >= 4 AND i <= 6;
+
+-- Set 3: Insert some to-be-committed rows
+2: BEGIN;
+2: INSERT INTO uao_index_only_scan_@amname@ SELECT i, 0 FROM generate_series(7, 9)i;
+
+-- Set 4: Insert some aborted rows
+BEGIN;
+INSERT INTO uao_index_only_scan_@amname@ SELECT i, 0 FROM generate_series(10, 12)i;
+ABORT;
+
+-- We should see rows from Set 1 only. Rows from other sets should be invisible.
+SELECT i FROM uao_index_only_scan_@amname@;
+
+2: COMMIT;
+
+-- We should see rows from Set 1 only. Rows from other sets should be invisible
+-- (in spite of the rows from Set 3 now committing, due to RR semantics)
+1: SELECT i FROM uao_index_only_scan_@amname@;
+1: END;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -120,6 +120,7 @@ test: uao/cursor_withhold_row
 test: uao/cursor_withhold2_row
 test: uao/delete_while_vacuum_row
 test: uao/index_build_reltuples_row
+test: uao/index_only_scan_row
 test: uao/insert_policy_row
 test: uao/insert_while_vacuum_row
 test: uao/max_concurrency_row
@@ -180,6 +181,7 @@ test: uao/cursor_withhold_column
 test: uao/cursor_withhold2_column
 test: uao/delete_while_vacuum_column
 test: uao/index_build_reltuples_column
+test: uao/index_only_scan_column
 test: uao/insert_policy_column
 test: uao/insert_while_vacuum_column
 test: uao/max_concurrency_column

--- a/src/test/isolation2/output/uao/index_only_scan.source
+++ b/src/test/isolation2/output/uao/index_only_scan.source
@@ -1,0 +1,83 @@
+-- This test file verifies the correctness of Index Only Scans for AO/CO tables.
+
+SET enable_seqscan TO off;
+SET
+SET optimizer TO off;
+SET
+
+CREATE TABLE uao_index_only_scan_@amname@(i int, j int) USING @amname@;
+CREATE
+CREATE INDEX ON uao_index_only_scan_@amname@(i);
+CREATE
+
+-- Set 1: Insert (and commit) some rows
+INSERT INTO uao_index_only_scan_@amname@ SELECT i, 0 FROM generate_series(1, 3)i;
+INSERT 3
+
+-- Establish a transaction with repeatable read isolation and take a snapshot
+-- early
+1: SET enable_seqscan TO off;
+SET
+1: SET optimizer TO off;
+SET
+1: BEGIN ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+1: EXPLAIN SELECT i FROM uao_index_only_scan_@amname@;
+ QUERY PLAN                                                                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.17..2265.67 rows=86100 width=4)                                                   
+   ->  Index Only Scan using uao_index_only_scan_@amname@_i_idx on uao_index_only_scan_@amname@  (cost=0.17..1117.67 rows=28700 width=4) 
+ Optimizer: Postgres query optimizer                                                                                                 
+(3 rows)
+-- We should see the rows from Set 1.
+1: SELECT i FROM uao_index_only_scan_@amname@;
+ i 
+---
+ 1 
+ 2 
+ 3 
+(3 rows)
+
+-- Set 2: Insert and then delete some rows
+INSERT INTO uao_index_only_scan_@amname@ SELECT i, 0 FROM generate_series(4, 6)i;
+INSERT 3
+DELETE FROM uao_index_only_scan_@amname@ WHERE i >= 4 AND i <= 6;
+DELETE 3
+
+-- Set 3: Insert some to-be-committed rows
+2: BEGIN;
+BEGIN
+2: INSERT INTO uao_index_only_scan_@amname@ SELECT i, 0 FROM generate_series(7, 9)i;
+INSERT 3
+
+-- Set 4: Insert some aborted rows
+BEGIN;
+BEGIN
+INSERT INTO uao_index_only_scan_@amname@ SELECT i, 0 FROM generate_series(10, 12)i;
+INSERT 3
+ABORT;
+ABORT
+
+-- We should see rows from Set 1 only. Rows from other sets should be invisible.
+SELECT i FROM uao_index_only_scan_@amname@;
+ i 
+---
+ 2 
+ 3 
+ 1 
+(3 rows)
+
+2: COMMIT;
+COMMIT
+
+-- We should see rows from Set 1 only. Rows from other sets should be invisible
+-- (in spite of the rows from Set 3 now committing, due to RR semantics)
+1: SELECT i FROM uao_index_only_scan_@amname@;
+ i 
+---
+ 1 
+ 2 
+ 3 
+(3 rows)
+1: END;
+END

--- a/src/test/isolation2/output/uao/snapshot_index_corruption.source
+++ b/src/test/isolation2/output/uao/snapshot_index_corruption.source
@@ -28,13 +28,10 @@ SET
 2: explain (costs off) select i from test_ao where i = 101;
  QUERY PLAN                                   
 ----------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)     
-   ->  Bitmap Heap Scan on test_ao            
-         Recheck Cond: (i = 101)              
-         ->  Bitmap Index Scan on test_ao_idx 
-               Index Cond: (i = 101)          
- Optimizer: Postgres query optimizer          
-(6 rows)
+ Gather Motion 1:1  (slice1; segments: 1)           
+   ->  Index Only Scan using test_ao_idx on test_ao 
+         Index Cond: (i = 101)                      
+(4 rows)
 2: select i from test_ao where i = 101;
  i   
 -----
@@ -69,13 +66,10 @@ CREATE
 2: explain (costs off) select i from test_ao where i = 100;
  QUERY PLAN                                   
 ----------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)     
-   ->  Bitmap Heap Scan on test_ao            
-         Recheck Cond: (i = 100)              
-         ->  Bitmap Index Scan on test_ao_idx 
-               Index Cond: (i = 100)          
- Optimizer: Postgres query optimizer          
-(6 rows)
+ Gather Motion 1:1  (slice1; segments: 1)           
+   ->  Index Only Scan using test_ao_idx on test_ao 
+         Index Cond: (i = 100)                      
+(4 rows)
 2: select i from test_ao where i = 100;
  i   
 -----

--- a/src/test/regress/expected/bfv_index.out
+++ b/src/test/regress/expected/bfv_index.out
@@ -1046,3 +1046,82 @@ DROP INDEX hash_idx3;
 DROP TABLE hash_prt_tbl;
 RESET enable_seqscan;
 RESET optimizer_enable_dynamictablescan;
+--
+-- Enable the index only scan in append only table.
+-- Note: expect ORCA to use seq scan rather than index only scan like planner,
+-- because ORCA hasn't yet implemented index only scan for AO/CO tables.
+--
+CREATE TABLE bfv_index_only_ao(a int, b int) WITH (appendonly =true);
+CREATE INDEX bfv_index_only_ao_a_b on bfv_index_only_ao(a) include (b);
+insert into bfv_index_only_ao select i,i from generate_series(1, 10000) i;
+explain select count(*) from bfv_index_only_ao where a < 100;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=5.37..5.38 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=5.31..5.36 rows=3 width=8)
+         ->  Partial Aggregate  (cost=5.31..5.32 rows=1 width=8)
+               ->  Index Only Scan using bfv_index_only_ao_a_b on bfv_index_only_ao  (cost=0.16..5.23 rows=33 width=0)
+                     Index Cond: (a < 100)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+select count(*) from bfv_index_only_ao where a < 100;
+ count 
+-------
+    99
+(1 row)
+
+explain select count(*) from bfv_index_only_ao where a < 1000;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=19.87..19.88 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=19.81..19.86 rows=3 width=8)
+         ->  Partial Aggregate  (cost=19.81..19.82 rows=1 width=8)
+               ->  Index Only Scan using bfv_index_only_ao_a_b on bfv_index_only_ao  (cost=0.16..18.98 rows=333 width=0)
+                     Index Cond: (a < 1000)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+select count(*) from bfv_index_only_ao where a < 1000;
+ count 
+-------
+   999
+(1 row)
+
+CREATE TABLE bfv_index_only_aocs(a int, b int) WITH (appendonly =true, orientation=column);
+CREATE INDEX bfv_index_only_aocs_a_b on bfv_index_only_aocs(a) include (b);
+insert into bfv_index_only_aocs select i,i from generate_series(1, 10000) i;
+explain select count(*) from bfv_index_only_aocs where a < 100;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=5.37..5.38 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=5.31..5.36 rows=3 width=8)
+         ->  Partial Aggregate  (cost=5.31..5.32 rows=1 width=8)
+               ->  Index Only Scan using bfv_index_only_aocs_a_b on bfv_index_only_aocs  (cost=0.16..5.23 rows=33 width=0)
+                     Index Cond: (a < 100)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+select count(*) from bfv_index_only_aocs where a < 100;
+ count 
+-------
+    99
+(1 row)
+
+explain select count(*) from bfv_index_only_aocs where a < 1000;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=19.87..19.88 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=19.81..19.86 rows=3 width=8)
+         ->  Partial Aggregate  (cost=19.81..19.82 rows=1 width=8)
+               ->  Index Only Scan using bfv_index_only_aocs_a_b on bfv_index_only_aocs  (cost=0.16..18.98 rows=333 width=0)
+                     Index Cond: (a < 1000)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+select count(*) from bfv_index_only_aocs where a < 1000;
+ count 
+-------
+   999
+(1 row)
+

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -1002,3 +1002,82 @@ DROP INDEX hash_idx3;
 DROP TABLE hash_prt_tbl;
 RESET enable_seqscan;
 RESET optimizer_enable_dynamictablescan;
+--
+-- Enable the index only scan in append only table.
+-- Note: expect ORCA to use seq scan rather than index only scan like planner,
+-- because ORCA hasn't yet implemented index only scan for AO/CO tables.
+--
+CREATE TABLE bfv_index_only_ao(a int, b int) WITH (appendonly =true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX bfv_index_only_ao_a_b on bfv_index_only_ao(a) include (b);
+insert into bfv_index_only_ao select i,i from generate_series(1, 10000) i;
+explain select count(*) from bfv_index_only_ao where a < 100;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+         ->  Seq Scan on bfv_index_only_ao  (cost=0.00..431.00 rows=1 width=1)
+               Filter: (a < 100)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+select count(*) from bfv_index_only_ao where a < 100;
+ count 
+-------
+    99
+(1 row)
+
+explain select count(*) from bfv_index_only_ao where a < 1000;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+         ->  Seq Scan on bfv_index_only_ao  (cost=0.00..431.00 rows=1 width=1)
+               Filter: (a < 1000)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+select count(*) from bfv_index_only_ao where a < 1000;
+ count 
+-------
+   999
+(1 row)
+
+CREATE TABLE bfv_index_only_aocs(a int, b int) WITH (appendonly =true, orientation=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX bfv_index_only_aocs_a_b on bfv_index_only_aocs(a) include (b);
+insert into bfv_index_only_aocs select i,i from generate_series(1, 10000) i;
+explain select count(*) from bfv_index_only_aocs where a < 100;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+         ->  Seq Scan on bfv_index_only_aocs  (cost=0.00..431.00 rows=1 width=1)
+               Filter: (a < 100)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+select count(*) from bfv_index_only_aocs where a < 100;
+ count 
+-------
+    99
+(1 row)
+
+explain select count(*) from bfv_index_only_aocs where a < 1000;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+         ->  Seq Scan on bfv_index_only_aocs  (cost=0.00..431.00 rows=1 width=1)
+               Filter: (a < 1000)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+select count(*) from bfv_index_only_aocs where a < 1000;
+ count 
+-------
+   999
+(1 row)
+

--- a/src/test/regress/expected/co_nestloop_idxscan.out
+++ b/src/test/regress/expected/co_nestloop_idxscan.out
@@ -30,7 +30,7 @@ explain select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b wh
  Gather Motion 3:1  (slice1; segments: 3)  (cost=1.02..1528.77 rows=6 width=8)
    ->  Hash Join  (cost=1.02..1528.77 rows=2 width=8)
          Hash Cond: (f.id = b.id)
-         ->  Seq Scan on foo f  (cost=0.00..1527.50 rows=17 width=8)
+         ->  Index Only Scan using foo_id_idx on foo f  (cost=0.14..400.56 rows=17 width=8)
          ->  Hash  (cost=1.01..1.01 rows=1 width=8)
                ->  Seq Scan on bar b  (cost=0.00..1.01 rows=1 width=8)
  Optimizer: Postgres query optimizer
@@ -52,12 +52,10 @@ explain select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b wh
  Gather Motion 3:1  (slice1; segments: 3)  (cost=200.15..301.18 rows=6 width=8)
    ->  Nested Loop  (cost=200.15..301.18 rows=2 width=8)
          ->  Seq Scan on bar b  (cost=0.00..1.01 rows=1 width=8)
-         ->  Bitmap Heap Scan on foo f  (cost=200.15..300.16 rows=1 width=8)
-               Recheck Cond: (id = b.id)
-               ->  Bitmap Index Scan on foo_id_idx  (cost=0.00..200.15 rows=1 width=0)
-                     Index Cond: (id = b.id)
+         ->  Index Only Scan using foo_id_idx on foo f  (cost=0.14..8.16 rows=1 width=8)
+               Index Cond: (id = b.id)
  Optimizer: Postgres query optimizer
-(8 rows)
+(6 rows)
 
 select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;
  id 
@@ -76,12 +74,10 @@ explain select f.id from co_nestloop_idxscan.bar b, co_nestloop_idxscan.foo f wh
  Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000200.15..10000000301.18 rows=6 width=8)
    ->  Nested Loop  (cost=10000000200.15..10000000301.18 rows=2 width=8)
          ->  Seq Scan on bar b  (cost=10000000000.00..10000000001.01 rows=1 width=8)
-         ->  Bitmap Heap Scan on foo f  (cost=200.15..300.16 rows=1 width=8)
-               Recheck Cond: (id = b.id)
-               ->  Bitmap Index Scan on foo_id_idx  (cost=0.00..200.15 rows=1 width=0)
-                     Index Cond: (id = b.id)
+         ->  Index Only Scan using foo_id_idx on foo f  (cost=0.14..8.16 rows=1 width=8)
+               Index Cond: (id = b.id)
  Optimizer: Postgres query optimizer
-(8 rows)
+(6 rows)
 
 select f.id from co_nestloop_idxscan.foo f, co_nestloop_idxscan.bar b where f.id = b.id;
  id 
@@ -109,16 +105,15 @@ set enable_hashagg=off;
 explain select b.id from co_nestloop_idxscan.bar b where b.id in (select f.id from co_nestloop_idxscan.foo f where f.id in (1, 2, 3, 4, 5, 6));
                                            QUERY PLAN                                           
 ------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000048.90..10000000054.01 rows=4 width=8)
-   ->  Nested Loop Semi Join  (cost=10000000048.90..10000000053.95 rows=2 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.14..10000000049.99 rows=3 width=8)
+   ->  Nested Loop Semi Join  (cost=10000000000.14..10000000049.95 rows=1 width=8)
+         Join Filter: (b.id = f.id)
          ->  Seq Scan on bar b  (cost=10000000000.00..10000000001.02 rows=1 width=8)
                Filter: (id = ANY ('{1,2,3,4,5,6}'::bigint[]))
-         ->  Bitmap Heap Scan on foo f  (cost=48.90..52.92 rows=1 width=8)
-               Recheck Cond: ((id = b.id) AND (id = ANY ('{1,2,3,4,5,6}'::bigint[])))
-               ->  Bitmap Index Scan on foo_id_idx  (cost=0.00..48.90 rows=1 width=0)
-                     Index Cond: ((id = b.id) AND (id = ANY ('{1,2,3,4,5,6}'::bigint[])))
+         ->  Index Only Scan using foo_id_idx on foo f  (cost=0.14..48.91 rows=2 width=8)
+               Index Cond: (id = ANY ('{1,2,3,4,5,6}'::bigint[]))
  Optimizer: Postgres query optimizer
-(9 rows)
+(8 rows)
 
 select b.id from co_nestloop_idxscan.bar b where b.id in (select f.id from co_nestloop_idxscan.foo f where f.id in (1, 2, 3, 4, 5, 6));
  id 
@@ -132,22 +127,17 @@ select b.id from co_nestloop_idxscan.bar b where b.id in (select f.id from co_ne
 reset enable_sort;
 reset enable_hashagg;
 explain select b.id from co_nestloop_idxscan.bar b where b.id in (select f.id from co_nestloop_idxscan.foo f where f.id in (1, 2, 3, 4, 5, 6));
-                                                    QUERY PLAN                                                    
-------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000054.02..10000000054.10 rows=4 width=8)
-   ->  HashAggregate  (cost=10000000054.02..10000000054.03 rows=2 width=8)
-         Group Key: (RowIdExpr)
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=10000000048.90..10000000054.01 rows=2 width=8)
-               Hash Key: (RowIdExpr)
-               ->  Nested Loop  (cost=10000000048.90..10000000053.95 rows=2 width=8)
-                     ->  Seq Scan on bar b  (cost=10000000000.00..10000000001.02 rows=1 width=8)
-                           Filter: (id = ANY ('{1,2,3,4,5,6}'::bigint[]))
-                     ->  Bitmap Heap Scan on foo f  (cost=48.90..52.92 rows=1 width=8)
-                           Recheck Cond: ((id = b.id) AND (id = ANY ('{1,2,3,4,5,6}'::bigint[])))
-                           ->  Bitmap Index Scan on foo_id_idx  (cost=0.00..48.90 rows=1 width=0)
-                                 Index Cond: ((id = b.id) AND (id = ANY ('{1,2,3,4,5,6}'::bigint[])))
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.14..10000000049.99 rows=3 width=8)
+   ->  Nested Loop Semi Join  (cost=10000000000.14..10000000049.95 rows=1 width=8)
+         Join Filter: (b.id = f.id)
+         ->  Seq Scan on bar b  (cost=10000000000.00..10000000001.02 rows=1 width=8)
+               Filter: (id = ANY ('{1,2,3,4,5,6}'::bigint[]))
+         ->  Index Only Scan using foo_id_idx on foo f  (cost=0.14..48.91 rows=2 width=8)
+               Index Cond: (id = ANY ('{1,2,3,4,5,6}'::bigint[]))
  Optimizer: Postgres query optimizer
-(13 rows)
+(8 rows)
 
 select b.id from co_nestloop_idxscan.bar b where b.id in (select f.id from co_nestloop_idxscan.foo f where f.id in (1, 2, 3, 4, 5, 6));
  id 

--- a/src/test/regress/expected/co_nestloop_idxscan_optimizer.out
+++ b/src/test/regress/expected/co_nestloop_idxscan_optimizer.out
@@ -113,16 +113,15 @@ set enable_hashagg=off;
 explain select b.id from co_nestloop_idxscan.bar b where b.id in (select f.id from co_nestloop_idxscan.foo f where f.id in (1, 2, 3, 4, 5, 6));
                                            QUERY PLAN                                           
 ------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000048.90..10000000054.01 rows=4 width=8)
-   ->  Nested Loop Semi Join  (cost=10000000048.90..10000000053.95 rows=2 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.14..10000000049.99 rows=3 width=8)
+   ->  Nested Loop Semi Join  (cost=10000000000.14..10000000049.95 rows=1 width=8)
+         Join Filter: (b.id = f.id)
          ->  Seq Scan on bar b  (cost=10000000000.00..10000000001.02 rows=1 width=8)
                Filter: (id = ANY ('{1,2,3,4,5,6}'::bigint[]))
-         ->  Bitmap Heap Scan on foo f  (cost=48.90..52.92 rows=1 width=8)
-               Recheck Cond: ((id = b.id) AND (id = ANY ('{1,2,3,4,5,6}'::bigint[])))
-               ->  Bitmap Index Scan on foo_id_idx  (cost=0.00..48.90 rows=1 width=0)
-                     Index Cond: ((id = b.id) AND (id = ANY ('{1,2,3,4,5,6}'::bigint[])))
+         ->  Index Only Scan using foo_id_idx on foo f  (cost=0.14..48.91 rows=2 width=8)
+               Index Cond: (id = ANY ('{1,2,3,4,5,6}'::bigint[]))
  Optimizer: Postgres query optimizer
-(9 rows)
+(8 rows)
 
 select b.id from co_nestloop_idxscan.bar b where b.id in (select f.id from co_nestloop_idxscan.foo f where f.id in (1, 2, 3, 4, 5, 6));
  id 
@@ -136,22 +135,17 @@ select b.id from co_nestloop_idxscan.bar b where b.id in (select f.id from co_ne
 reset enable_sort;
 reset enable_hashagg;
 explain select b.id from co_nestloop_idxscan.bar b where b.id in (select f.id from co_nestloop_idxscan.foo f where f.id in (1, 2, 3, 4, 5, 6));
-                                                    QUERY PLAN                                                    
-------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000054.02..10000000054.10 rows=4 width=8)
-   ->  HashAggregate  (cost=10000000054.02..10000000054.03 rows=2 width=8)
-         Group Key: (RowIdExpr)
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=10000000048.90..10000000054.01 rows=2 width=8)
-               Hash Key: (RowIdExpr)
-               ->  Nested Loop  (cost=10000000048.90..10000000053.95 rows=2 width=8)
-                     ->  Seq Scan on bar b  (cost=10000000000.00..10000000001.02 rows=1 width=8)
-                           Filter: (id = ANY ('{1,2,3,4,5,6}'::bigint[]))
-                     ->  Bitmap Heap Scan on foo f  (cost=48.90..52.92 rows=1 width=8)
-                           Recheck Cond: ((id = b.id) AND (id = ANY ('{1,2,3,4,5,6}'::bigint[])))
-                           ->  Bitmap Index Scan on foo_id_idx  (cost=0.00..48.90 rows=1 width=0)
-                                 Index Cond: ((id = b.id) AND (id = ANY ('{1,2,3,4,5,6}'::bigint[])))
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.14..10000000049.99 rows=3 width=8)
+   ->  Nested Loop Semi Join  (cost=10000000000.14..10000000049.95 rows=1 width=8)
+         Join Filter: (b.id = f.id)
+         ->  Seq Scan on bar b  (cost=10000000000.00..10000000001.02 rows=1 width=8)
+               Filter: (id = ANY ('{1,2,3,4,5,6}'::bigint[]))
+         ->  Index Only Scan using foo_id_idx on foo f  (cost=0.14..48.91 rows=2 width=8)
+               Index Cond: (id = ANY ('{1,2,3,4,5,6}'::bigint[]))
  Optimizer: Postgres query optimizer
-(13 rows)
+(8 rows)
 
 select b.id from co_nestloop_idxscan.bar b where b.id in (select f.id from co_nestloop_idxscan.foo f where f.id in (1, 2, 3, 4, 5, 6));
  id 

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -13213,28 +13213,24 @@ set optimizer_enable_nljoin=off;
 -- end_ignore
 -- Make sure we don't allow a regular (btree) index scan or index join for an AO table
 -- We disabled hash join, and bitmap index joins, NLJs, so this should leave ORCA no other choices
--- expect a sequential scan, not an index scan, from these two queries
+-- other than an index-only scan or sequential scan.
 explain (costs off) select * from t_ao_btree where a = 3 and b = 3;
                    QUERY PLAN                    
 -------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
-   ->  Bitmap Heap Scan on t_ao_btree
-         Recheck Cond: ((a = 3) AND (b = 3))
-         ->  Bitmap Index Scan on t_ao_btree_ix
-               Index Cond: ((a = 3) AND (b = 3))
+   ->  Index Only Scan using t_ao_btree_ix on t_ao_btree
+         Index Cond: ((a = 3) AND (b = 3))
  Optimizer: Postgres query optimizer
-(6 rows)
+(4 rows)
 
 explain (costs off) select * from tpart_ao_btree where a = 3 and b = 3;
                            QUERY PLAN                            
 -----------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
-   ->  Bitmap Heap Scan on tpart_ao_btree_1_prt_1
-         Recheck Cond: ((a = 3) AND (b = 3))
-         ->  Bitmap Index Scan on tpart_ao_btree_1_prt_1_a_b_idx
-               Index Cond: ((a = 3) AND (b = 3))
+   ->  Index Only Scan using tpart_ao_btree_1_prt_1_a_b_idx on tpart_ao_btree_1_prt_1
+         Index Cond: ((a = 3) AND (b = 3))
  Optimizer: Postgres query optimizer
-(6 rows)
+(4 rows)
 
 -- expect a fallback for all four of these queries
 select * from tpart_dim d join t_ao_btree f on d.a=f.a where d.b=1;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -13344,7 +13344,7 @@ set optimizer_enable_nljoin=off;
 -- end_ignore
 -- Make sure we don't allow a regular (btree) index scan or index join for an AO table
 -- We disabled hash join, and bitmap index joins, NLJs, so this should leave ORCA no other choices
--- expect a sequential scan, not an index scan, from these two queries
+-- other than an index-only scan or sequential scan.
 explain (costs off) select * from t_ao_btree where a = 3 and b = 3;
                 QUERY PLAN                
 ------------------------------------------

--- a/src/test/regress/input/uao_dml/ao_unique_index_build.source
+++ b/src/test/regress/input/uao_dml/ao_unique_index_build.source
@@ -3,6 +3,7 @@
 SET default_table_access_method TO @amname@;
 -- To force index scans for smoke tests
 SET enable_seqscan TO off;
+SET enable_indexonlyscan TO off;
 SET optimizer TO off;
 
 -- Case 1: Build with no conflicting rows.

--- a/src/test/regress/output/uao_dml/ao_unique_index_build.source
+++ b/src/test/regress/output/uao_dml/ao_unique_index_build.source
@@ -2,6 +2,7 @@
 SET default_table_access_method TO @amname@;
 -- To force index scans for smoke tests
 SET enable_seqscan TO off;
+SET enable_indexonlyscan TO off;
 SET optimizer TO off;
 -- Case 1: Build with no conflicting rows.
 CREATE TABLE unique_index_build_@amname@(i int) DISTRIBUTED REPLICATED;

--- a/src/test/regress/sql/bfv_index.sql
+++ b/src/test/regress/sql/bfv_index.sql
@@ -465,3 +465,27 @@ DROP TABLE hash_prt_tbl;
 
 RESET enable_seqscan;
 RESET optimizer_enable_dynamictablescan;
+--
+-- Enable the index only scan in append only table.
+-- Note: expect ORCA to use seq scan rather than index only scan like planner,
+-- because ORCA hasn't yet implemented index only scan for AO/CO tables.
+--
+CREATE TABLE bfv_index_only_ao(a int, b int) WITH (appendonly =true);
+CREATE INDEX bfv_index_only_ao_a_b on bfv_index_only_ao(a) include (b);
+
+insert into bfv_index_only_ao select i,i from generate_series(1, 10000) i;
+
+explain select count(*) from bfv_index_only_ao where a < 100;
+select count(*) from bfv_index_only_ao where a < 100;
+explain select count(*) from bfv_index_only_ao where a < 1000;
+select count(*) from bfv_index_only_ao where a < 1000;
+
+CREATE TABLE bfv_index_only_aocs(a int, b int) WITH (appendonly =true, orientation=column);
+CREATE INDEX bfv_index_only_aocs_a_b on bfv_index_only_aocs(a) include (b);
+
+insert into bfv_index_only_aocs select i,i from generate_series(1, 10000) i;
+
+explain select count(*) from bfv_index_only_aocs where a < 100;
+select count(*) from bfv_index_only_aocs where a < 100;
+explain select count(*) from bfv_index_only_aocs where a < 1000;
+select count(*) from bfv_index_only_aocs where a < 1000;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -2943,7 +2943,7 @@ set optimizer_enable_nljoin=off;
 
 -- Make sure we don't allow a regular (btree) index scan or index join for an AO table
 -- We disabled hash join, and bitmap index joins, NLJs, so this should leave ORCA no other choices
--- expect a sequential scan, not an index scan, from these two queries
+-- other than an index-only scan or sequential scan.
 explain (costs off) select * from t_ao_btree where a = 3 and b = 3;
 explain (costs off) select * from tpart_ao_btree where a = 3 and b = 3;
 -- expect a fallback for all four of these queries


### PR DESCRIPTION
Index scan has been disabled on ao/aocs table for that random
access performance on the ao/aocs table is extremely low.
While index only scan could save cycles from no access
of append-optimized varblocks, but only randomly reads
auxiliary Heap tables. Hence it is more performant than
index scan. Based on this theory, we enable index only scan
on append-optimized tables to serve satisfied queries that
no need to fetch tuples from physical append-optimized data
files. Check README for detail information.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
