### PR TITLE
Trying to remove redundant predicates

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesForLimit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesForLimit.mdp
@@ -276,7 +276,7 @@ a < 2 should also be outside the limit but not below.
     <dxl:Plan Id="0" SpaceSize="38">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.000626" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000544" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="18" Alias="?column?">
@@ -287,14 +287,14 @@ a < 2 should also be outside the limit but not below.
         <dxl:OneTimeFilter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.000622" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000540" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList/>
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.000618" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000536" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter/>
@@ -307,7 +307,7 @@ a < 2 should also be outside the limit but not below.
             </dxl:HashCondList>
             <dxl:RandomMotion InputSegments="-1" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000275" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000194" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -318,7 +318,7 @@ a < 2 should also be outside the limit but not below.
               <dxl:SortingColumnList/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000265" Rows="1.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000183" Rows="1.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -333,62 +333,49 @@ a < 2 should also be outside the limit but not below.
                     </dxl:Comparison>
                     <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                       <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                     </dxl:Comparison>
                   </dxl:And>
                 </dxl:Filter>
                 <dxl:OneTimeFilter/>
                 <dxl:Limit>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000199" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000150" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
                       <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="b">
-                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000191" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000146" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="a">
                         <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="1" Alias="b">
-                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000102" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000102" Rows="1.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="0" Alias="a">
                           <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="1" Alias="b">
-                          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter>
                         <dxl:And>
                           <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                          </dxl:Comparison>
-                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                             <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                           </dxl:Comparison>
                           <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                             <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                           </dxl:Comparison>
                         </dxl:And>
                       </dxl:Filter>

--- a/src/backend/gporca/data/dxl/minidump/JoinOrderDPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinOrderDPE.mdp
@@ -3144,10 +3144,10 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="84">
-      <dxl:HashJoin JoinType="Inner">
+    <dxl:Plan Id="0" SpaceSize="60">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1301.264895" Rows="95315.069401" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324482.209408" Rows="95315.069401" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -3170,16 +3170,10 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:JoinFilter/>
-        <dxl:HashCondList>
-          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-            <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
-          </dxl:Comparison>
-        </dxl:HashCondList>
-        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:SortingColumnList/>
+        <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.025537" Rows="156.000136" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324473.684429" Rows="95315.069401" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -3187,6 +3181,12 @@
             </dxl:ProjElem>
             <dxl:ProjElem ColId="1" Alias="b">
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="9" Alias="a">
+              <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="10" Alias="b">
+              <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="18" Alias="a">
               <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
@@ -3196,154 +3196,14 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:SortingColumnList/>
-          <dxl:HashJoin JoinType="Inner">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.016235" Rows="156.000136" Width="16"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="a">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="b">
-                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="18" Alias="a">
-                <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="19" Alias="b">
-                <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:JoinFilter/>
-            <dxl:HashCondList>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
-                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:Comparison>
-            </dxl:HashCondList>
-            <dxl:DynamicTableScan PartIndexId="3" SelectorIds="11">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.003571" Rows="156.000000" Width="8"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="18" Alias="a">
-                  <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="19" Alias="b">
-                  <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
-                </dxl:Comparison>
-              </dxl:Filter>
-              <dxl:Partitions>
-                <dxl:Partition Mdid="0.245943.1.0"/>
-              </dxl:Partitions>
-              <dxl:TableDescriptor Mdid="0.245931.1.0" TableName="jazz" LockMode="1">
-                <dxl:Columns>
-                  <dxl:Column ColId="18" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="19" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="21" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="22" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="23" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="24" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="25" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="26" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:DynamicTableScan>
-            <dxl:PartitionSelector RelationMdid="0.245931.1.0" SelectorId="11" ScanId="3" Partitions="3">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000171" Rows="3.000003" Width="8"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="a">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="b">
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:PartFilterExpr>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
-              </dxl:PartFilterExpr>
-              <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000171" Rows="3.000003" Width="8"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="a">
-                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="b">
-                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000001" Width="8"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="a">
-                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="b">
-                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
-                    </dxl:Comparison>
-                  </dxl:Filter>
-                  <dxl:Partitions>
-                    <dxl:Partition Mdid="0.245973.1.0"/>
-                  </dxl:Partitions>
-                  <dxl:TableDescriptor Mdid="0.245961.1.0" TableName="foo" LockMode="1">
-                    <dxl:Columns>
-                      <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:DynamicTableScan>
-              </dxl:BroadcastMotion>
-            </dxl:PartitionSelector>
-          </dxl:HashJoin>
-        </dxl:GatherMotion>
-        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
-          <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.032203" Rows="610.993500" Width="8"/>
-          </dxl:Properties>
-          <dxl:ProjList>
-            <dxl:ProjElem ColId="9" Alias="a">
-              <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="b">
+          <dxl:JoinFilter/>
+          <dxl:HashCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
               <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-          </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:SortingColumnList/>
-          <dxl:DynamicTableScan PartIndexId="2" SelectorIds="">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:HashCondList>
+          <dxl:DynamicTableScan SelectorIds="11">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.013988" Rows="610.993500" Width="8"/>
             </dxl:Properties>
@@ -3378,8 +3238,162 @@
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:DynamicTableScan>
-        </dxl:GatherMotion>
-      </dxl:HashJoin>
+          <dxl:PartitionSelector RelationMdid="0.245991.1.0" SelectorId="11" ScanId="2" Partitions="3">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1324039.890475" Rows="468.000409" Width="16"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="b">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="18" Alias="a">
+                <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="19" Alias="b">
+                <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:PartFilterExpr>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:Comparison>
+            </dxl:PartFilterExpr>
+            <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1324039.890475" Rows="468.000409" Width="16"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="a">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="b">
+                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="18" Alias="a">
+                  <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="19" Alias="b">
+                  <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1324039.845796" Rows="156.000136" Width="16"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="a">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="b">
+                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="18" Alias="a">
+                    <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="19" Alias="b">
+                    <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:JoinFilter>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:JoinFilter>
+                <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000171" Rows="3.000003" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="a">
+                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="1" Alias="b">
+                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList/>
+                  <dxl:DynamicTableScan SelectorIds="">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000001" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="a">
+                        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="1" Alias="b">
+                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
+                      </dxl:Comparison>
+                    </dxl:Filter>
+                    <dxl:Partitions>
+                      <dxl:Partition Mdid="0.245973.1.0"/>
+                    </dxl:Partitions>
+                    <dxl:TableDescriptor Mdid="0.245961.1.0" TableName="foo" LockMode="1">
+                      <dxl:Columns>
+                        <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                        <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:DynamicTableScan>
+                </dxl:BroadcastMotion>
+                <dxl:DynamicTableScan SelectorIds="">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.003571" Rows="156.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="18" Alias="a">
+                      <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="19" Alias="b">
+                      <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
+                    </dxl:Comparison>
+                  </dxl:Filter>
+                  <dxl:Partitions>
+                    <dxl:Partition Mdid="0.245943.1.0"/>
+                  </dxl:Partitions>
+                  <dxl:TableDescriptor Mdid="0.245931.1.0" TableName="jazz" LockMode="1">
+                    <dxl:Columns>
+                      <dxl:Column ColId="18" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="19" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="21" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="22" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="23" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="24" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="25" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="26" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:DynamicTableScan>
+              </dxl:NestedLoopJoin>
+            </dxl:BroadcastMotion>
+          </dxl:PartitionSelector>
+        </dxl:HashJoin>
+      </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/PushGbBelowJoin-NegativeCase.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushGbBelowJoin-NegativeCase.mdp
@@ -406,10 +406,10 @@
         </dxl:LogicalSelect>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="12480">
-      <dxl:Result>
+    <dxl:Plan Id="0" SpaceSize="80520">
+      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3017.002573" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="15085.006233" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="20" Alias="c9596">
@@ -417,46 +417,38 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:OneTimeFilter/>
-        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+        <dxl:SortingColumnList/>
+        <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3017.002573" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="15085.006215" Rows="1.000000" Width="4"/>
           </dxl:Properties>
-          <dxl:GroupingColumns>
-            <dxl:GroupingColumn ColId="20"/>
-            <dxl:GroupingColumn ColId="17"/>
-          </dxl:GroupingColumns>
           <dxl:ProjList>
             <dxl:ProjElem ColId="20" Alias="?column?">
               <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="17" Alias="max">
-              <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:Sort SortDiscardDuplicates="false">
+          <dxl:OneTimeFilter/>
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3017.002562" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="15085.006215" Rows="1.000000" Width="4"/>
             </dxl:Properties>
+            <dxl:GroupingColumns>
+              <dxl:GroupingColumn ColId="20"/>
+              <dxl:GroupingColumn ColId="17"/>
+            </dxl:GroupingColumns>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="17" Alias="max">
-                <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
               <dxl:ProjElem ColId="20" Alias="?column?">
                 <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
+              <dxl:ProjElem ColId="17" Alias="max">
+                <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList>
-              <dxl:SortingColumn ColId="20" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-              <dxl:SortingColumn ColId="17" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-            </dxl:SortingColumnList>
-            <dxl:LimitCount/>
-            <dxl:LimitOffset/>
-            <dxl:HashJoin JoinType="Inner">
+            <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3017.002562" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="15085.006205" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="17" Alias="max">
@@ -467,114 +459,117 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:JoinFilter>
-                <dxl:And>
-                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1756.1.0">
-                    <dxl:Ident ColId="16" ColName="avg" TypeMdid="0.1700.1.0"/>
-                    <dxl:FuncExpr FuncId="0.1740.1.0" FuncRetSet="false" TypeMdid="0.1700.1.0">
-                      <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
-                    </dxl:FuncExpr>
-                  </dxl:Comparison>
-                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                    <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
-                </dxl:And>
-              </dxl:JoinFilter>
-              <dxl:HashCondList>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
-              </dxl:HashCondList>
-              <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="20" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                <dxl:SortingColumn ColId="17" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:LimitCount/>
+              <dxl:LimitOffset/>
+              <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000270" Rows="1.000000" Width="20"/>
+                  <dxl:Cost StartupCost="0" TotalCost="15085.006205" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="8" Alias="c504">
-                    <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="16" Alias="avg">
-                    <dxl:Ident ColId="16" ColName="avg" TypeMdid="0.1700.1.0"/>
-                  </dxl:ProjElem>
                   <dxl:ProjElem ColId="17" Alias="max">
                     <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="20" Alias="?column?">
+                    <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
-                <dxl:Result>
+                <dxl:HashExprList>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
+                  </dxl:HashExpr>
+                  <dxl:HashExpr>
+                    <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000090" Rows="1.000000" Width="20"/>
+                    <dxl:Cost StartupCost="0" TotalCost="15085.006190" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="8" Alias="c504">
-                      <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="16" Alias="avg">
-                      <dxl:Ident ColId="16" ColName="avg" TypeMdid="0.1700.1.0"/>
-                    </dxl:ProjElem>
                     <dxl:ProjElem ColId="17" Alias="max">
                       <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
+                    <dxl:ProjElem ColId="20" Alias="?column?">
+                      <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:Filter>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                      <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                    </dxl:Comparison>
-                  </dxl:Filter>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                  <dxl:Filter/>
+                  <dxl:JoinFilter>
+                    <dxl:And>
+                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1756.1.0">
+                        <dxl:Ident ColId="16" ColName="avg" TypeMdid="0.1700.1.0"/>
+                        <dxl:FuncExpr FuncId="0.1740.1.0" FuncRetSet="false" TypeMdid="0.1700.1.0">
+                          <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
+                        </dxl:FuncExpr>
+                      </dxl:Comparison>
+                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                        <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+                      </dxl:Comparison>
+                    </dxl:And>
+                  </dxl:JoinFilter>
+                  <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000057" Rows="1.000000" Width="20"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000090" Rows="1.000000" Width="20"/>
                     </dxl:Properties>
-                    <dxl:GroupingColumns>
-                      <dxl:GroupingColumn ColId="8"/>
-                    </dxl:GroupingColumns>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="16" Alias="avg">
-                        <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
-                          <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                          </dxl:ValuesList>
-                          <dxl:ValuesList ParamType="aggdirectargs"/>
-                          <dxl:ValuesList ParamType="aggorder"/>
-                          <dxl:ValuesList ParamType="aggdistinct"/>
-                        </dxl:AggFunc>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="17" Alias="max">
-                        <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
-                          <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                          </dxl:ValuesList>
-                          <dxl:ValuesList ParamType="aggdirectargs"/>
-                          <dxl:ValuesList ParamType="aggorder"/>
-                          <dxl:ValuesList ParamType="aggdistinct"/>
-                        </dxl:AggFunc>
-                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="8" Alias="c504">
                         <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
+                      <dxl:ProjElem ColId="16" Alias="avg">
+                        <dxl:Ident ColId="16" ColName="avg" TypeMdid="0.1700.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="17" Alias="max">
+                        <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
                     </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:Sort SortDiscardDuplicates="false">
+                    <dxl:Filter>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                        <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                      </dxl:Comparison>
+                    </dxl:Filter>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000038" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000057" Rows="1.000000" Width="20"/>
                       </dxl:Properties>
+                      <dxl:GroupingColumns>
+                        <dxl:GroupingColumn ColId="8"/>
+                      </dxl:GroupingColumns>
                       <dxl:ProjList>
+                        <dxl:ProjElem ColId="16" Alias="avg">
+                          <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="17" Alias="max">
+                          <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="8" Alias="c504">
                           <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:SortingColumnList>
-                        <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      </dxl:SortingColumnList>
-                      <dxl:LimitCount/>
-                      <dxl:LimitOffset/>
-                      <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                      <dxl:Sort SortDiscardDuplicates="false">
                         <dxl:Properties>
                           <dxl:Cost StartupCost="0" TotalCost="431.000038" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
@@ -584,15 +579,14 @@
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:HashExprList>
-                          <dxl:HashExpr>
-                            <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                          </dxl:HashExpr>
-                        </dxl:HashExprList>
-                        <dxl:TableScan>
+                        <dxl:SortingColumnList>
+                          <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        </dxl:SortingColumnList>
+                        <dxl:LimitCount/>
+                        <dxl:LimitOffset/>
+                        <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="8"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000038" Rows="1.000000" Width="8"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="8" Alias="c504">
@@ -600,136 +594,108 @@
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="0.131046.1.1" TableName="t39">
-                            <dxl:Columns>
-                              <dxl:Column ColId="3" Attno="1" ColName="c499" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="4" Attno="2" ColName="c500" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="6" Attno="4" ColName="c502" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="7" Attno="5" ColName="c503" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="8" Attno="6" ColName="c504" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:RedistributeMotion>
-                    </dxl:Sort>
-                  </dxl:Aggregate>
-                </dxl:Result>
-              </dxl:GatherMotion>
-              <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2586.001386" Rows="1.000000" Width="8"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="2" Alias="min">
-                    <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="20" Alias="?column?">
-                    <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:JoinFilter>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                </dxl:JoinFilter>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000186" Rows="1.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="2" Alias="min">
-                      <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                      <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                      <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                    </dxl:Comparison>
-                  </dxl:Filter>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Limit>
+                          <dxl:SortingColumnList/>
+                          <dxl:HashExprList>
+                            <dxl:HashExpr>
+                              <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+                            </dxl:HashExpr>
+                          </dxl:HashExprList>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="1.000000" Width="8"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="8" Alias="c504">
+                                <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="0.131046.1.1" TableName="t39">
+                              <dxl:Columns>
+                                <dxl:Column ColId="3" Attno="1" ColName="c499" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="4" Attno="2" ColName="c500" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="6" Attno="4" ColName="c502" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="7" Attno="5" ColName="c503" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="8" Attno="6" ColName="c504" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:RedistributeMotion>
+                      </dxl:Sort>
+                    </dxl:Aggregate>
+                  </dxl:Result>
+                  <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000120" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="2155.000631" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="1" Alias="?column?">
-                        <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="2" Alias="min">
                         <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
+                      <dxl:ProjElem ColId="20" Alias="?column?">
+                        <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
                     </dxl:ProjList>
-                    <dxl:Result>
+                    <dxl:Filter/>
+                    <dxl:JoinFilter>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:JoinFilter>
+                    <dxl:Limit>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.000112" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000081" Rows="1.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="1" Alias="?column?">
-                          <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="2" Alias="min">
                           <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
-                      <dxl:Filter>
-                        <dxl:And>
+                      <dxl:Result>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="0.000077" Rows="1.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="2" Alias="min">
+                            <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter>
                           <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                             <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
                             <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                           </dxl:Comparison>
-                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                            <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                            <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                          </dxl:Comparison>
-                        </dxl:And>
-                      </dxl:Filter>
-                      <dxl:OneTimeFilter/>
-                      <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="0.000046" Rows="1.000000" Width="8"/>
-                        </dxl:Properties>
-                        <dxl:GroupingColumns>
-                          <dxl:GroupingColumn ColId="1"/>
-                        </dxl:GroupingColumns>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="2" Alias="min">
-                            <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
-                              <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                              </dxl:ValuesList>
-                              <dxl:ValuesList ParamType="aggdirectargs"/>
-                              <dxl:ValuesList ParamType="aggorder"/>
-                              <dxl:ValuesList ParamType="aggdistinct"/>
-                            </dxl:AggFunc>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="1" Alias="?column?">
-                            <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:Sort SortDiscardDuplicates="false">
+                        </dxl:Filter>
+                        <dxl:OneTimeFilter/>
+                        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="0.000038" Rows="1.000000" Width="4"/>
+                            <dxl:Cost StartupCost="0" TotalCost="0.000044" Rows="1.000000" Width="4"/>
                           </dxl:Properties>
+                          <dxl:GroupingColumns>
+                            <dxl:GroupingColumn ColId="1"/>
+                          </dxl:GroupingColumns>
                           <dxl:ProjList>
+                            <dxl:ProjElem ColId="2" Alias="min">
+                              <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+                                <dxl:ValuesList ParamType="aggargs">
+                                  <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
+                                </dxl:ValuesList>
+                                <dxl:ValuesList ParamType="aggdirectargs"/>
+                                <dxl:ValuesList ParamType="aggorder"/>
+                                <dxl:ValuesList ParamType="aggdistinct"/>
+                              </dxl:AggFunc>
+                            </dxl:ProjElem>
                             <dxl:ProjElem ColId="1" Alias="?column?">
                               <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:SortingColumnList>
-                            <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                          </dxl:SortingColumnList>
-                          <dxl:LimitCount/>
-                          <dxl:LimitOffset/>
-                          <dxl:Result>
+                          <dxl:Sort SortDiscardDuplicates="false">
                             <dxl:Properties>
                               <dxl:Cost StartupCost="0" TotalCost="0.000038" Rows="1.000000" Width="4"/>
                             </dxl:Properties>
@@ -738,78 +704,94 @@
                                 <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
-                            <dxl:Filter>
-                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                              </dxl:Comparison>
-                            </dxl:Filter>
-                            <dxl:OneTimeFilter/>
+                            <dxl:Filter/>
+                            <dxl:SortingColumnList>
+                              <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                            </dxl:SortingColumnList>
+                            <dxl:LimitCount/>
+                            <dxl:LimitOffset/>
                             <dxl:Result>
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                                <dxl:Cost StartupCost="0" TotalCost="0.000038" Rows="1.000000" Width="4"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="1" Alias="?column?">
-                                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                                  <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
                                 </dxl:ProjElem>
                               </dxl:ProjList>
-                              <dxl:Filter/>
+                              <dxl:Filter>
+                                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                  <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
+                                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                                </dxl:Comparison>
+                              </dxl:Filter>
                               <dxl:OneTimeFilter/>
                               <dxl:Result>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
-                                  <dxl:ProjElem ColId="0" Alias="">
-                                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                  <dxl:ProjElem ColId="1" Alias="?column?">
+                                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
                                 <dxl:OneTimeFilter/>
+                                <dxl:Result>
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="0" Alias="">
+                                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:OneTimeFilter/>
+                                </dxl:Result>
                               </dxl:Result>
                             </dxl:Result>
-                          </dxl:Result>
-                        </dxl:Sort>
-                      </dxl:Aggregate>
+                          </dxl:Sort>
+                        </dxl:Aggregate>
+                      </dxl:Result>
+                      <dxl:LimitCount>
+                        <dxl:ConstValue TypeMdid="0.20.1.0" Value="3613"/>
+                      </dxl:LimitCount>
+                      <dxl:LimitOffset>
+                        <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                      </dxl:LimitOffset>
+                    </dxl:Limit>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="20" Alias="?column?">
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                      <dxl:Result>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="19" Alias="">
+                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:OneTimeFilter/>
+                      </dxl:Result>
                     </dxl:Result>
-                    <dxl:LimitCount>
-                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="3613"/>
-                    </dxl:LimitCount>
-                    <dxl:LimitOffset>
-                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                    </dxl:LimitOffset>
-                  </dxl:Limit>
-                </dxl:Result>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="20" Alias="?column?">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="19" Alias="">
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                  </dxl:Result>
-                </dxl:Result>
-              </dxl:NestedLoopJoin>
-            </dxl:HashJoin>
-          </dxl:Sort>
-        </dxl:Aggregate>
-      </dxl:Result>
+                  </dxl:NestedLoopJoin>
+                </dxl:NestedLoopJoin>
+              </dxl:RedistributeMotion>
+            </dxl:Sort>
+          </dxl:Aggregate>
+        </dxl:Result>
+      </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -1654,7 +1654,9 @@ CExpressionPreprocessor::PexprFromConstraintsScalar(
 						{
 							canBeRemoved = true;
 						}
+						CRefCount::SafeRelease(pexprScalar);
 					}
+
 					// If the column attribute is not resolved to a constant value ,
 					// it means it's not redundant, so we can't remove it.
 					if (!canBeRemoved)
@@ -1717,8 +1719,13 @@ CExpressionPreprocessor::PexprFromConstraintsScalar(
 				{
 					pexprNew = (*childrenRedundantArray)[0];
 					pexprNew->AddRef();
+					CRefCount::SafeRelease(childrenArray);
+					CRefCount::SafeRelease(childrenRedundantArray);
 					return pexprNew;
 				}
+				pexprNew->AddRef();
+				CRefCount::SafeRelease(childrenArray);
+				CRefCount::SafeRelease(childrenRedundantArray);
 				return pexprNew;
 			}
 
@@ -1727,6 +1734,8 @@ CExpressionPreprocessor::PexprFromConstraintsScalar(
 			{
 				CExpression *pexprNew = (*childrenArray)[0];
 				pexprNew->AddRef();
+				CRefCount::SafeRelease(childrenArray);
+				CRefCount::SafeRelease(childrenRedundantArray);
 				return pexprNew;
 			}
 
@@ -1736,10 +1745,12 @@ CExpressionPreprocessor::PexprFromConstraintsScalar(
 			{
 				COperator *pop = pexpr->Pop();
 				pop->AddRef();
+				CRefCount::SafeRelease(childrenRedundantArray);
 				return GPOS_NEW(mp) CExpression(mp, pop, childrenArray);
 			}
 		}
-
+		CRefCount::SafeRelease(childrenArray);
+		CRefCount::SafeRelease(childrenRedundantArray);
 		pexpr->AddRef();
 		return pexpr;
 	}

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -1608,7 +1608,6 @@ CExpressionPreprocessor::PexprFromConstraintsScalar(
 	GPOS_ASSERT(pexpr->Pop()->FScalar());
 	if (!CUtils::FHasSubquery(pexpr))
 	{
-
 		//	Input:
 		// +--CLogicalNAryJoin
 		// |--CLogicalGet "foo" ("foo"), Columns: ["a" (0), "b" (1), "ctid" (2), "xmin" (3), "cmin" (4), "xmax" (5), "cmax" (6), "tableoid" (7), "gp_segment_id" (8)] Key sets: {[2,8]}

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -1641,7 +1641,9 @@ CExpressionPreprocessor::PexprFromConstraintsScalar(
 		//    +--CScalarIdent "c" (9)
 
 		CExpressionArray *childrenArray = GPOS_NEW(mp) CExpressionArray(mp);
-		if (COperator::EopScalarBoolOp == pexpr->Pop()->Eopid())
+		if (COperator::EopScalarBoolOp == pexpr->Pop()->Eopid() &&
+			CScalarBoolOp::EboolopNot !=
+				CScalarBoolOp::PopConvert(pexpr->Pop())->Eboolop())
 		{
 			const ULONG childrenCount = pexpr->Arity();
 			for (ULONG ul = 0; ul < childrenCount; ul++)

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -1609,6 +1609,39 @@ CExpressionPreprocessor::PexprFromConstraintsScalar(
 
 	if (!CUtils::FHasSubquery(pexpr))
 	{
+
+		//	Input:
+		// +--CLogicalNAryJoin
+		// |--CLogicalGet "foo" ("foo"), Columns: ["a" (0), "b" (1), "ctid" (2), "xmin" (3), "cmin" (4), "xmax" (5), "cmax" (6), "tableoid" (7), "gp_segment_id" (8)] Key sets: {[2,8]}
+		// |--CLogicalSelect
+		// |  |--CLogicalGet "bar" ("bar"), Columns: ["c" (9), "d" (10), "ctid" (11), "xmin" (12), "cmin" (13), "xmax" (14), "cmax" (15), "tableoid" (16), "gp_segment_id" (17)] Key sets: {[2,8]}
+		// |  +--CScalarCmp (=)
+		// |     |--CScalarIdent "d" (10)
+		// |     +--CScalarConst (1098678817.000)
+		// +--CScalarBoolOp (EboolopAnd)
+		//   |--CScalarCmp (=)
+		//   |  |--CScalarIdent "a" (0)
+		//   |  +--CScalarIdent "c" (9)
+		//   +--CScalarCmp (=)
+		//	  |--CScalarIdent "b" (1)
+		//	  +--CScalarIdent "d" (10)
+		//
+		// Output:
+		// +--CLogicalNAryJoin
+		// |--CLogicalSelect
+		// |  |--CLogicalGet "foo" ("foo"), Columns: ["a" (0), "b" (1), "ctid" (2), "xmin" (3), "cmin" (4), "xmax" (5), "cmax" (6), "tableoid" (7), "gp_segment_id" (8)] Key sets: {[2,8]}
+		// |  +--CScalarCmp (=)
+		// |     |--CScalarIdent "b" (1)
+		// |     +--CScalarConst (1098678817.000)
+		// |--CLogicalSelect
+		// |  |--CLogicalGet "bar" ("bar"), Columns: ["c" (9), "d" (10), "ctid" (11), "xmin" (12), "cmin" (13), "xmax" (14), "cmax" (15), "tableoid" (16), "gp_segment_id" (17)] Key sets: {[2,8]}
+		// |  +--CScalarCmp (=)
+		// |     |--CScalarIdent "d" (10)
+		// |     +--CScalarConst (1098678817.000)
+		// +--CScalarCmp (=)
+		//    |--CScalarIdent "a" (0)
+		//    +--CScalarIdent "c" (9)
+		
 		CExpressionArray *childrenArray = GPOS_NEW(mp) CExpressionArray(mp);
 		if (COperator::EopScalarBoolOp == pexpr->Pop()->Eopid())
 		{
@@ -1889,37 +1922,6 @@ CExpressionPreprocessor::PexprFromConstraints(
 
 	CExpressionArray *pdrgpexprChildren = GPOS_NEW(mp) CExpressionArray(mp);
 
-//	Input:
-// +--CLogicalNAryJoin
-// |--CLogicalGet "foo" ("foo"), Columns: ["a" (0), "b" (1), "ctid" (2), "xmin" (3), "cmin" (4), "xmax" (5), "cmax" (6), "tableoid" (7), "gp_segment_id" (8)] Key sets: {[2,8]}
-// |--CLogicalSelect
-// |  |--CLogicalGet "bar" ("bar"), Columns: ["c" (9), "d" (10), "ctid" (11), "xmin" (12), "cmin" (13), "xmax" (14), "cmax" (15), "tableoid" (16), "gp_segment_id" (17)] Key sets: {[2,8]}
-// |  +--CScalarCmp (=)
-// |     |--CScalarIdent "d" (10)
-// |     +--CScalarConst (1098678817.000)
-// +--CScalarBoolOp (EboolopAnd)
-//   |--CScalarCmp (=)
-//   |  |--CScalarIdent "a" (0)
-//   |  +--CScalarIdent "c" (9)
-//   +--CScalarCmp (=)
-//	  |--CScalarIdent "b" (1)
-//	  +--CScalarIdent "d" (10)
-//
-// Output:
-// +--CLogicalNAryJoin
-// |--CLogicalSelect
-// |  |--CLogicalGet "foo" ("foo"), Columns: ["a" (0), "b" (1), "ctid" (2), "xmin" (3), "cmin" (4), "xmax" (5), "cmax" (6), "tableoid" (7), "gp_segment_id" (8)] Key sets: {[2,8]}
-// |  +--CScalarCmp (=)
-// |     |--CScalarIdent "b" (1)
-// |     +--CScalarConst (1098678817.000)
-// |--CLogicalSelect
-// |  |--CLogicalGet "bar" ("bar"), Columns: ["c" (9), "d" (10), "ctid" (11), "xmin" (12), "cmin" (13), "xmax" (14), "cmax" (15), "tableoid" (16), "gp_segment_id" (17)] Key sets: {[2,8]}
-// |  +--CScalarCmp (=)
-// |     |--CScalarIdent "d" (10)
-// |     +--CScalarConst (1098678817.000)
-// +--CScalarCmp (=)
-//    |--CScalarIdent "a" (0)
-//    +--CScalarIdent "c" (9)
 
 	for (ULONG ul = 0; ul < ulChildren; ul++)
 	{

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -1606,7 +1606,6 @@ CExpressionPreprocessor::PexprFromConstraintsScalar(
 {
 	GPOS_ASSERT(nullptr != pexpr);
 	GPOS_ASSERT(pexpr->Pop()->FScalar());
-
 	if (!CUtils::FHasSubquery(pexpr))
 	{
 
@@ -1641,7 +1640,7 @@ CExpressionPreprocessor::PexprFromConstraintsScalar(
 		// +--CScalarCmp (=)
 		//    |--CScalarIdent "a" (0)
 		//    +--CScalarIdent "c" (9)
-		
+
 		CExpressionArray *childrenArray = GPOS_NEW(mp) CExpressionArray(mp);
 		if (COperator::EopScalarBoolOp == pexpr->Pop()->Eopid())
 		{
@@ -1658,7 +1657,7 @@ CExpressionPreprocessor::PexprFromConstraintsScalar(
 					CColRef *columnRef = iterator.Pcr();
 					CExpression *pexprScalar =
 						constraintsForOuterRefs->PexprScalarMappedFromEquivCols(
-							mp, columnRef, constraintsForOuterRefs);
+							mp, columnRef, nullptr);
 					if (nullptr != pexprScalar &&
 						COperator::EopScalarCmp == pexprScalar->Pop()->Eopid())
 					{

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -1724,7 +1724,10 @@ CExpressionPreprocessor::PexprFromConstraintsScalar(
 					constraintsForOuterRefs->PexprScalarMappedFromEquivCols(
 						mp, columnRef, nullptr);
 				if (nullptr != pexprScalar &&
-					COperator::EopScalarCmp == pexprScalar->Pop()->Eopid())
+					COperator::EopScalarCmp == pexprScalar->Pop()->Eopid() &&
+					IMDType::EcmptEq ==
+						CScalarCmp::PopConvert(pexprScalar->Pop())
+							->ParseCmpType())
 				{
 					canBeRemoved = true;
 				}

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -1705,7 +1705,7 @@ CExpressionPreprocessor::PexprFromConstraintsScalar(
 				CColRef *columnRef = iterator.Pcr();
 				CExpression *pexprScalar =
 					constraintsForOuterRefs->PexprScalarMappedFromEquivCols(
-						mp, columnRef, constraintsForOuterRefs);
+						mp, columnRef, nullptr);
 				if (nullptr != pexprScalar &&
 					COperator::EopScalarCmp == pexprScalar->Pop()->Eopid())
 				{

--- a/src/test/regress/expected/equivclass_optimizer.out
+++ b/src/test/regress/expected/equivclass_optimizer.out
@@ -105,13 +105,13 @@ set enable_mergejoin = off;
 --
 explain (costs off)
   select * from ec0 where ff = f1 and f1 = '42'::int8;
-                      QUERY PLAN                      
-------------------------------------------------------
+                QUERY PLAN                
+------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Index Scan using ec0_pkey on ec0
          Index Cond: (ff = '42'::bigint)
-         Filter: ((f1 = '42'::bigint) AND (ff = f1))
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
+         Filter: (f1 = '42'::bigint)
+ Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
 explain (costs off)

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -153,20 +153,18 @@ select * from t1,t2 where t1.x = 100 and t2.x >= t1.x;
 --
 set optimizer_segments=2;
 explain select * from t1,t2 where t1.x = 100 and t1.x = t2.y and t1.x <= t2.x;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
- Hash Join  (cost=0.00..862.01 rows=1 width=24)
-   Hash Cond: (t1.x = t2.y)
-   Join Filter: (t1.x <= t2.x)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
-         ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=12)
-               Filter: (x = 100)
-   ->  Hash  (cost=431.00..431.00 rows=1 width=12)
-         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
-               ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=12)
-                     Filter: (y = 100)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(11 rows)
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324038.40 rows=1 width=24)
+   ->  Nested Loop  (cost=0.00..1324038.40 rows=1 width=24)
+         Join Filter: (t1.x <= t2.x)
+         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+               ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=12)
+                     Filter: (x = 100)
+         ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=12)
+               Filter: (y = 100)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
 
 reset optimizer_segments;
 select * from t1,t2 where t1.x = 100 and t1.x = t2.y and t1.x <= t2.x;

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -1862,23 +1862,33 @@ select * from int4_tbl i4, tenk1 a
 where exists(select * from tenk1 b
              where a.twothousand = b.twothousand and a.fivethous <> b.fivethous)
       and i4.f1 = a.tenthous;
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Hash Semi Join
-         Hash Cond: (tenk1.twothousand = tenk1_1.twothousand)
-         Join Filter: (tenk1.fivethous <> tenk1_1.fivethous)
-         ->  Nested Loop
-               Join Filter: true
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                     ->  Seq Scan on int4_tbl
-               ->  Index Scan using tenk1_thous_tenthous on tenk1
-                     Index Cond: (tenthous = int4_tbl.f1)
-         ->  Hash
-               ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                     ->  Seq Scan on tenk1 tenk1_1
+   ->  GroupAggregate
+         Group Key: int4_tbl.f1, int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.unique1, tenk1_1.unique2, tenk1_1.two, tenk1_1.four, tenk1_1.ten, tenk1_1.twenty, tenk1_1.hundred, tenk1_1.thousand, tenk1_1.twothousand, tenk1_1.fivethous, tenk1_1.tenthous, tenk1_1.odd, tenk1_1.even, tenk1_1.stringu1, tenk1_1.stringu2, tenk1_1.string4, tenk1_1.ctid, tenk1_1.gp_segment_id
+         ->  Sort
+               Sort Key: int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.ctid, tenk1_1.gp_segment_id
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.ctid, tenk1_1.gp_segment_id
+                     ->  GroupAggregate
+                           Group Key: int4_tbl.f1, int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.unique1, tenk1_1.unique2, tenk1_1.two, tenk1_1.four, tenk1_1.ten, tenk1_1.twenty, tenk1_1.hundred, tenk1_1.thousand, tenk1_1.twothousand, tenk1_1.fivethous, tenk1_1.tenthous, tenk1_1.odd, tenk1_1.even, tenk1_1.stringu1, tenk1_1.stringu2, tenk1_1.string4, tenk1_1.ctid, tenk1_1.gp_segment_id
+                           ->  Sort
+                                 Sort Key: int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.ctid, tenk1_1.gp_segment_id
+                                 ->  Hash Join
+                                       Hash Cond: (tenk1.twothousand = tenk1_1.twothousand)
+                                       Join Filter: (tenk1_1.fivethous <> tenk1.fivethous)
+                                       ->  Seq Scan on tenk1
+                                       ->  Hash
+                                             ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                                   ->  Nested Loop
+                                                         Join Filter: true
+                                                         ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                                               ->  Seq Scan on int4_tbl
+                                                         ->  Index Scan using tenk1_thous_tenthous on tenk1 tenk1_1
+                                                               Index Cond: (tenthous = int4_tbl.f1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+(24 rows)
 
 --
 -- More complicated constructs
@@ -2253,27 +2263,26 @@ explain (costs off)
 select * from int8_tbl i1 left join (int8_tbl i2 join
   (select 123 as x) ss on i2.q1 = x) on i1.q2 = i2.q2
 order by 1, 2;
-                               QUERY PLAN                               
-------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   Merge Key: int8_tbl.q1, int8_tbl.q2
-   ->  Sort
-         Sort Key: int8_tbl.q1, int8_tbl.q2
-         ->  Hash Left Join
-               Hash Cond: (int8_tbl.q2 = int8_tbl_1.q2)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: int8_tbl.q2
-                     ->  Seq Scan on int8_tbl
-               ->  Hash
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                           Hash Key: int8_tbl_1.q2
-                           ->  Nested Loop
-                                 Join Filter: true
-                                 ->  Seq Scan on int8_tbl int8_tbl_1
-                                       Filter: (q1 = 123)
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Sort
+   Sort Key: int8_tbl.q1, int8_tbl.q2
+   ->  Hash Left Join
+         Hash Cond: (int8_tbl.q2 = int8_tbl_1.q2)
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               ->  Seq Scan on int8_tbl
+         ->  Hash
+               ->  Hash Join
+                     Hash Cond: (int8_tbl_1.q1 = ((123))::bigint)
+                     ->  Gather Motion 3:1  (slice2; segments: 3)
+                           ->  Seq Scan on int8_tbl int8_tbl_1
+                                 Filter: (q1 = 123)
+                     ->  Hash
+                           ->  Result
+                                 Filter: ((123) = 123)
                                  ->  Result
  Optimizer: Pivotal Optimizer (GPORCA)
-(18 rows)
+(17 rows)
 
 select * from int8_tbl i1 left join (int8_tbl i2 join
   (select 123 as x) ss on i2.q1 = x) on i1.q2 = i2.q2
@@ -2317,12 +2326,12 @@ select a.f1, b.f1, t.thousand, t.tenthous from
   (select sum(f1)+1 as f1 from int4_tbl i4a) a,
   (select sum(f1) as f1 from int4_tbl i4b) b
 where b.f1 = t.thousand and a.f1 = b.f1 and (a.f1+b.f1+999) = t.tenthous;
-                                              QUERY PLAN                                               
--------------------------------------------------------------------------------------------------------
- Hash Join
-   Hash Cond: ((sum(int4_tbl.f1)) = ((sum(int4_tbl_1.f1) + 1)))
-   Join Filter: (((((sum(int4_tbl_1.f1) + 1)) + (sum(int4_tbl.f1))) + 999) = (tenk1.tenthous)::bigint)
-   ->  Gather Motion 3:1  (slice1; segments: 3)
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: ((sum(int4_tbl.f1)) = (((sum(int4_tbl_1.f1)) + 1)))
+         Join Filter: ((((((sum(int4_tbl_1.f1)) + 1)) + (sum(int4_tbl.f1))) + 999) = (tenk1.tenthous)::bigint)
          ->  Nested Loop
                Join Filter: true
                ->  Broadcast Motion 1:3  (slice2)
@@ -2330,15 +2339,17 @@ where b.f1 = t.thousand and a.f1 = b.f1 and (a.f1+b.f1+999) = t.tenthous;
                            ->  Gather Motion 3:1  (slice3; segments: 3)
                                  ->  Partial Aggregate
                                        ->  Seq Scan on int4_tbl
-               ->  Index Scan using tenk1_thous_tenthous on tenk1
+               ->  Index Only Scan using tenk1_thous_tenthous on tenk1
                      Index Cond: (thousand = (sum(int4_tbl.f1)))
-   ->  Hash
-         ->  Finalize Aggregate
-               ->  Gather Motion 3:1  (slice4; segments: 3)
-                     ->  Partial Aggregate
-                           ->  Seq Scan on int4_tbl int4_tbl_1
+         ->  Hash
+               ->  Result
+                     ->  Broadcast Motion 1:3  (slice4)
+                           ->  Finalize Aggregate
+                                 ->  Gather Motion 3:1  (slice5; segments: 3)
+                                       ->  Partial Aggregate
+                                             ->  Seq Scan on int4_tbl int4_tbl_1
  Optimizer: Pivotal Optimizer (GPORCA)
-(19 rows)
+(21 rows)
 
 select a.f1, b.f1, t.thousand, t.tenthous from
   tenk1 t,
@@ -2416,18 +2427,22 @@ select count(*) from
   left join
   (select * from tenk1 y order by y.unique2) y
   on x.thousand = y.unique2 and x.twothousand = y.hundred and x.fivethous = y.unique2;
-                                                                   QUERY PLAN                                                                    
--------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
+                                                                      QUERY PLAN                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Hash Left Join
-               Hash Cond: ((tenk1.thousand = tenk1_1.unique2) AND (tenk1.twothousand = tenk1_1.hundred) AND (tenk1.fivethous = tenk1_1.unique2))
-               ->  Seq Scan on tenk1
-               ->  Hash
-                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                           ->  Seq Scan on tenk1 tenk1_1
+         ->  Partial Aggregate
+               ->  Hash Left Join
+                     Hash Cond: ((tenk1.thousand = tenk1_1.unique2) AND (tenk1.twothousand = tenk1_1.hundred) AND (tenk1.fivethous = tenk1_1.unique2))
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: tenk1.thousand, tenk1.twothousand, tenk1.thousand
+                           ->  Seq Scan on tenk1
+                     ->  Hash
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: tenk1_1.unique2, tenk1_1.hundred, tenk1_1.unique2
+                                 ->  Seq Scan on tenk1 tenk1_1
  Optimizer: Pivotal Optimizer (GPORCA)
-(9 rows)
+(13 rows)
 
 select count(*) from
   (select * from tenk1 x order by x.thousand, x.twothousand, x.fivethous) x
@@ -2560,19 +2575,20 @@ set enable_mergejoin to off;
 explain (costs off)
 select count(*) from tenk1 a, tenk1 b
   where a.hundred = b.thousand and (b.fivethous % 10) < 10;
-                            QUERY PLAN                             
--------------------------------------------------------------------
- Aggregate
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Nested Loop
-               Join Filter: true
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                     ->  Seq Scan on tenk1
-                           Filter: ((fivethous % 10) < 10)
-               ->  Index Scan using tenk1_hundred on tenk1 tenk1_1
-                     Index Cond: (hundred = tenk1.thousand)
+         ->  Partial Aggregate
+               ->  Nested Loop
+                     Join Filter: true
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                           ->  Seq Scan on tenk1
+                                 Filter: ((fivethous % 10) < 10)
+                     ->  Index Only Scan using tenk1_hundred on tenk1 tenk1_1
+                           Index Cond: (hundred = tenk1.thousand)
  Optimizer: Pivotal Optimizer (GPORCA)
-(10 rows)
+(11 rows)
 
 select count(*) from tenk1 a, tenk1 b
   where a.hundred = b.thousand and (b.fivethous % 10) < 10;
@@ -3229,16 +3245,22 @@ where q1 = thousand or q2 = thousand;
          Hash Cond: (tenk1.twothousand = int4_tbl.f1)
          ->  Nested Loop
                Join Filter: true
-               ->  Seq Scan on tenk1
-               ->  Result
+               ->  Nested Loop
+                     Join Filter: true
+                     ->  Result
+                     ->  Result
+               ->  Bitmap Heap Scan on tenk1
+                     Recheck Cond: ((thousand = (1)) OR (thousand = (0)))
+                     ->  BitmapOr
+                           ->  Bitmap Index Scan on tenk1_thous_tenthous
+                                 Index Cond: (thousand = (1))
+                           ->  Bitmap Index Scan on tenk1_thous_tenthous
+                                 Index Cond: (thousand = (0))
          ->  Hash
                ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                     ->  Nested Loop
-                           Join Filter: true
-                           ->  Seq Scan on int4_tbl
-                           ->  Result
+                     ->  Seq Scan on int4_tbl
  Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+(20 rows)
 
 explain (costs off)
 select * from
@@ -3273,25 +3295,24 @@ explain (costs off)
 select * from
   tenk1, int8_tbl a, int8_tbl b
 where thousand = a.q1 and tenthous = b.q1 and a.q2 = 1 and b.q2 = 2;
-                               QUERY PLAN                               
-------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
          Hash Cond: ((tenk1.thousand)::bigint = int8_tbl_1.q1)
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-               Hash Key: (tenk1.thousand)::bigint
-               ->  Nested Loop
-                     Join Filter: true
-                     ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                           ->  Seq Scan on int8_tbl
-                                 Filter: (q2 = 2)
-                     ->  Index Scan using tenk1_thous_tenthous on tenk1
-                           Index Cond: (tenthous = int8_tbl.q1)
+         ->  Nested Loop
+               Join Filter: true
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     ->  Seq Scan on int8_tbl
+                           Filter: (q2 = 2)
+               ->  Index Scan using tenk1_thous_tenthous on tenk1
+                     Index Cond: (tenthous = int8_tbl.q1)
          ->  Hash
-               ->  Seq Scan on int8_tbl int8_tbl_1
-                     Filter: (q2 = 1)
+               ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                     ->  Seq Scan on int8_tbl int8_tbl_1
+                           Filter: (q2 = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(16 rows)
+(15 rows)
 
 reset enable_nestloop;
 --
@@ -3313,41 +3334,42 @@ select t1.unique2, t1.stringu1, t2.unique1, t2.stringu2 from
   left join tenk1 t2
   on (subq1.y1 = t2.unique1)
 where t1.unique2 < 42 and t1.stringu1 > t2.stringu2;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
- Hash Join
-   Hash Cond: ((3) = tenk1_1.unique1)
-   Join Filter: (tenk1.stringu1 > tenk1_1.stringu2)
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Nested Loop
-               Join Filter: true
-               ->  Index Scan using tenk1_unique2 on tenk1
-                     Index Cond: (unique2 < 42)
-               ->  Materialize
-                     ->  Result
-                           ->  Broadcast Motion 1:3  (slice2)
-                                 ->  Hash Right Join
-                                       Hash Cond: ((1) = (1))
-                                       ->  Gather Motion 3:1  (slice3; segments: 3)
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (tenk1.unique1 = (3))
+         Join Filter: (tenk1_1.stringu1 > tenk1.stringu2)
+         ->  Seq Scan on tenk1
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: (3)
+                     ->  Hash Join
+                           Hash Cond: ((0) = int4_tbl.f1)
+                           ->  Hash Join
+                                 Hash Cond: (tenk1_1.unique2 = (11))
+                                 ->  Index Scan using tenk1_unique2 on tenk1 tenk1_1
+                                       Index Cond: ((unique2 < 42) AND (unique2 = 11))
+                                 ->  Hash
+                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)
                                              ->  Result
-                                                   Filter: ((1) = 1)
-                                                   ->  Seq Scan on onerow
-                                       ->  Hash
-                                             ->  Result
-                                                   ->  Gather Motion 3:1  (slice4; segments: 3)
-                                                         ->  Seq Scan on onerow onerow_1
-                                                               Filter: (11 < 42)
-   ->  Hash
-         ->  Gather Motion 3:1  (slice5; segments: 3)
-               ->  Nested Loop
-                     Join Filter: true
-                     ->  Seq Scan on tenk1 tenk1_1
-                     ->  Materialize
-                           ->  Broadcast Motion 3:3  (slice6; segments: 3)
-                                 ->  Seq Scan on int4_tbl
-                                       Filter: (f1 = 0)
+                                                   Filter: (((11) < 42) AND ((11) = 11))
+                                                   ->  Hash Left Join
+                                                         Hash Cond: ((1) = (1))
+                                                         ->  Result
+                                                               Filter: ((0) = 0)
+                                                               ->  Seq Scan on onerow
+                                                         ->  Hash
+                                                               ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                                                     ->  Result
+                                                                           Filter: ((1) = 1)
+                                                                           ->  Seq Scan on onerow onerow_1
+                           ->  Hash
+                                 ->  Broadcast Motion 3:3  (slice5; segments: 3)
+                                       ->  Seq Scan on int4_tbl
+                                             Filter: (f1 = 0)
  Optimizer: Pivotal Optimizer (GPORCA)
-(32 rows)
+(33 rows)
 
 --end_ignore
 select t1.unique2, t1.stringu1, t2.unique1, t2.stringu2 from
@@ -3401,21 +3423,14 @@ select t1.unique2, t1.stringu1, t2.unique1, t2.stringu2 from
   left join tenk1 t2
   on (subq1.y1 = t2.unique1)
 where t1.unique2 < 42 and t1.stringu1 > t2.stringu2;
-                               QUERY PLAN                                
--------------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Hash Join
-   Hash Cond: (int4_tbl.f1 = (0))
-   Join Filter: (tenk1.stringu1 > tenk1_1.stringu2)
+   Hash Cond: ((11) = tenk1_1.unique2)
+   Join Filter: (tenk1_1.stringu1 > tenk1.stringu2)
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Nested Loop
-               Join Filter: true
-               ->  Index Scan using tenk1_unique2 on tenk1
-                     Index Cond: (unique2 < 42)
-               ->  Materialize
-                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                           ->  Seq Scan on int4_tbl
-   ->  Hash
-         ->  Gather Motion 3:1  (slice3; segments: 3)
+         ->  Hash Join
+               Hash Cond: ((0) = int4_tbl.f1)
                ->  Nested Loop
                      Join Filter: true
                      ->  Result
@@ -3426,7 +3441,7 @@ where t1.unique2 < 42 and t1.stringu1 > t2.stringu2;
                                        ->  Result
                                  ->  Hash
                                        ->  Result
-                     ->  Index Scan using tenk1_unique1 on tenk1 tenk1_1
+                     ->  Index Scan using tenk1_unique1 on tenk1
                            Index Cond: (unique1 = (3))
                ->  Hash
                      ->  Broadcast Motion 3:3  (slice2; segments: 3)
@@ -3468,8 +3483,13 @@ select * from tenk1 a join tenk1 b on
    ->  Nested Loop
          Join Filter: true
          ->  Broadcast Motion 3:3  (slice2; segments: 3)
-               ->  Seq Scan on tenk1
-                     Filter: ((unique1 = 1) OR (unique2 = 3))
+               ->  Bitmap Heap Scan on tenk1
+                     Recheck Cond: ((unique1 = 1) OR (unique2 = 3))
+                     ->  BitmapOr
+                           ->  Bitmap Index Scan on tenk1_unique1
+                                 Index Cond: (unique1 = 1)
+                           ->  Bitmap Index Scan on tenk1_unique2
+                                 Index Cond: (unique2 = 3)
          ->  Bitmap Heap Scan on tenk1 tenk1_1
                Recheck Cond: (((unique1 = 2) OR (hundred = 4)) AND ((unique1 = 2) OR (hundred = 4)))
                Filter: ((((tenk1.unique1 = 1) AND (unique1 = 2)) OR ((tenk1.unique2 = 3) AND (hundred = 4))) AND ((unique1 = 2) OR (hundred = 4)))
@@ -3485,7 +3505,7 @@ select * from tenk1 a join tenk1 b on
                            ->  Bitmap Index Scan on tenk1_hundred
                                  Index Cond: (hundred = 4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+(26 rows)
 
 explain (costs off)
 select * from tenk1 a join tenk1 b on
@@ -3519,24 +3539,36 @@ explain (costs off)
 select * from tenk1 a join tenk1 b on
   (a.unique1 = 1 and b.unique1 = 2) or
   ((a.unique2 = 3 or a.unique2 = 7) and b.hundred = 4);
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
+                                                                                       QUERY PLAN                                                                                        
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
          Join Filter: true
          ->  Broadcast Motion 3:3  (slice2; segments: 3)
                ->  Seq Scan on tenk1
-                     Filter: ((unique1 = 1) OR ((unique2 = 3) OR (unique2 = 7)))
+                     Filter: ((unique1 = 2) OR (hundred = 4))
          ->  Bitmap Heap Scan on tenk1 tenk1_1
-               Recheck Cond: ((unique1 = 2) OR (hundred = 4))
-               Filter: (((tenk1.unique1 = 1) AND (unique1 = 2)) OR (((tenk1.unique2 = 3) OR (tenk1.unique2 = 7)) AND (hundred = 4)))
-               ->  BitmapOr
-                     ->  Bitmap Index Scan on tenk1_unique1
-                           Index Cond: (unique1 = 2)
-                     ->  Bitmap Index Scan on tenk1_hundred
-                           Index Cond: (hundred = 4)
+               Recheck Cond: (((unique1 = 1) OR ((unique2 = 3) OR (unique2 = 7))) AND ((unique1 = 1) OR (unique2 = 3) OR (unique2 = 7)))
+               Filter: ((((unique1 = 1) AND (tenk1.unique1 = 2)) OR (((unique2 = 3) OR (unique2 = 7)) AND (tenk1.hundred = 4))) AND ((unique1 = 1) OR ((unique2 = 3) OR (unique2 = 7))))
+               ->  BitmapAnd
+                     ->  BitmapOr
+                           ->  Bitmap Index Scan on tenk1_unique1
+                                 Index Cond: (unique1 = 1)
+                           ->  BitmapOr
+                                 ->  Bitmap Index Scan on tenk1_unique2
+                                       Index Cond: (unique2 = 3)
+                                 ->  Bitmap Index Scan on tenk1_unique2
+                                       Index Cond: (unique2 = 7)
+                     ->  BitmapOr
+                           ->  BitmapOr
+                                 ->  Bitmap Index Scan on tenk1_unique1
+                                       Index Cond: (unique1 = 1)
+                                 ->  Bitmap Index Scan on tenk1_unique2
+                                       Index Cond: (unique2 = 3)
+                           ->  Bitmap Index Scan on tenk1_unique2
+                                 Index Cond: (unique2 = 7)
  Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+(27 rows)
 
 --
 -- test placement of movable quals in a parameterized join tree
@@ -3546,81 +3578,93 @@ select * from tenk1 t1 left join
   (tenk1 t2 join tenk1 t3 on t2.thousand = t3.unique2)
   on t1.hundred = t2.hundred and t1.ten = t3.ten
 where t1.unique1 = 1;
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
- Hash Right Join
-   Hash Cond: ((tenk1.hundred = tenk1_2.hundred) AND (tenk1_1.ten = tenk1_2.ten))
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Nested Loop
-               Join Filter: true
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                     ->  Seq Scan on tenk1
-               ->  Index Scan using tenk1_unique2 on tenk1 tenk1_1
-                     Index Cond: (unique2 = tenk1.thousand)
-   ->  Hash
-         ->  Gather Motion 3:1  (slice3; segments: 3)
-               ->  Index Scan using tenk1_unique1 on tenk1 tenk1_2
-                     Index Cond: (unique1 = 1)
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Right Join
+         Hash Cond: ((tenk1.hundred = tenk1_2.hundred) AND (tenk1_1.ten = tenk1_2.ten))
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: tenk1.hundred
+               ->  Hash Join
+                     Hash Cond: (tenk1.thousand = tenk1_1.unique2)
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Hash Key: tenk1.thousand
+                           ->  Seq Scan on tenk1
+                     ->  Hash
+                           ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                 Hash Key: tenk1_1.unique2
+                                 ->  Seq Scan on tenk1 tenk1_1
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                     Hash Key: tenk1_2.hundred
+                     ->  Index Scan using tenk1_unique1 on tenk1 tenk1_2
+                           Index Cond: (unique1 = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+(20 rows)
 
 explain (costs off)
 select * from tenk1 t1 left join
   (tenk1 t2 join tenk1 t3 on t2.thousand = t3.unique2)
   on t1.hundred = t2.hundred and t1.ten + t2.ten = t3.ten
 where t1.unique1 = 1;
-                               QUERY PLAN                                
--------------------------------------------------------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Right Join
          Hash Cond: (tenk1.hundred = tenk1_2.hundred)
          Join Filter: ((tenk1_2.ten + tenk1.ten) = tenk1_1.ten)
          ->  Redistribute Motion 3:3  (slice2; segments: 3)
                Hash Key: tenk1.hundred
-               ->  Nested Loop
-                     Join Filter: true
-                     ->  Broadcast Motion 3:3  (slice3; segments: 3)
+               ->  Hash Join
+                     Hash Cond: (tenk1.thousand = tenk1_1.unique2)
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Hash Key: tenk1.thousand
                            ->  Seq Scan on tenk1
-                     ->  Index Scan using tenk1_unique2 on tenk1 tenk1_1
-                           Index Cond: (unique2 = tenk1.thousand)
+                     ->  Hash
+                           ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                 Hash Key: tenk1_1.unique2
+                                 ->  Seq Scan on tenk1 tenk1_1
          ->  Hash
-               ->  Redistribute Motion 3:3  (slice4; segments: 3)
+               ->  Redistribute Motion 3:3  (slice5; segments: 3)
                      Hash Key: tenk1_2.hundred
                      ->  Index Scan using tenk1_unique1 on tenk1 tenk1_2
                            Index Cond: (unique1 = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(18 rows)
+(21 rows)
 
 explain (costs off)
 select count(*) from
   tenk1 a join tenk1 b on a.unique1 = b.unique2
   left join tenk1 c on a.unique2 = b.unique1 and c.thousand = a.thousand
   join int4_tbl on b.thousand = f1;
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
- Aggregate
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Hash Join
-               Hash Cond: (tenk1.thousand = int4_tbl.f1)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: tenk1.thousand
-                     ->  Hash Left Join
-                           Hash Cond: (tenk1_1.thousand = tenk1_2.thousand)
-                           Join Filter: (tenk1_1.unique2 = tenk1.unique1)
+         ->  Partial Aggregate
+               ->  Hash Left Join
+                     Hash Cond: (tenk1_1.thousand = tenk1_2.thousand)
+                     Join Filter: (tenk1_1.unique2 = tenk1.unique1)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: tenk1_1.thousand
                            ->  Nested Loop
                                  Join Filter: true
                                  ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                        Hash Key: tenk1.unique2
-                                       ->  Seq Scan on tenk1
+                                       ->  Nested Loop
+                                             Join Filter: true
+                                             ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                                   ->  Seq Scan on int4_tbl
+                                             ->  Index Scan using tenk1_thous_tenthous on tenk1
+                                                   Index Cond: (thousand = int4_tbl.f1)
                                  ->  Index Scan using tenk1_unique1 on tenk1 tenk1_1
                                        Index Cond: (unique1 = tenk1.unique2)
-                           ->  Hash
-                                 ->  Broadcast Motion 3:3  (slice4; segments: 3)
-                                       ->  Seq Scan on tenk1 tenk1_2
-               ->  Hash
-                     ->  Seq Scan on int4_tbl
+                     ->  Hash
+                           ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                                 Hash Key: tenk1_2.thousand
+                                 ->  Seq Scan on tenk1 tenk1_2
  Optimizer: Pivotal Optimizer (GPORCA)
-(22 rows)
+(25 rows)
 
 select count(*) from
   tenk1 a join tenk1 b on a.unique1 = b.unique2
@@ -3638,8 +3682,8 @@ select b.unique1 from
   join int4_tbl i1 on b.thousand = f1
   right join int4_tbl i2 on i2.f1 = b.tenthous
   order by 1;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: tenk1.unique1
    ->  Sort
@@ -3648,29 +3692,31 @@ select b.unique1 from
                Hash Cond: (tenk1.tenthous = int4_tbl_1.f1)
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: tenk1.tenthous
-                     ->  Hash Join
-                           Hash Cond: (tenk1.thousand = int4_tbl.f1)
+                     ->  Hash Left Join
+                           Hash Cond: (tenk1_1.thousand = tenk1_2.thousand)
+                           Join Filter: (tenk1.unique1 = 42)
                            ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                 Hash Key: tenk1.thousand
-                                 ->  Hash Left Join
-                                       Hash Cond: (tenk1_1.thousand = tenk1_2.thousand)
-                                       Join Filter: (tenk1.unique1 = 42)
-                                       ->  Nested Loop
-                                             Join Filter: true
-                                             ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                                   Hash Key: tenk1.unique2
-                                                   ->  Seq Scan on tenk1
-                                             ->  Index Scan using tenk1_unique1 on tenk1 tenk1_1
-                                                   Index Cond: (unique1 = tenk1.unique2)
-                                       ->  Hash
-                                             ->  Broadcast Motion 3:3  (slice5; segments: 3)
-                                                   ->  Seq Scan on tenk1 tenk1_2
+                                 Hash Key: tenk1_1.thousand
+                                 ->  Nested Loop
+                                       Join Filter: true
+                                       ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                             Hash Key: tenk1.unique2
+                                             ->  Nested Loop
+                                                   Join Filter: true
+                                                   ->  Broadcast Motion 3:3  (slice5; segments: 3)
+                                                         ->  Seq Scan on int4_tbl
+                                                   ->  Index Scan using tenk1_thous_tenthous on tenk1
+                                                         Index Cond: (thousand = int4_tbl.f1)
+                                       ->  Index Scan using tenk1_unique1 on tenk1 tenk1_1
+                                             Index Cond: (unique1 = tenk1.unique2)
                            ->  Hash
-                                 ->  Seq Scan on int4_tbl
+                                 ->  Redistribute Motion 3:3  (slice6; segments: 3)
+                                       Hash Key: tenk1_2.thousand
+                                       ->  Seq Scan on tenk1 tenk1_2
                ->  Hash
                      ->  Seq Scan on int4_tbl int4_tbl_1
  Optimizer: Pivotal Optimizer (GPORCA)
-(30 rows)
+(32 rows)
 
 select b.unique1 from
   tenk1 a join tenk1 b on a.unique1 = b.unique2
@@ -3695,23 +3741,23 @@ select * from
 ) ss
 where fault = 122
 order by fault;
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: ((COALESCE(tenk1.unique1, '-1'::integer) + int8_tbl.q1))
    ->  Sort
          Sort Key: ((COALESCE(tenk1.unique1, '-1'::integer) + int8_tbl.q1))
          ->  Result
                Filter: ((COALESCE(tenk1.unique1, '-1'::integer) + int8_tbl.q1) = 122)
-               ->  Hash Left Join
-                     Hash Cond: (int8_tbl.q2 = (tenk1.unique2)::bigint)
+               ->  Hash Right Join
+                     Hash Cond: ((tenk1.unique2)::bigint = int8_tbl.q2)
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: int8_tbl.q2
-                           ->  Seq Scan on int8_tbl
+                           Hash Key: (tenk1.unique2)::bigint
+                           ->  Seq Scan on tenk1
                      ->  Hash
                            ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                 Hash Key: (tenk1.unique2)::bigint
-                                 ->  Seq Scan on tenk1
+                                 Hash Key: int8_tbl.q2
+                                 ->  Seq Scan on int8_tbl
  Optimizer: Pivotal Optimizer (GPORCA)
 (16 rows)
 
@@ -3767,13 +3813,13 @@ select q1, unique2, thousand, hundred
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Result
          Filter: ((COALESCE(tenk1.thousand, 123) = int8_tbl.q1) AND (int8_tbl.q1 = COALESCE(tenk1.hundred, 123)))
-         ->  Hash Left Join
-               Hash Cond: (int8_tbl.q1 = (tenk1.unique2)::bigint)
-               ->  Seq Scan on int8_tbl
+         ->  Hash Right Join
+               Hash Cond: ((tenk1.unique2)::bigint = int8_tbl.q1)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: (tenk1.unique2)::bigint
+                     ->  Seq Scan on tenk1
                ->  Hash
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: (tenk1.unique2)::bigint
-                           ->  Seq Scan on tenk1
+                     ->  Seq Scan on int8_tbl
  Optimizer: Pivotal Optimizer (GPORCA)
 (11 rows)
 
@@ -3793,13 +3839,13 @@ select f1, unique2, case when unique2 is null then f1 else 0 end
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Result
          Filter: (CASE WHEN (tenk1.unique2 IS NULL) THEN int4_tbl.f1 ELSE 0 END = 0)
-         ->  Hash Left Join
-               Hash Cond: (int4_tbl.f1 = tenk1.unique2)
-               ->  Seq Scan on int4_tbl
+         ->  Hash Right Join
+               Hash Cond: (tenk1.unique2 = int4_tbl.f1)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: tenk1.unique2
+                     ->  Seq Scan on tenk1
                ->  Hash
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: tenk1.unique2
-                           ->  Seq Scan on tenk1
+                     ->  Seq Scan on int4_tbl
  Optimizer: Pivotal Optimizer (GPORCA)
 (11 rows)
 
@@ -3818,26 +3864,29 @@ explain (costs off)
 select a.unique1, b.unique1, c.unique1, coalesce(b.twothousand, a.twothousand)
   from tenk1 a left join tenk1 b on b.thousand = a.unique1                        left join tenk1 c on c.unique2 = coalesce(b.twothousand, a.twothousand)
   where a.unique2 < 10 and coalesce(b.twothousand, a.twothousand) = 44;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Hash Left Join
-         Hash Cond: (COALESCE(tenk1_1.twothousand, tenk1.twothousand) = tenk1_2.unique2)
-         ->  Result
-               Filter: (COALESCE(tenk1_1.twothousand, tenk1.twothousand) = 44)
-               ->  Hash Left Join
-                     Hash Cond: (tenk1.unique1 = tenk1_1.thousand)
-                     ->  Index Scan using tenk1_unique2 on tenk1
-                           Index Cond: (unique2 < 10)
-                     ->  Hash
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                 Hash Key: tenk1_1.thousand
-                                 ->  Seq Scan on tenk1 tenk1_1
+   ->  Hash Right Join
+         Hash Cond: (tenk1.unique2 = COALESCE(tenk1_1.twothousand, tenk1_2.twothousand))
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: tenk1.unique2
+               ->  Seq Scan on tenk1
          ->  Hash
-               ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                     ->  Seq Scan on tenk1 tenk1_2
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Hash Key: COALESCE(tenk1_1.twothousand, tenk1_2.twothousand)
+                     ->  Result
+                           Filter: (COALESCE(tenk1_1.twothousand, tenk1_2.twothousand) = 44)
+                           ->  Hash Right Join
+                                 Hash Cond: (tenk1_1.thousand = tenk1_2.unique1)
+                                 ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                       Hash Key: tenk1_1.thousand
+                                       ->  Seq Scan on tenk1 tenk1_1
+                                 ->  Hash
+                                       ->  Index Scan using tenk1_unique2 on tenk1 tenk1_2
+                                             Index Cond: (unique2 < 10)
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(20 rows)
 
 select a.unique1, b.unique1, c.unique1, coalesce(b.twothousand, a.twothousand)
   from tenk1 a left join tenk1 b on b.thousand = a.unique1                        left join tenk1 c on c.unique2 = coalesce(b.twothousand, a.twothousand)
@@ -3862,31 +3911,33 @@ left join
    using (join_key)
   ) foo3
 using (join_key);
-                         QUERY PLAN                         
-------------------------------------------------------------
- Hash Right Join
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    Output: "Values".column1, int4_tbl.f1, (666)
    ->  Hash Left Join
-         Output: int4_tbl.f1, (666)
-         Hash Cond: (int4_tbl.f1 = tenk1.unique2)
+         Output: "Values".column1, int4_tbl.f1, (666)
+         Hash Cond: ("Values".column1 = int4_tbl.f1)
          ->  Result
-               Output: 666, int4_tbl.f1
-               ->  Gather Motion 3:1  (slice1; segments: 3)
-                     Output: int4_tbl.f1
-                     ->  Seq Scan on public.int4_tbl
-                           Output: int4_tbl.f1
-         ->  Hash
-               Output: tenk1.unique2
-               ->  Gather Motion 3:1  (slice2; segments: 3)
-                     Output: tenk1.unique2
-                     ->  Seq Scan on public.tenk1
-                           Output: tenk1.unique2
-   ->  Hash
-         Output: "Values".column1
-         ->  Values Scan on "Values"
                Output: "Values".column1
+               ->  Values Scan on "Values"
+                     Output: "Values".column1
+         ->  Hash
+               Output: int4_tbl.f1, (666)
+               ->  Hash Right Join
+                     Output: int4_tbl.f1, (666)
+                     Hash Cond: (tenk1.unique2 = int4_tbl.f1)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Output: tenk1.unique2
+                           Hash Key: tenk1.unique2
+                           ->  Seq Scan on public.tenk1
+                                 Output: tenk1.unique2
+                     ->  Hash
+                           Output: (666), int4_tbl.f1
+                           ->  Seq Scan on public.int4_tbl
+                                 Output: 666, int4_tbl.f1
  Optimizer: Pivotal Optimizer (GPORCA)
-(23 rows)
+(24 rows)
 
 select foo1.join_key as foo1_id, foo3.join_key AS foo3_id, bug_field from
   (values (0),(1)) foo1(join_key)
@@ -4869,8 +4920,8 @@ from
      left join uniquetbl u1 ON u1.f1 = t1.string4) ss
   on t0.f1 = ss.case1
 where ss.stringu2 !~* ss.case1;
-                                                     QUERY PLAN                                                     
---------------------------------------------------------------------------------------------------------------------
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
          Hash Cond: ((CASE tenk1.ten WHEN 0 THEN 'doh!'::text ELSE NULL::text END) = text_tbl.f1)
@@ -4878,23 +4929,20 @@ where ss.stringu2 !~* ss.case1;
                Hash Key: (CASE tenk1.ten WHEN 0 THEN 'doh!'::text ELSE NULL::text END)
                ->  Hash Left Join
                      Hash Cond: (tenk1.string4 = (uniquetbl.f1)::name)
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                           Hash Key: tenk1.string4
-                           ->  Nested Loop
-                                 Join Filter: true
-                                 ->  Broadcast Motion 3:3  (slice4; segments: 3)
-                                       ->  Seq Scan on int4_tbl
-                                 ->  Index Scan using tenk1_unique2 on tenk1
-                                       Index Cond: (unique2 = int4_tbl.f1)
-                                       Filter: (stringu2 !~* CASE ten WHEN 0 THEN 'doh!'::text ELSE NULL::text END)
+                     ->  Nested Loop
+                           Join Filter: true
+                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                 ->  Seq Scan on int4_tbl
+                           ->  Index Scan using tenk1_unique2 on tenk1
+                                 Index Cond: (unique2 = int4_tbl.f1)
+                                 Filter: (stringu2 !~* CASE ten WHEN 0 THEN 'doh!'::text ELSE NULL::text END)
                      ->  Hash
-                           ->  Redistribute Motion 3:3  (slice5; segments: 3)
-                                 Hash Key: (uniquetbl.f1)::name
+                           ->  Broadcast Motion 3:3  (slice4; segments: 3)
                                  ->  Seq Scan on uniquetbl
          ->  Hash
                ->  Seq Scan on text_tbl
  Optimizer: Pivotal Optimizer (GPORCA)
-(23 rows)
+(20 rows)
 
 select t0.*
 from
@@ -5154,17 +5202,18 @@ select * from generate_series(100,200) g,
 explain (costs off)
   select count(*) from tenk1 a,
     tenk1 b join lateral (values(a.unique1)) ss(x) on b.unique2 = ss.x;
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Aggregate
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Hash Join
-               Hash Cond: (b.unique2 = a.unique1)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: b.unique2
-                     ->  Seq Scan on tenk1 b
-               ->  Hash
-                     ->  Seq Scan on tenk1 a
+         ->  Partial Aggregate
+               ->  Hash Join
+                     Hash Cond: (b.unique2 = a.unique1)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: b.unique2
+                           ->  Seq Scan on tenk1 b
+                     ->  Hash
+                           ->  Seq Scan on tenk1 a
  Optimizer: Postgres query optimizer
 (11 rows)
 
@@ -5179,23 +5228,24 @@ select count(*) from tenk1 a,
 explain (costs off)
   select count(*) from tenk1 a,
     tenk1 b join lateral (values(a.unique1),(-1)) ss(x) on b.unique2 = ss.x;
-                               QUERY PLAN                               
-------------------------------------------------------------------------
- Aggregate
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Hash Join
-               Hash Cond: ("*VALUES*".column1 = b.unique2)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: "*VALUES*".column1
-                     ->  Nested Loop
-                           ->  Seq Scan on tenk1 a
-                           ->  Values Scan on "*VALUES*"
-               ->  Hash
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                           Hash Key: b.unique2
-                           ->  Seq Scan on tenk1 b
+         ->  Partial Aggregate
+               ->  Hash Join
+                     Hash Cond: ("*VALUES*".column1 = b.unique2)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: "*VALUES*".column1
+                           ->  Nested Loop
+                                 ->  Seq Scan on tenk1 a
+                                 ->  Values Scan on "*VALUES*"
+                     ->  Hash
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: b.unique2
+                                 ->  Seq Scan on tenk1 b
  Optimizer: Postgres query optimizer
-(14 rows)
+(15 rows)
 
 select count(*) from tenk1 a,
   tenk1 b join lateral (values(a.unique1),(-1)) ss(x) on b.unique2 = ss.x;
@@ -5732,8 +5782,8 @@ select c.*,a.*,ss1.q1,ss2.q1,ss3.* from
     lateral (select q1, coalesce(ss1.x,q2) as y from int8_tbl d) ss2
   ) on c.q2 = ss2.q1,
   lateral (select * from int4_tbl i where ss2.y > f1) ss3;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Output: c.q1, c.q2, a.q1, a.q2, b.q1, d.q1, i.f1
    ->  Nested Loop
@@ -6451,7 +6501,8 @@ left join j2 on j1.id1 = j2.id1 where j1.id2 = 1;
                ->  Seq Scan on public.j2
                      Output: j2.id1, j2.id2
  Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+ Settings: enable_nestloop=on
+(16 rows)
 
 -- validate logic in merge joins which skips mark and restore.
 -- it should only do this if all quals which were used to detect the unique
@@ -6510,40 +6561,33 @@ from onek t1, tenk1 t2
 where exists (select 1 from tenk1 t3
               where t3.thousand = t1.unique1 and t3.tenthous = t2.hundred)
       and t1.unique1 < 1;
-                                              QUERY PLAN                                               
--------------------------------------------------------------------------------------------------------
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   Output: onek.unique1, tenk1_1.hundred
-   ->  Nested Loop
-         Output: onek.unique1, tenk1_1.hundred
-         Join Filter: true
-         ->  Broadcast Motion 3:3  (slice2; segments: 3)
-               Output: tenk1_1.hundred
-               ->  Nested Loop
-                     Output: tenk1_1.hundred
-                     Join Filter: true
-                     ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                           Output: tenk1.tenthous
-                           ->  GroupAggregate
-                                 Output: tenk1.tenthous
-                                 Group Key: tenk1.tenthous
-                                 ->  Sort
-                                       Output: tenk1.tenthous
-                                       Sort Key: tenk1.tenthous
-                                       ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                             Output: tenk1.tenthous
-                                             Hash Key: tenk1.tenthous
-                                             ->  Index Scan using tenk1_thous_tenthous on public.tenk1
-                                                   Output: tenk1.tenthous
-                                                   Index Cond: (tenk1.thousand < 1)
-                     ->  Index Scan using tenk1_hundred on public.tenk1 tenk1_1
-                           Output: tenk1_1.hundred
-                           Index Cond: (tenk1_1.hundred = tenk1.tenthous)
-         ->  Index Scan using onek_unique1 on public.onek
-               Output: onek.unique1
-               Index Cond: (onek.unique1 < 1)
+   Output: onek.unique1, tenk1.hundred
+   ->  Hash Semi Join
+         Output: onek.unique1, tenk1.hundred
+         Hash Cond: ((onek.unique1 = tenk1_1.thousand) AND (tenk1.hundred = tenk1_1.tenthous))
+         ->  Nested Loop
+               Output: onek.unique1, tenk1.hundred
+               Join Filter: true
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     Output: onek.unique1
+                     ->  Index Scan using onek_unique1 on public.onek
+                           Output: onek.unique1
+                           Index Cond: (onek.unique1 < 1)
+               ->  Seq Scan on public.tenk1
+                     Output: tenk1.hundred
+         ->  Hash
+               Output: tenk1_1.thousand, tenk1_1.tenthous
+               ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                     Output: tenk1_1.thousand, tenk1_1.tenthous
+                     ->  Index Only Scan using tenk1_thous_tenthous on public.tenk1 tenk1_1
+                           Output: tenk1_1.thousand, tenk1_1.tenthous
+                           Index Cond: (tenk1_1.thousand < 1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(31 rows)
+ Settings: enable_bitmapscan=off, enable_hashjoin=off, enable_mergejoin=on, enable_nestloop=on, enable_seqscan=off
+(24 rows)
 
 -- ... unless it actually is unique
 create table j3 as select unique1, tenthous from onek;
@@ -6557,32 +6601,33 @@ from onek t1, tenk1 t2
 where exists (select 1 from j3
               where j3.unique1 = t1.unique1 and j3.tenthous = t2.hundred)
       and t1.unique1 < 1;
-                           QUERY PLAN                           
-----------------------------------------------------------------
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Output: onek.unique1, tenk1.hundred
    ->  Hash Semi Join
          Output: onek.unique1, tenk1.hundred
-         Hash Cond: (tenk1.hundred = j3.tenthous)
+         Hash Cond: ((onek.unique1 = j3.unique1) AND (tenk1.hundred = j3.tenthous))
          ->  Nested Loop
                Output: onek.unique1, tenk1.hundred
                Join Filter: true
                ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                     Output: tenk1.hundred
-                     ->  Seq Scan on public.tenk1
-                           Output: tenk1.hundred
-               ->  Index Scan using onek_unique1 on public.onek
                      Output: onek.unique1
-                     Index Cond: (onek.unique1 < 1)
+                     ->  Index Scan using onek_unique1 on public.onek
+                           Output: onek.unique1
+                           Index Cond: (onek.unique1 < 1)
+               ->  Seq Scan on public.tenk1
+                     Output: tenk1.hundred
          ->  Hash
-               Output: j3.tenthous
+               Output: j3.unique1, j3.tenthous
                ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                     Output: j3.tenthous
+                     Output: j3.unique1, j3.tenthous
                      ->  Seq Scan on public.j3
-                           Output: j3.tenthous
+                           Output: j3.unique1, j3.tenthous
                            Filter: (j3.unique1 < 1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(23 rows)
+ Settings: enable_bitmapscan=off, enable_hashjoin=off, enable_mergejoin=on, enable_nestloop=on, enable_seqscan=off
+(24 rows)
 
 drop table j3;
 reset enable_hashjoin;

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -3339,37 +3339,36 @@ where t1.unique2 < 42 and t1.stringu1 > t2.stringu2;
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
          Hash Cond: (tenk1.unique1 = (3))
-         Join Filter: (tenk1_1.stringu1 > tenk1.stringu2)
-         ->  Seq Scan on tenk1
+         ->  Nested Loop
+               Join Filter: (tenk1_1.stringu1 > tenk1.stringu2)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     ->  Index Scan using tenk1_unique2 on tenk1 tenk1_1
+                           Index Cond: ((unique2 < 42) AND (unique2 = 11))
+               ->  Seq Scan on tenk1
          ->  Hash
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: (3)
-                     ->  Hash Join
-                           Hash Cond: ((0) = int4_tbl.f1)
-                           ->  Hash Join
-                                 Hash Cond: (tenk1_1.unique2 = (11))
-                                 ->  Index Scan using tenk1_unique2 on tenk1 tenk1_1
-                                       Index Cond: ((unique2 < 42) AND (unique2 = 11))
+               ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                     ->  Nested Loop
+                           Join Filter: true
+                           ->  Hash Left Join
+                                 Hash Cond: ((1) = (1))
+                                 ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                                       Hash Key: (1)
+                                       ->  Result
+                                             Filter: ((0) = 0)
+                                             ->  Seq Scan on onerow
+                                                   Filter: ((11 < 42) AND (11 = 11))
                                  ->  Hash
-                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                       ->  Redistribute Motion 3:3  (slice6; segments: 3)
+                                             Hash Key: (1)
                                              ->  Result
-                                                   Filter: (((11) < 42) AND ((11) = 11))
-                                                   ->  Hash Left Join
-                                                         Hash Cond: ((1) = (1))
-                                                         ->  Result
-                                                               Filter: ((0) = 0)
-                                                               ->  Seq Scan on onerow
-                                                         ->  Hash
-                                                               ->  Broadcast Motion 3:3  (slice4; segments: 3)
-                                                                     ->  Result
-                                                                           Filter: ((1) = 1)
-                                                                           ->  Seq Scan on onerow onerow_1
-                           ->  Hash
-                                 ->  Broadcast Motion 3:3  (slice5; segments: 3)
+                                                   Filter: ((1) = 1)
+                                                   ->  Seq Scan on onerow onerow_1
+                           ->  Materialize
+                                 ->  Broadcast Motion 3:3  (slice4; segments: 3)
                                        ->  Seq Scan on int4_tbl
                                              Filter: (f1 = 0)
  Optimizer: Pivotal Optimizer (GPORCA)
-(33 rows)
+(32 rows)
 
 --end_ignore
 select t1.unique2, t1.stringu1, t2.unique1, t2.stringu2 from
@@ -3423,35 +3422,33 @@ select t1.unique2, t1.stringu1, t2.unique1, t2.stringu2 from
   left join tenk1 t2
   on (subq1.y1 = t2.unique1)
 where t1.unique2 < 42 and t1.stringu1 > t2.stringu2;
-                             QUERY PLAN                              
----------------------------------------------------------------------
- Hash Join
-   Hash Cond: ((11) = tenk1_1.unique2)
-   Join Filter: (tenk1_1.stringu1 > tenk1.stringu2)
-   ->  Gather Motion 3:1  (slice1; segments: 3)
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: ((0) = int4_tbl.f1)
          ->  Hash Join
-               Hash Cond: ((0) = int4_tbl.f1)
-               ->  Nested Loop
-                     Join Filter: true
-                     ->  Result
-                           ->  Hash Left Join
-                                 Hash Cond: ((1) = (1))
-                                 ->  Result
-                                       One-Time Filter: (11 < 42)
-                                       ->  Result
-                                 ->  Hash
-                                       ->  Result
-                     ->  Index Scan using tenk1_unique1 on tenk1
-                           Index Cond: (unique1 = (3))
+               Hash Cond: (tenk1.unique1 = (3))
+               Join Filter: (tenk1_1.stringu1 > tenk1.stringu2)
+               ->  Seq Scan on tenk1
                ->  Hash
                      ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                           ->  Seq Scan on int4_tbl
-   ->  Hash
-         ->  Gather Motion 3:1  (slice3; segments: 3)
-               ->  Index Scan using tenk1_unique2 on tenk1 tenk1_1
-                     Index Cond: ((unique2 < 42) AND (unique2 = 11))
+                           ->  Nested Loop
+                                 Join Filter: true
+                                 ->  Index Scan using tenk1_unique2 on tenk1 tenk1_1
+                                       Index Cond: ((unique2 < 42) AND (unique2 = 11))
+                                 ->  Hash Left Join
+                                       Hash Cond: ((1) = (1))
+                                       ->  Result
+                                             One-Time Filter: (11 < 42)
+                                             ->  Result
+                                       ->  Hash
+                                             ->  Result
+         ->  Hash
+               ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                     ->  Seq Scan on int4_tbl
  Optimizer: Pivotal Optimizer (GPORCA)
-(26 rows)
+(24 rows)
 
 select t1.unique2, t1.stringu1, t2.unique1, t2.stringu2 from
   tenk1 t1

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -1862,33 +1862,23 @@ select * from int4_tbl i4, tenk1 a
 where exists(select * from tenk1 b
              where a.twothousand = b.twothousand and a.fivethous <> b.fivethous)
       and i4.f1 = a.tenthous;
-                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                              
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  GroupAggregate
-         Group Key: int4_tbl.f1, int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.unique1, tenk1_1.unique2, tenk1_1.two, tenk1_1.four, tenk1_1.ten, tenk1_1.twenty, tenk1_1.hundred, tenk1_1.thousand, tenk1_1.twothousand, tenk1_1.fivethous, tenk1_1.tenthous, tenk1_1.odd, tenk1_1.even, tenk1_1.stringu1, tenk1_1.stringu2, tenk1_1.string4, tenk1_1.ctid, tenk1_1.gp_segment_id
-         ->  Sort
-               Sort Key: int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.ctid, tenk1_1.gp_segment_id
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.ctid, tenk1_1.gp_segment_id
-                     ->  GroupAggregate
-                           Group Key: int4_tbl.f1, int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.unique1, tenk1_1.unique2, tenk1_1.two, tenk1_1.four, tenk1_1.ten, tenk1_1.twenty, tenk1_1.hundred, tenk1_1.thousand, tenk1_1.twothousand, tenk1_1.fivethous, tenk1_1.tenthous, tenk1_1.odd, tenk1_1.even, tenk1_1.stringu1, tenk1_1.stringu2, tenk1_1.string4, tenk1_1.ctid, tenk1_1.gp_segment_id
-                           ->  Sort
-                                 Sort Key: int4_tbl.ctid, int4_tbl.gp_segment_id, tenk1_1.ctid, tenk1_1.gp_segment_id
-                                 ->  Hash Join
-                                       Hash Cond: (tenk1.twothousand = tenk1_1.twothousand)
-                                       Join Filter: (tenk1_1.fivethous <> tenk1.fivethous)
-                                       ->  Seq Scan on tenk1
-                                       ->  Hash
-                                             ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                                                   ->  Nested Loop
-                                                         Join Filter: true
-                                                         ->  Broadcast Motion 3:3  (slice4; segments: 3)
-                                                               ->  Seq Scan on int4_tbl
-                                                         ->  Index Scan using tenk1_thous_tenthous on tenk1 tenk1_1
-                                                               Index Cond: (tenthous = int4_tbl.f1)
+   ->  Hash Semi Join
+         Hash Cond: (tenk1.twothousand = tenk1_1.twothousand)
+         Join Filter: (tenk1.fivethous <> tenk1_1.fivethous)
+         ->  Nested Loop
+               Join Filter: true
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     ->  Seq Scan on int4_tbl
+               ->  Index Scan using tenk1_thous_tenthous on tenk1
+                     Index Cond: (tenthous = int4_tbl.f1)
+         ->  Hash
+               ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                     ->  Seq Scan on tenk1 tenk1_1
  Optimizer: Pivotal Optimizer (GPORCA)
-(24 rows)
+(14 rows)
 
 --
 -- More complicated constructs
@@ -2263,26 +2253,27 @@ explain (costs off)
 select * from int8_tbl i1 left join (int8_tbl i2 join
   (select 123 as x) ss on i2.q1 = x) on i1.q2 = i2.q2
 order by 1, 2;
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Sort
-   Sort Key: int8_tbl.q1, int8_tbl.q2
-   ->  Hash Left Join
-         Hash Cond: (int8_tbl.q2 = int8_tbl_1.q2)
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               ->  Seq Scan on int8_tbl
-         ->  Hash
-               ->  Hash Join
-                     Hash Cond: (int8_tbl_1.q1 = ((123))::bigint)
-                     ->  Gather Motion 3:1  (slice2; segments: 3)
-                           ->  Seq Scan on int8_tbl int8_tbl_1
-                                 Filter: (q1 = 123)
-                     ->  Hash
-                           ->  Result
-                                 Filter: ((123) = 123)
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: int8_tbl.q1, int8_tbl.q2
+   ->  Sort
+         Sort Key: int8_tbl.q1, int8_tbl.q2
+         ->  Hash Left Join
+               Hash Cond: (int8_tbl.q2 = int8_tbl_1.q2)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: int8_tbl.q2
+                     ->  Seq Scan on int8_tbl
+               ->  Hash
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Hash Key: int8_tbl_1.q2
+                           ->  Nested Loop
+                                 Join Filter: true
+                                 ->  Seq Scan on int8_tbl int8_tbl_1
+                                       Filter: (q1 = 123)
                                  ->  Result
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(18 rows)
 
 select * from int8_tbl i1 left join (int8_tbl i2 join
   (select 123 as x) ss on i2.q1 = x) on i1.q2 = i2.q2
@@ -2326,12 +2317,12 @@ select a.f1, b.f1, t.thousand, t.tenthous from
   (select sum(f1)+1 as f1 from int4_tbl i4a) a,
   (select sum(f1) as f1 from int4_tbl i4b) b
 where b.f1 = t.thousand and a.f1 = b.f1 and (a.f1+b.f1+999) = t.tenthous;
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Hash Join
-         Hash Cond: ((sum(int4_tbl.f1)) = (((sum(int4_tbl_1.f1)) + 1)))
-         Join Filter: ((((((sum(int4_tbl_1.f1)) + 1)) + (sum(int4_tbl.f1))) + 999) = (tenk1.tenthous)::bigint)
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Hash Join
+   Hash Cond: ((sum(int4_tbl.f1)) = ((sum(int4_tbl_1.f1) + 1)))
+   Join Filter: (((((sum(int4_tbl_1.f1) + 1)) + (sum(int4_tbl.f1))) + 999) = (tenk1.tenthous)::bigint)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Nested Loop
                Join Filter: true
                ->  Broadcast Motion 1:3  (slice2)
@@ -2339,17 +2330,15 @@ where b.f1 = t.thousand and a.f1 = b.f1 and (a.f1+b.f1+999) = t.tenthous;
                            ->  Gather Motion 3:1  (slice3; segments: 3)
                                  ->  Partial Aggregate
                                        ->  Seq Scan on int4_tbl
-               ->  Index Only Scan using tenk1_thous_tenthous on tenk1
+               ->  Index Scan using tenk1_thous_tenthous on tenk1
                      Index Cond: (thousand = (sum(int4_tbl.f1)))
-         ->  Hash
-               ->  Result
-                     ->  Broadcast Motion 1:3  (slice4)
-                           ->  Finalize Aggregate
-                                 ->  Gather Motion 3:1  (slice5; segments: 3)
-                                       ->  Partial Aggregate
-                                             ->  Seq Scan on int4_tbl int4_tbl_1
+   ->  Hash
+         ->  Finalize Aggregate
+               ->  Gather Motion 3:1  (slice4; segments: 3)
+                     ->  Partial Aggregate
+                           ->  Seq Scan on int4_tbl int4_tbl_1
  Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+(19 rows)
 
 select a.f1, b.f1, t.thousand, t.tenthous from
   tenk1 t,
@@ -2427,22 +2416,18 @@ select count(*) from
   left join
   (select * from tenk1 y order by y.unique2) y
   on x.thousand = y.unique2 and x.twothousand = y.hundred and x.fivethous = y.unique2;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Hash Left Join
-                     Hash Cond: ((tenk1.thousand = tenk1_1.unique2) AND (tenk1.twothousand = tenk1_1.hundred) AND (tenk1.fivethous = tenk1_1.unique2))
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: tenk1.thousand, tenk1.twothousand, tenk1.thousand
-                           ->  Seq Scan on tenk1
-                     ->  Hash
-                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                 Hash Key: tenk1_1.unique2, tenk1_1.hundred, tenk1_1.unique2
-                                 ->  Seq Scan on tenk1 tenk1_1
+         ->  Hash Left Join
+               Hash Cond: ((tenk1.thousand = tenk1_1.unique2) AND (tenk1.twothousand = tenk1_1.hundred) AND (tenk1.fivethous = tenk1_1.unique2))
+               ->  Seq Scan on tenk1
+               ->  Hash
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                           ->  Seq Scan on tenk1 tenk1_1
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(9 rows)
 
 select count(*) from
   (select * from tenk1 x order by x.thousand, x.twothousand, x.fivethous) x
@@ -2575,20 +2560,19 @@ set enable_mergejoin to off;
 explain (costs off)
 select count(*) from tenk1 a, tenk1 b
   where a.hundred = b.thousand and (b.fivethous % 10) < 10;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Finalize Aggregate
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Nested Loop
-                     Join Filter: true
-                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                           ->  Seq Scan on tenk1
-                                 Filter: ((fivethous % 10) < 10)
-                     ->  Index Only Scan using tenk1_hundred on tenk1 tenk1_1
-                           Index Cond: (hundred = tenk1.thousand)
+         ->  Nested Loop
+               Join Filter: true
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     ->  Seq Scan on tenk1
+                           Filter: ((fivethous % 10) < 10)
+               ->  Index Scan using tenk1_hundred on tenk1 tenk1_1
+                     Index Cond: (hundred = tenk1.thousand)
  Optimizer: Pivotal Optimizer (GPORCA)
-(11 rows)
+(10 rows)
 
 select count(*) from tenk1 a, tenk1 b
   where a.hundred = b.thousand and (b.fivethous % 10) < 10;
@@ -3245,22 +3229,16 @@ where q1 = thousand or q2 = thousand;
          Hash Cond: (tenk1.twothousand = int4_tbl.f1)
          ->  Nested Loop
                Join Filter: true
-               ->  Nested Loop
-                     Join Filter: true
-                     ->  Result
-                     ->  Result
-               ->  Bitmap Heap Scan on tenk1
-                     Recheck Cond: ((thousand = (1)) OR (thousand = (0)))
-                     ->  BitmapOr
-                           ->  Bitmap Index Scan on tenk1_thous_tenthous
-                                 Index Cond: (thousand = (1))
-                           ->  Bitmap Index Scan on tenk1_thous_tenthous
-                                 Index Cond: (thousand = (0))
+               ->  Seq Scan on tenk1
+               ->  Result
          ->  Hash
                ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                     ->  Seq Scan on int4_tbl
+                     ->  Nested Loop
+                           Join Filter: true
+                           ->  Seq Scan on int4_tbl
+                           ->  Result
  Optimizer: Pivotal Optimizer (GPORCA)
-(20 rows)
+(15 rows)
 
 explain (costs off)
 select * from
@@ -3295,24 +3273,25 @@ explain (costs off)
 select * from
   tenk1, int8_tbl a, int8_tbl b
 where thousand = a.q1 and tenthous = b.q1 and a.q2 = 1 and b.q2 = 2;
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
          Hash Cond: ((tenk1.thousand)::bigint = int8_tbl_1.q1)
-         ->  Nested Loop
-               Join Filter: true
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                     ->  Seq Scan on int8_tbl
-                           Filter: (q2 = 2)
-               ->  Index Scan using tenk1_thous_tenthous on tenk1
-                     Index Cond: (tenthous = int8_tbl.q1)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: (tenk1.thousand)::bigint
+               ->  Nested Loop
+                     Join Filter: true
+                     ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                           ->  Seq Scan on int8_tbl
+                                 Filter: (q2 = 2)
+                     ->  Index Scan using tenk1_thous_tenthous on tenk1
+                           Index Cond: (tenthous = int8_tbl.q1)
          ->  Hash
-               ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                     ->  Seq Scan on int8_tbl int8_tbl_1
-                           Filter: (q2 = 1)
+               ->  Seq Scan on int8_tbl int8_tbl_1
+                     Filter: (q2 = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+(16 rows)
 
 reset enable_nestloop;
 --
@@ -3334,42 +3313,41 @@ select t1.unique2, t1.stringu1, t2.unique1, t2.stringu2 from
   left join tenk1 t2
   on (subq1.y1 = t2.unique1)
 where t1.unique2 < 42 and t1.stringu1 > t2.stringu2;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Hash Join
-         Hash Cond: (tenk1.unique1 = (3))
-         Join Filter: (tenk1_1.stringu1 > tenk1.stringu2)
-         ->  Seq Scan on tenk1
-         ->  Hash
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: (3)
-                     ->  Hash Join
-                           Hash Cond: ((0) = int4_tbl.f1)
-                           ->  Hash Join
-                                 Hash Cond: (tenk1_1.unique2 = (11))
-                                 ->  Index Scan using tenk1_unique2 on tenk1 tenk1_1
-                                       Index Cond: ((unique2 < 42) AND (unique2 = 11))
-                                 ->  Hash
-                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Hash Join
+   Hash Cond: ((3) = tenk1_1.unique1)
+   Join Filter: (tenk1.stringu1 > tenk1_1.stringu2)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Nested Loop
+               Join Filter: true
+               ->  Index Scan using tenk1_unique2 on tenk1
+                     Index Cond: (unique2 < 42)
+               ->  Materialize
+                     ->  Result
+                           ->  Broadcast Motion 1:3  (slice2)
+                                 ->  Hash Right Join
+                                       Hash Cond: ((1) = (1))
+                                       ->  Gather Motion 3:1  (slice3; segments: 3)
                                              ->  Result
-                                                   Filter: (((11) < 42) AND ((11) = 11))
-                                                   ->  Hash Left Join
-                                                         Hash Cond: ((1) = (1))
-                                                         ->  Result
-                                                               Filter: ((0) = 0)
-                                                               ->  Seq Scan on onerow
-                                                         ->  Hash
-                                                               ->  Broadcast Motion 3:3  (slice4; segments: 3)
-                                                                     ->  Result
-                                                                           Filter: ((1) = 1)
-                                                                           ->  Seq Scan on onerow onerow_1
-                           ->  Hash
-                                 ->  Broadcast Motion 3:3  (slice5; segments: 3)
-                                       ->  Seq Scan on int4_tbl
-                                             Filter: (f1 = 0)
+                                                   Filter: ((1) = 1)
+                                                   ->  Seq Scan on onerow
+                                       ->  Hash
+                                             ->  Result
+                                                   ->  Gather Motion 3:1  (slice4; segments: 3)
+                                                         ->  Seq Scan on onerow onerow_1
+                                                               Filter: (11 < 42)
+   ->  Hash
+         ->  Gather Motion 3:1  (slice5; segments: 3)
+               ->  Nested Loop
+                     Join Filter: true
+                     ->  Seq Scan on tenk1 tenk1_1
+                     ->  Materialize
+                           ->  Broadcast Motion 3:3  (slice6; segments: 3)
+                                 ->  Seq Scan on int4_tbl
+                                       Filter: (f1 = 0)
  Optimizer: Pivotal Optimizer (GPORCA)
-(33 rows)
+(32 rows)
 
 --end_ignore
 select t1.unique2, t1.stringu1, t2.unique1, t2.stringu2 from
@@ -3423,14 +3401,21 @@ select t1.unique2, t1.stringu1, t2.unique1, t2.stringu2 from
   left join tenk1 t2
   on (subq1.y1 = t2.unique1)
 where t1.unique2 < 42 and t1.stringu1 > t2.stringu2;
-                             QUERY PLAN                              
----------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Hash Join
-   Hash Cond: ((11) = tenk1_1.unique2)
-   Join Filter: (tenk1_1.stringu1 > tenk1.stringu2)
+   Hash Cond: (int4_tbl.f1 = (0))
+   Join Filter: (tenk1.stringu1 > tenk1_1.stringu2)
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Hash Join
-               Hash Cond: ((0) = int4_tbl.f1)
+         ->  Nested Loop
+               Join Filter: true
+               ->  Index Scan using tenk1_unique2 on tenk1
+                     Index Cond: (unique2 < 42)
+               ->  Materialize
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                           ->  Seq Scan on int4_tbl
+   ->  Hash
+         ->  Gather Motion 3:1  (slice3; segments: 3)
                ->  Nested Loop
                      Join Filter: true
                      ->  Result
@@ -3441,7 +3426,7 @@ where t1.unique2 < 42 and t1.stringu1 > t2.stringu2;
                                        ->  Result
                                  ->  Hash
                                        ->  Result
-                     ->  Index Scan using tenk1_unique1 on tenk1
+                     ->  Index Scan using tenk1_unique1 on tenk1 tenk1_1
                            Index Cond: (unique1 = (3))
                ->  Hash
                      ->  Broadcast Motion 3:3  (slice2; segments: 3)
@@ -3483,13 +3468,8 @@ select * from tenk1 a join tenk1 b on
    ->  Nested Loop
          Join Filter: true
          ->  Broadcast Motion 3:3  (slice2; segments: 3)
-               ->  Bitmap Heap Scan on tenk1
-                     Recheck Cond: ((unique1 = 1) OR (unique2 = 3))
-                     ->  BitmapOr
-                           ->  Bitmap Index Scan on tenk1_unique1
-                                 Index Cond: (unique1 = 1)
-                           ->  Bitmap Index Scan on tenk1_unique2
-                                 Index Cond: (unique2 = 3)
+               ->  Seq Scan on tenk1
+                     Filter: ((unique1 = 1) OR (unique2 = 3))
          ->  Bitmap Heap Scan on tenk1 tenk1_1
                Recheck Cond: (((unique1 = 2) OR (hundred = 4)) AND ((unique1 = 2) OR (hundred = 4)))
                Filter: ((((tenk1.unique1 = 1) AND (unique1 = 2)) OR ((tenk1.unique2 = 3) AND (hundred = 4))) AND ((unique1 = 2) OR (hundred = 4)))
@@ -3505,7 +3485,7 @@ select * from tenk1 a join tenk1 b on
                            ->  Bitmap Index Scan on tenk1_hundred
                                  Index Cond: (hundred = 4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(26 rows)
+(21 rows)
 
 explain (costs off)
 select * from tenk1 a join tenk1 b on
@@ -3539,36 +3519,24 @@ explain (costs off)
 select * from tenk1 a join tenk1 b on
   (a.unique1 = 1 and b.unique1 = 2) or
   ((a.unique2 = 3 or a.unique2 = 7) and b.hundred = 4);
-                                                                                       QUERY PLAN                                                                                        
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
          Join Filter: true
          ->  Broadcast Motion 3:3  (slice2; segments: 3)
                ->  Seq Scan on tenk1
-                     Filter: ((unique1 = 2) OR (hundred = 4))
+                     Filter: ((unique1 = 1) OR ((unique2 = 3) OR (unique2 = 7)))
          ->  Bitmap Heap Scan on tenk1 tenk1_1
-               Recheck Cond: (((unique1 = 1) OR ((unique2 = 3) OR (unique2 = 7))) AND ((unique1 = 1) OR (unique2 = 3) OR (unique2 = 7)))
-               Filter: ((((unique1 = 1) AND (tenk1.unique1 = 2)) OR (((unique2 = 3) OR (unique2 = 7)) AND (tenk1.hundred = 4))) AND ((unique1 = 1) OR ((unique2 = 3) OR (unique2 = 7))))
-               ->  BitmapAnd
-                     ->  BitmapOr
-                           ->  Bitmap Index Scan on tenk1_unique1
-                                 Index Cond: (unique1 = 1)
-                           ->  BitmapOr
-                                 ->  Bitmap Index Scan on tenk1_unique2
-                                       Index Cond: (unique2 = 3)
-                                 ->  Bitmap Index Scan on tenk1_unique2
-                                       Index Cond: (unique2 = 7)
-                     ->  BitmapOr
-                           ->  BitmapOr
-                                 ->  Bitmap Index Scan on tenk1_unique1
-                                       Index Cond: (unique1 = 1)
-                                 ->  Bitmap Index Scan on tenk1_unique2
-                                       Index Cond: (unique2 = 3)
-                           ->  Bitmap Index Scan on tenk1_unique2
-                                 Index Cond: (unique2 = 7)
+               Recheck Cond: ((unique1 = 2) OR (hundred = 4))
+               Filter: (((tenk1.unique1 = 1) AND (unique1 = 2)) OR (((tenk1.unique2 = 3) OR (tenk1.unique2 = 7)) AND (hundred = 4)))
+               ->  BitmapOr
+                     ->  Bitmap Index Scan on tenk1_unique1
+                           Index Cond: (unique1 = 2)
+                     ->  Bitmap Index Scan on tenk1_hundred
+                           Index Cond: (hundred = 4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(27 rows)
+(15 rows)
 
 --
 -- test placement of movable quals in a parameterized join tree
@@ -3578,93 +3546,81 @@ select * from tenk1 t1 left join
   (tenk1 t2 join tenk1 t3 on t2.thousand = t3.unique2)
   on t1.hundred = t2.hundred and t1.ten = t3.ten
 where t1.unique1 = 1;
-                                       QUERY PLAN                                       
-----------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Hash Right Join
-         Hash Cond: ((tenk1.hundred = tenk1_2.hundred) AND (tenk1_1.ten = tenk1_2.ten))
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-               Hash Key: tenk1.hundred
-               ->  Hash Join
-                     Hash Cond: (tenk1.thousand = tenk1_1.unique2)
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                           Hash Key: tenk1.thousand
-                           ->  Seq Scan on tenk1
-                     ->  Hash
-                           ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                 Hash Key: tenk1_1.unique2
-                                 ->  Seq Scan on tenk1 tenk1_1
-         ->  Hash
-               ->  Redistribute Motion 3:3  (slice5; segments: 3)
-                     Hash Key: tenk1_2.hundred
-                     ->  Index Scan using tenk1_unique1 on tenk1 tenk1_2
-                           Index Cond: (unique1 = 1)
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Hash Right Join
+   Hash Cond: ((tenk1.hundred = tenk1_2.hundred) AND (tenk1_1.ten = tenk1_2.ten))
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Nested Loop
+               Join Filter: true
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     ->  Seq Scan on tenk1
+               ->  Index Scan using tenk1_unique2 on tenk1 tenk1_1
+                     Index Cond: (unique2 = tenk1.thousand)
+   ->  Hash
+         ->  Gather Motion 3:1  (slice3; segments: 3)
+               ->  Index Scan using tenk1_unique1 on tenk1 tenk1_2
+                     Index Cond: (unique1 = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(20 rows)
+(14 rows)
 
 explain (costs off)
 select * from tenk1 t1 left join
   (tenk1 t2 join tenk1 t3 on t2.thousand = t3.unique2)
   on t1.hundred = t2.hundred and t1.ten + t2.ten = t3.ten
 where t1.unique1 = 1;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Right Join
          Hash Cond: (tenk1.hundred = tenk1_2.hundred)
          Join Filter: ((tenk1_2.ten + tenk1.ten) = tenk1_1.ten)
          ->  Redistribute Motion 3:3  (slice2; segments: 3)
                Hash Key: tenk1.hundred
-               ->  Hash Join
-                     Hash Cond: (tenk1.thousand = tenk1_1.unique2)
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                           Hash Key: tenk1.thousand
+               ->  Nested Loop
+                     Join Filter: true
+                     ->  Broadcast Motion 3:3  (slice3; segments: 3)
                            ->  Seq Scan on tenk1
-                     ->  Hash
-                           ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                 Hash Key: tenk1_1.unique2
-                                 ->  Seq Scan on tenk1 tenk1_1
+                     ->  Index Scan using tenk1_unique2 on tenk1 tenk1_1
+                           Index Cond: (unique2 = tenk1.thousand)
          ->  Hash
-               ->  Redistribute Motion 3:3  (slice5; segments: 3)
+               ->  Redistribute Motion 3:3  (slice4; segments: 3)
                      Hash Key: tenk1_2.hundred
                      ->  Index Scan using tenk1_unique1 on tenk1 tenk1_2
                            Index Cond: (unique1 = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+(18 rows)
 
 explain (costs off)
 select count(*) from
   tenk1 a join tenk1 b on a.unique1 = b.unique2
   left join tenk1 c on a.unique2 = b.unique1 and c.thousand = a.thousand
   join int4_tbl on b.thousand = f1;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
- Finalize Aggregate
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Hash Left Join
-                     Hash Cond: (tenk1_1.thousand = tenk1_2.thousand)
-                     Join Filter: (tenk1_1.unique2 = tenk1.unique1)
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: tenk1_1.thousand
+         ->  Hash Join
+               Hash Cond: (tenk1.thousand = int4_tbl.f1)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: tenk1.thousand
+                     ->  Hash Left Join
+                           Hash Cond: (tenk1_1.thousand = tenk1_2.thousand)
+                           Join Filter: (tenk1_1.unique2 = tenk1.unique1)
                            ->  Nested Loop
                                  Join Filter: true
                                  ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                        Hash Key: tenk1.unique2
-                                       ->  Nested Loop
-                                             Join Filter: true
-                                             ->  Broadcast Motion 3:3  (slice4; segments: 3)
-                                                   ->  Seq Scan on int4_tbl
-                                             ->  Index Scan using tenk1_thous_tenthous on tenk1
-                                                   Index Cond: (thousand = int4_tbl.f1)
+                                       ->  Seq Scan on tenk1
                                  ->  Index Scan using tenk1_unique1 on tenk1 tenk1_1
                                        Index Cond: (unique1 = tenk1.unique2)
-                     ->  Hash
-                           ->  Redistribute Motion 3:3  (slice5; segments: 3)
-                                 Hash Key: tenk1_2.thousand
-                                 ->  Seq Scan on tenk1 tenk1_2
+                           ->  Hash
+                                 ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                       ->  Seq Scan on tenk1 tenk1_2
+               ->  Hash
+                     ->  Seq Scan on int4_tbl
  Optimizer: Pivotal Optimizer (GPORCA)
-(25 rows)
+(22 rows)
 
 select count(*) from
   tenk1 a join tenk1 b on a.unique1 = b.unique2
@@ -3682,8 +3638,8 @@ select b.unique1 from
   join int4_tbl i1 on b.thousand = f1
   right join int4_tbl i2 on i2.f1 = b.tenthous
   order by 1;
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: tenk1.unique1
    ->  Sort
@@ -3692,31 +3648,29 @@ select b.unique1 from
                Hash Cond: (tenk1.tenthous = int4_tbl_1.f1)
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: tenk1.tenthous
-                     ->  Hash Left Join
-                           Hash Cond: (tenk1_1.thousand = tenk1_2.thousand)
-                           Join Filter: (tenk1.unique1 = 42)
+                     ->  Hash Join
+                           Hash Cond: (tenk1.thousand = int4_tbl.f1)
                            ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                 Hash Key: tenk1_1.thousand
-                                 ->  Nested Loop
-                                       Join Filter: true
-                                       ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                             Hash Key: tenk1.unique2
-                                             ->  Nested Loop
-                                                   Join Filter: true
-                                                   ->  Broadcast Motion 3:3  (slice5; segments: 3)
-                                                         ->  Seq Scan on int4_tbl
-                                                   ->  Index Scan using tenk1_thous_tenthous on tenk1
-                                                         Index Cond: (thousand = int4_tbl.f1)
-                                       ->  Index Scan using tenk1_unique1 on tenk1 tenk1_1
-                                             Index Cond: (unique1 = tenk1.unique2)
+                                 Hash Key: tenk1.thousand
+                                 ->  Hash Left Join
+                                       Hash Cond: (tenk1_1.thousand = tenk1_2.thousand)
+                                       Join Filter: (tenk1.unique1 = 42)
+                                       ->  Nested Loop
+                                             Join Filter: true
+                                             ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                                   Hash Key: tenk1.unique2
+                                                   ->  Seq Scan on tenk1
+                                             ->  Index Scan using tenk1_unique1 on tenk1 tenk1_1
+                                                   Index Cond: (unique1 = tenk1.unique2)
+                                       ->  Hash
+                                             ->  Broadcast Motion 3:3  (slice5; segments: 3)
+                                                   ->  Seq Scan on tenk1 tenk1_2
                            ->  Hash
-                                 ->  Redistribute Motion 3:3  (slice6; segments: 3)
-                                       Hash Key: tenk1_2.thousand
-                                       ->  Seq Scan on tenk1 tenk1_2
+                                 ->  Seq Scan on int4_tbl
                ->  Hash
                      ->  Seq Scan on int4_tbl int4_tbl_1
  Optimizer: Pivotal Optimizer (GPORCA)
-(32 rows)
+(30 rows)
 
 select b.unique1 from
   tenk1 a join tenk1 b on a.unique1 = b.unique2
@@ -3741,23 +3695,23 @@ select * from
 ) ss
 where fault = 122
 order by fault;
-                                       QUERY PLAN                                       
-----------------------------------------------------------------------------------------
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: ((COALESCE(tenk1.unique1, '-1'::integer) + int8_tbl.q1))
    ->  Sort
          Sort Key: ((COALESCE(tenk1.unique1, '-1'::integer) + int8_tbl.q1))
          ->  Result
                Filter: ((COALESCE(tenk1.unique1, '-1'::integer) + int8_tbl.q1) = 122)
-               ->  Hash Right Join
-                     Hash Cond: ((tenk1.unique2)::bigint = int8_tbl.q2)
+               ->  Hash Left Join
+                     Hash Cond: (int8_tbl.q2 = (tenk1.unique2)::bigint)
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: (tenk1.unique2)::bigint
-                           ->  Seq Scan on tenk1
+                           Hash Key: int8_tbl.q2
+                           ->  Seq Scan on int8_tbl
                      ->  Hash
                            ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                 Hash Key: int8_tbl.q2
-                                 ->  Seq Scan on int8_tbl
+                                 Hash Key: (tenk1.unique2)::bigint
+                                 ->  Seq Scan on tenk1
  Optimizer: Pivotal Optimizer (GPORCA)
 (16 rows)
 
@@ -3813,13 +3767,13 @@ select q1, unique2, thousand, hundred
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Result
          Filter: ((COALESCE(tenk1.thousand, 123) = int8_tbl.q1) AND (int8_tbl.q1 = COALESCE(tenk1.hundred, 123)))
-         ->  Hash Right Join
-               Hash Cond: ((tenk1.unique2)::bigint = int8_tbl.q1)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: (tenk1.unique2)::bigint
-                     ->  Seq Scan on tenk1
+         ->  Hash Left Join
+               Hash Cond: (int8_tbl.q1 = (tenk1.unique2)::bigint)
+               ->  Seq Scan on int8_tbl
                ->  Hash
-                     ->  Seq Scan on int8_tbl
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: (tenk1.unique2)::bigint
+                           ->  Seq Scan on tenk1
  Optimizer: Pivotal Optimizer (GPORCA)
 (11 rows)
 
@@ -3839,13 +3793,13 @@ select f1, unique2, case when unique2 is null then f1 else 0 end
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Result
          Filter: (CASE WHEN (tenk1.unique2 IS NULL) THEN int4_tbl.f1 ELSE 0 END = 0)
-         ->  Hash Right Join
-               Hash Cond: (tenk1.unique2 = int4_tbl.f1)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: tenk1.unique2
-                     ->  Seq Scan on tenk1
+         ->  Hash Left Join
+               Hash Cond: (int4_tbl.f1 = tenk1.unique2)
+               ->  Seq Scan on int4_tbl
                ->  Hash
-                     ->  Seq Scan on int4_tbl
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: tenk1.unique2
+                           ->  Seq Scan on tenk1
  Optimizer: Pivotal Optimizer (GPORCA)
 (11 rows)
 
@@ -3864,29 +3818,26 @@ explain (costs off)
 select a.unique1, b.unique1, c.unique1, coalesce(b.twothousand, a.twothousand)
   from tenk1 a left join tenk1 b on b.thousand = a.unique1                        left join tenk1 c on c.unique2 = coalesce(b.twothousand, a.twothousand)
   where a.unique2 < 10 and coalesce(b.twothousand, a.twothousand) = 44;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Hash Right Join
-         Hash Cond: (tenk1.unique2 = COALESCE(tenk1_1.twothousand, tenk1_2.twothousand))
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-               Hash Key: tenk1.unique2
-               ->  Seq Scan on tenk1
+   ->  Hash Left Join
+         Hash Cond: (COALESCE(tenk1_1.twothousand, tenk1.twothousand) = tenk1_2.unique2)
+         ->  Result
+               Filter: (COALESCE(tenk1_1.twothousand, tenk1.twothousand) = 44)
+               ->  Hash Left Join
+                     Hash Cond: (tenk1.unique1 = tenk1_1.thousand)
+                     ->  Index Scan using tenk1_unique2 on tenk1
+                           Index Cond: (unique2 < 10)
+                     ->  Hash
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Hash Key: tenk1_1.thousand
+                                 ->  Seq Scan on tenk1 tenk1_1
          ->  Hash
-               ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                     Hash Key: COALESCE(tenk1_1.twothousand, tenk1_2.twothousand)
-                     ->  Result
-                           Filter: (COALESCE(tenk1_1.twothousand, tenk1_2.twothousand) = 44)
-                           ->  Hash Right Join
-                                 Hash Cond: (tenk1_1.thousand = tenk1_2.unique1)
-                                 ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                       Hash Key: tenk1_1.thousand
-                                       ->  Seq Scan on tenk1 tenk1_1
-                                 ->  Hash
-                                       ->  Index Scan using tenk1_unique2 on tenk1 tenk1_2
-                                             Index Cond: (unique2 < 10)
+               ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                     ->  Seq Scan on tenk1 tenk1_2
  Optimizer: Pivotal Optimizer (GPORCA)
-(20 rows)
+(17 rows)
 
 select a.unique1, b.unique1, c.unique1, coalesce(b.twothousand, a.twothousand)
   from tenk1 a left join tenk1 b on b.thousand = a.unique1                        left join tenk1 c on c.unique2 = coalesce(b.twothousand, a.twothousand)
@@ -3911,33 +3862,31 @@ left join
    using (join_key)
   ) foo3
 using (join_key);
-                               QUERY PLAN                               
-------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Hash Right Join
    Output: "Values".column1, int4_tbl.f1, (666)
    ->  Hash Left Join
-         Output: "Values".column1, int4_tbl.f1, (666)
-         Hash Cond: ("Values".column1 = int4_tbl.f1)
+         Output: int4_tbl.f1, (666)
+         Hash Cond: (int4_tbl.f1 = tenk1.unique2)
          ->  Result
-               Output: "Values".column1
-               ->  Values Scan on "Values"
-                     Output: "Values".column1
+               Output: 666, int4_tbl.f1
+               ->  Gather Motion 3:1  (slice1; segments: 3)
+                     Output: int4_tbl.f1
+                     ->  Seq Scan on public.int4_tbl
+                           Output: int4_tbl.f1
          ->  Hash
-               Output: int4_tbl.f1, (666)
-               ->  Hash Right Join
-                     Output: int4_tbl.f1, (666)
-                     Hash Cond: (tenk1.unique2 = int4_tbl.f1)
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: tenk1.unique2
+               ->  Gather Motion 3:1  (slice2; segments: 3)
+                     Output: tenk1.unique2
+                     ->  Seq Scan on public.tenk1
                            Output: tenk1.unique2
-                           Hash Key: tenk1.unique2
-                           ->  Seq Scan on public.tenk1
-                                 Output: tenk1.unique2
-                     ->  Hash
-                           Output: (666), int4_tbl.f1
-                           ->  Seq Scan on public.int4_tbl
-                                 Output: 666, int4_tbl.f1
+   ->  Hash
+         Output: "Values".column1
+         ->  Values Scan on "Values"
+               Output: "Values".column1
  Optimizer: Pivotal Optimizer (GPORCA)
-(24 rows)
+(23 rows)
 
 select foo1.join_key as foo1_id, foo3.join_key AS foo3_id, bug_field from
   (values (0),(1)) foo1(join_key)
@@ -4920,8 +4869,8 @@ from
      left join uniquetbl u1 ON u1.f1 = t1.string4) ss
   on t0.f1 = ss.case1
 where ss.stringu2 !~* ss.case1;
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
          Hash Cond: ((CASE tenk1.ten WHEN 0 THEN 'doh!'::text ELSE NULL::text END) = text_tbl.f1)
@@ -4929,20 +4878,23 @@ where ss.stringu2 !~* ss.case1;
                Hash Key: (CASE tenk1.ten WHEN 0 THEN 'doh!'::text ELSE NULL::text END)
                ->  Hash Left Join
                      Hash Cond: (tenk1.string4 = (uniquetbl.f1)::name)
-                     ->  Nested Loop
-                           Join Filter: true
-                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                                 ->  Seq Scan on int4_tbl
-                           ->  Index Scan using tenk1_unique2 on tenk1
-                                 Index Cond: (unique2 = int4_tbl.f1)
-                                 Filter: (stringu2 !~* CASE ten WHEN 0 THEN 'doh!'::text ELSE NULL::text END)
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Hash Key: tenk1.string4
+                           ->  Nested Loop
+                                 Join Filter: true
+                                 ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                       ->  Seq Scan on int4_tbl
+                                 ->  Index Scan using tenk1_unique2 on tenk1
+                                       Index Cond: (unique2 = int4_tbl.f1)
+                                       Filter: (stringu2 !~* CASE ten WHEN 0 THEN 'doh!'::text ELSE NULL::text END)
                      ->  Hash
-                           ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                           ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                                 Hash Key: (uniquetbl.f1)::name
                                  ->  Seq Scan on uniquetbl
          ->  Hash
                ->  Seq Scan on text_tbl
  Optimizer: Pivotal Optimizer (GPORCA)
-(20 rows)
+(23 rows)
 
 select t0.*
 from
@@ -5202,18 +5154,17 @@ select * from generate_series(100,200) g,
 explain (costs off)
   select count(*) from tenk1 a,
     tenk1 b join lateral (values(a.unique1)) ss(x) on b.unique2 = ss.x;
-                               QUERY PLAN                               
-------------------------------------------------------------------------
- Finalize Aggregate
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Hash Join
-                     Hash Cond: (b.unique2 = a.unique1)
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: b.unique2
-                           ->  Seq Scan on tenk1 b
-                     ->  Hash
-                           ->  Seq Scan on tenk1 a
+         ->  Hash Join
+               Hash Cond: (b.unique2 = a.unique1)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: b.unique2
+                     ->  Seq Scan on tenk1 b
+               ->  Hash
+                     ->  Seq Scan on tenk1 a
  Optimizer: Postgres query optimizer
 (11 rows)
 
@@ -5228,24 +5179,23 @@ select count(*) from tenk1 a,
 explain (costs off)
   select count(*) from tenk1 a,
     tenk1 b join lateral (values(a.unique1),(-1)) ss(x) on b.unique2 = ss.x;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Finalize Aggregate
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Hash Join
-                     Hash Cond: ("*VALUES*".column1 = b.unique2)
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: "*VALUES*".column1
-                           ->  Nested Loop
-                                 ->  Seq Scan on tenk1 a
-                                 ->  Values Scan on "*VALUES*"
-                     ->  Hash
-                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                 Hash Key: b.unique2
-                                 ->  Seq Scan on tenk1 b
+         ->  Hash Join
+               Hash Cond: ("*VALUES*".column1 = b.unique2)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: "*VALUES*".column1
+                     ->  Nested Loop
+                           ->  Seq Scan on tenk1 a
+                           ->  Values Scan on "*VALUES*"
+               ->  Hash
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Hash Key: b.unique2
+                           ->  Seq Scan on tenk1 b
  Optimizer: Postgres query optimizer
-(15 rows)
+(14 rows)
 
 select count(*) from tenk1 a,
   tenk1 b join lateral (values(a.unique1),(-1)) ss(x) on b.unique2 = ss.x;
@@ -5782,8 +5732,8 @@ select c.*,a.*,ss1.q1,ss2.q1,ss3.* from
     lateral (select q1, coalesce(ss1.x,q2) as y from int8_tbl d) ss2
   ) on c.q2 = ss2.q1,
   lateral (select * from int4_tbl i where ss2.y > f1) ss3;
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Output: c.q1, c.q2, a.q1, a.q2, b.q1, d.q1, i.f1
    ->  Nested Loop
@@ -6501,8 +6451,7 @@ left join j2 on j1.id1 = j2.id1 where j1.id2 = 1;
                ->  Seq Scan on public.j2
                      Output: j2.id1, j2.id2
  Optimizer: Pivotal Optimizer (GPORCA)
- Settings: enable_nestloop=on
-(16 rows)
+(15 rows)
 
 -- validate logic in merge joins which skips mark and restore.
 -- it should only do this if all quals which were used to detect the unique
@@ -6561,33 +6510,40 @@ from onek t1, tenk1 t2
 where exists (select 1 from tenk1 t3
               where t3.thousand = t1.unique1 and t3.tenthous = t2.hundred)
       and t1.unique1 < 1;
-                                                    QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   Output: onek.unique1, tenk1.hundred
-   ->  Hash Semi Join
-         Output: onek.unique1, tenk1.hundred
-         Hash Cond: ((onek.unique1 = tenk1_1.thousand) AND (tenk1.hundred = tenk1_1.tenthous))
-         ->  Nested Loop
-               Output: onek.unique1, tenk1.hundred
-               Join Filter: true
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                     Output: onek.unique1
-                     ->  Index Scan using onek_unique1 on public.onek
-                           Output: onek.unique1
-                           Index Cond: (onek.unique1 < 1)
-               ->  Seq Scan on public.tenk1
-                     Output: tenk1.hundred
-         ->  Hash
-               Output: tenk1_1.thousand, tenk1_1.tenthous
-               ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                     Output: tenk1_1.thousand, tenk1_1.tenthous
-                     ->  Index Only Scan using tenk1_thous_tenthous on public.tenk1 tenk1_1
-                           Output: tenk1_1.thousand, tenk1_1.tenthous
-                           Index Cond: (tenk1_1.thousand < 1)
+   Output: onek.unique1, tenk1_1.hundred
+   ->  Nested Loop
+         Output: onek.unique1, tenk1_1.hundred
+         Join Filter: true
+         ->  Broadcast Motion 3:3  (slice2; segments: 3)
+               Output: tenk1_1.hundred
+               ->  Nested Loop
+                     Output: tenk1_1.hundred
+                     Join Filter: true
+                     ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                           Output: tenk1.tenthous
+                           ->  GroupAggregate
+                                 Output: tenk1.tenthous
+                                 Group Key: tenk1.tenthous
+                                 ->  Sort
+                                       Output: tenk1.tenthous
+                                       Sort Key: tenk1.tenthous
+                                       ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                             Output: tenk1.tenthous
+                                             Hash Key: tenk1.tenthous
+                                             ->  Index Scan using tenk1_thous_tenthous on public.tenk1
+                                                   Output: tenk1.tenthous
+                                                   Index Cond: (tenk1.thousand < 1)
+                     ->  Index Scan using tenk1_hundred on public.tenk1 tenk1_1
+                           Output: tenk1_1.hundred
+                           Index Cond: (tenk1_1.hundred = tenk1.tenthous)
+         ->  Index Scan using onek_unique1 on public.onek
+               Output: onek.unique1
+               Index Cond: (onek.unique1 < 1)
  Optimizer: Pivotal Optimizer (GPORCA)
- Settings: enable_bitmapscan=off, enable_hashjoin=off, enable_mergejoin=on, enable_nestloop=on, enable_seqscan=off
-(24 rows)
+(31 rows)
 
 -- ... unless it actually is unique
 create table j3 as select unique1, tenthous from onek;
@@ -6601,33 +6557,32 @@ from onek t1, tenk1 t2
 where exists (select 1 from j3
               where j3.unique1 = t1.unique1 and j3.tenthous = t2.hundred)
       and t1.unique1 < 1;
-                                                    QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
+                           QUERY PLAN                           
+----------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Output: onek.unique1, tenk1.hundred
    ->  Hash Semi Join
          Output: onek.unique1, tenk1.hundred
-         Hash Cond: ((onek.unique1 = j3.unique1) AND (tenk1.hundred = j3.tenthous))
+         Hash Cond: (tenk1.hundred = j3.tenthous)
          ->  Nested Loop
                Output: onek.unique1, tenk1.hundred
                Join Filter: true
                ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                     Output: onek.unique1
-                     ->  Index Scan using onek_unique1 on public.onek
-                           Output: onek.unique1
-                           Index Cond: (onek.unique1 < 1)
-               ->  Seq Scan on public.tenk1
                      Output: tenk1.hundred
+                     ->  Seq Scan on public.tenk1
+                           Output: tenk1.hundred
+               ->  Index Scan using onek_unique1 on public.onek
+                     Output: onek.unique1
+                     Index Cond: (onek.unique1 < 1)
          ->  Hash
-               Output: j3.unique1, j3.tenthous
+               Output: j3.tenthous
                ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                     Output: j3.unique1, j3.tenthous
+                     Output: j3.tenthous
                      ->  Seq Scan on public.j3
-                           Output: j3.unique1, j3.tenthous
+                           Output: j3.tenthous
                            Filter: (j3.unique1 < 1)
  Optimizer: Pivotal Optimizer (GPORCA)
- Settings: enable_bitmapscan=off, enable_hashjoin=off, enable_mergejoin=on, enable_nestloop=on, enable_seqscan=off
-(24 rows)
+(23 rows)
 
 drop table j3;
 reset enable_hashjoin;


### PR DESCRIPTION
Issue:
======
Current implementation of ORCA does not remove the redundant predicates after transitive closure.

Solution:
=========

This PR is trying to remove the redundant predicates based on the following steps.

- After the normalization step the predicates are already pushed down the tree. So they are redundant in the join condition.

- If the child of the join is a EopScalarCmp, we are not checking for redundancy because we need one child for the Hash join condition.

- If the child of the join is EopScalarBoolOp we are iterating through each child of EopScalarBoolOp and if its a EopScalarCmp with equlity type, we are checking if the value of that column is a constant.

- If it's a constant then it can be removed as it has been already pushed down the tree in the previous normalization step.

- If a condition arises when all the childs are redundant then we are not removing all the childs as this will boil down to a nested loop. So in order to do a Hash join we are keeping one child even if its redundant based on if the column is a distribution key.


Setup:
======
create table foo(a text, b text);
create table bar(c text, d text);
explain select * from foo join bar on foo.a=bar.c and foo.b=bar.d where bar.d='cc';


Existing Behaviour:
===================
```      
                            QUERY PLAN
-------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=32)
   ->  Hash Join  (cost=0.00..862.00 rows=1 width=32)
         Hash Cond: ((foo.a = bar.c) AND (foo.b = bar.d))
         ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=16)
               Filter: (b = 'cc'::text)
         ->  Hash  (cost=431.00..431.00 rows=1 width=16)
               ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=16)
                     Filter: (d = 'cc'::text)
 Optimizer: Pivotal Optimizer (GPORCA)
(9 rows)
```

New Behaviour:
==============

```
                                  QUERY PLAN
-------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=32)
   ->  Hash Join  (cost=0.00..862.00 rows=1 width=32)
         Hash Cond: (foo.a = bar.c)
         ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=16)
               Filter: (b = 'cc'::text)
         ->  Hash  (cost=431.00..431.00 rows=1 width=16)
               ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=16)
                     Filter: (d = 'cc'::text)
 Optimizer: Pivotal Optimizer (GPORCA)
(9 rows)
```
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
