### PR TITLE
Fix an issue where the pg_appendonly entry is not removed during AO->heap

### DIFF
--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -47,16 +47,6 @@ static relopt_bool boolRelOpts_gp[] =
 {
 	{
 		{
-			SOPT_FILLFACTOR,
-			"Packs bitmap index pages only to this percentage",
-			RELOPT_KIND_BITMAP,
-			ShareUpdateExclusiveLock	/* since it applies only to later
-										 * inserts */
-		},
-		BITMAP_DEFAULT_FILLFACTOR, BITMAP_MIN_FILLFACTOR, 100
-	},
-	{
-		{
 			SOPT_CHECKSUM,
 			"Append table checksum",
 			RELOPT_KIND_APPENDOPTIMIZED,
@@ -70,6 +60,16 @@ static relopt_bool boolRelOpts_gp[] =
 
 static relopt_int intRelOpts_gp[] =
 {
+	{
+		{
+			SOPT_FILLFACTOR,
+			"Packs bitmap index pages only to this percentage",
+			RELOPT_KIND_BITMAP,
+			ShareUpdateExclusiveLock	/* since it applies only to later
+										 * inserts */
+		},
+		BITMAP_DEFAULT_FILLFACTOR, BITMAP_MIN_FILLFACTOR, 100
+	},
 	{
 		{
 			SOPT_BLOCKSIZE,

--- a/src/backend/catalog/pg_appendonly.c
+++ b/src/backend/catalog/pg_appendonly.c
@@ -675,7 +675,7 @@ TransferAppendonlyEntries(Oid fromrelid, Oid torelid)
 	pg_appendonly_tuple = heap_modify_tuple(pg_appendonly_tuple, pg_appendonly_dsc,
 								   newValues, newNulls, replace);
 
-	CatalogTupleInsert(pg_appendonly_rel, pg_appendonly_tuple);
+	CatalogTupleUpdate(pg_appendonly_rel, &pg_appendonly_tuple->t_self, pg_appendonly_tuple);
 
 	heap_freetuple(pg_appendonly_tuple);
 

--- a/src/test/regress/expected/alter_table_set_am.out
+++ b/src/test/regress/expected/alter_table_set_am.out
@@ -136,6 +136,14 @@ SELECT * FROM gp_toolkit.__gp_aovisimap('heap2ao2');
 -----+-------+---------
 (0 rows)
 
+-- pg_appendonly should have entries associated with the new AO tables
+SELECT c.relname FROM pg_class c, pg_appendonly p WHERE c.relname LIKE 'heap2ao%' AND c.oid = p.relid;
+ relname  
+----------
+ heap2ao
+ heap2ao2
+(2 rows)
+
 -- check inherited tables
 CREATE TABLE heapbase (a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
@@ -293,6 +301,13 @@ SELECT * FROM gp_toolkit.__gp_aovisimap('heapbase2');
 -----+-------+---------
 (0 rows)
 
+SELECT c.relname FROM pg_class c, pg_appendonly p WHERE c.relname LIKE 'heapbase%' AND c.oid = p.relid;
+  relname  
+-----------
+ heapbase
+ heapbase2
+(2 rows)
+
 -- aux tables are not created for child table
 SELECT * FROM gp_toolkit.__gp_aoseg('heapchild');
 ERROR:  'heapchild' is not an append-only row relation  (seg0 slice1 127.0.0.1:7002 pid=29947)
@@ -302,6 +317,11 @@ SELECT * FROM gp_toolkit.__gp_aoseg('heapchild2');
 ERROR:  'heapchild2' is not an append-only row relation  (seg0 slice1 127.0.0.1:7002 pid=29947)
 SELECT * FROM gp_toolkit.__gp_aovisimap('heapchild2');
 ERROR:  function not supported on relation
+SELECT c.relname FROM pg_class c, pg_appendonly p WHERE c.relname LIKE 'heapchild%' AND c.oid = p.relid;
+ relname 
+---------
+(0 rows)
+
 -- Scenario 3: AO to Heap
 SET gp_default_storage_options = 'blocksize=65536, compresstype=zlib, compresslevel=5, checksum=true';
 CREATE TABLE ao2heap(a int, b int) WITH (appendonly=true);
@@ -380,7 +400,13 @@ SELECT * FROM gp_toolkit.__gp_aoseg('ao2heap2');
 ERROR:  'ao2heap2' is not an append-only row relation  (seg0 slice1 127.0.1.1:7002 pid=6817)
 SELECT * FROM gp_toolkit.__gp_aovisimap('ao2heap2');
 ERROR:  function not supported on relation
--- The altered tabless should have heap AM.
+-- No pg_appendonly entries should be left too
+SELECT c.relname FROM pg_class c, pg_appendonly p WHERE c.relname LIKE 'ao2heap%' AND c.oid = p.relid;
+ relname 
+---------
+(0 rows)
+
+-- The altered tables should have heap AM.
 SELECT c.relname, a.amname FROM pg_class c JOIN pg_am a ON c.relam = a.oid WHERE c.relname LIKE 'ao2heap%';
  relname  | amname 
 ----------+--------
@@ -406,3 +432,22 @@ SELECT relname, relfrozenxid <> '0' FROM pg_class WHERE relname LIKE 'ao2heap%';
 
 DROP TABLE ao2heap;
 DROP TABLE ao2heap2;
+-- Final scenario: run the iterations of AT from "A" to "B" and back to "A", that includes:
+-- 1. Heap->AO->Heap->AO
+-- (TODO) 2. AO->AOCO->AO->AOCO
+-- (TODO) 3. Heap->AOCO->Heap->AOCO
+-- 1. Heap->AO->Heap->AO
+CREATE TABLE heapao(a int, b int) WITH (appendonly=true);
+CREATE INDEX heapaoindex ON heapao(b);
+INSERT INTO heapao SELECT i,i FROM generate_series(1,5) i;
+ALTER TABLE heapao SET ACCESS METHOD ao_row;
+ALTER TABLE heapao SET ACCESS METHOD heap;
+ALTER TABLE heapao SET ACCESS METHOD ao_row;
+-- Just checking data is intact. 
+SELECT count(*) FROM heapao;
+ count 
+-------
+     5
+(1 row)
+
+DROP TABLE heapao;


### PR DESCRIPTION
During changing access method from AO to heap, we need to transfer the
pg_appendonly entry of the AO table to be associated with the newly
created temp heap table (TransferAppendonlyEntries). But we (I) mistakenly
insert a new tuple instead of updating the existing tuple. So even the
one associated with the temp table is removed, we still end up having
the old pg_appendonly entry, which has the same oid as the resulting
heap table.

Fixing that. And add test cases for it too.

Ref: AO->heap PR: https://github.com/greenplum-db/gpdb/pull/13738

Also in ddd80abb1aba5b812fb085ad516dcee6c9e130f3 the fillfactor option was moved from intRelOpts_gp to boolRelOpts_gp during the review phase by mistake. Moving it back now.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
