### PR TITLE
Don't simplify uncorrelated EXISTS sublink

### DIFF
--- a/src/test/regress/expected/sublink_optimizer.out
+++ b/src/test/regress/expected/sublink_optimizer.out
@@ -1,6 +1,8 @@
 -- start_ignore
 DROP TABLE IF EXISTS d_xpect_setup;
+NOTICE:  table "d_xpect_setup" does not exist, skipping
 DROP VIEW IF EXISTS v_xpect_triangle_de;
+NOTICE:  view "v_xpect_triangle_de" does not exist, skipping
 -- end_ignore
 CREATE TABLE d_xpect_setup (
     key character varying(20) NOT NULL,
@@ -51,61 +53,65 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 insert into group_by_sublink select i from generate_series(1, 5) i;
 explain (costs off)
 select a from group_by_sublink where exists (select avg(a) from group_by_sublink group by a);
-                             QUERY PLAN                              
----------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   InitPlan 1 (returns $0)  (slice2)
-     ->  Gather Motion 3:1  (slice3; segments: 3)
-           ->  HashAggregate
-                 Group Key: group_by_sublink_1.a
-                 ->  Seq Scan on group_by_sublink group_by_sublink_1
-   ->  Result
-         One-Time Filter: $0
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Result
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Seq Scan on group_by_sublink
- Optimizer: Postgres query optimizer
-(10 rows)
+   SubPlan 1
+     ->  Limit
+           ->  Materialize
+                 ->  Gather Motion 3:1  (slice2; segments: 3)
+                       ->  GroupAggregate
+                             Group Key: group_by_sublink_1.a
+                             ->  Sort
+                                   Sort Key: group_by_sublink_1.a
+                                   ->  Seq Scan on group_by_sublink group_by_sublink_1
+ Optimizer: Pivotal Optimizer (GPORCA)
+(14 rows)
 
 select a from group_by_sublink where exists (select avg(a) from group_by_sublink group by a);
  a 
 ---
- 1
+ 5
  2
  3
  4
- 5
+ 1
 (5 rows)
 
 -- The below SQL will not "prune" any more, as remove unnecessary clauses during planning stage.
 -- Such as ORDER BY, DISTINCT, DISTINCT ON. But we can manually optimize it by rewriting the SQL.
 explain (costs off)
 select a from group_by_sublink where exists (select a from group_by_sublink order by a desc);
-                             QUERY PLAN                              
----------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   InitPlan 1 (returns $0)  (slice2)
-     ->  Gather Motion 3:1  (slice3; segments: 3)
-           ->  Sort
-                 Sort Key: group_by_sublink_1.a DESC
-                 ->  Seq Scan on group_by_sublink group_by_sublink_1
-   ->  Result
-         One-Time Filter: $0
-         ->  Seq Scan on group_by_sublink
- Optimizer: Postgres query optimizer
+   ->  Nested Loop Semi Join
+         Join Filter: true
+         ->  Seq Scan on group_by_sublink group_by_sublink_1
+         ->  Materialize
+               ->  Broadcast Motion 1:3  (slice2)
+                     ->  Limit
+                           ->  Gather Motion 3:1  (slice3; segments: 3)
+                                 ->  Seq Scan on group_by_sublink
+ Optimizer: Pivotal Optimizer (GPORCA)
 (10 rows)
 
 explain (costs off)
 select a from group_by_sublink where exists (select distinct a from group_by_sublink);
-                             QUERY PLAN                              
----------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   InitPlan 1 (returns $0)  (slice2)
-     ->  Gather Motion 3:1  (slice3; segments: 3)
-           ->  HashAggregate
-                 Group Key: group_by_sublink_1.a
-                 ->  Seq Scan on group_by_sublink group_by_sublink_1
-   ->  Result
-         One-Time Filter: $0
-         ->  Seq Scan on group_by_sublink
- Optimizer: Postgres query optimizer
+   ->  Nested Loop Semi Join
+         Join Filter: true
+         ->  Seq Scan on group_by_sublink group_by_sublink_1
+         ->  Materialize
+               ->  Broadcast Motion 1:3  (slice2)
+                     ->  Limit
+                           ->  Gather Motion 3:1  (slice3; segments: 3)
+                                 ->  Seq Scan on group_by_sublink
+ Optimizer: Pivotal Optimizer (GPORCA)
 (10 rows)
 


### PR DESCRIPTION
In Greenplum, different from upstream, will try to pull up the correlated EXISTS sublink which 
has aggregate, just like:

```
postgres=# create table t(a int, b int);
postgres=# create table s (a int, b int);
postgres=# explain (costs off) 
select * from t where exists (select sum(s.a) from s where s.a = t.a group by s.a);
                QUERY PLAN                
------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   ->  Hash Join
         Hash Cond: (t.a = s.a)
         ->  Seq Scan on t
         ->  Hash
               ->  HashAggregate
                     Group Key: s.a
                     ->  Seq Scan on s
 Optimizer: Postgres query optimizer
(9 rows)
```

So Greenplum changed the behavior of function `convert_EXISTS_sublink_to_join()` and 
`simplify_EXISTS_query()`, so `simplify_EXISTS_query()` will simplify the EXISTS sublink
which has aggregate node, it will reset `targetList` and other clauses to null, just like:

```
query->targetList = NIL;
query->distinctClause = NIL;
query->sortClause = NIL;
query->hasDistinctOn = false;
```

But when we exec uncorrelated EXISTS sublink which also has an aggregate node, we can't
reset `targetList`. Otherwise, we can't make a plan for an aggregate node that doesn't have
an aggregate column, just like #11849.

This patch tries to fix the above issue, and the thought is **NOT** simplify uncorrelated EXISTS
sublink anymore. This may lead to some SQL performance regressions, but this is the cleanest 
way to fix it. And these regressions can be avoided by rewriting the SQL.

Such as we can remove the ORDER BY, DISTINCT, DISTINCT ON, and other clauses manually
in the uncorrelated EXISTS sublink to get a more efficient plan.