### PR TITLE
Fix bitmap index scan NULL failed

### DIFF
--- a/contrib/bloom/blutils.c
+++ b/contrib/bloom/blutils.c
@@ -144,6 +144,7 @@ blhandler(PG_FUNCTION_ARGS)
 	amroutine->amestimateparallelscan = NULL;
 	amroutine->aminitparallelscan = NULL;
 	amroutine->amparallelrescan = NULL;
+    amroutine->aminitbitmap = NULL;
 
 	PG_RETURN_POINTER(amroutine);
 }

--- a/src/backend/access/bitmap/bitmap.c
+++ b/src/backend/access/bitmap/bitmap.c
@@ -108,6 +108,7 @@ bmhandler(PG_FUNCTION_ARGS)
 	amroutine->amendscan = bmendscan;
 	amroutine->ammarkpos = bmmarkpos;
 	amroutine->amrestrpos = bmrestrpos;
+    amroutine->aminitbitmap = bminitbitmap;
 
 	PG_RETURN_POINTER(amroutine);
 }
@@ -238,6 +239,29 @@ stream_begin_iterate(StreamNode *self, StreamBMIterator *iterator)
 
 		iterator->opaque = so;
 	}
+}
+
+/*
+ * bminitbitmap() -- return a empty bitmap.
+ * */
+void
+bminitbitmap(Node **bmNodeP)
+{
+    IndexStream  *is;
+
+    is = (IndexStream *)palloc0(sizeof(IndexStream));
+	is->type = BMS_INDEX;
+	is->begin_iterate = stream_begin_iterate;
+	is->free = indexstream_free;
+	is->set_instrument = NULL;
+	is->upd_instrument = NULL;
+	is->opaque = NULL;
+
+	StreamBitmap *sb = makeNode(StreamBitmap);
+	sb->streamNode = is;
+	*bmNodeP = (Node *) sb;
+
+    return;
 }
 
 /*

--- a/src/backend/access/brin/brin.c
+++ b/src/backend/access/brin/brin.c
@@ -132,6 +132,7 @@ brinhandler(PG_FUNCTION_ARGS)
 	amroutine->amestimateparallelscan = NULL;
 	amroutine->aminitparallelscan = NULL;
 	amroutine->amparallelrescan = NULL;
+    amroutine->aminitbitmap = NULL;
 
 	PG_RETURN_POINTER(amroutine);
 }

--- a/src/backend/access/gin/ginutil.c
+++ b/src/backend/access/gin/ginutil.c
@@ -76,6 +76,7 @@ ginhandler(PG_FUNCTION_ARGS)
 	amroutine->amestimateparallelscan = NULL;
 	amroutine->aminitparallelscan = NULL;
 	amroutine->amparallelrescan = NULL;
+    amroutine->aminitbitmap = NULL;
 
 	PG_RETURN_POINTER(amroutine);
 }

--- a/src/backend/access/gist/gist.c
+++ b/src/backend/access/gist/gist.c
@@ -98,6 +98,7 @@ gisthandler(PG_FUNCTION_ARGS)
 	amroutine->amestimateparallelscan = NULL;
 	amroutine->aminitparallelscan = NULL;
 	amroutine->amparallelrescan = NULL;
+    amroutine->aminitbitmap = NULL;
 
 	PG_RETURN_POINTER(amroutine);
 }

--- a/src/backend/access/hash/hash.c
+++ b/src/backend/access/hash/hash.c
@@ -97,6 +97,7 @@ hashhandler(PG_FUNCTION_ARGS)
 	amroutine->amestimateparallelscan = NULL;
 	amroutine->aminitparallelscan = NULL;
 	amroutine->amparallelrescan = NULL;
+    amroutine->aminitbitmap =NULL;
 
 	PG_RETURN_POINTER(amroutine);
 }

--- a/src/backend/access/index/indexam.c
+++ b/src/backend/access/index/indexam.c
@@ -28,6 +28,7 @@
  *		index_fetch_heap		- get the scan's next heap tuple
  *		index_getnext_slot	- get the next tuple from a scan
  *		index_getbitmap - get all tuples from a scan
+ *      index_initbitmap - get an empty bitmap
  *		index_bulk_delete	- bulk deletion of index tuples
  *		index_vacuum_cleanup	- post-deletion cleanup of an index
  *		index_can_return	- does index support index-only scans?
@@ -633,6 +634,20 @@ index_getnext_slot(IndexScanDesc scan, ScanDirection direction, TupleTableSlot *
 	}
 
 	return false;
+}
+
+/*
+ * index_initbitmap - get an empty bitmap
+ * */
+void
+index_initbitmap(IndexScanDesc scan, Node **bitmapP)
+{
+	SCAN_CHECKS;
+	CHECK_SCAN_PROCEDURE(amgetbitmap);
+
+    scan->indexRelation->rd_indam->aminitbitmap(bitmapP);
+
+    return;
 }
 
 /* ----------------

--- a/src/backend/access/nbtree/nbtree.c
+++ b/src/backend/access/nbtree/nbtree.c
@@ -150,6 +150,7 @@ bthandler(PG_FUNCTION_ARGS)
 	amroutine->amestimateparallelscan = btestimateparallelscan;
 	amroutine->aminitparallelscan = btinitparallelscan;
 	amroutine->amparallelrescan = btparallelrescan;
+    amroutine->aminitbitmap = btinitbitmap;
 
 	PG_RETURN_POINTER(amroutine);
 }
@@ -361,6 +362,20 @@ btgettuple(IndexScanDesc scan, ScanDirection dir)
 	} while (so->numArrayKeys && _bt_advance_array_keys(scan, dir));
 
 	return res;
+}
+
+/*
+ * btinitbitmap() -- construct an empty TIDBitmap.
+ * */
+void btinitbitmap(Node **bmNodeP)
+{
+    TIDBitmap  *tbm;
+
+    Assert(bmNodeP);
+    tbm = tbm_create(work_mem * 1024L, NULL);
+    *bmNodeP = (Node *) tbm;
+
+    return;
 }
 
 /*

--- a/src/backend/access/spgist/spgutils.c
+++ b/src/backend/access/spgist/spgutils.c
@@ -79,6 +79,7 @@ spghandler(PG_FUNCTION_ARGS)
 	amroutine->amestimateparallelscan = NULL;
 	amroutine->aminitparallelscan = NULL;
 	amroutine->amparallelrescan = NULL;
+    amroutine->aminitbitmap = NULL;
 
 	PG_RETURN_POINTER(amroutine);
 }

--- a/src/backend/executor/nodeBitmapIndexscan.c
+++ b/src/backend/executor/nodeBitmapIndexscan.c
@@ -96,6 +96,11 @@ MultiExecBitmapIndexScan(BitmapIndexScanState *node)
 	{
 		ExecReScan((PlanState *) node);
 		doscan = node->biss_RuntimeKeysReady;
+
+        /* Return an empty bitmap if biss_RuntimeKeysReady still false.*/
+        if (!doscan) {
+            index_initbitmap(scandesc, &bitmap);
+        }
 	}
 	else
 		doscan = true;

--- a/src/include/access/amapi.h
+++ b/src/include/access/amapi.h
@@ -134,6 +134,9 @@ typedef bool (*amgettuple_function) (IndexScanDesc scan,
 typedef int64 (*amgetbitmap_function) (IndexScanDesc scan,
 									   Node **bmNodeP);
 
+/* init empty bitmap */
+typedef void (*aminitbitmap_function) (Node **bmNodeP);
+
 /* end index scan */
 typedef void (*amendscan_function) (IndexScanDesc scan);
 
@@ -225,6 +228,7 @@ typedef struct IndexAmRoutine
 	amendscan_function amendscan;
 	ammarkpos_function ammarkpos;	/* can be NULL */
 	amrestrpos_function amrestrpos; /* can be NULL */
+    aminitbitmap_function aminitbitmap; /* can be NULL */
 
 	/* interface functions to support parallel index scans */
 	amestimateparallelscan_function amestimateparallelscan; /* can be NULL */

--- a/src/include/access/bitmap_private.h
+++ b/src/include/access/bitmap_private.h
@@ -256,6 +256,7 @@ extern bool bminsert(Relation rel, Datum *values, bool *isnull,
 extern IndexScanDesc bmbeginscan(Relation rel, int nkeys, int norderbys);
 extern bool bmgettuple(IndexScanDesc scan, ScanDirection dir);
 extern int64 bmgetbitmap(IndexScanDesc scan, Node **bmNodeP);
+extern void bminitbitmap(Node **bmNodeP);
 extern void bmrescan(IndexScanDesc scan, ScanKey scankey, int nscankeys,
 		 ScanKey orderbys, int norderbys);
 extern void bmendscan(IndexScanDesc scan);

--- a/src/include/access/genam.h
+++ b/src/include/access/genam.h
@@ -165,6 +165,7 @@ extern bool index_fetch_heap(IndexScanDesc scan, struct TupleTableSlot *slot);
 extern bool index_getnext_slot(IndexScanDesc scan, ScanDirection direction,
 							   struct TupleTableSlot *slot);
 extern int64 index_getbitmap(IndexScanDesc scan, Node **bitmapP);
+extern void index_initbitmap(IndexScanDesc scan, Node **bitmapP);
 
 extern IndexBulkDeleteResult *index_bulk_delete(IndexVacuumInfo *info,
 												IndexBulkDeleteResult *stats,

--- a/src/include/access/nbtree.h
+++ b/src/include/access/nbtree.h
@@ -704,6 +704,7 @@ extern Size btestimateparallelscan(void);
 extern void btinitparallelscan(void *target);
 extern bool btgettuple(IndexScanDesc scan, ScanDirection dir);
 extern int64 btgetbitmap(IndexScanDesc scan, Node **bmNodeP);
+extern void btinitbitmap(Node **bmNodeP);
 extern void btrescan(IndexScanDesc scan, ScanKey scankey, int nscankeys,
 					 ScanKey orderbys, int norderbys);
 extern void btparallelrescan(IndexScanDesc scan);

--- a/src/test/regress/expected/bitmap_index.out
+++ b/src/test/regress/expected/bitmap_index.out
@@ -952,5 +952,44 @@ select count(*) from foo_13446 where b = 1;
 (1 row)
 
 drop table foo_13446;
+-- test bitmap index scan when using NULL array-condition as index key
+SET enable_bitmapscan = ON;
+SET enable_indexscan = ON;
+SET enable_seqscan = OFF;
+create table foo(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index foo_i on foo using bitmap(a);
+explain (verbose on, costs off) select * from foo where a = any(null::int[]);
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: a
+   ->  Bitmap Heap Scan on public.foo
+         Output: a
+         Recheck Cond: (foo.a = ANY (NULL::integer[]))
+         ->  Bitmap Index Scan on foo_i
+               Index Cond: (foo.a = ANY (NULL::integer[]))
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select * from foo where a = any(null::int[]);
+ a 
+---
+(0 rows)
+
+insert into foo values(1);
+select * from foo where a = 1 and a = any(null::int[]);
+ a 
+---
+(0 rows)
+
+select * from foo where a = 1 or a = any(null::int[]);
+ a 
+---
+ 1
+(1 row)
+
+drop table foo;
 SET enable_seqscan = ON;
 SET enable_bitmapscan = ON;

--- a/src/test/regress/expected/bitmap_index_optimizer.out
+++ b/src/test/regress/expected/bitmap_index_optimizer.out
@@ -958,5 +958,44 @@ select count(*) from foo_13446 where b = 1;
 (1 row)
 
 drop table foo_13446;
+-- test bitmap index scan when using NULL array-condition as index key
+SET enable_bitmapscan = ON;
+SET enable_indexscan = ON;
+SET enable_seqscan = OFF;
+create table foo(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index foo_i on foo using bitmap(a);
+explain (verbose on, costs off) select * from foo where a = any(null::int[]);
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: a
+   ->  Bitmap Heap Scan on public.foo
+         Output: a
+         Recheck Cond: (foo.a = ANY (NULL::integer[]))
+         ->  Bitmap Index Scan on foo_i
+               Index Cond: (foo.a = ANY (NULL::integer[]))
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select * from foo where a = any(null::int[]);
+ a 
+---
+(0 rows)
+
+insert into foo values(1);
+select * from foo where a = 1 and a = any(null::int[]);
+ a 
+---
+(0 rows)
+
+select * from foo where a = 1 or a = any(null::int[]);
+ a 
+---
+ 1
+(1 row)
+
+drop table foo;
 SET enable_seqscan = ON;
 SET enable_bitmapscan = ON;

--- a/src/test/regress/sql/bitmap_index.sql
+++ b/src/test/regress/sql/bitmap_index.sql
@@ -407,6 +407,21 @@ select count(*) from foo_13446 where b = 1;
 
 drop table foo_13446;
 
+-- test bitmap index scan when using NULL array-condition as index key
+SET enable_bitmapscan = ON;
+SET enable_indexscan = ON;
+SET enable_seqscan = OFF;
+create table foo(a int);
+create index foo_i on foo using bitmap(a);
+explain (verbose on, costs off) select * from foo where a = any(null::int[]);
+select * from foo where a = any(null::int[]);
+
+insert into foo values(1);
+select * from foo where a = 1 and a = any(null::int[]);
+select * from foo where a = 1 or a = any(null::int[]);
+
+drop table foo;
+
 SET enable_seqscan = ON;
 SET enable_bitmapscan = ON;
 


### PR DESCRIPTION
when we create bitmap-index on column and using bitmap index scan with NULL array condition on this column, then failed. Like this:
> create temp table foo (a int); 
> create index foo_i on foo using bitmap(a); 

> select * from foo where a = any(null::int[]); 
> Conversant: ERROR "unrecognized result from subplan (nodeBitmapHeapscan.c:293)"

The reason is when we using bitmap-index scan on NULL Array key condition, MultiExecbitmapscan treate it as runtime key then it will return NULL to parent node. But for parent node like BitmapHeapNext cannot handle NULL return, then error happened. So we should return an empty bitmap instead of nothing to upper node(BitmapHeapNext), and force BitmapHeapNext scan this empty bitmap.

In this case, we add a new interface am-handler aminitbitmap for different index. But only btree and bitmap index could support bitmapindex scan, for other indexes we just set aminitbitmap handler to NULL.

Maybe someone concerns about add new index handler function here. If we don's use index handler then we need to have index-handle function for different index in Executor and that's what handler did. 


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
