### PR TITLE
[6X] checkpoint_memleak: Ensure promotion before recovery

### DIFF
--- a/src/test/isolation2/expected/checkpoint_memleak.out
+++ b/src/test/isolation2/expected/checkpoint_memleak.out
@@ -63,6 +63,15 @@ SELECT gp_request_fts_probe_scan();
  t                         
 (1 row)
 
+-- Do a utility mode SELECT on the erstwhile mirror to ensure that it has been
+-- promoted and can serve queries. Otherwise, gprecoverseg will fail below.
+-- Conveniently, the framework will make this statement block.
+1U: SELECT 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+
 -- Bring back primary and wait until primary and mirror are up & running
 !\retcode gprecoverseg -a;
 (exited with code 0)

--- a/src/test/isolation2/sql/checkpoint_memleak.sql
+++ b/src/test/isolation2/sql/checkpoint_memleak.sql
@@ -32,6 +32,11 @@ select gp_inject_fault('ckpt_mem_leak', 'reset', dbid) from gp_segment_configura
 SELECT pg_ctl(datadir, 'stop', 'immediate') FROM gp_segment_configuration WHERE role = 'p' AND content = 1;
 SELECT gp_request_fts_probe_scan();
 
+-- Do a utility mode SELECT on the erstwhile mirror to ensure that it has been
+-- promoted and can serve queries. Otherwise, gprecoverseg will fail below.
+-- Conveniently, the framework will make this statement block.
+1U: SELECT 1;
+
 -- Bring back primary and wait until primary and mirror are up & running
 !\retcode gprecoverseg -a;
 SELECT wait_until_all_segments_synchronized();


### PR DESCRIPTION
We weren't waiting for promotion of the mirror before recovery, causing
the test to flake sometimes with a gprecoverseg failure:

```
--- \/tmp\/build\/e18b2f02\/gpdb_src\/src\/test\/isolation2\/expected\/checkpoint_memleak\.out  2022-08-16 07:02:45.284609608 +0000
+++ \/tmp\/build\/e18b2f02\/gpdb_src\/src\/test\/isolation2\/results\/checkpoint_memleak\.out   2022-08-16 07:02:45.288609897 +0000
@@ -66,11 +83,21 @@

 -- Bring back primary and wait until primary and mirror are up & running
 !\retcode gprecoverseg -a;
-(exited with code 0)
..
+GP_IGNORE:20220816:06:56:16:066655 gprecoverseg:a71037bd-f5df-43e4-4f12-e72540b6da75:gpadmin-[INFO]:-Starting gprecoverseg with args: -a
...
+GP_IGNORE:20220816:06:56:16:066655 gprecoverseg:a71037bd-f5df-43e4-4f12-e72540b6da75:gpadmin-[INFO]:-Obtaining Segment details from master...
+GP_IGNORE:20220816:06:56:27:066655 gprecoverseg:a71037bd-f5df-43e4-4f12-e72540b6da75:gpadmin-[CRITICAL]:-gprecoverseg failed. (Reason='error 'ERROR:  failed to acquire resources on one or more segments
+GP_IGNORE:DETAIL:  Segments are in reset/recovery mode.
..
```

We fix that by waiting to establish a utility mode connection to the
promoted mirror, to ensure promotion.

Co-authored-by: Ashwin Agrawal <aashwin@vmware.com>
