### PR TITLE
[initdb] remove ending \n from pg_log_error

### DIFF
--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -1026,7 +1026,7 @@ test_config_settings(void)
 		}
 		if (n_connections > 0 || i == connslen - 1)
 		{
-			pg_log_error("%s: error %d from: %s\n",
+			pg_log_error("%s: error %d from: %s",
 						 progname, status, cmd);
 			exit(1);
 		}

--- a/src/bin/pg_basebackup/pg_basebackup.c
+++ b/src/bin/pg_basebackup/pg_basebackup.c
@@ -1798,7 +1798,7 @@ build_exclude_list(void)
 
 	if (PQExpBufferDataBroken(buf))
 	{
-		pg_log_error("out of memory\n");
+		pg_log_error("out of memory");
 		exit(1);
 	}
 
@@ -2293,7 +2293,7 @@ main(int argc, char **argv)
 					format = 't';
 				else
 				{
-					pg_log_error("invalid output format \"%s\", must be \"plain\" or \"tar\"\n",
+					pg_log_error("invalid output format \"%s\", must be \"plain\" or \"tar\"",
 								 optarg);
 					exit(1);
 				}
@@ -2365,7 +2365,7 @@ main(int argc, char **argv)
 				compresslevel = atoi(optarg);
 				if (compresslevel < 0 || compresslevel > 9)
 				{
-					pg_log_error("invalid compression level \"%s\"\n", optarg);
+					pg_log_error("invalid compression level \"%s\"", optarg);
 					exit(1);
 				}
 				break;


### PR DESCRIPTION
This seems like a omission when mergeing upstream postgresql 12,
some `fprintf` are changed to `pg_log_error`, every change removed
the ending `\n` except here.

This patch fixed issue #13700

Signed-off-by: Junwang Zhao <zhjwpku@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
