### PR TITLE
Fix: check empty read set before a select call, to avoid infinite loop

### DIFF
--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -2382,6 +2382,10 @@ waitOnOutbound(ChunkTransportStateEntry *pEntry)
 		n = select(maxfd + 1, (fd_set *) &curset, NULL, NULL, &timeout);
 		if (n == 0 || (n < 0 && errno == EINTR))
 		{
+			mpp_fd_set	emptyset;
+			MPP_FD_ZERO(&emptyset);
+			if (!memcmp(&curset, &emptyset, sizeof(curset)))
+				break;
 			continue;
 		}
 		else if (n < 0)
@@ -2622,6 +2626,12 @@ RecvTupleChunkFromAnyTCP(ChunkTransportState *transportStates,
 			/* handle events on dispatch connection */
 			if (need_check)
 				checkForCancelFromQD(transportStates);
+		}
+		else {
+			mpp_fd_set	emptyset;
+			MPP_FD_ZERO(&emptyset);
+			if (!memcmp(&rset, &emptyset, sizeof(rset)))
+				break;
 		}
 
 		if (waitFds)


### PR DESCRIPTION
According to the man pages of `select()`:
```
       If  the  readfds argument is not a null pointer, it points to an object
       of type fd_set that on input  specifies  the  file  descriptors  to  be
       checked for being ready to read, and on output indicates which file de‐
       scriptors are ready to read.
       
       On  failure,  the  objects pointed to by the readfds, writefds, and er‐
       rorfds arguments shall not be modified. If the timeout interval expires
       without  the  specified  condition  being true for any of the specified
       file descriptors, the objects pointed to by the readfds, writefds,  and
       errorfds arguments shall have all bits set to 0.
```

But in current interconnect proxy / tcp implementations, we didn't check if the read_fds set is empty (e.g. if due to the timeout expired, the fds set would be cleared, according to the document), so if the `select()` call keeps returning `0`, we may trap into an infinite loop, and would hang there.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
