### PR TITLE
pg_dump: Fix failing test on Ubuntu 18

### DIFF
--- a/src/bin/pg_dump/t/002_pg_dump.pl
+++ b/src/bin/pg_dump/t/002_pg_dump.pl
@@ -1569,7 +1569,7 @@ my %tests = (
 		\n\QOPTIONS (\E
 		\n\s+\Qcommand 'echo foo',\E
 		\n\s+\Qdelimiter '\E\s+\Q',\E
-		\n\s+\Qencoding '6',\E
+		\n\s+\Qencoding '\E\d\Q',\E
 		\n\s+\Qescape E'\\',\E
 		\n\s+\Qexecute_on 'ALL_SEGMENTS',\E
 		\n\s+\Qformat 'text',\E


### PR DESCRIPTION
Perl 5.26 packaged with Ubuntu 18 didn't like some newly introduced regex, this fixes the failing test for that platform.

Failed test was `should dump CREATE EXTERNAL WEB TABLE dump_test.dummy_ext_tab`

