### PR TITLE
Get streaming hash aggregate back

### DIFF
--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2562,6 +2562,9 @@ typedef struct AggState
 
 	/* if input tuple has an AggExprId, save the Attribute Number */
 	Index       AggExprId_AttrNum;
+
+	/* stream entries when out of memory instead of spilling to disk */
+	bool		streaming;
 } AggState;
 
 typedef struct TupleSplitState

--- a/src/include/nodes/pathnodes.h
+++ b/src/include/nodes/pathnodes.h
@@ -2032,7 +2032,7 @@ typedef struct AggPath
 	double		numGroups;		/* estimated number of groups in input */
 	List	   *groupClause;	/* a list of SortGroupClause's */
 	List	   *qual;			/* quals (HAVING quals), if any */
-	bool		streaming;
+	bool		streaming;		/* stream entries when out of memory instead of spilling to disk */
 } AggPath;
 
 /*

--- a/src/test/isolation2/expected/spilling_hashagg.out
+++ b/src/test/isolation2/expected/spilling_hashagg.out
@@ -4,10 +4,6 @@
 -- Test Orca properly removes duplicates in DQA
 -- (https://github.com/greenplum-db/gpdb/issues/14993)
 
--- GPDB_12_MERGE_FEATURE_NOT_SUPPORTED: After streaming hash aggregates are
--- supported then add a fault injection for 'force_hashagg_stream_hashtable'.
--- Until then this test doesn't actually test spilling.
-
 CREATE TABLE test_src_tbl AS WITH cte1 AS ( SELECT field5 from generate_series(1,1000) field5 ) SELECT field5 % 100 AS a, field5 % 100  + 1 AS b FROM cte1 DISTRIBUTED BY (a);
 CREATE 1000
 ANALYZE test_src_tbl;

--- a/src/test/isolation2/expected/spilling_hashagg_optimizer.out
+++ b/src/test/isolation2/expected/spilling_hashagg_optimizer.out
@@ -4,10 +4,6 @@
 -- Test Orca properly removes duplicates in DQA
 -- (https://github.com/greenplum-db/gpdb/issues/14993)
 
--- GPDB_12_MERGE_FEATURE_NOT_SUPPORTED: After streaming hash aggregates are
--- supported then add a fault injection for 'force_hashagg_stream_hashtable'.
--- Until then this test doesn't actually test spilling.
-
 CREATE TABLE test_src_tbl AS WITH cte1 AS ( SELECT field5 from generate_series(1,1000) field5 ) SELECT field5 % 100 AS a, field5 % 100  + 1 AS b FROM cte1 DISTRIBUTED BY (a);
 CREATE 1000
 ANALYZE test_src_tbl;

--- a/src/test/isolation2/sql/spilling_hashagg.sql
+++ b/src/test/isolation2/sql/spilling_hashagg.sql
@@ -8,10 +8,6 @@ DROP TABLE IF EXISTS test_hashagg_off;
 -- Test Orca properly removes duplicates in DQA
 -- (https://github.com/greenplum-db/gpdb/issues/14993)
 
--- GPDB_12_MERGE_FEATURE_NOT_SUPPORTED: After streaming hash aggregates are
--- supported then add a fault injection for 'force_hashagg_stream_hashtable'.
--- Until then this test doesn't actually test spilling.
-
 CREATE TABLE test_src_tbl AS
 WITH cte1 AS (
     SELECT field5 from generate_series(1,1000) field5


### PR DESCRIPTION
In multi-phase aggregate, this feature streams entries of the bottom
phase when out of memory instead of spilling to disk, it avoids the disk
I/O and roughly deduplicates to save the network I/O.

The planner always supports streaming aggregate and there are lots of
cases, but the executor part was lost while merging PostgreSQL 12, this
commit gets it back.