### PR TITLE
Declare BackoffPriorityIntToValue and ResourceQueueGetPriorityWeight as extern functions

### DIFF
--- a/src/backend/postmaster/backoff.c
+++ b/src/backend/postmaster/backoff.c
@@ -201,12 +201,10 @@ static volatile bool isSweeperProcess = false;
 
 /* Resource queue related routines */
 static int	BackoffPriorityValueToInt(const char *priorityVal);
-static char *BackoffPriorityIntToValue(int weight);
 extern List *GetResqueueCapabilityEntry(Oid queueid);
 
 static int BackoffDefaultWeight(void);
 static int BackoffSuperuserStatementWeight(void);
-static int ResourceQueueGetPriorityWeight(Oid queueId);
 
 /*
  * Helper method that verifies setting of default priority guc.
@@ -1392,7 +1390,7 @@ BackoffDefaultWeight(void)
  * GetResqueueCapabilityEntry will always  do a catalog lookup. In such cases
  * use the default weight.
  */
-static int
+int
 ResourceQueueGetPriorityWeight(Oid queueId)
 {
 	List	   *capabilitiesList = NULL;
@@ -1486,7 +1484,7 @@ BackoffPriorityValueToInt(const char *priorityVal)
  * method maps it to a text value corresponding to this weight. Caller is
  * responsible for deallocating the return pointer.
  */
-static char *
+char *
 BackoffPriorityIntToValue(int weight)
 {
 	const PriorityMapping *p = priority_map;

--- a/src/include/postmaster/backoff.h
+++ b/src/include/postmaster/backoff.h
@@ -29,5 +29,10 @@ extern Datum gp_list_backend_priorities(PG_FUNCTION_ARGS);
 extern void BackoffSweeperMain(Datum main_arg);
 extern bool BackoffSweeperStartRule(Datum main_arg);
 
+/* needed by metrics_collector */
+extern char *BackoffPriorityIntToValue(int weight);
+/* needed by metrics_collector */
+extern int ResourceQueueGetPriorityWeight(Oid queueId);
+
 
 #endif /* BACKOFF_H_ */


### PR DESCRIPTION
GPCC's metrics collector needs to call BackoffPriorityIntToValue and ResourceQueueGetPriorityWeight.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
