### PR TITLE
Added gp_resgroup_role view into gp_toolkit.

### DIFF
--- a/src/backend/catalog/gp_toolkit.sql
+++ b/src/backend/catalog/gp_toolkit.sql
@@ -1834,6 +1834,30 @@ CREATE VIEW gp_toolkit.gp_resgroup_status_per_segment AS
 GRANT SELECT ON gp_toolkit.gp_resgroup_status_per_segment TO public;
 
 --------------------------------------------------------------------------------
+-- @view:
+--        gp_toolkit.gp_resgroup_role
+--
+-- @doc:
+--        Assigned resource group to roles
+--
+--------------------------------------------------------------------------------
+
+CREATE VIEW gp_toolkit.gp_resgroup_role
+AS
+    SELECT
+        pgr.rolname AS rrrolname,
+		pgrg.rsgname AS rrrsgname
+	FROM
+		pg_catalog.pg_roles pgr
+	JOIN
+		pg_catalog.pg_resgroup pgrg
+	ON
+		pgr.rolresgroup = pgrg.oid
+	;
+
+GRANT SELECT ON gp_toolkit.gp_resgroup_role TO public;
+
+--------------------------------------------------------------------------------
 -- AO/CO diagnostics functions
 --------------------------------------------------------------------------------
 

--- a/src/backend/catalog/gp_toolkit_test.sql
+++ b/src/backend/catalog/gp_toolkit_test.sql
@@ -96,4 +96,6 @@ select * from gp_toolkit.gp_size_of_partition_and_indexes_disk;
 select * from gp_toolkit.gp_size_of_schema_disk;
 select * from gp_toolkit.gp_size_of_database;
 
+select * from gp_toolkit.gp_resgroup_role;
+
 

--- a/src/test/isolation2/expected/resgroup/resgroup_views.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_views.out
@@ -22,6 +22,12 @@ select rsgname , groupid , segment_id , cpu , memory_used , memory_shared_used f
  default_group | 6437    | -1         | 0.00 | 0           | 0                  
 (1 row)
 
+select * from gp_toolkit.gp_resgroup_role where rrrolname='postgres';
+ rrrolname | rrrsgname   
+-----------+-------------
+ postgres  | admin_group 
+(1 row)
+
 -- also log the raw output of the views, if any of above tests failed it is
 -- easier to find out the causes with these logs.
 

--- a/src/test/isolation2/sql/resgroup/resgroup_views.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_views.sql
@@ -34,6 +34,10 @@ select rsgname
  where rsgname='default_group'
    and segment_id=-1;
 
+select *
+  from gp_toolkit.gp_resgroup_role
+ where rrrolname='postgres';
+
 -- also log the raw output of the views, if any of above tests failed it is
 -- easier to find out the causes with these logs.
 


### PR DESCRIPTION
Added a new view into the resource manager tool `gp_toolkit` to perform the function that are used frequently:

gp_toolkit.gp_resgroup_role: assigned resource group to roles.

- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
