### PR TITLE
Fix partitioned index creation with external partitions backport

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -20608,6 +20608,34 @@ AttachPartitionEnsureIndexes(Relation rel, Relation attachrel)
 	}
 
 	/*
+	 * If we're attaching an external table, we must fail if any of the indexes
+	 * is a constraint index; otherwise, there's nothing to do here.  Do this
+	 * before starting work, to avoid wasting the effort of building a few
+	 * non-unique indexes before coming across a unique one.
+	 */
+	if (RelationIsExternal(attachrel))
+	{
+		foreach(cell, idxes)
+		{
+			Oid			idx = lfirst_oid(cell);
+			Relation	idxRel = index_open(idx, AccessShareLock);
+
+			if (idxRel->rd_index->indisunique ||
+				idxRel->rd_index->indisprimary)
+				ereport(ERROR,
+						(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+								errmsg("cannot attach external table \"%s\" as partition of partitioned table \"%s\"",
+									   RelationGetRelationName(attachrel),
+									   RelationGetRelationName(rel)),
+								errdetail("Table \"%s\" contains unique indexes.",
+										  RelationGetRelationName(rel))));
+			index_close(idxRel, AccessShareLock);
+		}
+
+		goto out;
+	}
+
+	/*
 	 * For each index on the partitioned table, find a matching one in the
 	 * partition-to-be; if one is not found, create one.
 	 */
@@ -20699,7 +20727,7 @@ AttachPartitionEnsureIndexes(Relation rel, Relation attachrel)
 
 		index_close(idxRel, AccessShareLock);
 	}
-
+out:
 	/* Clean up. */
 	for (i = 0; i < list_length(attachRelIdxs); i++)
 		index_close(attachrelIdxRels[i], AccessShareLock);

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -952,8 +952,22 @@ truncate foo_p;
 ERROR:  "foo_p_1_prt_3" is an external relation and can't be truncated
 analyze foo_p;
 WARNING:  skipping "foo_p_1_prt_3" --- cannot analyze non-tables or special system tables
+-- Create index on partitioned table containing external table
+create index idx_mpp32358 on foo_p(j);
+drop index idx_mpp32358;
+alter table foo_p exchange partition for(rank(3)) with table bar_p without validation;
+-- Exchange a indexed partition with an external table
+create index idx_mpp32358 on foo_p(j);
+alter table foo_p exchange partition for(rank(3)) with table bar_p without validation;
+drop index idx_mpp32358;
+alter table foo_p exchange partition for(rank(3)) with table bar_p without validation;
+-- Should fail. Can not exchange partition with external table if there are unique indexes on root partition.
+create unique index idx_mpp32358 on foo_p(i, j);
+alter table foo_p exchange partition for(rank(3)) with table bar_p without validation;
+ERROR:  cannot attach external table "bar_p" as partition of partitioned table "foo_p"
+DETAIL:  Table "foo_p" contains unique indexes.
 drop table foo_p;
-drop table bar_p;
+drop external table bar_p;
 -- Check for overflow of circular data types like time
 -- Should fail
 CREATE TABLE TIME_TBL_HOUR_2 (f1 time(2)) distributed by (f1)

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -956,8 +956,22 @@ truncate foo_p;
 ERROR:  "foo_p_1_prt_3" is an external relation and can't be truncated
 analyze foo_p;
 WARNING:  skipping "foo_p_1_prt_3" --- cannot analyze non-tables or special system tables
+-- Create index on partitioned table containing external table
+create index idx_mpp32358 on foo_p(j);
+drop index idx_mpp32358;
+alter table foo_p exchange partition for(rank(3)) with table bar_p without validation;
+-- Exchange a indexed partition with an external table
+create index idx_mpp32358 on foo_p(j);
+alter table foo_p exchange partition for(rank(3)) with table bar_p without validation;
+drop index idx_mpp32358;
+alter table foo_p exchange partition for(rank(3)) with table bar_p without validation;
+-- Should fail. Can not exchange partition with external table if there are unique indexes on root partition.
+create unique index idx_mpp32358 on foo_p(i, j);
+alter table foo_p exchange partition for(rank(3)) with table bar_p without validation;
+ERROR:  cannot attach external table "bar_p" as partition of partitioned table "foo_p"
+DETAIL:  Table "foo_p" contains unique indexes.
 drop table foo_p;
-drop table bar_p;
+drop external table bar_p;
 -- Check for overflow of circular data types like time
 -- Should fail
 CREATE TABLE TIME_TBL_HOUR_2 (f1 time(2)) distributed by (f1)

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -443,8 +443,22 @@ alter table foo_p exchange partition for(rank(3)) with table bar_p;
 alter table foo_p exchange partition for(rank(3)) with table bar_p without validation;
 truncate foo_p;
 analyze foo_p;
+-- Create index on partitioned table containing external table
+create index idx_mpp32358 on foo_p(j);
+drop index idx_mpp32358;
+alter table foo_p exchange partition for(rank(3)) with table bar_p without validation;
+
+-- Exchange a indexed partition with an external table
+create index idx_mpp32358 on foo_p(j);
+alter table foo_p exchange partition for(rank(3)) with table bar_p without validation;
+drop index idx_mpp32358;
+alter table foo_p exchange partition for(rank(3)) with table bar_p without validation;
+-- Should fail. Can not exchange partition with external table if there are unique indexes on root partition.
+create unique index idx_mpp32358 on foo_p(i, j);
+alter table foo_p exchange partition for(rank(3)) with table bar_p without validation;
+
 drop table foo_p;
-drop table bar_p;
+drop external table bar_p;
 
 -- Check for overflow of circular data types like time
 -- Should fail


### PR DESCRIPTION
When a partitioned tables contains external tables as partitions, it is
not possible to implement unique or primary key indexes -- but when
regular indexes are created, there is no reason to do anything other
than ignoring such partitions.  We were raising errors upon encountering
the foreign partitions, which is unfriendly and doesn't protect against
any actual problems.

Relax this restriction so that index creation is allowed on partitioned
tables containing external partitions, becoming a no-op on them. This
applies to CREATE INDEX, as well as ALTER TABLE / EXCHANGE PARTITION.

This commit is back-porting from https://github.com/postgres/postgres/commit/55ed3defc966cf718fe1e8c0efe964580bb23351.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
