### PR TITLE
Fix sort node statistics in EXPLAIN (ANALYZE, VERBOSE)

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -3265,7 +3265,7 @@ show_sort_info(SortState *sortstate, ExplainState *es)
 				sortMethod, spaceType, (long) agg->vsum);
 			if (es->verbose)
 			{
-				appendStringInfo(es->str, "  Max Memory: %ldkB  Avg Memory: %ldkb (%d segments)",
+				appendStringInfo(es->str, "  Max Memory: %ldkB  Avg Memory: %ldkB (%d segments)",
 								 (long) agg->vmax,
 								 (long) (agg->vsum / agg->vcnt),
 								 agg->vcnt);

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1005,13 +1005,8 @@ cdbexplain_depositStatsToNode(PlanState *planstate, CdbExplain_RecvStatCtx *ctx)
 	cdbexplain_depStatAcc_init0(&totalWorkfileCreated);
 	cdbexplain_depStatAcc_init0(&totalPartTableScanned);
 	for (int i = 0; i < NUM_SORT_METHOD; i++)
-	{
 		for (int j = 0; j < NUM_SORT_SPACE_TYPE; j++)
-		{
 			cdbexplain_depStatAcc_init0(&sortSpaceUsed[j][i]);
-			cdbexplain_depStatAcc_init0(&sortSpaceUsed[j][i]);
-		}
-	}
 
 	/* Initialize per-slice accumulators. */
 	cdbexplain_depStatAcc_init0(&peakmemused);
@@ -1057,14 +1052,6 @@ cdbexplain_depositStatsToNode(PlanState *planstate, CdbExplain_RecvStatCtx *ctx)
 									  (double) rsi->sortstats.spaceUsed, rsh, rsi, nsi);
 		}
 
-		Assert(rsi->sortstats.sortMethod < NUM_SORT_METHOD);
-		Assert(rsi->sortstats.spaceType < NUM_SORT_SPACE_TYPE);
-		if (rsi->sortstats.sortMethod != SORT_TYPE_STILL_IN_PROGRESS)
-		{
-			cdbexplain_depStatAcc_upd(&sortSpaceUsed[rsi->sortstats.spaceType][rsi->sortstats.sortMethod],
-									  (double) rsi->sortstats.spaceUsed, rsh, rsi, nsi);
-		}
-
 		/* Update per-slice accumulators. */
 		cdbexplain_depStatAcc_upd(&peakmemused, rsh->worker.peakmemused, rsh, rsi, nsi);
 		cdbexplain_depStatAcc_upd(&vmem_reserved, rsh->worker.vmem_reserved, rsh, rsi, nsi);
@@ -1078,13 +1065,8 @@ cdbexplain_depositStatsToNode(PlanState *planstate, CdbExplain_RecvStatCtx *ctx)
 	ns->totalWorkfileCreated = totalWorkfileCreated.agg;
 	ns->totalPartTableScanned = totalPartTableScanned.agg;
 	for (int i = 0; i < NUM_SORT_METHOD; i++)
-	{
 		for (int j = 0; j < NUM_SORT_SPACE_TYPE; j++)
-		{
 			ns->sortSpaceUsed[j][i] = sortSpaceUsed[j][i].agg;
-			ns->sortSpaceUsed[j][i] = sortSpaceUsed[j][i].agg;
-		}
-	}
 
 	/* Roll up summary over all nodes of slice into RecvStatCtx. */
 	ctx->workmemused_max = Max(ctx->workmemused_max, workmemused.agg.vmax);

--- a/src/test/regress/data/.gitignore
+++ b/src/test/regress/data/.gitignore
@@ -1,1 +1,2 @@
 wet_region.out
+minirepro_q.sql

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -7,6 +7,10 @@
 -- s/Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./Executor memory: ####K bytes avg x #### workers, ####K bytes max (seg#)./
 -- m/Work_mem: \d+\w bytes max\./
 -- s/Work_mem: \d+\w bytes max\. */Work_mem: ###K bytes max./
+-- m/Memory: \d+kB  Max Memory: \d+kB  Peak Memory: \d+kB  Avg Memory: \d+kB \(3 segments\)/
+-- s/Memory: \d+kB  Max Memory: \d+kB  Peak Memory: \d+kB  Avg Memory: \d+kB \(3 segments\)/Memory: ###kB  Max Memory: ###kB  Peak Memory: ###kB  Avg Memory: ###kB \(3 segments\)/
+-- m/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(0 spilling\)/
+-- s/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(0 spilling\)/work_mem: ###kB  Segments: 3  Max: ###kB \(segment ##\)  Workfile: \(0 spilling\)/
 -- m/Execution Time: \d+\.\d+ ms/
 -- s/Execution Time: \d+\.\d+ ms/Execution Time: ##.### ms/
 -- m/Planning Time: \d+\.\d+ ms/
@@ -110,8 +114,8 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
 -- s/Segments: \d+/Segments: #/
 -- m/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+",?/
 -- s/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+",?/Pivotal Optimizer \(GPORCA\)"/
--- m/ Memory: \d+/
--- s/ Memory: \d+/ Memory: ###/
+-- m/ Memory: \d+$/
+-- s/ Memory: \d+$/ Memory: ###/
 -- m/Maximum Memory Used: \d+/
 -- s/Maximum Memory Used: \d+/Maximum Memory Used: ###/
 -- m/Workers: \d+/
@@ -508,6 +512,27 @@ QUERY PLAN
     Memory used: 128000
   Execution Time: 72.942
 (1 row)
+--- Check explain analyze sort infomation in verbose mode
+EXPLAIN (ANALYZE, VERBOSE) SELECT * from boxes ORDER BY apple_id;
+QUERY PLAN
+Gather Motion 3:1  (slice1; segments: 3)  (cost=2197.59..3301.17 rows=77900 width=12) (actual time=0.380..0.380 rows=0 loops=1)
+  Output: id, apple_id, location_id
+  Merge Key: apple_id
+  ->  Sort  (cost=2197.59..2262.51 rows=25967 width=12) (never executed)
+        Output: id, apple_id, location_id
+        Sort Key: boxes.apple_id
+        Sort Method:  quicksort  Memory: 75kB  Max Memory: 25kB  Avg Memory: 25kB (3 segments)
+        Executor Memory: 177kB  Segments: 3  Max: 59kB (segment 0)
+        work_mem: 177kB  Segments: 3  Max: 59kB (segment 0)  Workfile: (0 spilling)
+        ->  Seq Scan on public.boxes  (cost=0.00..293.67 rows=25967 width=12) (never executed)
+              Output: id, apple_id, location_id
+Optimizer: Postgres query optimizer
+Planning Time: 0.397 ms
+  (slice0)    Executor memory: 40K bytes.
+  (slice1)    Executor memory: 59K bytes avg x 3 workers, 59K bytes max (seg0).  Work_mem: 59K bytes max.
+Memory used:  128000kB
+Execution Time: 0.782 ms
+(17 rows)
 -- explain_processing_on
 --
 -- Test a simple case with JSON and XML output, too.

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -7,6 +7,10 @@
 -- s/Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./Executor memory: ####K bytes avg x #### workers, ####K bytes max (seg#)./
 -- m/Work_mem: \d+\w bytes max\./
 -- s/Work_mem: \d+\w bytes max\. */Work_mem: ###K bytes max./
+-- m/Memory: \d+kB  Max Memory: \d+kB  Peak Memory: \d+kB  Avg Memory: \d+kB \(3 segments\)/
+-- s/Memory: \d+kB  Max Memory: \d+kB  Peak Memory: \d+kB  Avg Memory: \d+kB \(3 segments\)/Memory: ###kB  Max Memory: ###kB  Peak Memory: ###kB  Avg Memory: ###kB \(3 segments\)/
+-- m/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(0 spilling\)/
+-- s/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(0 spilling\)/work_mem: ###kB  Segments: 3  Max: ###kB \(segment ##\)  Workfile: \(0 spilling\)/
 -- m/Execution Time: \d+\.\d+ ms/
 -- s/Execution Time: \d+\.\d+ ms/Execution Time: ##.### ms/
 -- m/Planning Time: \d+\.\d+ ms/
@@ -108,8 +112,8 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
 -- s/Segments: \d+/Segments: #/
 -- m/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+",?/
 -- s/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+",?/Pivotal Optimizer \(GPORCA\)"/
--- m/ Memory: \d+/
--- s/ Memory: \d+/ Memory: ###/
+-- m/ Memory: \d+$/
+-- s/ Memory: \d+$/ Memory: ###/
 -- m/Maximum Memory Used: \d+/
 -- s/Maximum Memory Used: \d+/Maximum Memory Used: ###/
 -- m/Workers: \d+/
@@ -458,6 +462,27 @@ QUERY PLAN
     Memory used: 128000
   Execution Time: 3.332
 (1 row)
+--- Check explain analyze sort infomation in verbose mode
+EXPLAIN (ANALYZE, VERBOSE) SELECT * from boxes ORDER BY apple_id;
+QUERY PLAN
+Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12) (actual time=0.388..0.388 rows=0 loops=1)
+  Output: id, apple_id, location_id
+  Merge Key: apple_id
+  ->  Sort  (cost=0.00..431.00 rows=1 width=12) (never executed)
+        Output: id, apple_id, location_id
+        Sort Key: boxes.apple_id
+        Sort Method:  quicksort  Memory: 75kB  Max Memory: 25kB  Avg Memory: 25kB (3 segments)
+        Executor Memory: 177kB  Segments: 3  Max: 59kB (segment 0)
+        work_mem: 177kB  Segments: 3  Max: 59kB (segment 0)  Workfile: (0 spilling)
+        ->  Seq Scan on public.boxes  (cost=0.00..431.00 rows=1 width=12) (never executed)
+              Output: id, apple_id, location_id
+Optimizer: Pivotal Optimizer (GPORCA)
+Planning Time: 4.622 ms
+  (slice0)    Executor memory: 40K bytes.
+  (slice1)    Executor memory: 59K bytes avg x 3 workers, 59K bytes max (seg0).  Work_mem: 59K bytes max.
+Memory used:  128000kB
+Execution Time: 0.846 ms
+(17 rows)
 -- explain_processing_on
 --
 -- Test a simple case with JSON and XML output, too.

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -7,6 +7,10 @@
 -- s/Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./Executor memory: ####K bytes avg x #### workers, ####K bytes max (seg#)./
 -- m/Work_mem: \d+\w bytes max\./
 -- s/Work_mem: \d+\w bytes max\. */Work_mem: ###K bytes max./
+-- m/Memory: \d+kB  Max Memory: \d+kB  Peak Memory: \d+kB  Avg Memory: \d+kB \(3 segments\)/
+-- s/Memory: \d+kB  Max Memory: \d+kB  Peak Memory: \d+kB  Avg Memory: \d+kB \(3 segments\)/Memory: ###kB  Max Memory: ###kB  Peak Memory: ###kB  Avg Memory: ###kB \(3 segments\)/
+-- m/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(0 spilling\)/
+-- s/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(0 spilling\)/work_mem: ###kB  Segments: 3  Max: ###kB \(segment ##\)  Workfile: \(0 spilling\)/
 -- m/Execution Time: \d+\.\d+ ms/
 -- s/Execution Time: \d+\.\d+ ms/Execution Time: ##.### ms/
 -- m/Planning Time: \d+\.\d+ ms/
@@ -65,8 +69,8 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
 -- s/Segments: \d+/Segments: #/
 -- m/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+",?/
 -- s/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+",?/Pivotal Optimizer \(GPORCA\)"/
--- m/ Memory: \d+/
--- s/ Memory: \d+/ Memory: ###/
+-- m/ Memory: \d+$/
+-- s/ Memory: \d+$/ Memory: ###/
 -- m/Maximum Memory Used: \d+/
 -- s/Maximum Memory Used: \d+/Maximum Memory Used: ###/
 -- m/Workers: \d+/
@@ -89,6 +93,9 @@ RESET cpu_index_tuple_cost;
 --- Check Explain Analyze YAML output that include the slices information
 -- explain_processing_off
 EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
+
+--- Check explain analyze sort infomation in verbose mode
+EXPLAIN (ANALYZE, VERBOSE) SELECT * from boxes ORDER BY apple_id;
 -- explain_processing_on
 
 --


### PR DESCRIPTION
NodeSummary's sort statistics were incorrectly updated, some exact same
processes were called twice due to the merge mistake.

FYI, the reason for making mistakes is Greenplum 6 does the statistics
for memory sort and disk sort separately, but now we don't.

Co-authored-by: Hongxu Ma <interma@outlook.com>

## Here are some reminders before you submit the pull request
- [x] Add tests for the change

Fixes #13767