### PR TITLE
ALTER TABLE SET ACCESS METHOD: AO->AOCO support

### DIFF
--- a/src/backend/catalog/pg_appendonly.c
+++ b/src/backend/catalog/pg_appendonly.c
@@ -597,9 +597,7 @@ ATAOEntries(Form_pg_class relform1, Form_pg_class relform2)
 					SwapAppendonlyEntries(relform1->oid, relform2->oid);
 					break;
 				case AO_COLUMN_TABLE_AM_OID:
-					ereport(ERROR,
-							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								errmsg("alter table does not support switch from AO to AOCO")));
+					SwapAppendonlyEntries(relform1->oid, relform2->oid);
 					break;
 				default:
 					ereport(ERROR,

--- a/src/backend/nodes/makefuncs.c
+++ b/src/backend/nodes/makefuncs.c
@@ -503,6 +503,7 @@ makeColumnDef(const char *colname, Oid typeOid, int32 typmod, Oid collOid)
 	n->collClause = NULL;
 	n->collOid = collOid;
 	n->constraints = NIL;
+	n->encoding = NIL;
 	n->fdwoptions = NIL;
 	n->location = -1;
 

--- a/src/test/regress/expected/alter_table_set_am.out
+++ b/src/test/regress/expected/alter_table_set_am.out
@@ -610,12 +610,168 @@ SELECT c.relname, a.amname, c.reloptions FROM pg_class c JOIN pg_am a ON c.relam
 
 DROP TABLE ataoset;
 DROP TABLE ataoset2;
--- Final scenario: run the iterations of AT from "A" to "B" and back to "A", that includes:
+-- Scenario 5: AO to AOCO 
+SET gp_default_storage_options = 'blocksize=65536, compresstype=zlib, compresslevel=5, checksum=true';
+CREATE TABLE ao2co(a int, b int) WITH (appendonly=true);
+CREATE TABLE ao2co2(a int, b int) WITH (appendonly=true);
+CREATE TABLE ao2co3(a int, b int) WITH (appendonly=true);
+CREATE TABLE ao2co4(a int, b int) WITH (appendonly=true);
+CREATE INDEX index_ao2co ON ao2co(b);
+CREATE INDEX index_ao2co3 ON ao2co3(b);
+INSERT INTO ao2co SELECT i,i FROM generate_series(1,5) i;
+INSERT INTO ao2co2 SELECT i,i FROM generate_series(1,5) i;
+INSERT INTO ao2co3 SELECT i,i FROM generate_series(1,5) i;
+INSERT INTO ao2co4 SELECT i,i FROM generate_series(1,5) i;
+-- ERROR: conflicting storage option specified.
+ALTER TABLE ao2co SET ACCESS METHOD ao_column WITH (appendoptimized=true, orientation=row);
+ERROR:  ACCESS METHOD is specified as "ao_column" but the WITH option indicates it to be "ao_row"
+LINE 1: ALTER TABLE ao2co SET ACCESS METHOD ao_column WITH (appendop...
+                                                      ^
+-- Use of *both* ACCESS METHOD and WITH clauses is allowed, but we'll print a hint to indicate the redundancy.
+ALTER TABLE ao2co SET ACCESS METHOD ao_row WITH (appendoptimized=true, orientation=row);
+HINT:  Only one of these is needed to indicate access method: the SET ACCESS METHOD clause or the options in the WITH clause.
+NOTICE:  Redundant clauses are used to indicate the access method.
+CREATE TEMP TABLE relfilebeforeao AS
+    SELECT -1 segid, relname, relfilenode FROM pg_class WHERE relname LIKE 'ao2co%'
+    UNION SELECT gp_segment_id segid, relname, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname LIKE 'ao2co%' ORDER BY segid;
+-- Check once the reloptions
+SELECT c.relname, a.amname, c.reloptions FROM pg_class c JOIN pg_am a ON c.relam = a.oid WHERE c.relname LIKE 'ao2co%';
+ relname | amname |            reloptions             
+---------+--------+-----------------------------------
+ ao2co   | ao_row | {blocksize=65536,compresslevel=5}
+ ao2co2  | ao_row | {blocksize=65536,compresslevel=5}
+ ao2co3  | ao_row | {blocksize=65536,compresslevel=5}
+ ao2co4  | ao_row | {blocksize=65536,compresslevel=5}
+(4 rows)
+
+-- Altering AO to AOCO with various syntaxes, reloptions:
+ALTER TABLE ao2co SET ACCESS METHOD ao_column;
+ALTER TABLE ao2co2 SET WITH (appendoptimized=true, orientation=column);
+ALTER TABLE ao2co3 SET ACCESS METHOD ao_column WITH (blocksize=32768, compresslevel=3);
+ALTER TABLE ao2co4 SET WITH (appendoptimized=true, orientation=column, blocksize=32768, compresslevel=3);
+-- The tables are rewritten
+CREATE TEMP TABLE relfileafterao AS
+    SELECT -1 segid, relname, relfilenode FROM pg_class WHERE relname LIKE 'ao2co%'
+    UNION SELECT gp_segment_id segid, relname, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname LIKE 'ao2co%' ORDER BY segid;
+SELECT * FROM relfilebeforeao INTERSECT SELECT * FROM relfileafterao;
+ segid | relname | relfilenode 
+-------+---------+-------------
+(0 rows)
+
+DROP TABLE relfilebeforeao;
+DROP TABLE relfileafterao;
+-- Check data is intact
+SELECT count(*) FROM ao2co;
+ count 
+-------
+     5
+(1 row)
+
+SELECT count(*) FROM ao2co2;
+ count 
+-------
+     5
+(1 row)
+
+SELECT count(*) FROM ao2co3;
+ count 
+-------
+     5
+(1 row)
+
+SELECT count(*) FROM ao2co4;
+ count 
+-------
+     5
+(1 row)
+
+-- Aux tables should have been deleted for the old AO table and recreated for the new AOCO table
+-- Only tested for 2 out of the 4 tables being created, where the tables were altered w/wo reloptions. 
+-- No need to test the other ones created by the alternative syntax SET WITH().
+SELECT * FROM gp_toolkit.__gp_aoseg('ao2co');
+ERROR:  'ao2co' is not an append-only row relation
+SELECT * FROM gp_toolkit.__gp_aovisimap('ao2co');
+ tid | segno | row_num 
+-----+-------+---------
+(0 rows)
+
+SELECT count(*) FROM gp_toolkit.__gp_aocsseg('ao2co');
+ count 
+-------
+     6
+(1 row)
+
+SELECT * FROM gp_toolkit.__gp_aoblkdir('ao2co');
+ tupleid | segno | columngroup_no | entry_no | first_row_no | file_offset | row_count 
+---------+-------+----------------+----------+--------------+-------------+-----------
+(0 rows)
+
+SELECT * FROM gp_toolkit.__gp_aoseg('ao2co3');
+ERROR:  'ao2co3' is not an append-only row relation
+SELECT * FROM gp_toolkit.__gp_aovisimap('ao2co3');
+ tid | segno | row_num 
+-----+-------+---------
+(0 rows)
+
+SELECT count(*) FROM gp_toolkit.__gp_aocsseg('ao2co3');
+ count 
+-------
+     6
+(1 row)
+
+SELECT * FROM gp_toolkit.__gp_aoblkdir('ao2co3');
+ tupleid | segno | columngroup_no | entry_no | first_row_no | file_offset | row_count 
+---------+-------+----------------+----------+--------------+-------------+-----------
+(0 rows)
+
+-- pg_attribute_encoding should have columns for the AOCO table
+SELECT c.relname, a.attnum, a.attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid = c.oid AND c.relname LIKE 'ao2co%';
+ relname | attnum |                     attoptions                      
+---------+--------+-----------------------------------------------------
+ ao2co   |      1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ ao2co   |      2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ ao2co2  |      1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ ao2co2  |      2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ ao2co3  |      1 | {blocksize=32768,compresslevel=3,compresstype=zlib}
+ ao2co3  |      2 | {blocksize=32768,compresslevel=3,compresstype=zlib}
+ ao2co4  |      1 | {blocksize=32768,compresslevel=3,compresstype=zlib}
+ ao2co4  |      2 | {blocksize=32768,compresslevel=3,compresstype=zlib}
+(8 rows)
+
+-- AM and reloptions changed accordingly
+SELECT c.relname, a.amname, c.reloptions FROM pg_class c JOIN pg_am a ON c.relam = a.oid WHERE c.relname LIKE 'ao2co%';
+ relname |  amname   |            reloptions             
+---------+-----------+-----------------------------------
+ ao2co   | ao_column | {blocksize=65536,compresslevel=5}
+ ao2co2  | ao_column | {blocksize=65536,compresslevel=5}
+ ao2co3  | ao_column | {blocksize=32768,compresslevel=3}
+ ao2co4  | ao_column | {blocksize=32768,compresslevel=3}
+(4 rows)
+
+-- pg_appendonly should reflect the changes in reloptions
+SELECT c.relname,a.blocksize,a.compresslevel,a.checksum,a.compresstype,a.columnstore
+FROM pg_appendonly a, pg_class c WHERE a.relid = c.oid AND relname like ('ao2co%');
+ relname | blocksize | compresslevel | checksum | compresstype | columnstore 
+---------+-----------+---------------+----------+--------------+-------------
+ ao2co   |     65536 |             5 | t        | zlib         | t
+ ao2co2  |     65536 |             5 | t        | zlib         | t
+ ao2co3  |     32768 |             3 | t        | zlib         | t
+ ao2co4  |     32768 |             3 | t        | zlib         | t
+(4 rows)
+
+DROP TABLE ao2co;
+DROP TABLE ao2co2;
+DROP TABLE ao2co3;
+DROP TABLE ao2co4;
+-- Final scenario: the iterations of altering table from storage type "A" to "B" and back to "A". 
+-- The following cases will cover all variations of such iterations:
 -- 1. Heap->AO->Heap->AO
 -- (TODO) 2. AO->AOCO->AO->AOCO
 -- (TODO) 3. Heap->AOCO->Heap->AOCO
 -- 1. Heap->AO->Heap->AO
-CREATE TABLE heapao(a int, b int) WITH (appendonly=true);
+CREATE TABLE heapao(a int, b int);
 CREATE INDEX heapaoindex ON heapao(b);
 INSERT INTO heapao SELECT i,i FROM generate_series(1,5) i;
 ALTER TABLE heapao SET ACCESS METHOD ao_row;


### PR DESCRIPTION
**READY to review**

Description
=============
Currently adding support for the following cases:
 
```
CREATE TABLE foo(a int) WITH (appendonly=true);
ALTER TABLE foo SET ACCESS METHOD ao_column;
-- or:
ALTER TABLE foo SET WITH (appendonly=true, orientation=column);
```

Similar to other variations of ATSETAM commands, user can also
    specify reloptions in a WITH clause, such as:

```
ALTER TABLE foo SET ACCESS METHOD ao_column WITH (blocksize=65536);
```

If no reloptions are given, the new AOCO table will use the existing
    table-level options for its column encoding options. If any reloption
    is given in the WITH clause, it will be recorded in the catalog and
    then used for the column encoding option too.

Note that there was once a thought to support specifying column-level
    encoding in the ATSETAM command, but was abandoned because there exists
    better alternatives. Discussions see https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/NaNH6TssgA8

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/ao2aoco

Things that's not covered in this PR
=============

SET column-level options w/o changing AM
--------------

We have another story that we'll try to support setting column-specific encoding in the following syntax:
```
ALTER TABLE foo ALTER COLUMN a SET (blocksize=65536);
```

Note that, after that is supported, we may also do ATSETAM to AOCO table and set column-level options in one statement, e.g.:
```
ALTER TABLE foo SET ACCESS METHOD ao_column, ALTER COLUMN b SET (blocksize=65536);
```
This doesn't even need a syntax change. But the thing is that we won't be able to set the DEFAULT column encoding options. To do that we would still need to define new syntax in one way or another. For me, doing so in the `WITH` clause for both `ALTER TABLE SET ACCESS METHOD WITH()` and `ALTER TABLE SET WITH()` commands seems to be a better way.

ADD COLUMN with ENCODING
--------------

There's also a thought to support `ADD COLUMN` with changing AM to AOCO, e.g.:
```
ALTER TABLE foo SET ACCESS METHOD ao_column, ADD b int ENCODING (blocksize=32768);
```
But the issue is that at the time when we add the column & encoding, the table is still non-AOCO and we need to work around that. That requires some nontrivial change to the ALTER TABLE framework given how things are. Since this is mostly just a syntactic sugar, we probably don't need to deal with that now.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
