### PR TITLE
Improve the performance of source_bytes computation during gpexpand.

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -49,6 +49,9 @@ except ImportError as e:
 MAX_PARALLEL_EXPANDS = 96
 MAX_BATCH_SIZE = 128
 
+FIRST_NORMAL_OID = 16384
+RELKIND_FOREIGN_TABLE = 'f'
+
 SEGMENT_CONFIGURATION_BACKUP_FILE = "gpexpand.gp_segment_configuration"
 
 DBNAME = 'postgres'
@@ -1577,32 +1580,82 @@ class gpexpand:
         # including new segments has been started once before so finalize
         self.finalize_prepare()
 
+    def generate_sql_to_populate_table_size(self, sql):
+        # This function generate a SQL that can compute table size
+        # taking the advantage of MPP. Previous code put pg_relation_size
+        # in target list of a query involving only catalog, thus each
+        # tuple will lead to a dispatch to compute pg_relation_size
+        # thus bad performance. Now we let pg_relation_size compute
+        # at each segment and then group by the table oid and sum
+        # together to get each table's size. pg_relation_size is
+        # volatile function, so the following CTE sql's subquery
+        # x will never be pulled up which means the pg_relation_size
+        # will always be evaluated before later motion to gurantee
+        # correctness no matter single stage or multi stage agg.
+        #
+        # Also note, we filter out those relations with relkind is
+        # RELKIND_FOREIGN_TABLE, because we only expand those
+        # are external writable, and even for external writable ones
+        # we simple modify the numsegments and do not move data.
+        # Refer to C code: ATExecExpandTable and ATExecExpandPartitionTablePrepare.
+        cte_sql = """with table_size_cte(table_oid, size) as
+        (
+           select table_oid, sum(size)
+           from (
+             select oid as table_oid,
+                    pg_relation_size(oid) as size
+             from gp_dist_random('pg_class')
+             where oid >= %d and relkind <> '%s'
+           ) x(table_oid, size)
+           group by table_oid
+        )
+        """ % (FIRST_NORMAL_OID, RELKIND_FOREIGN_TABLE)
+
+        final_sql = """{cte_sql}
+        select
+          s1.dbname,
+          s1.fq_name,
+          s1.table_oid,
+          s1.root_partition_oid,
+          s1.rank,
+          s1.external_writable,
+          s1.undone_status,
+          s1.expansion_started,
+          s1.expansion_finished,
+          coalesce(table_size_cte.size, 0) as source_bytes
+        from ({orig_sql})s1 left join table_size_cte
+        on s1.table_oid = table_size_cte.table_oid
+        """
+        return final_sql.format(cte_sql=cte_sql,
+                                orig_sql=sql)
+
     def _populate_regular_tables(self, dbname):
-        src_bytes_str = "0" if self.options.simple_progress else "pg_relation_size(quote_ident(n.nspname) || '.' || quote_ident(c.relname))"
         sql = """SELECT
-    current_database(),
-    quote_ident(n.nspname) || '.' || quote_ident(c.relname) as fq_name,
-    c.oid as tableoid,
-    NULL as root_partition_oid,
-    2 as rank,
-    pe.writable is not null as external_writable,
-    '%s' as undone_status,
-    NULL as expansion_started,
-    NULL as expansion_finished,
-    %s as source_bytes
-FROM
-    pg_class c
-    JOIN pg_namespace n ON (c.relnamespace=n.oid)
-    JOIN pg_catalog.gp_distribution_policy p on (c.oid = p.localoid)
-    LEFT JOIN pg_partitioned_table pp on (c.oid=pp.partrelid)
-    LEFT JOIN pg_exttable pe on (c.oid=pe.reloid and pe.writable)
-WHERE
-    pp.partrelid is NULL
-    AND NOT c.relispartition
-    AND n.nspname != 'gpexpand'
-    AND n.nspname != 'pg_bitmapindex'
-    AND c.relpersistence != 't'
-                  """ % (undone_status, src_bytes_str)
+                   current_database() as dbname,
+                   quote_ident(n.nspname) || '.' || quote_ident(c.relname) as fq_name,
+                   c.oid as table_oid,
+                   NULL as root_partition_oid,
+                   2 as rank,
+                   pe.writable is not null as external_writable,
+                   '%s' as undone_status,
+                   NULL as expansion_started,
+                   NULL as expansion_finished,
+                   0 as source_bytes
+                FROM
+                       pg_class c
+                  JOIN pg_namespace n ON (c.relnamespace=n.oid)
+                  JOIN  pg_catalog.gp_distribution_policy p on (c.oid = p.localoid)
+              LEFT JOIN pg_partitioned_table pp on (c.oid=pp.partrelid)
+              LEFT JOIN pg_exttable pe on (c.oid=pe.reloid and pe.writable)
+                WHERE
+                      pp.partrelid is NULL
+                  AND NOT c.relispartition
+                  AND n.nspname != 'gpexpand'
+                  AND n.nspname != 'pg_bitmapindex'
+                  AND c.relpersistence != 't' """ % undone_status
+
+        if not self.options.simple_progress:
+            sql = self.generate_sql_to_populate_table_size(sql)
         self.logger.debug(sql)
         table_conn = self.connect_database(dbname)
 
@@ -1665,19 +1718,18 @@ WHERE
             self.logger.debug(prepare_cmd)
             dbconn.execSQL(table_conn, prepare_cmd, autocommit=True)
 
-        src_bytes_str = "0" if self.options.simple_progress else "pg_relation_size(c.oid)"
         get_status_detail_cmd = """
              SELECT
-                current_database(),
+                current_database() as dbname,
                 quote_ident(n.nspname) || '.' || quote_ident(c.relname) as fq_name,
-                c.oid as tableoid,
+                c.oid as table_oid,
                 d.oid as root_partition_oid,
                 2 as rank,
                 false as external_writable,
                 '%s' as undone_status,
                 NULL as expansion_started,
                 NULL as expansion_finished,
-                %s as source_bytes
+                0 as source_bytes
             FROM
                 pg_inherits a,
                 pg_partitioned_table b,
@@ -1691,7 +1743,10 @@ WHERE
                 c.relnamespace = n.oid and
                 c.relkind != 'p' and
                 c.relkind != 'f'
-        """ % (undone_status, src_bytes_str)
+        """ % undone_status
+
+        if not self.options.simple_progress:
+            get_status_detail_cmd = self.generate_sql_to_populate_table_size(get_status_detail_cmd)
         self.logger.debug(get_status_detail_cmd)
 
         try:

--- a/src/test/regress/expected/db_size_functions.out
+++ b/src/test/regress/expected/db_size_functions.out
@@ -333,3 +333,31 @@ select pg_relation_size(oid) between 3000000 and 5000000 from pg_class where rel
  t
 (1 row)
 
+create table heapsizetest_size(a bigint);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+copy (select pg_relation_size(oid) from pg_class where relname = 'heapsizetest') to '/tmp/t_heapsizetest_size_xxx';
+copy heapsizetest_size from '/tmp/t_heapsizetest_size_xxx';
+select count(distinct a) from heapsizetest_size;
+ count 
+-------
+     1
+(1 row)
+
+\! rm /tmp/t_heapsizetest_size_xxx
+insert into heapsizetest_size
+select sum(size)
+from
+(
+  select pg_relation_size(oid)
+  from gp_dist_random('pg_class')
+  where relname = 'heapsizetest'
+) x(size);
+-- both method should compute the same result
+select count(distinct a) from heapsizetest_size;
+ count 
+-------
+     1
+(1 row)
+
+drop table heapsizetest_size;

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -3045,3 +3045,115 @@ select * from param_t a where a.i in
 (1 row)
 
 drop table if exists param_t;
+-- A guard test case for gpexpand's populate SQL
+-- Some simple notes and background is: we want to compute
+-- table size efficiently, it is better to avoid invoke
+-- pg_relation_size() in serial on QD, since this function
+-- will dispatch for each tuple. The bad pattern SQL is like
+--   select pg_relation_size(oid) from pg_class where xxx
+-- The idea is force pg_relations_size is evaluated on each
+-- segment and the sum the result together to get the final
+-- result. To make sure correctness, we have to evaluate
+-- pg_relation_size before any motion. The skill here is
+-- to wrap this in a subquery, due to volatile of pg_relation_size,
+-- this subquery won't be pulled up. Plus the skill of
+-- gp_dist_random('pg_class') we can achieve this goal.
+-- the below test is to verify the plan, we should see pg_relation_size
+-- is evaludated on each segment and then motion then sum together. The
+-- SQL pattern is a catalog join a table size "dict".
+set gp_enable_multiphase_agg = on;
+-- force nestloop join to make test stable since we
+-- are testing plan and do not care about where we
+-- put hash table.
+set enable_hashjoin = off;
+set enable_nestloop = on;
+set enable_indexscan = off;
+set enable_bitmapscan = off;
+explain (verbose on, costs off)
+with cte(table_oid, size) as
+(
+   select
+     table_oid,
+     sum(size) size
+   from (
+     select oid,
+          pg_relation_size(oid)
+     from gp_dist_random('pg_class')
+   ) x(table_oid, size)
+  group by table_oid
+)
+select pc.relname, ts.size
+from pg_class pc, cte ts
+where pc.oid = ts.table_oid;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: pc.relname, (sum((pg_relation_size((pg_class.oid)::regclass, 'main'::text))))
+   ->  Nested Loop
+         Output: pc.relname, (sum((pg_relation_size((pg_class.oid)::regclass, 'main'::text))))
+         Join Filter: (pc.oid = pg_class.oid)
+         ->  Redistribute Motion 1:3  (slice2)
+               Output: pc.relname, pc.oid
+               Hash Key: pc.oid
+               ->  Seq Scan on pg_catalog.pg_class pc
+                     Output: pc.relname, pc.oid
+         ->  Materialize
+               Output: pg_class.oid, (sum((pg_relation_size((pg_class.oid)::regclass, 'main'::text))))
+               ->  HashAggregate
+                     Output: pg_class.oid, sum((pg_relation_size((pg_class.oid)::regclass, 'main'::text)))
+                     Group Key: pg_class.oid
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Output: pg_class.oid, (pg_relation_size((pg_class.oid)::regclass, 'main'::text))
+                           Hash Key: pg_class.oid
+                           ->  Seq Scan on pg_catalog.pg_class
+                                 Output: pg_class.oid, pg_relation_size((pg_class.oid)::regclass, 'main'::text)
+ Optimizer: Postgres query optimizer
+(21 rows)
+
+set gp_enable_multiphase_agg = off;
+explain (verbose on, costs off)
+with cte(table_oid, size) as
+(
+   select
+     table_oid,
+     sum(size) size
+   from (
+     select oid,
+          pg_relation_size(oid)
+     from gp_dist_random('pg_class')
+   ) x(table_oid, size)
+  group by table_oid
+)
+select pc.relname, ts.size
+from pg_class pc, cte ts
+where pc.oid = ts.table_oid;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: pc.relname, (sum((pg_relation_size((pg_class.oid)::regclass, 'main'::text))))
+   ->  Nested Loop
+         Output: pc.relname, (sum((pg_relation_size((pg_class.oid)::regclass, 'main'::text))))
+         Join Filter: (pc.oid = pg_class.oid)
+         ->  Redistribute Motion 1:3  (slice2)
+               Output: pc.relname, pc.oid
+               Hash Key: pc.oid
+               ->  Seq Scan on pg_catalog.pg_class pc
+                     Output: pc.relname, pc.oid
+         ->  Materialize
+               Output: pg_class.oid, (sum((pg_relation_size((pg_class.oid)::regclass, 'main'::text))))
+               ->  HashAggregate
+                     Output: pg_class.oid, sum((pg_relation_size((pg_class.oid)::regclass, 'main'::text)))
+                     Group Key: pg_class.oid
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Output: pg_class.oid, (pg_relation_size((pg_class.oid)::regclass, 'main'::text))
+                           Hash Key: pg_class.oid
+                           ->  Seq Scan on pg_catalog.pg_class
+                                 Output: pg_class.oid, pg_relation_size((pg_class.oid)::regclass, 'main'::text)
+ Optimizer: Postgres query optimizer
+(21 rows)
+
+reset gp_enable_multiphase_agg;
+reset enable_hashjoin;
+reset enable_nestloop;
+reset enable_indexscan;
+reset enable_bitmapscan;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -3162,3 +3162,115 @@ select * from param_t a where a.i in
 (1 row)
 
 drop table if exists param_t;
+-- A guard test case for gpexpand's populate SQL
+-- Some simple notes and background is: we want to compute
+-- table size efficiently, it is better to avoid invoke
+-- pg_relation_size() in serial on QD, since this function
+-- will dispatch for each tuple. The bad pattern SQL is like
+--   select pg_relation_size(oid) from pg_class where xxx
+-- The idea is force pg_relations_size is evaluated on each
+-- segment and the sum the result together to get the final
+-- result. To make sure correctness, we have to evaluate
+-- pg_relation_size before any motion. The skill here is
+-- to wrap this in a subquery, due to volatile of pg_relation_size,
+-- this subquery won't be pulled up. Plus the skill of
+-- gp_dist_random('pg_class') we can achieve this goal.
+-- the below test is to verify the plan, we should see pg_relation_size
+-- is evaludated on each segment and then motion then sum together. The
+-- SQL pattern is a catalog join a table size "dict".
+set gp_enable_multiphase_agg = on;
+-- force nestloop join to make test stable since we
+-- are testing plan and do not care about where we
+-- put hash table.
+set enable_hashjoin = off;
+set enable_nestloop = on;
+set enable_indexscan = off;
+set enable_bitmapscan = off;
+explain (verbose on, costs off)
+with cte(table_oid, size) as
+(
+   select
+     table_oid,
+     sum(size) size
+   from (
+     select oid,
+          pg_relation_size(oid)
+     from gp_dist_random('pg_class')
+   ) x(table_oid, size)
+  group by table_oid
+)
+select pc.relname, ts.size
+from pg_class pc, cte ts
+where pc.oid = ts.table_oid;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: pc.relname, (sum((pg_relation_size((pg_class.oid)::regclass, 'main'::text))))
+   ->  Nested Loop
+         Output: pc.relname, (sum((pg_relation_size((pg_class.oid)::regclass, 'main'::text))))
+         Join Filter: (pc.oid = pg_class.oid)
+         ->  Redistribute Motion 1:3  (slice2)
+               Output: pc.relname, pc.oid
+               Hash Key: pc.oid
+               ->  Seq Scan on pg_catalog.pg_class pc
+                     Output: pc.relname, pc.oid
+         ->  Materialize
+               Output: pg_class.oid, (sum((pg_relation_size((pg_class.oid)::regclass, 'main'::text))))
+               ->  HashAggregate
+                     Output: pg_class.oid, sum((pg_relation_size((pg_class.oid)::regclass, 'main'::text)))
+                     Group Key: pg_class.oid
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Output: pg_class.oid, (pg_relation_size((pg_class.oid)::regclass, 'main'::text))
+                           Hash Key: pg_class.oid
+                           ->  Seq Scan on pg_catalog.pg_class
+                                 Output: pg_class.oid, pg_relation_size((pg_class.oid)::regclass, 'main'::text)
+ Optimizer: Postgres query optimizer
+(21 rows)
+
+set gp_enable_multiphase_agg = off;
+explain (verbose on, costs off)
+with cte(table_oid, size) as
+(
+   select
+     table_oid,
+     sum(size) size
+   from (
+     select oid,
+          pg_relation_size(oid)
+     from gp_dist_random('pg_class')
+   ) x(table_oid, size)
+  group by table_oid
+)
+select pc.relname, ts.size
+from pg_class pc, cte ts
+where pc.oid = ts.table_oid;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: pc.relname, (sum((pg_relation_size((pg_class.oid)::regclass, 'main'::text))))
+   ->  Nested Loop
+         Output: pc.relname, (sum((pg_relation_size((pg_class.oid)::regclass, 'main'::text))))
+         Join Filter: (pc.oid = pg_class.oid)
+         ->  Redistribute Motion 1:3  (slice2)
+               Output: pc.relname, pc.oid
+               Hash Key: pc.oid
+               ->  Seq Scan on pg_catalog.pg_class pc
+                     Output: pc.relname, pc.oid
+         ->  Materialize
+               Output: pg_class.oid, (sum((pg_relation_size((pg_class.oid)::regclass, 'main'::text))))
+               ->  HashAggregate
+                     Output: pg_class.oid, sum((pg_relation_size((pg_class.oid)::regclass, 'main'::text)))
+                     Group Key: pg_class.oid
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Output: pg_class.oid, (pg_relation_size((pg_class.oid)::regclass, 'main'::text))
+                           Hash Key: pg_class.oid
+                           ->  Seq Scan on pg_catalog.pg_class
+                                 Output: pg_class.oid, pg_relation_size((pg_class.oid)::regclass, 'main'::text)
+ Optimizer: Postgres query optimizer
+(21 rows)
+
+reset gp_enable_multiphase_agg;
+reset enable_hashjoin;
+reset enable_nestloop;
+reset enable_indexscan;
+reset enable_bitmapscan;

--- a/src/test/regress/sql/db_size_functions.sql
+++ b/src/test/regress/sql/db_size_functions.sql
@@ -111,3 +111,27 @@ drop table ao_with_malformed_visimaprelid;
 -- plausible difference to the above scenarios would be that the function
 -- might get executed on different nodes, for example.)
 select pg_relation_size(oid) between 3000000 and 5000000 from pg_class where relname = 'heapsizetest'; -- 3637248
+
+create table heapsizetest_size(a bigint);
+
+copy (select pg_relation_size(oid) from pg_class where relname = 'heapsizetest') to '/tmp/t_heapsizetest_size_xxx';
+copy heapsizetest_size from '/tmp/t_heapsizetest_size_xxx';
+
+select count(distinct a) from heapsizetest_size;
+
+\! rm /tmp/t_heapsizetest_size_xxx
+
+insert into heapsizetest_size
+select sum(size)
+from
+(
+  select pg_relation_size(oid)
+  from gp_dist_random('pg_class')
+  where relname = 'heapsizetest'
+) x(size);
+
+-- both method should compute the same result
+select count(distinct a) from heapsizetest_size;
+
+drop table heapsizetest_size;
+

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -1214,3 +1214,72 @@ select * from param_t a where a.i in
 
 
 drop table if exists param_t;
+
+-- A guard test case for gpexpand's populate SQL
+-- Some simple notes and background is: we want to compute
+-- table size efficiently, it is better to avoid invoke
+-- pg_relation_size() in serial on QD, since this function
+-- will dispatch for each tuple. The bad pattern SQL is like
+--   select pg_relation_size(oid) from pg_class where xxx
+-- The idea is force pg_relations_size is evaluated on each
+-- segment and the sum the result together to get the final
+-- result. To make sure correctness, we have to evaluate
+-- pg_relation_size before any motion. The skill here is
+-- to wrap this in a subquery, due to volatile of pg_relation_size,
+-- this subquery won't be pulled up. Plus the skill of
+-- gp_dist_random('pg_class') we can achieve this goal.
+
+-- the below test is to verify the plan, we should see pg_relation_size
+-- is evaludated on each segment and then motion then sum together. The
+-- SQL pattern is a catalog join a table size "dict".
+
+set gp_enable_multiphase_agg = on;
+-- force nestloop join to make test stable since we
+-- are testing plan and do not care about where we
+-- put hash table.
+set enable_hashjoin = off;
+set enable_nestloop = on;
+set enable_indexscan = off;
+set enable_bitmapscan = off;
+
+explain (verbose on, costs off)
+with cte(table_oid, size) as
+(
+   select
+     table_oid,
+     sum(size) size
+   from (
+     select oid,
+          pg_relation_size(oid)
+     from gp_dist_random('pg_class')
+   ) x(table_oid, size)
+  group by table_oid
+)
+select pc.relname, ts.size
+from pg_class pc, cte ts
+where pc.oid = ts.table_oid;
+
+set gp_enable_multiphase_agg = off;
+
+explain (verbose on, costs off)
+with cte(table_oid, size) as
+(
+   select
+     table_oid,
+     sum(size) size
+   from (
+     select oid,
+          pg_relation_size(oid)
+     from gp_dist_random('pg_class')
+   ) x(table_oid, size)
+  group by table_oid
+)
+select pc.relname, ts.size
+from pg_class pc, cte ts
+where pc.oid = ts.table_oid;
+
+reset gp_enable_multiphase_agg;
+reset enable_hashjoin;
+reset enable_nestloop;
+reset enable_indexscan;
+reset enable_bitmapscan;


### PR DESCRIPTION
During gpexpand, it will record all the tables that need to do data
redistribution and in order to show the progress the table size is
also saved in the status_details table.

Previously, we directly invoke pg_relation_size to compute that value
in the target list of a SQL involving only catalog tables. This will
lead to very bad performance because for each table it will do a dispatch
to compute its size and the whole progress is done in serial.

This commit rewrite the SQL generating the status_details information.
The skills used to MPP compute table size is:
  1. we use gp_dist_random('pg_class') to get a force random RangeTable
  2. since pg_relations_size is volatile, wrap the computation in a
     subquery before group-by to prevent optimizer to pull up subquery
     and force the pg_relation_size is evaluated before motion then
     sum it together
  3. join with the main SQL

We add test cases in regress/subselect_gp and regress/db_size_functions
to guard the above SQL skill.

We have done local test to show the performance gain. In a local 8*8
64-segments cluster, we create 100 partition tables, each partition
table contains 2 middle level partitions, each middle level partition
contains 365 leaf partitions. Then in this database, we compare the
speed of the old populate SQL (evaluate pg_relation_size on QD via
dispatching, a tuple a dispatch) and the new SQL (a single SQL and only
need to dispatch once). This patch's SQL only takes about 3.8 sec, however,
the old SQL takes about 50 sec.

Authored-by: Miao Chen <miaochen@mail.ustc.edu.cn>
Authored-by: Zhenghua Lyu <kainwen@gmail.com>