### PR TITLE
Fix compiler warnings from Dynamic Scan commit

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -5669,9 +5669,9 @@ CTranslatorDXLToPlStmt::TranslateDXLBitmapTblScan(
 	DynamicBitmapHeapScan *dscan;
 	BitmapHeapScan *bitmap_tbl_scan;
 
+	dscan = MakeNode(DynamicBitmapHeapScan);
 	if (is_dynamic)
 	{
-		dscan = MakeNode(DynamicBitmapHeapScan);
 		bitmap_tbl_scan = &dscan->bitmapheapscan;
 
 		CDXLPhysicalDynamicBitmapTableScan *phy_dyn_bitmap_tblscan_dxlop =

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2822,7 +2822,7 @@ _readBitmapIndexScan(void)
 static DynamicBitmapIndexScan *
 _readDynamicBitmapIndexScan(void)
 {
-	READ_LOCALS(DynamicBitmapIndexScan);
+	READ_LOCALS_NO_FIELDS(DynamicBitmapIndexScan);
 
 	/* DynamicBitmapIndexScan has some content from BitmapIndexScan. */
 	readBitmapIndexScanFields(&local_node->biscan);


### PR DESCRIPTION
Fixes a couple compiler warnings introduced in https://github.com/greenplum-db/gpdb/pull/13551
