### PR TITLE
Support specification of reloptions when switching storage model

### DIFF
--- a/src/include/commands/tablecmds.h
+++ b/src/include/commands/tablecmds.h
@@ -17,6 +17,7 @@
 #include "access/attnum.h"
 #include "catalog/dependency.h"
 #include "catalog/gp_distribution_policy.h"
+#include "catalog/pg_am.h"
 #include "executor/executor.h"
 #include "executor/tuptable.h"
 #include "nodes/execnodes.h"
@@ -27,6 +28,10 @@
 #include "parser/parse_node.h"
 #include "storage/lock.h"
 #include "utils/relcache.h"
+
+/* Convenient macro for checking AO AMs */
+#define IsAccessMethodAO(am_oid) \
+	(am_oid == AO_ROW_TABLE_AM_OID || am_oid == AO_COLUMN_TABLE_AM_OID)
 
 extern const char *synthetic_sql;
 

--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -318,9 +318,9 @@ alter table atsdb drop column n;
 alter table atsdb set with(appendonly = true, compresslevel = 3);
 select relname, segrelid != 0, reloptions from pg_class, pg_appendonly where pg_class.oid =
 'atsdb'::regclass and relid = pg_class.oid;
- relname | ?column? | reloptions 
----------+----------+------------
- atsdb   | t        | 
+ relname | ?column? |    reloptions     
+---------+----------+-------------------
+ atsdb   | t        | {compresslevel=3}
 (1 row)
 
 select * from distcheck where rel = 'atsdb';
@@ -443,9 +443,9 @@ select * from distcheck where rel = 'atsdb';
 
 select relname, segrelid != 0, reloptions from pg_class, pg_appendonly where pg_class.oid =
 'atsdb'::regclass and relid = pg_class.oid;
- relname | ?column? | reloptions 
----------+----------+------------
- atsdb   | t        | 
+ relname | ?column? |    reloptions     
+---------+----------+-------------------
+ atsdb   | t        | {compresslevel=3}
 (1 row)
 
 select * from atsdb;

--- a/src/test/regress/expected/alter_table_set_am.out
+++ b/src/test/regress/expected/alter_table_set_am.out
@@ -34,6 +34,14 @@ CREATE INDEX heapi ON heap2ao(b);
 ALTER TABLE heap2ao2 ADD CONSTRAINT unique_constraint UNIQUE (a);
 INSERT INTO heap2ao SELECT i,i FROM generate_series(1,5) i;
 INSERT INTO heap2ao2 SELECT i,i FROM generate_series(1,5) i;
+-- Check reloptions once before altering.
+SELECT reloptions from pg_class where relname in ('heap2ao', 'heap2ao2');
+   reloptions    
+-----------------
+ 
+ {fillfactor=70}
+(2 rows)
+
 CREATE TEMP TABLE relfilebeforeao AS
     SELECT -1 segid, relfilenode FROM pg_class WHERE relname in ('heap2ao', 'heap2ao2', 'heapi')
     UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
@@ -60,6 +68,7 @@ SELECT c.relname, a.amname FROM pg_class c JOIN pg_am a ON c.relam = a.oid WHERE
 (2 rows)
 
 -- The altered tables should inherit storage options from gp_default_storage_options
+-- And, the original heap reloptions are gone (in this case, 'fillfactor'). 
 SELECT blocksize,compresslevel,checksum,compresstype,columnstore
 FROM pg_appendonly WHERE relid in ('heap2ao'::regclass::oid, 'heap2ao2'::regclass::oid);
  blocksize | compresslevel | checksum | compresstype | columnstore 
@@ -432,6 +441,166 @@ SELECT relname, relfrozenxid <> '0' FROM pg_class WHERE relname LIKE 'ao2heap%';
 
 DROP TABLE ao2heap;
 DROP TABLE ao2heap2;
+-- Scenario 4: Set reloptions along with change of AM.
+CREATE TABLE ataoset(a int);
+CREATE TABLE ataoset2(a int);
+INSERT INTO ataoset select * from generate_series(1, 5);
+INSERT INTO ataoset2 select * from generate_series(1, 5);
+-- Error: user specifies a different AM than the one indicated in the WITH clause
+ALTER TABLE ataoset SET ACCESS METHOD ao_row WITH(appendonly=true, orientation=column);
+ERROR:  ACCESS METHOD is specified as "ao_row" but the WITH option indicates it to be "ao_column"
+LINE 1: ALTER TABLE ataoset SET ACCESS METHOD ao_row WITH(appendonly...
+                                                     ^
+-- Error: user specifiies AO reloption when altering an AO table to heap.
+CREATE TABLE ao2heaperror (a int) WITH (appendonly=true);
+ALTER TABLE ao2heaperror SET ACCESS METHOD heap WITH (blocksize=65536);
+ERROR:  unrecognized parameter "blocksize"
+DROP TABLE ao2heaperror;
+-- Scenario 4.1: change from heap to AO with customized storage options
+CREATE TEMP TABLE relfilebeforeat AS
+    SELECT -1 segid, relname, relfilenode FROM pg_class WHERE relname LIKE 'ataoset%'
+    UNION SELECT gp_segment_id segid, relname, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname LIKE 'ataoset%' ORDER BY segid;
+ALTER TABLE ataoset SET WITH (appendonly=true, blocksize=65536, compresslevel=7);
+ALTER TABLE ataoset2 SET ACCESS METHOD ao_row WITH (blocksize=65536, compresslevel=7);
+CREATE TEMP TABLE relfileafterat AS
+    SELECT -1 segid, relname, relfilenode FROM pg_class WHERE relname LIKE 'ataoset%'
+    UNION SELECT gp_segment_id segid, relname, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname LIKE 'ataoset%' ORDER BY segid;
+-- relfilenode changed
+SELECT * FROM relfilebeforeat INTERSECT SELECT * FROM relfileafterat;
+ segid | relname | relfilenode 
+-------+---------+-------------
+(0 rows)
+
+DROP TABLE relfilebeforeat;
+DROP TABLE relfileafterat;
+-- table AMs are changed to AO, and reloptions changed to what we set
+SELECT c.relname, a.amname, c.reloptions FROM pg_class c JOIN pg_am a ON c.relam = a.oid WHERE c.relname LIKE 'ataoset%';
+ relname  | amname |            reloptions             
+----------+--------+-----------------------------------
+ ataoset  | ao_row | {blocksize=65536,compresslevel=7}
+ ataoset2 | ao_row | {blocksize=65536,compresslevel=7}
+(2 rows)
+
+-- data are intact
+SELECT count(*) FROM ataoset;
+ count 
+-------
+     5
+(1 row)
+
+SELECT count(*) FROM ataoset2;
+ count 
+-------
+     5
+(1 row)
+
+-- Scenario 4.2. Alter the table w/ the exact same reloptions. 
+-- AM, relfilenodes and reloptions all should remain the same
+CREATE TEMP TABLE relfilebeforeat AS
+    SELECT -1 segid, relname, relfilenode FROM pg_class WHERE relname LIKE 'ataoset%'
+    UNION SELECT gp_segment_id segid, relname, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname LIKE 'ataoset%' ORDER BY segid;
+-- Firstly alter them with the exact same options as case 1.
+-- Secondly alter them with same option values but different order.
+-- Neither should trigger table rewrite. 
+ALTER TABLE ataoset SET WITH (appendonly=true, blocksize=65536, compresslevel=7);
+ALTER TABLE ataoset SET WITH (appendonly=true, compresslevel=7, blocksize=65536);
+ALTER TABLE ataoset2 SET ACCESS METHOD ao_row WITH (blocksize=65536, compresslevel=7);
+ALTER TABLE ataoset2 SET ACCESS METHOD ao_row WITH (compresslevel=7, blocksize=65536);
+CREATE TEMP TABLE relfileafterat AS
+    SELECT -1 segid, relname, relfilenode FROM pg_class WHERE relname LIKE 'ataoset%'
+    UNION SELECT gp_segment_id segid, relname, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname LIKE 'ataoset%' ORDER BY segid;
+-- no change to relfilenode
+SELECT * FROM relfilebeforeat EXCEPT SELECT * FROM relfileafterat;
+ segid | relname | relfilenode 
+-------+---------+-------------
+(0 rows)
+
+DROP TABLE relfilebeforeat;
+DROP TABLE relfileafterat;
+-- table AMs are still AO, but reloptions should reflect the order of options in the most recent ALTER TABLE
+SELECT c.relname, a.amname, c.reloptions FROM pg_class c JOIN pg_am a ON c.relam = a.oid WHERE c.relname LIKE 'ataoset%';
+ relname  | amname |            reloptions             
+----------+--------+-----------------------------------
+ ataoset  | ao_row | {compresslevel=7,blocksize=65536}
+ ataoset2 | ao_row | {compresslevel=7,blocksize=65536}
+(2 rows)
+
+-- data still intact
+SELECT count(*) FROM ataoset;
+ count 
+-------
+     5
+(1 row)
+
+SELECT count(*) FROM ataoset2;
+ count 
+-------
+     5
+(1 row)
+
+-- Scenario 4.3. Use the same syntax to alter from AO to AO, but specifying different storage options.
+--         Table should be rewritten.
+CREATE TEMP TABLE relfilebeforeao AS
+    SELECT -1 segid, relname, relfilenode FROM pg_class WHERE relname LIKE 'ataoset%'
+    UNION SELECT gp_segment_id segid, relname, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname LIKE 'ataoset%' ORDER BY segid;
+ERROR:  relation "relfilebeforeao" already exists
+ALTER TABLE ataoset SET WITH (appendonly=true, blocksize=32768);
+ALTER TABLE ataoset2 SET ACCESS METHOD ao_row WITH (blocksize=32768);
+CREATE TEMP TABLE relfileafterao AS
+    SELECT -1 segid, relname, relfilenode FROM pg_class WHERE relname LIKE 'ataoset%'
+    UNION SELECT gp_segment_id segid, relname, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname LIKE 'ataoset%' ORDER BY segid;
+ERROR:  relation "relfileafterao" already exists
+-- table is rewritten
+SELECT * FROM relfilebeforeao INTERSECT SELECT * FROM relfileafterao;
+ segid | relfilenode 
+-------+-------------
+(0 rows)
+
+-- reloptions changed too
+SELECT c.relname, a.amname, c.reloptions FROM pg_class c JOIN pg_am a ON c.relam = a.oid WHERE c.relname LIKE 'ataoset%';
+ relname  | amname |            reloptions             
+----------+--------+-----------------------------------
+ ataoset  | ao_row | {compresslevel=7,blocksize=32768}
+ ataoset2 | ao_row | {compresslevel=7,blocksize=32768}
+(2 rows)
+
+DROP TABLE relfilebeforeao;
+DROP TABLE relfileafterao;
+-- Scenario 4.4. Alter the tables back to heap and set some reloptions too.
+CREATE TEMP TABLE relfilebeforeat AS
+    SELECT -1 segid, relname, relfilenode FROM pg_class WHERE relname LIKE 'ataoset%'
+    UNION SELECT gp_segment_id segid, relname, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname LIKE 'ataoset%' ORDER BY segid;
+ALTER TABLE ataoset SET ACCESS METHOD heap WITH (fillfactor=70);
+ALTER TABLE ataoset2 SET ACCESS METHOD heap WITH (fillfactor=70);
+CREATE TEMP TABLE relfileafterat AS
+    SELECT -1 segid, relname, relfilenode FROM pg_class WHERE relname LIKE 'ataoset%'
+    UNION SELECT gp_segment_id segid, relname, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname LIKE 'ataoset%' ORDER BY segid;
+-- there's a table rewrite
+SELECT * FROM relfilebeforeat INTERSECT SELECT * FROM relfileafterat;
+ segid | relname | relfilenode 
+-------+---------+-------------
+(0 rows)
+
+DROP TABLE relfilebeforeat;
+DROP TABLE relfileafterat;
+-- reloptions and AM also changed
+SELECT c.relname, a.amname, c.reloptions FROM pg_class c JOIN pg_am a ON c.relam = a.oid WHERE c.relname LIKE 'ataoset%';
+ relname  | amname |   reloptions    
+----------+--------+-----------------
+ ataoset  | heap   | {fillfactor=70}
+ ataoset2 | heap   | {fillfactor=70}
+(2 rows)
+
+DROP TABLE ataoset;
+DROP TABLE ataoset2;
 -- Final scenario: run the iterations of AT from "A" to "B" and back to "A", that includes:
 -- 1. Heap->AO->Heap->AO
 -- (TODO) 2. AO->AOCO->AO->AOCO


### PR DESCRIPTION
This allow users to specify reloptions when they are switching the
storage model of the table:

```
ALTER TABLE <> SET ACCESS METHOD <> WITH ([reloptions]);
```

We also support the legacy `appendonly`/`appendoptimized` options
in the SET WITH clause:

```
ALTER TABLE <> SET WITH (appendonly|appendoptimized=true|false, [reloptions]);
```

Examples:
```
CREATE TABLE tab (a int);
ALTER TABLE tab SET ACCESS METHOD ao_row WITH (blocksize=65536);
```
or:
```
ALTER TABLE tab SET WITH (appendonly=true, blocksize=65536);
```

Note that if a user specifies different access methods in a single
statement, an error will be thrown. E.g.:

```
ALTER TABLE ataoset SET ACCESS METHOD ao_row WITH(appendonly=true, orientation=column);
ERROR:  ACCESS METHOD is specified as "ao_row" but the WITH option indicates it to be "ao_column"
LINE 1: ALTER TABLE ataoset SET ACCESS METHOD ao_row WITH(appendonly...
                                                                                                        ^
```

Also, normally access method change requires table rewrite. But
if a user uses the above syntax but specify the same access method
and/or reloptions with the existing table, we will not do a table rewrite.

Also adjusted the test output of `alter_distribution_policy` that
the altered reloptions should be shown.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
