### PR TITLE
pg_dump: fix compiler error in getBMIndxInfo

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -6976,7 +6976,7 @@ getBMIndxInfo(Archive *fout)
 	Oid bitmap_index_namespace;
 
 	/* On GPDB5 pg_bitmapindex OID is 3012 */
-	fout->remoteVersion >= 90400 ? bitmap_index_namespace = PG_BITMAPINDEX_NAMESPACE : 3012;
+	bitmap_index_namespace = fout->remoteVersion >= 90400 ? PG_BITMAPINDEX_NAMESPACE : 3012;
 
 	resetPQExpBuffer(query);
 


### PR DESCRIPTION
On some compilers, we were getting a sometimes initialized error:

pg_dump.c:6979:2: error: variable 'bitmap_index_namespace' is used uninitialized whenever '?:' condition is false [-Werror,-Wsometimes-uninitialized]
        fout->remoteVersion >= 90400 ? bitmap_index_namespace = PG_BITMAPINDEX_NAMESPACE : 3012;
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
pg_dump.c:6996:7: note: uninitialized use occurs here
                                                bitmap_index_namespace, bitmap_index_namespace);
                                                ^~~~~~~~~~~~~~~~~~~~~~
pg_dump.c:6979:2: note: remove the '?:' if its condition is always true
        fout->remoteVersion >= 90400 ? bitmap_index_namespace = PG_BITMAPINDEX_NAMESPACE : 3012;
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                 ~~~~~~~
pg_dump.c:6976:28: note: initialize the variable 'bitmap_index_namespace' to silence this warning
        Oid bitmap_index_namespace;
                                  ^
                                   = 0
1 error generated.
