### PR TITLE
Fix windows clients compilation of libpgcommon

### DIFF
--- a/src/common/hashfn.c
+++ b/src/common/hashfn.c
@@ -27,7 +27,17 @@
  *
  *-------------------------------------------------------------------------
  */
+
+/*
+ * GPDB: We carry a dependency on pthread_win32.h in elog.h, which causes
+ * compilation errors when building Windows clients (as elog.h is included by
+ * postgres.h). So use postgres-fe.h instead for this case.
+ */
+#if defined (WIN32) && defined (FRONTEND)
+#include "postgres_fe.h"
+#else
 #include "postgres.h"
+#endif
 
 #include "common/hashfn.h"
 


### PR DESCRIPTION
The commit https://github.com/greenplum-db/gpdb/commit/ab12230fa11574bf2e7470242489864fe8a63c1b
added some WIN32 ifdefs to fix fe-connect compilation errors.

The commit https://github.com/greenplum-db/gpdb/commit/5d3dc2e81f272396281eddc082bd998ab96fd0da
allows hashfn.c to be compiled into both frontend and backend code but
broke the win32 clients compilation with

```
src\include\utils\elog.h(86): fatal error C1083: Cannot open include
file: 'pthread-win32.h': No such file or directory (compiling source file src/common/hashfn.c)
```

We carry a dependency on pthread_win32.h in elog.h, which causes
compilation errors when building Windows clients (as elog.h is included by
postgres.h). So use postgres-fe.h instead for this case.

Also add windows client tests to pipeline.