### PR TITLE
Enable catchup within range on segment backport.

### DIFF
--- a/src/backend/fts/ftsmessagehandler.c
+++ b/src/backend/fts/ftsmessagehandler.c
@@ -26,6 +26,7 @@
 #include "utils/faultinjector.h"
 #include "utils/guc.h"
 #include "replication/gp_replication.h"
+#include "replication/walsender.h"
 #include "storage/fd.h"
 
 #define FTS_PROBE_FILE_NAME "fts_probe_file.bak"
@@ -270,13 +271,15 @@ HandleFtsWalRepProbe(void)
 	}
 	else
 	{
-		GetMirrorStatus(&response);
+		bool ready_for_syncrep;
+
+		GetMirrorStatus(&response, &ready_for_syncrep);
 
 		/*
 		 * We check response.IsSyncRepEnabled even though syncrep is again checked
 		 * later in the set function to avoid acquiring the SyncRepLock again.
 		 */
-		if (response.IsMirrorUp && !response.IsSyncRepEnabled)
+		if (!response.IsSyncRepEnabled && ready_for_syncrep)
 		{
 			SetSyncStandbysDefined();
 			/* Syncrep is enabled now, so respond accordingly. */
@@ -309,7 +312,7 @@ HandleFtsWalRepSyncRepOff(void)
 	ereport(LOG,
 			(errmsg("turning off synchronous wal replication due to FTS request")));
 	UnsetSyncStandbysDefined();
-	GetMirrorStatus(&response);
+	GetMirrorStatus(&response, NULL);
 
 	SendFtsResponse(&response, FTS_MSG_SYNCREP_OFF);
 }

--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -998,9 +998,6 @@ processResponse(fts_context *context)
 
 		/* If primary and mirror are in sync, then both have to be ALIVE. */
 		AssertImply(IsInSync, IsPrimaryAlive && IsMirrorAlive);
-		/* Primary must enable syncrep as long as it thinks mirror is alive. */
-		AssertImply(IsMirrorAlive && IsPrimaryAlive,
-					ftsInfo->result.isSyncRepEnabled);
 
 		switch(ftsInfo->state)
 		{

--- a/src/backend/fts/test/ftsmessagehandler_test.c
+++ b/src/backend/fts/test/ftsmessagehandler_test.c
@@ -77,12 +77,11 @@ test_HandleFtsWalRepProbePrimary(void **state)
 
 	expect_any(GetMirrorStatus, response);
 	will_assign_memory(GetMirrorStatus, response, &mockresponse, sizeof(FtsResponse));
+	expect_any(GetMirrorStatus, ready_for_syncrep);
+	will_assign_value(GetMirrorStatus, ready_for_syncrep, (bool) false);
 	will_be_called(GetMirrorStatus);
 
-	will_be_called(SetSyncStandbysDefined);
-
-	/* SyncRep should be enabled as soon as we found mirror is up. */
-	mockresponse.IsSyncRepEnabled = true;
+	/* mirror being up does not mean SyncRep should be enabled. */
 	expectSendFtsResponse(FTS_MSG_PROBE, &mockresponse);
 
 	HandleFtsWalRepProbe();
@@ -101,6 +100,7 @@ test_HandleFtsWalRepSyncRepOff(void **state)
 
 	expect_any(GetMirrorStatus, response);
 	will_assign_memory(GetMirrorStatus, response, &mockresponse, sizeof(FtsResponse));
+	expect_any(GetMirrorStatus, ready_for_syncrep);
 	will_be_called(GetMirrorStatus);
 
 	will_be_called(UnsetSyncStandbysDefined);

--- a/src/backend/replication/gp_replication.c
+++ b/src/backend/replication/gp_replication.c
@@ -540,14 +540,17 @@ is_probe_retry_needed()
 
 /*
  * Check the WalSndCtl to obtain if mirror is up or down, if the wal sender is
- * in streaming, and if synchronous replication is enabled or not.
+ * in streaming, and if synchronous replication is enabled or not, decide if
+ * the primary is ready for syncrep if needed.
  */
 void
-GetMirrorStatus(FtsResponse *response)
+GetMirrorStatus(FtsResponse *response, bool *ready_for_syncrep)
 {
 	response->IsMirrorUp = false;
 	response->IsInSync = false;
 	response->RequestRetry = false;
+	if (ready_for_syncrep != NULL)
+		*ready_for_syncrep = false;
 
 	LWLockAcquire(SyncRepLock, LW_SHARED);
 
@@ -566,6 +569,12 @@ GetMirrorStatus(FtsResponse *response)
 
 		is_up = is_mirror_up(walsender);
 		is_streaming = (walsender->state == WALSNDSTATE_STREAMING);
+
+		if (ready_for_syncrep != NULL)
+			*ready_for_syncrep = is_up &&
+								((walsender->state == WALSNDSTATE_STREAMING) ||
+								 (walsender->state == WALSNDSTATE_CATCHUP &&
+								  walsender->caughtup_within_range));
 
 		response->IsMirrorUp = is_up;
 		response->IsInSync = (is_up && is_streaming);

--- a/src/backend/replication/test/gp_replication_test.c
+++ b/src/backend/replication/test/gp_replication_test.c
@@ -89,7 +89,7 @@ test_GetMirrorStatus_Pid_Zero(void **state)
 	 */
 	PMAcceptingConnectionsStartTime = data->replications[0].replica_disconnected_at - 1;
 
-	GetMirrorStatus(&response);
+	GetMirrorStatus(&response, NULL);
 
 	assert_false(response.RequestRetry);
 	assert_false(response.IsMirrorUp);
@@ -116,7 +116,7 @@ test_GetMirrorStatus_RequestRetry(void **state)
 	PMAcceptingConnectionsStartTime = data->replications[0].replica_disconnected_at - gp_fts_mark_mirror_down_grace_period;
 
 	expect_ereport();
-	GetMirrorStatus(&response);
+	GetMirrorStatus(&response, NULL);
 
 	assert_true(response.RequestRetry);
 }
@@ -151,7 +151,7 @@ test_GetMirrorStatus_Exceed_ContinuouslyReplicationAttempt(void **state)
 	PMAcceptingConnectionsStartTime = data->replications[0].replica_disconnected_at - gp_fts_mark_mirror_down_grace_period;
 
 	expect_ereport();
-	GetMirrorStatus(&response);
+	GetMirrorStatus(&response, NULL);
 
 	assert_false(response.RequestRetry);
 }
@@ -182,7 +182,7 @@ test_GetMirrorStatus_Delayed_AcceptingConnectionsStartTime(void **state)
 	PMAcceptingConnectionsStartTime = ((pg_time_t) time(NULL)) - gp_fts_mark_mirror_down_grace_period/2;
 
 	expect_ereport();
-	GetMirrorStatus(&response);
+	GetMirrorStatus(&response, NULL);
 
 	assert_true(response.RequestRetry);
 }
@@ -202,7 +202,7 @@ test_GetMirrorStatus_Overflow(void **state)
 	data->replications[0].replica_disconnected_at = INT64_MAX;
 	PMAcceptingConnectionsStartTime = ((pg_time_t) time(NULL));
 
-	GetMirrorStatus(&response);
+	GetMirrorStatus(&response, NULL);
 
 	assert_false(response.RequestRetry);
 	assert_false(response.IsMirrorUp);
@@ -225,7 +225,7 @@ test_GetMirrorStatus_WALSNDSTATE_STARTUP(void **state)
 	PMAcceptingConnectionsStartTime = data->replications[0].replica_disconnected_at;
 
 	expect_ereport();
-	GetMirrorStatus(&response);
+	GetMirrorStatus(&response, NULL);
 
 	assert_true(response.RequestRetry);
 	assert_false(response.IsMirrorUp);
@@ -252,7 +252,7 @@ test_GetMirrorStatus_WALSNDSTATE_BACKUP(void **state)
 	 */
 	PMAcceptingConnectionsStartTime = data->replications[0].replica_disconnected_at - 1;
 
-	GetMirrorStatus(&response);
+	GetMirrorStatus(&response, NULL);
 
 	assert_false(response.RequestRetry);
 	assert_false(response.IsMirrorUp);
@@ -267,7 +267,7 @@ test_GetMirrorStatus_WALSNDSTATE_CATCHUP(void **state)
 
 	data = test_setup(1, WALSNDSTATE_CATCHUP, 3);
 
-	GetMirrorStatus(&response);
+	GetMirrorStatus(&response, NULL);
 
 	/* For mirror to be up in catchup state, WalSnd.write must be a valid. */
 	assert_false(response.IsMirrorUp);
@@ -282,7 +282,7 @@ test_GetMirrorStatus_WALSNDSTATE_STREAMING(void **state)
 
 	data = test_setup(1, WALSNDSTATE_STREAMING, 0);
 
-	GetMirrorStatus(&response);
+	GetMirrorStatus(&response, NULL);
 
 	assert_true(response.IsMirrorUp);
 	assert_true(response.IsInSync);
@@ -297,7 +297,7 @@ test_GetMirrorStatus_up_not_in_sync(void **state)
 	data = test_setup(1, WALSNDSTATE_CATCHUP, 0);
 	WalSndCtl->walsnds[0].write = 12345;
 
-	GetMirrorStatus(&response);
+	GetMirrorStatus(&response, NULL);
 
 	assert_true(response.IsMirrorUp);
 	assert_false(response.IsInSync);

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4401,7 +4401,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"repl_catchup_within_range", PGC_SUSET, REPLICATION_STANDBY,
 			gettext_noop("Sets the maximum number of xlog segments allowed to lag"
 					  " when the backends can start blocking despite the WAL"
-					   " sender being in catchup phase. (Master Mirroring)"),
+					   " sender being in catchup phase."),
 			NULL,
 			GUC_SUPERUSER_ONLY
 		},

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -309,10 +309,10 @@ extern int	gp_snapshotadd_timeout; /* GUC var - timeout specifier for snapshot-c
 extern int	gp_fts_probe_retries; /* GUC var - specifies probe number of retries for FTS */
 extern int	gp_fts_probe_timeout; /* GUC var - specifies probe timeout for FTS */
 extern int	gp_fts_probe_interval; /* GUC var - specifies polling interval for FTS */
-extern int gp_fts_mark_mirror_down_grace_period;
+extern int	gp_fts_mark_mirror_down_grace_period;
 extern int	gp_fts_replication_attempt_count; /* GUC var - specifies replication max attempt count for FTS */
-extern int  gp_dtx_recovery_interval;
-extern int  gp_dtx_recovery_prepared_period;
+extern int	gp_dtx_recovery_interval;
+extern int	gp_dtx_recovery_prepared_period;
 
 extern int gp_gang_creation_retry_count; /* How many retries ? */
 extern int gp_gang_creation_retry_timer; /* How long between retries */

--- a/src/include/replication/gp_replication.h
+++ b/src/include/replication/gp_replication.h
@@ -73,7 +73,7 @@ extern void FTSReplicationStatusUpdateForWalState(const char *app_name, WalSndSt
 extern void FTSReplicationStatusMarkDisconnectForReplication(const char *app_name);
 extern pg_time_t FTSGetReplicationDisconnectTime(const char *app_name);
 
-extern void GetMirrorStatus(FtsResponse *response);
+extern void GetMirrorStatus(FtsResponse *response, bool *ready_for_syncrep);
 extern void SetSyncStandbysDefined(void);
 extern void UnsetSyncStandbysDefined(void);
 

--- a/src/test/isolation2/expected/segwalrep/commit_blocking_on_standby.out
+++ b/src/test/isolation2/expected/segwalrep/commit_blocking_on_standby.out
@@ -207,3 +207,103 @@ select wait_until_standby_in_state('streaming');
 -----------------------------
  streaming                   
 (1 row)
+
+
+-- Scenario3: verify repl_catchup_within_range is enabled on segment.
+-- It is similar as Scenario2, just running the test against primary/mirror
+-- instead of master/standby.
+
+select gp_inject_fault_infinite('wal_sender_loop', 'infinite_loop', dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+select gp_inject_fault_infinite('walrecv_skip_flush', 'skip', dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+0U: select pg_terminate_backend(pid) from pg_stat_replication;
+ pg_terminate_backend 
+----------------------
+ t                    
+(1 row)
+
+0U: show repl_catchup_within_range;
+ repl_catchup_within_range 
+---------------------------
+ 1                         
+(1 row)
+
+0U: begin;
+BEGIN
+0U: select wait_until_standby_in_state('catchup');
+ wait_until_standby_in_state 
+-----------------------------
+ catchup                     
+(1 row)
+
+select gp_wait_until_triggered_fault('wal_sender_loop', 1, dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+0U: select application_name, state from pg_stat_replication;
+ application_name | state   
+------------------+---------
+ gp_walreceiver   | catchup 
+(1 row)
+0U: commit;
+COMMIT
+
+select gp_inject_fault('wal_sender_after_caughtup_within_range', 'suspend', dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+select gp_inject_fault('wal_sender_loop', 'reset', dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+select gp_wait_until_triggered_fault( 'wal_sender_after_caughtup_within_range', 1, dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+1&: create table commit_blocking_on_mirror_tbl (a int, b int) distributed by (a);  <waiting ...>
+
+0U: select wait_for_pg_stat_activity(60);
+ wait_for_pg_stat_activity 
+---------------------------
+                           
+(1 row)
+0U: select datname, waiting, waiting_reason, query from pg_stat_activity where waiting_reason = 'replication';
+ datname        | waiting | waiting_reason | query                                                                         
+----------------+---------+----------------+-------------------------------------------------------------------------------
+ isolation2test | t       | replication    | create table commit_blocking_on_mirror_tbl (a int, b int) distributed by (a); 
+(1 row)
+
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration where content=0;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+(2 rows)
+
+1<:  <... completed>
+CREATE
+
+insert into commit_blocking_on_mirror_tbl values (2, 1);
+INSERT 1
+0U: select wait_until_standby_in_state('streaming');
+ wait_until_standby_in_state 
+-----------------------------
+ streaming                   
+(1 row)

--- a/src/test/isolation2/sql/segwalrep/commit_blocking_on_standby.sql
+++ b/src/test/isolation2/sql/segwalrep/commit_blocking_on_standby.sql
@@ -147,3 +147,50 @@ select gp_inject_fault('all', 'reset', dbid)
 insert into commit_blocking_on_standby_t2 values (1);
 
 select wait_until_standby_in_state('streaming');
+
+
+-- Scenario3: verify repl_catchup_within_range is enabled on segment.
+-- It is similar as Scenario2, just running the test against primary/mirror
+-- instead of master/standby.
+
+select gp_inject_fault_infinite('wal_sender_loop', 'infinite_loop', dbid)
+       from gp_segment_configuration where content=0 and role='p';
+
+select gp_inject_fault_infinite('walrecv_skip_flush', 'skip', dbid)
+       from gp_segment_configuration where content=0 and role='m';
+
+0U: select pg_terminate_backend(pid) from pg_stat_replication;
+
+0U: show repl_catchup_within_range;
+
+0U: begin;
+0U: select wait_until_standby_in_state('catchup');
+
+select gp_wait_until_triggered_fault('wal_sender_loop', 1, dbid)
+       from gp_segment_configuration where content=0 and role='p';
+
+0U: select application_name, state from pg_stat_replication;
+0U: commit;
+
+select gp_inject_fault('wal_sender_after_caughtup_within_range', 'suspend', dbid)
+       from gp_segment_configuration where content=0 and role='p';
+
+select gp_inject_fault('wal_sender_loop', 'reset', dbid)
+       from gp_segment_configuration where content=0 and role='p';
+
+select gp_wait_until_triggered_fault(
+       'wal_sender_after_caughtup_within_range', 1, dbid)
+       from gp_segment_configuration where content=0 and role='p';
+
+1&: create table commit_blocking_on_mirror_tbl (a int, b int) distributed by (a);
+
+0U: select wait_for_pg_stat_activity(60);
+0U: select datname, waiting, waiting_reason, query from pg_stat_activity where waiting_reason = 'replication';
+
+select gp_inject_fault('all', 'reset', dbid)
+       from gp_segment_configuration where content=0;
+
+1<:
+
+insert into commit_blocking_on_mirror_tbl values (2, 1);
+0U: select wait_until_standby_in_state('streaming');


### PR DESCRIPTION
This is backport of https://github.com/greenplum-db/gpdb/pull/13891.

Commits start blocking only if STREAMING or CATCHUP within range.

In real scenarios it often happens that the mirror node is down (probably not
really down) and out-of-sync for some time and that could lead to large wal lag
on the mirror node, and when the mirror is added back by fts, fts currently
soon sets syncrep on. While at the time the mirror is catching up and thus it
stalls the new write query for a long time until wal catchup finishes.

There was a guc repl_catchup_within_range that "Sets the maximum number of xlog
segments allowed to lag when the backends can start blocking despite the WAL
sender being in catchup phase." It was for the coordinator only. Now we could
use it on segments also, to allow commits start blocking only if walsender is
in STREAMING state or in CATCHUP state but repl_catchup_within_range.

Co-authored-by: Haolin Wang [whaolin@vmware.com](mailto:whaolin@vmware.com)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
