### PR TITLE
Fix gpdb hooks calling in PortalStart in case of exceptions caught.

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -306,7 +306,7 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 		{
 			PG_TRY();
 			{
-				switch(*gp_resmanager_memory_policy)
+				switch (*gp_resmanager_memory_policy)
 				{
 					case RESMANAGER_MEMORY_POLICY_AUTO:
 						PolicyAutoAssignOperatorMemoryKB(queryDesc->plannedstmt,
@@ -323,7 +323,10 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 			}
 			PG_CATCH();
 			{
-				mppExecutorCleanup(queryDesc);
+				/* GPDB hook for collecting query info */
+				if (query_info_collect_hook)
+					(*query_info_collect_hook)(QueryCancelCleanup ? METRICS_QUERY_CANCELED : METRICS_QUERY_ERROR, queryDesc);
+
 				PG_RE_THROW();
 			}
 			PG_END_TRY();


### PR DESCRIPTION
**This PR is a following fix after #12694, as the `queryDesc->estate` may be NULL in the catch block, which may cause a PANIC.**


According to a reported error in PolicyEagerFreeAssignOperatorMemoryKB makes query end without calling GPDB hooks https://github.com/greenplum-db/gpdb/issues/12690 , the code path in standard_ExecutorStart didn't handle exception in PolicyAutoAssignOperatorMemoryKB and PolicyEagerFreeAssignOperatorMemoryKB calling, which may cause the OOM exception not handled in standard_ExecutorStart but throw to upper PortalStart methods, while there is also exception handling machanism in PortalStart but GPDB hooks will not be called because of portal->queryDesc will be NULL in certain transation states. This PR fixed this issue.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
