### PR TITLE
Revert mppExecutorCleanup() call in standard_ExecutorStart's catch block

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -384,29 +384,20 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 
 		if (!should_skip_operator_memory_assign)
 		{
-			PG_TRY();
+			switch(*gp_resmanager_memory_policy)
 			{
-				switch(*gp_resmanager_memory_policy)
-				{
-					case RESMANAGER_MEMORY_POLICY_AUTO:
-						PolicyAutoAssignOperatorMemoryKB(queryDesc->plannedstmt,
+				case RESMANAGER_MEMORY_POLICY_AUTO:
+					PolicyAutoAssignOperatorMemoryKB(queryDesc->plannedstmt,
 													 queryDesc->plannedstmt->query_mem);
-						break;
-					case RESMANAGER_MEMORY_POLICY_EAGER_FREE:
-						PolicyEagerFreeAssignOperatorMemoryKB(queryDesc->plannedstmt,
+					break;
+				case RESMANAGER_MEMORY_POLICY_EAGER_FREE:
+					PolicyEagerFreeAssignOperatorMemoryKB(queryDesc->plannedstmt,
 														  queryDesc->plannedstmt->query_mem);
-						break;
-					default:
-						Assert(IsResManagerMemoryPolicyNone());
-						break;
-				}
+					break;
+				default:
+					Assert(IsResManagerMemoryPolicyNone());
+					break;
 			}
-			PG_CATCH();
-			{
-				mppExecutorCleanup(queryDesc);
-				PG_RE_THROW();
-			}
-			PG_END_TRY();
 		}
 	}
 


### PR DESCRIPTION
**This PR reverts the commit feb285612914edb9a5078178b3adfe9e0459cabe , as the `queryDesc->estate` may be `NULL` in the catch block, which may cause a PANIC.**


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
