### PR TITLE
Fix qp_with_clause testcase without asserts (#13862)

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -2843,7 +2843,7 @@ CExpressionPreprocessor::PexprTransposeSelectAndProject(CMemoryPool *mp,
 			exprhdl.Attach(pprojexpr);
 			exprhdl.DeriveProps(nullptr /*pdpctxt*/);
 
-			if (exprhdl.Arity() > 0 && exprhdl.DeriveHasNonScalarFunction(1))
+			if (exprhdl.Arity() > 1 && exprhdl.DeriveHasNonScalarFunction(1))
 			{
 				// Bail if project expression contains a set-returning function
 				pdrgpexpr->Release();

--- a/src/test/regress/expected/qp_with_clause_optimizer.out
+++ b/src/test/regress/expected/qp_with_clause_optimizer.out
@@ -2032,6 +2032,8 @@ and CITY_CNT/LANG_CNT > (select  max(CITY_CNT/LANG_CNT)  from allcountrystats,co
 WHERE allcountrystats.code = country.code
 and FOO.region = country.region
 group by FOO.region order by FOO.region;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  region_city_cnt | region_lang_cnt |          region           
 -----------------+-----------------+---------------------------
              840 |             192 | Caribbean
@@ -2141,6 +2143,8 @@ where longlivingregions.region = denseregions.region and allcountrystats.code = 
 and country.indepyear > 1900
 order by name
 LIMIT 50;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  city_cnt | lang_cnt |                 name                  | REGION_LIFETIME  | REGION_POP | lang_count | REGION_GNP |          region           
 ----------+----------+---------------------------------------+------------------+------------+------------+------------+---------------------------
         4 |        5 | Afghanistan                           | 61.3500003814697 | 1490776000 |         54 |  810604.00 | Southern and Central Asia
@@ -2871,6 +2875,8 @@ and CITY_CNT/LANG_CNT > (select  max(CITY_CNT/LANG_CNT)  from allcountrystats,co
 WHERE allcountrystats.code = country.code
 and FOO.region = country.region
 group by FOO.region order by FOO.region;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  region_city_cnt | region_lang_cnt |          region           
 -----------------+-----------------+---------------------------
              840 |             192 | Caribbean
@@ -2980,6 +2986,8 @@ where longlivingregions.region = denseregions.region and allcountrystats.code = 
 and country.indepyear > 1900
 order by name
 LIMIT 50;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  city_cnt | lang_cnt |                 name                  | REGION_SURFACE_AREA | REGION_LIFETIME  | REGION_POP | lang_count | REGION_GNP |          region           
 ----------+----------+---------------------------------------+---------------------+------------------+------------+------------+------------+---------------------------
         4 |        5 | Afghanistan                           |         90749795.00 | 61.3500003814697 | 1490776000 |         54 |  810604.00 | Southern and Central Asia
@@ -3273,6 +3281,8 @@ and CITY_CNT/LANG_CNT > (select  max(CITY_CNT/LANG_CNT)  from allcountrystats,co
 WHERE allcountrystats.code = country.code
 and FOO.region = country.region
 group by FOO.region order by FOO.region;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  region_city_cnt | region_lang_cnt |          region           
 -----------------+-----------------+---------------------------
              840 |             192 | Caribbean
@@ -4485,6 +4495,8 @@ and CITY_CNT/LANG_CNT > (select  max(CITY_CNT/LANG_CNT)  from allcountrystats,co
 WHERE allcountrystats.code = country.code
 and FOO.region = country.region
 group by FOO.region order by FOO.region;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  region_city_cnt | region_lang_cnt |          region           
 -----------------+-----------------+---------------------------
              840 |             192 | Caribbean
@@ -4598,6 +4610,8 @@ where longlivingregions.region = denseregions.region and allcountrystats.code = 
 and country.indepyear > 1900
 order by name
 LIMIT 50;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  city_cnt | lang_cnt |                 name                  | REGION_SURFACE_AREA | REGION_LIFETIME  | REGION_POP | lang_count | REGION_GNP |          region           
 ----------+----------+---------------------------------------+---------------------+------------------+------------+------------+------------+---------------------------
         4 |        5 | Afghanistan                           |         90749795.00 | 61.3500003814697 | 1490776000 |         54 |  810604.00 | Southern and Central Asia
@@ -5280,6 +5294,8 @@ and CITY_CNT/LANG_CNT > (select  max(CITY_CNT/LANG_CNT)  from allcountrystats,co
 WHERE allcountrystats.code = country.code
 and FOO.region = country.region
 group by FOO.region order by FOO.region;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  region_city_cnt | region_lang_cnt |          region           
 -----------------+-----------------+---------------------------
              840 |             192 | Caribbean
@@ -5393,6 +5409,8 @@ where longlivingregions.region = denseregions.region and allcountrystats.code = 
 and country.indepyear > 1900
 order by name
 LIMIT 50;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  city_cnt | lang_cnt |                 name                  | REGION_SURFACE_AREA | REGION_LIFETIME  | REGION_POP | lang_count | REGION_GNP |          region           
 ----------+----------+---------------------------------------+---------------------+------------------+------------+------------+------------+---------------------------
         4 |        5 | Afghanistan                           |         90749795.00 | 61.3500003814697 | 1490776000 |         54 |  810604.00 | Southern and Central Asia
@@ -6122,6 +6140,8 @@ and CITY_CNT/LANG_CNT > (select  max(CITY_CNT/LANG_CNT)  from allcountrystats,co
 WHERE allcountrystats.code = country.code
 and FOO.region = country.region
 group by FOO.region order by FOO.region;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  region_city_cnt | region_lang_cnt |          region           
 -----------------+-----------------+---------------------------
              840 |             192 | Caribbean
@@ -6231,6 +6251,8 @@ where longlivingregions.region = denseregions.region and allcountrystats.code = 
 and country.indepyear > 1900
 order by name
 LIMIT 50;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  city_cnt | lang_cnt |                 name                  | REGION_SURFACE_AREA | REGION_LIFETIME  | REGION_POP | lang_count | REGION_GNP |          region           
 ----------+----------+---------------------------------------+---------------------+------------------+------------+------------+------------+---------------------------
         4 |        5 | Afghanistan                           |         90749795.00 | 61.3500003814697 | 1490776000 |         54 |  810604.00 | Southern and Central Asia
@@ -7020,6 +7042,8 @@ and CITY_AO_CNT/LANG_CNT > (select  max(CITY_AO_CNT/LANG_CNT)  from allcountry_a
 WHERE allcountry_aostats.code = country_ao.code
 and FOO.region = country_ao.region
 group by FOO.region order by FOO.region;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  region_city_ao_cnt | region_lang_cnt |          region           
 --------------------+-----------------+---------------------------
                 840 |             192 | Caribbean
@@ -7133,6 +7157,8 @@ where longlivingregions.region = denseregions.region and allcountry_aostats.code
 and country_ao.indepyear > 1900
 order by name
 LIMIT 50;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  city_ao_cnt | lang_cnt |                 name                  | REGION_SURFACE_AREA | REGION_LIFETIME  | REGION_POP | lang_count | REGION_GNP |          region           
 -------------+----------+---------------------------------------+---------------------+------------------+------------+------------+------------+---------------------------
            4 |        5 | Afghanistan                           |         90749795.00 | 61.3500003814697 | 1490776000 |         54 |  810604.00 | Southern and Central Asia
@@ -7916,6 +7942,8 @@ and CITY_CO_CNT/LANG_CNT > (select  max(CITY_CO_CNT/LANG_CNT)  from allcountry_c
 WHERE allcountry_costats.code = country_co.code
 and FOO.region = country_co.region
 group by FOO.region order by FOO.region;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  region_city_co_cnt | region_lang_cnt |          region           
 --------------------+-----------------+---------------------------
                 840 |             192 | Caribbean
@@ -8029,6 +8057,8 @@ where longlivingregions.region = denseregions.region and allcountry_costats.code
 and country_co.indepyear > 1900
 order by name
 LIMIT 50;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  city_co_cnt | lang_cnt |                 name                  | REGION_SURFACE_AREA | REGION_LIFETIME  | REGION_POP | lang_count | REGION_GNP |          region           
 -------------+----------+---------------------------------------+---------------------+------------------+------------+------------+------------+---------------------------
            4 |        5 | Afghanistan                           |         90749795.00 | 61.3500003814697 | 1490776000 |         54 |  810604.00 | Southern and Central Asia
@@ -8266,6 +8296,8 @@ where longlivingregions.region = denseregions.region and allcountrystats.code = 
 and country.indepyear > 1900
 order by name
 LIMIT 50;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  city_cnt | lang_cnt |                 name                  | REGION_SURFACE_AREA | REGION_LIFETIME  | REGION_POP | lang_count | REGION_GNP |          region           
 ----------+----------+---------------------------------------+---------------------+------------------+------------+------------+------------+---------------------------
         4 |        5 | Afghanistan                           |         90749795.00 | 61.3500003814697 | 1490776000 |         54 |  810604.00 | Southern and Central Asia
@@ -8566,7 +8598,6 @@ select LC from lang_total;
 ERROR:  column "lc" does not exist
 LINE 5: select LC from lang_total;
                ^
-HINT:  Perhaps you meant to reference the column "lang_total.cc" or the column "lang_total.clc".
 -- query 3 use column list when there are duplicate names within the CTE
 with capitals("CO_C","C_ID","CAPITAL",country) as 
 (select country.code,id,city.name,country.name from city,country 
@@ -9504,6 +9535,22 @@ where longlivingregions.region = denseregions.region and allcountrystats.code = 
 and country.indepyear > 1900
 );
 \d+ view_with_shared_scans;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Queries on master-only tables
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Non-default collation
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Queries on master-only tables
                            View "qp_with_clause.view_with_shared_scans"
        Column        |       Type       | Collation | Nullable | Default | Storage  | Description 
 ---------------------+------------------+-----------+----------+---------+----------+-------------
@@ -9606,6 +9653,8 @@ UNION ALL
   WHERE longlivingregions.region = denseregions.region AND allcountrystats.code = country.code AND country.region = longlivingregions.region AND country.indepyear > 1900;
 
 select city_cnt,lang_cnt,name,region from view_with_shared_scans order by name LIMIT 50;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  city_cnt | lang_cnt |                 name                  |          region           
 ----------+----------+---------------------------------------+---------------------------
         4 |        5 | Afghanistan                           | Southern and Central Asia
@@ -9661,6 +9710,8 @@ select city_cnt,lang_cnt,name,region from view_with_shared_scans order by name L
 (50 rows)
 
 select city_cnt,lang_cnt,name,"REGION_POP","REGION_GNP",region from view_with_shared_scans where region = 'Eastern Europe';
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  city_cnt | lang_cnt |        name        | REGION_POP | REGION_GNP |     region     
 ----------+----------+--------------------+------------+------------+----------------
       189 |       12 | Russian Federation |  307026000 |  659980.00 | Eastern Europe
@@ -11140,12 +11191,12 @@ NOTICE:  drop cascades to table emp
 NOTICE:  drop cascades to table bar
 NOTICE:  drop cascades to table foo
 NOTICE:  drop cascades to table tbl87
-NOTICE:  drop cascades to table countrylanguage_co
-NOTICE:  drop cascades to table country_co
-NOTICE:  drop cascades to table city_co
-NOTICE:  drop cascades to table countrylanguage_ao
-NOTICE:  drop cascades to table country_ao
-NOTICE:  drop cascades to table city_ao
+NOTICE:  drop cascades to append only columnar table countrylanguage_co
+NOTICE:  drop cascades to append only columnar table country_co
+NOTICE:  drop cascades to append only columnar table city_co
+NOTICE:  drop cascades to append only table countrylanguage_ao
+NOTICE:  drop cascades to append only table country_ao
+NOTICE:  drop cascades to append only table city_ao
 NOTICE:  drop cascades to table countrylanguage
 NOTICE:  drop cascades to table country
 NOTICE:  drop cascades to table city

--- a/src/test/regress/sql/qp_with_clause.sql
+++ b/src/test/regress/sql/qp_with_clause.sql
@@ -21,6 +21,8 @@ DROP TABLE IF EXISTS countrylanguage cascade;
 
 --end_ignore
 
+SET optimizer_trace_fallback=on;
+
 BEGIN;
 
 --SET client_encoding = 'LATIN1';
@@ -5605,6 +5607,7 @@ select * from
 (select * from country where percentage > 50) e2
 where e1.code = e2.code order by e2.COUNTRY,e1.language LIMIT 20;
 
+SET optimizer_trace_fallback=off;
 -- query 2 using multiple CTEs with same names as tables. 
 with country as 
 (select country.code,country.name COUNTRY, city.name CAPITAL, language, isofficial, percentage
@@ -5622,6 +5625,7 @@ where e1.code = e2.code order by e2.COUNTRY,e1.language
 select code1,country1,capital1,language1,isofficial1,percentage1,country.COUNTRY from country,countrylanguage where country.code = countrylanguage.code1
 and country.percentage = countrylanguage.percentage1
 order by COUNTRY,percentage1 LIMIT 20;-- queries using same name for CTEs and the subquery aliases in the main query
+SET optimizer_trace_fallback=on;
 
 -- query1
 with c1 as 
@@ -10367,3 +10371,5 @@ SELECT * FROM c as c1, zoo WHERE zoo.c = c1.b;
 -- start_ignore
 drop schema qp_with_clause cascade;
 -- end_ignore
+
+RESET optimizer_trace_fallback;


### PR DESCRIPTION
- Fix off-by-one error in 71dd8b0239
- Add optimizer_trace_fallback to catch issue in non-assert build

NOTE to reviewers:
- This is already merged in 6X_STABLE https://github.com/greenplum-db/gpdb/commit/1ece764c280ee8544617e013af9cbe6629be3c40
- qp_with_clause_optimizer answer file contains fallback "Out of stack space".  It is a separate issue which will be addressed.  It is related to https://github.com/greenplum-db/gpdb/commit/2d49b616fe7c89ce24c287beb3e36755aca4c38b mishandling cyclic loop in memo group.