### PR TITLE
ORCA Update reset stat to handle cyclic memo path

### DIFF
--- a/src/test/regress/expected/qp_with_clause.out
+++ b/src/test/regress/expected/qp_with_clause.out
@@ -615,7 +615,6 @@ where e1.code = e2.code order by e2.COUNTRY,e1.language LIMIT 20;
  GIB  | Gibraltar              | Gibraltar              | English        | t          |       88.9 | GIB  | Gibraltar              | Gibraltar              | English        | t          |       88.9
 (20 rows)
 
-SET optimizer_trace_fallback=off;
 -- query 2 using multiple CTEs with same names as tables. 
 with country as 
 (select country.code,country.name COUNTRY, city.name CAPITAL, language, isofficial, percentage
@@ -657,7 +656,6 @@ order by COUNTRY,percentage1 LIMIT 20;-- queries using same name for CTEs and th
  GIB   | Gibraltar              | Gibraltar              | English        | t           |        88.9 | Gibraltar
 (20 rows)
 
-SET optimizer_trace_fallback=on;
 -- query1
 with c1 as 
 (select country.code,country.name COUNTRY, city.name CAPITAL, language, isofficial, percentage

--- a/src/test/regress/expected/qp_with_clause_optimizer.out
+++ b/src/test/regress/expected/qp_with_clause_optimizer.out
@@ -615,7 +615,6 @@ where e1.code = e2.code order by e2.COUNTRY,e1.language LIMIT 20;
  GIB  | Gibraltar              | Gibraltar              | English        | t          |       88.9 | GIB  | Gibraltar              | Gibraltar              | English        | t          |       88.9
 (20 rows)
 
-SET optimizer_trace_fallback=off;
 -- query 2 using multiple CTEs with same names as tables. 
 with country as 
 (select country.code,country.name COUNTRY, city.name CAPITAL, language, isofficial, percentage
@@ -657,7 +656,6 @@ order by COUNTRY,percentage1 LIMIT 20;-- queries using same name for CTEs and th
  GIB   | Gibraltar              | Gibraltar              | English        | t           |        88.9 | Gibraltar
 (20 rows)
 
-SET optimizer_trace_fallback=on;
 -- query1
 with c1 as 
 (select country.code,country.name COUNTRY, city.name CAPITAL, language, isofficial, percentage

--- a/src/test/regress/sql/qp_with_clause.sql
+++ b/src/test/regress/sql/qp_with_clause.sql
@@ -5607,7 +5607,6 @@ select * from
 (select * from country where percentage > 50) e2
 where e1.code = e2.code order by e2.COUNTRY,e1.language LIMIT 20;
 
-SET optimizer_trace_fallback=off;
 -- query 2 using multiple CTEs with same names as tables. 
 with country as 
 (select country.code,country.name COUNTRY, city.name CAPITAL, language, isofficial, percentage
@@ -5625,7 +5624,6 @@ where e1.code = e2.code order by e2.COUNTRY,e1.language
 select code1,country1,capital1,language1,isofficial1,percentage1,country.COUNTRY from country,countrylanguage where country.code = countrylanguage.code1
 and country.percentage = countrylanguage.percentage1
 order by COUNTRY,percentage1 LIMIT 20;-- queries using same name for CTEs and the subquery aliases in the main query
-SET optimizer_trace_fallback=on;
 
 -- query1
 with c1 as 


### PR DESCRIPTION
Commit 2d49b616fe updated memo group reset to include reset of a group's
duplicate. Previously, group reset would recursively traverse only the
children. However, by also traversing duplicates it became possible to
form cyclic reset paths in the memo (e.g. a group's child is a duplicate
of parent group). This can lead to a infinite reset loop.

Admittedly, this patch should only be a temporary solution. Intent of
the function FResetStats() is to only reset if logical operators were
added to any group reachable from reset group. In order to do that we
must first search the children before resetting ourselves. Ultimately,
we need a way to properly detect cycles.

Co-authored-by: Jingyu Wang <wjingyu@vmware.com>
