### PR TITLE
use gpdb server encoding as default external table encoding

### DIFF
--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -333,9 +333,9 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 				 nodeTag(dencoding->arg));
 	}
 
-	/* If encoding is defaulted, use database encoding */
+	/* If encoding is defaulted, use database server encoding */
 	if (encoding < 0)
-		encoding = pg_get_client_encoding();
+		encoding = GetDatabaseEncoding();
 
 	/*
 	 * If the number of locations (file or http URIs) exceed the number of

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -264,6 +264,15 @@ CREATE PROTOCOL demoprot_non_superuser (readfunc = 'read_from_file', writefunc =
 CREATE TRUSTED PROTOCOL demoprot_non_superuser (readfunc = 'read_from_file', writefunc = 'write_to_file');
 RESET ROLE;
 
+-- Test pg_exttable's encoding: QE's encoding should be consistent with QD
+-- GitHub Issue #9727: https://github.com/greenplum-db/gpdb/issues/9727
+SET client_encoding = 'ISO-8859-1';
+CREATE EXTERNAL TABLE issue_9727 (d varchar(20)) location ('gpfdist://9727/d.dat') format 'csv' (DELIMITER '|');
+SELECT encoding from pg_exttable where urilocation='{gpfdist://9727:8080/d.dat}';
+SELECT encoding from gp_dist_random('pg_exttable') where urilocation='{gpfdist://9727:8080/d.dat}';
+DROP EXTERNAL TABLE issue_9727;
+RESET client_encoding;
+
 --
 -- WET tests
 --

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -342,6 +342,26 @@ ERROR:  must be superuser to create an external protocol
 CREATE TRUSTED PROTOCOL demoprot_non_superuser (readfunc = 'read_from_file', writefunc = 'write_to_file');
 ERROR:  must be superuser to create an external protocol
 RESET ROLE;
+-- Test pg_exttable's encoding: QE's encoding should be consistent with QD
+-- GitHub Issue #9727: https://github.com/greenplum-db/gpdb/issues/9727
+SET client_encoding = 'ISO-8859-1';
+CREATE EXTERNAL TABLE issue_9727 (d varchar(20)) location ('gpfdist://9727/d.dat') format 'csv' (DELIMITER '|');
+SELECT encoding from pg_exttable where urilocation='{gpfdist://9727:8080/d.dat}';
+ encoding 
+----------
+        6
+(1 row)
+
+SELECT encoding from gp_dist_random('pg_exttable') where urilocation='{gpfdist://9727:8080/d.dat}';
+ encoding 
+----------
+        6
+        6
+        6
+(3 rows)
+
+DROP EXTERNAL TABLE issue_9727;
+RESET client_encoding;
 --
 -- WET tests
 --


### PR DESCRIPTION
this pr backport https://github.com/greenplum-db/gpdb/pull/13885 in master branch, fixes issue https://github.com/greenplum-db/gpdb/issues/9727

We make the default encoding of the external table the same as the database encoding.

Before this fix, if user doesn't set the encoding option in create external table [statement](https://gpdb.docs.pivotal.io/6-16/ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.html), it applies the current client_encoding as the default value:
```
 /* If encoding is defaulted, use database encoding */ 
 if (encoding < 0) 
 	encoding = pg_get_client_encoding(); 
```
This will cause a problem that when client_encoding is different from server encoding, the encoding column of pg_exttable will be different in QD and QEs.

However, the actual encoding behavior is decided by the encoding in QEs. And this behavior is reasonable and stable. So we should just make the encoding column in QD the same as the encoding column in QEs, that is the server encoding.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
