### PR TITLE
Queries on Distributed Replicated tables hangs when using optimizer

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpecNonSingleton.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpecNonSingleton.h
@@ -36,8 +36,8 @@ private:
 	// should Replicated distribution satisfy current distribution
 	BOOL m_fAllowReplicated;
 
-	// check if we should allow enforcers based on the distribution of first child
-	BOOL m_fAllowEnforcers;
+	// should allow this non-singleton spec to be enforced?
+	BOOL m_fAllowEnforced;
 
 	// private copy ctor
 	CDistributionSpecNonSingleton(const CDistributionSpecNonSingleton &);
@@ -48,7 +48,7 @@ public:
 
 	//ctor
 	explicit CDistributionSpecNonSingleton(BOOL fAllowReplicated,
-										   BOOL fAllowEnforcers = true);
+										   BOOL fAllowEnforced);
 
 	// should Replicated distribution satisfy current distribution
 	BOOL
@@ -57,11 +57,11 @@ public:
 		return m_fAllowReplicated;
 	}
 
-	// check if we should allow enforcers based on the distribution of first child
+	// should allow this non-singleton spec to be enforced?
 	BOOL
-	FAllowEnforcers() const
+	FAllowEnforced() const
 	{
-		return m_fAllowEnforcers;
+		return m_fAllowEnforced;
 	}
 
 	// accessor

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpecNonSingleton.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpecNonSingleton.h
@@ -36,6 +36,9 @@ private:
 	// should Replicated distribution satisfy current distribution
 	BOOL m_fAllowReplicated;
 
+	// check if we should allow enforcers based on the distribution of first child
+	BOOL m_fAllowEnforcers;
+
 	// private copy ctor
 	CDistributionSpecNonSingleton(const CDistributionSpecNonSingleton &);
 
@@ -44,13 +47,21 @@ public:
 	CDistributionSpecNonSingleton();
 
 	//ctor
-	explicit CDistributionSpecNonSingleton(BOOL fAllowReplicated);
+	explicit CDistributionSpecNonSingleton(BOOL fAllowReplicated,
+										   BOOL fAllowEnforcers = true);
 
 	// should Replicated distribution satisfy current distribution
 	BOOL
 	FAllowReplicated() const
 	{
 		return m_fAllowReplicated;
+	}
+
+	// check if we should allow enforcers based on the distribution of first child
+	BOOL
+	FAllowEnforcers() const
+	{
+		return m_fAllowEnforcers;
 	}
 
 	// accessor

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecNonSingleton.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecNonSingleton.cpp
@@ -30,7 +30,7 @@ using namespace gpopt;
 //
 //---------------------------------------------------------------------------
 CDistributionSpecNonSingleton::CDistributionSpecNonSingleton()
-	: m_fAllowReplicated(true), m_fAllowEnforcers(true)
+	: m_fAllowReplicated(true), m_fAllowEnforced(true)
 {
 }
 
@@ -44,8 +44,8 @@ CDistributionSpecNonSingleton::CDistributionSpecNonSingleton()
 //
 //---------------------------------------------------------------------------
 CDistributionSpecNonSingleton::CDistributionSpecNonSingleton(
-	BOOL fAllowReplicated, BOOL fAllowEnforcers)
-	: m_fAllowReplicated(fAllowReplicated), m_fAllowEnforcers(fAllowEnforcers)
+	BOOL fAllowReplicated, BOOL fAllowEnforced)
+	: m_fAllowReplicated(fAllowReplicated), m_fAllowEnforced(fAllowEnforced)
 {
 }
 

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecNonSingleton.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecNonSingleton.cpp
@@ -30,7 +30,7 @@ using namespace gpopt;
 //
 //---------------------------------------------------------------------------
 CDistributionSpecNonSingleton::CDistributionSpecNonSingleton()
-	: m_fAllowReplicated(true)
+	: m_fAllowReplicated(true), m_fAllowEnforcers(true)
 {
 }
 
@@ -44,8 +44,8 @@ CDistributionSpecNonSingleton::CDistributionSpecNonSingleton()
 //
 //---------------------------------------------------------------------------
 CDistributionSpecNonSingleton::CDistributionSpecNonSingleton(
-	BOOL fAllowReplicated)
-	: m_fAllowReplicated(fAllowReplicated)
+	BOOL fAllowReplicated, BOOL fAllowEnforcers)
+	: m_fAllowReplicated(fAllowReplicated), m_fAllowEnforcers(fAllowEnforcers)
 {
 }
 

--- a/src/backend/gporca/libgpopt/src/base/CEnfdDistribution.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CEnfdDistribution.cpp
@@ -156,9 +156,8 @@ CEnfdDistribution::Epet(CExpressionHandle &exprhdl, CPhysical *popPhysical,
 		}
 
 		//If the child is non-singleton and enforcers flag is false, set the distribution type as prohibited
-		if ((CDistributionSpec::EdtNonSingleton == m_pds->Edt()) &&
-			(!CDistributionSpecNonSingleton::PdsConvert(m_pds)
-				  ->FAllowEnforcers()))
+		if (CDistributionSpec::EdtNonSingleton == m_pds->Edt() &&
+			!CDistributionSpecNonSingleton::PdsConvert(m_pds)->FAllowEnforced())
 		{
 			return EpetProhibited;
 		}

--- a/src/backend/gporca/libgpopt/src/base/CEnfdDistribution.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CEnfdDistribution.cpp
@@ -15,6 +15,7 @@
 
 #include "gpopt/base/CDistributionSpec.h"
 #include "gpopt/base/CDistributionSpecHashed.h"
+#include "gpopt/base/CDistributionSpecNonSingleton.h"
 #include "gpopt/base/CDistributionSpecSingleton.h"
 #include "gpopt/base/CDrvdPropPlan.h"
 #include "gpopt/base/CPartIndexMap.h"
@@ -152,6 +153,14 @@ CEnfdDistribution::Epet(CExpressionHandle &exprhdl, CPhysical *popPhysical,
 			!ppimDrvd->FSubset(pppsReqd->Ppim()))
 		{
 			return CEnfdProp::EpetProhibited;
+		}
+
+		//If the child is non-singleton and enforcers flag is false, set the distribution type as prohibited
+		if ((CDistributionSpec::EdtNonSingleton == m_pds->Edt()) &&
+			(!CDistributionSpecNonSingleton::PdsConvert(m_pds)
+				  ->FAllowEnforcers()))
+		{
+			return EpetProhibited;
 		}
 
 		// N.B.: subtlety ahead:

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalSequence.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalSequence.cpp
@@ -250,11 +250,13 @@ CPhysicalSequence::PdsRequired(CMemoryPool *mp,
 		return GPOS_NEW(mp) CDistributionSpecAny(this->Eopid());
 	}
 
-	//If first child is non-singleton, non-universal and tainted replicated/replicated, request a non-singleton distribution on second child without enforcers
+	// first child is tainted replicated/replicated,
+	// impose non-singleton distribution without enforcers on second child
 	if (CDistributionSpec::EdtTaintedReplicated == pds->Edt() ||
 		CDistributionSpec::EdtStrictReplicated == pds->Edt())
 	{
-		return GPOS_NEW(mp) CDistributionSpecNonSingleton(true, false);
+		return GPOS_NEW(mp) CDistributionSpecNonSingleton(
+			true /* fAllowReplicated */, false /* fAllowEnforced */);
 	}
 
 	// first child is non-singleton, request a non-singleton distribution on second child

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalSequence.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalSequence.cpp
@@ -250,6 +250,13 @@ CPhysicalSequence::PdsRequired(CMemoryPool *mp,
 		return GPOS_NEW(mp) CDistributionSpecAny(this->Eopid());
 	}
 
+	//If first child is non-singleton, non-universal and tainted replicated/replicated, request a non-singleton distribution on second child without enforcers
+	if (CDistributionSpec::EdtTaintedReplicated == pds->Edt() ||
+		CDistributionSpec::EdtStrictReplicated == pds->Edt())
+	{
+		return GPOS_NEW(mp) CDistributionSpecNonSingleton(true, false);
+	}
+
 	// first child is non-singleton, request a non-singleton distribution on second child
 	return GPOS_NEW(mp) CDistributionSpecNonSingleton();
 }

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalSerialUnionAll.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalSerialUnionAll.cpp
@@ -134,8 +134,8 @@ CPhysicalSerialUnionAll::PdsRequired(
 	// we need to the inner child to be distributed across segments that does
 	// not generate duplicate results. That is, inner child should not be replicated.
 
-	return GPOS_NEW(mp)
-		CDistributionSpecNonSingleton(false /*fAllowReplicated*/);
+	return GPOS_NEW(mp) CDistributionSpecNonSingleton(
+		false /*fAllowReplicated*/, true /*fAllowEnforced*/);
 }
 
 // EOF

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -13778,13 +13778,13 @@ select m1.i
 from mat m1 join mat m2 on m1.j = m2.j;
                                                                                       QUERY PLAN                                                                                       
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..1252.25 rows=1 width=4)
+ Sequence  (cost=0.00..1252.25 rows=1 width=4)
    Output: share0_ref3.i
-   ->  Sequence  (cost=0.00..1252.25 rows=1 width=4)
-         Output: share0_ref3.i
-         ->  Shared Scan (share slice:id 1:0)  (cost=0.00..390.25 rows=1 width=1)
-               Output: share0_ref1.i, share0_ref1.j
-               ->  Materialize  (cost=0.00..390.25 rows=1 width=1)
+   ->  Shared Scan (share slice:id 0:0)  (cost=0.00..390.25 rows=1 width=1)
+         Output: share0_ref1.i, share0_ref1.j
+         ->  Materialize  (cost=0.00..390.25 rows=1 width=1)
+               Output: material_bitmapscan.i, material_bitmapscan.j
+               ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..390.25 rows=1 width=8)
                      Output: material_bitmapscan.i, material_bitmapscan.j
                      ->  Bitmap Heap Scan on orca.material_bitmapscan  (cost=0.00..390.25 rows=1 width=8)
                            Output: material_bitmapscan.i, material_bitmapscan.j
@@ -13792,24 +13792,23 @@ from mat m1 join mat m2 on m1.j = m2.j;
                            Filter: ((material_bitmapscan.i = 2) AND (material_bitmapscan.j = 2) AND (material_bitmapscan.l = 'Thu Jun 03 00:00:00 2021'::timestamp without time zone))
                            ->  Bitmap Index Scan on material_bitmapscan_idx  (cost=0.00..0.00 rows=0 width=0)
                                  Index Cond: (material_bitmapscan.k = 'Thu Jun 03 00:00:00 2021'::timestamp without time zone)
-         ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-               Output: share0_ref3.i
-               Hash Cond: (share0_ref3.j = share0_ref2.j)
-               ->  Result  (cost=0.00..431.00 rows=1 width=8)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+         Output: share0_ref3.i
+         Hash Cond: (share0_ref3.j = share0_ref2.j)
+         ->  Result  (cost=0.00..431.00 rows=1 width=8)
+               Output: share0_ref3.i, share0_ref3.j
+               Filter: (share0_ref3.j = 2)
+               ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
                      Output: share0_ref3.i, share0_ref3.j
-                     Filter: (share0_ref3.j = 2)
-                     ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=8)
-                           Output: share0_ref3.i, share0_ref3.j
-               ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+               Output: share0_ref2.j
+               ->  Result  (cost=0.00..431.00 rows=1 width=4)
                      Output: share0_ref2.j
-                     ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                           Output: share0_ref2.j
-                           Filter: (share0_ref2.j = 2)
-                           ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=4)
-                                 Output: share0_ref2.i, share0_ref2.j
+                     Filter: (share0_ref2.j = 2)
+                     ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=4)
+                           Output: share0_ref2.i, share0_ref2.j
  Optimizer: Pivotal Optimizer (GPORCA)
- Settings: optimizer=on
-(31 rows)
+(30 rows)
 
 with mat as(
     select i, j from material_bitmapscan where i = 2 and j = 2


### PR DESCRIPTION
During the optimisation of CTE’s for distributed replicated tables, Sequence operator optimize the first child with any distribution
Requirement and compute the distribution request on the other children based on derived distribution of the first child.
If distribution of first child is a Singleton, requests singleton on all children
If distribution of first child is a Non-Singleton, requests Non-Singleton on all children,
Here when the first child is a Replicated/TaintedReplicated, still we requests Non-Singleton, Hence optimiser adding redistribution motion on top of second child, which is creating a wrong plan hence query is getting hung.

So we are trying to request Non-singleton without enforcers when the first child is non-singleton, non-universal and Replicated/TaintedReplicated.
Which can avoid adding redistribution motion on top of second child.
```
Old plan:
                             QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1 (slice4; segments: 3) (cost=0.00..1293.00 rows=1 width=24)
  -> Sequence (cost=0.00..1293.00 rows=1 width=24)
     -> Shared Scan (share slice:id 4:0) (cost=0.00..431.00 rows=1 width=1)
        -> Materialize (cost=0.00..431.00 rows=1 width=1)
           -> WindowAgg (cost=0.00..431.00 rows=1 width=16)
              Partition By: testtable.name
              -> Sort (cost=0.00..431.00 rows=1 width=5)
                 Sort Key: testtable.name
                 -> Seq Scan on testtable (cost=0.00..431.00 rows=1 width=5)
     -> Redistribute Motion 1:3 (slice3) (cost=0.00..862.00 rows=1 width=24)
        -> Hash Left Join (cost=0.00..862.00 rows=1 width=24)
           Hash Cond: (“outer”.tblnm = pg_catalog.textin(unknownout(“outer”.tblnm), ‘’::void, (-1)))
           -> Result (cost=0.00..431.00 rows=1 width=8)
              -> Gather Motion 1:1 (slice1; segments: 1) (cost=0.00..431.00 rows=1 width=1)
                 -> Result (cost=0.00..431.00 rows=1 width=1)
                    -> Shared Scan (share slice:id 1:0) (cost=0.00..431.00 rows=1 width=1)
           -> Hash (cost=431.00..431.00 rows=1 width=16)
              -> Result (cost=0.00..431.00 rows=1 width=16)
                 -> Aggregate (cost=0.00..431.00 rows=1 width=8)
                    -> Gather Motion 1:1 (slice2; segments: 1) (cost=0.00..431.00 rows=1 width=1)
                       -> Result (cost=0.00..431.00 rows=1 width=1)
                          -> Shared Scan (share slice:id 2:0) (cost=0.00..431.00 rows=1 width=1)
 Optimizer: Pivotal Optimizer (GPORCA)
(23 rows)

New Plan:
                                QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------
 Sequence (cost=0.00..1293.00 rows=1 width=24) (actual time=1.120..1.120 rows=0 loops=1)
  -> Shared Scan (share slice:id 0:0) (cost=0.00..431.00 rows=1 width=1) (actual time=0.708..0.708 rows=0 loops=1)
     -> Materialize (cost=0.00..431.00 rows=1 width=1) (actual time=0.706..0.707 rows=0 loops=1)
        -> Gather Motion 1:1 (slice1; segments: 1) (cost=0.00..431.00 rows=1 width=16) (actual time=0.697..0.697 rows=0 loops=1)
           -> WindowAgg (cost=0.00..431.00 rows=1 width=16) (never executed)
              Partition By: testtable.name
              -> Sort (cost=0.00..431.00 rows=1 width=10) (never executed)
                 Sort Key: testtable.name
                 Sort Method: quicksort Memory: 33kB
                 -> Seq Scan on testtable (cost=0.00..431.00 rows=1 width=10) (never executed)
  -> Hash Left Join (cost=0.00..862.00 rows=1 width=24) (actual time=0.410..0.410 rows=0 loops=1)
     Hash Cond: (“outer”.tblnm = pg_catalog.textin(unknownout(“outer”.tblnm), ‘’::void, (-1)))
     Extra Text: Hash chain length 1.0 avg, 1 max, using 1 of 65536 buckets.
     -> Result (cost=0.00..431.00 rows=1 width=8) (actual time=0.001..0.001 rows=0 loops=1)
        -> Shared Scan (share slice:id 0:0) (cost=0.00..431.00 rows=1 width=1) (actual time=0.001..0.001 rows=0 loops=1)
     -> Hash (cost=431.00..431.00 rows=1 width=16) (actual time=0.014..0.014 rows=1 loops=1)
        Buckets: 65536 Batches: 1 Memory Usage: 1kB
        -> Result (cost=0.00..431.00 rows=1 width=16) (actual time=0.006..0.006 rows=1 loops=1)
           -> Aggregate (cost=0.00..431.00 rows=1 width=8) (actual time=0.004..0.004 rows=1 loops=1)
              -> Shared Scan (share slice:id 0:0) (cost=0.00..431.00 rows=1 width=1) (actual time=0.002..0.002 rows=0 loops=1)
 Optimizer: Pivotal Optimizer (GPORCA)
```

Co-authored-by: Hari krishna Maddileti <hmaddileti@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
