### PR TITLE
[6X] Avoid large replication lag due to FPI WAL records from hintbits

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -9981,6 +9981,8 @@ XLogSaveBufferForHint(Buffer buffer, bool buffer_std)
 		rdata[1].next = NULL;
 
 		recptr = XLogInsert(RM_XLOG_ID, XLOG_FPI, rdata);
+
+		wait_to_avoid_large_repl_lag();
 	}
 
 	return recptr;

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -1644,10 +1644,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 
 	{
 		{"gp_disable_tuple_hints", PGC_USERSET, DEVELOPER_OPTIONS,
-			gettext_noop("Specify if reader should set hint bits on tuples."),
+			gettext_noop("Specify if hint bits on tuples should be deferred."),
 			NULL,
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
+		/*
+		 * If gp_disable_tuple_hints is off, always mark buffer dirty.
+		 * If gp_disable_tuple_hints is on, defer marking the buffer dirty
+		 * until after transaction is identified as old.
+		 * (unless it is a catalog table) See: markDirty
+		 */
 		&gp_disable_tuple_hints,
 		true,
 		NULL, NULL, NULL

--- a/src/test/isolation2/expected/segwalrep/select_throttle.out
+++ b/src/test/isolation2/expected/segwalrep/select_throttle.out
@@ -1,0 +1,103 @@
+-- Test: SELECT or other read-only operations which set hint bits on pages,
+-- and in turn generate Full Page Images (FPI) WAL records should be throttled.
+-- We will only throttle when our transaction wal exceeds
+-- wait_for_replication_threshold
+-- For this test we will:
+-- 1. Set wait_for_replication_threshold to 1kB for quicker test
+-- 2. create two tables (one small and one large)
+-- 3. set gp_disable_tuple_hints=off so buffer will be immediately marked dirty on hint bit change
+-- 4. Suspend walsender
+-- 5. Perform a read-only operation (SELECT) which would now set the hint bits
+--  For the small table this operation should finish,
+--  but for large table the SELECT should be throttled
+--  since it would generate a lot of WAL greater than wait_for_replication_threshold
+-- 6. Confirm that the query is waiting on Syncrep
+-- 7. Reset the walsender and the transaction should complete
+--
+
+include: helpers/server_helpers.sql;
+CREATE
+
+-- set wait_for_replication_threshold to 1kB for quicker test
+ALTER SYSTEM SET wait_for_replication_threshold = 1;
+ALTER
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)
+
+CREATE TABLE select_no_throttle(a int) DISTRIBUTED BY (a);
+CREATE
+INSERT INTO select_no_throttle SELECT generate_series (1, 10);
+INSERT 10
+CREATE TABLE select_throttle(a int) DISTRIBUTED BY (a);
+CREATE
+INSERT INTO select_throttle SELECT generate_series (1, 100000);
+INSERT 100000
+
+-- Enable tuple hints so that buffer will be marked dirty upon a hint bit change
+-- (so that we don't have to wait for the tuple to age. See logic in markDirty)
+1U: SET gp_disable_tuple_hints=off;
+SET
+
+-- flush the data to disk
+checkpoint;
+CHECKPOINT
+
+-- Suspend walsender
+SELECT gp_inject_fault_infinite('wal_sender_loop', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- the following SELECTS will set the hint bit on (the buffer will be marked dirty)
+-- This query should not wait
+1U: SELECT count(*) FROM select_no_throttle;
+ count 
+-------
+ 1     
+(1 row)
+checkpoint;
+CHECKPOINT
+-- This query should wait for Syncrep since its WAL size for hint bits is greater than wait_for_replication_threshold
+1U&: SELECT count(*) FROM select_throttle;  <waiting ...>
+
+-- check if the above query is waiting on SyncRep in pg_stat_activity
+SELECT is_query_waiting_for_syncrep(50, 'SELECT count(*) FROM select_throttle;');
+ is_query_waiting_for_syncrep 
+------------------------------
+ t                            
+(1 row)
+
+-- reset walsender
+SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+-- after this, system continue to proceed
+
+1U<:  <... completed>
+ count 
+-------
+ 33327 
+(1 row)
+
+SELECT wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+1U: RESET gp_disable_tuple_hints;
+RESET
+1Uq: ... <quitting>
+
+ALTER SYSTEM RESET wait_for_replication_threshold;
+ALTER
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t              
+(1 row)

--- a/src/test/isolation2/expected/setup.out
+++ b/src/test/isolation2/expected/setup.out
@@ -1,3 +1,6 @@
+CREATE OR REPLACE LANGUAGE plpythonu;
+CREATE
+
 -- Helper function, to call either __gp_aoseg, or gp_aocsseg, depending
 -- on whether the table is row- or column-oriented. This allows us to
 -- run the same test queries on both.
@@ -24,4 +27,7 @@ CREATE
 
 -- Helper function
 CREATE or REPLACE FUNCTION wait_until_waiting_for_required_lock (rel_name text, lmode text, segment_id integer) /*in func*/ RETURNS bool AS $$ declare retries int; /* in func */ begin /* in func */ retries := 1200; /* in func */ loop /* in func */ if (select not granted from pg_locks l where granted='f' and l.relation::regclass = rel_name::regclass and l.mode=lmode and l.gp_segment_id=segment_id) then /* in func */ return true; /* in func */ end if; /* in func */ if retries <= 0 then /* in func */ return false; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ retries := retries - 1; /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
+CREATE
+
+CREATE OR REPLACE FUNCTION is_query_waiting_for_syncrep(iterations int, check_query text) RETURNS bool AS $$ for i in range(iterations): results = plpy.execute("SELECT * FROM\ (SELECT gp_execution_segment() AS gp_segment_id, query, waiting_reason\ FROM gp_dist_random('pg_stat_activity')) s\ WHERE gp_segment_id = 1 AND\ query = '%s' AND\ waiting_reason = 'replication'" % check_query ) if results: return True return False $$ LANGUAGE plpythonu VOLATILE;
 CREATE

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -239,6 +239,7 @@ test: segwalrep/max_slot_wal_keep_size
 test: segwalrep/dtx_recovery_wait_lsn
 test: pg_basebackup
 test: pg_basebackup_with_tablespaces
+test: segwalrep/select_throttle
 test: fts_manual_probe
 test: fts_session_reset
 test: fts_segment_reset

--- a/src/test/isolation2/sql/segwalrep/select_throttle.sql
+++ b/src/test/isolation2/sql/segwalrep/select_throttle.sql
@@ -1,0 +1,60 @@
+-- Test: SELECT or other read-only operations which set hint bits on pages,
+-- and in turn generate Full Page Images (FPI) WAL records should be throttled.
+-- We will only throttle when our transaction wal exceeds
+-- wait_for_replication_threshold
+-- For this test we will:
+-- 1. Set wait_for_replication_threshold to 1kB for quicker test
+-- 2. create two tables (one small and one large)
+-- 3. set gp_disable_tuple_hints=off so buffer will be immediately marked dirty on hint bit change
+-- 4. Suspend walsender
+-- 5. Perform a read-only operation (SELECT) which would now set the hint bits
+--  For the small table this operation should finish,
+--  but for large table the SELECT should be throttled
+--  since it would generate a lot of WAL greater than wait_for_replication_threshold
+-- 6. Confirm that the query is waiting on Syncrep
+-- 7. Reset the walsender and the transaction should complete
+--
+
+include: helpers/server_helpers.sql;
+
+-- set wait_for_replication_threshold to 1kB for quicker test
+ALTER SYSTEM SET wait_for_replication_threshold = 1;
+SELECT pg_reload_conf();
+
+CREATE TABLE select_no_throttle(a int) DISTRIBUTED BY (a);
+INSERT INTO select_no_throttle SELECT generate_series (1, 10);
+CREATE TABLE select_throttle(a int) DISTRIBUTED BY (a);
+INSERT INTO select_throttle SELECT generate_series (1, 100000);
+
+-- Enable tuple hints so that buffer will be marked dirty upon a hint bit change
+-- (so that we don't have to wait for the tuple to age. See logic in markDirty)
+1U: SET gp_disable_tuple_hints=off;
+
+-- flush the data to disk
+checkpoint;
+
+-- Suspend walsender
+SELECT gp_inject_fault_infinite('wal_sender_loop', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
+
+-- the following SELECTS will set the hint bit on (the buffer will be marked dirty)
+-- This query should not wait
+1U: SELECT count(*) FROM select_no_throttle;
+checkpoint;
+-- This query should wait for Syncrep since its WAL size for hint bits is greater than wait_for_replication_threshold
+1U&: SELECT count(*) FROM select_throttle;
+
+-- check if the above query is waiting on SyncRep in pg_stat_activity
+SELECT is_query_waiting_for_syncrep(50, 'SELECT count(*) FROM select_throttle;');
+
+-- reset walsender
+SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
+-- after this, system continue to proceed
+
+1U<:
+
+SELECT wait_until_all_segments_synchronized();
+1U: RESET gp_disable_tuple_hints;
+1Uq:
+
+ALTER SYSTEM RESET wait_for_replication_threshold;
+SELECT pg_reload_conf();


### PR DESCRIPTION
This is a 6X backport of 611b788d18d.

Conflicts resolved:

(1) xloginsert.c doesn't exist on 6X. Side note: we also don't have
XLOG_FPI_FOR_HINT as we don't have 0bd624d63b0, but that doesn't matter
much as we still add the throttle logic for XLogSaveBufferForHint().

(2) SRFs aren't supported in the WHERE clause, so had to change
is_query_waiting_for_syncrep() a bit.

(3) wait_event is not present in pg_stat_activity, used waiting_reason
instead.

(4) Had to include server_helpers.sql to get
wait_until_all_segments_synchronized().

Original commit message follows:

SELECT or other read only operations can result in setting hintbits on
pages, which in turn results in generating Full Page Images (FPI) WAL
records. These operations are not throttled currently and hence can
generate huge wal traffic on primary without waiting for mirror. This
causes concurrent transactions to suffer from replication lag.

One of scenario this was seen in production was during SELECT post
restore of large heap table from backup. Ideally, these situations
should be avoided by performing vacuum on such tables or via some
other mechanisms. Though there is still possibility the best practice
guidance is not followed and hence to still avoid the situation better
to have throttling in writing the FPI code as well.

Co-authored-by: Divyesh Vanjare <vanjared@vmware.com>
