### PR TITLE
[6X] Fix inadvertent CLOG truncation during segment upgrade

### DIFF
--- a/contrib/pg_upgrade/check.c
+++ b/contrib/pg_upgrade/check.c
@@ -97,7 +97,7 @@ check_and_dump_old_cluster(bool live_check, char **sequence_script_file_name)
 	 * copy_clog_xlog_xid(), to populate the new cluster's oldest XID.
 	 */
 	if (GET_MAJOR_VERSION(old_cluster.major_version) < 901)
-		compute_old_cluster_chkpnt_oldstxid();
+		set_old_cluster_chkpnt_oldstxid();
 
 	if (!user_opts.check || is_greenplum_dispatcher_mode())
 		init_tablespaces();

--- a/contrib/pg_upgrade/check.c
+++ b/contrib/pg_upgrade/check.c
@@ -91,6 +91,14 @@ check_and_dump_old_cluster(bool live_check, char **sequence_script_file_name)
 	/* Extract a list of databases and tables from the old cluster */
 	get_db_and_rel_infos(&old_cluster);
 
+	/*
+	 * GPDB5: The chkpnt_oldstxid field is missing from a 5X cluster's control
+	 * file. So, we have to calculate it ourselves here, before it gets used in
+	 * copy_clog_xlog_xid(), to populate the new cluster's oldest XID.
+	 */
+	if (GET_MAJOR_VERSION(old_cluster.major_version) < 901)
+		compute_old_cluster_chkpnt_oldstxid();
+
 	if (!user_opts.check || is_greenplum_dispatcher_mode())
 		init_tablespaces();
 

--- a/contrib/pg_upgrade/controldata.c
+++ b/contrib/pg_upgrade/controldata.c
@@ -42,6 +42,7 @@ get_control_data(ClusterInfo *cluster, bool live_check)
 	bool		got_oid = false;
 	bool		got_nextxlogfile = false;
 	bool		got_multi = false;
+	bool		got_oldestxid = false;
 	bool		got_mxoff = false;
 	bool		got_oldestmulti = false;
 	bool		got_log_id = false;
@@ -368,6 +369,17 @@ get_control_data(ClusterInfo *cluster, bool live_check)
 			cluster->controldata.chkpnt_nxtmulti = str2uint(p);
 			got_multi = true;
 		}
+		else if ((p = strstr(bufin, "Latest checkpoint's oldestXID:")) != NULL)
+		{
+			p = strchr(p, ':');
+
+			if (p == NULL || strlen(p) <= 1)
+				pg_fatal("%d: controldata retrieval problem\n", __LINE__);
+
+			p++;				/* remove ':' char */
+			cluster->controldata.chkpnt_oldstxid = str2uint(p);
+			got_oldestxid = true;
+		}
 		else if ((p = strstr(bufin, "Latest checkpoint's oldestMultiXid:")) != NULL)
 		{
 			p = strchr(p, ':');
@@ -589,7 +601,7 @@ get_control_data(ClusterInfo *cluster, bool live_check)
 
 	/* verify that we got all the mandatory pg_control data */
 	if (!got_xid || !got_oid ||
-		!got_multi || !got_mxoff ||
+		!got_multi || !got_mxoff || (!got_oldestxid && GET_MAJOR_VERSION(cluster->major_version) >= 901) ||
 		(!got_oldestmulti &&
 		 cluster->controldata.cat_ver >= MULTIXACT_FORMATCHANGE_CAT_VER) ||
 		(!live_check && !got_nextxlogfile) ||
@@ -609,6 +621,9 @@ get_control_data(ClusterInfo *cluster, bool live_check)
 
 		if (!got_multi)
 			pg_log(PG_REPORT, "  latest checkpoint next MultiXactId\n");
+
+		if (!got_oldestxid)
+			pg_log(PG_REPORT, "  latest checkpoint oldestXID\n");
 
 		if (!got_mxoff)
 			pg_log(PG_REPORT, "  latest checkpoint next MultiXactOffset\n");

--- a/contrib/pg_upgrade/greenplum/controldata_gp.c
+++ b/contrib/pg_upgrade/greenplum/controldata_gp.c
@@ -3,6 +3,34 @@
 #include "postgres_fe.h"
 
 /*
+ * Copies of backend xid comparison utilities
+ */
+#define InvalidTransactionId		((TransactionId) 0)
+#define FirstNormalTransactionId	((TransactionId) 3)
+
+#define TransactionIdIsValid(xid)		((xid) != InvalidTransactionId)
+#define TransactionIdIsNormal(xid)	((xid) >= FirstNormalTransactionId)
+
+/*
+ * TransactionIdPrecedes --- is id1 logically < id2?
+ */
+static bool
+TransactionIdPrecedes(TransactionId id1, TransactionId id2)
+{
+	/*
+	 * If either ID is a permanent XID then we can just do unsigned
+	 * comparison.  If both are normal, do a modulo-2^32 comparison.
+	 */
+	int32		diff;
+
+	if (!TransactionIdIsNormal(id1) || !TransactionIdIsNormal(id2))
+		return (id1 < id2);
+
+	diff = (int32) (id1 - id2);
+	return (diff < 0);
+}
+
+/*
  * Called for GPDB segments only -- since we have copied the master's
  * pg_control file, we need to assign a new system identifier to each segment.
  */
@@ -162,4 +190,24 @@ freeze_all_databases(void)
        PQfinish(conn_template1);
 
        check_ok();
+}
+
+/*
+ * GPDB5: Calculate the oldest datfrozenxid in the old cluster by taking the
+ * minimum across all databases in the old cluster.
+ */
+void
+compute_old_cluster_chkpnt_oldstxid()
+{
+	TransactionId	oldestXid = InvalidTransactionId;
+
+	for (int dbnum = 0; dbnum < old_cluster.dbarr.ndbs; dbnum++)
+	{
+		DbInfo *active_db = &old_cluster.dbarr.dbs[dbnum];
+		if (!TransactionIdIsValid(oldestXid) ||
+			TransactionIdPrecedes(active_db->datfrozenxid, oldestXid))
+			oldestXid = active_db->datfrozenxid;
+	}
+
+	old_cluster.controldata.chkpnt_oldstxid = oldestXid;
 }

--- a/contrib/pg_upgrade/greenplum/pg_upgrade_greenplum.h
+++ b/contrib/pg_upgrade/greenplum/pg_upgrade_greenplum.h
@@ -90,7 +90,7 @@ bool get_check_fatal_occurred(void);
 bool is_skip_target_check(void);
 
 /* pg_upgrade_greenplum.c */
-void freeze_all_databases(void);
+extern void freeze_master_data(void);
 void reset_system_identifier(void);
 
 /* frozenxids_gp.c */
@@ -152,6 +152,6 @@ is_gpdb6(ClusterInfo *cluster)
 	return GET_MAJOR_VERSION(cluster->major_version) == 904;
 }
 
-extern void compute_old_cluster_chkpnt_oldstxid(void);
+extern void set_old_cluster_chkpnt_oldstxid(void);
 
 #endif /* PG_UPGRADE_GREENPLUM_H */

--- a/contrib/pg_upgrade/greenplum/pg_upgrade_greenplum.h
+++ b/contrib/pg_upgrade/greenplum/pg_upgrade_greenplum.h
@@ -152,4 +152,6 @@ is_gpdb6(ClusterInfo *cluster)
 	return GET_MAJOR_VERSION(cluster->major_version) == 904;
 }
 
+extern void compute_old_cluster_chkpnt_oldstxid(void);
+
 #endif /* PG_UPGRADE_GREENPLUM_H */

--- a/contrib/pg_upgrade/pg_upgrade.c
+++ b/contrib/pg_upgrade/pg_upgrade.c
@@ -727,6 +727,13 @@ copy_clog_xlog_xid(void)
 	/* copy old commit logs to new data dir */
 	copy_subdir_files("pg_clog");
 
+	prep_status("Setting oldest XID for new cluster");
+	exec_prog(UTILITY_LOG_FILE, NULL, true,
+			  true, "\"%s/pg_resetxlog\" --binary-upgrade -f -u %u \"%s\"",
+			  new_cluster.bindir, old_cluster.controldata.chkpnt_oldstxid,
+			  new_cluster.pgdata);
+	check_ok();
+
 	/* set the next transaction id and epoch of the new cluster */
 	prep_status("Setting next transaction ID and epoch for new cluster");
 	exec_prog(UTILITY_LOG_FILE, NULL, true, true,

--- a/contrib/pg_upgrade/pg_upgrade.h
+++ b/contrib/pg_upgrade/pg_upgrade.h
@@ -304,6 +304,7 @@ typedef struct
 	uint32		chkpnt_nxtmulti;
 	uint32		chkpnt_nxtmxoff;
 	uint32		chkpnt_oldstMulti;
+	uint32		chkpnt_oldstxid;
 	uint32		align;
 	uint32		blocksz;
 	uint32		largesz;


### PR DESCRIPTION
We recently ran into a pg_clog truncation issue when gpupgrade was trying to upgrade segments.

## Repro:
```
-- In source cluster:
createdb test
psql test
CREATE TABLE foo(i int);
-- Insert some tuples in a segment that will refer to the current clog file
INSERT INTO foo SELECT 1 FROM generate_series(1, 5);

gpconfig -c debug_burn_xids -v on --skipvalidation
gpstop -au

echo "INSERT INTO foo VALUES(1);" > /tmp/clog_preservation.sql
pgbench -n -f /tmp/clog_preservation.sql -c 8 -t 512 test

gpupgrade initialize --source-gphome /usr/local/gpdb5 --target-gphome /usr/local/gpdb6 --source-master-port 15432 --disk-free-ratio 0 --verbose --skip-version-check
gpupgrade execute

-- Connect to the target cluster
SELECT count(*) FROM foo;
ERROR:  could not access status of transaction 693  (seg0 slice1 192.168.0.148:50434 pid=2191113)
DETAIL:  Could not open file "pg_clog/0000": No such file or directory. 
```

## Root cause:
freeze_all_databases, when executed for segments, froze the catalog and doing so truncated the CLOG. If there were
tuples in the old cluster that didn't have the visibility hint bit set and referred to a truncated CLOG file, scanning those
tuples result in the ERROR above.

## Fix:
This has 2 commits (may squash after review):
1. Backports pg_resetxlog infrastructure to set oldest xid of a server
2. Uses pg_resetxlog infrastructure to set the oldest xid instead of the new server instead of freezing the catalog. Setting the oldest xid was the original intent of the freeze operation.

**Please refer to individual commit messages for details**


## Notes:
* Upgradeable test which mimics the repro above: https://github.com/greenplum-db/gpupgrade/pull/688
* 6X dev pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/6X_resetxlog_u