### PR TITLE
Fix compiler warnings for non-assert builds

### DIFF
--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -307,7 +307,7 @@ create_gang_retry:
 						continue;
 
 					segdbDesc = newGangDefinition->db_descriptors[pos];
-					int fd_desc = PQsocket(segdbDesc->conn);
+					int fd_desc PG_USED_FOR_ASSERTS_ONLY = PQsocket(segdbDesc->conn);
 					Assert(fd_desc > 0);
 					Assert(fd_desc == revents[i].fd);
 

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -152,7 +152,9 @@ static TupleTableSlot *ExecHashJoinGetSavedTuple(HashJoinState *hjstate,
 												 uint32 *hashvalue,
 												 TupleTableSlot *tupleSlot);
 static bool ExecHashJoinNewBatch(HashJoinState *hjstate);
+#ifdef USE_ASSERT_CHECKING
 static bool isNotDistinctJoin(List *qualList);
+#endif
 static bool ExecParallelHashJoinNewBatch(HashJoinState *hjstate);
 static void ExecParallelHashJoinPartitionOuter(HashJoinState *node);
 
@@ -1736,6 +1738,7 @@ ReleaseHashTable(HashJoinState *node)
 
 }
 
+#ifdef USE_ASSERT_CHECKING
 /* Is this an IS-NOT-DISTINCT-join qual list (as opposed the an equijoin)?
  *
  * XXX We perform an abbreviated test based on the assumptions that 
@@ -1762,6 +1765,7 @@ isNotDistinctJoin(List *qualList)
 	}
 	return false;
 }
+#endif
 
 static void
 ExecEagerFreeHashJoin(HashJoinState *node)

--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -952,7 +952,7 @@ shareinput_writer_notifyready(shareinput_Xslice_reference *ref)
 {
 	shareinput_Xslice_state *state = ref->xslice_state;
 
-	uint32 old_ready = pg_atomic_exchange_u32(&state->ready, 1);
+	uint32 old_ready PG_USED_FOR_ASSERTS_ONLY = pg_atomic_exchange_u32(&state->ready, 1);
 	Assert(old_ready == 0);
 
 #ifdef FAULT_INJECTOR


### PR DESCRIPTION
Use PG_USED_FOR_ASSERTS_ONLY to supress unused variable warnings for
assert only variables. Plus guard isNotDistinctJoin under
USE_ASSERT_CHECKING.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
