### PR TITLE
COPY/CLUSTER: Use ntuples for gp_fastsequence allocation 

### DIFF
--- a/src/backend/access/aocs/aocs_compaction.c
+++ b/src/backend/access/aocs/aocs_compaction.c
@@ -24,6 +24,7 @@
 #include "access/appendonly_compaction.h"
 #include "access/appendonlywriter.h"
 #include "catalog/catalog.h"
+#include "catalog/gp_fastsequence.h"
 #include "catalog/indexing.h"
 #include "catalog/pg_appendonly.h"
 #include "cdb/cdbaocsam.h"
@@ -371,7 +372,11 @@ AOCSCompact(Relation aorel,
 
 		if (*insert_segno != -1)
 		{
-			insertDesc = aocs_insert_init(aorel, *insert_segno);
+			/*
+			 * Note: since we don't know how many rows will actually be inserted
+			 * we provide the default number of rows to bump gp_fastsequence by.
+			 */
+			insertDesc = aocs_insert_init(aorel, *insert_segno, NUM_FAST_SEQUENCES);
 
 			AOCSSegmentFileFullCompaction(aorel,
 										  insertDesc,

--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -34,6 +34,7 @@
 #include "access/tuptoaster.h"
 #include "access/xact.h"
 #include "catalog/catalog.h"
+#include "catalog/gp_fastsequence.h"
 #include "catalog/indexing.h"
 #include "catalog/pg_am.h"
 #include "catalog/pg_appendonly.h"
@@ -795,7 +796,11 @@ AppendOnlyCompact(Relation aorel,
 		}
 		if (*insert_segno != -1)
 		{
-			insertDesc = appendonly_insert_init(aorel, *insert_segno);
+			/*
+			 * Note: since we don't know how many rows will actually be inserted,
+			 * we provide the default number of rows to bump gp_fastsequence by.
+			 */
+			insertDesc = appendonly_insert_init(aorel, *insert_segno, NUM_FAST_SEQUENCES);
 			AppendOnlySegmentFileFullCompaction(aorel,
 												insertDesc,
 												fsinfo,

--- a/src/backend/catalog/gp_fastsequence.c
+++ b/src/backend/catalog/gp_fastsequence.c
@@ -118,6 +118,12 @@ insert_or_update_fastsequence(Relation gp_fastsequence_rel,
 
 		CatalogTupleInsertFrozen(gp_fastsequence_rel, newTuple);
 
+		elogif(Debug_appendonly_print_insert_tuple, LOG,
+			   "Frozen insert to gp_fastsequence (rel, segno, last_sequence): (%u, %ld, %ld)",
+			   objid,
+			   objmod,
+			   newLastSequence);
+
 		heap_freetuple(newTuple);
 	}
 	else
@@ -151,6 +157,14 @@ insert_or_update_fastsequence(Relation gp_fastsequence_rel,
 		newTuple->t_data->t_ctid = oldTuple->t_data->t_ctid;
 		newTuple->t_self = oldTuple->t_self;
 		heap_inplace_update(gp_fastsequence_rel, newTuple);
+
+		elogif(Debug_appendonly_print_insert_tuple, LOG,
+			   "In-place update to gp_fastsequence (ctid, rel, segno, last_sequence): ((%u, %u), %u, %ld, %ld)",
+			   ItemPointerGetBlockNumberNoCheck(&newTuple->t_data->t_ctid),
+			   ItemPointerGetOffsetNumberNoCheck(&newTuple->t_data->t_ctid),
+			   objid,
+			   objmod,
+			   newLastSequence);
 
 		heap_freetuple(newTuple);
 	}

--- a/src/include/cdb/cdbaocsam.h
+++ b/src/include/cdb/cdbaocsam.h
@@ -302,7 +302,7 @@ extern void aocs_rescan(AOCSScanDesc scan);
 extern void aocs_endscan(AOCSScanDesc scan);
 
 extern bool aocs_getnext(AOCSScanDesc scan, ScanDirection direction, TupleTableSlot *slot);
-extern AOCSInsertDesc aocs_insert_init(Relation rel, int segno);
+extern AOCSInsertDesc aocs_insert_init(Relation rel, int segno, int64 num_rows);
 extern void aocs_insert_values(AOCSInsertDesc idesc, Datum *d, bool *null, AOTupleId *aoTupleId);
 static inline void aocs_insert(AOCSInsertDesc idesc, TupleTableSlot *slot)
 {

--- a/src/include/cdb/cdbappendonlyam.h
+++ b/src/include/cdb/cdbappendonlyam.h
@@ -388,7 +388,9 @@ extern bool appendonly_fetch(
 	TupleTableSlot *slot);
 extern void appendonly_fetch_finish(AppendOnlyFetchDesc aoFetchDesc);
 extern void appendonly_dml_init(Relation relation, CmdType operation);
-extern AppendOnlyInsertDesc appendonly_insert_init(Relation rel, int segno);
+extern AppendOnlyInsertDesc appendonly_insert_init(Relation rel,
+												   int segno,
+												   int64 num_rows);
 extern void appendonly_insert(
 		AppendOnlyInsertDesc aoInsertDesc, 
 		MemTuple instup, 

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -30,6 +30,8 @@ test: copy_eol
 # file related tests (like gp_log_system, etc) faster.
 test: disable_autovacuum
 test: gp_toolkit
+# test gp_fastsequence allocation (early in schedule as log grepping is expensive)
+test: uao_dml/gp_fastsequence_row uao_dml/gp_fastsequence_column
 test: python_processed64bit
 test: enable_autovacuum
 

--- a/src/test/regress/input/uao_dml/gp_fastsequence.source
+++ b/src/test/regress/input/uao_dml/gp_fastsequence.source
@@ -1,0 +1,83 @@
+-- White-box test to validate insert and update behavior for gp_fastsequence
+-- in various scenarios involving the insert code path for AO and AOCO tables.
+
+CREATE SCHEMA test_gp_fastsequence_@amname@;
+SET search_path="$user",test_gp_fastsequence_@amname@,public;
+
+SET default_table_access_method=@amname@;
+
+CREATE OR REPLACE FUNCTION fastseq_details(input_query_regex text)
+  RETURNS TABLE (logdatabase text, logsegment text, logseverity text, logdebug text, logmessage text)
+  LANGUAGE plpgsql AS
+$func$
+BEGIN
+  RETURN QUERY
+  SELECT * FROM
+  (SELECT l1.logdatabase, l1.logsegment, l1.logseverity, input_query_regex AS logdebug,
+    regexp_replace(l1.logmessage,
+                   '^Frozen insert to gp_fastsequence \(rel, segno, last_sequence\): \(\d+',
+                   'Frozen insert to gp_fastsequence (rel, segno, last_sequence): (reloid',
+                   'p') AS logmessage
+    FROM gp_toolkit.gp_log_system l1
+    WHERE l1.logsegment = 'seg0'
+      AND l1.logsession = (SELECT 'con' || current_setting('gp_session_id'))
+      AND l1.logmessage LIKE 'Frozen insert to gp_fastsequence%'
+      AND l1.logdebug LIKE input_query_regex
+
+    UNION
+
+    SELECT l2.logdatabase, l2.logsegment, l2.logseverity, input_query_regex AS logdebug,
+    regexp_replace(l2.logmessage,
+                   '^In-place update to gp_fastsequence \(ctid, rel, segno, last_sequence\): \(\(\d+, \d+\), \d+',
+                   'In-place update to gp_fastsequence (ctid, rel, segno, last_sequence): ((block, offset), first_row_num',
+                   'p') AS logmessage
+    FROM gp_toolkit.gp_log_system l2
+    WHERE l2.logsegment = 'seg0'
+      AND l2.logsession = (SELECT 'con' || current_setting('gp_session_id'))
+      AND l2.logmessage LIKE 'In-place update to gp_fastsequence%'
+      AND l2.logdebug LIKE input_query_regex) s
+  ORDER BY logdebug, logmessage;
+END
+$func$;
+
+SET debug_appendonly_print_insert_tuple TO on;
+
+-- INSERT case: since we can't tell how many rows there are, we can't
+-- preallocate gp_fastsequence accordingly, and we must do allocations on the
+-- basis of NUM_FAST_SEQUENCES (100). So there will be 1 frozen insert and 9
+-- in-place updates for each table.
+CREATE TABLE test_fastseq_insert_@amname@(i int, j int DEFAULT 2) WITH (appendonly=true) DISTRIBUTED BY (j);
+INSERT INTO test_fastseq_insert_@amname@ SELECT generate_series(1, 900);
+
+SELECT * from fastseq_details('INSERT INTO test_fastseq_insert%');
+
+-- COPY case: since we can tell how many rows there are, we can preallocate
+-- gp_fastsequence accordingly. So there will be 1 frozen insert and 1 in-place
+-- update for each table.
+CREATE TABLE test_fastseq_copy_@amname@(i int, j int DEFAULT 2) WITH (appendonly=true) DISTRIBUTED BY (j);
+COPY test_fastseq_copy_@amname@(i) FROM PROGRAM 'seq 1 900';
+
+SELECT * from fastseq_details('COPY test_fastseq_copy_%');
+
+-- CLUSTER case: since we can tell how many rows there are, we can preallocate
+-- gp_fastsequence accordingly. So there will be 1 frozen insert and 1 in-place
+-- update for each table.
+CREATE TABLE test_fastseq_cluster_@amname@(i int, j int DEFAULT 2) WITH (appendonly=true) DISTRIBUTED BY (j);
+CREATE INDEX test_fastseq_cluster_@amname@_idx ON test_fastseq_cluster_@amname@(i);
+INSERT INTO test_fastseq_cluster_@amname@ SELECT generate_series(1, 900);
+CLUSTER test_fastseq_cluster_@amname@ USING test_fastseq_cluster_@amname@_idx;
+
+SELECT * from fastseq_details('CLUSTER test_fastseq_cluster_%');
+
+-- VACUUM FULL case: since we can't tell how many visible rows there are, we can't
+-- preallocate gp_fastsequence accordingly, and we must do allocations on the
+-- basis of NUM_FAST_SEQUENCES (100). So there will be 1 frozen insert and 9
+-- in-place updates for each table.
+CREATE TABLE test_fastseq_vacuum_@amname@(i int, j int DEFAULT 2) WITH (appendonly=true) DISTRIBUTED BY (j);
+INSERT INTO test_fastseq_vacuum_@amname@ SELECT generate_series(1, 901);
+DELETE FROM test_fastseq_vacuum_@amname@ WHERE i = 901;
+VACUUM FULL test_fastseq_vacuum_@amname@;
+
+SELECT * from fastseq_details('VACUUM FULL test_fastseq_vacuum_%');
+
+RESET debug_appendonly_print_insert_tuple;

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -352,12 +352,12 @@ IN (SELECT segrelid FROM pg_appendonly WHERE relid IN (SELECT oid FROM pg_class
 WHERE relname='tenk_ao1'));
    case    | objmod | last_sequence | gp_segment_id 
 -----------+--------+---------------+---------------
- NormalXid |      0 |             0 |             1
- FrozenXid |      1 |         17000 |             1
  NormalXid |      0 |             0 |             0
- FrozenXid |      1 |         17000 |             0
+ FrozenXid |      1 |         16998 |             0
  NormalXid |      0 |             0 |             2
- FrozenXid |      1 |         16400 |             2
+ FrozenXid |      1 |         16395 |             2
+ NormalXid |      0 |             0 |             1
+ FrozenXid |      1 |         16996 |             1
 (6 rows)
 
 -- commit

--- a/src/test/regress/output/uao_dml/gp_fastsequence.source
+++ b/src/test/regress/output/uao_dml/gp_fastsequence.source
@@ -1,0 +1,110 @@
+-- White-box test to validate insert and update behavior for gp_fastsequence
+-- in various scenarios involving the insert code path for AO and AOCO tables.
+CREATE SCHEMA test_gp_fastsequence_@amname@;
+SET search_path="$user",test_gp_fastsequence_@amname@,public;
+SET default_table_access_method=@amname@;
+CREATE OR REPLACE FUNCTION fastseq_details(input_query_regex text)
+  RETURNS TABLE (logdatabase text, logsegment text, logseverity text, logdebug text, logmessage text)
+  LANGUAGE plpgsql AS
+$func$
+BEGIN
+  RETURN QUERY
+  SELECT * FROM
+  (SELECT l1.logdatabase, l1.logsegment, l1.logseverity, input_query_regex AS logdebug,
+    regexp_replace(l1.logmessage,
+                   '^Frozen insert to gp_fastsequence \(rel, segno, last_sequence\): \(\d+',
+                   'Frozen insert to gp_fastsequence (rel, segno, last_sequence): (reloid',
+                   'p') AS logmessage
+    FROM gp_toolkit.gp_log_system l1
+    WHERE l1.logsegment = 'seg0'
+      AND l1.logsession = (SELECT 'con' || current_setting('gp_session_id'))
+      AND l1.logmessage LIKE 'Frozen insert to gp_fastsequence%'
+      AND l1.logdebug LIKE input_query_regex
+
+    UNION
+
+    SELECT l2.logdatabase, l2.logsegment, l2.logseverity, input_query_regex AS logdebug,
+    regexp_replace(l2.logmessage,
+                   '^In-place update to gp_fastsequence \(ctid, rel, segno, last_sequence\): \(\(\d+, \d+\), \d+',
+                   'In-place update to gp_fastsequence (ctid, rel, segno, last_sequence): ((block, offset), first_row_num',
+                   'p') AS logmessage
+    FROM gp_toolkit.gp_log_system l2
+    WHERE l2.logsegment = 'seg0'
+      AND l2.logsession = (SELECT 'con' || current_setting('gp_session_id'))
+      AND l2.logmessage LIKE 'In-place update to gp_fastsequence%'
+      AND l2.logdebug LIKE input_query_regex) s
+  ORDER BY logdebug, logmessage;
+END
+$func$;
+SET debug_appendonly_print_insert_tuple TO on;
+-- INSERT case: since we can't tell how many rows there are, we can't
+-- preallocate gp_fastsequence accordingly, and we must do allocations on the
+-- basis of NUM_FAST_SEQUENCES (100). So there will be 1 frozen insert and 9
+-- in-place updates for each table.
+CREATE TABLE test_fastseq_insert_@amname@(i int, j int DEFAULT 2) WITH (appendonly=true) DISTRIBUTED BY (j);
+INSERT INTO test_fastseq_insert_@amname@ SELECT generate_series(1, 900);
+SELECT * from fastseq_details('INSERT INTO test_fastseq_insert%');
+ logdatabase | logsegment | logseverity |             logdebug             |                                                   logmessage                                                    
+-------------+------------+-------------+----------------------------------+-----------------------------------------------------------------------------------------------------------------
+ regression  | seg0       | LOG         | INSERT INTO test_fastseq_insert% | Frozen insert to gp_fastsequence (rel, segno, last_sequence): (reloid, 1, 100)
+ regression  | seg0       | LOG         | INSERT INTO test_fastseq_insert% | In-place update to gp_fastsequence (ctid, rel, segno, last_sequence): ((block, offset), first_row_num, 1, 1000)
+ regression  | seg0       | LOG         | INSERT INTO test_fastseq_insert% | In-place update to gp_fastsequence (ctid, rel, segno, last_sequence): ((block, offset), first_row_num, 1, 200)
+ regression  | seg0       | LOG         | INSERT INTO test_fastseq_insert% | In-place update to gp_fastsequence (ctid, rel, segno, last_sequence): ((block, offset), first_row_num, 1, 300)
+ regression  | seg0       | LOG         | INSERT INTO test_fastseq_insert% | In-place update to gp_fastsequence (ctid, rel, segno, last_sequence): ((block, offset), first_row_num, 1, 400)
+ regression  | seg0       | LOG         | INSERT INTO test_fastseq_insert% | In-place update to gp_fastsequence (ctid, rel, segno, last_sequence): ((block, offset), first_row_num, 1, 500)
+ regression  | seg0       | LOG         | INSERT INTO test_fastseq_insert% | In-place update to gp_fastsequence (ctid, rel, segno, last_sequence): ((block, offset), first_row_num, 1, 600)
+ regression  | seg0       | LOG         | INSERT INTO test_fastseq_insert% | In-place update to gp_fastsequence (ctid, rel, segno, last_sequence): ((block, offset), first_row_num, 1, 700)
+ regression  | seg0       | LOG         | INSERT INTO test_fastseq_insert% | In-place update to gp_fastsequence (ctid, rel, segno, last_sequence): ((block, offset), first_row_num, 1, 800)
+ regression  | seg0       | LOG         | INSERT INTO test_fastseq_insert% | In-place update to gp_fastsequence (ctid, rel, segno, last_sequence): ((block, offset), first_row_num, 1, 900)
+(10 rows)
+
+-- COPY case: since we can tell how many rows there are, we can preallocate
+-- gp_fastsequence accordingly. So there will be 1 frozen insert and 1 in-place
+-- update for each table.
+CREATE TABLE test_fastseq_copy_@amname@(i int, j int DEFAULT 2) WITH (appendonly=true) DISTRIBUTED BY (j);
+COPY test_fastseq_copy_@amname@(i) FROM PROGRAM 'seq 1 900';
+SELECT * from fastseq_details('COPY test_fastseq_copy_%');
+ logdatabase | logsegment | logseverity |         logdebug         |                                                   logmessage                                                    
+-------------+------------+-------------+--------------------------+-----------------------------------------------------------------------------------------------------------------
+ regression  | seg0       | LOG         | COPY test_fastseq_copy_% | Frozen insert to gp_fastsequence (rel, segno, last_sequence): (reloid, 1, 900)
+ regression  | seg0       | LOG         | COPY test_fastseq_copy_% | In-place update to gp_fastsequence (ctid, rel, segno, last_sequence): ((block, offset), first_row_num, 1, 1000)
+(2 rows)
+
+-- CLUSTER case: since we can tell how many rows there are, we can preallocate
+-- gp_fastsequence accordingly. So there will be 1 frozen insert and 1 in-place
+-- update for each table.
+CREATE TABLE test_fastseq_cluster_@amname@(i int, j int DEFAULT 2) WITH (appendonly=true) DISTRIBUTED BY (j);
+CREATE INDEX test_fastseq_cluster_@amname@_idx ON test_fastseq_cluster_@amname@(i);
+INSERT INTO test_fastseq_cluster_@amname@ SELECT generate_series(1, 900);
+CLUSTER test_fastseq_cluster_@amname@ USING test_fastseq_cluster_@amname@_idx;
+SELECT * from fastseq_details('CLUSTER test_fastseq_cluster_%');
+ logdatabase | logsegment | logseverity |            logdebug            |                                                   logmessage                                                    
+-------------+------------+-------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------
+ regression  | seg0       | LOG         | CLUSTER test_fastseq_cluster_% | In-place update to gp_fastsequence (ctid, rel, segno, last_sequence): ((block, offset), first_row_num, 0, 1000)
+ regression  | seg0       | LOG         | CLUSTER test_fastseq_cluster_% | In-place update to gp_fastsequence (ctid, rel, segno, last_sequence): ((block, offset), first_row_num, 0, 900)
+(2 rows)
+
+-- VACUUM FULL case: since we can't tell how many visible rows there are, we can't
+-- preallocate gp_fastsequence accordingly, and we must do allocations on the
+-- basis of NUM_FAST_SEQUENCES (100). So there will be 1 frozen insert and 9
+-- in-place updates for each table.
+CREATE TABLE test_fastseq_vacuum_@amname@(i int, j int DEFAULT 2) WITH (appendonly=true) DISTRIBUTED BY (j);
+INSERT INTO test_fastseq_vacuum_@amname@ SELECT generate_series(1, 901);
+DELETE FROM test_fastseq_vacuum_@amname@ WHERE i = 901;
+VACUUM FULL test_fastseq_vacuum_@amname@;
+SELECT * from fastseq_details('VACUUM FULL test_fastseq_vacuum_%');
+ logdatabase | logsegment | logseverity |             logdebug              |                                                   logmessage                                                    
+-------------+------------+-------------+-----------------------------------+-----------------------------------------------------------------------------------------------------------------
+ regression  | seg0       | LOG         | VACUUM FULL test_fastseq_vacuum_% | Frozen insert to gp_fastsequence (rel, segno, last_sequence): (reloid, 2, 100)
+ regression  | seg0       | LOG         | VACUUM FULL test_fastseq_vacuum_% | In-place update to gp_fastsequence (ctid, rel, segno, last_sequence): ((block, offset), first_row_num, 2, 1000)
+ regression  | seg0       | LOG         | VACUUM FULL test_fastseq_vacuum_% | In-place update to gp_fastsequence (ctid, rel, segno, last_sequence): ((block, offset), first_row_num, 2, 200)
+ regression  | seg0       | LOG         | VACUUM FULL test_fastseq_vacuum_% | In-place update to gp_fastsequence (ctid, rel, segno, last_sequence): ((block, offset), first_row_num, 2, 300)
+ regression  | seg0       | LOG         | VACUUM FULL test_fastseq_vacuum_% | In-place update to gp_fastsequence (ctid, rel, segno, last_sequence): ((block, offset), first_row_num, 2, 400)
+ regression  | seg0       | LOG         | VACUUM FULL test_fastseq_vacuum_% | In-place update to gp_fastsequence (ctid, rel, segno, last_sequence): ((block, offset), first_row_num, 2, 500)
+ regression  | seg0       | LOG         | VACUUM FULL test_fastseq_vacuum_% | In-place update to gp_fastsequence (ctid, rel, segno, last_sequence): ((block, offset), first_row_num, 2, 600)
+ regression  | seg0       | LOG         | VACUUM FULL test_fastseq_vacuum_% | In-place update to gp_fastsequence (ctid, rel, segno, last_sequence): ((block, offset), first_row_num, 2, 700)
+ regression  | seg0       | LOG         | VACUUM FULL test_fastseq_vacuum_% | In-place update to gp_fastsequence (ctid, rel, segno, last_sequence): ((block, offset), first_row_num, 2, 800)
+ regression  | seg0       | LOG         | VACUUM FULL test_fastseq_vacuum_% | In-place update to gp_fastsequence (ctid, rel, segno, last_sequence): ((block, offset), first_row_num, 2, 900)
+(10 rows)
+
+RESET debug_appendonly_print_insert_tuple;


### PR DESCRIPTION
For multi-insert, our insert workflow already supports batched WAL and
there is no page locking by virtue of buffer cache bypass for AO/CO
relations. So there is not much to gain over the existing
call-single-insert-in-a-loop approach that we have. There is except for
optimizing gp_fastsequence in-place updates. This is described below:

For COPY, we know the number of tuples to be inserted for every
invocation of table_multi_insert(). Due to the sizing of the copy
buffer, we can call table_multi_insert() with #rows = 1000 in the best
case => which implies we can cut down on the number of in-place updates
by a factor of 10 in the best case(as we don't have to do 10 piecemeal
allocations of NUM_FAST_SEQUENCES each). This can give us a performance
boost, specially when we have concurrent queries on the same table (as
GetFastSequences() grabs a RowExclusive lock).

We can do the same thing for CLUSTER, where we know how many tuples are
involved in the invoked insert.

We can't do this for piecemeal INSERTs and VACUUM because we don't know
the number of tuples and the number of visible tuples respectively.

PS: We extend the use of debug_appendonly_print_insert_tuple to give us
insight into gp_fastsequence manipulation.