### PR TITLE
Remove OpenLab CI from README as it's EOL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 **Concourse Pipeline** [![Concourse Build Status](https://prod.ci.gpdb.pivotal.io/api/v1/teams/main/pipelines/gpdb_master/badge)](https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb_master) |
 **Travis Build** [![Travis Build Status](https://travis-ci.org/greenplum-db/gpdb.svg?branch=master)](https://travis-ci.org/greenplum-db/gpdb) |
-**Zuul Regression Test On Arm** [![Zuul Regression Test Status](http://openlabtesting.org:15000/badge?project=greenplum-db%2Fgpdb)](https://status.openlabtesting.org/builds/builds?project=greenplum-db%2Fgpdb&job_name=gpdb-installcheck-world-tests-on-arm64)
 
 ----------------------------------------------------------------------
 


### PR DESCRIPTION
Thanks OpenLab for providing ARM regression tests service for a very
long time.

This PR is also to raise some attention from developers. As #13903 mentions,
even if OpenLab is EOL, they can generously donate us some ARM VM resources
for testing Greenplum.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
