### PR TITLE
Fix assert op executor node

### DIFF
--- a/src/backend/executor/nodeAssertOp.c
+++ b/src/backend/executor/nodeAssertOp.c
@@ -114,8 +114,7 @@ ExecInitAssertOp(AssertOp *node, EState *estate, int eflags)
 	/*
 	 * Initialize result type and projection.
 	 */
-	ExecInitResultTypeTL(&assertOpState->ps);
-	ExecInitResultSlot(&assertOpState->ps, &TTSOpsMinimalTuple);
+	ExecInitResultTupleSlotTL(&assertOpState->ps, &TTSOpsMinimalTuple);
 
 	ExecAssignProjectionInfo(&assertOpState->ps, NULL);
 

--- a/src/backend/executor/nodeAssertOp.c
+++ b/src/backend/executor/nodeAssertOp.c
@@ -66,10 +66,10 @@ CheckForAssertViolations(AssertOpState* node, TupleTableSlot* slot)
 /*
  * Evaluate Constraints (in node->ps.qual) and project output TupleTableSlot.
  * */
-TupleTableSlot*
-ExecAssertOp(struct PlanState *node)
+static TupleTableSlot*
+ExecAssertOp(PlanState *pstate)
 {
-	PlanState *outerNode = outerPlanState(node);
+	PlanState *outerNode = outerPlanState(pstate);
 	TupleTableSlot *slot = ExecProcNode(outerNode);
 
 	if (TupIsNull(slot))
@@ -77,11 +77,11 @@ ExecAssertOp(struct PlanState *node)
 		return NULL;
 	}
 
-	AssertOpState *pstate = castNode(AssertOpState, node);
+	AssertOpState *node = castNode(AssertOpState, pstate);
 
-	CheckForAssertViolations(pstate, slot);
+	CheckForAssertViolations(node, slot);
 
-	return ExecProject(pstate->ps.ps_ProjInfo);
+	return ExecProject(node->ps.ps_ProjInfo);
 }
 
 /**

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -454,8 +454,12 @@ CTranslatorDXLToPlStmt::TranslateDXLOperatorToPlan(
 									 ctxt_translation_prev_siblings);
 			break;
 		}
-		// GPDB_12_MERGE_FIXME: stop generating AssertOp from ORCA
-		//			case EdxlopPhysicalAssert: { plan = TranslateDXLAssert(dxlnode, output_context, ctxt_translation_prev_siblings); break;}
+		case EdxlopPhysicalAssert:
+		{
+			plan = TranslateDXLAssert(dxlnode, output_context,
+									  ctxt_translation_prev_siblings);
+			break;
+		}
 		case EdxlopPhysicalCTEProducer:
 		{
 			plan = TranslateDXLCTEProducerToSharedScan(

--- a/src/include/executor/nodeAssertOp.h
+++ b/src/include/executor/nodeAssertOp.h
@@ -16,7 +16,7 @@
 #ifndef NODEASSERTOP_H
 #define NODEASSERTOP_H
 
-extern TupleTableSlot* ExecAssertOp(AssertOpState *node);
+extern TupleTableSlot* ExecAssertOp(struct PlanState *node);
 extern AssertOpState* ExecInitAssertOp(AssertOp *node, EState *estate, int eflags);
 extern void ExecEndAssertOp(AssertOpState *node);
 extern void ExecReScanAssertOp(AssertOpState *node);

--- a/src/include/executor/nodeAssertOp.h
+++ b/src/include/executor/nodeAssertOp.h
@@ -16,7 +16,6 @@
 #ifndef NODEASSERTOP_H
 #define NODEASSERTOP_H
 
-extern TupleTableSlot* ExecAssertOp(struct PlanState *node);
 extern AssertOpState* ExecInitAssertOp(AssertOp *node, EState *estate, int eflags);
 extern void ExecEndAssertOp(AssertOpState *node);
 extern void ExecReScanAssertOp(AssertOpState *node);

--- a/src/pl/plpgsql/src/expected/plpgsql_trap.out
+++ b/src/pl/plpgsql/src/expected/plpgsql_trap.out
@@ -72,7 +72,7 @@ begin
 		when data_exception then  -- category match
 			raise notice 'caught data_exception';
 			x := -1;
-		when NUMERIC_VALUE_OUT_OF_RANGE OR CARDINALITY_VIOLATION then
+		when NUMERIC_VALUE_OUT_OF_RANGE OR CARDINALITY_VIOLATION OR TOO_MANY_ROWS then
 			raise notice 'caught numeric_value_out_of_range or cardinality_violation';
 			x := -2;
 	end;

--- a/src/pl/plpgsql/src/sql/plpgsql_trap.sql
+++ b/src/pl/plpgsql/src/sql/plpgsql_trap.sql
@@ -48,7 +48,7 @@ begin
 		when data_exception then  -- category match
 			raise notice 'caught data_exception';
 			x := -1;
-		when NUMERIC_VALUE_OUT_OF_RANGE OR CARDINALITY_VIOLATION then
+		when NUMERIC_VALUE_OUT_OF_RANGE OR CARDINALITY_VIOLATION OR TOO_MANY_ROWS then
 			raise notice 'caught numeric_value_out_of_range or cardinality_violation';
 			x := -2;
 	end;

--- a/src/test/regress/expected/bfv_statistic_optimizer.out
+++ b/src/test/regress/expected/bfv_statistic_optimizer.out
@@ -488,8 +488,6 @@ FROM duplicate_memo_group_test_t1
      LEFT OUTER JOIN duplicate_memo_group_test_t3 a4 ON a1.c3 = a4.c3
 ) AS column2
 FROM duplicate_memo_group_test_t3 a2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: Assert not supported
  column1 | column2 
 ---------+---------
 (0 rows)

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -7973,18 +7973,14 @@ with x as (select * from orca.r) select * from x order by a;
 -- with x as (select * from orca.rcte where a < 10) select * from x x1, x x2 where x2.a = x1.b limit 1;
 -- correlated execution
 select (select 1 union select 2);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: Assert not supported
-ERROR:  more than one row returned by a subquery used as an expression
+ERROR:  one or more assertions failed
+DETAIL:  Expected no more than one row to be returned by expression
 select (select generate_series(1,5));
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: Assert not supported
-ERROR:  more than one row returned by a subquery used as an expression
+ERROR:  one or more assertions failed
+DETAIL:  Expected no more than one row to be returned by expression
 select (select a from orca.foo inner1 where inner1.a=outer1.a  union select b from orca.foo inner2 where inner2.b=outer1.b) from orca.foo outer1;
 ERROR:  more than one row returned by a subquery used as an expression  (seg0 slice1 127.0.1.1:7002 pid=573815)
 select (select generate_series(1,1)) as series;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: Assert not supported
  series 
 --------
       1
@@ -8725,8 +8721,6 @@ select (select (select sum(foo.a + bar.d) * 2 from jazz) from bar) from foo grou
 
 -- nested group by
 select (select max(f) from bar where d = 1 group by a, e) from foo group by a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: Assert not supported
  max 
 -----
    1
@@ -8763,8 +8757,6 @@ select max(a) from foo group by (select e from bar where bar.e = foo.a);
 
 -- nested subquery in group by
 select max(a) from foo group by (select g from jazz where foo.a = (select max(a) from foo where c = 1 group by b));
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: Assert not supported
  max 
 -----
    3
@@ -8773,8 +8765,6 @@ DETAIL:  DXL-to-PlStmt Translation: Assert not supported
 
 -- group by inside groupby inside group by
 select max(a) from foo group by (select min(g) from jazz where foo.a = (select max(g) from jazz group by h) group by h);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: Assert not supported
  max 
 -----
    2
@@ -8801,8 +8791,6 @@ select * from foo order by ((select min(bar.e + 1) * 2 from bar group by foo.a) 
 
 -- everything in the kitchen sink
 select max(b), (select foo.a * count(bar.e) from bar), (with cte as (select e, min(d) as dd from bar group by e) select max(a) * sum(dd) from cte), count(*) from foo group by foo.a, (select min(g) from jazz where foo.a = (select max(g) from jazz group by h) group by h), (with cte as (select min(g) from jazz group by h) select a from cte) order by ((select min(bar.e + 1) * 2 from bar group by foo.a) - foo.a);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: Assert not supported
  max | ?column? | ?column? | count 
 -----+----------+----------+-------
    3 |        9 |       18 |     1
@@ -9197,8 +9185,6 @@ WITH (appendonly=true, compresstype=zlib) DISTRIBUTED BY (uid136);
  UPDATE pg_class
  SET
          relpages = 30915::int, reltuples = 7.28661e+07::real WHERE relname = 'tmp_verd_s_pp_provtabs_agt_0015_extract1' AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'xvclin');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: Assert not supported
 insert into pg_statistic
 values (
   'orca.tmp_verd_s_pp_provtabs_agt_0015_extract1'::regclass,
@@ -10627,8 +10613,6 @@ insert into canSetTag_input_data values(3, 0, 'B', 1);
 create table canSetTag_bug_table as
 SELECT attr, class, (select canSetTag_Func(count(distinct class)::int) from canSetTag_input_data)
    as dclass FROM canSetTag_input_data GROUP BY attr, class distributed by (attr);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: Assert not supported
 drop function canSetTag_Func(x int);
 drop table canSetTag_bug_table;
 drop table canSetTag_input_data;
@@ -11255,8 +11239,6 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'name'
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into bar values('person');
 select * from unnest((select string_to_array(name, ',') from bar)) as a;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: Assert not supported
    a    
 --------
  person

--- a/src/test/regress/expected/groupingsets_optimizer.out
+++ b/src/test/regress/expected/groupingsets_optimizer.out
@@ -610,8 +610,6 @@ DETAIL:  Feature not supported: Grouping function with multiple arguments
 (3 rows)
 
 select(select (select grouping(c) from (values (1)) v2(c) GROUP BY c) from (values (1,2)) v1(a,b) group by (a,b)) from (values(6,7)) v3(e,f) GROUP BY ROLLUP(e,f);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: Assert not supported
  grouping 
 ----------
         0

--- a/src/test/regress/expected/partition_prune_optimizer.out
+++ b/src/test/regress/expected/partition_prune_optimizer.out
@@ -3216,39 +3216,51 @@ create table boolp_f partition of boolp for values in('f');
 NOTICE:  table has parent, setting distribution columns to match parent table
 explain (analyze, costs off, summary off, timing off)
 select * from boolp where a = (select value from boolvalues where value);
-                                QUERY PLAN                                
---------------------------------------------------------------------------
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   InitPlan 1 (returns $0)  (slice2)
-     ->  Gather Motion 3:1  (slice3; segments: 3) (actual rows=1 loops=1)
-           ->  Seq Scan on boolvalues (actual rows=1 loops=1)
-                 Filter: value
-                 Rows Removed by Filter: 1
-   ->  Append (never executed)
-         ->  Seq Scan on boolp_f (never executed)
-               Filter: (a = $0)
-         ->  Seq Scan on boolp_t (never executed)
-               Filter: (a = $0)
- Optimizer: Postgres query optimizer
-(12 rows)
+   ->  Hash Join (never executed)
+         Hash Cond: (boolvalues.value = boolp.a)
+         ->  Redistribute Motion 1:3  (slice2) (never executed)
+               ->  Assert (actual rows=1 loops=1)
+                     Assert Cond: ((row_number() OVER (?)) = 1)
+                     ->  WindowAgg (actual rows=1 loops=1)
+                           ->  Gather Motion 3:1  (slice3; segments: 3) (actual rows=1 loops=1)
+                                 ->  Seq Scan on boolvalues (actual rows=1 loops=1)
+                                       Filter: value
+                                       Rows Removed by Filter: 1
+         ->  Hash (never executed)
+               Buckets: 262144  Batches: 1  Memory Usage: 2048kB
+               ->  Broadcast Motion 3:3  (slice4; segments: 3) (never executed)
+                     ->  Dynamic Seq Scan on boolp (never executed)
+                           Number of partitions to scan: 2 
+                           Partitions scanned:  Avg 2.0 x 3 workers.  Max 2 parts (seg0).
+ Optimizer: Pivotal Optimizer (GPORCA)
+(18 rows)
 
 explain (analyze, costs off, summary off, timing off)
 select * from boolp where a = (select value from boolvalues where not value);
-                                QUERY PLAN                                
---------------------------------------------------------------------------
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   InitPlan 1 (returns $0)  (slice2)
-     ->  Gather Motion 3:1  (slice3; segments: 3) (actual rows=1 loops=1)
-           ->  Seq Scan on boolvalues (actual rows=1 loops=1)
-                 Filter: (NOT value)
-                 Rows Removed by Filter: 1
-   ->  Append (never executed)
-         ->  Seq Scan on boolp_f (never executed)
-               Filter: (a = $0)
-         ->  Seq Scan on boolp_t (never executed)
-               Filter: (a = $0)
- Optimizer: Postgres query optimizer
-(12 rows)
+   ->  Hash Join (never executed)
+         Hash Cond: (boolvalues.value = boolp.a)
+         ->  Redistribute Motion 1:3  (slice2) (never executed)
+               ->  Assert (actual rows=1 loops=1)
+                     Assert Cond: ((row_number() OVER (?)) = 1)
+                     ->  WindowAgg (actual rows=1 loops=1)
+                           ->  Gather Motion 3:1  (slice3; segments: 3) (actual rows=1 loops=1)
+                                 ->  Seq Scan on boolvalues (actual rows=1 loops=1)
+                                       Filter: (NOT value)
+                                       Rows Removed by Filter: 1
+         ->  Hash (never executed)
+               Buckets: 262144  Batches: 1  Memory Usage: 2048kB
+               ->  Broadcast Motion 3:3  (slice4; segments: 3) (never executed)
+                     ->  Dynamic Seq Scan on boolp (never executed)
+                           Number of partitions to scan: 2 
+                           Partitions scanned:  Avg 2.0 x 3 workers.  Max 2 parts (seg0).
+ Optimizer: Pivotal Optimizer (GPORCA)
+(18 rows)
 
 drop table boolp;
 --

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -1804,8 +1804,6 @@ SELECT a, (SELECT (SELECT d FROM qp_csq_t3 WHERE a=c)) FROM qp_csq_t1 GROUP BY a
 -- Basic queries in SELECT list
 -- -- -- --
 select A.i, (select C.j from C group by C.j having max(C.j) = any (select min(B.j) from B)) as C_j from A,B,C where A.i = 99 order by A.i, C_j limit 10;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: Assert not supported
  i  | c_j 
 ----+-----
  99 |   1
@@ -3724,32 +3722,33 @@ EXPLAIN SELECT a FROM qp_tab1 f1 LEFT JOIN qp_tab2 on a=c WHERE NOT EXISTS(SELEC
 GPDB_12_MERGE_FIXME: Fallsback due to unsupported exec location.
 -- end_ignore
 EXPLAIN SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS (SELECT * FROM qp_tab3 WHERE qp_tab2.c = qp_tab3.e));
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: Assert not supported
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=1.02..10001.04 rows=1 width=4)
-   Merge Key: qp_tab1.a
-   InitPlan 1 (returns $0)  (slice2)
-     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=1.02..2.09 rows=3 width=1)
-           ->  Hash Semi Join  (cost=1.02..2.05 rows=1 width=1)
-                 Hash Cond: (qp_tab2.c = qp_tab3.e)
-                 ->  Seq Scan on qp_tab2  (cost=0.00..1.01 rows=1 width=4)
-                 ->  Hash  (cost=1.01..1.01 rows=1 width=4)
-                       ->  Seq Scan on qp_tab3  (cost=0.00..1.01 rows=1 width=4)
-   ->  Unique  (cost=1.02..10001.03 rows=0 width=4)
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1765377.02 rows=1 width=4)
+   ->  GroupAggregate  (cost=0.00..1765377.02 rows=1 width=4)
          Group Key: qp_tab1.a
-         ->  Sort  (cost=1.02..1.02 rows=1 width=4)
+         ->  Sort  (cost=0.00..1765377.02 rows=1 width=4)
                Sort Key: qp_tab1.a
-               ->  Result  (cost=0.00..1.01 rows=1 width=4)
-                     One-Time Filter: (NOT $0)
-                     ->  Seq Scan on qp_tab1  (cost=0.00..1.01 rows=1 width=4)
- Optimizer: Postgres query optimizer
-(17 rows)
+               ->  Result  (cost=0.00..1765377.02 rows=1 width=4)
+                     Filter: (NOT (true))
+                     ->  Nested Loop Left Join  (cost=0.00..1765377.02 rows=1 width=5)
+                           Join Filter: true
+                           ->  Seq Scan on qp_tab1  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Assert  (cost=0.00..862.00 rows=1 width=1)
+                                 Assert Cond: ((row_number() OVER (?)) = 1)
+                                 ->  Materialize  (cost=0.00..862.00 rows=1 width=9)
+                                       ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..862.00 rows=1 width=9)
+                                             ->  WindowAgg  (cost=0.00..862.00 rows=1 width=9)
+                                                   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=1)
+                                                         ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=1)
+                                                               Hash Cond: (qp_tab2.c = qp_tab3.e)
+                                                               ->  Seq Scan on qp_tab2  (cost=0.00..431.00 rows=1 width=4)
+                                                               ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                                                     ->  Seq Scan on qp_tab3  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(22 rows)
 
 SELECT DISTINCT a FROM qp_tab1 WHERE NOT (SELECT TRUE FROM qp_tab2 WHERE EXISTS (SELECT * FROM qp_tab3 WHERE qp_tab2.c = qp_tab3.e));
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: Assert not supported
  a 
 ---
 (0 rows)

--- a/src/test/regress/expected/qp_dml_joins.out
+++ b/src/test/regress/expected/qp_dml_joins.out
@@ -3971,6 +3971,7 @@ SELECT SUM(a) FROM dml_heap_r;
  5106
 (1 row)
 
+ANALYZE dml_heap_s, dml_heap_r;
 UPDATE dml_heap_r SET a = ( SELECT DISTINCT(b) FROM dml_heap_s ) FROM dml_heap_s WHERE dml_heap_r.b = dml_heap_s.a;
 ERROR:  more than one row returned by a subquery used as an expression
 SELECT SUM(a) FROM dml_heap_r;

--- a/src/test/regress/expected/qp_dml_joins_optimizer.out
+++ b/src/test/regress/expected/qp_dml_joins_optimizer.out
@@ -2312,7 +2312,8 @@ SELECT COUNT(*) FROM dml_heap_s;
 (1 row)
 
 DELETE FROM dml_heap_s WHERE a = (SELECT dml_heap_r.a FROM dml_heap_r,dml_heap_s WHERE dml_heap_r.a = dml_heap_s.a);
-ERROR:  more than one row returned by a subquery used as an expression
+ERROR:  one or more assertions failed  (seg0 slice1 10.138.0.30:7002 pid=2841924)
+DETAIL:  Expected no more than one row to be returned by expression
 SELECT COUNT(*) FROM dml_heap_s;
  count 
 -------
@@ -3971,11 +3972,9 @@ SELECT SUM(a) FROM dml_heap_r;
  5106
 (1 row)
 
--- start_ignore
-GPDB_12_MERGE_FIXME: Unsupported exec location fallback
--- end_ignore
+ANALYZE dml_heap_s, dml_heap_r;
 UPDATE dml_heap_r SET a = ( SELECT DISTINCT(b) FROM dml_heap_s ) FROM dml_heap_s WHERE dml_heap_r.b = dml_heap_s.a;
-ERROR:  more than one row returned by a subquery used as an expression
+ERROR:  more than one row returned by a subquery used as an expression  (seg0 slice1 10.138.0.30:7002 pid=3043178)
 SELECT SUM(a) FROM dml_heap_r;
  sum  
 ------
@@ -3990,7 +3989,7 @@ SELECT SUM(b) FROM dml_heap_r;
 (1 row)
 
 UPDATE dml_heap_r SET b = (SELECT dml_heap_r.b FROM dml_heap_r,dml_heap_s WHERE dml_heap_r.a = dml_heap_s.a );
-ERROR:  more than one row returned by a subquery used as an expression
+ERROR:  more than one row returned by a subquery used as an expression  (seg0 10.138.0.30:7002 pid=3036540)
 SELECT SUM(b) FROM dml_heap_r;
  sum  
 ------

--- a/src/test/regress/expected/qp_misc_optimizer.out
+++ b/src/test/regress/expected/qp_misc_optimizer.out
@@ -739,8 +739,6 @@ select rnum, c1, sum( (select 1 from tversion) ) from tjoin1 group by rnum, c1
 group by
 f1,f2,f3
 ) Q ) P;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  DXL-to-PlStmt Translation: Assert not supported
      test_name_part     | pass_ind 
 ------------------------+----------
  SubqueryInAggregate_p1 |        1

--- a/src/test/regress/expected/qp_subquery_optimizer.out
+++ b/src/test/regress/expected/qp_subquery_optimizer.out
@@ -493,7 +493,8 @@ select * from join_tab1 where i = (select i from join_tab4 where t='satday');
 
                       
 select * from join_tab1 where i = (select i from join_tab4);
-ERROR:  more than one row returned by a subquery used as an expression
+ERROR:  one or more assertions failed
+DETAIL:  Expected no more than one row to be returned by expression
 --
 -- Test references to outer query in join quals
 --

--- a/src/test/regress/expected/qp_union_intersect.out
+++ b/src/test/regress/expected/qp_union_intersect.out
@@ -1725,6 +1725,7 @@ DETAIL:  Failing row contains (5, null, s, 5).
 --
 -- To make the output stable, arbitrarily fix optimizer_segments to 2, to get the latter.
 set optimizer_segments=2;
+ANALYZE dml_union_r, dml_union_s;
 SELECT COUNT(DISTINCT(a)) FROM dml_union_r;
  count 
 -------

--- a/src/test/regress/expected/qp_union_intersect_optimizer.out
+++ b/src/test/regress/expected/qp_union_intersect_optimizer.out
@@ -637,7 +637,8 @@ SELECT COUNT(*) FROM dml_union_r;
 (1 row)
 
 INSERT INTO dml_union_r SELECT (SELECT dml_union_r.d::int FROM dml_union_r INTERSECT SELECT dml_union_s.d FROM dml_union_s ORDER BY 1),1,'newval',1.000;
-ERROR:  more than one row returned by a subquery used as an expression
+ERROR:  one or more assertions failed  (seg0 slice1 10.138.0.30:7002 pid=2878957)
+DETAIL:  Expected no more than one row to be returned by expression
 SELECT COUNT(*) FROM dml_union_r;
  count 
 -------
@@ -1725,6 +1726,7 @@ DETAIL:  Failing row contains (1, null, s, 1).
 --
 -- To make the output stable, arbitrarily fix optimizer_segments to 2, to get the latter.
 set optimizer_segments=2;
+ANALYZE dml_union_r, dml_union_s;
 SELECT COUNT(DISTINCT(a)) FROM dml_union_r;
  count 
 -------
@@ -1732,12 +1734,13 @@ SELECT COUNT(DISTINCT(a)) FROM dml_union_r;
 (1 row)
 
 UPDATE dml_union_r SET a = ( SELECT a FROM dml_union_r UNION ALL SELECT a FROM dml_union_s);
-ERROR:  more than one row returned by a subquery used as an expression
+ERROR:  more than one row returned by a subquery used as an expression  (seg2 slice1 10.138.0.30:7004 pid=3108610)
 reset optimizer_segments;
 --SELECT COUNT(DISTINCT(a)) FROM dml_union_r;
 -- @description union_update_test31: Negative Tests  more than one row returned by a sub-query used as an expression
 UPDATE dml_union_r SET b = ( SELECT a FROM dml_union_r EXCEPT ALL SELECT a FROM dml_union_s);
-ERROR:  more than one row returned by a subquery used as an expression
+ERROR:  one or more assertions failed  (seg2 10.138.0.30:7004 pid=2878859)
+DETAIL:  Expected no more than one row to be returned by expression
 --
 -- Test mixing a set-returning function, which can be evaluated anywhere,
 -- (it has General locus) and a diststributed table, in an Append.

--- a/src/test/regress/expected/update_gp.out
+++ b/src/test/regress/expected/update_gp.out
@@ -107,6 +107,7 @@ CREATE TABLE keo3 ( sky_per character varying(24), bky_per character varying(24)
 INSERT INTO keo3 VALUES ('1', '1');
 CREATE TABLE keo4 ( keo_para_required_period character varying(6), keo_para_budget_date character varying(24)) DISTRIBUTED RANDOMLY;
 INSERT INTO keo4 VALUES ('1', '1');
+ANALYZE keo1, keo2, keo3, keo4;
 -- Explicit Redistribution motion should be added in case of GPDB Planner (test case not applicable for ORCA)
 EXPLAIN (COSTS OFF) UPDATE keo1 SET user_vie_act_cntr_marg_cum = 234.682 FROM
     ( SELECT a.user_vie_project_code_pk FROM keo1 a INNER JOIN keo2 b
@@ -117,39 +118,41 @@ EXPLAIN (COSTS OFF) UPDATE keo1 SET user_vie_act_cntr_marg_cum = 234.682 FROM
                 (SELECT min (keo4.keo_para_budget_date) FROM keo4)))
     ) t1
 WHERE t1.user_vie_project_code_pk = keo1.user_vie_project_code_pk;
-                                                       QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
  Update on keo1
    InitPlan 3 (returns $2)  (slice1)
-     ->  Finalize Aggregate
+     ->  Aggregate
            InitPlan 2 (returns $1)  (slice3)
              ->  Gather Motion 3:1  (slice4; segments: 3)
                    InitPlan 1 (returns $0)  (slice5)
-                     ->  Finalize Aggregate
+                     ->  Aggregate
                            ->  Gather Motion 3:1  (slice6; segments: 3)
-                                 ->  Partial Aggregate
-                                       ->  Seq Scan on keo4
+                                 ->  Seq Scan on keo4
                    ->  Seq Scan on keo4 keo4_1
                          Filter: ((keo_para_budget_date)::text = $0)
            ->  Gather Motion 3:1  (slice2; segments: 3)
-                 ->  Partial Aggregate
-                       ->  Seq Scan on keo3
-                             Filter: ((bky_per)::text = ($1)::text)
+                 ->  Seq Scan on keo3
+                       Filter: ((bky_per)::text = ($1)::text)
    ->  Explicit Redistribute Motion 3:3  (slice7; segments: 3)
          ->  Hash Join
-               Hash Cond: ((b.projects_pk)::text = (a.user_vie_project_code_pk)::text)
-               ->  Seq Scan on keo2 b
-               ->  Hash
-                     ->  Broadcast Motion 3:3  (slice8; segments: 3)
-                           ->  Hash Join
-                                 Hash Cond: ((keo1.user_vie_project_code_pk)::text = (a.user_vie_project_code_pk)::text)
+               Hash Cond: ((a.user_vie_project_code_pk)::text = (b.projects_pk)::text)
+               ->  Hash Join
+                     Hash Cond: ((a.user_vie_project_code_pk)::text = (keo1.user_vie_project_code_pk)::text)
+                     ->  Redistribute Motion 3:3  (slice8; segments: 3)
+                           Hash Key: a.user_vie_project_code_pk
+                           ->  Seq Scan on keo1 a
+                                 Filter: ((user_vie_fiscal_year_period_sk)::text = $2)
+                     ->  Hash
+                           ->  Redistribute Motion 3:3  (slice9; segments: 3)
+                                 Hash Key: keo1.user_vie_project_code_pk
                                  ->  Seq Scan on keo1
-                                 ->  Hash
-                                       ->  Broadcast Motion 3:3  (slice9; segments: 3)
-                                             ->  Seq Scan on keo1 a
-                                                   Filter: ((user_vie_fiscal_year_period_sk)::text = $2)
+               ->  Hash
+                     ->  Redistribute Motion 3:3  (slice10; segments: 3)
+                           Hash Key: b.projects_pk
+                           ->  Seq Scan on keo2 b
  Optimizer: Postgres query optimizer
-(30 rows)
+(32 rows)
 
 UPDATE keo1 SET user_vie_act_cntr_marg_cum = 234.682 FROM
     ( SELECT a.user_vie_project_code_pk FROM keo1 a INNER JOIN keo2 b

--- a/src/test/regress/expected/update_gp_optimizer.out
+++ b/src/test/regress/expected/update_gp_optimizer.out
@@ -117,39 +117,46 @@ EXPLAIN (COSTS OFF) UPDATE keo1 SET user_vie_act_cntr_marg_cum = 234.682 FROM
                 (SELECT min (keo4.keo_para_budget_date) FROM keo4)))
     ) t1
 WHERE t1.user_vie_project_code_pk = keo1.user_vie_project_code_pk;
-                                                       QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
+                                                                                       QUERY PLAN                                                                                        
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Update on keo1
-   InitPlan 3 (returns $2)  (slice1)
-     ->  Finalize Aggregate
-           InitPlan 2 (returns $1)  (slice3)
-             ->  Gather Motion 3:1  (slice4; segments: 3)
-                   InitPlan 1 (returns $0)  (slice5)
-                     ->  Finalize Aggregate
-                           ->  Gather Motion 3:1  (slice6; segments: 3)
-                                 ->  Partial Aggregate
-                                       ->  Seq Scan on keo4
-                   ->  Seq Scan on keo4 keo4_1
-                         Filter: ((keo_para_budget_date)::text = $0)
-           ->  Gather Motion 3:1  (slice2; segments: 3)
-                 ->  Partial Aggregate
-                       ->  Seq Scan on keo3
-                             Filter: ((bky_per)::text = ($1)::text)
-   ->  Explicit Redistribute Motion 3:3  (slice7; segments: 3)
-         ->  Hash Join
-               Hash Cond: ((b.projects_pk)::text = (a.user_vie_project_code_pk)::text)
-               ->  Seq Scan on keo2 b
-               ->  Hash
-                     ->  Broadcast Motion 3:3  (slice8; segments: 3)
-                           ->  Hash Join
-                                 Hash Cond: ((keo1.user_vie_project_code_pk)::text = (a.user_vie_project_code_pk)::text)
-                                 ->  Seq Scan on keo1
-                                 ->  Hash
-                                       ->  Broadcast Motion 3:3  (slice9; segments: 3)
-                                             ->  Seq Scan on keo1 a
-                                                   Filter: ((user_vie_fiscal_year_period_sk)::text = $2)
- Optimizer: Postgres query optimizer
-(30 rows)
+   ->  Result
+         ->  Split
+               ->  Hash Join
+                     Hash Cond: ((keo1_1.user_vie_project_code_pk)::text = (keo1_2.user_vie_project_code_pk)::text)
+                     ->  Seq Scan on keo1 keo1_1
+                     ->  Hash
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                 ->  Hash Join
+                                       Hash Cond: ((keo1_2.user_vie_project_code_pk)::text = (keo2.projects_pk)::text)
+                                       ->  Redistribute Motion 1:3  (slice2; segments: 1)
+                                             ->  Hash Join
+                                                   Hash Cond: ((keo1_2.user_vie_fiscal_year_period_sk)::text = (max((keo3.sky_per)::text)))
+                                                   ->  Gather Motion 3:1  (slice3; segments: 3)
+                                                         ->  Seq Scan on keo1 keo1_2
+                                                   ->  Hash
+                                                         ->  Aggregate
+                                                               ->  Hash Join
+                                                                     Hash Cond: ((keo3.bky_per)::text = (keo4.keo_para_required_period)::text)
+                                                                     ->  Gather Motion 3:1  (slice4; segments: 3)
+                                                                           ->  Seq Scan on keo3
+                                                                     ->  Hash
+                                                                           ->  Assert
+                                                                                 Assert Cond: ((row_number() OVER (?)) = 1)
+                                                                                 ->  WindowAgg
+                                                                                       ->  Hash Join
+                                                                                             Hash Cond: ((keo4.keo_para_budget_date)::text = (min((keo4_1.keo_para_budget_date)::text)))
+                                                                                             ->  Gather Motion 3:1  (slice5; segments: 3)
+                                                                                                   ->  Seq Scan on keo4
+                                                                                             ->  Hash
+                                                                                                   ->  Aggregate
+                                                                                                         ->  Gather Motion 3:1  (slice6; segments: 3)
+                                                                                                               ->  Seq Scan on keo4 keo4_1
+                                       ->  Hash
+                                             ->  Broadcast Motion 3:3  (slice7; segments: 3)
+                                                   ->  Seq Scan on keo2
+ Optimizer: Pivotal Optimizer (GPORCA)
+(37 rows)
 
 UPDATE keo1 SET user_vie_act_cntr_marg_cum = 234.682 FROM
     ( SELECT a.user_vie_project_code_pk FROM keo1 a INNER JOIN keo2 b

--- a/src/test/regress/expected/update_gp_optimizer.out
+++ b/src/test/regress/expected/update_gp_optimizer.out
@@ -107,6 +107,7 @@ CREATE TABLE keo3 ( sky_per character varying(24), bky_per character varying(24)
 INSERT INTO keo3 VALUES ('1', '1');
 CREATE TABLE keo4 ( keo_para_required_period character varying(6), keo_para_budget_date character varying(24)) DISTRIBUTED RANDOMLY;
 INSERT INTO keo4 VALUES ('1', '1');
+ANALYZE keo1, keo2, keo3, keo4;
 -- Explicit Redistribution motion should be added in case of GPDB Planner (test case not applicable for ORCA)
 EXPLAIN (COSTS OFF) UPDATE keo1 SET user_vie_act_cntr_marg_cum = 234.682 FROM
     ( SELECT a.user_vie_project_code_pk FROM keo1 a INNER JOIN keo2 b
@@ -129,34 +130,36 @@ WHERE t1.user_vie_project_code_pk = keo1.user_vie_project_code_pk;
                            ->  Broadcast Motion 3:3  (slice1; segments: 3)
                                  ->  Hash Join
                                        Hash Cond: ((keo1_2.user_vie_project_code_pk)::text = (keo2.projects_pk)::text)
-                                       ->  Redistribute Motion 1:3  (slice2; segments: 1)
-                                             ->  Hash Join
-                                                   Hash Cond: ((keo1_2.user_vie_fiscal_year_period_sk)::text = (max((keo3.sky_per)::text)))
-                                                   ->  Gather Motion 3:1  (slice3; segments: 3)
-                                                         ->  Seq Scan on keo1 keo1_2
-                                                   ->  Hash
-                                                         ->  Aggregate
-                                                               ->  Hash Join
-                                                                     Hash Cond: ((keo3.bky_per)::text = (keo4.keo_para_required_period)::text)
-                                                                     ->  Gather Motion 3:1  (slice4; segments: 3)
-                                                                           ->  Seq Scan on keo3
-                                                                     ->  Hash
-                                                                           ->  Assert
-                                                                                 Assert Cond: ((row_number() OVER (?)) = 1)
-                                                                                 ->  WindowAgg
+                                       ->  Hash Join
+                                             Hash Cond: ((max((keo3.sky_per)::text)) = (keo1_2.user_vie_fiscal_year_period_sk)::text)
+                                             ->  Redistribute Motion 1:3  (slice2; segments: 1)
+                                                   ->  Aggregate
+                                                         ->  Hash Join
+                                                               Hash Cond: ((keo3.bky_per)::text = (keo4_1.keo_para_required_period)::text)
+                                                               ->  Gather Motion 3:1  (slice3; segments: 3)
+                                                                     ->  Seq Scan on keo3
+                                                               ->  Hash
+                                                                     ->  Assert
+                                                                           Assert Cond: ((row_number() OVER (?)) = 1)
+                                                                           ->  WindowAgg
+                                                                                 ->  Gather Motion 3:1  (slice4; segments: 3)
                                                                                        ->  Hash Join
-                                                                                             Hash Cond: ((keo4.keo_para_budget_date)::text = (min((keo4_1.keo_para_budget_date)::text)))
-                                                                                             ->  Gather Motion 3:1  (slice5; segments: 3)
-                                                                                                   ->  Seq Scan on keo4
-                                                                                             ->  Hash
+                                                                                             Hash Cond: ((min((keo4.keo_para_budget_date)::text)) = (keo4_1.keo_para_budget_date)::text)
+                                                                                             ->  Redistribute Motion 1:3  (slice5; segments: 1)
                                                                                                    ->  Aggregate
                                                                                                          ->  Gather Motion 3:1  (slice6; segments: 3)
-                                                                                                               ->  Seq Scan on keo4 keo4_1
+                                                                                                               ->  Seq Scan on keo4
+                                                                                             ->  Hash
+                                                                                                   ->  Broadcast Motion 3:3  (slice7; segments: 3)
+                                                                                                         ->  Seq Scan on keo4 keo4_1
+                                             ->  Hash
+                                                   ->  Broadcast Motion 3:3  (slice8; segments: 3)
+                                                         ->  Seq Scan on keo1 keo1_2
                                        ->  Hash
-                                             ->  Broadcast Motion 3:3  (slice7; segments: 3)
+                                             ->  Broadcast Motion 3:3  (slice9; segments: 3)
                                                    ->  Seq Scan on keo2
  Optimizer: Pivotal Optimizer (GPORCA)
-(37 rows)
+(39 rows)
 
 UPDATE keo1 SET user_vie_act_cntr_marg_cum = 234.682 FROM
     ( SELECT a.user_vie_project_code_pk FROM keo1 a INNER JOIN keo2 b

--- a/src/test/regress/output/table_functions_optimizer.source
+++ b/src/test/regress/output/table_functions_optimizer.source
@@ -311,7 +311,8 @@ ERROR:  subquery must return only one column
 LINE 1: SELECT scalar_1((select 1, 2));
                         ^
 SELECT scalar_1((select 1 union select 2));  -- subquery returns multiple rows
-ERROR:  more than one row returned by a subquery used as an expression
+ERROR:  one or more assertions failed
+DETAIL:  Expected no more than one row to be returned by expression
 SELECT scalar_1(TABLE(select 1));  -- TableValue expression does not match type
 ERROR:  function scalar_1(anytable) does not exist
 LINE 1: SELECT scalar_1(TABLE(select 1));

--- a/src/test/regress/sql/qp_dml_joins.sql
+++ b/src/test/regress/sql/qp_dml_joins.sql
@@ -1679,6 +1679,7 @@ rollback;
 
 --Negative test - Update with sub-query returning more than one row
 SELECT SUM(a) FROM dml_heap_r;
+ANALYZE dml_heap_s, dml_heap_r;
 UPDATE dml_heap_r SET a = ( SELECT DISTINCT(b) FROM dml_heap_s ) FROM dml_heap_s WHERE dml_heap_r.b = dml_heap_s.a;
 SELECT SUM(a) FROM dml_heap_r;
 

--- a/src/test/regress/sql/qp_union_intersect.sql
+++ b/src/test/regress/sql/qp_union_intersect.sql
@@ -645,6 +645,7 @@ UPDATE dml_union_s SET b = (SELECT NULL UNION SELECT NULL)::numeric;
 --
 -- To make the output stable, arbitrarily fix optimizer_segments to 2, to get the latter.
 set optimizer_segments=2;
+ANALYZE dml_union_r, dml_union_s;
 SELECT COUNT(DISTINCT(a)) FROM dml_union_r;
 UPDATE dml_union_r SET a = ( SELECT a FROM dml_union_r UNION ALL SELECT a FROM dml_union_s);
 reset optimizer_segments;

--- a/src/test/regress/sql/update_gp.sql
+++ b/src/test/regress/sql/update_gp.sql
@@ -82,6 +82,7 @@ INSERT INTO keo3 VALUES ('1', '1');
 
 CREATE TABLE keo4 ( keo_para_required_period character varying(6), keo_para_budget_date character varying(24)) DISTRIBUTED RANDOMLY;
 INSERT INTO keo4 VALUES ('1', '1');
+ANALYZE keo1, keo2, keo3, keo4;
 -- Explicit Redistribution motion should be added in case of GPDB Planner (test case not applicable for ORCA)
 EXPLAIN (COSTS OFF) UPDATE keo1 SET user_vie_act_cntr_marg_cum = 234.682 FROM
     ( SELECT a.user_vie_project_code_pk FROM keo1 a INNER JOIN keo2 b


### PR DESCRIPTION
AssertOp is used by ORCA for run-time assertion checking. For example,
it guarantees that the following query will not violate implicit
cardinality contraints (i.e. foo cannot contain more than 1 row):

  ```sql
  CREATE TABLE foo(a int);
  CREATE TABLE bar(b int);

  SELECT * FROM foo WHERE (SELECT a FROM foo) IN (SELECT b FROM bar);
  ```

PLANNER handles that check in the executor subplan node where it can
determine if the subquery is used in an expression sublink where it
should only return 1 row. However, this is not sufficient for ORCA which
may generate de-correlated plan that contains a join node instead of a
subplan node.

Postgres 12 merge commit 2e653c6e54b disabled this feature in ORCA so
that implementation may be fixed at a later date. This commit does that.