### PR TITLE
ALTER TABLE SET ACCESS METHOD: AOCO->Heap support

### DIFF
--- a/src/backend/catalog/pg_appendonly.c
+++ b/src/backend/catalog/pg_appendonly.c
@@ -27,6 +27,7 @@
 #include "access/table.h"
 #include "catalog/dependency.h"
 #include "catalog/indexing.h"
+#include "catalog/pg_attribute_encoding.h"
 #include "utils/builtins.h"
 #include "utils/inval.h"
 #include "utils/lsyscache.h"
@@ -609,9 +610,10 @@ ATAOEntries(Form_pg_class relform1, Form_pg_class relform2)
 			switch(relform2->relam)
 			{
 				case HEAP_TABLE_AM_OID:
-					ereport(ERROR,
-							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								errmsg("alter table does not support switch from AOCO to Heap")));
+					/* For pg_appendonly entries, it's the same as AO->Heap. */
+					TransferAppendonlyEntries(relform1->oid, relform2->oid);
+					/* Remove the pg_attribute_encoding entries, since heap tables shouldn't have these. */
+					RemoveAttributeEncodingsByRelid(relform1->oid);
 					break;
 				case AO_ROW_TABLE_AM_OID:
 					ereport(ERROR,

--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -883,9 +883,16 @@ make_new_heap(Oid OIDOldHeap, Oid NewTableSpace, Oid NewAccessMethod,
 
 	CacheInvalidateRelcacheByRelid(OIDNewHeap);
 
-	cloneAttributeEncoding(OIDOldHeap,
-						   OIDNewHeap,
-						   RelationGetNumberOfAttributes(OldHeap));
+	/* 
+	 * Copy the pg_attribute_encoding entries over if new table needs them.
+	 * Note that in the case of AM change from heap/ao to aoco, we still need 
+	 * to do this since we created those entries for the heap/ao table at the 
+	 * phase 2 of ATSETAM (see ATExecCmd).
+	 */
+	if (NewAccessMethod == AO_COLUMN_TABLE_AM_OID)
+		cloneAttributeEncoding(OIDOldHeap,
+							   OIDNewHeap,
+							   RelationGetNumberOfAttributes(OldHeap));
 
 	table_close(OldHeap, NoLock);
 

--- a/src/test/regress/expected/alter_table_set_am.out
+++ b/src/test/regress/expected/alter_table_set_am.out
@@ -765,6 +765,163 @@ DROP TABLE ao2co;
 DROP TABLE ao2co2;
 DROP TABLE ao2co3;
 DROP TABLE ao2co4;
+-- Scenario 6: AOCO to Heap
+SET gp_default_storage_options = 'blocksize=65536, compresstype=zlib, compresslevel=5, checksum=true';
+CREATE TABLE co2heap(a int, b int) WITH (appendonly=true, orientation=column);
+CREATE TABLE co2heap2(a int, b int) WITH (appendonly=true, orientation=column);
+CREATE TABLE co2heap3(a int, b int) WITH (appendonly=true, orientation=column);
+CREATE TABLE co2heap4(a int, b int) WITH (appendonly=true, orientation=column);
+CREATE INDEX aoi ON co2heap(b);
+INSERT INTO co2heap SELECT i,i FROM generate_series(1,5) i;
+INSERT INTO co2heap2 SELECT i,i FROM generate_series(1,5) i;
+INSERT INTO co2heap3 SELECT i,i FROM generate_series(1,5) i;
+INSERT INTO co2heap4 SELECT i,i FROM generate_series(1,5) i;
+-- Prior-ATSETAM checks:
+-- Check once that the AO tables have the custom reloptions 
+SELECT relname, reloptions FROM pg_class WHERE relname LIKE 'co2heap%';
+ relname  |            reloptions             
+----------+-----------------------------------
+ co2heap  | {blocksize=65536,compresslevel=5}
+ co2heap2 | {blocksize=65536,compresslevel=5}
+ co2heap3 | {blocksize=65536,compresslevel=5}
+ co2heap4 | {blocksize=65536,compresslevel=5}
+(4 rows)
+
+-- Check once that the AO tables have relfrozenxid = 0
+SELECT relname, relfrozenxid FROM pg_class WHERE relname LIKE 'co2heap%';
+ relname  | relfrozenxid 
+----------+--------------
+ co2heap  |            0
+ co2heap2 |            0
+ co2heap3 |            0
+ co2heap4 |            0
+(4 rows)
+
+-- Check once that the pg_attribute_encoding has entries for the AOCO tables.
+SELECT c.relname, a.attnum, attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid=c.oid AND c.relname LIKE 'co2heap%';
+ relname  | attnum |                     attoptions                      
+----------+--------+-----------------------------------------------------
+ co2heap  |      1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ co2heap  |      2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ co2heap2 |      1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ co2heap2 |      2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ co2heap3 |      1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ co2heap3 |      2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ co2heap4 |      1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ co2heap4 |      2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+(8 rows)
+
+CREATE TEMP TABLE relfilebeforeco2heap AS
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname LIKE 'co2heap%'
+    UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname LIKE 'co2heap%' ORDER BY segid;
+-- Various cases of altering AOCO to AO:
+-- 1. Basic ATSETAMs:
+ALTER TABLE co2heap SET ACCESS METHOD heap;
+ALTER TABLE co2heap2 SET WITH (appendoptimized=false);
+-- 2. ATSETAM with reloptions:
+ALTER TABLE co2heap3 SET ACCESS METHOD heap WITH (fillfactor=70);
+ALTER TABLE co2heap4 SET WITH (appendoptimized=false, fillfactor=70);
+-- The tables and indexes should have been rewritten (should have different relfilenodes)
+CREATE TEMP TABLE relfileafterco2heap AS
+    SELECT -1 segid, relfilenode FROM pg_class WHERE relname LIKE 'co2heap%'
+    UNION SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname LIKE 'co2heap%' ORDER BY segid;
+SELECT * FROM relfilebeforeco2heap INTERSECT SELECT * FROM relfileafterco2heap;
+ segid | relfilenode 
+-------+-------------
+(0 rows)
+
+-- Check data is intact
+SELECT count(*) FROM co2heap;
+ count 
+-------
+     5
+(1 row)
+
+SELECT count(*) FROM co2heap2;
+ count 
+-------
+     5
+(1 row)
+
+SELECT count(*) FROM co2heap3;
+ count 
+-------
+     5
+(1 row)
+
+SELECT count(*) FROM co2heap4;
+ count 
+-------
+     5
+(1 row)
+
+-- No AO aux tables should be left.
+-- Only testing 2 out of the 4 tables being created, where the tables were altered w/wo reloptions. 
+-- No need to test the other ones created by the alternative syntax SET WITH().
+SELECT * FROM gp_toolkit.__gp_aoseg('co2heap');
+ERROR:  'co2heap' is not an append-only row relation
+SELECT * FROM gp_toolkit.__gp_aovisimap('co2heap');
+ERROR:  function not supported on relation
+SELECT count(*) FROM gp_toolkit.__gp_aocsseg('co2heap');
+ERROR:  'co2heap' is not an append-only columnar relation
+SELECT * FROM gp_toolkit.__gp_aoblkdir('co2heap');
+ERROR:  function not supported on non append-optimized relation
+SELECT * FROM gp_toolkit.__gp_aoseg('co2heap3');
+ERROR:  'co2heap3' is not an append-only row relation
+SELECT * FROM gp_toolkit.__gp_aovisimap('co2heap3');
+ERROR:  function not supported on relation
+SELECT count(*) FROM gp_toolkit.__gp_aocsseg('co2heap3');
+ERROR:  'co2heap3' is not an append-only columnar relation
+SELECT * FROM gp_toolkit.__gp_aoblkdir('co2heap3');
+ERROR:  function not supported on non append-optimized relation
+-- No pg_appendonly entries should be left too
+SELECT c.relname FROM pg_class c, pg_appendonly p WHERE c.relname LIKE 'co2heap%' AND c.oid = p.relid;
+ relname 
+---------
+(0 rows)
+
+-- The altered tables should have heap AM.
+SELECT c.relname, a.amname FROM pg_class c JOIN pg_am a ON c.relam = a.oid WHERE c.relname LIKE 'co2heap%';
+ relname  | amname 
+----------+--------
+ co2heap  | heap
+ co2heap2 | heap
+ co2heap3 | heap
+ co2heap4 | heap
+(4 rows)
+
+-- The new heap tables shouldn't have the old AO table's reloptions
+SELECT relname, reloptions FROM pg_class WHERE relname LIKE 'co2heap%';
+ relname  |   reloptions    
+----------+-----------------
+ co2heap  | 
+ co2heap2 | 
+ co2heap3 | {fillfactor=70}
+ co2heap4 | {fillfactor=70}
+(4 rows)
+
+-- The new heap tables should have a valid relfrozenxid
+SELECT relname, relfrozenxid <> '0' FROM pg_class WHERE relname LIKE 'co2heap%';
+ relname  | ?column? 
+----------+----------
+ co2heap  | t
+ co2heap2 | t
+ co2heap3 | t
+ co2heap4 | t
+(4 rows)
+
+-- The pg_attribute_encoding entries for the altered tables should have all gone.
+SELECT c.relname, a.attnum, attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid=c.oid AND c.relname LIKE 'co2heap%';
+ relname | attnum | attoptions 
+---------+--------+------------
+(0 rows)
+
+DROP TABLE co2heap;
+DROP TABLE co2heap2;
+DROP TABLE co2heap3;
+DROP TABLE co2heap4;
 -- Final scenario: the iterations of altering table from storage type "A" to "B" and back to "A". 
 -- The following cases will cover all variations of such iterations:
 -- 1. Heap->AO->Heap->AO


### PR DESCRIPTION
Should be ready to review. But might need to make minor rebasing adjustment after https://github.com/greenplum-db/gpdb/pull/13835 is merged.

One note: in the above AO->AOCO PR we add column encoding in `ATExecCmd`, whereas in this AOCO->Heap PR we remove the same in `ATAOEntries` due to the following reasons:
* Table rewriting of AOCO table needs those encodings, so adding column encoding needs to happen **before** that, and removing them needs to happen **after** that.
* We can take WITH options (or even more from future syntax support) into consideration when adding the column encoding.

----------------

As part of the ATSETAM support, this commit adds support for
changing AM of a table from AOCO to heap. E.g.:

```
CREATE TABLE foo (appendonly=true, orientation=column);
ALTER TABLE foo SET ACCESS METHOD heap;
-- Or:
ALTER TABLE foo SET WITH (appendonly=false);
```

Optionally, user can specify reloptions in a WITH clause too, e.g.:

```
ALTER TABLE foo SET ACCESS METHOD heap WITH (fillfactor=70);
```

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/aoco2heap

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
