### PR TITLE
[6X] pg_upgrade: check for parent partitions with seg entries

### DIFF
--- a/src/test/regress/expected/table_statistics.out
+++ b/src/test/regress/expected/table_statistics.out
@@ -657,6 +657,10 @@ select  count(*) from pg_class where relname like 'stat_part_co_t3';
      1
 (1 row)
 
+-- Drop table as its not supported by pg_upgrade.
+-- See check_parent_partitions_with_seg_entries pg_upgrade check and associated
+-- test in gpupgrade repo.
+DROP TABLE stat_part_co_t3;
 \echo '-- start_ignore'
 -- start_ignore
 drop schema stat_heap4 cascade;
@@ -904,6 +908,10 @@ select  count(*) from pg_class where relname like 'stat_part_co_t4';
      1
 (1 row)
 
+-- Drop table as its not supported by pg_upgrade.
+-- See check_parent_partitions_with_seg_entries pg_upgrade check and associated
+-- test in gpupgrade repo.
+DROP TABLE stat_part_co_t4;
 \echo '-- start_ignore'
 -- start_ignore
 drop schema stat_heap5 cascade;
@@ -1109,6 +1117,10 @@ select  count(*) from pg_class where relname like 'stat_part_co_t5';
      1
 (1 row)
 
+-- Drop table as its not supported by pg_upgrade.
+-- See check_parent_partitions_with_seg_entries pg_upgrade check and associated
+-- test in gpupgrade repo.
+DROP TABLE stat_part_co_t5;
 \echo '-- start_ignore'
 -- start_ignore
 drop schema stat_heap6 cascade;
@@ -1375,6 +1387,10 @@ select  count(*) from pg_class where relname like 'stat_part_co_t6';
      1
 (1 row)
 
+-- Drop table as its not supported by pg_upgrade.
+-- See check_parent_partitions_with_seg_entries pg_upgrade check and associated
+-- test in gpupgrade repo.
+DROP TABLE stat_part_co_t6;
 \echo '-- start_ignore'
 -- start_ignore
 drop schema stat_heap7 cascade;

--- a/src/test/regress/sql/table_statistics.sql
+++ b/src/test/regress/sql/table_statistics.sql
@@ -430,6 +430,11 @@ Alter table stat_part_co_t3 set distributed by (j);
 
 select  count(*) from pg_class where relname like 'stat_part_co_t3';
 
+-- Drop table as its not supported by pg_upgrade.
+-- See check_parent_partitions_with_seg_entries pg_upgrade check and associated
+-- test in gpupgrade repo.
+DROP TABLE stat_part_co_t3;
+
 \echo '-- start_ignore'
 drop schema stat_heap4 cascade;
 create schema stat_heap4;
@@ -592,6 +597,10 @@ Alter table stat_part_co_t4 set with (reorganize=true);
 
 select  count(*) from pg_class where relname like 'stat_part_co_t4';
 
+-- Drop table as its not supported by pg_upgrade.
+-- See check_parent_partitions_with_seg_entries pg_upgrade check and associated
+-- test in gpupgrade repo.
+DROP TABLE stat_part_co_t4;
 
 \echo '-- start_ignore'
 drop schema stat_heap5 cascade;
@@ -731,6 +740,11 @@ select  count(*) from pg_class where relname like 'stat_part_co_t5';
 Alter table stat_part_co_t5 set distributed by (j);
 
 select  count(*) from pg_class where relname like 'stat_part_co_t5';
+
+-- Drop table as its not supported by pg_upgrade.
+-- See check_parent_partitions_with_seg_entries pg_upgrade check and associated
+-- test in gpupgrade repo.
+DROP TABLE stat_part_co_t5;
 
 \echo '-- start_ignore'
 drop schema stat_heap6 cascade;
@@ -902,6 +916,10 @@ Alter table stat_part_co_t6 set with (reorganize=true);
 
 select  count(*) from pg_class where relname like 'stat_part_co_t6';
 
+-- Drop table as its not supported by pg_upgrade.
+-- See check_parent_partitions_with_seg_entries pg_upgrade check and associated
+-- test in gpupgrade repo.
+DROP TABLE stat_part_co_t6;
 
 \echo '-- start_ignore'
 drop schema stat_heap7 cascade;


### PR DESCRIPTION
Check for AO and AOCO root partitions that contain entries in pg_aocsseg without a corresponding relfile. When upgrading the primaries pg_upgrade performs a vacuum freeze of the database before restoring the AO segment tables. Since the segment catalog is copied from the master pg_aocsseg may contain entries without a corresponding relfile causing pg_upgrade to fail with:
```
  "ERROR","58P01","could not open Append-Only segment file
  ""base/16410/20863.1665"": No such file or directory",,,,,,"VACUUM
  (FREEZE);",0,,"aomd.c"
```

Tests PR: https://github.com/greenplum-db/gpupgrade/pull/686

Pipelines: 
https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/upgradeCheckAocsRootParts_6X and https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/upgradeCheckAocsRootParts_6X_full