### PR TITLE
Re-enable test with database name containing quotes.

### DIFF
--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -49,12 +49,8 @@ reset client_min_messages;
 CREATE DATABASE "funny""db'with\\quotes";
 ALTER DATABASE "funny""db'with\\quotes" SET search_path="funny""schema'with\\quotes";
 
--- GPDB_91_MERGE_FIXME: It would be good to leave the database in place, to
--- also test gpcheckcat and pg_upgrade after all the regression tests have
--- completed. As of this writing pg_upgrade does not in fact handle that well.
--- Remove this DROP DATABASE once it's fixed. That should happen when we
--- reach commit a2385cac13, which was backported to PostgreSQL 9.1.
-DROP DATABASE "funny""db'with\\quotes";
+-- Leave the database in place, to also test gpcheckcat and pg_upgrade after
+-- all the regression tests have completed.
 
 -- set_config() used to have quoting problems as well when dispatching to
 -- segments.

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -69,12 +69,8 @@ DROP DATABASE IF EXISTS "funny""db'with\\quotes";
 reset client_min_messages;
 CREATE DATABASE "funny""db'with\\quotes";
 ALTER DATABASE "funny""db'with\\quotes" SET search_path="funny""schema'with\\quotes";
--- GPDB_91_MERGE_FIXME: It would be good to leave the database in place, to
--- also test gpcheckcat and pg_upgrade after all the regression tests have
--- completed. As of this writing pg_upgrade does not in fact handle that well.
--- Remove this DROP DATABASE once it's fixed. That should happen when we
--- reach commit a2385cac13, which was backported to PostgreSQL 9.1.
-DROP DATABASE "funny""db'with\\quotes";
+-- Leave the database in place, to also test gpcheckcat and pg_upgrade after
+-- all the regression tests have completed.
 -- set_config() used to have quoting problems as well when dispatching to
 -- segments.
 CREATE TABLE IF NOT EXISTS should_be_visible();


### PR DESCRIPTION
Since the PostgreSQL 9.4.20 merge, commit 928bca1a30, pg_upgrade can
handle database names that contain quotes correctly. Re-enable test for
it.

Fixes https://github.com/greenplum-db/gpdb/issues/3857

Cherry picked from PR https://github.com/greenplum-db/gpdb/pull/6713

Authored-by: Heikki Linnakangas
