### PR TITLE
Eliminate alien nodes before execution for entry db

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -1423,6 +1423,16 @@ formIdleSegmentIdList(void)
 		}
 	}
 
+	if (cdbs->entry_db_info != NULL)
+	{
+		for (i = 0; i < cdbs->total_entry_dbs; i++)
+		{
+			CdbComponentDatabaseInfo *cdi = &cdbs->entry_db_info[i];
+			for (j = 0; j < cdi->numIdleQEs; j++)
+				segments = lappend_int(segments, cdi->config->segindex);
+		}
+	}
+
 	return segments;
 }
 

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -557,7 +557,7 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 	 *
 	 * TODO: eliminate aliens even on master, if not EXPLAIN ANALYZE
 	 */
-	estate->eliminateAliens = execute_pruned_plan && estate->es_sliceTable && estate->es_sliceTable->hasMotions && !IS_QUERY_DISPATCHER();
+	estate->eliminateAliens = execute_pruned_plan && estate->es_sliceTable && estate->es_sliceTable->hasMotions && (Gp_role == GP_ROLE_EXECUTE);
 
 	/*
 	 * Set up an AFTER-trigger statement context, unless told not to, or


### PR DESCRIPTION
https://github.com/greenplum-db/gpdb/pull/2588 eliminates alien nodes before execution but entry db nodes was missed.
This PR adds alien nodes elimination for entry db.
There is a small fix in `formIdleSegmentIdList` function to  propagate GUC change to **entry db** (e.g. `execute_pruned_plan` that was used in test).

The is a PR https://github.com/arenadata/gpdb/pull/352 in GPDB fork in **6x** that also adds test for entry db nodes elimination.

As there is no memory accounting for **X_Alien** nodes in **master** alien nodes elimination can be tested manually (i.e. test from https://github.com/greenplum-db/gpdb/pull/2663 is not applicable).
