### PR TITLE
GetOldestXmin() should use flags as its second parameter

### DIFF
--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -613,7 +613,7 @@ AppendOptimizedRecycleDeadSegments(Relation aorel)
 		else
 		{
 			if (cutoff_xid == InvalidTransactionId)
-				cutoff_xid = GetOldestXmin(NULL, true);
+				cutoff_xid = GetOldestXmin(NULL, PROCARRAY_FLAGS_VACUUM);
 
 			visible_to_all = TransactionIdPrecedes(xmin, cutoff_xid);
 		}


### PR DESCRIPTION
This only one was missed while upstream merging, just set it to
`PROCARRAY_FLAGS_VACUUM` to align the codes, and avoid future risk.

The behavior is actually not changed, `GetLocalOldestXmin()` doesn't check
`PROCARRAY_VACUUM_FLAG` in Greenplum, which was removed from
`PROCARRAY_PROC_FLAGS_MASK`, `true` (0x01) is not checked either.

Reference:

	commit af4b1a0869bd3bb52e5f662e4491554b7f611489
	Author: Simon Riggs <simon@2ndQuadrant.com>
	Date:   Wed Mar 22 16:51:01 2017 +0000

	    Refactor GetOldestXmin() to use flags

	    Replace ignoreVacuum parameter with more flexible flags.

	    Author: Eiji Seki
	    Review: Haribabu Kommi

Fixes #13830 