### PR TITLE
(cherry pick from master to 6X) Fix query string truncation while writing it to server logs

### DIFF
--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -3608,7 +3608,7 @@ append_string_to_pipe_chunk(PipeProtoChunk *buffer, const char* input)
 	 */
 	if (len >= PIPE_MAX_PAYLOAD * 20)
 	{
-		len = PIPE_MAX_PAYLOAD * 20 - 1;
+		len = pg_mbcliplen(input, len, PIPE_MAX_PAYLOAD * 20 - 1);
 	}
 
 	char *data = buffer->data + buffer->hdr.len;


### PR DESCRIPTION
Long queries are truncated when logged. This wasn't done correctly
because it doesn't consider the encoding. This results in some utf
characters being truncated in the middle.

(cherry picked from commit 24f51bb06b8595ca2dc583004b5191fad72f4e4c)

Authored-by: t1mursadykov <sti@arenadata.io>

--------

Rebased version of https://github.com/greenplum-db/gpdb/pull/12008

I do not have permission to modify the original PR, so I open this one and register it to ship it.