### PR TITLE
Derive Combined Hashed Spec For Outer Joins - Patch

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/4WayJoinInferredPredsRemovedWith2Motion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/4WayJoinInferredPredsRemovedWith2Motion.mdp
@@ -4649,7 +4649,7 @@ explain select * from cs catalog_sales, it item, sr store_returns, ss store_sale
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="12951">
+    <dxl:Plan Id="0" SpaceSize="104185">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1725.989618" Rows="129.961520" Width="44"/>

--- a/src/backend/gporca/data/dxl/minidump/AddPredsInSubqueries.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AddPredsInSubqueries.mdp
@@ -392,7 +392,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="125">
+    <dxl:Plan Id="0" SpaceSize="141">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.001677" Rows="1.000000" Width="104"/>

--- a/src/backend/gporca/data/dxl/minidump/CTEWithMergedGroup.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTEWithMergedGroup.mdp
@@ -425,7 +425,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="90318341536">
+    <dxl:Plan Id="0" SpaceSize="158660247168">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356250696.455244" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/CapGbCardToSelectCard.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CapGbCardToSelectCard.mdp
@@ -10888,7 +10888,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
         </dxl:LogicalJoin>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="108">
+    <dxl:Plan Id="0" SpaceSize="98">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="102938.691528" Rows="13.696907" Width="127"/>

--- a/src/backend/gporca/data/dxl/minidump/ConvertHashToRandomInsert.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ConvertHashToRandomInsert.mdp
@@ -642,7 +642,7 @@ explain analyze insert into t1 select t2.a,t3.b from t2, t3 where t2.a = t3.a;
         </dxl:LogicalJoin>
       </dxl:LogicalInsert>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="28">
+    <dxl:Plan Id="0" SpaceSize="18">
       <dxl:DMLInsert Columns="0,6" ActionCol="10" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="877.746838" Rows="1000.000000" Width="7"/>

--- a/src/backend/gporca/data/dxl/minidump/Delete-With-Limit-In-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Delete-With-Limit-In-Subquery.mdp
@@ -721,7 +721,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalDelete>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="222">
+    <dxl:Plan Id="0" SpaceSize="238">
       <dxl:DMLDelete Columns="0" ActionCol="21" OidCol="0" CtidCol="1" SegmentIdCol="7" InputSorted="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.965580" Rows="1.000000" Width="1"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-PartAO-SemiJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-PartAO-SemiJoin.mdp
@@ -1229,7 +1229,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1073">
+    <dxl:Plan Id="0" SpaceSize="1195">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="831.364792" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
@@ -1298,7 +1298,7 @@
         </dxl:Or>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="9790292">
+    <dxl:Plan Id="0" SpaceSize="9183946">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1357145192.840398" Rows="1.000000" Width="1"/>

--- a/src/backend/gporca/data/dxl/minidump/EagerAggGroupColumnInJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggGroupColumnInJoin.mdp
@@ -329,7 +329,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="88">
+    <dxl:Plan Id="0" SpaceSize="96">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000604" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/Equiv-HashedDistr-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Equiv-HashedDistr-1.mdp
@@ -1934,7 +1934,7 @@
         </dxl:UnionAll>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="90">
+    <dxl:Plan Id="0" SpaceSize="66">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="34972.709569" Rows="19097.637457" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/Equiv-HashedDistr-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Equiv-HashedDistr-2.mdp
@@ -1936,7 +1936,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="360">
+    <dxl:Plan Id="0" SpaceSize="264">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="34974.557438" Rows="9548.818729" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/EquivClassesAndOr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EquivClassesAndOr.mdp
@@ -344,7 +344,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="298">
+    <dxl:Plan Id="0" SpaceSize="300">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.002536" Rows="1.000000" Width="60"/>

--- a/src/backend/gporca/data/dxl/minidump/ExpandNAryJoinGreedyWithLOJOnly.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExpandNAryJoinGreedyWithLOJOnly.mdp
@@ -3934,7 +3934,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="90416">
+    <dxl:Plan Id="0" SpaceSize="142051">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2586.168979" Rows="10.000001" Width="20"/>

--- a/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisj.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisj.mdp
@@ -14562,7 +14562,7 @@ WHERE ((sale_type = 's'::text AND dyear = 2001 AND year_total &gt; 0::numeric) O
         </dxl:LogicalProject>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2486">
+    <dxl:Plan Id="0" SpaceSize="2542">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="5944.261371" Rows="20169.272000" Width="76"/>

--- a/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisjWithComputedColumns.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisjWithComputedColumns.mdp
@@ -459,7 +459,7 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2960">
+    <dxl:Plan Id="0" SpaceSize="3190">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.002852" Rows="1.000000" Width="64"/>

--- a/src/backend/gporca/data/dxl/minidump/HAWQ-TPCH-Stat-Derivation.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HAWQ-TPCH-Stat-Derivation.mdp
@@ -6367,7 +6367,7 @@ ORDER BY s_name;
         </dxl:LogicalJoin>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1835616">
+    <dxl:Plan Id="0" SpaceSize="1863552">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="24583535.993774" Rows="49.989277" Width="65"/>

--- a/src/backend/gporca/data/dxl/minidump/HJN-DeeperOuter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HJN-DeeperOuter.mdp
@@ -356,7 +356,7 @@ SELECT z.*,x.* FROM x,y,z WHERE x.i=y.i AND x.i=z.i;
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="332">
+    <dxl:Plan Id="0" SpaceSize="354">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.001468" Rows="1.000000" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-ForPartialIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-ForPartialIndex.mdp
@@ -387,7 +387,7 @@ explain select t1.a from t1, foo_prt t2, t3 where (t1.b = t2.a) and t2.a = t3.b;
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="454">
+    <dxl:Plan Id="0" SpaceSize="804">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.000695" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-Redistribute-Const-Table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-Redistribute-Const-Table.mdp
@@ -388,7 +388,7 @@ Table X (int i, int j) is distributed by i, column i has index
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="23">
+    <dxl:Plan Id="0" SpaceSize="22">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="6.000265" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesInnerOfLOJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesInnerOfLOJ.mdp
@@ -349,7 +349,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="195">
+    <dxl:Plan Id="0" SpaceSize="285">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.000804" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/InnerJoinBroadcastTableHashSpec.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InnerJoinBroadcastTableHashSpec.mdp
@@ -1,0 +1,529 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Test case: Verify inner join derives match spec with outer relation's nulls colocation value
+
+drop table if exists t1;
+drop table if exists t2;
+
+CREATE TABLE t1 (a1 int, b1 int, c1 int) DISTRIBUTED BY (a1);
+CREATE TABLE t2 (a2 int, b2 int, c2 int) DISTRIBUTED BY (a2);
+
+INSERT INTO t1 VALUES(1, 1, 1);
+INSERT INTO t2 VALUES(1, 2, 4);
+
+analyze t1;
+analyze t2;
+
+EXPLAIN SELECT b2, sum(c1) FROM t1, t2 WHERE a1 = b2 GROUP BY b2 ORDER BY b2;
+
+                                                     QUERY PLAN
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=12)
+   Merge Key: t2.b2
+   ->  Sort  (cost=0.00..862.00 rows=1 width=12)
+         Sort Key: t2.b2
+         ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=12)
+               Group Key: t2.b2
+               ->  Sort  (cost=0.00..862.00 rows=1 width=8)
+                     Sort Key: t2.b2
+                     ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
+                           Hash Cond: (t1.a1 = t2.b2)
+                           ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                       ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(15 rows)
+
+]]></dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.16385.1.0" Name="t1" Rows="1.000000" RelPages="1" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.16385.1.0" Name="t1" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b1" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c1" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.16388.1.0" Name="t2" Rows="1.000000" RelPages="1" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.16388.1.0" Name="t2" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a2" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b2" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c2" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16385.1.0.0" Name="a1" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16385.1.0.2" Name="c1" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16388.1.0.1" Name="b2" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16388.1.0.0" Name="a2" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:GPDBAgg Mdid="0.2108.1.0" Name="sum" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="12" ColName="b2" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="21" ColName="sum" TypeMdid="0.20.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalLimit>
+        <dxl:SortingColumnList>
+          <dxl:SortingColumn ColId="12" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+        </dxl:SortingColumnList>
+        <dxl:LimitCount/>
+        <dxl:LimitOffset/>
+        <dxl:LogicalGroupBy>
+          <dxl:GroupingColumns>
+            <dxl:GroupingColumn ColId="12"/>
+          </dxl:GroupingColumns>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="21" Alias="sum">
+              <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="23">
+                <dxl:ValuesList ParamType="aggargs">
+                  <dxl:Ident ColId="3" ColName="c1" TypeMdid="0.23.1.0"/>
+                </dxl:ValuesList>
+                <dxl:ValuesList ParamType="aggdirectargs"/>
+                <dxl:ValuesList ParamType="aggorder"/>
+                <dxl:ValuesList ParamType="aggdistinct"/>
+              </dxl:AggFunc>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:LogicalJoin JoinType="Inner">
+            <dxl:LogicalGet>
+              <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="t1" LockMode="1">
+                <dxl:Columns>
+                  <dxl:Column ColId="1" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="2" Attno="2" ColName="b1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="3" Attno="3" ColName="c1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:LogicalGet>
+            <dxl:LogicalGet>
+              <dxl:TableDescriptor Mdid="0.16388.1.0" TableName="t2" LockMode="1">
+                <dxl:Columns>
+                  <dxl:Column ColId="11" Attno="1" ColName="a2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="12" Attno="2" ColName="b2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="13" Attno="3" ColName="c2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="15" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="16" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="17" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="18" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="19" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="20" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:LogicalGet>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="1" ColName="a1" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="12" ColName="b2" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:LogicalJoin>
+        </dxl:LogicalGroupBy>
+      </dxl:LogicalLimit>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="50">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="862.000572" Rows="1.000000" Width="12"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="11" Alias="b2">
+            <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="20" Alias="sum">
+            <dxl:Ident ColId="20" ColName="sum" TypeMdid="0.20.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList>
+          <dxl:SortingColumn ColId="11" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+        </dxl:SortingColumnList>
+        <dxl:Sort SortDiscardDuplicates="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="862.000527" Rows="1.000000" Width="12"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="11" Alias="b2">
+              <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="20" Alias="sum">
+              <dxl:Ident ColId="20" ColName="sum" TypeMdid="0.20.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="11" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
+          <dxl:LimitCount/>
+          <dxl:LimitOffset/>
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="862.000527" Rows="1.000000" Width="12"/>
+            </dxl:Properties>
+            <dxl:GroupingColumns>
+              <dxl:GroupingColumn ColId="11"/>
+            </dxl:GroupingColumns>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="11" Alias="b2">
+                <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="20" Alias="sum">
+                <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="23">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:Ident ColId="2" ColName="c1" TypeMdid="0.23.1.0"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                  <dxl:ValuesList ParamType="aggorder"/>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:Sort SortDiscardDuplicates="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="862.000517" Rows="1.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="2" Alias="c1">
+                  <dxl:Ident ColId="2" ColName="c1" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="11" Alias="b2">
+                  <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="11" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:LimitCount/>
+              <dxl:LimitOffset/>
+              <dxl:HashJoin JoinType="Inner">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000517" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="2" Alias="c1">
+                    <dxl:Ident ColId="2" ColName="c1" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="11" Alias="b2">
+                    <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:JoinFilter/>
+                <dxl:HashCondList>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:HashCondList>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="a1">
+                      <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="2" Alias="c1">
+                      <dxl:Ident ColId="2" ColName="c1" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="t1" LockMode="1">
+                    <dxl:Columns>
+                      <dxl:Column ColId="0" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="2" Attno="3" ColName="c1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+                <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000082" Rows="3.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="11" Alias="b2">
+                      <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList/>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="11" Alias="b2">
+                        <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.16388.1.0" TableName="t2" LockMode="1">
+                      <dxl:Columns>
+                        <dxl:Column ColId="10" Attno="1" ColName="a2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="11" Attno="2" ColName="b2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                        <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:BroadcastMotion>
+              </dxl:HashJoin>
+            </dxl:Sort>
+          </dxl:Aggregate>
+        </dxl:Sort>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/InnerJoinOverJoinExcept.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InnerJoinOverJoinExcept.mdp
@@ -295,7 +295,7 @@ ON (a.col = b.col);
         </dxl:LogicalJoin>
       </dxl:LogicalInsert>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1080">
+    <dxl:Plan Id="0" SpaceSize="1248">
       <dxl:DMLInsert Columns="0" ActionCol="32" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.011396" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/InnerJoinOverJoinExceptAll.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InnerJoinOverJoinExceptAll.mdp
@@ -333,7 +333,7 @@ ON (a.col = b.col);
         </dxl:LogicalJoin>
       </dxl:LogicalInsert>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="930">
+    <dxl:Plan Id="0" SpaceSize="1127">
       <dxl:DMLInsert Columns="0" ActionCol="34" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.011735" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/InnerJoinReplicatedTableHashSpec.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InnerJoinReplicatedTableHashSpec.mdp
@@ -1,0 +1,535 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Test case: redundant redistribution motion is enforced after the hash join between hashed and replicated relations 
+
+drop table if exists t1;
+drop table if exists t2;
+
+CREATE TABLE t1 (a1 int, b1 int, c1 int) DISTRIBUTED REPLICATED;
+CREATE TABLE t2 (a2 int, b2 int, c2 int) DISTRIBUTED BY (a2);
+
+INSERT INTO t1 VALUES(1, 1, 1);
+INSERT INTO t2 VALUES(1, 2, 4);
+
+analyze t1;
+analyze t2;
+
+EXPLAIN SELECT b2, sum(c1) FROM t1, t2 WHERE a1 = b2 GROUP BY b2 ORDER BY b2;
+
+                                                 QUERY PLAN
+------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=12)
+   Merge Key: t2.b2
+   ->  Sort  (cost=0.00..862.00 rows=1 width=12)
+         Sort Key: t2.b2
+         ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=12)
+               Group Key: t2.b2
+               ->  Sort  (cost=0.00..862.00 rows=1 width=8)
+                     Sort Key: t2.b2
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+                           Hash Key: t2.b2
+                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
+                                 Hash Cond: (t2.b2 = t1.a1)
+                                 ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+                                       ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(16 rows)
+
+]]></dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.16427.1.0" Name="t1" Rows="1.000000" RelPages="1" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.16427.1.0" Name="t1" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Replicated" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b1" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c1" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.16430.1.0" Name="t2" Rows="1.000000" RelPages="1" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.16430.1.0" Name="t2" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a2" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b2" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c2" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:GPDBAgg Mdid="0.2108.1.0" Name="sum" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:ColumnStatistics Mdid="1.16427.1.0.0" Name="a1" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.16427.1.0.2" Name="c1" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16430.1.0.1" Name="b2" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16430.1.0.0" Name="a2" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="12" ColName="b2" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="21" ColName="sum" TypeMdid="0.20.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalLimit>
+        <dxl:SortingColumnList>
+          <dxl:SortingColumn ColId="12" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+        </dxl:SortingColumnList>
+        <dxl:LimitCount/>
+        <dxl:LimitOffset/>
+        <dxl:LogicalGroupBy>
+          <dxl:GroupingColumns>
+            <dxl:GroupingColumn ColId="12"/>
+          </dxl:GroupingColumns>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="21" Alias="sum">
+              <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="23">
+                <dxl:ValuesList ParamType="aggargs">
+                  <dxl:Ident ColId="3" ColName="c1" TypeMdid="0.23.1.0"/>
+                </dxl:ValuesList>
+                <dxl:ValuesList ParamType="aggdirectargs"/>
+                <dxl:ValuesList ParamType="aggorder"/>
+                <dxl:ValuesList ParamType="aggdistinct"/>
+              </dxl:AggFunc>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:LogicalJoin JoinType="Inner">
+            <dxl:LogicalGet>
+              <dxl:TableDescriptor Mdid="0.16427.1.0" TableName="t1" LockMode="1">
+                <dxl:Columns>
+                  <dxl:Column ColId="1" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="2" Attno="2" ColName="b1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="3" Attno="3" ColName="c1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:LogicalGet>
+            <dxl:LogicalGet>
+              <dxl:TableDescriptor Mdid="0.16430.1.0" TableName="t2" LockMode="1">
+                <dxl:Columns>
+                  <dxl:Column ColId="11" Attno="1" ColName="a2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="12" Attno="2" ColName="b2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="13" Attno="3" ColName="c2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="15" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="16" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="17" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="18" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="19" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="20" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:LogicalGet>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="1" ColName="a1" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="12" ColName="b2" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:LogicalJoin>
+        </dxl:LogicalGroupBy>
+      </dxl:LogicalLimit>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="255">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="862.000465" Rows="1.000000" Width="12"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="11" Alias="b2">
+            <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="20" Alias="sum">
+            <dxl:Ident ColId="20" ColName="sum" TypeMdid="0.20.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList>
+          <dxl:SortingColumn ColId="11" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+        </dxl:SortingColumnList>
+        <dxl:Sort SortDiscardDuplicates="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="862.000421" Rows="1.000000" Width="12"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="11" Alias="b2">
+              <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="20" Alias="sum">
+              <dxl:Ident ColId="20" ColName="sum" TypeMdid="0.20.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="11" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
+          <dxl:LimitCount/>
+          <dxl:LimitOffset/>
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="862.000421" Rows="1.000000" Width="12"/>
+            </dxl:Properties>
+            <dxl:GroupingColumns>
+              <dxl:GroupingColumn ColId="11"/>
+            </dxl:GroupingColumns>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="11" Alias="b2">
+                <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="20" Alias="sum">
+                <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="23">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:Ident ColId="2" ColName="c1" TypeMdid="0.23.1.0"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                  <dxl:ValuesList ParamType="aggorder"/>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:Sort SortDiscardDuplicates="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="862.000410" Rows="1.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="2" Alias="c1">
+                  <dxl:Ident ColId="2" ColName="c1" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="11" Alias="b2">
+                  <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="11" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:LimitCount/>
+              <dxl:LimitOffset/>
+              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000410" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="2" Alias="c1">
+                    <dxl:Ident ColId="2" ColName="c1" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="11" Alias="b2">
+                    <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr Opfamily="0.1977.1.0">
+                    <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:HashJoin JoinType="Inner">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="862.000398" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="2" Alias="c1">
+                      <dxl:Ident ColId="2" ColName="c1" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="11" Alias="b2">
+                      <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:JoinFilter/>
+                  <dxl:HashCondList>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:HashCondList>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="11" Alias="b2">
+                        <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.16430.1.0" TableName="t2" LockMode="1">
+                      <dxl:Columns>
+                        <dxl:Column ColId="10" Attno="1" ColName="a2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="11" Attno="2" ColName="b2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                        <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="3.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="a1">
+                        <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="2" Alias="c1">
+                        <dxl:Ident ColId="2" ColName="c1" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.16427.1.0" TableName="t1" LockMode="1">
+                      <dxl:Columns>
+                        <dxl:Column ColId="0" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="2" Attno="3" ColName="c1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                        <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:HashJoin>
+              </dxl:RedistributeMotion>
+            </dxl:Sort>
+          </dxl:Aggregate>
+        </dxl:Sort>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/Insert-With-HJ-CTE-Agg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-With-HJ-CTE-Agg.mdp
@@ -508,7 +508,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalInsert>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1110">
+    <dxl:Plan Id="0" SpaceSize="1180">
       <dxl:DMLInsert Columns="38,39,42,43,44" ActionCol="48" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="867.122533" Rows="96.000000" Width="36"/>

--- a/src/backend/gporca/data/dxl/minidump/Intersect-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Intersect-OuterRefs.mdp
@@ -1413,7 +1413,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3740">
+    <dxl:Plan Id="0" SpaceSize="4060">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.065290" Rows="77.229878" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinArityAssociativityCommutativityAboveLimit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinArityAssociativityCommutativityAboveLimit.mdp
@@ -336,7 +336,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1006">
+    <dxl:Plan Id="0" SpaceSize="2488">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.001370" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinArityAssociativityCommutativityAtLimit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinArityAssociativityCommutativityAtLimit.mdp
@@ -336,7 +336,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1930">
+    <dxl:Plan Id="0" SpaceSize="5270">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.001370" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinArityAssociativityCommutativityBelowLimit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinArityAssociativityCommutativityBelowLimit.mdp
@@ -336,7 +336,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="174">
+    <dxl:Plan Id="0" SpaceSize="415">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.001643" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinOptimizationLevelGreedyNonPartTblInnerJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinOptimizationLevelGreedyNonPartTblInnerJoin.mdp
@@ -2868,7 +2868,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="388">
+    <dxl:Plan Id="0" SpaceSize="617">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.848201" Rows="10.000000" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJReorderComplexNestedLOJs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJReorderComplexNestedLOJs.mdp
@@ -1619,7 +1619,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="423426">
+    <dxl:Plan Id="0" SpaceSize="2778615">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2586.297294" Rows="6.196244" Width="56"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJReorderWithComplexPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJReorderWithComplexPredicate.mdp
@@ -1957,7 +1957,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="83">
+    <dxl:Plan Id="0" SpaceSize="95">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.153370" Rows="2.000000" Width="36"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJReorderWithIDF.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJReorderWithIDF.mdp
@@ -1540,7 +1540,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="83">
+    <dxl:Plan Id="0" SpaceSize="95">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.153459" Rows="1.200000" Width="36"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJReorderWithSimplePredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJReorderWithSimplePredicate.mdp
@@ -1540,7 +1540,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="336">
+    <dxl:Plan Id="0" SpaceSize="449">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.211204" Rows="2.000000" Width="36"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ_bb_mpph.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_bb_mpph.mdp
@@ -5773,7 +5773,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="23174200">
+    <dxl:Plan Id="0" SpaceSize="25862900">
       <dxl:Limit>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2587.327627" Rows="1.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoinBroadcastTableHashSpec.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoinBroadcastTableHashSpec.mdp
@@ -1,0 +1,613 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Test case: Verify inner join derives match spec with outer relation's nulls colocation value
+
+drop table if exists t1;
+drop table if exists t2;
+
+CREATE TABLE t1 (a1 int, b1 int, c1 int) DISTRIBUTED BY (a1);
+CREATE TABLE t2 (a2 int, b2 int, c2 int) DISTRIBUTED BY (a2);
+
+INSERT INTO t1 VALUES(1, 1, 1);
+INSERT INTO t2 VALUES(1, 2, 4);
+
+analyze t1;
+analyze t2;
+
+EXPLAIN SELECT b2, sum(c1) FROM t1 LEFT JOIN t2 ON a1 = b2 GROUP BY b2 ORDER BY b2;
+
+                                                              QUERY PLAN
+---------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=12)
+   Merge Key: t2.b2
+   ->  Sort  (cost=0.00..862.00 rows=1 width=12)
+         Sort Key: t2.b2
+         ->  Finalize GroupAggregate  (cost=0.00..862.00 rows=1 width=12)
+               Group Key: t2.b2
+               ->  Sort  (cost=0.00..862.00 rows=1 width=12)
+                     Sort Key: t2.b2
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=12)
+                           Hash Key: t2.b2
+                           ->  Partial GroupAggregate  (cost=0.00..862.00 rows=1 width=12)
+                                 Group Key: t2.b2
+                                 ->  Sort  (cost=0.00..862.00 rows=1 width=8)
+                                       Sort Key: t2.b2
+                                       ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=8)
+                                             Hash Cond: (t1.a1 = t2.b2)
+                                             ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                                         ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(21 rows)
+
+]]></dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:ColumnStatistics Mdid="1.16439.1.0.2" Name="c1" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16439.1.0.0" Name="a1" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:RelationStatistics Mdid="2.16439.1.0" Name="t1" Rows="1.000000" RelPages="1" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.16439.1.0" Name="t1" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b1" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c1" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.16442.1.0" Name="t2" Rows="1.000000" RelPages="1" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.16442.1.0" Name="t2" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a2" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b2" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c2" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:GPDBAgg Mdid="0.2108.1.0" Name="sum" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:ColumnStatistics Mdid="1.16442.1.0.1" Name="b2" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16442.1.0.0" Name="a2" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="12" ColName="b2" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="21" ColName="sum" TypeMdid="0.20.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalLimit>
+        <dxl:SortingColumnList>
+          <dxl:SortingColumn ColId="12" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+        </dxl:SortingColumnList>
+        <dxl:LimitCount/>
+        <dxl:LimitOffset/>
+        <dxl:LogicalGroupBy>
+          <dxl:GroupingColumns>
+            <dxl:GroupingColumn ColId="12"/>
+          </dxl:GroupingColumns>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="21" Alias="sum">
+              <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="23">
+                <dxl:ValuesList ParamType="aggargs">
+                  <dxl:Ident ColId="3" ColName="c1" TypeMdid="0.23.1.0"/>
+                </dxl:ValuesList>
+                <dxl:ValuesList ParamType="aggdirectargs"/>
+                <dxl:ValuesList ParamType="aggorder"/>
+                <dxl:ValuesList ParamType="aggdistinct"/>
+              </dxl:AggFunc>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:LogicalJoin JoinType="Left">
+            <dxl:LogicalGet>
+              <dxl:TableDescriptor Mdid="0.16439.1.0" TableName="t1" LockMode="1">
+                <dxl:Columns>
+                  <dxl:Column ColId="1" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="2" Attno="2" ColName="b1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="3" Attno="3" ColName="c1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:LogicalGet>
+            <dxl:LogicalGet>
+              <dxl:TableDescriptor Mdid="0.16442.1.0" TableName="t2" LockMode="1">
+                <dxl:Columns>
+                  <dxl:Column ColId="11" Attno="1" ColName="a2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="12" Attno="2" ColName="b2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="13" Attno="3" ColName="c2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="15" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="16" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="17" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="18" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="19" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="20" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:LogicalGet>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="1" ColName="a1" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="12" ColName="b2" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:LogicalJoin>
+        </dxl:LogicalGroupBy>
+      </dxl:LogicalLimit>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="130">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="862.000593" Rows="1.000000" Width="12"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="11" Alias="b2">
+            <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="20" Alias="sum">
+            <dxl:Ident ColId="20" ColName="sum" TypeMdid="0.20.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList>
+          <dxl:SortingColumn ColId="11" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+        </dxl:SortingColumnList>
+        <dxl:Sort SortDiscardDuplicates="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="862.000549" Rows="1.000000" Width="12"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="11" Alias="b2">
+              <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="20" Alias="sum">
+              <dxl:Ident ColId="20" ColName="sum" TypeMdid="0.20.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="11" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
+          <dxl:LimitCount/>
+          <dxl:LimitOffset/>
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="862.000549" Rows="1.000000" Width="12"/>
+            </dxl:Properties>
+            <dxl:GroupingColumns>
+              <dxl:GroupingColumn ColId="11"/>
+            </dxl:GroupingColumns>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="11" Alias="b2">
+                <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="20" Alias="sum">
+                <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="23">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                  <dxl:ValuesList ParamType="aggorder"/>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:Sort SortDiscardDuplicates="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="862.000534" Rows="1.000000" Width="12"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="11" Alias="b2">
+                  <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                  <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="11" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:LimitCount/>
+              <dxl:LimitOffset/>
+              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000534" Rows="1.000000" Width="12"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="11" Alias="b2">
+                    <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                    <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr Opfamily="0.1977.1.0">
+                    <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:Result>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="862.000515" Rows="1.000000" Width="12"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="11" Alias="b2">
+                      <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                      <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="862.000515" Rows="1.000000" Width="12"/>
+                    </dxl:Properties>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="11"/>
+                    </dxl:GroupingColumns>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                        <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="23">
+                          <dxl:ValuesList ParamType="aggargs">
+                            <dxl:Ident ColId="2" ColName="c1" TypeMdid="0.23.1.0"/>
+                          </dxl:ValuesList>
+                          <dxl:ValuesList ParamType="aggdirectargs"/>
+                          <dxl:ValuesList ParamType="aggorder"/>
+                          <dxl:ValuesList ParamType="aggdistinct"/>
+                        </dxl:AggFunc>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="11" Alias="b2">
+                        <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:Sort SortDiscardDuplicates="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="862.000508" Rows="2.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="2" Alias="c1">
+                          <dxl:Ident ColId="2" ColName="c1" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="11" Alias="b2">
+                          <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList>
+                        <dxl:SortingColumn ColId="11" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      </dxl:SortingColumnList>
+                      <dxl:LimitCount/>
+                      <dxl:LimitOffset/>
+                      <dxl:HashJoin JoinType="Left">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="862.000508" Rows="2.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="2" Alias="c1">
+                            <dxl:Ident ColId="2" ColName="c1" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="11" Alias="b2">
+                            <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:JoinFilter/>
+                        <dxl:HashCondList>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                            <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:HashCondList>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="0" Alias="a1">
+                              <dxl:Ident ColId="0" ColName="a1" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="2" Alias="c1">
+                              <dxl:Ident ColId="2" ColName="c1" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="0.16439.1.0" TableName="t1" LockMode="1">
+                            <dxl:Columns>
+                              <dxl:Column ColId="0" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="2" Attno="3" ColName="c1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                        <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000082" Rows="3.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="11" Alias="b2">
+                              <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList/>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="11" Alias="b2">
+                                <dxl:Ident ColId="11" ColName="b2" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="0.16442.1.0" TableName="t2" LockMode="1">
+                              <dxl:Columns>
+                                <dxl:Column ColId="10" Attno="1" ColName="a2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="11" Attno="2" ColName="b2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:BroadcastMotion>
+                      </dxl:HashJoin>
+                    </dxl:Sort>
+                  </dxl:Aggregate>
+                </dxl:Result>
+              </dxl:RedistributeMotion>
+            </dxl:Sort>
+          </dxl:Aggregate>
+        </dxl:Sort>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoinDPv2JoinOrder.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoinDPv2JoinOrder.mdp
@@ -1442,7 +1442,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="96">
+    <dxl:Plan Id="0" SpaceSize="97">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1325421.228417" Rows="333733.333333" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/MultiLevel-IN-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultiLevel-IN-Subquery.mdp
@@ -686,7 +686,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="918">
+    <dxl:Plan Id="0" SpaceSize="950">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1294.489763" Rows="999.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/NestedSubqLimitBindings.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NestedSubqLimitBindings.mdp
@@ -481,7 +481,7 @@ select a from t as t1 where a in (
         </dxl:LogicalGet>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4437504">
+    <dxl:Plan Id="0" SpaceSize="7046592">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="4165951483148.106445" Rows="1.000000" Width="1"/>

--- a/src/backend/gporca/data/dxl/minidump/NoRedistributeOnAppend.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NoRedistributeOnAppend.mdp
@@ -425,7 +425,7 @@ GROUP BY b;
         </dxl:LogicalCTEAnchor>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="26828515328">
+    <dxl:Plan Id="0" SpaceSize="28999731200">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2155.000796" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-AvoidRangePred-DPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-AvoidRangePred-DPE.mdp
@@ -825,7 +825,7 @@ FROM abuela JOIN bar ON a = c AND b BETWEEN d - 1 AND d + 4
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="227">
+    <dxl:Plan Id="0" SpaceSize="252">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.015414" Rows="3.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-GroupBy.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-GroupBy.mdp
@@ -533,7 +533,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="621">
+    <dxl:Plan Id="0" SpaceSize="692">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.020930" Rows="100.000000" Width="14"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverIntersect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverIntersect.mdp
@@ -1284,7 +1284,7 @@ select * from (select * from p1 intersect select * from p2) as p, tt where p.b=t
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1277">
+    <dxl:Plan Id="0" SpaceSize="1619">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1301.575209" Rows="10000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoin.mdp
@@ -412,7 +412,7 @@ explain select count(*) from r_p, s c, s d, s e where r_p.a = c.c and r_p.a = d.
         </dxl:LogicalJoin>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="19053">
+    <dxl:Plan Id="0" SpaceSize="1931989">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.010923" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
@@ -3255,7 +3255,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="14603">
+    <dxl:Plan Id="0" SpaceSize="16102">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1749455.606498" Rows="321694266.492042" Width="355"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-RightOuterHashJoin-DPE-IsNull.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-RightOuterHashJoin-DPE-IsNull.mdp
@@ -303,7 +303,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="9">
+    <dxl:Plan Id="0" SpaceSize="11">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.003532" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/RightJoinNoDPSNonDistKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RightJoinNoDPSNonDistKey.mdp
@@ -759,7 +759,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="10">
+    <dxl:Plan Id="0" SpaceSize="11">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.162553" Rows="1009.000091" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/SixWayDPv2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SixWayDPv2.mdp
@@ -492,7 +492,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="452864">
+    <dxl:Plan Id="0" SpaceSize="534472">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2586.003056" Rows="1.000000" Width="48"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqExists-With-External-Corrs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqExists-With-External-Corrs.mdp
@@ -456,7 +456,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="12288">
+    <dxl:Plan Id="0" SpaceSize="22026">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.001472" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqExists-Without-External-Corrs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqExists-Without-External-Corrs.mdp
@@ -431,7 +431,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="124702">
+    <dxl:Plan Id="0" SpaceSize="150026">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="12930.008073" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/TPCH-Partitioned-256GB.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TPCH-Partitioned-256GB.mdp
@@ -3673,7 +3673,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="26846">
+    <dxl:Plan Id="0" SpaceSize="57782">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2449307.347267" Rows="10325183.250315" Width="697"/>

--- a/src/backend/gporca/data/dxl/minidump/TPCH-Q5.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TPCH-Q5.mdp
@@ -6502,7 +6502,7 @@
         </dxl:LogicalGroupBy>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="217067356">
+    <dxl:Plan Id="0" SpaceSize="854532444">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="505295.883530" Rows="25.000000" Width="34"/>

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalFullMergeJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalFullMergeJoin.h
@@ -25,7 +25,7 @@ public:
 	explicit CPhysicalFullMergeJoin(
 		CMemoryPool *mp, CExpressionArray *outer_merge_clauses,
 		CExpressionArray *inner_merge_clauses,
-		IMdIdArray *hash_opfamilies = NULL,
+		IMdIdArray *hash_opfamilies = NULL, BOOL is_null_aware = true,
 		CXform::EXformId order_origin_xform = CXform::ExfSentinel);
 
 	// dtor

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalHashJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalHashJoin.h
@@ -43,6 +43,11 @@ private:
 	// Hash op families of the operators used in the join conditions
 	IMdIdArray *m_hash_opfamilies;
 
+	// if the join condition is null-aware
+	// true by default, and false if the join condition is composed of
+	// equality predicates only
+	BOOL m_is_null_aware;
+
 	// array redistribute request sent to the first hash join child
 	CDistributionSpecArray *m_pdrgpdsRedistributeRequests;
 
@@ -117,6 +122,7 @@ public:
 	CPhysicalHashJoin(CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys,
 					  CExpressionArray *pdrgpexprInnerKeys,
 					  IMdIdArray *hash_opfamilies = NULL,
+					  BOOL is_null_aware = true,
 					  CXform::EXformId origin_xform = CXform::ExfSentinel);
 
 	// dtor

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalInnerHashJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalInnerHashJoin.h
@@ -57,6 +57,7 @@ public:
 						   CExpressionArray *pdrgpexprOuterKeys,
 						   CExpressionArray *pdrgpexprInnerKeys,
 						   IMdIdArray *hash_opfamilies = NULL,
+						   BOOL is_null_aware = true,
 						   CXform::EXformId origin_xform = CXform::ExfSentinel);
 
 	// dtor

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftAntiSemiHashJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftAntiSemiHashJoin.h
@@ -36,7 +36,7 @@ public:
 	CPhysicalLeftAntiSemiHashJoin(
 		CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys,
 		CExpressionArray *pdrgpexprInnerKeys,
-		IMdIdArray *hash_opfamilies = NULL,
+		IMdIdArray *hash_opfamilies = NULL, BOOL is_null_aware = true,
 		CXform::EXformId origin_xform = CXform::ExfSentinel);
 
 	// dtor

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftAntiSemiHashJoinNotIn.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftAntiSemiHashJoinNotIn.h
@@ -37,7 +37,7 @@ public:
 	CPhysicalLeftAntiSemiHashJoinNotIn(
 		CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys,
 		CExpressionArray *pdrgpexprInnerKeys,
-		IMdIdArray *hash_opfamilies = NULL,
+		IMdIdArray *hash_opfamilies = NULL, BOOL is_null_aware = true,
 		CXform::EXformId origin_xform = CXform::ExfSentinel);
 
 	// ident accessors

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftOuterHashJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftOuterHashJoin.h
@@ -41,7 +41,7 @@ public:
 	CPhysicalLeftOuterHashJoin(
 		CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys,
 		CExpressionArray *pdrgpexprInnerKeys,
-		IMdIdArray *hash_opfamilies = NULL,
+		IMdIdArray *hash_opfamilies = NULL, BOOL is_null_aware = true,
 		CXform::EXformId origin_xform = CXform::ExfSentinel);
 
 	// dtor

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftSemiHashJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftSemiHashJoin.h
@@ -36,7 +36,7 @@ public:
 	CPhysicalLeftSemiHashJoin(
 		CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys,
 		CExpressionArray *pdrgpexprInnerKeys,
-		IMdIdArray *hash_opfamilies = NULL,
+		IMdIdArray *hash_opfamilies = NULL, BOOL is_null_aware = true,
 		CXform::EXformId origin_xform = CXform::ExfSentinel);
 
 	// dtor

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalRightOuterHashJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalRightOuterHashJoin.h
@@ -40,7 +40,7 @@ public:
 	CPhysicalRightOuterHashJoin(
 		CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys,
 		CExpressionArray *pdrgpexprInnerKeys,
-		IMdIdArray *hash_opfamilies = NULL,
+		IMdIdArray *hash_opfamilies = NULL, BOOL is_null_aware = true,
 		CXform::EXformId origin_xform = CXform::ExfSentinel);
 
 	// dtor

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
@@ -218,7 +218,8 @@ private:
 											  CExpressionArray *pdrgpexprOuter,
 											  CExpressionArray *pdrgpexprInner,
 											  IMdIdArray *join_opfamilies,
-											  CXformResult *pxfres);
+											  CXformResult *pxfres,
+											  BOOL is_hash_join_null_aware);
 
 	// helper for transforming SubqueryAll into aggregate subquery
 	static void SubqueryAllToAgg(
@@ -791,12 +792,10 @@ CXformUtils::TransformImplementBinaryOp(CXformContext *pxfctxt,
 
 template <class T>
 void
-CXformUtils::AddHashOrMergeJoinAlternative(CMemoryPool *mp,
-										   CExpression *pexprJoin,
-										   CExpressionArray *pdrgpexprOuter,
-										   CExpressionArray *pdrgpexprInner,
-										   IMdIdArray *opfamilies,
-										   CXformResult *pxfres)
+CXformUtils::AddHashOrMergeJoinAlternative(
+	CMemoryPool *mp, CExpression *pexprJoin, CExpressionArray *pdrgpexprOuter,
+	CExpressionArray *pdrgpexprInner, IMdIdArray *opfamilies,
+	CXformResult *pxfres, BOOL is_hash_join_null_aware)
 {
 	GPOS_ASSERT(CUtils::FLogicalJoin(pexprJoin->Pop()));
 	GPOS_ASSERT(3 == pexprJoin->Arity());
@@ -809,8 +808,9 @@ CXformUtils::AddHashOrMergeJoinAlternative(CMemoryPool *mp,
 		(*pexprJoin)[ul]->AddRef();
 	}
 	CLogicalJoin *popLogicalJoin = CLogicalJoin::PopConvert(pexprJoin->Pop());
-	T *op = GPOS_NEW(mp) T(mp, pdrgpexprOuter, pdrgpexprInner, opfamilies,
-						   popLogicalJoin->OriginXform());
+	T *op =
+		GPOS_NEW(mp) T(mp, pdrgpexprOuter, pdrgpexprInner, opfamilies,
+					   is_hash_join_null_aware, popLogicalJoin->OriginXform());
 	CExpression *pexprResult = GPOS_NEW(mp)
 		CExpression(mp, op, (*pexprJoin)[0], (*pexprJoin)[1], (*pexprJoin)[2]);
 	pxfres->Add(pexprResult);
@@ -862,9 +862,9 @@ CXformUtils::ImplementHashJoin(CXformContext *pxfctxt, CXformResult *pxfres,
 		else
 		{
 			// we have computed hash join keys on scalar child before, reuse them
-			AddHashOrMergeJoinAlternative<T>(mp, pexpr, pdrgpexprOuter,
-											 pdrgpexprInner, join_opfamilies,
-											 pxfres);
+			AddHashOrMergeJoinAlternative<T>(
+				mp, pexpr, pdrgpexprOuter, pdrgpexprInner, join_opfamilies,
+				pxfres, true /*is_hash_join_null_aware*/);
 		}
 
 		return;
@@ -887,12 +887,18 @@ CXformUtils::ImplementHashJoin(CXformContext *pxfctxt, CXformResult *pxfres,
 	CExpressionArray *pdrgpexpr =
 		CCastUtils::PdrgpexprCastEquality(mp, pexprScalar);
 	ULONG ulPreds = pdrgpexpr->Size();
+	BOOL is_hash_join_null_aware = false;
 	for (ULONG ul = 0; ul < ulPreds; ul++)
 	{
 		CExpression *pexprPred = (*pdrgpexpr)[ul];
 		if (CPhysicalJoin::FHashJoinCompatible(pexprPred, pexprOuter,
 											   pexprInner))
 		{
+			if (!is_hash_join_null_aware)
+			{
+				is_hash_join_null_aware |= CPredicateUtils::FINDF(pexprPred);
+			}
+
 			CExpression *pexprPredInner;
 			CExpression *pexprPredOuter;
 			IMDId *mdid_scop;
@@ -936,7 +942,7 @@ CXformUtils::ImplementHashJoin(CXformContext *pxfctxt, CXformResult *pxfres,
 	{
 		AddHashOrMergeJoinAlternative<T>(mp, pexprResult, pdrgpexprOuter,
 										 pdrgpexprInner, join_opfamilies,
-										 pxfres);
+										 pxfres, is_hash_join_null_aware);
 	}
 	else
 	{
@@ -986,9 +992,9 @@ CXformUtils::ImplementMergeJoin(CXformContext *pxfctxt, CXformResult *pxfres,
 		else
 		{
 			// we have computed join keys on scalar child before, reuse them
-			AddHashOrMergeJoinAlternative<T>(mp, pexpr, pdrgpexprOuter,
-											 pdrgpexprInner, join_opfamilies,
-											 pxfres);
+			AddHashOrMergeJoinAlternative<T>(
+				mp, pexpr, pdrgpexprOuter, pdrgpexprInner, join_opfamilies,
+				pxfres, true /*is_hash_join_null_aware*/);
 		}
 
 		return;
@@ -1068,9 +1074,9 @@ CXformUtils::ImplementMergeJoin(CXformContext *pxfctxt, CXformResult *pxfres,
 	// Add an alternative only if we found at least one merge-joinable predicate
 	if (0 != pdrgpexprOuter->Size())
 	{
-		AddHashOrMergeJoinAlternative<T>(mp, pexprResult, pdrgpexprOuter,
-										 pdrgpexprInner, join_opfamilies,
-										 pxfres);
+		AddHashOrMergeJoinAlternative<T>(
+			mp, pexprResult, pdrgpexprOuter, pdrgpexprInner, join_opfamilies,
+			pxfres, true /*is_hash_join_null_aware*/);
 	}
 	else
 	{

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalFullMergeJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalFullMergeJoin.cpp
@@ -28,7 +28,7 @@ using namespace gpopt;
 // ctor
 CPhysicalFullMergeJoin::CPhysicalFullMergeJoin(
 	CMemoryPool *mp, CExpressionArray *outer_merge_clauses,
-	CExpressionArray *inner_merge_clauses, IMdIdArray *,
+	CExpressionArray *inner_merge_clauses, IMdIdArray *, BOOL,
 	CXform::EXformId origin_xform)
 	: CPhysicalJoin(mp, origin_xform),
 	  m_outer_merge_clauses(outer_merge_clauses),

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalInnerHashJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalInnerHashJoin.cpp
@@ -31,9 +31,9 @@ using namespace gpopt;
 CPhysicalInnerHashJoin::CPhysicalInnerHashJoin(
 	CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys,
 	CExpressionArray *pdrgpexprInnerKeys, IMdIdArray *hash_opfamilies,
-	CXform::EXformId origin_xform)
+	BOOL is_null_aware, CXform::EXformId origin_xform)
 	: CPhysicalHashJoin(mp, pdrgpexprOuterKeys, pdrgpexprInnerKeys,
-						hash_opfamilies, origin_xform)
+						hash_opfamilies, is_null_aware, origin_xform)
 {
 }
 

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalLeftAntiSemiHashJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalLeftAntiSemiHashJoin.cpp
@@ -30,9 +30,9 @@ using namespace gpopt;
 CPhysicalLeftAntiSemiHashJoin::CPhysicalLeftAntiSemiHashJoin(
 	CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys,
 	CExpressionArray *pdrgpexprInnerKeys, IMdIdArray *hash_opfamilies,
-	CXform::EXformId origin_xform)
+	BOOL is_null_aware, CXform::EXformId origin_xform)
 	: CPhysicalHashJoin(mp, pdrgpexprOuterKeys, pdrgpexprInnerKeys,
-						hash_opfamilies, origin_xform)
+						hash_opfamilies, is_null_aware, origin_xform)
 {
 }
 

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalLeftAntiSemiHashJoinNotIn.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalLeftAntiSemiHashJoinNotIn.cpp
@@ -29,9 +29,10 @@ using namespace gpopt;
 CPhysicalLeftAntiSemiHashJoinNotIn::CPhysicalLeftAntiSemiHashJoinNotIn(
 	CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys,
 	CExpressionArray *pdrgpexprInnerKeys, IMdIdArray *hash_opfamilies,
-	CXform::EXformId origin_xform)
+	BOOL is_null_aware, CXform::EXformId origin_xform)
 	: CPhysicalLeftAntiSemiHashJoin(mp, pdrgpexprOuterKeys, pdrgpexprInnerKeys,
-									hash_opfamilies, origin_xform)
+									hash_opfamilies, is_null_aware,
+									origin_xform)
 {
 }
 

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalLeftOuterHashJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalLeftOuterHashJoin.cpp
@@ -32,9 +32,9 @@ using namespace gpopt;
 CPhysicalLeftOuterHashJoin::CPhysicalLeftOuterHashJoin(
 	CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys,
 	CExpressionArray *pdrgpexprInnerKeys, IMdIdArray *hash_opfamilies,
-	CXform::EXformId origin_xform)
+	BOOL is_null_aware, CXform::EXformId origin_xform)
 	: CPhysicalHashJoin(mp, pdrgpexprOuterKeys, pdrgpexprInnerKeys,
-						hash_opfamilies, origin_xform)
+						hash_opfamilies, is_null_aware, origin_xform)
 {
 }
 
@@ -140,6 +140,11 @@ CPhysicalLeftOuterHashJoin::PdsDerive(CMemoryPool *mp,
 		pds = pdsOuter;
 	}
 
+	// TODO: Similar to the case where both outer and inner relations
+	// are hash distributed, when only the outer relation is hash
+	// distributed, we can also return a combined hash distribution spec.
+	// The combined spec contains nulls colocated outer relation, and
+	// nulls not colocated inner relation.
 	if (CDistributionSpec::EdtHashed == pds->Edt())
 	{
 		CDistributionSpecHashed *pdsHashed =

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalLeftSemiHashJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalLeftSemiHashJoin.cpp
@@ -31,9 +31,9 @@ using namespace gpopt;
 CPhysicalLeftSemiHashJoin::CPhysicalLeftSemiHashJoin(
 	CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys,
 	CExpressionArray *pdrgpexprInnerKeys, IMdIdArray *hash_opfamilies,
-	CXform::EXformId origin_xform)
+	BOOL is_null_aware, CXform::EXformId origin_xform)
 	: CPhysicalHashJoin(mp, pdrgpexprOuterKeys, pdrgpexprInnerKeys,
-						hash_opfamilies, origin_xform)
+						hash_opfamilies, is_null_aware, origin_xform)
 {
 }
 

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalRightOuterHashJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalRightOuterHashJoin.cpp
@@ -32,9 +32,9 @@ using namespace gpopt;
 CPhysicalRightOuterHashJoin::CPhysicalRightOuterHashJoin(
 	CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys,
 	CExpressionArray *pdrgpexprInnerKeys, IMdIdArray *hash_opfamilies,
-	CXform::EXformId origin_xform)
+	BOOL is_null_aware, CXform::EXformId origin_xform)
 	: CPhysicalHashJoin(mp, pdrgpexprOuterKeys, pdrgpexprInnerKeys,
-						hash_opfamilies, origin_xform)
+						hash_opfamilies, is_null_aware, origin_xform)
 {
 	ULONG ulDistrReqs = 1 + NumDistrReq();
 	SetDistrRequests(ulDistrReqs);

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -261,7 +261,8 @@ COuterJoin1Test:
 ExpandNAryJoinGreedyWithLOJOnly NaryWithLojAndNonLojChilds LOJ_bb_mpph LOJ-Condition-False
 LeftJoin-With-Pred-On-Inner LeftJoin-With-Pred-On-Inner2
 LeftJoin-With-Col-Const-Pred LeftJoin-With-Coalesce LOJWithFalsePred LeftJoin-DPv2-With-Select
-DPv2GreedyOnly DPv2MinCardOnly DPv2QueryOnly LOJ-PushDown LeftJoinDPv2JoinOrder LeftJoinNullsNotColocated;
+DPv2GreedyOnly DPv2MinCardOnly DPv2QueryOnly LOJ-PushDown LeftJoinDPv2JoinOrder
+LeftJoinNullsNotColocated InnerJoinBroadcastTableHashSpec LeftJoinBroadcastTableHashSpec InnerJoinReplicatedTableHashSpec;
 
 COuterJoin2Test:
 LOJ-IsNullPred Select-Proj-OuterJoin OuterJoin-With-OuterRefs Join-Disj-Subqs

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -3489,6 +3489,161 @@ explain (costs off) select * from t_9427 where a in (select a from t_9427 where 
 
 drop table t_9427;
 reset optimizer;
+-- Test hashed distribution spec derivation and -- 
+-- motion enforcement given INDF join condition --
+-- Outer joins' inner table yields false nulls  --
+-- colocation if join condition is null-aware   --
+drop table o1;
+ERROR:  table "o1" does not exist
+drop table o2;
+ERROR:  table "o2" does not exist
+drop table o3;
+ERROR:  table "o3" does not exist
+create table o1 (a1 int, b1 int) distributed by (a1);
+create table o2 (a2 int, b2 int) distributed by (a2);
+create table o3 (a3 int, b3 int) distributed by (a3);
+insert into o1 select i, i from generate_series(1,20) i;
+insert into o2 select i, null from generate_series(11,30) i;
+insert into o3 values (NULL, 20);
+select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3;
+ a1 | b1 | a2 | b2 | a3 | b3 
+----+----+----+----+----+----
+  1 |  1 |    |    |    | 20
+ 12 | 12 | 12 |    |    |   
+ 15 | 15 | 15 |    |    |   
+ 20 | 20 | 20 |    |    |   
+  5 |  5 |    |    |    | 20
+  6 |  6 |    |    |    | 20
+  9 |  9 |    |    |    | 20
+ 10 | 10 |    |    |    | 20
+ 11 | 11 | 11 |    |    |   
+ 13 | 13 | 13 |    |    |   
+ 14 | 14 | 14 |    |    |   
+ 17 | 17 | 17 |    |    |   
+  2 |  2 |    |    |    | 20
+  3 |  3 |    |    |    | 20
+  4 |  4 |    |    |    | 20
+  7 |  7 |    |    |    | 20
+  8 |  8 |    |    |    | 20
+ 16 | 16 | 16 |    |    |   
+ 18 | 18 | 18 |    |    |   
+ 19 | 19 | 19 |    |    |   
+(20 rows)
+
+select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 is distinct from b3;
+ a1 | b1 | a2 | b2 | a3 | b3 
+----+----+----+----+----+----
+  2 |  2 |    |    |    | 20
+  3 |  3 |    |    |    | 20
+  4 |  4 |    |    |    | 20
+  7 |  7 |    |    |    | 20
+  8 |  8 |    |    |    | 20
+ 16 | 16 | 16 |    |    |   
+ 18 | 18 | 18 |    |    |   
+ 19 | 19 | 19 |    |    |   
+  1 |  1 |    |    |    | 20
+ 12 | 12 | 12 |    |    |   
+ 15 | 15 | 15 |    |    |   
+ 20 | 20 | 20 |    |    |   
+  5 |  5 |    |    |    | 20
+  6 |  6 |    |    |    | 20
+  9 |  9 |    |    |    | 20
+ 10 | 10 |    |    |    | 20
+ 11 | 11 | 11 |    |    |   
+ 13 | 13 | 13 |    |    |   
+ 14 | 14 | 14 |    |    |   
+ 17 | 17 | 17 |    |    |   
+(20 rows)
+
+select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 = b3;
+ a1 | b1 | a2 | b2 | a3 | b3 
+----+----+----+----+----+----
+  1 |  1 |    |    |    |   
+ 12 | 12 | 12 |    |    |   
+ 15 | 15 | 15 |    |    |   
+ 20 | 20 | 20 |    |    |   
+  5 |  5 |    |    |    |   
+  6 |  6 |    |    |    |   
+  9 |  9 |    |    |    |   
+ 10 | 10 |    |    |    |   
+ 11 | 11 | 11 |    |    |   
+ 13 | 13 | 13 |    |    |   
+ 14 | 14 | 14 |    |    |   
+ 17 | 17 | 17 |    |    |   
+  2 |  2 |    |    |    |   
+  3 |  3 |    |    |    |   
+  4 |  4 |    |    |    |   
+  7 |  7 |    |    |    |   
+  8 |  8 |    |    |    |   
+ 16 | 16 | 16 |    |    |   
+ 18 | 18 | 18 |    |    |   
+ 19 | 19 | 19 |    |    |   
+(20 rows)
+
+explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=40000000007.26..40000000009.47 rows=20 width=24)
+   ->  Nested Loop Left Join  (cost=40000000007.26..40000000009.47 rows=7 width=24)
+         Join Filter: (NOT (o2.a2 IS DISTINCT FROM o3.a3))
+         ->  Merge Left Join  (cost=20000000007.26..20000000007.61 rows=7 width=16)
+               Merge Cond: (o1.a1 = o2.a2)
+               ->  Sort  (cost=10000000003.63..10000000003.68 rows=7 width=8)
+                     Sort Key: o1.a1
+                     ->  Seq Scan on o1  (cost=10000000000.00..10000000003.20 rows=7 width=8)
+               ->  Sort  (cost=10000000003.63..10000000003.68 rows=7 width=8)
+                     Sort Key: o2.a2
+                     ->  Seq Scan on o2  (cost=10000000000.00..10000000003.20 rows=7 width=8)
+         ->  Materialize  (cost=10000000000.00..10000000001.07 rows=1 width=8)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=10000000000.00..10000000001.05 rows=1 width=8)
+                     ->  Seq Scan on o3  (cost=10000000000.00..10000000001.01 rows=1 width=8)
+ Optimizer: Postgres query optimizer
+(15 rows)
+
+explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 is distinct from b3;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=40000000007.26..40000000009.62 rows=20 width=24)
+   ->  Nested Loop Left Join  (cost=40000000007.26..40000000009.62 rows=7 width=24)
+         Join Filter: ((NOT (o2.a2 IS DISTINCT FROM o3.a3)) AND (o2.b2 IS DISTINCT FROM o3.b3))
+         ->  Merge Left Join  (cost=20000000007.26..20000000007.61 rows=7 width=16)
+               Merge Cond: (o1.a1 = o2.a2)
+               ->  Sort  (cost=10000000003.63..10000000003.68 rows=7 width=8)
+                     Sort Key: o1.a1
+                     ->  Seq Scan on o1  (cost=10000000000.00..10000000003.20 rows=7 width=8)
+               ->  Sort  (cost=10000000003.63..10000000003.68 rows=7 width=8)
+                     Sort Key: o2.a2
+                     ->  Seq Scan on o2  (cost=10000000000.00..10000000003.20 rows=7 width=8)
+         ->  Materialize  (cost=10000000000.00..10000000001.07 rows=1 width=8)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=10000000000.00..10000000001.05 rows=1 width=8)
+                     ->  Seq Scan on o3  (cost=10000000000.00..10000000001.01 rows=1 width=8)
+ Optimizer: Postgres query optimizer
+(15 rows)
+
+explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 = b3;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=30000000009.12..30000000009.25 rows=20 width=24)
+   ->  Merge Left Join  (cost=30000000009.12..30000000009.25 rows=7 width=24)
+         Merge Cond: (o2.b2 = o3.b3)
+         Join Filter: (NOT (o2.a2 IS DISTINCT FROM o3.a3))
+         ->  Sort  (cost=20000000008.04..20000000008.09 rows=7 width=16)
+               Sort Key: o2.b2
+               ->  Merge Left Join  (cost=20000000007.26..20000000007.61 rows=7 width=16)
+                     Merge Cond: (o1.a1 = o2.a2)
+                     ->  Sort  (cost=10000000003.63..10000000003.68 rows=7 width=8)
+                           Sort Key: o1.a1
+                           ->  Seq Scan on o1  (cost=10000000000.00..10000000003.20 rows=7 width=8)
+                     ->  Sort  (cost=10000000003.63..10000000003.68 rows=7 width=8)
+                           Sort Key: o2.a2
+                           ->  Seq Scan on o2  (cost=10000000000.00..10000000003.20 rows=7 width=8)
+         ->  Sort  (cost=10000000001.07..10000000001.08 rows=1 width=8)
+               Sort Key: o3.b3
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=10000000000.00..10000000001.05 rows=1 width=8)
+                     ->  Seq Scan on o3  (cost=10000000000.00..10000000001.01 rows=1 width=8)
+ Optimizer: Postgres query optimizer
+(19 rows)
+
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -3488,6 +3488,149 @@ explain (costs off) select * from t_9427 where a in (select a from t_9427 where 
 
 drop table t_9427;
 reset optimizer;
+-- Test hashed distribution spec derivation and -- 
+-- motion enforcement given INDF join condition --
+-- Outer joins' inner table yields false nulls  --
+-- colocation if join condition is null-aware   --
+drop table o1;
+ERROR:  table "o1" does not exist
+drop table o2;
+ERROR:  table "o2" does not exist
+drop table o3;
+ERROR:  table "o3" does not exist
+create table o1 (a1 int, b1 int) distributed by (a1);
+create table o2 (a2 int, b2 int) distributed by (a2);
+create table o3 (a3 int, b3 int) distributed by (a3);
+insert into o1 select i, i from generate_series(1,20) i;
+insert into o2 select i, null from generate_series(11,30) i;
+insert into o3 values (NULL, 20);
+select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3;
+ a1 | b1 | a2 | b2 | a3 | b3 
+----+----+----+----+----+----
+  2 |  2 |    |    |    | 20
+  3 |  3 |    |    |    | 20
+  4 |  4 |    |    |    | 20
+  7 |  7 |    |    |    | 20
+  8 |  8 |    |    |    | 20
+ 16 | 16 | 16 |    |    |   
+ 18 | 18 | 18 |    |    |   
+ 19 | 19 | 19 |    |    |   
+  5 |  5 |    |    |    | 20
+  6 |  6 |    |    |    | 20
+  9 |  9 |    |    |    | 20
+ 10 | 10 |    |    |    | 20
+ 11 | 11 | 11 |    |    |   
+ 13 | 13 | 13 |    |    |   
+ 14 | 14 | 14 |    |    |   
+ 17 | 17 | 17 |    |    |   
+  1 |  1 |    |    |    | 20
+ 12 | 12 | 12 |    |    |   
+ 15 | 15 | 15 |    |    |   
+ 20 | 20 | 20 |    |    |   
+(20 rows)
+
+select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 is distinct from b3;
+ a1 | b1 | a2 | b2 | a3 | b3 
+----+----+----+----+----+----
+  5 |  5 |    |    |    | 20
+  6 |  6 |    |    |    | 20
+  9 |  9 |    |    |    | 20
+ 10 | 10 |    |    |    | 20
+ 11 | 11 | 11 |    |    |   
+ 13 | 13 | 13 |    |    |   
+ 14 | 14 | 14 |    |    |   
+ 17 | 17 | 17 |    |    |   
+  1 |  1 |    |    |    | 20
+ 12 | 12 | 12 |    |    |   
+ 15 | 15 | 15 |    |    |   
+ 20 | 20 | 20 |    |    |   
+  2 |  2 |    |    |    | 20
+  3 |  3 |    |    |    | 20
+  4 |  4 |    |    |    | 20
+  7 |  7 |    |    |    | 20
+  8 |  8 |    |    |    | 20
+ 16 | 16 | 16 |    |    |   
+ 18 | 18 | 18 |    |    |   
+ 19 | 19 | 19 |    |    |   
+(20 rows)
+
+select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 = b3;
+ a1 | b1 | a2 | b2 | a3 | b3 
+----+----+----+----+----+----
+  5 |  5 |    |    |    |   
+  6 |  6 |    |    |    |   
+  9 |  9 |    |    |    |   
+ 10 | 10 |    |    |    |   
+ 11 | 11 | 11 |    |    |   
+ 13 | 13 | 13 |    |    |   
+ 14 | 14 | 14 |    |    |   
+ 17 | 17 | 17 |    |    |   
+  1 |  1 |    |    |    |   
+ 12 | 12 | 12 |    |    |   
+ 15 | 15 | 15 |    |    |   
+ 20 | 20 | 20 |    |    |   
+  2 |  2 |    |    |    |   
+  3 |  3 |    |    |    |   
+  4 |  4 |    |    |    |   
+  7 |  7 |    |    |    |   
+  8 |  8 |    |    |    |   
+ 16 | 16 | 16 |    |    |   
+ 18 | 18 | 18 |    |    |   
+ 19 | 19 | 19 |    |    |   
+(20 rows)
+
+explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.01 rows=44 width=24)
+   ->  Hash Left Join  (cost=0.00..1293.01 rows=15 width=24)
+         Hash Cond: (NOT (o2.a2 IS DISTINCT FROM o3.a3))
+         ->  Hash Left Join  (cost=0.00..862.00 rows=14 width=16)
+               Hash Cond: (o1.a1 = o2.a2)
+               ->  Seq Scan on o1  (cost=0.00..431.00 rows=7 width=8)
+               ->  Hash  (cost=431.00..431.00 rows=7 width=8)
+                     ->  Seq Scan on o2  (cost=0.00..431.00 rows=7 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Seq Scan on o3  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
+explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 is distinct from b3;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.01 rows=40 width=24)
+   ->  Hash Left Join  (cost=0.00..1293.01 rows=14 width=24)
+         Hash Cond: (NOT (o2.a2 IS DISTINCT FROM o3.a3))
+         Join Filter: (o2.b2 IS DISTINCT FROM o3.b3)
+         ->  Hash Left Join  (cost=0.00..862.00 rows=14 width=16)
+               Hash Cond: (o1.a1 = o2.a2)
+               ->  Seq Scan on o1  (cost=0.00..431.00 rows=7 width=8)
+               ->  Hash  (cost=431.00..431.00 rows=7 width=8)
+                     ->  Seq Scan on o2  (cost=0.00..431.00 rows=7 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Seq Scan on o3  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+
+explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 = b3;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.01 rows=40 width=24)
+   ->  Hash Left Join  (cost=0.00..1293.01 rows=14 width=24)
+         Hash Cond: ((NOT (o2.a2 IS DISTINCT FROM o3.a3)) AND (o2.b2 = o3.b3))
+         ->  Hash Left Join  (cost=0.00..862.00 rows=14 width=16)
+               Hash Cond: (o1.a1 = o2.a2)
+               ->  Seq Scan on o1  (cost=0.00..431.00 rows=7 width=8)
+               ->  Hash  (cost=431.00..431.00 rows=7 width=8)
+                     ->  Seq Scan on o2  (cost=0.00..431.00 rows=7 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Seq Scan on o3  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';

--- a/src/test/regress/sql/bfv_joins.sql
+++ b/src/test/regress/sql/bfv_joins.sql
@@ -401,6 +401,31 @@ explain (costs off) select * from t_9427 where a in (select a from t_9427 where 
 drop table t_9427;
 reset optimizer;
 
+-- Test hashed distribution spec derivation and -- 
+-- motion enforcement given INDF join condition --
+-- Outer joins' inner table yields false nulls  --
+-- colocation if join condition is null-aware   --
+drop table o1;
+drop table o2;
+drop table o3;
+
+create table o1 (a1 int, b1 int) distributed by (a1);
+create table o2 (a2 int, b2 int) distributed by (a2);
+create table o3 (a3 int, b3 int) distributed by (a3);
+
+insert into o1 select i, i from generate_series(1,20) i;
+insert into o2 select i, null from generate_series(11,30) i;
+insert into o3 values (NULL, 20);
+
+select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3;
+select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 is distinct from b3;
+select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 = b3;
+
+explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3;
+explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 is distinct from b3;
+explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 = b3;
+
+
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';


### PR DESCRIPTION
Issue: Community reports regression that post-fc662ea plans had redundant redistribution motion in inner joins

Root cause: Blanket change of Nulls Colocation to false in computing a matching hashed distribution spec

Solution: In matching a hashed distribution spec in inner join operations, set Nulls Colocation to true; and in matching a hashed distribution spec in outer join operations, set Nulls Colocation to false only if the join condition isn't null-aware. This reflects the Nulls Colocation property required for / delivered by the outer relation in hash join operations.

Implementation:
    [CPhysicalHashJoin] -- Return Nulls Colocation in spec matching for inner joins, and Non Nulls Colocation for outer joins.
    [CPhysicalLeftOuterHashJoin] -- Add TODO comment. Left outer join should be able to return a combined hash spec even when only one relation is hash distributed.
    [CXformUtils] -- Check if the join condition is composed of equality predicates only. The output is passed to AddHashOrMergeJoinAlternative for determination of join condition null-awareness.
    [CPhysical*Join] -- Add is_null_aware member to all the classes using the AddHashOrMergeJoinAlternative template. If the join is null-aware, nulls colocation has to be set true in deriving/requesting hash distribution specs. If the join isn't null-aware, nulls colocation can be set false.
    [regression] -- Test hashed distribution spec derivation and motion enforcement in outer join with INDF join condition
    [minidump] -- Space size change only. Added user's example to verify inner join matches the outer relation's Nulls Colocation.