### PR TITLE
Fix improper copying of group statistics in Orca

### DIFF
--- a/src/backend/gporca/libgpopt/src/mdcache/CMDAccessor.cpp
+++ b/src/backend/gporca/libgpopt/src/mdcache/CMDAccessor.cpp
@@ -1117,7 +1117,8 @@ CMDAccessor::Pstats(CMemoryPool *mp, IMDId *rel_mdid, CColRefSet *pcrsHist,
 
 	return GPOS_NEW(mp) CStatistics(
 		mp, col_histogram_mapping, colid_width_mapping, rows, fEmptyTable,
-		pmdRelStats->RelPages(), pmdRelStats->RelAllVisible());
+		pmdRelStats->RelPages(), pmdRelStats->RelAllVisible(),
+		1.0 /* default rebinds */, 0 /* default predicates*/);
 }
 
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatistics.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CStatistics.h
@@ -143,7 +143,8 @@ public:
 
 	CStatistics(CMemoryPool *mp, UlongToHistogramMap *col_histogram_mapping,
 				UlongToDoubleMap *colid_width_mapping, CDouble rows,
-				BOOL is_empty, ULONG relpages, ULONG relallvisible);
+				BOOL is_empty, ULONG relpages, ULONG relallvisible,
+				CDouble rebinds, ULONG num_predicates);
 
 
 	// dtor

--- a/src/backend/gporca/server/include/unittest/dxl/statistics/CStatisticsTest.h
+++ b/src/backend/gporca/server/include/unittest/dxl/statistics/CStatisticsTest.h
@@ -119,6 +119,9 @@ public:
 	// GbAgg test when grouping on repeated columns
 	static GPOS_RESULT EresUnittest_GbAggWithRepeatedGbCols();
 
+	// test that stats copy methods copy all fields
+	static GPOS_RESULT EresUnittest_CStatisticsCopy();
+
 
 };	// class CStatisticsTest
 }  // namespace gpnaucrates

--- a/src/backend/gporca/server/src/unittest/dxl/statistics/CStatisticsTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/statistics/CStatisticsTest.cpp
@@ -707,18 +707,16 @@ CStatisticsTest::EresUnittest_CStatisticsCopy()
 	CMemoryPool *mp = amp.Pmp();
 
 	// create another statistics structure with a single int4 column with id 10
-	UlongToHistogramMap *phmulhist2 = GPOS_NEW(mp) UlongToHistogramMap(mp);
-	phmulhist2->Insert(GPOS_NEW(mp) ULONG(10), PhistExampleInt4Dim(mp));
+	UlongToHistogramMap *phmulhist = GPOS_NEW(mp) UlongToHistogramMap(mp);
+	phmulhist->Insert(GPOS_NEW(mp) ULONG(10), PhistExampleInt4Dim(mp));
 
-	UlongToDoubleMap *phmuldoubleWidth2 = GPOS_NEW(mp) UlongToDoubleMap(mp);
-	phmuldoubleWidth2->Insert(GPOS_NEW(mp) ULONG(10),
-							  GPOS_NEW(mp) CDouble(4.0));
+	UlongToDoubleMap *phmuldoubleWidth = GPOS_NEW(mp) UlongToDoubleMap(mp);
+	phmuldoubleWidth->Insert(GPOS_NEW(mp) ULONG(10), GPOS_NEW(mp) CDouble(4.0));
 
-	CStatistics *pstats = GPOS_NEW(mp)
-		CStatistics(mp, phmulhist2, phmuldoubleWidth2, 100.0 /* rows */,
-					false /* is_empty */, ULONG(5) /* relpages */,
-					ULONG(10) /* relallvisible */, CDouble(100.0) /* rebinds */,
-					ULONG(3) /* num predicates */);
+	CStatistics *pstats = GPOS_NEW(mp) CStatistics(
+		mp, phmulhist, phmuldoubleWidth, 100.0 /* rows */, false /* is_empty */,
+		ULONG(5) /* relpages */, ULONG(10) /* relallvisible */,
+		CDouble(100.0) /* rebinds */, ULONG(3) /* num predicates */);
 
 	IStatistics *stats_copy = pstats->CopyStats(mp);
 
@@ -747,6 +745,8 @@ CStatisticsTest::EresUnittest_CStatisticsCopy()
 	}
 	stats_copy->Release();
 	stats_copy_remap->Release();
+	pstats->Release();
+	colref_mapping->Release();
 
 	return eres;
 }

--- a/src/backend/gporca/server/src/unittest/dxl/statistics/CStatisticsTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/statistics/CStatisticsTest.cpp
@@ -58,6 +58,8 @@ CStatisticsTest::EresUnittest()
 	CUnittest rgutSharedOptCtxt[] = {
 		GPOS_UNITTEST_FUNC(CStatisticsTest::EresUnittest_CStatisticsBasic),
 		GPOS_UNITTEST_FUNC(CStatisticsTest::EresUnittest_UnionAll),
+		GPOS_UNITTEST_FUNC(CStatisticsTest::EresUnittest_CStatisticsCopy),
+
 		// TODO,  Mar 18 2013 temporarily disabling the test
 		// GPOS_UNITTEST_FUNC(CStatisticsTest::EresUnittest_CStatisticsSelectDerivation),
 	};
@@ -695,6 +697,58 @@ CStatisticsTest::EresUnittest_CStatisticsSelectDerivation()
 		mp, szQuerySelect, szPlanSelect,
 		true  // ignore mismatch in output dxl due to column id differences
 	);
+}
+
+// test that stats copy methods copy all fields
+GPOS_RESULT
+CStatisticsTest::EresUnittest_CStatisticsCopy()
+{
+	CAutoMemoryPool amp;
+	CMemoryPool *mp = amp.Pmp();
+
+	// create another statistics structure with a single int4 column with id 10
+	UlongToHistogramMap *phmulhist2 = GPOS_NEW(mp) UlongToHistogramMap(mp);
+	phmulhist2->Insert(GPOS_NEW(mp) ULONG(10), PhistExampleInt4Dim(mp));
+
+	UlongToDoubleMap *phmuldoubleWidth2 = GPOS_NEW(mp) UlongToDoubleMap(mp);
+	phmuldoubleWidth2->Insert(GPOS_NEW(mp) ULONG(10),
+							  GPOS_NEW(mp) CDouble(4.0));
+
+	CStatistics *pstats = GPOS_NEW(mp)
+		CStatistics(mp, phmulhist2, phmuldoubleWidth2, 100.0 /* rows */,
+					false /* is_empty */, ULONG(5) /* relpages */,
+					ULONG(10) /* relallvisible */, CDouble(100.0) /* rebinds */,
+					ULONG(3) /* num predicates */);
+
+	IStatistics *stats_copy = pstats->CopyStats(mp);
+
+	UlongToColRefMap *colref_mapping = GPOS_NEW(mp) UlongToColRefMap(mp);
+	IStatistics *stats_copy_remap =
+		pstats->CopyStatsWithRemap(mp, colref_mapping, false);
+
+	GPOS_RESULT eres = GPOS_OK;
+	if (pstats->Width() != stats_copy->Width() ||
+		pstats->NumRebinds() != stats_copy->NumRebinds() ||
+		pstats->RelPages() != stats_copy->RelPages() ||
+		pstats->RelAllVisible() != stats_copy->RelAllVisible() ||
+		pstats->GetNumberOfPredicates() != stats_copy->GetNumberOfPredicates())
+	{
+		eres = GPOS_FAILED;
+	}
+
+	if (pstats->Width() != stats_copy_remap->Width() ||
+		pstats->NumRebinds() != stats_copy_remap->NumRebinds() ||
+		pstats->RelPages() != stats_copy_remap->RelPages() ||
+		pstats->RelAllVisible() != stats_copy_remap->RelAllVisible() ||
+		pstats->GetNumberOfPredicates() !=
+			stats_copy_remap->GetNumberOfPredicates())
+	{
+		eres = GPOS_FAILED;
+	}
+	stats_copy->Release();
+	stats_copy_remap->Release();
+
+	return eres;
 }
 
 // EOF


### PR DESCRIPTION
In Orca, we copy group statistics to avoid costly stats re-deriving.
However, we unintentionally didn't copy the relpages, relallvisible, and
rebinds fields.  These fields are used in costing, and in some cases the
wrong rebind value caused us to improperly cost a NLJ much lower and
Orca selected a non-optimal plan.