### PR TITLE
[6X] Add a GUC to control the output of suboverflow transaction sql statement

### DIFF
--- a/gpcontrib/gp_subtransaction_overflow/expected/subtransaction_overflow_test.out
+++ b/gpcontrib/gp_subtransaction_overflow/expected/subtransaction_overflow_test.out
@@ -33,7 +33,7 @@ BEGIN
 	for i in 0..1000
 	LOOP
 		BEGIN
-			INSERT INTO t_1352_2 values(i);
+			INSERT INTO t_1352_2 VALUES(i);
 		EXCEPTION
 			WHEN UNIQUE_VIOLATION THEN
 				NULL;
@@ -61,6 +61,7 @@ BEGIN
 END;
 $$
 LANGUAGE plpgsql;
+set gp_log_suboverflow_statement = on;
 BEGIN;
 SELECT transaction_test0();
  transaction_test0 
@@ -68,7 +69,7 @@ SELECT transaction_test0();
  
 (1 row)
 
-SELECT segid, count(*) as num_suboverflowed FROM gp_suboverflowed_backend
+SELECT segid, count(*) AS num_suboverflowed FROM gp_suboverflowed_backend
 WHERE array_length(pids, 1) > 0
 GROUP BY segid
 ORDER BY segid;
@@ -79,6 +80,16 @@ ORDER BY segid;
      2 |                 1
 (3 rows)
 
+SELECT DISTINCT logsegment, logmessage FROM gp_toolkit.gp_log_system
+	WHERE logdebug = 'INSERT INTO t_1352_1 VALUES(i)'
+	ORDER BY logsegment, logmessage;
+ logsegment |                          logmessage                          
+------------+--------------------------------------------------------------
+ seg0       | Statement caused suboverflow: INSERT INTO t_1352_1 VALUES(i)
+ seg1       | Statement caused suboverflow: INSERT INTO t_1352_1 VALUES(i)
+ seg2       | Statement caused suboverflow: INSERT INTO t_1352_1 VALUES(i)
+(3 rows)
+
 COMMIT;
 BEGIN;
 SELECT transaction_test1();
@@ -87,15 +98,25 @@ SELECT transaction_test1();
  
 (1 row)
 
-SELECT segid, count(*) as num_suboverflowed FROM gp_suboverflowed_backend
+SELECT segid, count(*) AS num_suboverflowed FROM gp_suboverflowed_backend
 WHERE array_length(pids, 1) > 0
-GROUP by segid
+GROUP BY segid
 ORDER BY segid;
  segid | num_suboverflowed 
 -------+-------------------
      0 |                 1
      1 |                 1
      2 |                 1
+(3 rows)
+
+SELECT DISTINCT logsegment, logmessage FROM gp_toolkit.gp_log_system
+	WHERE logdebug = 'INSERT INTO t_1352_2 VALUES(i)'
+	ORDER BY logsegment, logmessage;
+ logsegment |                          logmessage                          
+------------+--------------------------------------------------------------
+ seg0       | Statement caused suboverflow: INSERT INTO t_1352_2 VALUES(i)
+ seg1       | Statement caused suboverflow: INSERT INTO t_1352_2 VALUES(i)
+ seg2       | Statement caused suboverflow: INSERT INTO t_1352_2 VALUES(i)
 (3 rows)
 
 COMMIT;
@@ -106,7 +127,7 @@ SELECT transaction_test2();
  
 (1 row)
 
-SELECT segid, count(*) as num_suboverflowed FROM gp_suboverflowed_backend
+SELECT segid, count(*) AS num_suboverflowed FROM gp_suboverflowed_backend
 WHERE array_length(pids, 1) > 0
 GROUP BY segid
 ORDER BY segid;
@@ -118,6 +139,17 @@ ORDER BY segid;
      2 |                 1
 (4 rows)
 
+SELECT DISTINCT logsegment, logmessage FROM gp_toolkit.gp_log_system
+	WHERE logmessage = 'Statement caused suboverflow: SELECT transaction_test2();'
+	ORDER BY logsegment;
+ logsegment |                        logmessage                         
+------------+-----------------------------------------------------------
+ seg0       | Statement caused suboverflow: SELECT transaction_test2();
+ seg-1      | Statement caused suboverflow: SELECT transaction_test2();
+ seg1       | Statement caused suboverflow: SELECT transaction_test2();
+ seg2       | Statement caused suboverflow: SELECT transaction_test2();
+(4 rows)
+
 COMMIT;
 BEGIN;
 SELECT transaction_test0();
@@ -126,7 +158,7 @@ SELECT transaction_test0();
  
 (1 row)
 
-select segid, count(*) as num_suboverflowed FROM
+select segid, count(*) AS num_suboverflowed FROM
 	(SELECT segid, unnest(pids)
 	FROM gp_suboverflowed_backend
 	WHERE array_length(pids, 1) > 0) AS tmp
@@ -140,3 +172,4 @@ ORDER BY segid;
 (3 rows)
 
 COMMIT;
+set gp_log_suboverflow_statement = off;

--- a/src/backend/access/transam/varsup.c
+++ b/src/backend/access/transam/varsup.c
@@ -29,7 +29,6 @@
 #include "access/distributedlog.h"
 #include "cdb/cdbvars.h"
 
-
 /* Number of OIDs to prefetch (preallocate) per XLOG write */
 #define VAR_OID_PREFETCH		8192
 
@@ -271,7 +270,11 @@ GetNewTransactionId(bool isSubXact)
 				mypgxact->nxids = nxids + 1;
 			}
 			else
+			{
 				mypgxact->overflowed = true;
+				ereportif (gp_log_suboverflow_statement, LOG,
+						(errmsg("Statement caused suboverflow: %s", debug_query_string)));
+			}
 		}
 	}
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -156,6 +156,7 @@ bool		gp_create_table_random_default_distribution = true;
 bool		gp_allow_non_uniform_partitioning_ddl = true;
 bool		gp_enable_exchange_default_partition = false;
 int			dtx_phase2_retry_count = 0;
+bool		gp_log_suboverflow_statement = false;
 
 bool		log_dispatch_stats = false;
 
@@ -3211,6 +3212,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 		 NULL,
 		 },
 		 &gp_log_resqueue_priority_sleep_time,
+		 false,
+		 NULL, NULL, NULL
+	},
+
+	{
+		{"gp_log_suboverflow_statement", PGC_SUSET, LOGGING_WHAT,
+		 gettext_noop("Enable logging of statements that cause subtransaction overflow."),
+		 NULL,
+		 },
+		 &gp_log_suboverflow_statement,
 		 false,
 		 NULL, NULL, NULL
 	},

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -298,6 +298,7 @@ extern bool gp_create_table_random_default_distribution;
 extern bool gp_allow_non_uniform_partitioning_ddl;
 extern bool gp_enable_exchange_default_partition;
 extern int  dtx_phase2_retry_count;
+extern bool gp_log_suboverflow_statement;
 
 /* WAL replication debug gucs */
 extern bool debug_walrepl_snd;

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -53,6 +53,7 @@
 		"gp_log_resgroup_memory",
 		"gp_log_resqueue_memory",
 		"gp_log_stack_trace_lines",
+		"gp_log_suboverflow_statement",
 		"gp_max_packet_size",
 		"gp_max_partition_level",
 		"gp_max_slices",

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -328,6 +328,7 @@
 		"max_replication_slots",
 		"max_resource_portals_per_transaction",
 		"max_resource_queues",
+		"max_slot_wal_keep_size",
 		"max_stack_depth",
 		"max_standby_archive_delay",
 		"max_standby_streaming_delay",
@@ -537,4 +538,3 @@
 		"xmlbinary",
 		"xmloption",
 		"zero_damaged_pages",
-		"max_slot_wal_keep_size",


### PR DESCRIPTION
We might want to also consider adding a log message to print the query string
that caused the overflow. This is important as only 1 statement out of thousands
executed in a backend may trigger the overflow, or the backend can come out of
the overflow state before it is inspected with our view/UDF. Logging the
statement will ensure that customers can pinpoint the offending statements.
