### PR TITLE
auto_explain: fix failure when executor hooks are run in QEs

### DIFF
--- a/contrib/auto_explain/Makefile
+++ b/contrib/auto_explain/Makefile
@@ -4,7 +4,7 @@ MODULE_big = auto_explain
 OBJS = auto_explain.o $(WIN32RES)
 PGFILEDESC = "auto_explain - logging facility for execution plans"
 
-REGRESS = auto_explain
+REGRESS = auto_explain bfv_preload_auto_explain
 REGRESS_OPTS = --init-file=init_file
 
 ifdef USE_PGXS

--- a/contrib/auto_explain/auto_explain.c
+++ b/contrib/auto_explain/auto_explain.c
@@ -66,9 +66,15 @@ static int	nesting_level = 0;
 /* Is the current top-level query to be sampled? */
 static bool current_query_sampled = false;
 
+/*
+ * If auto_explain is enabled as shared_preload_library
+ * and some work (as executor) is doing at master we need to disable auto_explain.
+ * At this case auto_explain will be disabled by check Gp_role.
+ */
 #define auto_explain_enabled() \
 	(auto_explain_log_min_duration >= 0 && \
 	 (nesting_level == 0 || auto_explain_log_nested_statements) && \
+	 Gp_role == GP_ROLE_DISPATCH && \
 	 current_query_sampled)
 
 /* Saved hook values in case of unload */

--- a/contrib/auto_explain/expected/bfv_preload_auto_explain.out
+++ b/contrib/auto_explain/expected/bfv_preload_auto_explain.out
@@ -1,0 +1,66 @@
+-- start_ignore
+\! gpconfig -c shared_preload_libraries -v 'auto_explain';
+20220725:08:37:39:077123 gpconfig:evgeniy-pc:evgeniy-[INFO]:-completed successfully with parameters '-c shared_preload_libraries -v auto_explain'
+\! gpconfig -c auto_explain.log_min_duration -v 0 --skipvalidation;
+20220725:08:37:39:077208 gpconfig:evgeniy-pc:evgeniy-[INFO]:-completed successfully with parameters '-c auto_explain.log_min_duration -v 0 --skipvalidation'
+\! gpconfig -c auto_explain.log_analize -v true --skipvalidation;
+20220725:08:37:39:077292 gpconfig:evgeniy-pc:evgeniy-[INFO]:-completed successfully with parameters '-c auto_explain.log_analize -v true --skipvalidation'
+\! gpstop -raiq;
+\c
+-- end_ignore
+SET CLIENT_MIN_MESSAGES = LOG;
+-- check that auto_explain doesn't work on coordinator with Gp_role is not a GP_ROLE_DISPATCH
+-- Query 'SELECT count(1) from (select i from t1 limit 10) t join t2 using (i)' generate executor's slice on coordinator:
+--             ->  Redistribute Motion 1:3  (slice2)
+--                   Output: t1.i
+--                   Hash Key: t1.i
+--                   ->  Limit
+--                         Output: t1.i
+--                         ->  Gather Motion 3:1  (slice1; segments: 3)
+-- IMPORTANT: ./configure with --enable-orca
+CREATE TABLE t1(i int);
+LOG:  statement: CREATE TABLE t1(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE t2(i int);
+LOG:  statement: CREATE TABLE t2(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
+LOG:  statement: SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
+LOG:  duration: 3.033 ms  plan:
+Query Text: SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
+Finalize Aggregate  (cost=475.67..475.68 rows=1 width=8) (actual time=3.018..3.018 rows=1 loops=1)
+  ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=475.61..475.66 rows=3 width=8) (actual time=2.911..3.009 rows=3 loops=1)
+        ->  Partial Aggregate  (cost=475.61..475.62 rows=1 width=8) (actual time=2.629..2.630 rows=1 loops=1)
+              ->  Hash Join  (cost=35.95..474.81 rows=321 width=0) (never executed)
+                    Hash Cond: (t2.i = t1.i)
+                    ->  Seq Scan on t2  (cost=0.00..355.00 rows=32100 width=4) (never executed)
+                    ->  Hash  (cost=35.90..35.90 rows=3 width=4) (never executed)
+                          Buckets: 524288  Batches: 1  Memory Usage: 4096kB
+                          ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=35.50..35.90 rows=3 width=4) (never executed)
+                                Hash Key: t1.i
+                                ->  Limit  (cost=35.50..35.67 rows=10 width=4) (never executed)
+                                      ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=35.50..36.01 rows=30 width=4) (never executed)
+                                            ->  Limit  (cost=35.50..35.61 rows=10 width=4) (never executed)
+                                                  ->  Seq Scan on t1  (cost=0.00..355.00 rows=32100 width=4) (never executed)
+Optimizer: Postgres query optimizer
+  (slice0)    Executor memory: 57K bytes.
+  (slice1)    Executor memory: 4120K bytes avg x 3 workers, 4120K bytes max (seg0).  Work_mem: 4096K bytes max.
+  (slice2)    Executor memory: 38K bytes (seg2).
+  (slice3)    Executor memory: 38K bytes avg x 3 workers, 38K bytes max (seg0).
+Memory used:  128000kB
+ count 
+-------
+     0
+(1 row)
+
+DROP TABLE t1;
+LOG:  statement: DROP TABLE t1;
+DROP TABLE t2;
+LOG:  statement: DROP TABLE t2;
+-- start_ignore
+\! gpconfig -r shared_preload_libraries;
+20220725:08:37:44:077741 gpconfig:evgeniy-pc:evgeniy-[INFO]:-completed successfully with parameters '-r shared_preload_libraries'
+\! gpstop -raiq;
+-- end_ignore

--- a/contrib/auto_explain/expected/bfv_preload_auto_explain_optimizer.out
+++ b/contrib/auto_explain/expected/bfv_preload_auto_explain_optimizer.out
@@ -1,0 +1,65 @@
+-- start_ignore
+\! gpconfig -c shared_preload_libraries -v 'auto_explain';
+20220725:08:28:26:008391 gpconfig:evgeniy-pc:evgeniy-[INFO]:-completed successfully with parameters '-c shared_preload_libraries -v auto_explain'
+\! gpconfig -c auto_explain.log_min_duration -v 0 --skipvalidation;
+20220725:08:28:27:008476 gpconfig:evgeniy-pc:evgeniy-[INFO]:-completed successfully with parameters '-c auto_explain.log_min_duration -v 0 --skipvalidation'
+\! gpconfig -c auto_explain.log_analize -v true --skipvalidation;
+20220725:08:28:27:008560 gpconfig:evgeniy-pc:evgeniy-[INFO]:-completed successfully with parameters '-c auto_explain.log_analize -v true --skipvalidation'
+\! gpstop -raiq;
+\c
+-- end_ignore
+SET CLIENT_MIN_MESSAGES = LOG;
+-- check that auto_explain doesn't work on coordinator with Gp_role is not a GP_ROLE_DISPATCH
+-- Query 'SELECT count(1) from (select i from t1 limit 10) t join t2 using (i)' generate executor's slice on coordinator:
+--             ->  Redistribute Motion 1:3  (slice2)
+--                   Output: t1.i
+--                   Hash Key: t1.i
+--                   ->  Limit
+--                         Output: t1.i
+--                         ->  Gather Motion 3:1  (slice1; segments: 3)
+-- IMPORTANT: ./configure with --enable-orca
+CREATE TABLE t1(i int);
+LOG:  statement: CREATE TABLE t1(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE t2(i int);
+LOG:  statement: CREATE TABLE t2(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
+LOG:  statement: SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
+LOG:  statement: SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);  (entry db 127.0.1.1:7000 pid=9001)
+LOG:  duration: 2.940 ms  plan:
+Query Text: SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
+Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=2.929..2.930 rows=1 loops=1)
+  ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=1) (actual time=2.925..2.925 rows=0 loops=1)
+        ->  Hash Join  (cost=0.00..862.00 rows=1 width=1) (never executed)
+              Hash Cond: (t1.i = t2.i)
+              ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                    Hash Key: t1.i
+                    ->  Limit  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                          ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                                ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4) (never executed)
+              ->  Hash  (cost=431.00..431.00 rows=1 width=4) (never executed)
+                    Buckets: 524288  Batches: 1  Memory Usage: 4096kB
+                    ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4) (never executed)
+Optimizer: Pivotal Optimizer (GPORCA)
+  (slice0)    Executor memory: 48K bytes.
+  (slice1)    Executor memory: 4117K bytes avg x 3 workers, 4117K bytes max (seg0).  Work_mem: 4096K bytes max.
+  (slice2)    Executor memory: 63K bytes (entry db).
+  (slice3)    Executor memory: 38K bytes avg x 3 workers, 38K bytes max (seg0).
+Memory used:  128000kB
+ count 
+-------
+     0
+(1 row)
+
+DROP TABLE t1;
+LOG:  statement: DROP TABLE t1;
+DROP TABLE t2;
+LOG:  statement: DROP TABLE t2;
+-- start_ignore
+\! gpconfig -r shared_preload_libraries;
+20220725:08:28:31:009010 gpconfig:evgeniy-pc:evgeniy-[INFO]:-completed successfully with parameters '-r shared_preload_libraries'
+\! gpstop -raiq;
+-- end_ignore

--- a/contrib/auto_explain/init_file
+++ b/contrib/auto_explain/init_file
@@ -17,4 +17,10 @@ s/Memory used:\s+[0-9]+kB.*/Memory used:/
 m/work_mem: \d+kB  Segments: \d+  Max: \d+kB \(segment \d+\)/
 s/work_mem: \d+kB  Segments: \d+  Max: \d+kB \(segment \d+\)/work_mem: 99kB  Segments: 9  Max: 99kB/
 
+m/LOG:  statement: SELECT count\(1\) from \(select i from t1 limit 10\) t join t2 using \(i\);  \(entry db .*/
+s/LOG:  statement: SELECT count\(1\) from \(select i from t1 limit 10\) t join t2 using \(i\);  \(entry db .*/LOG:  statement: SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);  (entry db)/
+
+m/Buckets: \d+  Batches: 1  Memory Usage: \d+kB/
+s/Buckets: \d+  Batches: 1  Memory Usage: \d+kB/Buckets: 1048576  Batches: 1  Memory Usage: 8192kB/
+
 -- end_matchsubs

--- a/contrib/auto_explain/sql/bfv_preload_auto_explain.sql
+++ b/contrib/auto_explain/sql/bfv_preload_auto_explain.sql
@@ -1,0 +1,32 @@
+-- start_ignore
+\! gpconfig -c shared_preload_libraries -v 'auto_explain';
+\! gpconfig -c auto_explain.log_min_duration -v 0 --skipvalidation;
+\! gpconfig -c auto_explain.log_analyze -v true --skipvalidation;
+\! gpstop -raiq;
+\c
+-- end_ignore
+
+SET CLIENT_MIN_MESSAGES = LOG;
+
+-- check that auto_explain doesn't work on coordinator with Gp_role is not a GP_ROLE_DISPATCH
+-- Query 'SELECT count(1) from (select i from t1 limit 10) t join t2 using (i)' generate executor's slice on coordinator:
+--             ->  Redistribute Motion 1:3  (slice2)
+--                   Output: t1.i
+--                   Hash Key: t1.i
+--                   ->  Limit
+--                         Output: t1.i
+--                         ->  Gather Motion 3:1  (slice1; segments: 3)
+-- IMPORTANT: ./configure with --enable-orca
+
+CREATE TABLE t1(i int);
+CREATE TABLE t2(i int);
+SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
+DROP TABLE t1;
+DROP TABLE t2;
+
+-- start_ignore
+\! gpconfig -r auto_explain.log_min_duration;
+\! gpconfig -r auto_explain.log_analyze;
+\! gpconfig -r shared_preload_libraries;
+\! gpstop -raiq;
+-- end_ignore


### PR DESCRIPTION
The reason of failure is that auto_explain hooks are fully executed on QEs.
The global variable Gp_role is initialized after auto_explain is loaded as shared preload library.
The QE has valid planstate objects just for nodes in query plan corresponded to the slice of current QE.
As result, for "intermediate" slices we have NULL pointer to subtree state for "child" (within slice borders)
Motion nodes (subtree itself is valid and points to real node but state for this subtree is not).
ExplainNode() routine called within ExplainPrintPlan() function fails trying to dereference that pointer.

To fix the failure I've changed the guard check Gp_role != GP_ROLE_DISPATCH in _PG_init() of auto_explain
to macro IS_QUERY_DISPATCHER() that relies on GpIdentity.segindex value to define the kind of node on which
code is executed. As a consequence, hooks of auto_explain are activated just on coordinator node.
To exclude execution of hooks on coordinator on entrydb kind of worker (having gp_role=executor)
I've added additional check Gp_role != GP_ROLE_DISPATCH into macro auto_explain_enabled().
This check disables auto_explain when some work (as executor) is doing at master.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
