### PR TITLE
remove useless extern

### DIFF
--- a/src/backend/catalog/oid_dispatch.c
+++ b/src/backend/catalog/oid_dispatch.c
@@ -193,7 +193,7 @@ ClearOidAssignmentsOnCommit(void)
 	preserve_oids_on_commit = false;
 }
 
-extern void
+void
 RestoreOidAssignments(List *oid_assignments)
 {
 	dispatch_oids = oid_assignments;


### PR DESCRIPTION
I think the `extern` keyword tells the compiler that the function
is defined somewhere else, since here for `RestoreOidAssignments`
it is a definition, `extern` is useless, so remove it.

Signed-off-by: Junwang Zhao <zhjwpku@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
