### PR TITLE
[doc] fix configure help display mismatch

### DIFF
--- a/configure
+++ b/configure
@@ -570,6 +570,7 @@ ac_hostname=`(hostname || uname -n) 2>/dev/null | sed 1q`
 #
 # Initializations.
 #
+ac_default_prefix=/usr/local
 ac_clean_files=
 ac_config_libobj_dir=.
 LIBOBJS=
@@ -1592,10 +1593,10 @@ Optional Packages:
   --with-libs=DIRS        alternative spelling of --with-libraries
   --with-pgport=PORTNUM   set default port number [5432]
   --with-blocksize=BLOCKSIZE
-                          set table block size in kB [8]
+                          set table block size in kB [32]
   --with-segsize=SEGSIZE  set table segment size in GB [1]
   --with-wal-blocksize=BLOCKSIZE
-                          set WAL block size in kB [8]
+                          set WAL block size in kB [32]
   --with-CC=CMD           set compiler (deprecated)
   --with-llvm             build with LLVM based JIT support
   --with-icu              build with ICU support

--- a/configure.in
+++ b/configure.in
@@ -297,7 +297,7 @@ AC_SUBST(enable_tap_tests)
 # Block size
 #
 AC_MSG_CHECKING([for block size])
-PGAC_ARG_REQ(with, blocksize, [BLOCKSIZE], [set table block size in kB [8]],
+PGAC_ARG_REQ(with, blocksize, [BLOCKSIZE], [set table block size in kB [32]],
              [blocksize=$withval],
              [blocksize=32])
 case ${blocksize} in
@@ -361,7 +361,7 @@ AC_DEFINE_UNQUOTED([RELSEG_SIZE], ${RELSEG_SIZE}, [
 # WAL block size
 #
 AC_MSG_CHECKING([for WAL block size])
-PGAC_ARG_REQ(with, wal-blocksize, [BLOCKSIZE], [set WAL block size in kB [8]],
+PGAC_ARG_REQ(with, wal-blocksize, [BLOCKSIZE], [set WAL block size in kB [32]],
              [wal_blocksize=$withval],
              [wal_blocksize=32])
 case ${wal_blocksize} in


### PR DESCRIPTION
Since `blocksize` & `wal_blocksize` are default to 32 in greenplum,
the configure **--help message** should refect that.

Signed-off-by: Junwang Zhao <zhjwpku@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
