### PR TITLE
gppkg: check if SCP command runs succeed

### DIFF
--- a/gpMgmt/bin/gppylib/operations/package.py
+++ b/gpMgmt/bin/gppylib/operations/package.py
@@ -1587,7 +1587,7 @@ class GpScp(Operation):
                                      dstFile=self.target_path,
                                      dstHost=host))
         self.pool.join()
-
+        self.pool.check_results()
 
 class HostOperation(Operation):
     """


### PR DESCRIPTION
```
gppkg will use scp(1) to copy file to another host but if the
filesystem is read-only or disk full, GpScp will not emit an
error and the install process will be continuing.

check the scp(1) exit code, if not succeed, emit an error to
stop the install process.
```