### PR TITLE
gp_aoblkdir: Block directory inspection function

### DIFF
--- a/gpcontrib/gp_internal_tools/gp_ao_co_diagnostics.c
+++ b/gpcontrib/gp_internal_tools/gp_ao_co_diagnostics.c
@@ -49,6 +49,9 @@ extern Datum
 gp_aocsseg_history(PG_FUNCTION_ARGS);
 
 extern Datum
+gp_aoblkdir(PG_FUNCTION_ARGS);
+
+extern Datum
 gp_aovisimap(PG_FUNCTION_ARGS);
 
 extern Datum
@@ -67,6 +70,7 @@ PG_FUNCTION_INFO_V1(gp_aoseg_history_wrapper);
 PG_FUNCTION_INFO_V1(gp_aoseg_wrapper);
 PG_FUNCTION_INFO_V1(gp_aocsseg_wrapper);
 PG_FUNCTION_INFO_V1(gp_aocsseg_history_wrapper);
+PG_FUNCTION_INFO_V1(gp_aoblkdir_wrapper);
 PG_FUNCTION_INFO_V1(gp_aovisimap_wrapper);
 PG_FUNCTION_INFO_V1(gp_aovisimap_entry_wrapper);
 PG_FUNCTION_INFO_V1(gp_aovisimap_hidden_info_wrapper);
@@ -83,6 +87,8 @@ extern Datum
 gp_aocsseg_wrapper(PG_FUNCTION_ARGS);
 extern Datum
 gp_aocsseg_history_wrapper(PG_FUNCTION_ARGS);
+extern Datum
+gp_aoblkdir_wrapper(PG_FUNCTION_ARGS);
 extern Datum
 gp_aovisimap_wrapper(PG_FUNCTION_ARGS);
 extern Datum
@@ -226,6 +232,21 @@ gp_aocsseg_history_wrapper(PG_FUNCTION_ARGS)
   Datum returnValue = gp_aocsseg_history(fcinfo);
 
   PG_RETURN_DATUM(returnValue);
+}
+
+/*
+ * Interface to gp_aoblkdir_wrapper function.
+ *
+ * CREATE FUNCTION gp_aoblkdir_wrapper(regclass) RETURNS TABLE
+ * (segno integer, columngroup_no integer, first_row_no bigint, file_offset bigint, row_count bigint)
+ * AS '$libdir/gp_ao_co_diagnostics.so', 'gp_aoblkdir_wrapper' LANGUAGE C STRICT;
+ */
+Datum
+gp_aoblkdir_wrapper(PG_FUNCTION_ARGS)
+{
+	Datum returnValue = gp_aoblkdir(fcinfo);
+
+	PG_RETURN_DATUM(returnValue);
 }
 
 /* 

--- a/src/backend/access/appendonly/Makefile
+++ b/src/backend/access/appendonly/Makefile
@@ -15,7 +15,7 @@ OBJS = appendonlyam_handler.o appendonlyam.o aosegfiles.o aomd.o \
 	   appendonlyblockdirectory.o appendonly_visimap.o \
 	   appendonly_visimap_entry.o appendonly_visimap_store.o \
 	   appendonly_compaction.o appendonly_visimap_udf.o \
-	   aomd_filehandler.o
+	   appendonly_blkdir_udf.o aomd_filehandler.o
 
 include $(top_srcdir)/src/backend/common.mk
 

--- a/src/backend/access/appendonly/appendonly_blkdir_udf.c
+++ b/src/backend/access/appendonly/appendonly_blkdir_udf.c
@@ -1,0 +1,210 @@
+/*------------------------------------------------------------------------------
+ *
+ * AppendOnly_Blkdir UDFs
+ *   User-defined functions (UDF) for support of append-only block directory
+ *
+ * Copyright (c) 2013-Present VMware, Inc. or its affiliates.
+ *
+ *
+ * IDENTIFICATION
+ *	    src/backend/access/appendonly/appendonly_blkdir_udf.c
+ *
+ *------------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "access/appendonly_visimap.h"
+#include "access/table.h"
+#include "catalog/aoblkdir.h"
+#include "cdb/cdbappendonlyblockdirectory.h"
+#include "cdb/cdbvars.h"
+#include "funcapi.h"
+#include "utils/snapmgr.h"
+
+Datum gp_aoblkdir(PG_FUNCTION_ARGS);
+
+/*
+ * This UDF emits block directory entries for an AO/AOCO relation. It does so
+ * by flattening the minipage column of ao_blkdir relations, yielding 1 minipage
+ * entry / output row.
+ *
+ * Format:
+ * tupleid | segno | columngroup_no | entry_no | first_row_no | file_offset | row_count
+ *
+ * This UDF also respects gp_select_invisible to report block directory entries
+ * that are invisible. To determine invisible entries we can use the tupleid
+ * projected here and tie it to the corresponding pg_aoblkdir tuple's xmax.
+ */
+
+Datum
+gp_aoblkdir(PG_FUNCTION_ARGS)
+{
+	Oid       	aoRelOid = PG_GETARG_OID(0);
+	HeapTuple 	tuple;
+
+	typedef struct Context
+	{
+		Relation 				aorel;
+		SysScanDesc 			scan;
+		MinipagePerColumnGroup	currMinipage;
+		bool					currMinipageValid;
+		int 					currMinipageEntryIdx;
+		Relation				blkdirrel;
+	} Context;
+
+	FuncCallContext *funcctx;
+	Context			*context;
+
+	if (SRF_IS_FIRSTCALL())
+	{
+		TupleDesc     tupdesc;
+		MemoryContext oldcontext;
+		Snapshot      sst;
+		Oid           blkdirrelid;
+
+		/* create a function context for cross-call persistence */
+		funcctx = SRF_FIRSTCALL_INIT();
+
+		/*
+		 * switch to memory context appropriate for multiple function calls
+		 */
+		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
+
+		/* build tupdesc for result tuples */
+		tupdesc = CreateTemplateTupleDesc(7);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "tupleid",
+						   TIDOID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "segno",
+						   INT4OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 3, "columngroup_no",
+						   INT4OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 4, "entry_no",
+						   INT4OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 5, "first_row_no",
+						   INT8OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 6, "file_offset",
+						   INT8OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 7, "row_count",
+						   INT8OID, -1, 0);
+		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
+
+		/* initialize Context for SRF */
+		context = (Context *) palloc0(sizeof(Context));
+		context->aorel = table_open(aoRelOid, AccessShareLock);
+		if (!RelationIsAppendOptimized(context->aorel))
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						errmsg("function not supported on non append-optimized relation")));
+		sst = GetLatestSnapshot();
+		GetAppendOnlyEntryAuxOids(aoRelOid, sst,
+								  NULL, &blkdirrelid, NULL,
+								  NULL, NULL);
+		sst = gp_select_invisible ? SnapshotAny : GetLatestSnapshot();
+		if (blkdirrelid == InvalidOid)
+			ereport(ERROR,
+					(errmsg("appendoptimized relation doesn't have a block directory"),
+					 errhint("relation must have or must have had an index")));
+		context->blkdirrel = table_open(blkdirrelid, AccessShareLock);
+		context->scan = systable_beginscan(context->blkdirrel,
+										   InvalidOid,
+										   false,
+										   sst,
+										   0,
+										   NULL);
+		context->currMinipage.minipage = palloc0(minipage_size(NUM_MINIPAGE_ENTRIES));
+		context->currMinipageValid = false;
+		context->currMinipageEntryIdx = -1;
+		funcctx->user_fctx = (void *) context;
+
+		MemoryContextSwitchTo(oldcontext);
+	}
+
+	funcctx = SRF_PERCALL_SETUP();
+	context = (Context *) funcctx->user_fctx;
+
+	if (!context->currMinipageValid)
+	{
+		Datum	minipage;
+		bool	minipageNull;
+
+		/* We need to fetch the next tuple from the blkdir relation */
+		if (!systable_getnext(context->scan))
+			goto srf_done;
+
+		/* deform the tuple and populate slot->values/nulls */
+		slot_getallattrs(context->scan->slot);
+
+		minipage = slot_getattr(context->scan->slot, Anum_pg_aoblkdir_minipage, &minipageNull);
+		/*
+		 * There should not really be any NULL values. We opt to report it
+		 * instead of ERRORing out.
+		 */
+		context->currMinipageValid = !minipageNull;
+		if (context->currMinipageValid)
+		{
+			/*
+			 * Cache the latest scanned minipage and use it to emit the next
+			 * (context->currMinipage->numMinipageEntries) rows
+			 */
+			copy_out_minipage(&context->currMinipage, minipage, false);
+			context->currMinipageEntryIdx = 0;
+		}
+	}
+
+	{
+		Datum          	values[7];
+		bool			nulls[7];
+		TupleTableSlot 	*slot = context->scan->slot;
+		Datum          	result;
+
+		values[0] = ItemPointerGetDatum(&slot->tts_tid);
+		nulls[0] = false;
+
+		values[1] = slot_getattr(slot, Anum_pg_aoblkdir_segno, &nulls[1]);
+		values[2] = slot_getattr(slot, Anum_pg_aoblkdir_columngroupno, &nulls[2]);
+
+		/* emit minipage entry */
+		if (context->currMinipageValid)
+		{
+			MinipagePerColumnGroup *currMinipage = &context->currMinipage;
+			MinipageEntry *minipageEntry;
+
+			Assert(context->currMinipageEntryIdx < currMinipage->numMinipageEntries);
+
+			minipageEntry = &currMinipage->minipage->entry[context->currMinipageEntryIdx];
+
+			values[3] = context->currMinipageEntryIdx++;
+			values[4] = Int64GetDatum(minipageEntry->firstRowNum);
+			values[5] = Int64GetDatum(minipageEntry->fileOffset);
+			values[6] = Int64GetDatum(minipageEntry->rowCount);
+
+			nulls[3] = false;
+			nulls[4] = false;
+			nulls[5] = false;
+			nulls[6] = false;
+
+			context->currMinipageValid =
+				(context->currMinipageEntryIdx != currMinipage->numMinipageEntries);
+		}
+		else
+		{
+			nulls[3] = true;
+			nulls[4] = true;
+			nulls[5] = true;
+			nulls[6] = true;
+		}
+
+		tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
+		result = HeapTupleGetDatum(tuple);
+		SRF_RETURN_NEXT(funcctx, result);
+	}
+
+srf_done:
+	table_close(context->aorel, AccessShareLock);
+	systable_endscan(context->scan);
+	table_close(context->blkdirrel, AccessShareLock);
+	pfree(context);
+	funcctx->user_fctx = NULL;
+	SRF_RETURN_DONE(funcctx);
+}

--- a/src/backend/catalog/gp_toolkit.sql
+++ b/src/backend/catalog/gp_toolkit.sql
@@ -1880,6 +1880,16 @@ AS '$libdir/gp_ao_co_diagnostics' , 'gp_aocsseg_history_wrapper'
 LANGUAGE C STRICT EXECUTE ON ALL SEGMENTS;
 GRANT EXECUTE ON FUNCTION gp_toolkit.__gp_aocsseg_history(regclass) TO public;
 
+CREATE FUNCTION gp_toolkit.__gp_aoblkdir(regclass)
+RETURNS TABLE (tupleid tid,
+    segno integer,
+    columngroup_no integer,
+    entry_no integer,
+    first_row_no bigint,
+    file_offset bigint,
+    row_count bigint)
+AS '$libdir/gp_ao_co_diagnostics.so', 'gp_aoblkdir_wrapper' LANGUAGE C STRICT;
+
 CREATE FUNCTION gp_toolkit.__gp_aovisimap(regclass)
 RETURNS TABLE (tid tid,
     segno int,

--- a/src/include/cdb/cdbappendonlyblockdirectory.h
+++ b/src/include/cdb/cdbappendonlyblockdirectory.h
@@ -157,6 +157,11 @@ typedef struct AOFetchSegmentFile
 	int64 logicalEof;
 } AOFetchSegmentFile;
 
+typedef struct AppendOnlyBlockDirectorySeqScan {
+	AppendOnlyBlockDirectory blkdir;
+	SysScanDesc sysScan;
+} AppendOnlyBlockDirectorySeqScan;
+
 extern void AppendOnlyBlockDirectoryEntry_GetBeginRange(
 	AppendOnlyBlockDirectoryEntry	*directoryEntry,
 	int64							*fileOffset,
@@ -217,4 +222,40 @@ extern void AppendOnlyBlockDirectory_DeleteSegmentFile(
 		Snapshot snapshot,
 		int segno,
 		int columnGroupNo);
+
+static inline uint32
+minipage_size(uint32 nEntry)
+{
+	return offsetof(Minipage, entry) + sizeof(MinipageEntry) * nEntry;
+}
+
+/*
+ * copy_out_minipage
+ *
+ * Copy out the minipage content from a deformed tuple.
+ */
+static inline void
+copy_out_minipage(MinipagePerColumnGroup *minipageInfo,
+				  Datum minipage_value,
+				  bool minipage_isnull)
+{
+	struct varlena *value;
+	struct varlena *detoast_value;
+
+	Assert(!minipage_isnull);
+
+	value = (struct varlena *)
+		DatumGetPointer(minipage_value);
+	detoast_value = pg_detoast_datum(value);
+	Assert(VARSIZE(detoast_value) <= minipage_size(NUM_MINIPAGE_ENTRIES));
+
+	memcpy(minipageInfo->minipage, detoast_value, VARSIZE(detoast_value));
+	if (detoast_value != value)
+		pfree(detoast_value);
+
+	Assert(minipageInfo->minipage->nEntry <= NUM_MINIPAGE_ENTRIES);
+
+	minipageInfo->numMinipageEntries = minipageInfo->minipage->nEntry;
+}
+
 #endif

--- a/src/test/regress/expected/alter_table_set_am.out
+++ b/src/test/regress/expected/alter_table_set_am.out
@@ -118,7 +118,6 @@ SELECT * FROM relfilebeforeao INTERSECT SELECT * FROM relfileafterao;
 (0 rows)
 
 -- aux tables are created, pg_appendonly row is created
--- FIXME: add check for gp_aoblkdir
 SELECT * FROM gp_toolkit.__gp_aoseg('heap2ao');
  segment_id | segno | eof | tupcount | varblockcount | eof_uncompressed | modcount | formatversion | state 
 ------------+-------+-----+----------+---------------+------------------+----------+---------------+-------
@@ -127,10 +126,18 @@ SELECT * FROM gp_toolkit.__gp_aoseg('heap2ao');
           1 |     0 |  40 |        1 |             1 |               40 |        1 |             3 |     1
 (3 rows)
 
-SELECT * FROM gp_toolkit.__gp_aovisimap('heap2ao');
- tid | segno | row_num 
------+-------+---------
+SELECT gp_segment_id, (gp_toolkit.__gp_aovisimap('heap2ao')).* FROM gp_dist_random('gp_id');
+ gp_segment_id | tid | segno | row_num 
+---------------+-----+-------+---------
 (0 rows)
+
+SELECT gp_segment_id, (gp_toolkit.__gp_aoblkdir('heap2ao')).* FROM gp_dist_random('gp_id');
+ gp_segment_id | tupleid | segno | columngroup_no | entry_no | first_row_no | file_offset | row_count 
+---------------+---------+-------+----------------+----------+--------------+-------------+-----------
+             0 | (0,1)   |     0 |              0 |        0 |            1 |           0 |         3
+             1 | (0,1)   |     0 |              0 |        0 |            1 |           0 |         1
+             2 | (0,1)   |     0 |              0 |        0 |            1 |           0 |         1
+(3 rows)
 
 SELECT * FROM gp_toolkit.__gp_aoseg('heap2ao2');
  segment_id | segno | eof | tupcount | varblockcount | eof_uncompressed | modcount | formatversion | state 
@@ -140,9 +147,9 @@ SELECT * FROM gp_toolkit.__gp_aoseg('heap2ao2');
           0 |     0 |  72 |        3 |             1 |               88 |        1 |             3 |     1
 (3 rows)
 
-SELECT * FROM gp_toolkit.__gp_aovisimap('heap2ao2');
- tid | segno | row_num 
------+-------+---------
+SELECT gp_segment_id, (gp_toolkit.__gp_aovisimap('heap2ao2')).* FROM gp_dist_random('gp_id');
+ gp_segment_id | tid | segno | row_num 
+---------------+-----+-------+---------
 (0 rows)
 
 -- pg_appendonly should have entries associated with the new AO tables
@@ -292,9 +299,9 @@ SELECT * FROM gp_toolkit.__gp_aoseg('heapbase');
           2 |     0 |  40 |        1 |             1 |               40 |        1 |             3 |     1
 (3 rows)
 
-SELECT * FROM gp_toolkit.__gp_aovisimap('heapbase');
- tid | segno | row_num 
------+-------+---------
+SELECT gp_segment_id, (gp_toolkit.__gp_aovisimap('heapbase')).* FROM gp_dist_random('gp_id');
+ gp_segment_id | tid | segno | row_num 
+---------------+-----+-------+---------
 (0 rows)
 
 SELECT * FROM gp_toolkit.__gp_aoseg('heapbase2');
@@ -305,9 +312,9 @@ SELECT * FROM gp_toolkit.__gp_aoseg('heapbase2');
           0 |     0 |  72 |        3 |             1 |               88 |        1 |             3 |     1
 (3 rows)
 
-SELECT * FROM gp_toolkit.__gp_aovisimap('heapbase2');
- tid | segno | row_num 
------+-------+---------
+SELECT gp_segment_id, (gp_toolkit.__gp_aovisimap('heapbase2')).* FROM gp_dist_random('gp_id');
+ gp_segment_id | tid | segno | row_num 
+---------------+-----+-------+---------
 (0 rows)
 
 SELECT c.relname FROM pg_class c, pg_appendonly p WHERE c.relname LIKE 'heapbase%' AND c.oid = p.relid;
@@ -319,13 +326,13 @@ SELECT c.relname FROM pg_class c, pg_appendonly p WHERE c.relname LIKE 'heapbase
 
 -- aux tables are not created for child table
 SELECT * FROM gp_toolkit.__gp_aoseg('heapchild');
-ERROR:  'heapchild' is not an append-only row relation  (seg0 slice1 127.0.0.1:7002 pid=29947)
-SELECT * FROM gp_toolkit.__gp_aovisimap('heapchild');
-ERROR:  function not supported on relation
+ERROR:  'heapchild' is not an append-only row relation  (seg0 slice1 192.168.0.148:7002 pid=674753)
+SELECT gp_segment_id, (gp_toolkit.__gp_aovisimap('heapchild')).* FROM gp_dist_random('gp_id');
+ERROR:  function not supported on relation  (seg0 slice1 192.168.0.148:7002 pid=674753)
 SELECT * FROM gp_toolkit.__gp_aoseg('heapchild2');
-ERROR:  'heapchild2' is not an append-only row relation  (seg0 slice1 127.0.0.1:7002 pid=29947)
-SELECT * FROM gp_toolkit.__gp_aovisimap('heapchild2');
-ERROR:  function not supported on relation
+ERROR:  'heapchild2' is not an append-only row relation  (seg0 slice1 192.168.0.148:7002 pid=674753)
+SELECT gp_segment_id, (gp_toolkit.__gp_aovisimap('heapchild2')).* FROM gp_dist_random('gp_id');
+ERROR:  function not supported on relation  (seg0 slice1 192.168.0.148:7002 pid=674753)
 SELECT c.relname FROM pg_class c, pg_appendonly p WHERE c.relname LIKE 'heapchild%' AND c.oid = p.relid;
  relname 
 ---------
@@ -402,13 +409,15 @@ SELECT * FROM ao2heap2;
 
 -- No AO aux tables should be left
 SELECT * FROM gp_toolkit.__gp_aoseg('ao2heap');
-ERROR:  'ao2heap' is not an append-only row relation  (seg0 slice1 127.0.1.1:7002 pid=6817)
-SELECT * FROM gp_toolkit.__gp_aovisimap('ao2heap');
-ERROR:  function not supported on relation
+ERROR:  'ao2heap' is not an append-only row relation  (seg0 slice1 192.168.0.148:7002 pid=674753)
+SELECT gp_segment_id, (gp_toolkit.__gp_aovisimap('ao2heap')).* FROM gp_dist_random('gp_id');
+ERROR:  function not supported on relation  (seg0 slice1 192.168.0.148:7002 pid=674753)
+SELECT gp_segment_id, (gp_toolkit.__gp_aoblkdir('ao2heap')).* FROM gp_dist_random('gp_id');
+ERROR:  function not supported on non append-optimized relation  (seg2 slice1 192.168.0.148:7004 pid=1401173)
 SELECT * FROM gp_toolkit.__gp_aoseg('ao2heap2');
-ERROR:  'ao2heap2' is not an append-only row relation  (seg0 slice1 127.0.1.1:7002 pid=6817)
-SELECT * FROM gp_toolkit.__gp_aovisimap('ao2heap2');
-ERROR:  function not supported on relation
+ERROR:  'ao2heap2' is not an append-only row relation  (seg0 slice1 192.168.0.148:7002 pid=674753)
+SELECT gp_segment_id, (gp_toolkit.__gp_aovisimap('ao2heap2')).* FROM gp_dist_random('gp_id');
+ERROR:  function not supported on relation  (seg0 slice1 192.168.0.148:7002 pid=674753)
 -- No pg_appendonly entries should be left too
 SELECT c.relname FROM pg_class c, pg_appendonly p WHERE c.relname LIKE 'ao2heap%' AND c.oid = p.relid;
  relname 

--- a/src/test/regress/expected/gp_toolkit_ao_funcs.out
+++ b/src/test/regress/expected/gp_toolkit_ao_funcs.out
@@ -10,12 +10,14 @@
 DROP TABLE IF EXISTS toolkit_ao_test;
 CREATE TABLE toolkit_ao_test (a INT, b INT, c INT)
   WITH (appendonly=true) DISTRIBUTED BY (c);
+CREATE INDEX ON toolkit_ao_test(a);
 INSERT INTO toolkit_ao_test SELECT i as a, i as b, 1 FROM generate_series(1,20) AS i;
 UPDATE toolkit_ao_test SET b = 0 WHERE a = 1;
 DELETE FROM toolkit_ao_test WHERE a = 2;
 DROP TABLE IF EXISTS toolkit_aocs_test;
 CREATE TABLE toolkit_aocs_test (a INT, b INT, C INT)
   WITH (appendonly=true, orientation=column) DISTRIBUTED BY (c);
+CREATE INDEX ON toolkit_aocs_test(a);
 INSERT INTO toolkit_aocs_test SELECT i as a, i as b FROM generate_series(1,20) AS i;
 UPDATE toolkit_aocs_test SET b = 0 WHERE a = 1;
 DELETE FROM toolkit_aocs_test WHERE a = 2;
@@ -66,6 +68,16 @@ SELECT count(*) FROM gp_toolkit.__gp_aoseg('toolkit_ao_test');
      1
 (1 row)
 
+SELECT * FROM gp_toolkit.__gp_aoblkdir('toolkit_ao_test');
+ tupleid | segno | columngroup_no | entry_no | first_row_no | file_offset | row_count 
+---------+-------+----------------+----------+--------------+-------------+-----------
+(0 rows)
+
+SELECT * FROM gp_toolkit.__gp_aoblkdir('toolkit_aocs_test');
+ tupleid | segno | columngroup_no | entry_no | first_row_no | file_offset | row_count 
+---------+-------+----------------+----------+--------------+-------------+-----------
+(0 rows)
+
 -- The same, but on the segments.
 SELECT (t).* FROM (
   SELECT gp_toolkit.__gp_aovisimap('toolkit_ao_test') AS t FROM gp_dist_random('gp_id')
@@ -83,4 +95,26 @@ SELECT (t).segno, (t).first_row_num, (t).hidden_tupcount >= 1 as hidden_tupcount
 -------+---------------+-------------------------+-----------------------
      1 |             0 | t                       | t
 (1 row)
+
+SELECT (t).* FROM (
+  SELECT gp_toolkit.__gp_aoblkdir('toolkit_ao_test') AS t FROM gp_dist_random('gp_id')
+) AS x;
+ tupleid | segno | columngroup_no | entry_no | first_row_no | file_offset | row_count 
+---------+-------+----------------+----------+--------------+-------------+-----------
+ (0,2)   |     1 |              0 |        0 |            1 |           0 |       100
+ (0,2)   |     1 |              0 |        1 |          101 |         392 |         1
+(2 rows)
+
+SELECT (t).* FROM (
+  SELECT gp_toolkit.__gp_aoblkdir('toolkit_aocs_test') AS t FROM gp_dist_random('gp_id')
+) AS x;
+ tupleid | segno | columngroup_no | entry_no | first_row_no | file_offset | row_count 
+---------+-------+----------------+----------+--------------+-------------+-----------
+ (0,4)   |     1 |              0 |        0 |            1 |           0 |       100
+ (0,4)   |     1 |              0 |        1 |          101 |         120 |         1
+ (0,5)   |     1 |              1 |        0 |            1 |           0 |       100
+ (0,5)   |     1 |              1 |        1 |          101 |         120 |         1
+ (0,6)   |     1 |              2 |        0 |            1 |           0 |       100
+ (0,6)   |     1 |              2 |        1 |          101 |          48 |         1
+(6 rows)
 

--- a/src/test/regress/sql/alter_table_set_am.sql
+++ b/src/test/regress/sql/alter_table_set_am.sql
@@ -78,11 +78,12 @@ CREATE TEMP TABLE relfileafterao AS
 SELECT * FROM relfilebeforeao INTERSECT SELECT * FROM relfileafterao;
 
 -- aux tables are created, pg_appendonly row is created
--- FIXME: add check for gp_aoblkdir
 SELECT * FROM gp_toolkit.__gp_aoseg('heap2ao');
-SELECT * FROM gp_toolkit.__gp_aovisimap('heap2ao');
+SELECT gp_segment_id, (gp_toolkit.__gp_aovisimap('heap2ao')).* FROM gp_dist_random('gp_id');
+SELECT gp_segment_id, (gp_toolkit.__gp_aoblkdir('heap2ao')).* FROM gp_dist_random('gp_id');
+
 SELECT * FROM gp_toolkit.__gp_aoseg('heap2ao2');
-SELECT * FROM gp_toolkit.__gp_aovisimap('heap2ao2');
+SELECT gp_segment_id, (gp_toolkit.__gp_aovisimap('heap2ao2')).* FROM gp_dist_random('gp_id');
 
 -- pg_appendonly should have entries associated with the new AO tables
 SELECT c.relname FROM pg_class c, pg_appendonly p WHERE c.relname LIKE 'heap2ao%' AND c.oid = p.relid;
@@ -146,16 +147,16 @@ SELECT count(*) FROM (SELECT * FROM inheritchildrelfilebefore UNION SELECT * FRO
 
 -- aux tables are created, pg_appendonly row is created
 SELECT * FROM gp_toolkit.__gp_aoseg('heapbase');
-SELECT * FROM gp_toolkit.__gp_aovisimap('heapbase');
+SELECT gp_segment_id, (gp_toolkit.__gp_aovisimap('heapbase')).* FROM gp_dist_random('gp_id');
 SELECT * FROM gp_toolkit.__gp_aoseg('heapbase2');
-SELECT * FROM gp_toolkit.__gp_aovisimap('heapbase2');
+SELECT gp_segment_id, (gp_toolkit.__gp_aovisimap('heapbase2')).* FROM gp_dist_random('gp_id');
 SELECT c.relname FROM pg_class c, pg_appendonly p WHERE c.relname LIKE 'heapbase%' AND c.oid = p.relid;
 
 -- aux tables are not created for child table
 SELECT * FROM gp_toolkit.__gp_aoseg('heapchild');
-SELECT * FROM gp_toolkit.__gp_aovisimap('heapchild');
+SELECT gp_segment_id, (gp_toolkit.__gp_aovisimap('heapchild')).* FROM gp_dist_random('gp_id');
 SELECT * FROM gp_toolkit.__gp_aoseg('heapchild2');
-SELECT * FROM gp_toolkit.__gp_aovisimap('heapchild2');
+SELECT gp_segment_id, (gp_toolkit.__gp_aovisimap('heapchild2')).* FROM gp_dist_random('gp_id');
 SELECT c.relname FROM pg_class c, pg_appendonly p WHERE c.relname LIKE 'heapchild%' AND c.oid = p.relid;
 
 -- Scenario 3: AO to Heap
@@ -197,9 +198,10 @@ SELECT * FROM ao2heap2;
 
 -- No AO aux tables should be left
 SELECT * FROM gp_toolkit.__gp_aoseg('ao2heap');
-SELECT * FROM gp_toolkit.__gp_aovisimap('ao2heap');
+SELECT gp_segment_id, (gp_toolkit.__gp_aovisimap('ao2heap')).* FROM gp_dist_random('gp_id');
+SELECT gp_segment_id, (gp_toolkit.__gp_aoblkdir('ao2heap')).* FROM gp_dist_random('gp_id');
 SELECT * FROM gp_toolkit.__gp_aoseg('ao2heap2');
-SELECT * FROM gp_toolkit.__gp_aovisimap('ao2heap2');
+SELECT gp_segment_id, (gp_toolkit.__gp_aovisimap('ao2heap2')).* FROM gp_dist_random('gp_id');
 
 -- No pg_appendonly entries should be left too
 SELECT c.relname FROM pg_class c, pg_appendonly p WHERE c.relname LIKE 'ao2heap%' AND c.oid = p.relid;

--- a/src/test/regress/sql/gp_toolkit_ao_funcs.sql
+++ b/src/test/regress/sql/gp_toolkit_ao_funcs.sql
@@ -12,6 +12,7 @@
 DROP TABLE IF EXISTS toolkit_ao_test;
 CREATE TABLE toolkit_ao_test (a INT, b INT, c INT)
   WITH (appendonly=true) DISTRIBUTED BY (c);
+CREATE INDEX ON toolkit_ao_test(a);
 INSERT INTO toolkit_ao_test SELECT i as a, i as b, 1 FROM generate_series(1,20) AS i;
 UPDATE toolkit_ao_test SET b = 0 WHERE a = 1;
 DELETE FROM toolkit_ao_test WHERE a = 2;
@@ -19,6 +20,7 @@ DELETE FROM toolkit_ao_test WHERE a = 2;
 DROP TABLE IF EXISTS toolkit_aocs_test;
 CREATE TABLE toolkit_aocs_test (a INT, b INT, C INT)
   WITH (appendonly=true, orientation=column) DISTRIBUTED BY (c);
+CREATE INDEX ON toolkit_aocs_test(a);
 INSERT INTO toolkit_aocs_test SELECT i as a, i as b FROM generate_series(1,20) AS i;
 UPDATE toolkit_aocs_test SET b = 0 WHERE a = 1;
 DELETE FROM toolkit_aocs_test WHERE a = 2;
@@ -32,6 +34,8 @@ SELECT * FROM gp_toolkit.__gp_aovisimap('toolkit_ao_test');
 SELECT count(*) FROM gp_toolkit.__gp_aovisimap_hidden_info('toolkit_ao_test');
 SELECT * FROM gp_toolkit.__gp_aovisimap_entry('toolkit_ao_test');
 SELECT count(*) FROM gp_toolkit.__gp_aoseg('toolkit_ao_test');
+SELECT * FROM gp_toolkit.__gp_aoblkdir('toolkit_ao_test');
+SELECT * FROM gp_toolkit.__gp_aoblkdir('toolkit_aocs_test');
 
 -- The same, but on the segments.
 SELECT (t).* FROM (
@@ -39,4 +43,10 @@ SELECT (t).* FROM (
 ) AS x;
 SELECT (t).segno, (t).first_row_num, (t).hidden_tupcount >= 1 as hidden_tupcount_nonzero, (t).bitmap like '01%' as bitmap_starts_with_01 FROM (
   SELECT gp_toolkit.__gp_aovisimap_entry('toolkit_ao_test') AS t FROM gp_dist_random('gp_id')
+) AS x;
+SELECT (t).* FROM (
+  SELECT gp_toolkit.__gp_aoblkdir('toolkit_ao_test') AS t FROM gp_dist_random('gp_id')
+) AS x;
+SELECT (t).* FROM (
+  SELECT gp_toolkit.__gp_aoblkdir('toolkit_aocs_test') AS t FROM gp_dist_random('gp_id')
 ) AS x;


### PR DESCRIPTION
This commit introduces the `gp_toolkit.__gp_aoblkdir` UDF to print all of
the block directory entries for an AO/AOCO relation. It essentially
flattens the minipage binary column in `pg_aoblkdir_*` relations, printing
a minipage entry in every output row.

This function is in the same spirit as `__gp_aovisimap()` and can be run
in utility mode or with `gp_dist_random()` to obtain meaningful results.

Example:

```sql
postgres=# create table baz(i int, j int) with (appendonly=true);
postgres=# create index on baz(i);
postgres=# insert into baz select i, i FROM generate_series(1, 10) i;
postgres=# insert into baz select i, i FROM generate_series(1, 10) i;

postgres=# SELECT gp_segment_id, (gp_toolkit.__gp_aoblkdir('baz')).* FROM gp_dist_random('gp_id')
		order by 1, 2, 3, 4, 5, 6, 7, 8;
 gp_segment_id | tupleid | segno | columngroup_no | entry_no | first_row_no | file_offset | row_count
---------------+---------+-------+----------------+----------+--------------+-------------+-----------
             0 | (0,2)   |     1 |              0 |        0 |            1 |           0 |       100
             0 | (0,2)   |     1 |              0 |        1 |          101 |         128 |         5
             1 | (0,2)   |     1 |              0 |        0 |            1 |           0 |       100
             1 | (0,2)   |     1 |              0 |        1 |          101 |          40 |         1
             2 | (0,2)   |     1 |              0 |        0 |            1 |           0 |       100
             2 | (0,2)   |     1 |              0 |        1 |          101 |         104 |         4
(6 rows)

PGOPTIONS='-c gp_role=utility' psql postgres -p 7002
psql (12beta2)
Type "help" for help.

postgres=# select * from gp_toolkit.__gp_aoblkdir('baz');
 tupleid | segno | columngroup_no | entry_no | first_row_no | file_offset | row_count
---------+-------+----------------+----------+--------------+-------------+-----------
 (0,2)   |     1 |              0 |        0 |            1 |           0 |       100
 (0,2)   |     1 |              0 |        1 |          101 |         128 |         5
(2 rows)
```

This UDF also respects `gp_select_invisible` to report block directory
entries that are invisible. To determine invisible entries we can use
the tupleid projected here and tie it to the corresponding pg_aoblkdir
tuple's xmax.
