### PR TITLE
AO read: Avoid use-before-assignment in debug print

### DIFF
--- a/src/backend/cdb/cdbappendonlystorageread.c
+++ b/src/backend/cdb/cdbappendonlystorageread.c
@@ -235,7 +235,7 @@ AppendOnlyStorageRead_DoOpenFile(AppendOnlyStorageRead *storageRead,
 	elogif(Debug_appendonly_print_read_block, LOG,
 		   "Append-Only storage read: opening table '%s', segment file '%s', fileFlags 0x%x",
 		   storageRead->relationName,
-		   storageRead->segmentFileName,
+		   filePathName,
 		   fileFlags);
 
 	/*


### PR DESCRIPTION
Currently with debug_appendonly_print_read_block set, we can run into
ths assertion failure as AppendOnlyStorageRead->segmentFileName isn't
populated until AppendOnlyStorageRead_FinishOpenFile() is called.

Unexpected internal error (assert.c:44)",
"FailedAssertion(""!(strvalue != ((void *)0))"

1    0x558983f311ea postgres errstart + 0x3cb
2    0x558983f2fe48 postgres ExceptionalCondition + 0x91
3    0x55898404fde1 postgres <symbol not found> + 0x8404fde1
4    0x55898404f5f6 postgres pg_vsnprintf + 0x8f
5    0x55898405b412 postgres pvsnprintf + 0x34
6    0x55898405cf47 postgres appendStringInfoVA + 0x8a
7    0x558983f32112 postgres errmsg_internal + 0x192
8    0x55898400f72a postgres <symbol not found> + 0x8400f72a
9    0x55898400fa5e postgres AppendOnlyStorageRead_TryOpenFile + 0xa7
...

So, use the passed in filePathName argument instead.
