### PR TITLE
Remove unnecessary null pointer checks in gpcloud code

### DIFF
--- a/gpcontrib/gpcloud/src/gpreader.cpp
+++ b/gpcontrib/gpcloud/src/gpreader.cpp
@@ -53,7 +53,7 @@ int thread_cleanup(void) {
     for (int i = 0; i < CRYPTO_num_locks(); i++) {
         MUTEX_CLEANUP(mutex_buf[i]);
     }
-    delete mutex_buf;
+    delete[] mutex_buf;
     mutex_buf = NULL;
     return 1;
 }
@@ -109,17 +109,13 @@ GPReader* reader_init(const char* url_with_options) {
         reader->open(params);
         return reader;
     } catch (S3Exception& e) {
-        if (reader != NULL) {
-            delete reader;
-        }
+        delete reader;
         s3extErrorMessage =
             "reader_init caught a " + e.getType() + " exception: " + e.getFullMessage();
         S3ERROR("reader_init caught %s: %s", e.getType().c_str(), s3extErrorMessage.c_str());
         return NULL;
     } catch (...) {
-        if (reader != NULL) {
-            delete reader;
-        }
+        delete reader;
         S3ERROR("Caught an unexpected exception.");
         s3extErrorMessage = "Caught an unexpected exception.";
         return NULL;

--- a/gpcontrib/gpcloud/src/gpwriter.cpp
+++ b/gpcontrib/gpcloud/src/gpwriter.cpp
@@ -89,17 +89,13 @@ GPWriter* writer_init(const char* url_with_options, const char* format) {
         writer->open(params);
         return writer;
     } catch (S3Exception& e) {
-        if (writer != NULL) {
-            delete writer;
-        }
+        delete writer;
         s3extErrorMessage =
             "writer_init caught a " + e.getType() + " exception: " + e.getFullMessage();
         S3ERROR("writer_init caught %s: %s", e.getType().c_str(), s3extErrorMessage.c_str());
         return NULL;
     } catch (...) {
-        if (writer != NULL) {
-            delete writer;
-        }
+        delete writer;
         S3ERROR("Caught an unexpected exception.");
         s3extErrorMessage = "Caught an unexpected exception.";
         return NULL;


### PR DESCRIPTION
(1) Remove unnecessary null pointer checks
In C++, there is no need to check whether a pointer is null or not.
This pr removes these unnecessary null pointer checks.
This issue is reported in #8194.

(2) Fix bug using delete to destroy objects allocated by new[]
Using `delete` on a pointer returned by `new []` results in undefined behavior.
This pr fix this bug reported by issue #13811. 
