### PR TITLE
Gang loss with gp_dist_wait_status during running transaction.

### DIFF
--- a/src/backend/utils/gdd/gddfuncs.c
+++ b/src/backend/utils/gdd/gddfuncs.c
@@ -337,8 +337,6 @@ gp_dist_wait_status(PG_FUNCTION_ARGS)
 	}
 
 	cdbdisp_clearCdbPgResults(&ctx->cdb_pgresults);
-	if (Gp_role == GP_ROLE_DISPATCH)
-		DisconnectAndDestroyAllGangs(false);
 
 	SRF_RETURN_DONE(funcctx);
 }

--- a/src/test/regress/expected/deadlock.out
+++ b/src/test/regress/expected/deadlock.out
@@ -56,3 +56,12 @@ NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to table l
 drop cascades to table r
 drop cascades to table sanity_check_distribution
+-- Check gp_dist_wait_status not failing within a transaction
+-- Github issue: https://github.com/greenplum-db/gpdb/issues/13795
+BEGIN;
+	select * from gp_dist_wait_status();
+ segid | waiter_dxid | holder_dxid | holdTillEndXact | waiter_lpid | holder_lpid | waiter_lockmode | waiter_locktype | waiter_sessionid | holder_sessionid 
+-------+-------------+-------------+-----------------+-------------+-------------+-----------------+-----------------+------------------+------------------
+(0 rows)
+
+COMMIT;

--- a/src/test/regress/sql/deadlock.sql
+++ b/src/test/regress/sql/deadlock.sql
@@ -47,3 +47,10 @@ select count(*) from gp_dist_random('l') left outer join gp_dist_random('r') on 
 
 
 drop schema if exists deadlock cascade;
+
+-- Check gp_dist_wait_status not failing within a transaction
+-- Github issue: https://github.com/greenplum-db/gpdb/issues/13795
+
+BEGIN;
+	select * from gp_dist_wait_status();
+COMMIT;


### PR DESCRIPTION
gp_dist_wait_status used to destroy a gang after
execution, which led to a transaction failing.
This fix deletes related code lines, so that the
transaction won't fail.

(cherry picked from commit 1735b5ca3dd37d83e58d3fd4d5da3d31d4d948dc)
