### PR TITLE
Fix gpcheckcat false alarms for pg_default_acl

### DIFF
--- a/gpMgmt/bin/gppylib/gpcatalog.py
+++ b/gpMgmt/bin/gppylib/gpcatalog.py
@@ -52,6 +52,7 @@ DEPENDENCY_EXCLUSION = [
     'pg_compression',
     'pg_conversion',
     'pg_database',
+    'pg_default_acl',
     'pg_enum',
     'pg_namespace',
     'pg_resgroup',

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -561,6 +561,19 @@ Feature: gpcheckcat tests
         Then gpcheckcat should return a return code of 3
         And the user runs "dropdb mis_attr_db"
 
+    Scenario: gpcheckcat should not report dependency error from pg_default_acl
+        Given database "check_dependency_error" is dropped and recreated
+        And the user runs "psql -d check_dependency_error -c "CREATE ROLE foo; ALTER DEFAULT PRIVILEGES FOR ROLE foo REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;""
+        Then psql should return a return code of 0
+        When the user runs "gpcheckcat check_dependency_error"
+        Then gpcheckcat should return a return code of 0
+        And gpcheckcat should not print "SUMMARY REPORT: FAILED" to stdout
+        And gpcheckcat should not print "has a dependency issue on oid" to stdout
+        And gpcheckcat should print "Found no catalog issue" to stdout
+        And the user runs "dropdb check_dependency_error"
+        And the user runs "psql -c "DROP ROLE foo""
+
+
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster
 


### PR DESCRIPTION
gpcheckcat currently flags default privilege objects as having missing
dependencies. This is because it searches for dependencies of
pg_default_acl oids in pg_depend instead of in pg_shdepend. The fix is
to recognize pg_default_acl as a table outside the purview of pg_depend.

Minimal repro:

```
postgres=# CREATE ROLE foo;
postgres=# ALTER DEFAULT PRIVILEGES FOR ROLE foo REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;
postgres=# SELECT oid, * FROM pg_default_acl;
  oid  | defaclrole | defaclnamespace | defaclobjtype |  defaclacl
-------+------------+-----------------+---------------+-------------
 17304 |      17303 |               0 | f             | {foo=X/foo}
(1 row)

postgres=# SELECT * FROM pg_shdepend WHERE objid = 17304;
 dbid  | classid | objid | objsubid | refclassid | refobjid | deptype
-------+---------+-------+----------+------------+----------+---------
 12812 |     826 | 17304 |        0 |       1260 |    17303 | o
(2 rows)

$ gpcheckcat postgres
...
Object oid: 17304
Table name: pg_default_acl

Name of test which found this issue: dependency_pg_default_acl
Table pg_default_acl has a dependency issue on oid 17304 at content -1
Table pg_default_acl has a dependency issue on oid 17304 at content 0
Table pg_default_acl has a dependency issue on oid 17304 at content 1
Table pg_default_acl has a dependency issue on oid 17304 at content 2
```