### PR TITLE
[gpdemo] delete clusterConfigPostgresAddonsFile when clean demo

### DIFF
--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -131,19 +131,23 @@ cleanDemo(){
     ##
 
     if [ "${GPDEMO_DESTRUCTIVE_CLEAN}" != "false" ]; then
-        if [ -f hostfile ];  then
+        if [ -f hostfile ]; then
             echo "Deleting hostfile"
             rm -f hostfile
         fi
-        if [ -f clusterConfigFile ];  then
+        if [ -f clusterConfigFile ]; then
             echo "Deleting clusterConfigFile"
             rm -f clusterConfigFile
         fi
-        if [ -d ${DATADIRS} ];  then
+        if [ -f clusterConfigPostgresAddonsFile ]; then
+            echo "Deleting clusterConfigPostgresAddonsFile"
+            rm -f clusterConfigPostgresAddonsFile
+        fi
+        if [ -d ${DATADIRS} ]; then
             echo "Deleting ${DATADIRS}"
             rm -rf ${DATADIRS}
         fi
-        if [ -d logs ];  then
+        if [ -d logs ]; then
             rm -rf logs
         fi
         rm -f optimizer-state.log gpdemo-env.sh


### PR DESCRIPTION
`clusterConfigPostgresAddonsFile` should be removed when destruting
the cluster.

Signed-off-by: Junwang Zhao <zhjwpku@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
