### PR TITLE
Improving gprecoverseg performance by parallel execution of checks

### DIFF
--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -604,6 +604,12 @@ class Command(object):
             self.logger.debug(self.results)
             raise ExecutionError("non-zero rc: %d" % self.results.rc, self)
 
+    def get_command_name(self):
+        if self.name:
+            return self.name
+        else:
+            self.logger.debug("Command Name not set, command:%s" % self.cmdStr)
+            return ""
 
 class SQLCommand(Command):
     """Base class for commands that execute SQL statements.  Classes


### PR DESCRIPTION
Previously in gprecoverseg when we try to stop the segments it was taking too long to get and verify the list of postmaster processes on segments as this part was mostly executed in serial fashion. 
`_get_running_postgres_segments` which is executing several tasks and fetching information and that part is in serial fashion which needs to be changed.
Currently `_get_running_postgres_segments` performs following tasks (of which many are on remote host):

1. dereference the sym-link on remote host by getting realpath
2. From remote hosts, get pid of the process from postmaster file
3. Check on remote host if the above pid exists by executing `kill -0 <pid>`
4. Check if the given PID is of a postmaster process (on remote host)

gprecoverseg does all the above checks on PID before going to stop the segment to make sure that we are stopping the correct segment and the PID mentioned is actually running on the system and the process exists. This is because in case of failures, the process might not exists on the machine. And if we go to stop the instances which are already stopped, pg_ctl will throw the error. 

This current PR covers following: 

- After the current changes,dereferencing, getting pid from postmaster file, checking If process exists and making sure that PID is of a postmaster process will be executed in parallel on all the segments. 
- Unit test cases for the newly added functions
- Added get function to worker pool to return the command-name which helps in co-relating the command with the segment when getting is from worker pool. 
- Also some IDE added visual enhancement to code like adding new line, introducing space etc. 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
