### PR TITLE
Remove one line about replacement_sort_tuples

### DIFF
--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -113,7 +113,6 @@
 		"pljava_release_lingering_savepoints",
 		"pljava_statement_cache_size",
 		"pljava_vmoptions",
-		"replacement_sort_tuples",
 		"row_security",
 		"search_path",
 		"statement_mem",


### PR DESCRIPTION
The GUC replacement_sort_tuples was introduced in GP 9.6 to indicate the threshold to use replacement selection rather than quicksort. See the doc:

https://www.postgresql.org/docs/9.6/runtime-config-resource.html#GUC-REPLACEMENT-SORT-TUPLES

In PG12, the GUC was removed with all code related to replacement selection sort, and doesn't appear in GPDB7. However, in GPDB7 there is still one line about replacement_sort_tuples in sync_guc_name.h (without any other related code). It should be treated as a mistake.

The fix is to simply move the line and doesn't impact any existing behavior.