### PR TITLE
Remove fixme comment in aset.c:AllocSetTransferAccounting.

### DIFF
--- a/src/backend/utils/mmgr/aset.c
+++ b/src/backend/utils/mmgr/aset.c
@@ -1699,9 +1699,10 @@ AllocSetSetPeakUsage(MemoryContext context, Size nbytes)
 void
 AllocSetTransferAccounting(MemoryContext context, MemoryContext new_parent)
 {
-	/* GPDB_12_MERGE_FIXME: If you mix AllocSetContexts and other contexts,
-	 * what happens to accounting? */
-	if (!IsA(context, AllocSetContext))
+	/*
+	 * Mixing AllocSetContexts and other contexts will lose the accounting info.
+	 */
+	if (!IsA(context, AllocSetContext) || (new_parent != NULL && !IsA(new_parent, AllocSetContext)))
 		return;
 
 	AllocSet set = (AllocSet)context;


### PR DESCRIPTION
As AllocSetTransferAccounting() was called during MemoryContextSetParent().

Before update the memory accouting info, it asserts MemoryContextIsValid(),
which includes AllocSetContext, SlabContext and GenerationContext.

Currently, there is no mixed context situation and other context doesn't have
the accounting info, so I think it's ok to remove the comment.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
