### PR TITLE
[orafce] Rename pipe type to orafce_pipe to resolve its conflict with pipe function from unistd.h.

### DIFF
--- a/gpcontrib/orafce/pipe.c
+++ b/gpcontrib/orafce/pipe.c
@@ -91,7 +91,7 @@ typedef struct {
 	int16 count;
 	int16 limit;
 	int size;
-} pipe;
+} orafce_pipe;
 
 typedef struct {
 	int32 size;
@@ -130,7 +130,7 @@ typedef struct
 
 #endif
 
-	pipe *pipes;
+	orafce_pipe *pipes;
 	alert_event *events;
 	alert_lock *locks;
 	size_t size;
@@ -143,7 +143,7 @@ typedef struct
 message_buffer *output_buffer = NULL;
 message_buffer *input_buffer = NULL;
 
-pipe* pipes = NULL;
+orafce_pipe* pipes = NULL;
 
 #define NOT_INITIALIZED		NULL
 
@@ -274,7 +274,7 @@ ora_lock_shmem(size_t size, int max_pipes, int max_events, int max_locks, bool r
 
 			sh_mem->size = size - sh_memory_size;
 			ora_sinit(sh_mem->data, size, true);
-			pipes = sh_mem->pipes = ora_salloc(max_pipes*sizeof(pipe));
+			pipes = sh_mem->pipes = ora_salloc(max_pipes*sizeof(orafce_pipe));
 			sid = sh_mem->sid = 1;
 			for (i = 0; i < max_pipes; i++)
 				pipes[i].is_valid = false;
@@ -347,11 +347,11 @@ ora_lock_shmem(size_t size, int max_pipes, int max_events, int max_locks, bool r
  * can be enhanced access/hash.h
  */
 
-static pipe*
+static orafce_pipe*
 find_pipe(text* pipe_name, bool* created, bool only_check)
 {
 	int i;
-	pipe *result = NULL;
+	orafce_pipe *result = NULL;
 
 	*created = false;
 	for (i = 0; i < MAX_PIPES; i++)
@@ -401,7 +401,7 @@ find_pipe(text* pipe_name, bool* created, bool only_check)
 
 
 static bool
-new_last(pipe *p, void *ptr)
+new_last(orafce_pipe *p, void *ptr)
 {
 	queue_item *q, *aux_q;
 
@@ -436,7 +436,7 @@ new_last(pipe *p, void *ptr)
 
 
 static void*
-remove_first(pipe *p, bool *found)
+remove_first(orafce_pipe *p, bool *found)
 {
 	struct _queue_item *q;
 	void *ptr = NULL;
@@ -468,7 +468,7 @@ remove_first(pipe *p, bool *found)
 static message_buffer*
 get_from_pipe(text *pipe_name, bool *found)
 {
-	pipe *p;
+	orafce_pipe *p;
 	bool created;
 	message_buffer *shm_msg;
 	message_buffer *result = NULL;
@@ -504,7 +504,7 @@ get_from_pipe(text *pipe_name, bool *found)
 static bool
 add_to_pipe(text *pipe_name, message_buffer *ptr, int limit, bool limit_is_valid)
 {
-	pipe *p;
+	orafce_pipe *p;
 	bool created;
 	bool result = false;
 	message_buffer *sh_ptr;
@@ -556,7 +556,7 @@ add_to_pipe(text *pipe_name, message_buffer *ptr, int limit, bool limit_is_valid
 static void
 remove_pipe(text *pipe_name, bool purge)
 {
-	pipe *p;
+	orafce_pipe *p;
 	bool created;
 
 	if (NULL != (p = find_pipe(pipe_name, &created, true)))
@@ -1162,7 +1162,7 @@ dbms_pipe_create_pipe (PG_FUNCTION_ARGS)
 	WATCH_PRE(timeout, endtime, cycle);
 	if (ora_lock_shmem(SHMEMMSGSZ, MAX_PIPES,MAX_EVENTS,MAX_LOCKS,false))
 	{
-		pipe *p;
+		orafce_pipe *p;
 		if (NULL != (p = find_pipe(pipe_name, &created, false)))
 		{
 			if (!created)

--- a/gpcontrib/orafce/sqlscan.c
+++ b/gpcontrib/orafce/sqlscan.c
@@ -1,6 +1,6 @@
-#line 2 "sqlscan.c"
+#line 1 "sqlscan.c"
 
-#line 4 "sqlscan.c"
+#line 3 "sqlscan.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -1004,7 +1004,7 @@ static unsigned char unescape_single_char(unsigned char c);
 #define _pg_mbstrlen_with_len(buf,loc) 	pg_mbstrlen_with_len(buf,loc)
 #endif
 
-#line 1008 "sqlscan.c"
+#line 1007 "sqlscan.c"
 #define YY_NO_INPUT 1
 /*
  * OK, here is a short description of lex/flex rules behavior.
@@ -1132,7 +1132,7 @@ static unsigned char unescape_single_char(unsigned char c);
  * Note that xcstart must appear before operator, as explained above!
  *  Also whitespace (comment) must appear before operator.
  */
-#line 1136 "sqlscan.c"
+#line 1135 "sqlscan.c"
 
 #define INITIAL 0
 #define xb 1
@@ -1357,7 +1357,7 @@ YY_DECL
 #line 308 "sqlscan.l"
 
 
-#line 1361 "sqlscan.c"
+#line 1360 "sqlscan.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -2176,7 +2176,7 @@ YY_RULE_SETUP
 #line 862 "sqlscan.l"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 2180 "sqlscan.c"
+#line 2179 "sqlscan.c"
 
 	case YY_END_OF_BUFFER:
 		{


### PR DESCRIPTION
This Patch is back-ported from https://github.com/orafce/orafce/commit/1f162a6da427ae31ab0fcff8c3f0abdb3c5eddb2

Co-Authored-by: Bradford Boyle <bradfordb@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
