### PR TITLE
docs - corrected a clerical error about 'gp_resource_group_memory_limit'

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -4557,13 +4557,13 @@
           default <codeph>gp_resource_group_memory_limit</codeph> of <codeph>0.7</codeph> and a
           segment host named <codeph>seghost1</codeph> has 4 primary segments and 4 mirror segments.
           Greenplum Database assigns each primary segment on <codeph>seghost1</codeph>
-          <codeph>(0.7 / 4 = 0.175%)</codeph> of overall system memory. If failover occurs and two
+          <codeph>(0.7 / 4 = 0.175)</codeph> of overall system memory. If failover occurs and two
           mirrors on <codeph>seghost1</codeph> fail over to become primary segments, each of the
           original 4 primaries retain their memory allotment of <codeph>0.175</codeph>, and the two
-          new primary segments are each allotted <codeph>(0.7 / 6 = 0.116%)</codeph> of system
+          new primary segments are each allotted <codeph>(0.7 / 6 = 0.116)</codeph> of system
           memory. <codeph>seghost1</codeph>'s overall memory allocation in this scenario is</p><p>
           <codeblock>
-0.7 + (0.116 * 2) = 0.932%</codeblock>
+0.7 + (0.116 * 2) = 0.932</codeblock>
         </p>
         <p>which is above the percentage configured in the
             <codeph>gp_resource_group_memory_limit</codeph> setting.</p></note>


### PR DESCRIPTION
There is a clerical error about 'gp_resource_group_memory_limit' introductions.

For example, 0.175 means 17.5%, so we should not add '%' after 0.175.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [x] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
