### PR TITLE
Fix gp fastsequence truncate 6x

### DIFF
--- a/src/backend/catalog/gp_fastsequence.c
+++ b/src/backend/catalog/gp_fastsequence.c
@@ -44,8 +44,8 @@ static void insert_or_update_fastsequence(
  * only exist for lifespan of the corresponding table.
  *
  * Given those special needs, this function inserts 2 initial rows to
- * fastsequence for segfile 0 (used for special cases like CTAS and ALTER) and
- * segfile 1. Only segfile 0 or segfile 1 can be used to insert tuples within
+ * fastsequence for segfile 0 (used for special cases like CTAS and ALTER, TRUNCATE) 
+ * and segfile 1. Only segfile 0 or segfile 1 can be used to insert tuples within
  * same transaction creating the table hence initial entry is only created for
  * these. Entries for rest of segfiles will get created with frozenXids during
  * inserts. These entries are inserted while creating the AO/CO table to

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -60,6 +60,7 @@
 #include "catalog/storage.h"
 #include "catalog/storage_xlog.h"
 #include "catalog/toasting.h"
+#include "catalog/gp_fastsequence.h"
 #include "cdb/cdbappendonlyam.h"
 #include "cdb/cdbappendonlyxlog.h"
 #include "cdb/cdbaocsam.h"
@@ -1459,6 +1460,14 @@ ao_aux_tables_safe_truncate(Relation rel)
 	relid_set_new_relfilenode(aoseg_relid, RecentXmin);
 	relid_set_new_relfilenode(aoblkdir_relid, RecentXmin);
 	relid_set_new_relfilenode(aovisimap_relid, RecentXmin);
+
+	/*
+	 * Reset existing gp_fastsequence entries for the segrel to an initial entry.
+	 * This mimics the state of the gp_fastsequence row when an empty AO/AOCS
+	 * table is created.
+	 */
+	RemoveFastSequenceEntry(aoseg_relid);
+	InsertInitialFastSequenceEntries(aoseg_relid);
 }
 
 /*

--- a/src/test/regress/input/aocs.source
+++ b/src/test/regress/input/aocs.source
@@ -614,3 +614,35 @@ select count(*) from aocs_small_and_dense_content;
 
 select gp_inject_fault('appendonly_skip_compression', 'reset', dbid)
 from gp_segment_configuration where role = 'p' and content = 0;
+
+
+-- test truncate ao table in current transaction and sub-transaction
+-- more details can look at https://github.com/greenplum-db/gpdb/issues/13699
+
+-- should success, create and truncate ao table in the same transaction;
+begin;
+create table fix_aoco_truncate_last_sequence(a int, b int) with (appendonly = true, orientation = column);
+create index index_fix_aoco_truncate_last_sequence on fix_aoco_truncate_last_sequence(b);
+insert into fix_aoco_truncate_last_sequence select i, i from generate_series(1, 5) i;
+select count(*) from fix_aoco_truncate_last_sequence;
+truncate table fix_aoco_truncate_last_sequence;
+select count(*) from fix_aoco_truncate_last_sequence;
+abort;
+
+-- should success, create and truncate ao table in the different transaction,
+-- and create index for it. 
+begin;
+create table fix_aoco_truncate_last_sequence(a int, b int) with (appendonly = true, orientation = column);
+create index index_fix_aoco_truncate_last_sequence on fix_aoco_truncate_last_sequence(b);
+insert into fix_aoco_truncate_last_sequence select i, i from generate_series(1, 5) i;
+select count(*) from fix_aoco_truncate_last_sequence;
+savepoint s1; 
+truncate table fix_aoco_truncate_last_sequence;
+insert into fix_aoco_truncate_last_sequence select 1, 1 from generate_series(1, 10);
+select count(*) from fix_aoco_truncate_last_sequence;
+rollback to s1; 
+select count(*) from fix_aoco_truncate_last_sequence;
+truncate table fix_aoco_truncate_last_sequence;
+insert into fix_aoco_truncate_last_sequence select 1, 1 from generate_series(1, 5); 
+select count(*) from fix_aoco_truncate_last_sequence;
+abort;

--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -347,7 +347,7 @@ last_sequence = 0, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE ob
 IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
 WHERE relname='tenk_ao2'));
 
--- WITH OIDS is no longer supported
+-- OIDS
 CREATE TABLE aowithoids(a int, b int) WITH (appendonly=true,oids=true);
 COPY aowithoids FROM STDIN;
 1	1

--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -340,14 +340,14 @@ WHERE relname='tenk_ao2'));
 -- TRUNCATE
 TRUNCATE tenk_ao2;
 
--- Truncate changes relfilnode, as a result old pg_aoseg table is truncated but
--- gp_fastsequence remains intact.
+-- Truncate changes relfilnode, as a result old pg_aoseg table is truncated, and
+-- gp_fastsequence entries are also reinitialized
 SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
-last_sequence > 0, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+last_sequence = 0, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
 IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
 WHERE relname='tenk_ao2'));
 
--- OIDS
+-- WITH OIDS is no longer supported
 CREATE TABLE aowithoids(a int, b int) WITH (appendonly=true,oids=true);
 COPY aowithoids FROM STDIN;
 1	1
@@ -771,3 +771,36 @@ select * from ao_inh_p4;
 --------------------------------------------------------------------------------
 SELECT objid FROM gp_fastsequence AS gfs LEFT OUTER JOIN (SELECT oid FROM
 pg_class) AS pgc ON (gfs.objid = pgc.oid) WHERE pgc.oid IS NULL;
+
+
+-- test truncate ao table in current transaction and sub-transaction
+-- more details can look at https://github.com/greenplum-db/gpdb/issues/13699
+
+-- should success, create and truncate ao table in the same transaction;
+begin;
+create table fix_ao_truncate_last_sequence(a int, b int) with (appendonly = true);
+create index index_fix_ao_truncate_last_sequence on fix_ao_truncate_last_sequence(b);
+insert into fix_ao_truncate_last_sequence select i, i from generate_series(1, 5) i;
+select count(*) from fix_ao_truncate_last_sequence;
+truncate table fix_ao_truncate_last_sequence;
+select count(*) from fix_ao_truncate_last_sequence;
+abort;
+
+-- should success, create and truncate ao table in the different transaction,
+-- and create index for it.
+begin;
+create table fix_ao_truncate_last_sequence(a int, b int) with (appendonly = true);
+create index index_fix_ao_truncate_last_sequence on fix_ao_truncate_last_sequence(b);
+insert into fix_ao_truncate_last_sequence select i, i from generate_series(1, 5) i;
+select count(*) from fix_ao_truncate_last_sequence;
+savepoint s1;
+truncate table fix_ao_truncate_last_sequence;
+insert into fix_ao_truncate_last_sequence select 1, 1 from generate_series(1, 10);
+select count(*) from fix_ao_truncate_last_sequence;
+rollback to s1;
+select count(*) from fix_ao_truncate_last_sequence;
+truncate table fix_ao_truncate_last_sequence;
+insert into fix_ao_truncate_last_sequence select 1, 1 from generate_series(1, 5);
+select count(*) from fix_ao_truncate_last_sequence;
+abort;
+

--- a/src/test/regress/output/aocs.source
+++ b/src/test/regress/output/aocs.source
@@ -1223,3 +1223,61 @@ from gp_segment_configuration where role = 'p' and content = 0;
  Success:
 (1 row)
 
+-- test truncate ao table in current transaction and sub-transaction
+-- more details can look at https://github.com/greenplum-db/gpdb/issues/13699
+-- should success, create and truncate ao table in the same transaction;
+begin;
+create table fix_aoco_truncate_last_sequence(a int, b int) with (appendonly = true, orientation = column);
+create index index_fix_aoco_truncate_last_sequence on fix_aoco_truncate_last_sequence(b);
+insert into fix_aoco_truncate_last_sequence select i, i from generate_series(1, 5) i;
+select count(*) from fix_aoco_truncate_last_sequence;
+ count 
+-------
+     5
+(1 row)
+
+truncate table fix_aoco_truncate_last_sequence;
+select count(*) from fix_aoco_truncate_last_sequence;
+ count 
+-------
+     0
+(1 row)
+
+abort;
+-- should success, create and truncate ao table in the different transaction,
+-- and create index for it. 
+begin;
+create table fix_aoco_truncate_last_sequence(a int, b int) with (appendonly = true, orientation = column);
+create index index_fix_aoco_truncate_last_sequence on fix_aoco_truncate_last_sequence(b);
+insert into fix_aoco_truncate_last_sequence select i, i from generate_series(1, 5) i;
+select count(*) from fix_aoco_truncate_last_sequence;
+ count 
+-------
+     5
+(1 row)
+
+savepoint s1; 
+truncate table fix_aoco_truncate_last_sequence;
+insert into fix_aoco_truncate_last_sequence select 1, 1 from generate_series(1, 10);
+select count(*) from fix_aoco_truncate_last_sequence;
+ count 
+-------
+    10
+(1 row)
+
+rollback to s1; 
+select count(*) from fix_aoco_truncate_last_sequence;
+ count 
+-------
+     5
+(1 row)
+
+truncate table fix_aoco_truncate_last_sequence;
+insert into fix_aoco_truncate_last_sequence select 1, 1 from generate_series(1, 5); 
+select count(*) from fix_aoco_truncate_last_sequence;
+ count 
+-------
+     5
+(1 row)
+
+abort;

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -743,7 +743,7 @@ WHERE relname='tenk_ao2'));
  NormalXid |      1 | t        |             0
 (6 rows)
 
--- WITH OIDS is no longer supported
+-- OIDS
 CREATE TABLE aowithoids(a int, b int) WITH (appendonly=true,oids=true);
 NOTICE:  OIDS=TRUE is not recommended for user-created tables
 HINT:  Use OIDS=FALSE to prevent wrap-around of the OID counter.

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -727,10 +727,10 @@ WHERE relname='tenk_ao2'));
 
 -- TRUNCATE
 TRUNCATE tenk_ao2;
--- Truncate changes relfilnode, as a result old pg_aoseg table is truncated but
--- gp_fastsequence remains intact.
+-- Truncate changes relfilnode, as a result old pg_aoseg table is truncated, and
+-- gp_fastsequence entries are also reinitialized
 SELECT CASE WHEN xmin = 2 THEN 'FrozenXid' ELSE 'NormalXid' END, objmod,
-last_sequence > 0, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
+last_sequence = 0, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid
 IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
 WHERE relname='tenk_ao2'));
    case    | objmod | ?column? | gp_segment_id 
@@ -743,7 +743,7 @@ WHERE relname='tenk_ao2'));
  NormalXid |      1 | t        |             0
 (6 rows)
 
--- OIDS
+-- WITH OIDS is no longer supported
 CREATE TABLE aowithoids(a int, b int) WITH (appendonly=true,oids=true);
 NOTICE:  OIDS=TRUE is not recommended for user-created tables
 HINT:  Use OIDS=FALSE to prevent wrap-around of the OID counter.
@@ -1644,3 +1644,65 @@ pg_class) AS pgc ON (gfs.objid = pgc.oid) WHERE pgc.oid IS NULL;
 -------
 (0 rows)
 
+-- test truncate ao table in current transaction and sub-transaction
+-- more details can look at https://github.com/greenplum-db/gpdb/issues/13699
+-- should success, create and truncate ao table in the same transaction;
+begin;
+create table fix_ao_truncate_last_sequence(a int, b int) with (appendonly = true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index index_fix_ao_truncate_last_sequence on fix_ao_truncate_last_sequence(b);
+insert into fix_ao_truncate_last_sequence select i, i from generate_series(1, 5) i;
+select count(*) from fix_ao_truncate_last_sequence;
+ count 
+-------
+     5
+(1 row)
+
+truncate table fix_ao_truncate_last_sequence;
+select count(*) from fix_ao_truncate_last_sequence;
+ count 
+-------
+     0
+(1 row)
+
+abort;
+-- should success, create and truncate ao table in the different transaction,
+-- and create index for it.
+begin;
+create table fix_ao_truncate_last_sequence(a int, b int) with (appendonly = true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index index_fix_ao_truncate_last_sequence on fix_ao_truncate_last_sequence(b);
+insert into fix_ao_truncate_last_sequence select i, i from generate_series(1, 5) i;
+select count(*) from fix_ao_truncate_last_sequence;
+ count 
+-------
+     5
+(1 row)
+
+savepoint s1;
+truncate table fix_ao_truncate_last_sequence;
+insert into fix_ao_truncate_last_sequence select 1, 1 from generate_series(1, 10);
+select count(*) from fix_ao_truncate_last_sequence;
+ count 
+-------
+    10
+(1 row)
+
+rollback to s1;
+select count(*) from fix_ao_truncate_last_sequence;
+ count 
+-------
+     5
+(1 row)
+
+truncate table fix_ao_truncate_last_sequence;
+insert into fix_ao_truncate_last_sequence select 1, 1 from generate_series(1, 5);
+select count(*) from fix_ao_truncate_last_sequence;
+ count 
+-------
+     5
+(1 row)
+
+abort;


### PR DESCRIPTION
This is the backport of #13762, all details and discussion can be found there.

And @ashwinstar  made a refactor on 7X-Alpha, more details can look at #13780, 
this refactor will avoid the truncate issue, which will keep the `last_sequence` in 
the table `gp_fastsequence` increasing, even we run `TRUNCATE TABLE` on it.

But this fix will reset `last_sequence` in `gp_fastsequence` when we truncate it.
There are some differences, we should notice that.