### PR TITLE
pg_dump: Rework binary upgrade metadata queries.

### DIFF
--- a/src/bin/pg_dump/pg_backup.h
+++ b/src/bin/pg_dump/pg_backup.h
@@ -205,6 +205,11 @@ typedef struct _dumpOptions
 
 	int			sequence_data;	/* dump sequence data even in schema-only mode */
 	int			do_nothing;
+
+	/* GPDB */
+	bool		dumpGpPolicy;
+	bool		isGPbackend;
+	bool 		gp_partitioning_available;
 } DumpOptions;
 
 /*

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -6889,6 +6889,7 @@ getTables(Archive *fout, int *numTables)
 		else
 			tblinfo[i].checkoption = pg_strdup(PQgetvalue(res, i, i_checkoption));
 		tblinfo[i].toast_reloptions = pg_strdup(PQgetvalue(res, i, i_toastreloptions));
+		tblinfo[i].parrelid = atooid(PQgetvalue(res, i, i_parrelid));
 		if (PQgetisnull(res, i, i_reloftype))
 			tblinfo[i].reloftype = NULL;
 		else

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -223,6 +223,9 @@ typedef struct _typeInfo
 	int			nDomChecks;
 	struct _constraintInfo *domChecks;
 	char		*typstorage; /* GPDB: store the type's encoding clause */
+	Oid			typarrayoid; /* OID for type's auto-generated array type, or 0 */
+	char		*typarrayname; /* name of type's auto-generated array type */
+	Oid			typarrayns; /* schema for type's auto-generated array type */
 } TypeInfo;
 
 
@@ -390,7 +393,27 @@ typedef struct _tableInfo
 	struct _tableDataInfo *dataObj; /* TableDataInfo, if dumping its data */
 	int			numTriggers;	/* number of triggers for table */
 	struct _triggerInfo *triggers;	/* array of TriggerInfo structs */
+
+	/* GPDB */
+	Oid		toast_index; 				/* OID of toast table's index */
+	Oid		toast_type;					/* OID of toast table's composite type */
+	struct _aotableInfo	*aotbl; /* AO auxilliary table metadata */
+	char	*distclause; /* distributed by clause */
 } TableInfo;
+
+/* AO auxilliary table metadata */
+typedef struct _aotableInfo
+{
+	bool 	columnstore;
+	Oid 	segrelid;
+	Oid 	segreltype;
+	Oid 	blkdirrelid;
+	Oid 	blkdirreltype;
+	Oid 	blkdiridxid;
+	Oid 	visimaprelid;
+	Oid 	visimapreltype;
+	Oid 	visimapidxid;
+} AOTableInfo;
 
 typedef struct _tableAttachInfo
 {
@@ -435,7 +458,16 @@ typedef struct _indxInfo
 
 	/* if there is an associated constraint object, its dumpId: */
 	DumpId		indexconstraint;
+	struct _bmIndxInfo *bmidx; /* bitmap index auxiliary table metadata */
 } IndxInfo;
+
+/* bitmap index auxiliary table metadata */
+typedef struct _bmIndxInfo
+{
+	Oid		bmrelid;
+	Oid		bmreltype;
+	Oid		bmidxid;
+} BMIndxInfo;
 
 typedef struct _indexAttachInfo
 {
@@ -698,6 +730,7 @@ extern CollInfo *findCollationByOid(Oid oid);
 extern NamespaceInfo *findNamespaceByOid(Oid oid);
 extern ExtensionInfo *findExtensionByOid(Oid oid);
 extern PublicationInfo *findPublicationByOid(Oid oid);
+extern IndxInfo	*findIndexByOid(Oid oid);
 
 extern void recordExtensionMembership(CatalogId catId, ExtensionInfo *ext);
 extern ExtensionInfo *findOwningExtension(CatalogId catalogId);
@@ -760,6 +793,8 @@ extern void getSubscriptions(Archive *fout);
 /* START MPP ADDITION */
 extern ExtProtInfo *getExtProtocols(Archive *fout, int *numExtProtocols);
 extern BinaryUpgradeInfo *getBinaryUpgradeObjects(void);
+extern void getAOTableInfo(Archive *fout);
+extern void getBMIndxInfo(Archive *fout);
 /* END MPP ADDITION */
 
 #endif							/* PG_DUMP_H */

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -225,16 +225,6 @@ typedef struct _typeInfo
 	char		*typstorage; /* GPDB: store the type's encoding clause */
 } TypeInfo;
 
-typedef struct _typeCache
-{
-	DumpableObject dobj;
-
-	Oid			typnsp;
-
-	Oid			arraytypoid;
-	char	   *arraytypname;
-	Oid			arraytypnsp;
-} TypeCache;
 
 typedef struct _shellTypeInfo
 {


### PR DESCRIPTION
This PR refactors the functions used to gather metadata required for binary upgrade schema dumps to avoid repetitive queries in performance-critical paths. 

Upgrades require us to preassign the OIDs of tables, indexes, and types so that they match in the old and new clusters. Previously, multiple queries were executed for each object to gather the necessary info to record in the dump file. Now we gather all of the info required up front and use hash table lookups to set and dump the correct OIDs.

Currently, a database with 100k AO tables can result in well over 1 million queries just to gather the required metadata from the old cluster. This PR eliminates those queries.

The names of pg_toast, pg_aoseg, and pg_bitmapindex tables for the given table/index are set to match what they will be in the new cluster, using the OID of the owning table. In many cases these will be the same as the ones in the old cluster, but not always. Some operations can cause the old table names not to match its owner's OID, but the new cluster will be using the correct name, and it's the new cluster's name that we have to use

The AOTableInfo and BMIndxInfo structs have been added, and metadata fields have been added to the end of the TableInfo, IndxInfo, and TypeInfo structs.

Also, pg_dump now locks all interesting tables in a single statement. This reduces the potentially significant overhead of dispatching many LOCK TABLE queries and reduces the window where external DDL changes can occur.

The query to check for `DISTRIBUTED BY` is now embedded in the single getTables query instead of executing once per table.

These changes result in a significant performance improvement in all cases, but particularly when handling AO tables.

A dump of the regression database shows a performance increase of over 20x and continues to scale as object count increases.

Old: 
```
time pg_dump --schema-only --quote-all-identifiers -s regression --binary-upgrade      
0.82s user 0.21s system 1% cpu 1:27.17 total
```

PR:
```
time pg_dump --schema-only --quote-all-identifiers -s regression --binary-upgrade
0.43s user 0.06s system 12% cpu 3.966 total
```

To illustrate the reason why AO tables are a limiting factor, currently the creation of an AO table actually creates a minimum of 7 catalog objects. When doing a binary upgrade schema dump, we need to record the OIDs of each of these 7 objects to restore in the new cluster. Currently, that requires 7 queries to the old database to collect the info for 1 AO table. 
Practically, most AO tables have an index and a toast table, meaning we need to create 13 objects. 
This gets out of hand very quickly if the AO table is heavily partitioned and this doesn't consider the pg_upgrade overhead with AO tables, only pg_dump. Currently, every type object being dumped does an extra query checking for typarray value, which is always 0 for these composite types, but the query is sent anyway, so we add 5 more queries for a total of 18 for the AO table.

Here's the OID assignment for an AO table with a toast field and an index.

```
"adding OID assignment: catalog ""1259"", namespace: 2200, name: ""ao_table"": 93730"                <--- table
"adding OID assignment: catalog ""1247"", namespace: 2200, name: ""ao_table"": 93731"                <---composite type for table

"adding OID assignment: catalog ""1259"", namespace: 99, name: ""pg_toast_93730"": 93737"            <--- toast table
"adding OID assignment: catalog ""1247"", namespace: 99, name: ""pg_toast_93730"": 93738"            <--- composite type for toast table 
"adding OID assignment: catalog ""1259"", namespace: 99, name: ""pg_toast_93730_index"": 93739"      <--- index for toast table

"adding OID assignment: catalog ""1259"", namespace: 6104, name: ""pg_aoseg_93730"": 93732"          <--- pg_aoseg table
"adding OID assignment: catalog ""1247"", namespace: 6104, name: ""pg_aoseg_93730"": 93733"          <--- composite type for pg_aoseg table

"adding OID assignment: catalog ""1259"", namespace: 6104, name: ""pg_aoblkdir_93730"": 93740"       <--- blkdir table (created if `ao_table` has an index)
"adding OID assignment: catalog ""1247"", namespace: 6104, name: ""pg_aoblkdir_93730"": 93741"       <--- composite type for blkdir table
"adding OID assignment: catalog ""1259"", namespace: 6104, name: ""pg_aoblkdir_93730_index"": 93742" <--- index for blkdir table

"adding OID assignment: catalog ""1259"", namespace: 6104, name: ""pg_aovisimap_93730"": 93734"      <--- aovisimap table
"adding OID assignment: catalog ""1247"", namespace: 6104, name: ""pg_aovisimap_93730"": 93735"      <--- composite type for aovisimap table 
"adding OID assignment: catalog ""1259"", namespace: 6104, name: ""pg_aovisimap_93730_index"": 93736"<--- index for aovisimap table
```
