### PR TITLE
Fix flaky test in insert_root_partition_truncate_deadlock_without_gdd

### DIFF
--- a/src/test/isolation2/expected/gdd/insert_root_partition_truncate_deadlock.out
+++ b/src/test/isolation2/expected/gdd/insert_root_partition_truncate_deadlock.out
@@ -13,7 +13,7 @@
 create table rank_13652 (id int, year int) partition by range (year) (start (2006) end (2009) every (1));
 CREATE
 
-select gp_inject_fault('func_init_plan_end', 'suspend', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+1: select gp_inject_fault('func_init_plan_end', 'suspend', dbid, current_setting('gp_session_id')::int) from gp_segment_configuration where content = 0 and role = 'p';
  gp_inject_fault 
 -----------------
  Success:        

--- a/src/test/isolation2/expected/insert_root_partition_truncate_deadlock_without_gdd.out
+++ b/src/test/isolation2/expected/insert_root_partition_truncate_deadlock_without_gdd.out
@@ -13,7 +13,7 @@
 create table rank_13652 (id int, year int) partition by range (year) (start (2006) end (2009) every (1));
 CREATE
 
-select gp_inject_fault('func_init_plan_end', 'suspend', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+1: select gp_inject_fault('func_init_plan_end', 'suspend', dbid, current_setting('gp_session_id')::int) from gp_segment_configuration where content = 0 and role = 'p';
  gp_inject_fault 
 -----------------
  Success:        

--- a/src/test/isolation2/sql/gdd/insert_root_partition_truncate_deadlock.sql
+++ b/src/test/isolation2/sql/gdd/insert_root_partition_truncate_deadlock.sql
@@ -14,7 +14,7 @@ create table rank_13652 (id int, year int)
 partition by range (year)
 (start (2006) end (2009) every (1));
 
-select gp_inject_fault('func_init_plan_end', 'suspend', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+1: select gp_inject_fault('func_init_plan_end', 'suspend', dbid, current_setting('gp_session_id')::int) from gp_segment_configuration where content = 0 and role = 'p';
 
 1&: insert into rank_13652 select i,i%3+2006 from generate_series(1, 30)i;
 select gp_wait_until_triggered_fault('func_init_plan_end', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';

--- a/src/test/isolation2/sql/insert_root_partition_truncate_deadlock_without_gdd.sql
+++ b/src/test/isolation2/sql/insert_root_partition_truncate_deadlock_without_gdd.sql
@@ -14,7 +14,7 @@ create table rank_13652 (id int, year int)
 partition by range (year)
 (start (2006) end (2009) every (1));
 
-select gp_inject_fault('func_init_plan_end', 'suspend', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+1: select gp_inject_fault('func_init_plan_end', 'suspend', dbid, current_setting('gp_session_id')::int) from gp_segment_configuration where content = 0 and role = 'p';
 
 1&: insert into rank_13652 select i,i%3+2006 from generate_series(1, 30)i;
 select gp_wait_until_triggered_fault('func_init_plan_end', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';


### PR DESCRIPTION
The injected fault 'func_init_plan_end' is set only triggered once, and it's
possible that the fault can be triggered by dtx recovery process before than
insert statement. So in this case, the insert statement is not blocked which
causes the pipeline failed.

Inject the fault 'func_init_plan_end' in the same session as the insert, and
specify the current sessionid, so that the fault can't be triggered by other
sessions.

The test insert_root_partition_truncate_deadlock with gdd have the same problem.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
