### PR TITLE
Backport gp_switch_wal() and gp_stat_archiver to 6X (gp_pitr extension)

### DIFF
--- a/gpcontrib/gp_pitr/Makefile
+++ b/gpcontrib/gp_pitr/Makefile
@@ -1,10 +1,10 @@
 EXTENSION = gp_pitr
 MODULES = gp_pitr
 
-EXTENSION_VERSION = 1.0
+EXTENSION_VERSION = 1.1
 
 
-DATA = gp_pitr--1.0.sql
+DATA = gp_pitr--1.1.sql gp_pitr--1.0--1.1.sql
 
 OBJS = gp_pitr.o
 

--- a/gpcontrib/gp_pitr/gp_pitr--1.0--1.1.sql
+++ b/gpcontrib/gp_pitr/gp_pitr--1.0--1.1.sql
@@ -1,0 +1,41 @@
+/* gpcontrib/gp_pitr/gp_pitr--1.0--1.1.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION gp_pitr UPDATE TO '1.1'" to load this file. \quit
+
+-- pg_switch_xlog wrapper functions to switch WAL segment files on Greenplum cluster-wide
+CREATE FUNCTION gp_switch_wal_on_all_segments (OUT gp_segment_id int, OUT pg_switch_wal pg_lsn)
+    RETURNS SETOF RECORD AS
+$$
+DECLARE
+seg_id int;
+BEGIN
+EXECUTE 'SELECT pg_catalog.gp_execution_segment()' INTO seg_id;
+-- check if execute in entrydb QE to prevent giving wrong results
+IF seg_id = -1 THEN
+    RAISE EXCEPTION 'Cannot execute in entrydb, this query is not currently supported by GPDB.';
+END IF;
+RETURN QUERY SELECT pg_catalog.gp_execution_segment() AS gp_segment_id, * FROM pg_catalog.pg_switch_xlog();
+END;
+$$ LANGUAGE plpgsql EXECUTE ON ALL SEGMENTS;
+
+CREATE FUNCTION gp_switch_wal (OUT gp_segment_id int, OUT pg_switch_wal pg_lsn)
+    RETURNS SETOF RECORD
+AS
+  'SELECT * FROM @extschema@.gp_switch_wal_on_all_segments()
+   UNION ALL
+   SELECT pg_catalog.gp_execution_segment() AS gp_segment_id, * FROM pg_catalog.pg_switch_xlog()'
+LANGUAGE SQL EXECUTE ON MASTER;
+
+COMMENT ON FUNCTION gp_switch_wal_on_all_segments() IS 'Switch WAL segment files on all primary segments';
+COMMENT ON FUNCTION gp_switch_wal() IS 'Switch WAL segment files on all segments';
+
+REVOKE EXECUTE ON FUNCTION gp_switch_wal_on_all_segments() FROM public;
+REVOKE EXECUTE ON FUNCTION gp_switch_wal() FROM public;
+
+CREATE OR REPLACE VIEW gp_stat_archiver AS
+SELECT -1 AS gp_segment_id, * FROM pg_stat_archiver
+UNION
+SELECT gp_execution_segment() AS gp_segment_id, * FROM gp_dist_random('pg_stat_archiver');
+
+GRANT SELECT ON gp_stat_archiver TO PUBLIC;

--- a/gpcontrib/gp_pitr/gp_pitr--1.0.sql
+++ b/gpcontrib/gp_pitr/gp_pitr--1.0.sql
@@ -1,8 +1,0 @@
-\echo Use "CREATE EXTENSION gp_pitr" to load this file. \quit
-
-CREATE FUNCTION gp_create_restore_point(restore_point_name text
-                    --,OUT segment_id smallint, OUT restore_lsn pg_lsn -- columns left unnamed for compatibility
-                    )
-RETURNS SETOF record
-AS '$libdir/gp_pitr', 'gp_create_restore_point'
-LANGUAGE C IMMUTABLE STRICT;

--- a/gpcontrib/gp_pitr/gp_pitr--1.1.sql
+++ b/gpcontrib/gp_pitr/gp_pitr--1.1.sql
@@ -1,0 +1,48 @@
+/* gpcontrib/gp_pitr/gp_pitr--1.1.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION gp_pitr" to load this file. \quit
+
+CREATE FUNCTION gp_create_restore_point(restore_point_name text
+    --,OUT segment_id smallint, OUT restore_lsn pg_lsn -- columns left unnamed for compatibility
+)
+    RETURNS SETOF record
+AS '$libdir/gp_pitr', 'gp_create_restore_point'
+LANGUAGE C IMMUTABLE STRICT;
+
+-- pg_switch_xlog wrapper functions to switch WAL segment files on Greenplum cluster-wide
+CREATE FUNCTION gp_switch_wal_on_all_segments (OUT gp_segment_id int, OUT pg_switch_wal pg_lsn)
+    RETURNS SETOF RECORD AS
+$$
+DECLARE
+seg_id int;
+BEGIN
+EXECUTE 'SELECT pg_catalog.gp_execution_segment()' INTO seg_id;
+-- check if execute in entrydb QE to prevent giving wrong results
+IF seg_id = -1 THEN
+    RAISE EXCEPTION 'Cannot execute in entrydb, this query is not currently supported by GPDB.';
+END IF;
+RETURN QUERY SELECT pg_catalog.gp_execution_segment() AS gp_segment_id, * FROM pg_catalog.pg_switch_xlog();
+END;
+$$ LANGUAGE plpgsql EXECUTE ON ALL SEGMENTS;
+
+CREATE FUNCTION gp_switch_wal (OUT gp_segment_id int, OUT pg_switch_wal pg_lsn)
+    RETURNS SETOF RECORD
+AS
+  'SELECT * FROM @extschema@.gp_switch_wal_on_all_segments()
+   UNION ALL
+   SELECT pg_catalog.gp_execution_segment() AS gp_segment_id, * FROM pg_catalog.pg_switch_xlog()'
+LANGUAGE SQL EXECUTE ON MASTER;
+
+COMMENT ON FUNCTION gp_switch_wal_on_all_segments() IS 'Switch WAL segment files on all primary segments';
+COMMENT ON FUNCTION gp_switch_wal() IS 'Switch WAL segment files on all segments';
+
+REVOKE EXECUTE ON FUNCTION gp_switch_wal_on_all_segments() FROM public;
+REVOKE EXECUTE ON FUNCTION gp_switch_wal() FROM public;
+
+CREATE OR REPLACE VIEW gp_stat_archiver AS
+SELECT -1 AS gp_segment_id, * FROM pg_stat_archiver
+UNION
+SELECT gp_execution_segment() AS gp_segment_id, * FROM gp_dist_random('pg_stat_archiver');
+
+GRANT SELECT ON gp_stat_archiver TO PUBLIC;

--- a/gpcontrib/gp_pitr/gp_pitr.control
+++ b/gpcontrib/gp_pitr/gp_pitr.control
@@ -1,3 +1,3 @@
 comment = 'Distributed point-in-time-recovery functions'
-default_version = '1.0'
+default_version = '1.1'
 relocatable = false

--- a/src/test/gpdb_pitr/expected/gpdb_pitr_setup.out
+++ b/src/test/gpdb_pitr/expected/gpdb_pitr_setup.out
@@ -150,21 +150,28 @@ SELECT * FROM gpdb_two_phase_commit_after_restore_point ORDER BY num;
  10  
 (10 rows)
 
--- Run pg_switch_xlog() so that the WAL segment files with the restore
--- points are archived to the WAL Archive directories.
-SELECT true FROM pg_switch_xlog();
- bool 
-------
- t    
-(1 row)
-SELECT (SELECT true FROM pg_switch_xlog()) FROM gp_dist_random('gp_id');
- bool 
-------
- t    
- t    
- t    
-(3 rows)
+CREATE TEMP TABLE gp_current_wal_lsn AS SELECT -1 AS content_id, pg_current_xlog_location() AS current_lsn UNION SELECT gp_segment_id AS content_id, pg_current_xlog_location() FROM gp_dist_random('gp_id');
+CREATE 4
 
--- Call a checkpoint to flush buffers (including the switch xlog record)
-CHECKPOINT;
-CHECKPOINT
+-- Run gp_switch_wal() so that the WAL segment files with the restore
+-- points are eligible for archival to the WAL Archive directories.
+SELECT true FROM gp_switch_wal();
+ bool 
+------
+ t    
+ t    
+ t    
+ t    
+(4 rows)
+
+-- Ensure that the last WAL segment file for each GP segment was archived.
+-- This function loops until the archival is complete. It times out after
+-- approximately 10mins.
+CREATE OR REPLACE FUNCTION check_archival() RETURNS BOOLEAN AS $$ DECLARE archived BOOLEAN; /*in func*/ DECLARE archived_count INTEGER; /*in func*/ BEGIN /*in func*/ FOR i in 1..3000 LOOP SELECT bool_and(seg_archived), count(*) FROM (SELECT last_archived_wal = pg_xlogfile_name(current_lsn) AS seg_archived FROM gp_current_wal_lsn l INNER JOIN gp_stat_archiver a ON l.content_id = a.gp_segment_id) s INTO archived, archived_count; /*in func*/ IF archived AND archived_count = 4 THEN RETURN archived; /*in func*/ END IF; /*in func*/ PERFORM pg_sleep(0.2); /*in func*/ END LOOP; /*in func*/ END $$ LANGUAGE plpgsql;
+CREATE
+
+SELECT check_archival();
+ check_archival 
+----------------
+ t              
+(1 row)

--- a/src/test/gpdb_pitr/sql/gpdb_pitr_setup.sql
+++ b/src/test/gpdb_pitr/sql/gpdb_pitr_setup.sql
@@ -63,10 +63,37 @@ SELECT * FROM gpdb_two_phase_commit_after_acquire_share_lock;
 SELECT * FROM gpdb_one_phase_commit;
 SELECT * FROM gpdb_two_phase_commit_after_restore_point ORDER BY num;
 
--- Run pg_switch_xlog() so that the WAL segment files with the restore
--- points are archived to the WAL Archive directories.
-SELECT true FROM pg_switch_xlog();
-SELECT (SELECT true FROM pg_switch_xlog()) FROM gp_dist_random('gp_id');
+CREATE TEMP TABLE gp_current_wal_lsn AS
+SELECT -1 AS content_id, pg_current_xlog_location() AS current_lsn
+UNION
+SELECT gp_segment_id AS content_id, pg_current_xlog_location() FROM gp_dist_random('gp_id');
 
--- Call a checkpoint to flush buffers (including the switch xlog record)
-CHECKPOINT;
+-- Run gp_switch_wal() so that the WAL segment files with the restore
+-- points are eligible for archival to the WAL Archive directories.
+SELECT true FROM gp_switch_wal();
+
+-- Ensure that the last WAL segment file for each GP segment was archived.
+-- This function loops until the archival is complete. It times out after
+-- approximately 10mins.
+CREATE OR REPLACE FUNCTION check_archival() RETURNS BOOLEAN AS $$
+DECLARE archived BOOLEAN; /*in func*/
+DECLARE archived_count INTEGER; /*in func*/
+BEGIN /*in func*/
+FOR i in 1..3000 LOOP
+SELECT bool_and(seg_archived), count(*)
+FROM
+    (SELECT last_archived_wal =
+            pg_xlogfile_name(current_lsn) AS seg_archived
+     FROM gp_current_wal_lsn l
+              INNER JOIN gp_stat_archiver a
+                         ON l.content_id = a.gp_segment_id) s
+    INTO archived, archived_count; /*in func*/
+IF archived AND archived_count = 4 THEN
+            RETURN archived; /*in func*/
+END IF; /*in func*/
+        PERFORM pg_sleep(0.2); /*in func*/
+END LOOP; /*in func*/
+END $$
+LANGUAGE plpgsql;
+
+SELECT check_archival();


### PR DESCRIPTION
 - This commit creates a new version of the gp_pitr extension (version 1.1.)

 - The new version of the extension contains:

	gp_stat_arcrhiver view
	(copied to gp_pitr extension from the original GPDB7 commit:
	 https://github.com/greenplum-db/gpdb/commit/9792ebdedf7ae5830af4c69e8cf75c8084396cac)

	GPDB7 commit description: introduce the gp_stat_archiver system view
	This is a view that will show the output of the system view
	pg_stat_archiver across all segments and the coordinator.
	For testing, we exercise the view in the gpdb_pitr test suite.

	gp_switch_wal() function
	(copied to gp_pitr extension from the original GPDB7 commit:
	https://github.com/greenplum-db/gpdb/commit/7a850e94dedfbbb69f5a84b780d3d0710d8c98e4)

	GPDB7 commit description: When calling pg_switch_wal, it will only
	execute on the coordinator segment. To run pg_switch_wal on
	the primary segments, we would need to use gp_dist_random
	or use utility-mode connections. To make things easier for
	end-users and help with external WAL archiving projects,
	this commit introduces a new catalog function that switches WAL
	segment files on all segments by using the GPDB-specific EXECUTE ON
	[COORDINATOR | ALL SEGMENTS] feature of CREATE FUNCTION (a less hacky
	way compared to using gp_dist_random for function calls).

