### PR TITLE
Support authentication using aws default profiles into S3 pluginSupport

### DIFF
--- a/gpcontrib/gpcloud/include/s3conf.h
+++ b/gpcontrib/gpcloud/include/s3conf.h
@@ -29,5 +29,6 @@ extern struct sockaddr_in s3ext_logserveraddr;
 
 class S3Params;
 void CheckEssentialConfig(const S3Params& params);
+void GetAwsProfileInfo(const string configSection, string& accessId, string& secret);
 
 #endif

--- a/gpcontrib/gpcloud/regress/Makefile
+++ b/gpcontrib/gpcloud/regress/Makefile
@@ -16,6 +16,7 @@ installcheck:
 	@cp -rf input source_replaced/input
 	@cp -rf output source_replaced/output
 	@./generate_config_file.sh $(config_file)
+	@./generate_aws_profiles.sh
 	@perl -p -i -e 's/\@config_file\@/$(config_file)/;s/\@read_prefix\@/$(read_prefix)/;s/\@write_prefix\@/$(write_prefix)/;s/\@write_encrypt_prefix\@/$(write_encrypt_prefix)/' source_replaced/input/*.source source_replaced/output/*.source
 	@cp $(top_builddir)/src/test/regress/init_file source_replaced/init_file
 	@perl -p -i -e 's/-- end_matchsubs/\nm\/\\(\.\*\\.cpp:\\d\+\\)\/\ns\/\\(\.\*\\.cpp:\\d\+\\)\/\/\n-- end_matchsubs/' source_replaced/init_file

--- a/gpcontrib/gpcloud/regress/generate_aws_profiles.sh
+++ b/gpcontrib/gpcloud/regress/generate_aws_profiles.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+AWS_PROFILES_DIR=$HOME/.aws
+AWS_PROFILES=$AWS_PROFILES_DIR/credentials
+
+if [ ! -e "$AWS_PROFILES_DIR" ]; then
+    mkdir -p ${AWS_PROFILES_DIR}
+fi
+
+if [ ! -d "$AWS_PROFILES_DIR" ]; then
+    echo "ERROR:  $AWS_PROFILES_DIR is not directory."
+    exit 1
+fi
+
+if [ -f "$AWS_PROFILES" ]; then
+    echo "Warning: file $AWS_PROFILES already exists."
+    exit 0
+fi
+
+if [ -n "$gpcloud_access_key_id" ] && [ -n "$gpcloud_secret_access_key" ]; then
+    cat > $AWS_PROFILES <<-EOF
+    [no_accessid_secret]
+    aws_access_key_id = "$gpcloud_access_key_id"
+    aws_secret_access_key = "$gpcloud_secret_access_key"
+EOF
+else
+    echo "Error: environment varibles \$gpcloud_access_key_id and \$gpcloud_secret_access_key are not set."
+    exit 1
+fi
+
+exit 0

--- a/gpcontrib/gpcloud/regress/generate_config_file.sh
+++ b/gpcontrib/gpcloud/regress/generate_config_file.sh
@@ -53,6 +53,13 @@ if [ -n "$gpcloud_access_key_id" ] && [ -n "$gpcloud_secret_access_key" ]; then
 	threadnum = 3
 	chunksize = 16777217
 	proxy = socks5://127.0.0.1:1090
+
+	[no_accessid_secret]
+	accessid = ""
+	secret = ""
+
+	threadnum = 3
+	chunksize = 16777217
 	EOF
 else
 	echo "Error: environment varibles \$gpcloud_access_key_id and \$gpcloud_secret_access_key are not set."

--- a/gpcontrib/gpcloud/regress/input/1_21_no_accessid_secret.source
+++ b/gpcontrib/gpcloud/regress/input/1_21_no_accessid_secret.source
@@ -1,7 +1,7 @@
-CREATE READABLE EXTERNAL TABLE s3regress_oneline (date text, time text, open float, high float,
+CREATE READABLE EXTERNAL TABLE s3regress_no_accessid_secret (date text, time text, open float, high float,
 	low float, volume int)
 LOCATION('s3://s3-us-west-2.amazonaws.com/@read_prefix@/oneline/ config=@config_file@ section=no_accessid_secret') format 'csv';
 
-SELECT count(*) FROM s3regress_oneline;
+SELECT count(*) FROM s3regress_no_accessid_secret;
 
-DROP EXTERNAL TABLE s3regress_oneline;
+DROP EXTERNAL TABLE s3regress_no_accessid_secret;

--- a/gpcontrib/gpcloud/regress/input/1_21_no_accessid_secret.source
+++ b/gpcontrib/gpcloud/regress/input/1_21_no_accessid_secret.source
@@ -1,0 +1,7 @@
+CREATE READABLE EXTERNAL TABLE s3regress_oneline (date text, time text, open float, high float,
+	low float, volume int)
+LOCATION('s3://s3-us-west-2.amazonaws.com/@read_prefix@/oneline/ config=@config_file@ section=no_accessid_secret') format 'csv';
+
+SELECT count(*) FROM s3regress_oneline;
+
+DROP EXTERNAL TABLE s3regress_oneline;

--- a/gpcontrib/gpcloud/regress/output/1_21_no_accessid_secret.source
+++ b/gpcontrib/gpcloud/regress/output/1_21_no_accessid_secret.source
@@ -1,10 +1,10 @@
-CREATE READABLE EXTERNAL TABLE s3regress_oneline (date text, time text, open float, high float,
+CREATE READABLE EXTERNAL TABLE s3regress_no_accessid_secret (date text, time text, open float, high float,
 	low float, volume int)
 LOCATION('s3://s3-us-west-2.amazonaws.com/@read_prefix@/oneline/ config=@config_file@ section=no_accessid_secret') format 'csv';
-SELECT count(*) FROM s3regress_oneline;
+SELECT count(*) FROM s3regress_no_accessid_secret;
  count 
 -------
      1
 (1 row)
 
-DROP EXTERNAL TABLE s3regress_oneline;
+DROP EXTERNAL TABLE s3regress_no_accessid_secret;

--- a/gpcontrib/gpcloud/regress/output/1_21_no_accessid_secret.source
+++ b/gpcontrib/gpcloud/regress/output/1_21_no_accessid_secret.source
@@ -1,0 +1,10 @@
+CREATE READABLE EXTERNAL TABLE s3regress_oneline (date text, time text, open float, high float,
+	low float, volume int)
+LOCATION('s3://s3-us-west-2.amazonaws.com/@read_prefix@/oneline/ config=@config_file@ section=no_accessid_secret') format 'csv';
+SELECT count(*) FROM s3regress_oneline;
+ count 
+-------
+     1
+(1 row)
+
+DROP EXTERNAL TABLE s3regress_oneline;

--- a/gpcontrib/gpcloud/regress/regress_schedule
+++ b/gpcontrib/gpcloud/regress/regress_schedule
@@ -1,7 +1,7 @@
 test: 0_00_prepare_protocols
 
 # ~ 1s
-test: 1_03_bad_data 1_04_empty_prefix 1_05_one_line 1_06_1correct_1wrong 2_02_invalid_region 2_03_invalid_config 2_04_invalid_header 2_05_limit_zero 3_01_create_wet 3_02_quick_shoot_wet 3_11_write_with_encryption 4_01_create_invalid_wet 2_06_invalid_sub_query 1_17_no_eol_at_eof 2_07_wrong_proxy
+test: 1_03_bad_data 1_04_empty_prefix 1_05_one_line 1_06_1correct_1wrong 2_02_invalid_region 2_03_invalid_config 2_04_invalid_header 2_05_limit_zero 3_01_create_wet 3_02_quick_shoot_wet 3_11_write_with_encryption 4_01_create_invalid_wet 2_06_invalid_sub_query 1_17_no_eol_at_eof 2_07_wrong_proxy 1_21_no_accessid_secret
 test: 5_01_normal_http_param
 
 # tens of seconds


### PR DESCRIPTION
This is a new feature for supporting authentication using aws default profiles into S3 pluginSupport.
When both accessid and secret are empty in s3 config file, we will try to get accessid and secret from aws default profiles(~/.aws/credentials).
The section (like “default”) we used in config file is same.

```
# in s3.conf
[default]
accessid = ""
secret = ""
```

```
# in ～/.aws/credentials
[default]
aws_access_key_id=AKIAIOSFONN7EXALE
aws_secret_access_key=wJalrXUtnFEM7MDENG/bPCYEXAMPLEKEY
```
And if only either accessid or secret is empty in s3 config file, we will still report errors and exit. 