### PR TITLE
Fix Bitmap index null-array condition failed

### DIFF
--- a/src/backend/access/bitmap/bitmap.c
+++ b/src/backend/access/bitmap/bitmap.c
@@ -241,6 +241,26 @@ stream_begin_iterate(StreamNode *self, StreamBMIterator *iterator)
 }
 
 /*
+ * bminitbitmap() -- return an empty bitmap.
+ * */
+void
+bminitbitmap(Node **bmNodeP)
+{
+    IndexStream  *is;
+
+    is = (IndexStream *)palloc0(sizeof(IndexStream));
+    is->type = BMS_INDEX;
+    is->begin_iterate = stream_begin_iterate;
+    is->free = indexstream_free;
+
+    StreamBitmap *sb = makeNode(StreamBitmap);
+    sb->streamNode = is;
+    *bmNodeP = (Node *) sb;
+
+    return;
+}
+
+/*
  * bmgetbitmap() -- return a stream bitmap.
  */
 int64

--- a/src/backend/access/index/indexam.c
+++ b/src/backend/access/index/indexam.c
@@ -28,6 +28,7 @@
  *		index_fetch_heap		- get the scan's next heap tuple
  *		index_getnext_slot	- get the next tuple from a scan
  *		index_getbitmap - get all tuples from a scan
+ *      index_initbitmap - get an empty bitmap
  *		index_bulk_delete	- bulk deletion of index tuples
  *		index_vacuum_cleanup	- post-deletion cleanup of an index
  *		index_can_return	- does index support index-only scans?
@@ -49,6 +50,7 @@
 #include "access/tableam.h"
 #include "access/transam.h"
 #include "access/xlog.h"
+#include "access/bitmap_private.h"
 #include "catalog/index.h"
 #include "catalog/pg_type.h"
 #include "pgstat.h"
@@ -56,7 +58,7 @@
 #include "storage/lmgr.h"
 #include "storage/predicate.h"
 #include "utils/snapmgr.h"
-
+#include "utils/fmgroids.h"
 
 /* ----------------------------------------------------------------
  *					macros used in index_ routines
@@ -633,6 +635,31 @@ index_getnext_slot(IndexScanDesc scan, ScanDirection direction, TupleTableSlot *
 	}
 
 	return false;
+}
+
+/*
+ * index_initbitmap -- get an empty bitmap
+ * */
+void
+index_initbitmap(IndexScanDesc scan, Node **bitmapP)
+{
+    Relation relation = scan->indexRelation;
+
+    if (relation->rd_amhandler == F_BMHANDLER)
+    {
+        bminitbitmap(bitmapP);
+    }
+    else if (relation->rd_amhandler == F_BTHANDLER)
+    {
+        *bitmapP = (Node *)tbm_create(work_mem * 1024L, NULL);
+    }
+    else
+    {
+        elog(ERROR, "Not support rd_amhandler %u to initbitmap under bitmapscan",
+            relation->rd_amhandler);
+    }
+
+    return;
 }
 
 /* ----------------

--- a/src/backend/executor/nodeBitmapIndexscan.c
+++ b/src/backend/executor/nodeBitmapIndexscan.c
@@ -96,6 +96,10 @@ MultiExecBitmapIndexScan(BitmapIndexScanState *node)
 	{
 		ExecReScan((PlanState *) node);
 		doscan = node->biss_RuntimeKeysReady;
+
+        /* Return an empty bitmap if biss_RuntimeKeysReady still false.*/
+        if (!doscan)
+            index_initbitmap(scandesc, &bitmap);
 	}
 	else
 		doscan = true;

--- a/src/include/access/bitmap_private.h
+++ b/src/include/access/bitmap_private.h
@@ -256,6 +256,7 @@ extern bool bminsert(Relation rel, Datum *values, bool *isnull,
 extern IndexScanDesc bmbeginscan(Relation rel, int nkeys, int norderbys);
 extern bool bmgettuple(IndexScanDesc scan, ScanDirection dir);
 extern int64 bmgetbitmap(IndexScanDesc scan, Node **bmNodeP);
+extern void bminitbitmap(Node **bmNodeP);
 extern void bmrescan(IndexScanDesc scan, ScanKey scankey, int nscankeys,
 		 ScanKey orderbys, int norderbys);
 extern void bmendscan(IndexScanDesc scan);

--- a/src/include/access/genam.h
+++ b/src/include/access/genam.h
@@ -165,6 +165,7 @@ extern bool index_fetch_heap(IndexScanDesc scan, struct TupleTableSlot *slot);
 extern bool index_getnext_slot(IndexScanDesc scan, ScanDirection direction,
 							   struct TupleTableSlot *slot);
 extern int64 index_getbitmap(IndexScanDesc scan, Node **bitmapP);
+extern void index_initbitmap(IndexScanDesc scan, Node **bitmapP);
 
 extern IndexBulkDeleteResult *index_bulk_delete(IndexVacuumInfo *info,
 												IndexBulkDeleteResult *stats,

--- a/src/test/regress/expected/bitmap_index.out
+++ b/src/test/regress/expected/bitmap_index.out
@@ -952,5 +952,41 @@ select count(*) from foo_13446 where b = 1;
 (1 row)
 
 drop table foo_13446;
+-- test bitmap index scan when using NULL array-condition as index key
+create table foo(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index foo_i on foo using bitmap(a);
+explain (verbose on, costs off) select * from foo where a = any(null::int[]);
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: a
+   ->  Bitmap Heap Scan on public.foo
+         Output: a
+         Recheck Cond: (foo.a = ANY (NULL::integer[]))
+         ->  Bitmap Index Scan on foo_i
+               Index Cond: (foo.a = ANY (NULL::integer[]))
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select * from foo where a = any(null::int[]);
+ a 
+---
+(0 rows)
+
+insert into foo values(1);
+select * from foo where a = 1 and a = any(null::int[]);
+ a 
+---
+(0 rows)
+
+select * from foo where a = 1 or a = any(null::int[]);
+ a 
+---
+ 1
+(1 row)
+
+drop table foo;
 SET enable_seqscan = ON;
 SET enable_bitmapscan = ON;

--- a/src/test/regress/expected/bitmap_index_optimizer.out
+++ b/src/test/regress/expected/bitmap_index_optimizer.out
@@ -958,5 +958,41 @@ select count(*) from foo_13446 where b = 1;
 (1 row)
 
 drop table foo_13446;
+-- test bitmap index scan when using NULL array-condition as index key
+create table foo(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index foo_i on foo using bitmap(a);
+explain (verbose on, costs off) select * from foo where a = any(null::int[]);
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: a
+   ->  Bitmap Heap Scan on public.foo
+         Output: a
+         Recheck Cond: (foo.a = ANY (NULL::integer[]))
+         ->  Bitmap Index Scan on foo_i
+               Index Cond: (foo.a = ANY (NULL::integer[]))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+select * from foo where a = any(null::int[]);
+ a 
+---
+(0 rows)
+
+insert into foo values(1);
+select * from foo where a = 1 and a = any(null::int[]);
+ a 
+---
+(0 rows)
+
+select * from foo where a = 1 or a = any(null::int[]);
+ a 
+---
+ 1
+(1 row)
+
+drop table foo;
 SET enable_seqscan = ON;
 SET enable_bitmapscan = ON;

--- a/src/test/regress/sql/bitmap_index.sql
+++ b/src/test/regress/sql/bitmap_index.sql
@@ -407,6 +407,18 @@ select count(*) from foo_13446 where b = 1;
 
 drop table foo_13446;
 
+-- test bitmap index scan when using NULL array-condition as index key
+create table foo(a int);
+create index foo_i on foo using bitmap(a);
+explain (verbose on, costs off) select * from foo where a = any(null::int[]);
+select * from foo where a = any(null::int[]);
+
+insert into foo values(1);
+select * from foo where a = 1 and a = any(null::int[]);
+select * from foo where a = 1 or a = any(null::int[]);
+
+drop table foo;
+
 SET enable_seqscan = ON;
 SET enable_bitmapscan = ON;
 


### PR DESCRIPTION
when we create bitmap-index on column and using bitmap index scan with NULL array condition on this column, then failed. Like this:
> create temp table foo (a int); 
> create index foo_i on foo using bitmap(a); 

> select * from foo where a = any(null::int[]); 
> Conversant: ERROR "unrecognized result from subplan (nodeBitmapHeapscan.c:293)"

The reason is when we using bitmap-index scan on NULL Array key condition, MultiExecbitmapscan treate it as runtime key then it will return NULL to parent node. But for parent node like BitmapHeapNext cannot handle NULL return, then error happened. So we should return an empty bitmap instead of nothing to upper node(BitmapHeapNext), and force BitmapHeapNext scan this empty bitmap.


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
