### PR TITLE
docs - lead() and lag() migration, remove from deprecated objects

### DIFF
--- a/gpdb-doc/markdown/ref_guide/deprecated-objects.html.md
+++ b/gpdb-doc/markdown/ref_guide/deprecated-objects.html.md
@@ -289,7 +289,6 @@ The following list includes the Greenplum Database 6 deprecated functions and pr
 -   pg\_catalog.json\_each\_text
 -   pg\_catalog.json\_extract\_path\_op
 -   pg\_catalog.json\_extract\_path\_text\_op
--   pg\_catalog.lag
 -   pg\_catalog.lag\_any
 -   pg\_catalog.lag\_bit
 -   pg\_catalog.lag\_bool
@@ -361,7 +360,6 @@ The following list includes the Greenplum Database 6 deprecated functions and pr
 -   pg\_catalog.last\_value\_varbit
 -   pg\_catalog.last\_value\_varchar
 -   pg\_catalog.last\_value\_xid
--   pg\_catalog.lead
 -   pg\_catalog.lead\_any
 -   pg\_catalog.lead\_bit
 -   pg\_catalog.lead\_bool


### PR DESCRIPTION
address the changes to the lead()/lag() function signatures between greenplum 5 and greenplum 6.
- remove lead() and lag() from the deprecated objects topic.
- refine the mention in the migration topic and add a new topic that specifies how to migrate these functions.

question:  i obtained the SQL to identify the views from https://github.com/greenplum-db/gpdb/pull/10849.  can someone confirm that this is correct?

doc review site link for new migration topic (behind VPN):  https://docs-staging.vmware.com/en/VMware-Tanzu-Greenplum/lisa-pgb/greenplum-database/GUID-install_guide-migrate.html#laglead.