### PR TITLE
7X: pgcrypto: add fips support

### DIFF
--- a/contrib/pgcrypto/Makefile
+++ b/contrib/pgcrypto/Makefile
@@ -30,13 +30,14 @@ DATA = pgcrypto--1.3.sql pgcrypto--1.2--1.3.sql pgcrypto--1.1--1.2.sql \
 	pgcrypto--1.0--1.1.sql pgcrypto--unpackaged--1.0.sql
 PGFILEDESC = "pgcrypto - cryptographic functions"
 
-REGRESS_OPTS = --dbname=$(CONTRIB_TESTDB) --init-file=$(top_builddir)/src/test/regress/init_file 
+REGRESS_OPTS = --dbname=$(CONTRIB_TESTDB) --init-file=$(top_builddir)/src/test/regress/init_file
 
 REGRESS = init md5 sha1 hmac-md5 hmac-sha1 blowfish rijndael \
 	$(CF_TESTS) \
 	crypt-des crypt-md5 crypt-blowfish crypt-xdes \
 	pgp-armor pgp-decrypt pgp-encrypt $(CF_PGP_TESTS) \
-	pgp-pubkey-decrypt pgp-pubkey-encrypt pgp-info
+	pgp-pubkey-decrypt pgp-pubkey-encrypt pgp-info \
+	setup_fips fips
 
 EXTRA_CLEAN = gen-rtab
 

--- a/contrib/pgcrypto/expected/fips_1.out
+++ b/contrib/pgcrypto/expected/fips_1.out
@@ -1,0 +1,131 @@
+ALTER DATABASE contrib_regression SET pgcrypto.fips TO on;
+ERROR:  FIPS enabled OpenSSL is required for strict FIPS mode (openssl.c:1055)
+HINT:  Recompile OpenSSL with the FIPS module, or install a FIPS enabled OpenSSL distribution.
+\c contrib_regression
+SHOW pgcrypto.fips;
+ pgcrypto.fips 
+---------------
+ off
+(1 row)
+
+CREATE TABLE fipstest (data text, res text, salt text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'data' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO fipstest VALUES ('password', '', '');
+SELECT 'Test digest md5: EXPECTED ERROR FAIL FIPS' as comment;
+                  comment                  
+-------------------------------------------
+ Test digest md5: EXPECTED ERROR FAIL FIPS
+(1 row)
+
+SELECT digest('santa claus', 'md5');
+               digest               
+------------------------------------
+ \x7c4f44266cee2dbfacaa009ef5e167dc
+(1 row)
+
+SELECT 'Test digest sha256: EXPECTED PASS' as comment;
+              comment              
+-----------------------------------
+ Test digest sha256: EXPECTED PASS
+(1 row)
+
+SELECT digest('santa claus', 'sha256');
+                               digest                               
+--------------------------------------------------------------------
+ \x675b8f61fc27140b5f06fec4613d8b3d9b913a82074d4c790374558c18d2cb7d
+(1 row)
+
+SELECT 'Test hmac md5: EXPECTED ERROR FAIL FIPS' as comment;
+                 comment                 
+-----------------------------------------
+ Test hmac md5: EXPECTED ERROR FAIL FIPS
+(1 row)
+
+SELECT hmac('santa claus', 'aaa', 'md5');
+                hmac                
+------------------------------------
+ \xd13b4c8c8a6e9d6236e8cc0b141968c5
+(1 row)
+
+SELECT 'Test hmac sha256: EXPECTED PASS' as comment;
+             comment             
+---------------------------------
+ Test hmac sha256: EXPECTED PASS
+(1 row)
+
+SELECT hmac('santa claus', 'aaa', 'sha256');
+                                hmac                                
+--------------------------------------------------------------------
+ \xc88fe8ff0541b1bb25abd971fa7642d256a1c0109f7e56875d593a3daaeacf54
+(1 row)
+
+SELECT 'Test gen_salt : EXPECTED FAIL FIPS' as comment;
+              comment               
+------------------------------------
+ Test gen_salt : EXPECTED FAIL FIPS
+(1 row)
+
+UPDATE fipstest SET salt = gen_salt('md5');
+SELECT 'Test crypt : EXPECTED FAIL FIPS' as comment;
+             comment             
+---------------------------------
+ Test crypt : EXPECTED FAIL FIPS
+(1 row)
+
+UPDATE fipstest SET res = crypt(data, salt);
+SELECT res = crypt(data, res) AS "worked" FROM fipstest;
+ worked 
+--------
+ t
+(1 row)
+
+SELECT 'Test pgp : EXPECTED PASS' as comment;
+         comment          
+--------------------------
+ Test pgp : EXPECTED PASS
+(1 row)
+
+select pgp_sym_decrypt(pgp_sym_encrypt('santa clause', 'mypass', 'cipher-algo=aes256'), 'mypass');
+ pgp_sym_decrypt 
+-----------------
+ santa clause
+(1 row)
+
+SELECT 'Test pgp : EXPECTED FAIL FIPS' as comment;
+            comment            
+-------------------------------
+ Test pgp : EXPECTED FAIL FIPS
+(1 row)
+
+select pgp_sym_decrypt(pgp_sym_encrypt('santa clause', 'mypass', 'cipher-algo=bf'), 'mypass');
+ pgp_sym_decrypt 
+-----------------
+ santa clause
+(1 row)
+
+SELECT 'Test raw encrypt : EXPECTED PASS' as comment;
+             comment              
+----------------------------------
+ Test raw encrypt : EXPECTED PASS
+(1 row)
+
+SELECT encrypt('santa claus', 'mypass', 'aes') as raw_aes;
+              raw_aes               
+------------------------------------
+ \xe7ac3ad57bde59c5b78c08805afdb774
+(1 row)
+
+SELECT 'Test raw encrypt : EXPECTED FAIL FIPS' as comment;
+                comment                
+---------------------------------------
+ Test raw encrypt : EXPECTED FAIL FIPS
+(1 row)
+
+SELECT encrypt('santa claus', 'mypass', 'bf') as raw_blowfish;
+            raw_blowfish            
+------------------------------------
+ \x0f4fe496594a2e762fb29a22fc6750e2
+(1 row)
+
+DROP TABLE fipstest;

--- a/contrib/pgcrypto/expected/fips_2.out
+++ b/contrib/pgcrypto/expected/fips_2.out
@@ -1,0 +1,103 @@
+ALTER DATABASE contrib_regression SET pgcrypto.fips TO on;
+\c contrib_regression
+SHOW pgcrypto.fips;
+ pgcrypto.fips 
+---------------
+ on
+(1 row)
+
+CREATE TABLE fipstest (data text, res text, salt text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'data' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO fipstest VALUES ('password', '', '');
+SELECT 'Test digest md5: EXPECTED ERROR FAIL FIPS' as comment;
+                  comment                  
+-------------------------------------------
+ Test digest md5: EXPECTED ERROR FAIL FIPS
+(1 row)
+
+SELECT digest('santa claus', 'md5');
+ERROR:  Cannot use "md5": No such hash algorithm
+SELECT 'Test digest sha256: EXPECTED PASS' as comment;
+              comment              
+-----------------------------------
+ Test digest sha256: EXPECTED PASS
+(1 row)
+
+SELECT digest('santa claus', 'sha256');
+                               digest                               
+--------------------------------------------------------------------
+ \x675b8f61fc27140b5f06fec4613d8b3d9b913a82074d4c790374558c18d2cb7d
+(1 row)
+
+SELECT 'Test hmac md5: EXPECTED ERROR FAIL FIPS' as comment;
+                 comment                 
+-----------------------------------------
+ Test hmac md5: EXPECTED ERROR FAIL FIPS
+(1 row)
+
+SELECT hmac('santa claus', 'aaa', 'md5');
+ERROR:  Cannot use "md5": No such hash algorithm
+SELECT 'Test hmac sha256: EXPECTED PASS' as comment;
+             comment             
+---------------------------------
+ Test hmac sha256: EXPECTED PASS
+(1 row)
+
+SELECT hmac('santa claus', 'aaa', 'sha256');
+                                hmac                                
+--------------------------------------------------------------------
+ \xc88fe8ff0541b1bb25abd971fa7642d256a1c0109f7e56875d593a3daaeacf54
+(1 row)
+
+SELECT 'Test gen_salt : EXPECTED FAIL FIPS' as comment;
+              comment               
+------------------------------------
+ Test gen_salt : EXPECTED FAIL FIPS
+(1 row)
+
+UPDATE fipstest SET salt = gen_salt('md5');
+ERROR:  requested functionality not allowed in FIPS mode (pgcrypto.c:201)
+SELECT 'Test crypt : EXPECTED FAIL FIPS' as comment;
+             comment             
+---------------------------------
+ Test crypt : EXPECTED FAIL FIPS
+(1 row)
+
+UPDATE fipstest SET res = crypt(data, salt);
+ERROR:  requested functionality not allowed in FIPS mode (pgcrypto.c:254)
+SELECT res = crypt(data, res) AS "worked" FROM fipstest;
+ERROR:  requested functionality not allowed in FIPS mode (pgcrypto.c:254)
+SELECT 'Test pgp : EXPECTED PASS' as comment;
+         comment          
+--------------------------
+ Test pgp : EXPECTED PASS
+(1 row)
+
+select pgp_sym_decrypt(pgp_sym_encrypt('santa clause', 'mypass', 'cipher-algo=aes256'), 'mypass');
+ERROR:  requested functionality not allowed in FIPS mode (openssl.c:1055)
+SELECT 'Test pgp : EXPECTED FAIL FIPS' as comment;
+            comment            
+-------------------------------
+ Test pgp : EXPECTED FAIL FIPS
+(1 row)
+
+select pgp_sym_decrypt(pgp_sym_encrypt('santa clause', 'mypass', 'cipher-algo=bf'), 'mypass');
+ERROR:  Unsupported cipher algorithm
+SELECT 'Test raw encrypt : EXPECTED PASS' as comment;
+             comment              
+----------------------------------
+ Test raw encrypt : EXPECTED PASS
+(1 row)
+
+SELECT encrypt('santa claus', 'mypass', 'aes') as raw_aes;
+ERROR:  requested functionality not allowed in FIPS mode (openssl.c:1055)
+SELECT 'Test raw encrypt : EXPECTED FAIL FIPS' as comment;
+                comment                
+---------------------------------------
+ Test raw encrypt : EXPECTED FAIL FIPS
+(1 row)
+
+SELECT encrypt('santa claus', 'mypass', 'bf') as raw_blowfish;
+ERROR:  requested functionality not allowed in FIPS mode (openssl.c:1055)
+DROP TABLE fipstest;

--- a/contrib/pgcrypto/expected/fips_2.out
+++ b/contrib/pgcrypto/expected/fips_2.out
@@ -7,8 +7,6 @@ SHOW pgcrypto.fips;
 (1 row)
 
 CREATE TABLE fipstest (data text, res text, salt text);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'data' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO fipstest VALUES ('password', '', '');
 SELECT 'Test digest md5: EXPECTED ERROR FAIL FIPS' as comment;
                   comment                  
@@ -17,7 +15,7 @@ SELECT 'Test digest md5: EXPECTED ERROR FAIL FIPS' as comment;
 (1 row)
 
 SELECT digest('santa claus', 'md5');
-ERROR:  Cannot use "md5": No such hash algorithm
+ERROR:  Cannot use "md5": 
 SELECT 'Test digest sha256: EXPECTED PASS' as comment;
               comment              
 -----------------------------------
@@ -37,7 +35,7 @@ SELECT 'Test hmac md5: EXPECTED ERROR FAIL FIPS' as comment;
 (1 row)
 
 SELECT hmac('santa claus', 'aaa', 'md5');
-ERROR:  Cannot use "md5": No such hash algorithm
+ERROR:  Cannot use "md5": 
 SELECT 'Test hmac sha256: EXPECTED PASS' as comment;
              comment             
 ---------------------------------
@@ -57,7 +55,7 @@ SELECT 'Test gen_salt : EXPECTED FAIL FIPS' as comment;
 (1 row)
 
 UPDATE fipstest SET salt = gen_salt('md5');
-ERROR:  requested functionality not allowed in FIPS mode (pgcrypto.c:201)
+ERROR:  requested functionality not allowed in FIPS mode (pgcrypto.c:213)
 SELECT 'Test crypt : EXPECTED FAIL FIPS' as comment;
              comment             
 ---------------------------------
@@ -65,9 +63,9 @@ SELECT 'Test crypt : EXPECTED FAIL FIPS' as comment;
 (1 row)
 
 UPDATE fipstest SET res = crypt(data, salt);
-ERROR:  requested functionality not allowed in FIPS mode (pgcrypto.c:254)
+ERROR:  requested functionality not allowed in FIPS mode (pgcrypto.c:266)
 SELECT res = crypt(data, res) AS "worked" FROM fipstest;
-ERROR:  requested functionality not allowed in FIPS mode (pgcrypto.c:254)
+ERROR:  requested functionality not allowed in FIPS mode (pgcrypto.c:266)
 SELECT 'Test pgp : EXPECTED PASS' as comment;
          comment          
 --------------------------
@@ -75,7 +73,7 @@ SELECT 'Test pgp : EXPECTED PASS' as comment;
 (1 row)
 
 select pgp_sym_decrypt(pgp_sym_encrypt('santa clause', 'mypass', 'cipher-algo=aes256'), 'mypass');
-ERROR:  requested functionality not allowed in FIPS mode (openssl.c:1055)
+ERROR:  requested functionality not allowed in FIPS mode (openssl.c:772)
 SELECT 'Test pgp : EXPECTED FAIL FIPS' as comment;
             comment            
 -------------------------------
@@ -91,7 +89,7 @@ SELECT 'Test raw encrypt : EXPECTED PASS' as comment;
 (1 row)
 
 SELECT encrypt('santa claus', 'mypass', 'aes') as raw_aes;
-ERROR:  requested functionality not allowed in FIPS mode (openssl.c:1055)
+ERROR:  requested functionality not allowed in FIPS mode (openssl.c:772)
 SELECT 'Test raw encrypt : EXPECTED FAIL FIPS' as comment;
                 comment                
 ---------------------------------------
@@ -99,5 +97,5 @@ SELECT 'Test raw encrypt : EXPECTED FAIL FIPS' as comment;
 (1 row)
 
 SELECT encrypt('santa claus', 'mypass', 'bf') as raw_blowfish;
-ERROR:  requested functionality not allowed in FIPS mode (openssl.c:1055)
+ERROR:  requested functionality not allowed in FIPS mode (openssl.c:772)
 DROP TABLE fipstest;

--- a/contrib/pgcrypto/expected/setup_fips.out
+++ b/contrib/pgcrypto/expected/setup_fips.out
@@ -1,0 +1,7 @@
+-- Setup for fips.sql test
+-- We are setting shared_preload_libraries so that we can set the extension GUC
+-- 'pgcrypto.fips' immediately after creating the extension on master.
+-- start_ignore
+\! gpconfig -c shared_preload_libraries -v '$libdir/pgcrypto'
+\! gpstop -air
+-- end_ignore

--- a/contrib/pgcrypto/internal.c
+++ b/contrib/pgcrypto/internal.c
@@ -614,3 +614,24 @@ px_find_cipher(const char *name, PX_Cipher **res)
 	*res = c;
 	return 0;
 }
+
+void
+px_disable_fipsmode(void)
+{
+	ereport(ERROR,
+		(errmsg("pgcrypto FIPS mode is only supported in OpenSSL enabled builds")));
+}
+
+void
+px_enable_fipsmode(void)
+{
+	ereport(ERROR,
+			(errmsg("pgcrypto FIPS mode is only supported in OpenSSL enabled builds")));
+}
+
+void
+px_check_fipsmode(void)
+{
+	ereport(ERROR,
+			(errmsg("pgcrypto FIPS mode is only supported in OpenSSL enabled builds")));
+}

--- a/contrib/pgcrypto/openssl.c
+++ b/contrib/pgcrypto/openssl.c
@@ -50,6 +50,16 @@
 #define MAX_IV		(128/8)
 
 /*
+ * Fips mode
+ */
+static bool fips = false;
+
+#define NOT_FIPS_CERTIFIED \
+	if (fips) \
+		ereport(ERROR, \
+				(errmsg("requested functionality not allowed in FIPS mode")));
+
+/*
  * Hashes
  */
 
@@ -635,7 +645,7 @@ ossl_aes_cbc_init(PX_Cipher *c, const uint8 *key, unsigned klen, const uint8 *iv
  * aliases
  */
 
-static PX_Alias ossl_aliases[] = {
+static PX_Alias ossl_aliases_all[] = {
 	{"bf", "bf-cbc"},
 	{"blowfish", "bf-cbc"},
 	{"blowfish-cbc", "bf-cbc"},
@@ -652,6 +662,8 @@ static PX_Alias ossl_aliases[] = {
 	{"rijndael-ecb", "aes-ecb"},
 	{NULL}
 };
+
+static PX_Alias *ossl_aliases = ossl_aliases_all;
 
 static const struct ossl_cipher ossl_bf_cbc = {
 	bf_init,
@@ -730,7 +742,7 @@ struct ossl_cipher_lookup
 	const struct ossl_cipher *ciph;
 };
 
-static const struct ossl_cipher_lookup ossl_cipher_types[] = {
+static const struct ossl_cipher_lookup ossl_cipher_types_all[] = {
 	{"bf-cbc", &ossl_bf_cbc},
 	{"bf-ecb", &ossl_bf_ecb},
 	{"bf-cfb", &ossl_bf_cfb},
@@ -745,6 +757,8 @@ static const struct ossl_cipher_lookup ossl_cipher_types[] = {
 	{NULL}
 };
 
+static const struct ossl_cipher_lookup *ossl_cipher_types = ossl_cipher_types_all;
+
 /* PUBLIC functions */
 
 int
@@ -754,6 +768,8 @@ px_find_cipher(const char *name, PX_Cipher **res)
 	PX_Cipher  *c = NULL;
 	EVP_CIPHER_CTX *ctx;
 	OSSLCipher *od;
+
+	NOT_FIPS_CERTIFIED
 
 	name = px_resolve_alias(ossl_aliases, name);
 	for (i = ossl_cipher_types; i->name; i++)
@@ -807,3 +823,97 @@ px_find_cipher(const char *name, PX_Cipher **res)
 	*res = c;
 	return 0;
 }
+
+void
+px_disable_fipsmode(void)
+{
+#ifndef OPENSSL_FIPS
+	/*
+	 * If this build doesn't support FIPS mode at all, we shouldn't be able
+	 * to reach this point, so Assert that and return to handle production
+	 * builds gracefully.
+	 */
+	Assert(!fips);
+#else
+	ossl_aliases = ossl_aliases_all;
+	ossl_cipher_types = ossl_cipher_types_all;
+	fips = false;
+
+	if (!FIPS_mode_set)
+		return;
+
+	FIPS_mode_set(0);
+#endif
+
+	return;
+}
+
+void
+px_enable_fipsmode(void)
+{
+#ifndef OPENSSL_FIPS
+	ereport(ERROR,
+			(errmsg("FIPS enabled OpenSSL is required for strict FIPS mode"),
+			 errhint("Recompile OpenSSL with the FIPS module, or install a FIPS enabled OpenSSL distribution.")));
+#else
+
+	/*
+	 * While AES and 3DES are allowed ciphers under FIPS-140 level 2, pgcrypto
+	 * is calling the lowlevel API for these which is disallowed under FIPS.
+	 * However, rather than returning NULL as is done when calling the high
+	 * level functions, the lowlevel API throws a SIGABORT so we need to avoid
+	 * calling this altogether.
+	 */
+	ossl_aliases = NULL;
+	ossl_cipher_types = NULL;
+
+	/* Make sure that we are linked against a FIPS enabled OpenSSL */
+	if (!FIPS_mode_set)
+	{
+		ereport(ERROR,
+				(errmsg("FIPS enabled OpenSSL is required for strict FIPS mode"),
+				 errhint("Recompile OpenSSL with the FIPS module, or install a FIPS enabled OpenSSL distribution.")));
+	}
+
+	/*
+	 * A non-zero return value means that FIPS mode was enabled, but the
+	 * full range of possible non-zero return values is not documented so
+	 * rather than checking for success we check for failure.
+	 */
+	if (FIPS_mode_set(1) == 0)
+	{
+		char		errbuf[128];
+
+		ERR_load_crypto_strings();
+		ERR_error_string_n(ERR_get_error(), errbuf, sizeof(errbuf));
+		ERR_free_strings();
+
+		ereport(ERROR,
+				(errmsg("unable to enable FIPS mode: %lx, %s",
+						ERR_get_error(), errbuf)));
+	}
+
+	fips = true;
+#endif
+}
+
+void
+px_check_fipsmode(void)
+{
+#ifndef OPENSSL_FIPS
+	ereport(ERROR,
+			(errmsg("FIPS enabled OpenSSL is required for strict FIPS mode"),
+			 errhint("Recompile OpenSSL with the FIPS module, or install a FIPS enabled OpenSSL distribution.")));
+#else
+
+	/* Make sure that we are linked against a FIPS enabled OpenSSL */
+	if (!FIPS_mode_set || FIPS_mode() == 0)
+	{
+		ereport(ERROR,
+				(errmsg("FIPS enabled OpenSSL is required for strict FIPS mode"),
+				 errhint("Recompile OpenSSL with the FIPS module, or install a FIPS enabled OpenSSL distribution.")));
+	}
+
+#endif
+}
+

--- a/contrib/pgcrypto/openssl.c
+++ b/contrib/pgcrypto/openssl.c
@@ -907,7 +907,7 @@ px_check_fipsmode(void)
 #else
 
 	/* Make sure that we are linked against a FIPS enabled OpenSSL */
-	if (!FIPS_mode_set || FIPS_mode() == 0)
+	if (!FIPS_mode_set)
 	{
 		ereport(ERROR,
 				(errmsg("FIPS enabled OpenSSL is required for strict FIPS mode"),

--- a/contrib/pgcrypto/pgp.c
+++ b/contrib/pgcrypto/pgp.c
@@ -66,7 +66,7 @@ struct cipher_info
 	int			block_len;
 };
 
-static const struct digest_info digest_list[] = {
+static const struct digest_info digest_list_all[] = {
 	{"md5", PGP_DIGEST_MD5},
 	{"sha1", PGP_DIGEST_SHA1},
 	{"sha-1", PGP_DIGEST_SHA1},
@@ -77,7 +77,18 @@ static const struct digest_info digest_list[] = {
 	{NULL, 0}
 };
 
-static const struct cipher_info cipher_list[] = {
+static const struct digest_info digest_list_fips[] = {
+	{"sha1", PGP_DIGEST_SHA1},
+	{"sha-1", PGP_DIGEST_SHA1},
+	{"sha256", PGP_DIGEST_SHA256},
+	{"sha384", PGP_DIGEST_SHA384},
+	{"sha512", PGP_DIGEST_SHA512},
+	{NULL, 0}
+};
+
+static const struct digest_info *digest_list = digest_list_all;
+
+static const struct cipher_info cipher_list_all[] = {
 	{"3des", PGP_SYM_DES3, "3des-ecb", 192 / 8, 64 / 8},
 	{"cast5", PGP_SYM_CAST5, "cast5-ecb", 128 / 8, 64 / 8},
 	{"bf", PGP_SYM_BLOWFISH, "bf-ecb", 128 / 8, 64 / 8},
@@ -89,6 +100,17 @@ static const struct cipher_info cipher_list[] = {
 	{"twofish", PGP_SYM_TWOFISH, "twofish-ecb", 256 / 8, 128 / 8},
 	{NULL, 0, NULL}
 };
+
+static const struct cipher_info cipher_list_fips[] = {
+	{"3des", PGP_SYM_DES3, "3des-ecb", 192 / 8, 64 / 8},
+	{"aes", PGP_SYM_AES_128, "aes-ecb", 128 / 8, 128 / 8},
+	{"aes128", PGP_SYM_AES_128, "aes-ecb", 128 / 8, 128 / 8},
+	{"aes192", PGP_SYM_AES_192, "aes-ecb", 192 / 8, 128 / 8},
+	{"aes256", PGP_SYM_AES_256, "aes-ecb", 256 / 8, 128 / 8},
+	{NULL, 0, NULL}
+};
+
+static const struct cipher_info *cipher_list = cipher_list_all;
 
 static const struct cipher_info *
 get_cipher_info(int code)
@@ -369,4 +391,18 @@ pgp_set_symkey(PGP_Context *ctx, const uint8 *key, int len)
 	ctx->sym_key = key;
 	ctx->sym_key_len = len;
 	return 0;
+}
+
+void
+pgp_disable_fipsmode(void)
+{
+	cipher_list = cipher_list_all;
+	digest_list = digest_list_all;
+}
+
+void
+pgp_enable_fipsmode(void)
+{
+	cipher_list = cipher_list_fips;
+	digest_list = digest_list_fips;
 }

--- a/contrib/pgcrypto/pgp.h
+++ b/contrib/pgcrypto/pgp.h
@@ -325,3 +325,6 @@ int			pgp_rsa_encrypt(PGP_PubKey *pk, PGP_MPI *m, PGP_MPI **c);
 int			pgp_rsa_decrypt(PGP_PubKey *pk, PGP_MPI *c, PGP_MPI **m);
 
 extern struct PullFilterOps pgp_decrypt_filter;
+
+void		pgp_disable_fipsmode(void);
+void		pgp_enable_fipsmode(void);

--- a/contrib/pgcrypto/px.h
+++ b/contrib/pgcrypto/px.h
@@ -196,6 +196,10 @@ void		px_set_debug_handler(void (*handler) (const char *));
 
 void		px_memset(void *ptr, int c, size_t len);
 
+void		px_enable_fipsmode(void);
+void		px_disable_fipsmode(void);
+void		px_check_fipsmode(void);
+
 #ifdef PX_DEBUG
 void		px_debug(const char *fmt,...) pg_attribute_printf(1, 2);
 #else

--- a/contrib/pgcrypto/sql/fips.sql
+++ b/contrib/pgcrypto/sql/fips.sql
@@ -1,0 +1,40 @@
+ALTER DATABASE contrib_regression SET pgcrypto.fips TO on;
+\c contrib_regression
+
+SHOW pgcrypto.fips;
+
+CREATE TABLE fipstest (data text, res text, salt text);
+INSERT INTO fipstest VALUES ('password', '', '');
+
+SELECT 'Test digest md5: EXPECTED ERROR FAIL FIPS' as comment;
+SELECT digest('santa claus', 'md5');
+
+SELECT 'Test digest sha256: EXPECTED PASS' as comment;
+SELECT digest('santa claus', 'sha256');
+
+SELECT 'Test hmac md5: EXPECTED ERROR FAIL FIPS' as comment;
+SELECT hmac('santa claus', 'aaa', 'md5');
+
+SELECT 'Test hmac sha256: EXPECTED PASS' as comment;
+SELECT hmac('santa claus', 'aaa', 'sha256');
+
+SELECT 'Test gen_salt : EXPECTED FAIL FIPS' as comment;
+UPDATE fipstest SET salt = gen_salt('md5');
+
+SELECT 'Test crypt : EXPECTED FAIL FIPS' as comment;
+UPDATE fipstest SET res = crypt(data, salt);
+SELECT res = crypt(data, res) AS "worked" FROM fipstest;
+
+SELECT 'Test pgp : EXPECTED PASS' as comment;
+select pgp_sym_decrypt(pgp_sym_encrypt('santa clause', 'mypass', 'cipher-algo=aes256'), 'mypass');
+
+SELECT 'Test pgp : EXPECTED FAIL FIPS' as comment;
+select pgp_sym_decrypt(pgp_sym_encrypt('santa clause', 'mypass', 'cipher-algo=bf'), 'mypass');
+
+SELECT 'Test raw encrypt : EXPECTED PASS' as comment;
+SELECT encrypt('santa claus', 'mypass', 'aes') as raw_aes;
+
+SELECT 'Test raw encrypt : EXPECTED FAIL FIPS' as comment;
+SELECT encrypt('santa claus', 'mypass', 'bf') as raw_blowfish;
+
+DROP TABLE fipstest;

--- a/contrib/pgcrypto/sql/setup_fips.sql
+++ b/contrib/pgcrypto/sql/setup_fips.sql
@@ -1,0 +1,9 @@
+-- Setup for fips.sql test
+
+-- We are setting shared_preload_libraries so that we can set the extension GUC
+-- 'pgcrypto.fips' immediately after creating the extension on master.
+
+-- start_ignore
+\! gpconfig -c shared_preload_libraries -v 'pgcrypto.so'
+\! gpstop -air
+-- end_ignore

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -118,6 +118,12 @@ s/ERROR:  invalid partition constraint on "[^"]+".*/ERROR:  invalid partition co
 m/ERROR:  FIPS enabled OpenSSL is required for strict FIPS mode .*/
 s/ERROR:  FIPS enabled OpenSSL is required for strict FIPS mode .*/ERROR:  FIPS enabled OpenSSL is required for strict FIPS mode (openssl.c:XXX)/
 
+# Mask out OpenSSL behavior change in different version
+m/ERROR:  Cannot use "md5": No such hash algorithm/
+s/ERROR:  Cannot use "md5": No such hash algorithm/ERROR:  Cannot use "md5": /
+m/ERROR: Cannot use "md5": Some PX error \(not specified\)/
+s/ERROR: Cannot use "md5": Some PX error \(not specified\)/ERROR:  Cannot use "md5": /
+
 # Mask out gp_execution_segment()
 m/One-Time Filter: \(gp_execution_segment\(\) = \d+/
 s/One-Time Filter: \(gp_execution_segment\(\) = \d+/One-Time Filter: \(gp_execution_segment\(\) = ###/

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -111,6 +111,12 @@ s/\d+ was concurrently dropped/##### was concurrently dropped/
 # Mask out linenumber of the erroring file
 m/ERROR:  ANALYZE cannot merge since not all non-empty leaf partitions have consistent hyperloglog statistics for merge.*/
 s/ERROR:  ANALYZE cannot merge since not all non-empty leaf partitions have consistent hyperloglog statistics for merge.*/ERROR:  ANALYZE cannot merge since not all non-empty leaf partitions have consistent hyperloglog statistics for merge (analyze.c:XXX)/
+m/ERROR:  Cannot run ANALYZE MERGE since not all non-empty leaf partitions have available statistics for the merge.*/
+s/ERROR:  Cannot run ANALYZE MERGE since not all non-empty leaf partitions have available statistics for the merge.*/ERROR:  Cannot run ANALYZE MERGE since not all non-empty leaf partitions have available statistics for the merge (analyze.c:XXX)/
+m/ERROR:  invalid partition constraint on "[^"]+".*/
+s/ERROR:  invalid partition constraint on "[^"]+".*/ERROR:  invalid partition constraint on "[^"]+".*(cdbpartition.c:XXX)/
+m/ERROR:  FIPS enabled OpenSSL is required for strict FIPS mode .*/
+s/ERROR:  FIPS enabled OpenSSL is required for strict FIPS mode .*/ERROR:  FIPS enabled OpenSSL is required for strict FIPS mode (openssl.c:XXX)/
 
 # Mask out gp_execution_segment()
 m/One-Time Filter: \(gp_execution_segment\(\) = \d+/


### PR DESCRIPTION
this feature from 5X 5c751a06d52e43b2e99c81bad8714b69d8047de5 and 923ecc088d04f851c9f3a52fc26dfa00ac3ef314 (6X #13799)

there is no logic change, all behaviors are the same as GPDB 5X.

this PR was tested manually on Archlinux with FIPS not enabled and passed the main pipeline.