### PR TITLE
Fix bug that Orca failed to derive distribution spec correctly for hash joins

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/4WayJoinInferredPredsRemovedWith2Motion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/4WayJoinInferredPredsRemovedWith2Motion.mdp
@@ -4649,7 +4649,7 @@ explain select * from cs catalog_sales, it item, sr store_returns, ss store_sale
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="134775">
+    <dxl:Plan Id="0" SpaceSize="104185">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1725.989618" Rows="129.961520" Width="44"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndex-ChooseHashJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndex-ChooseHashJoin.mdp
@@ -3456,7 +3456,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="17">
+    <dxl:Plan Id="0" SpaceSize="12">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1070.584957" Rows="992059.668838" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/BroadcastSkewedHashjoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BroadcastSkewedHashjoin.mdp
@@ -3111,7 +3111,7 @@ Intent: The join should pick up a Broadcast over Redistribute. The hashjoin is s
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="12">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="871.634495" Rows="77880.861751" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/CJoinOrderDPTest/JoinOrderWithOutDP.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CJoinOrderDPTest/JoinOrderWithOutDP.mdp
@@ -1764,7 +1764,7 @@ INNER JOIN  (SELECT FOO10.i1 AS i1
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="798218">
+    <dxl:Plan Id="0" SpaceSize="197120">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2155.369590" Rows="100.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/CTAS-With-Global-Local-Agg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS-With-Global-Local-Agg.mdp
@@ -710,7 +710,7 @@
         </dxl:LogicalGroupBy>
       </dxl:LogicalCTAS>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="17">
+    <dxl:Plan Id="0" SpaceSize="14">
       <dxl:PhysicalCTAS Name="fake ctas rel" IsTemporary="true" StorageType="Heap" DistributionPolicy="Random" InsertColumns="10" VarTypeModList="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="438.394467" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/CTE-4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-4.mdp
@@ -271,7 +271,7 @@
         </dxl:LogicalCTEAnchor>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="28">
+    <dxl:Plan Id="0" SpaceSize="25">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.003882" Rows="10.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/CTE-Join-Redistribute-Producer.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-Join-Redistribute-Producer.mdp
@@ -410,7 +410,7 @@ with v as (select * from t1) select * from v v1, v v2 where v1.b=v2.b;
         </dxl:LogicalJoin>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="25">
+    <dxl:Plan Id="0" SpaceSize="20">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.388166" Rows="1000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/CTE-NoPushProperties.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-NoPushProperties.mdp
@@ -1726,7 +1726,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="42">
+    <dxl:Plan Id="0" SpaceSize="24">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.483722" Rows="1000.000000" Width="26"/>

--- a/src/backend/gporca/data/dxl/minidump/CTE-PushProperties.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-PushProperties.mdp
@@ -1755,7 +1755,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="119">
+    <dxl:Plan Id="0" SpaceSize="62">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.388623" Rows="400.000000" Width="26"/>

--- a/src/backend/gporca/data/dxl/minidump/CTE-volatile.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-volatile.mdp
@@ -410,7 +410,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="42">
+    <dxl:Plan Id="0" SpaceSize="32">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.055688" Rows="100.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/CTEMergeGroupsCircularDeriveStats.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTEMergeGroupsCircularDeriveStats.mdp
@@ -251,7 +251,7 @@
         <dxl:LogicalCTEConsumer CTEId="1" Columns="19,20,21,22"/>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="15">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000587" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/CTEWithMergedGroup.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTEWithMergedGroup.mdp
@@ -425,7 +425,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="157158227264">
+    <dxl:Plan Id="0" SpaceSize="158660247168">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356250696.455244" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/CapGbCardToSelectCard.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CapGbCardToSelectCard.mdp
@@ -10888,7 +10888,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
         </dxl:LogicalJoin>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="118">
+    <dxl:Plan Id="0" SpaceSize="98">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="102938.691528" Rows="13.696907" Width="127"/>

--- a/src/backend/gporca/data/dxl/minidump/ConstTblGetUnderSubqWithOuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ConstTblGetUnderSubqWithOuterRef.mdp
@@ -279,7 +279,7 @@ SELECT * FROM foo,bar WHERE a=(SELECT c);
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="84">
+    <dxl:Plan Id="0" SpaceSize="80">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="883135.989715" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/ConvertHashToRandomInsert.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ConvertHashToRandomInsert.mdp
@@ -642,7 +642,7 @@ explain analyze insert into t1 select t2.a,t3.b from t2, t3 where t2.a = t3.a;
         </dxl:LogicalJoin>
       </dxl:LogicalInsert>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="30">
+    <dxl:Plan Id="0" SpaceSize="18">
       <dxl:DMLInsert Columns="0,6" ActionCol="10" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="877.746838" Rows="1000.000000" Width="7"/>

--- a/src/backend/gporca/data/dxl/minidump/ConvertHashToRandomSelect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ConvertHashToRandomSelect.mdp
@@ -202,7 +202,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="11">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1,2,3,4,5" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000696" Rows="1.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/DPE-IN.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPE-IN.mdp
@@ -971,7 +971,7 @@ select * from P,X where P.a=X.a  and X.a  in (1,2);
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="8">
+    <dxl:Plan Id="0" SpaceSize="7">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.284504" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/DPE-NOT-IN.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPE-NOT-IN.mdp
@@ -963,7 +963,7 @@ select * from P,X where P.a=X.a  and X.a not in (1,2);
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="8">
+    <dxl:Plan Id="0" SpaceSize="7">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="863.294061" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/DPE-with-unsupported-pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DPE-with-unsupported-pred.mdp
@@ -2371,7 +2371,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="79">
+    <dxl:Plan Id="0" SpaceSize="75">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324807.970884" Rows="2844.444444" Width="28"/>

--- a/src/backend/gporca/data/dxl/minidump/DQA-InnerJoin-GroupBy-HashAggregate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-InnerJoin-GroupBy-HashAggregate.mdp
@@ -466,7 +466,7 @@
         </dxl:LogicalGroupBy>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="40">
+    <dxl:Plan Id="0" SpaceSize="36">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.007060" Rows="10.000001" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/DeleteRandomlyDistributedTableJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeleteRandomlyDistributedTableJoin.mdp
@@ -277,7 +277,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalDelete>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="19">
+    <dxl:Plan Id="0" SpaceSize="17">
       <dxl:DMLDelete Columns="0" ActionCol="16" OidCol="0" CtidCol="1" SegmentIdCol="7" InputSorted="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.023911" Rows="1.000000" Width="1"/>

--- a/src/backend/gporca/data/dxl/minidump/EagerAggGroupColumnInJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EagerAggGroupColumnInJoin.mdp
@@ -329,7 +329,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="104">
+    <dxl:Plan Id="0" SpaceSize="96">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000604" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin2.mdp
@@ -11330,7 +11330,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="24">
+    <dxl:Plan Id="0" SpaceSize="22">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="865.875352" Rows="3866.533707" Width="116"/>

--- a/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin3.mdp
@@ -13863,7 +13863,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="11">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="3209.039368" Rows="716144.000000" Width="402"/>

--- a/src/backend/gporca/data/dxl/minidump/Equiv-HashedDistr-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Equiv-HashedDistr-1.mdp
@@ -1934,7 +1934,7 @@
         </dxl:UnionAll>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="102">
+    <dxl:Plan Id="0" SpaceSize="66">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="34972.709569" Rows="19097.637457" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/Equiv-HashedDistr-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Equiv-HashedDistr-2.mdp
@@ -1936,7 +1936,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="408">
+    <dxl:Plan Id="0" SpaceSize="264">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="34974.557438" Rows="9548.818729" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/EquivClassesAndOr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EquivClassesAndOr.mdp
@@ -344,7 +344,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="347">
+    <dxl:Plan Id="0" SpaceSize="300">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.002536" Rows="1.000000" Width="60"/>

--- a/src/backend/gporca/data/dxl/minidump/EstimateJoinRowsForCastPredicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EstimateJoinRowsForCastPredicates.mdp
@@ -515,7 +515,7 @@ explain select * from A,B where A.j=B.j;
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="17">
+    <dxl:Plan Id="0" SpaceSize="12">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.541395" Rows="10000.000000" Width="14"/>

--- a/src/backend/gporca/data/dxl/minidump/ExpandJoinOrder.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExpandJoinOrder.mdp
@@ -865,7 +865,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3561">
+    <dxl:Plan Id="0" SpaceSize="2316">
       <dxl:Limit>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="31120.423435" Rows="100.000000" Width="128"/>

--- a/src/backend/gporca/data/dxl/minidump/ExpandNAryJoinGreedyWithLOJOnly.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExpandNAryJoinGreedyWithLOJOnly.mdp
@@ -3934,7 +3934,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="165817">
+    <dxl:Plan Id="0" SpaceSize="142051">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2586.168979" Rows="10.000001" Width="20"/>

--- a/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisj.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisj.mdp
@@ -15779,7 +15779,7 @@ WHERE ((sale_type = 's'::text AND dyear = 2001 AND year_total &gt; 0::numeric) O
         </dxl:LogicalProject>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2802">
+    <dxl:Plan Id="0" SpaceSize="2386">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="5944.261371" Rows="20169.272000" Width="76"/>

--- a/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisjWithComputedColumns.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisjWithComputedColumns.mdp
@@ -459,7 +459,7 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4030">
+    <dxl:Plan Id="0" SpaceSize="3190">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.002852" Rows="1.000000" Width="64"/>

--- a/src/backend/gporca/data/dxl/minidump/FullJoin-Subquery-CastedPredicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/FullJoin-Subquery-CastedPredicates.mdp
@@ -487,7 +487,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3196">
+    <dxl:Plan Id="0" SpaceSize="2048">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1299.001542" Rows="3.000000" Width="20"/>

--- a/src/backend/gporca/data/dxl/minidump/GroupingOnSameTblCol-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GroupingOnSameTblCol-1.mdp
@@ -11022,7 +11022,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
         </dxl:LogicalJoin>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="84">
+    <dxl:Plan Id="0" SpaceSize="76">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="458.857269" Rows="3.941034" Width="127"/>

--- a/src/backend/gporca/data/dxl/minidump/HAWQ-TPCH-Stat-Derivation.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HAWQ-TPCH-Stat-Derivation.mdp
@@ -6367,7 +6367,7 @@ ORDER BY s_name;
         </dxl:LogicalJoin>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3270672">
+    <dxl:Plan Id="0" SpaceSize="1863552">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="24583535.993774" Rows="49.989277" Width="65"/>

--- a/src/backend/gporca/data/dxl/minidump/HJN-DPE-Bitmap-Outer-Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HJN-DPE-Bitmap-Outer-Child.mdp
@@ -1917,7 +1917,7 @@ select * from dbs_target, dbs_helper where dbs_target.c1 = dbs_helper.c1 and dbs
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="30">
+    <dxl:Plan Id="0" SpaceSize="20">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="829.034339" Rows="35.148716" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/HJN-DeeperOuter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HJN-DeeperOuter.mdp
@@ -356,7 +356,7 @@ SELECT z.*,x.* FROM x,y,z WHERE x.i=y.i AND x.i=z.i;
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="410">
+    <dxl:Plan Id="0" SpaceSize="354">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.001468" Rows="1.000000" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/HJN-Redistribute-One-Side.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HJN-Redistribute-One-Side.mdp
@@ -4551,7 +4551,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="49">
+    <dxl:Plan Id="0" SpaceSize="32">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="11941.357050" Rows="1.000000" Width="275"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondDisjointWithHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondDisjointWithHashedDistr.mdp
@@ -824,7 +824,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18">
+    <dxl:Plan Id="0" SpaceSize="13">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="863.431632" Rows="1000.888592" Width="20"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondIntersectWithHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondIntersectWithHashedDistr.mdp
@@ -830,7 +830,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="34">
+    <dxl:Plan Id="0" SpaceSize="23">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="864.151759" Rows="1000.000000" Width="20"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondSubsetOfHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondSubsetOfHashedDistr.mdp
@@ -824,7 +824,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18">
+    <dxl:Plan Id="0" SpaceSize="13">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="863.431632" Rows="1000.888592" Width="20"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondSupersetOfHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondSupersetOfHashedDistr.mdp
@@ -816,7 +816,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="22">
+    <dxl:Plan Id="0" SpaceSize="17">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="863.780122" Rows="100.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKey-WithComplexPreds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKey-WithComplexPreds.mdp
@@ -285,7 +285,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="44">
+    <dxl:Plan Id="0" SpaceSize="27">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="437.000677" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-Bitmap-WithComplexPreds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-Bitmap-WithComplexPreds.mdp
@@ -290,7 +290,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="44">
+    <dxl:Plan Id="0" SpaceSize="27">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="822.296104" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-Bitmap.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-Bitmap.mdp
@@ -273,7 +273,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="31">
+    <dxl:Plan Id="0" SpaceSize="21">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="822.295674" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexGet-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexGet-OuterRefs.mdp
@@ -260,7 +260,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="34">
+    <dxl:Plan Id="0" SpaceSize="24">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="437.001095" Rows="1.000000" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesInnerOfLOJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesInnerOfLOJ.mdp
@@ -816,7 +816,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="376">
+    <dxl:Plan Id="0" SpaceSize="285">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.000804" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/InnerJoinBroadcastTableHashSpec.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InnerJoinBroadcastTableHashSpec.mdp
@@ -360,7 +360,7 @@ EXPLAIN SELECT b2, sum(c1) FROM t1, t2 WHERE a1 = b2 GROUP BY b2 ORDER BY b2;
         </dxl:LogicalGroupBy>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="60">
+    <dxl:Plan Id="0" SpaceSize="50">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000572" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/InnerJoinReplicatedTableHashSpec.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InnerJoinReplicatedTableHashSpec.mdp
@@ -358,7 +358,7 @@ EXPLAIN SELECT b2, sum(c1) FROM t1, t2 WHERE a1 = b2 GROUP BY b2 ORDER BY b2;
         </dxl:LogicalGroupBy>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="260">
+    <dxl:Plan Id="0" SpaceSize="255">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000465" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/Insert-With-HJ-CTE-Agg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-With-HJ-CTE-Agg.mdp
@@ -508,7 +508,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalInsert>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1160">
+    <dxl:Plan Id="0" SpaceSize="1180">
       <dxl:DMLInsert Columns="38,39,42,43,44" ActionCol="48" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="867.122533" Rows="96.000000" Width="36"/>

--- a/src/backend/gporca/data/dxl/minidump/Intersect-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Intersect-OuterRefs.mdp
@@ -1413,7 +1413,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4320">
+    <dxl:Plan Id="0" SpaceSize="4060">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.065290" Rows="77.229878" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/JOIN-NonRedistributableCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JOIN-NonRedistributableCol.mdp
@@ -270,7 +270,7 @@ explain select * from foo, testhstore where foo.b = testhstore.h;
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="17">
+    <dxl:Plan Id="0" SpaceSize="12">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000526" Rows="1.000000" Width="14"/>

--- a/src/backend/gporca/data/dxl/minidump/JOIN-Pred-Cast-Int4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JOIN-Pred-Cast-Int4.mdp
@@ -453,7 +453,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="11">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.022378" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/JOIN-Pred-Cast-Varchar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JOIN-Pred-Cast-Varchar.mdp
@@ -649,7 +649,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="17">
+    <dxl:Plan Id="0" SpaceSize="12">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.566515" Rows="10000.000000" Width="14"/>

--- a/src/backend/gporca/data/dxl/minidump/JOIN-cast2text-int4-Eq-cast2text-double.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JOIN-cast2text-int4-Eq-cast2text-double.mdp
@@ -474,7 +474,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="17">
+    <dxl:Plan Id="0" SpaceSize="12">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.031867" Rows="100.000000" Width="13"/>

--- a/src/backend/gporca/data/dxl/minidump/JOIN-int4-Eq-double.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JOIN-int4-Eq-double.mdp
@@ -453,7 +453,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="11">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.030459" Rows="100.000000" Width="13"/>

--- a/src/backend/gporca/data/dxl/minidump/JOIN-int4-Eq-int2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JOIN-int4-Eq-int2.mdp
@@ -352,7 +352,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="11">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.022512" Rows="100.000000" Width="6"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
@@ -4049,7 +4049,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="125612">
+    <dxl:Plan Id="0" SpaceSize="80990">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="3422679.529071" Rows="19136.250000" Width="31"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinArityAssociativityCommutativityAboveLimit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinArityAssociativityCommutativityAboveLimit.mdp
@@ -336,7 +336,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3667">
+    <dxl:Plan Id="0" SpaceSize="2488">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.001370" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinArityAssociativityCommutativityAtLimit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinArityAssociativityCommutativityAtLimit.mdp
@@ -336,7 +336,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="8201">
+    <dxl:Plan Id="0" SpaceSize="5270">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.001370" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinArityAssociativityCommutativityBelowLimit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinArityAssociativityCommutativityBelowLimit.mdp
@@ -336,7 +336,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="293">
+    <dxl:Plan Id="0" SpaceSize="415">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.001643" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinCitextVarchar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinCitextVarchar.mdp
@@ -347,7 +347,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="11">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.001378" Rows="4.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinColWithOnlyNDV.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinColWithOnlyNDV.mdp
@@ -11699,7 +11699,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="11">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="97948.947313" Rows="4424643.209483" Width="856"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinDefaultOpfamiliesUsingNonDefaultOpfamilyOp.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinDefaultOpfamiliesUsingNonDefaultOpfamilyOp.mdp
@@ -333,7 +333,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="17">
+    <dxl:Plan Id="0" SpaceSize="12">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000704" Rows="4.800000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinOptimizationLevelGreedyNonPartTblInnerJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinOptimizationLevelGreedyNonPartTblInnerJoin.mdp
@@ -2868,7 +2868,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="761">
+    <dxl:Plan Id="0" SpaceSize="617">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.848201" Rows="10.000000" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinOrderDPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinOrderDPE.mdp
@@ -3144,7 +3144,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="87">
+    <dxl:Plan Id="0" SpaceSize="84">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1301.264895" Rows="95315.069401" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinTinterval.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinTinterval.mdp
@@ -311,7 +311,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="79">
+    <dxl:Plan Id="0" SpaceSize="54">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000771" Rows="1.000000" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJReorderComplexNestedLOJs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJReorderComplexNestedLOJs.mdp
@@ -1619,7 +1619,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6114743">
+    <dxl:Plan Id="0" SpaceSize="2778615">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2586.297294" Rows="6.196244" Width="56"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJReorderWithComplexPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJReorderWithComplexPredicate.mdp
@@ -1957,7 +1957,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="142">
+    <dxl:Plan Id="0" SpaceSize="95">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.153370" Rows="2.000000" Width="36"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJReorderWithIDF.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJReorderWithIDF.mdp
@@ -1540,7 +1540,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="136">
+    <dxl:Plan Id="0" SpaceSize="95">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.153459" Rows="1.200000" Width="36"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJReorderWithOneSidedFilter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJReorderWithOneSidedFilter.mdp
@@ -1954,7 +1954,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="15">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1765474.620713" Rows="4.000000" Width="36"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJReorderWithSimplePredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJReorderWithSimplePredicate.mdp
@@ -1540,7 +1540,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="583">
+    <dxl:Plan Id="0" SpaceSize="449">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.211204" Rows="2.000000" Width="36"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ_bb_mpph.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_bb_mpph.mdp
@@ -5773,7 +5773,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="34318200">
+    <dxl:Plan Id="0" SpaceSize="25862900">
       <dxl:Limit>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2587.327627" Rows="1.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_and_predicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_and_predicate.mdp
@@ -352,7 +352,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18">
+    <dxl:Plan Id="0" SpaceSize="13">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="437.000687" Rows="1.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_or_predicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_or_predicate.mdp
@@ -360,7 +360,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18">
+    <dxl:Plan Id="0" SpaceSize="13">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="437.000687" Rows="1.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoinDPv2JoinOrder.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoinDPv2JoinOrder.mdp
@@ -1444,7 +1444,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="145">
+    <dxl:Plan Id="0" SpaceSize="97">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1325421.228417" Rows="333733.333333" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin-Tpcds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin-Tpcds.mdp
@@ -11631,7 +11631,7 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
         </dxl:LogicalCTEAnchor>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="96397">
+    <dxl:Plan Id="0" SpaceSize="85902">
       <dxl:Limit>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="5904.512295" Rows="5.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin.mdp
@@ -301,7 +301,7 @@ and ei.entity_id  = i.ad_id;
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4080">
+    <dxl:Plan Id="0" SpaceSize="2904">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2586.003316" Rows="2.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/ManyTextUnionsInSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ManyTextUnionsInSubquery.mdp
@@ -588,7 +588,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="14116300">
+    <dxl:Plan Id="0" SpaceSize="13648900">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.003419" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/MultiColumnDQA-InnerJoin-GroupBy-HashAggregate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultiColumnDQA-InnerJoin-GroupBy-HashAggregate.mdp
@@ -445,7 +445,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="9">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.006109" Rows="10.000001" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/MultiDistKeyJoinCardinality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultiDistKeyJoinCardinality.mdp
@@ -1162,7 +1162,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="30">
+    <dxl:Plan Id="0" SpaceSize="20">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.346837" Rows="1000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/MultiDistKeyWithOtherPredsJoinCardinality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultiDistKeyWithOtherPredsJoinCardinality.mdp
@@ -687,7 +687,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="52">
+    <dxl:Plan Id="0" SpaceSize="32">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.740340" Rows="1368.264678" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/MultipleDampedPredJoinCardinality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultipleDampedPredJoinCardinality.mdp
@@ -4718,7 +4718,7 @@ explain select * from t1, t2 where t1.a=t2.a and t1.b=t2.b;
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="21">
+    <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.346837" Rows="1000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/Nested-Setops-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Nested-Setops-2.mdp
@@ -597,7 +597,7 @@
         </dxl:LogicalProject>
       </dxl:Difference>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="244000000">
+    <dxl:Plan Id="0" SpaceSize="177876000">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2592.974241" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/NoDistKeyMultiPredJoinCardinality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NoDistKeyMultiPredJoinCardinality.mdp
@@ -1584,7 +1584,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="43">
+    <dxl:Plan Id="0" SpaceSize="26">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.448529" Rows="1000.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/NoRedistributeOnAppend.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NoRedistributeOnAppend.mdp
@@ -425,7 +425,7 @@ GROUP BY b;
         </dxl:LogicalCTEAnchor>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="32557795328">
+    <dxl:Plan Id="0" SpaceSize="28999731200">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2155.000796" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/OneDistKeyMultiPredJoinCardinality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OneDistKeyMultiPredJoinCardinality.mdp
@@ -1220,7 +1220,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="21">
+    <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.423489" Rows="1000.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/PartSelectorOnJoinSide.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartSelectorOnJoinSide.mdp
@@ -2264,7 +2264,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="14">
+    <dxl:Plan Id="0" SpaceSize="9">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="898.322204" Rows="73705.404960" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-AvoidRangePred-DPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-AvoidRangePred-DPE.mdp
@@ -1926,7 +1926,7 @@ FROM abuela JOIN bar ON a = c AND b BETWEEN d - 1 AND d + 4
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="261">
+    <dxl:Plan Id="0" SpaceSize="202">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.008634" Rows="3.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-GroupBy.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-GroupBy.mdp
@@ -828,7 +828,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="743">
+    <dxl:Plan Id="0" SpaceSize="701">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.020922" Rows="100.000000" Width="14"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DisablePartSelectionJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DisablePartSelectionJoin.mdp
@@ -845,7 +845,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="11">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.108395" Rows="1.000000" Width="20"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-HJ3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-HJ3.mdp
@@ -468,7 +468,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="9">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000831" Rows="1.000000" Width="28"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverExcept.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverExcept.mdp
@@ -1788,7 +1788,7 @@ select * from (select * from p1 except select * from p2) as p, tt where p.b=tt.b
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="198">
+    <dxl:Plan Id="0" SpaceSize="103">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1298.385913" Rows="4000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverGbAgg-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverGbAgg-2.mdp
@@ -1609,7 +1609,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="16">
+    <dxl:Plan Id="0" SpaceSize="14">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.027897" Rows="101.010101" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverIntersect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverIntersect.mdp
@@ -1788,7 +1788,7 @@ select * from (select * from p1 intersect select * from p2) as p, tt where p.b=t
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2036">
+    <dxl:Plan Id="0" SpaceSize="680">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1301.575209" Rows="10000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-1.mdp
@@ -1788,7 +1788,7 @@ select * from (select * from p1 union all select * from p2) as p, tt where p.b=t
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="15">
+    <dxl:Plan Id="0" SpaceSize="9">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1297.273809" Rows="20000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-JoinOverUnion-2.mdp
@@ -1137,7 +1137,7 @@ select * from (select * from tt union all select * from p2) as p, tt where p.b=t
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="14">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1294.717330" Rows="5431.276543" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoin.mdp
@@ -518,7 +518,7 @@ explain select count(*) from r_p, s c, s d, s e where r_p.a = c.c and r_p.a = d.
         </dxl:LogicalJoin>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="594117">
+    <dxl:Plan Id="0" SpaceSize="298009">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.010909" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE-2.mdp
@@ -2566,7 +2566,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="303">
+    <dxl:Plan Id="0" SpaceSize="261">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="23515.903551" Rows="12277684.984863" Width="246"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
@@ -4765,7 +4765,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="31498">
+    <dxl:Plan Id="0" SpaceSize="16648">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1749361.683589" Rows="321694266.492042" Width="355"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SQScalar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SQScalar.mdp
@@ -739,7 +739,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="32">
+    <dxl:Plan Id="0" SpaceSize="28">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000898" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/RightJoinNoDPSNonDistKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/RightJoinNoDPSNonDistKey.mdp
@@ -1290,7 +1290,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="10">
+    <dxl:Plan Id="0" SpaceSize="11">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.159887" Rows="1009.000091" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/SixWayDPv2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SixWayDPv2.mdp
@@ -492,7 +492,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1037742">
+    <dxl:Plan Id="0" SpaceSize="534472">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2586.003056" Rows="1.000000" Width="48"/>

--- a/src/backend/gporca/data/dxl/minidump/Subq2CorrSQInLOJOn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq2CorrSQInLOJOn.mdp
@@ -2430,7 +2430,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="47">
+    <dxl:Plan Id="0" SpaceSize="32">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="568384082185.659546" Rows="1000.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqExists-With-External-Corrs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqExists-With-External-Corrs.mdp
@@ -456,7 +456,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="30156">
+    <dxl:Plan Id="0" SpaceSize="22026">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.001472" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqExists-Without-External-Corrs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqExists-Without-External-Corrs.mdp
@@ -431,7 +431,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="357461">
+    <dxl:Plan Id="0" SpaceSize="150026">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="12930.008073" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/TPCDS-39-InnerJoin-JoinEstimate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TPCDS-39-InnerJoin-JoinEstimate.mdp
@@ -2648,7 +2648,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="11">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="9093.176214" Rows="11530621.000000" Width="123"/>

--- a/src/backend/gporca/data/dxl/minidump/TPCH-Partitioned-256GB.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TPCH-Partitioned-256GB.mdp
@@ -4043,7 +4043,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="91668">
+    <dxl:Plan Id="0" SpaceSize="57782">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2343319.893955" Rows="10325183.250315" Width="697"/>

--- a/src/backend/gporca/data/dxl/minidump/TranslateFilterWithCTEAndTableScanIntoFilterAndOneTimeFilter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TranslateFilterWithCTEAndTableScanIntoFilterAndOneTimeFilter.mdp
@@ -612,7 +612,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1116">
+    <dxl:Plan Id="0" SpaceSize="616">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1852062876647.470947" Rows="10.000001" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/Union-NOT-Plus-OR-Constraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Union-NOT-Plus-OR-Constraint.mdp
@@ -288,7 +288,7 @@ explain SELECT a.f3 FROM tb a JOIN tb b ON a.f1 = b.f1 AND NOT ( a.f2 = 0 OR a.f
         </dxl:LogicalProject>
       </dxl:Union>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2168">
+    <dxl:Plan Id="0" SpaceSize="1488">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.001805" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/UnionAll.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnionAll.mdp
@@ -8890,7 +8890,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="13">
+    <dxl:Plan Id="0" SpaceSize="12">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1773.052304" Rows="2163263.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/UpdateCardinalityAssert.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateCardinalityAssert.mdp
@@ -274,7 +274,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalUpdate>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="9">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:DMLUpdate Columns="0,1" ActionCol="18" OidCol="19" CtidCol="2" SegmentIdCol="8" InputSorted="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.102559" Rows="1.000000" Width="1"/>

--- a/src/backend/gporca/data/dxl/minidump/UpdateDistrKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateDistrKey.mdp
@@ -269,7 +269,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalUpdate>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="30">
+    <dxl:Plan Id="0" SpaceSize="20">
       <dxl:DMLUpdate Columns="0,1" ActionCol="18" OidCol="19" CtidCol="2" SegmentIdCol="8" InputSorted="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1880.351554" Rows="10000.000000" Width="1"/>

--- a/src/backend/gporca/data/dxl/minidump/cte-duplicate-columns-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/cte-duplicate-columns-2.mdp
@@ -245,7 +245,7 @@ where x1.b = x2.b;
         </dxl:LogicalJoin>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="30">
+    <dxl:Plan Id="0" SpaceSize="20">
       <dxl:Sequence>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.001043" Rows="1.000000" Width="24"/>

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalFullMergeJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalFullMergeJoin.h
@@ -24,6 +24,7 @@ public:
 	explicit CPhysicalFullMergeJoin(
 		CMemoryPool *mp, CExpressionArray *outer_merge_clauses,
 		CExpressionArray *inner_merge_clauses, IMdIdArray *hash_opfamilies,
+		BOOL is_null_aware = true,
 		CXform::EXformId origin_xform = CXform::ExfSentinel);
 
 	// dtor

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalHashJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalHashJoin.h
@@ -43,6 +43,11 @@ private:
 	// Hash op families of the operators used in the join conditions
 	IMdIdArray *m_hash_opfamilies;
 
+	// if the join condition is null-aware
+	// true by default, and false if the join condition doesn't contain
+	// any INDF predicates
+	BOOL m_is_null_aware;
+
 	// array redistribute request sent to the first hash join child
 	CDistributionSpecArray *m_pdrgpdsRedistributeRequests;
 
@@ -115,7 +120,7 @@ public:
 	// ctor
 	CPhysicalHashJoin(CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys,
 					  CExpressionArray *pdrgpexprInnerKeys,
-					  IMdIdArray *hash_opfamilies,
+					  IMdIdArray *hash_opfamilies, BOOL is_null_aware = true,
 					  CXform::EXformId origin_xform = CXform::ExfSentinel);
 
 	// dtor

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalInnerHashJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalInnerHashJoin.h
@@ -56,6 +56,7 @@ public:
 						   CExpressionArray *pdrgpexprOuterKeys,
 						   CExpressionArray *pdrgpexprInnerKeys,
 						   IMdIdArray *hash_opfamilies,
+						   BOOL is_null_aware = true,
 						   CXform::EXformId origin_xform = CXform::ExfSentinel);
 
 	// dtor

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftAntiSemiHashJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftAntiSemiHashJoin.h
@@ -36,6 +36,7 @@ public:
 	CPhysicalLeftAntiSemiHashJoin(
 		CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys,
 		CExpressionArray *pdrgpexprInnerKeys, IMdIdArray *hash_opfamilies,
+		BOOL is_null_aware = true,
 		CXform::EXformId origin_xform = CXform::ExfSentinel);
 
 	// dtor

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftAntiSemiHashJoinNotIn.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftAntiSemiHashJoinNotIn.h
@@ -36,6 +36,7 @@ public:
 	CPhysicalLeftAntiSemiHashJoinNotIn(
 		CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys,
 		CExpressionArray *pdrgpexprInnerKeys, IMdIdArray *hash_opfamilies,
+		BOOL is_null_aware = true,
 		CXform::EXformId origin_xform = CXform::ExfSentinel);
 
 	// ident accessors

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftOuterHashJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftOuterHashJoin.h
@@ -40,6 +40,7 @@ public:
 	CPhysicalLeftOuterHashJoin(
 		CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys,
 		CExpressionArray *pdrgpexprInnerKeys, IMdIdArray *hash_opfamilies,
+		BOOL is_null_aware = true,
 		CXform::EXformId origin_xform = CXform::ExfSentinel);
 
 	// dtor

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftSemiHashJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalLeftSemiHashJoin.h
@@ -35,6 +35,7 @@ public:
 	CPhysicalLeftSemiHashJoin(
 		CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys,
 		CExpressionArray *pdrgpexprInnerKeys, IMdIdArray *hash_opfamilies,
+		BOOL is_null_aware = true,
 		CXform::EXformId origin_xform = CXform::ExfSentinel);
 
 	// dtor

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalRightOuterHashJoin.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalRightOuterHashJoin.h
@@ -39,6 +39,7 @@ public:
 	CPhysicalRightOuterHashJoin(
 		CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys,
 		CExpressionArray *pdrgpexprInnerKeys, IMdIdArray *hash_opfamilies,
+		BOOL is_null_aware = true,
 		CXform::EXformId origin_xform = CXform::ExfSentinel);
 
 	// dtor

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
@@ -144,7 +144,8 @@ private:
 											  CExpressionArray *pdrgpexprOuter,
 											  CExpressionArray *pdrgpexprInner,
 											  IMdIdArray *join_opfamilies,
-											  CXformResult *pxfres);
+											  CXformResult *pxfres,
+											  BOOL is_hash_join_null_aware);
 
 	// helper for transforming SubqueryAll into aggregate subquery
 	static void SubqueryAllToAgg(
@@ -653,12 +654,10 @@ CXformUtils::TransformImplementBinaryOp(CXformContext *pxfctxt,
 
 template <class T>
 void
-CXformUtils::AddHashOrMergeJoinAlternative(CMemoryPool *mp,
-										   CExpression *pexprJoin,
-										   CExpressionArray *pdrgpexprOuter,
-										   CExpressionArray *pdrgpexprInner,
-										   IMdIdArray *opfamilies,
-										   CXformResult *pxfres)
+CXformUtils::AddHashOrMergeJoinAlternative(
+	CMemoryPool *mp, CExpression *pexprJoin, CExpressionArray *pdrgpexprOuter,
+	CExpressionArray *pdrgpexprInner, IMdIdArray *opfamilies,
+	CXformResult *pxfres, BOOL is_hash_join_null_aware)
 {
 	GPOS_ASSERT(CUtils::FLogicalJoin(pexprJoin->Pop()));
 	GPOS_ASSERT(3 == pexprJoin->Arity());
@@ -671,8 +670,9 @@ CXformUtils::AddHashOrMergeJoinAlternative(CMemoryPool *mp,
 		(*pexprJoin)[ul]->AddRef();
 	}
 	CLogicalJoin *popLogicalJoin = CLogicalJoin::PopConvert(pexprJoin->Pop());
-	T *op = GPOS_NEW(mp) T(mp, pdrgpexprOuter, pdrgpexprInner, opfamilies,
-						   popLogicalJoin->OriginXform());
+	T *op =
+		GPOS_NEW(mp) T(mp, pdrgpexprOuter, pdrgpexprInner, opfamilies,
+					   is_hash_join_null_aware, popLogicalJoin->OriginXform());
 	CExpression *pexprResult = GPOS_NEW(mp)
 		CExpression(mp, op, (*pexprJoin)[0], (*pexprJoin)[1], (*pexprJoin)[2]);
 	pxfres->Add(pexprResult);
@@ -724,9 +724,9 @@ CXformUtils::ImplementHashJoin(CXformContext *pxfctxt, CXformResult *pxfres,
 		else
 		{
 			// we have computed hash join keys on scalar child before, reuse them
-			AddHashOrMergeJoinAlternative<T>(mp, pexpr, pdrgpexprOuter,
-											 pdrgpexprInner, join_opfamilies,
-											 pxfres);
+			AddHashOrMergeJoinAlternative<T>(
+				mp, pexpr, pdrgpexprOuter, pdrgpexprInner, join_opfamilies,
+				pxfres, true /*is_hash_join_null_aware*/);
 		}
 
 		return;
@@ -749,12 +749,18 @@ CXformUtils::ImplementHashJoin(CXformContext *pxfctxt, CXformResult *pxfres,
 	CExpressionArray *pdrgpexpr =
 		CCastUtils::PdrgpexprCastEquality(mp, pexprScalar);
 	ULONG ulPreds = pdrgpexpr->Size();
+	BOOL is_hash_join_null_aware = false;
 	for (ULONG ul = 0; ul < ulPreds; ul++)
 	{
 		CExpression *pexprPred = (*pdrgpexpr)[ul];
 		if (CPhysicalJoin::FHashJoinCompatible(pexprPred, pexprOuter,
 											   pexprInner))
 		{
+			if (!is_hash_join_null_aware)
+			{
+				is_hash_join_null_aware |= CPredicateUtils::FINDF(pexprPred);
+			}
+
 			CExpression *pexprPredInner;
 			CExpression *pexprPredOuter;
 			IMDId *mdid_scop;
@@ -799,7 +805,7 @@ CXformUtils::ImplementHashJoin(CXformContext *pxfctxt, CXformResult *pxfres,
 	{
 		AddHashOrMergeJoinAlternative<T>(mp, pexprResult, pdrgpexprOuter,
 										 pdrgpexprInner, join_opfamilies,
-										 pxfres);
+										 pxfres, is_hash_join_null_aware);
 	}
 	else
 	{
@@ -849,9 +855,9 @@ CXformUtils::ImplementMergeJoin(CXformContext *pxfctxt, CXformResult *pxfres,
 		else
 		{
 			// we have computed join keys on scalar child before, reuse them
-			AddHashOrMergeJoinAlternative<T>(mp, pexpr, pdrgpexprOuter,
-											 pdrgpexprInner, join_opfamilies,
-											 pxfres);
+			AddHashOrMergeJoinAlternative<T>(
+				mp, pexpr, pdrgpexprOuter, pdrgpexprInner, join_opfamilies,
+				pxfres, true /*is_hash_join_null_aware*/);
 		}
 
 		return;
@@ -932,9 +938,9 @@ CXformUtils::ImplementMergeJoin(CXformContext *pxfctxt, CXformResult *pxfres,
 	// Add an alternative only if we found at least one merge-joinable predicate
 	if (0 != pdrgpexprOuter->Size())
 	{
-		AddHashOrMergeJoinAlternative<T>(mp, pexprResult, pdrgpexprOuter,
-										 pdrgpexprInner, join_opfamilies,
-										 pxfres);
+		AddHashOrMergeJoinAlternative<T>(
+			mp, pexprResult, pdrgpexprOuter, pdrgpexprInner, join_opfamilies,
+			pxfres, true /*is_hash_join_null_aware*/);
 	}
 	else
 	{

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalFullMergeJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalFullMergeJoin.cpp
@@ -28,7 +28,7 @@ using namespace gpopt;
 // ctor
 CPhysicalFullMergeJoin::CPhysicalFullMergeJoin(
 	CMemoryPool *mp, CExpressionArray *outer_merge_clauses,
-	CExpressionArray *inner_merge_clauses, IMdIdArray *,
+	CExpressionArray *inner_merge_clauses, IMdIdArray *, BOOL,
 	CXform::EXformId origin_xform)
 	: CPhysicalJoin(mp, origin_xform),
 	  m_outer_merge_clauses(outer_merge_clauses),

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalInnerHashJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalInnerHashJoin.cpp
@@ -33,9 +33,9 @@ using namespace gpopt;
 CPhysicalInnerHashJoin::CPhysicalInnerHashJoin(
 	CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys,
 	CExpressionArray *pdrgpexprInnerKeys, IMdIdArray *hash_opfamilies,
-	CXform::EXformId origin_xform)
+	BOOL is_null_aware, CXform::EXformId origin_xform)
 	: CPhysicalHashJoin(mp, pdrgpexprOuterKeys, pdrgpexprInnerKeys,
-						hash_opfamilies, origin_xform)
+						hash_opfamilies, is_null_aware, origin_xform)
 {
 }
 

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalLeftAntiSemiHashJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalLeftAntiSemiHashJoin.cpp
@@ -30,9 +30,9 @@ using namespace gpopt;
 CPhysicalLeftAntiSemiHashJoin::CPhysicalLeftAntiSemiHashJoin(
 	CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys,
 	CExpressionArray *pdrgpexprInnerKeys, IMdIdArray *hash_opfamilies,
-	CXform::EXformId origin_xform)
+	BOOL is_null_aware, CXform::EXformId origin_xform)
 	: CPhysicalHashJoin(mp, pdrgpexprOuterKeys, pdrgpexprInnerKeys,
-						hash_opfamilies, origin_xform)
+						hash_opfamilies, is_null_aware, origin_xform)
 {
 }
 

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalLeftAntiSemiHashJoinNotIn.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalLeftAntiSemiHashJoinNotIn.cpp
@@ -29,9 +29,10 @@ using namespace gpopt;
 CPhysicalLeftAntiSemiHashJoinNotIn::CPhysicalLeftAntiSemiHashJoinNotIn(
 	CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys,
 	CExpressionArray *pdrgpexprInnerKeys, IMdIdArray *hash_opfamilies,
-	CXform::EXformId origin_xform)
+	BOOL is_null_aware, CXform::EXformId origin_xform)
 	: CPhysicalLeftAntiSemiHashJoin(mp, pdrgpexprOuterKeys, pdrgpexprInnerKeys,
-									hash_opfamilies, origin_xform)
+									hash_opfamilies, is_null_aware,
+									origin_xform)
 {
 }
 

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalLeftOuterHashJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalLeftOuterHashJoin.cpp
@@ -32,9 +32,9 @@ using namespace gpopt;
 CPhysicalLeftOuterHashJoin::CPhysicalLeftOuterHashJoin(
 	CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys,
 	CExpressionArray *pdrgpexprInnerKeys, IMdIdArray *hash_opfamilies,
-	CXform::EXformId origin_xform)
+	BOOL is_null_aware, CXform::EXformId origin_xform)
 	: CPhysicalHashJoin(mp, pdrgpexprOuterKeys, pdrgpexprInnerKeys,
-						hash_opfamilies, origin_xform)
+						hash_opfamilies, is_null_aware, origin_xform)
 {
 }
 

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalLeftSemiHashJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalLeftSemiHashJoin.cpp
@@ -31,9 +31,9 @@ using namespace gpopt;
 CPhysicalLeftSemiHashJoin::CPhysicalLeftSemiHashJoin(
 	CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys,
 	CExpressionArray *pdrgpexprInnerKeys, IMdIdArray *hash_opfamilies,
-	CXform::EXformId origin_xform)
+	BOOL is_null_aware, CXform::EXformId origin_xform)
 	: CPhysicalHashJoin(mp, pdrgpexprOuterKeys, pdrgpexprInnerKeys,
-						hash_opfamilies, origin_xform)
+						hash_opfamilies, is_null_aware, origin_xform)
 {
 }
 

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalRightOuterHashJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalRightOuterHashJoin.cpp
@@ -32,9 +32,9 @@ using namespace gpopt;
 CPhysicalRightOuterHashJoin::CPhysicalRightOuterHashJoin(
 	CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys,
 	CExpressionArray *pdrgpexprInnerKeys, IMdIdArray *hash_opfamilies,
-	CXform::EXformId origin_xform)
+	BOOL is_null_aware, CXform::EXformId origin_xform)
 	: CPhysicalHashJoin(mp, pdrgpexprOuterKeys, pdrgpexprInnerKeys,
-						hash_opfamilies, origin_xform)
+						hash_opfamilies, is_null_aware, origin_xform)
 {
 	ULONG ulDistrReqs = 1 + NumDistrReq();
 	SetDistrRequests(ulDistrReqs);

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -3379,6 +3379,154 @@ EXPLAIN SELECT * FROM t1 JOIN t2 ON t1.a=t2.a;
 
 RESET optimizer_enable_hashjoin;
 RESET optimizer_enable_nljoin;
+-- Test hashed distribution spec derivation and -- 
+-- motion enforcement given INDF join condition --
+-- Outer joins' inner table yields false nulls  --
+-- colocation if join condition is null-aware   --
+drop table o1;
+ERROR:  table "o1" does not exist
+drop table o2;
+ERROR:  table "o2" does not exist
+drop table o3;
+ERROR:  table "o3" does not exist
+create table o1 (a1 int, b1 int) distributed by (a1);
+create table o2 (a2 int, b2 int) distributed by (a2);
+create table o3 (a3 int, b3 int) distributed by (a3);
+insert into o1 select i, i from generate_series(1,20) i;
+insert into o2 select i, null from generate_series(11,30) i;
+insert into o3 values (NULL, 20);
+select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3;
+ a1 | b1 | a2 | b2 | a3 | b3 
+----+----+----+----+----+----
+  1 |  1 |    |    |    | 20
+ 12 | 12 | 12 |    |    |   
+ 15 | 15 | 15 |    |    |   
+ 20 | 20 | 20 |    |    |   
+  2 |  2 |    |    |    | 20
+  3 |  3 |    |    |    | 20
+  4 |  4 |    |    |    | 20
+  7 |  7 |    |    |    | 20
+  8 |  8 |    |    |    | 20
+ 16 | 16 | 16 |    |    |   
+ 18 | 18 | 18 |    |    |   
+ 19 | 19 | 19 |    |    |   
+  5 |  5 |    |    |    | 20
+  6 |  6 |    |    |    | 20
+  9 |  9 |    |    |    | 20
+ 10 | 10 |    |    |    | 20
+ 11 | 11 | 11 |    |    |   
+ 13 | 13 | 13 |    |    |   
+ 14 | 14 | 14 |    |    |   
+ 17 | 17 | 17 |    |    |   
+(20 rows)
+
+select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 is distinct from b3;
+ a1 | b1 | a2 | b2 | a3 | b3 
+----+----+----+----+----+----
+  1 |  1 |    |    |    | 20
+ 12 | 12 | 12 |    |    |   
+ 15 | 15 | 15 |    |    |   
+ 20 | 20 | 20 |    |    |   
+  5 |  5 |    |    |    | 20
+  6 |  6 |    |    |    | 20
+  9 |  9 |    |    |    | 20
+ 10 | 10 |    |    |    | 20
+ 11 | 11 | 11 |    |    |   
+ 13 | 13 | 13 |    |    |   
+ 14 | 14 | 14 |    |    |   
+ 17 | 17 | 17 |    |    |   
+  2 |  2 |    |    |    | 20
+  3 |  3 |    |    |    | 20
+  4 |  4 |    |    |    | 20
+  7 |  7 |    |    |    | 20
+  8 |  8 |    |    |    | 20
+ 16 | 16 | 16 |    |    |   
+ 18 | 18 | 18 |    |    |   
+ 19 | 19 | 19 |    |    |   
+(20 rows)
+
+select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 = b3;
+ a1 | b1 | a2 | b2 | a3 | b3 
+----+----+----+----+----+----
+ 12 | 12 | 12 |    |    |   
+ 15 | 15 | 15 |    |    |   
+ 20 | 20 | 20 |    |    |   
+  1 |  1 |    |    |    |   
+ 16 | 16 | 16 |    |    |   
+ 18 | 18 | 18 |    |    |   
+ 19 | 19 | 19 |    |    |   
+  8 |  8 |    |    |    |   
+  4 |  4 |    |    |    |   
+  7 |  7 |    |    |    |   
+  2 |  2 |    |    |    |   
+  3 |  3 |    |    |    |   
+ 11 | 11 | 11 |    |    |   
+ 13 | 13 | 13 |    |    |   
+ 14 | 14 | 14 |    |    |   
+ 17 | 17 | 17 |    |    |   
+  6 |  6 |    |    |    |   
+  5 |  5 |    |    |    |   
+ 10 | 10 |    |    |    |   
+  9 |  9 |    |    |    |   
+(20 rows)
+
+explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000679.75..16298130027.03 rows=638277381 width=24)
+   ->  Nested Loop Left Join  (cost=10000000679.75..16289619661.95 rows=212759127 width=24)
+         Join Filter: (NOT (o2.a2 IS DISTINCT FROM o3.a3))
+         ->  Hash Left Join  (cost=679.75..128744.45 rows=2471070 width=16)
+               Hash Cond: (o1.a1 = o2.a2)
+               ->  Seq Scan on o1  (cost=0.00..321.00 rows=28700 width=8)
+               ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
+                     ->  Seq Scan on o2  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Materialize  (cost=0.00..1899.50 rows=86100 width=8)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1469.00 rows=86100 width=8)
+                     ->  Seq Scan on o3  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 is distinct from b3;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000679.75..16830019334.16 rows=637639104 width=24)
+   ->  Nested Loop Left Join  (cost=10000000679.75..16821517479.45 rows=212546368 width=24)
+         Join Filter: ((NOT (o2.a2 IS DISTINCT FROM o3.a3)) AND (o2.b2 IS DISTINCT FROM o3.b3))
+         ->  Hash Left Join  (cost=679.75..128744.45 rows=2471070 width=16)
+               Hash Cond: (o1.a1 = o2.a2)
+               ->  Seq Scan on o1  (cost=0.00..321.00 rows=28700 width=8)
+               ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
+                     ->  Seq Scan on o2  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Materialize  (cost=0.00..1899.50 rows=86100 width=8)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1469.00 rows=86100 width=8)
+                     ->  Seq Scan on o3  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 = b3;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1933.50..335368.23 rows=7413210 width=24)
+   ->  Hash Right Join  (cost=1933.50..236525.43 rows=2471070 width=24)
+         Hash Cond: (o2.a2 = o1.a1)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=1253.75..108101.98 rows=28700 width=16)
+               Hash Key: o2.a2
+               ->  Hash Left Join  (cost=1253.75..107527.98 rows=28700 width=16)
+                     Hash Cond: (o2.b2 = o3.b3)
+                     Join Filter: (NOT (o2.a2 IS DISTINCT FROM o3.a3))
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..895.00 rows=28700 width=8)
+                           Hash Key: o2.b2
+                           ->  Seq Scan on o2  (cost=0.00..321.00 rows=28700 width=8)
+                     ->  Hash  (cost=895.00..895.00 rows=28700 width=8)
+                           ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..895.00 rows=28700 width=8)
+                                 Hash Key: o3.b3
+                                 ->  Seq Scan on o3  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
+               ->  Seq Scan on o1  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres query optimizer
+(18 rows)
+
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -3374,6 +3374,149 @@ EXPLAIN SELECT * FROM t1 JOIN t2 ON t1.a=t2.a;
 
 RESET optimizer_enable_hashjoin;
 RESET optimizer_enable_nljoin;
+-- Test hashed distribution spec derivation and -- 
+-- motion enforcement given INDF join condition --
+-- Outer joins' inner table yields false nulls  --
+-- colocation if join condition is null-aware   --
+drop table o1;
+ERROR:  table "o1" does not exist
+drop table o2;
+ERROR:  table "o2" does not exist
+drop table o3;
+ERROR:  table "o3" does not exist
+create table o1 (a1 int, b1 int) distributed by (a1);
+create table o2 (a2 int, b2 int) distributed by (a2);
+create table o3 (a3 int, b3 int) distributed by (a3);
+insert into o1 select i, i from generate_series(1,20) i;
+insert into o2 select i, null from generate_series(11,30) i;
+insert into o3 values (NULL, 20);
+select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3;
+ a1 | b1 | a2 | b2 | a3 | b3 
+----+----+----+----+----+----
+  2 |  2 |    |    |    |   
+  3 |  3 |    |    |    |   
+  4 |  4 |    |    |    |   
+  7 |  7 |    |    |    |   
+  8 |  8 |    |    |    |   
+ 16 | 16 | 16 |    |    |   
+ 18 | 18 | 18 |    |    |   
+ 19 | 19 | 19 |    |    |   
+  1 |  1 |    |    |    |   
+ 12 | 12 | 12 |    |    |   
+ 15 | 15 | 15 |    |    |   
+ 20 | 20 | 20 |    |    |   
+  5 |  5 |    |    |    |   
+  6 |  6 |    |    |    |   
+  9 |  9 |    |    |    |   
+ 10 | 10 |    |    |    |   
+ 11 | 11 | 11 |    |    |   
+ 13 | 13 | 13 |    |    |   
+ 14 | 14 | 14 |    |    |   
+ 17 | 17 | 17 |    |    |   
+(20 rows)
+
+select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 is distinct from b3;
+ a1 | b1 | a2 | b2 | a3 | b3 
+----+----+----+----+----+----
+  2 |  2 |    |    |    |   
+  3 |  3 |    |    |    |   
+  4 |  4 |    |    |    |   
+  7 |  7 |    |    |    |   
+  8 |  8 |    |    |    |   
+ 16 | 16 | 16 |    |    |   
+ 18 | 18 | 18 |    |    |   
+ 19 | 19 | 19 |    |    |   
+  1 |  1 |    |    |    |   
+ 12 | 12 | 12 |    |    |   
+ 15 | 15 | 15 |    |    |   
+ 20 | 20 | 20 |    |    |   
+  5 |  5 |    |    |    |   
+  6 |  6 |    |    |    |   
+  9 |  9 |    |    |    |   
+ 10 | 10 |    |    |    |   
+ 11 | 11 | 11 |    |    |   
+ 13 | 13 | 13 |    |    |   
+ 14 | 14 | 14 |    |    |   
+ 17 | 17 | 17 |    |    |   
+(20 rows)
+
+select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 = b3;
+ a1 | b1 | a2 | b2 | a3 | b3 
+----+----+----+----+----+----
+  1 |  1 |    |    |    |   
+ 12 | 12 | 12 |    |    |   
+ 15 | 15 | 15 |    |    |   
+ 20 | 20 | 20 |    |    |   
+  5 |  5 |    |    |    |   
+  6 |  6 |    |    |    |   
+  9 |  9 |    |    |    |   
+ 10 | 10 |    |    |    |   
+ 11 | 11 | 11 |    |    |   
+ 13 | 13 | 13 |    |    |   
+ 14 | 14 | 14 |    |    |   
+ 17 | 17 | 17 |    |    |   
+  2 |  2 |    |    |    |   
+  3 |  3 |    |    |    |   
+  4 |  4 |    |    |    |   
+  7 |  7 |    |    |    |   
+  8 |  8 |    |    |    |   
+ 16 | 16 | 16 |    |    |   
+ 18 | 18 | 18 |    |    |   
+ 19 | 19 | 19 |    |    |   
+(20 rows)
+
+explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Hash Left Join  (cost=0.00..1293.00 rows=3 width=24)
+   Hash Cond: (NOT (o2.a2 IS DISTINCT FROM o3.a3))
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=16)
+         ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=16)
+               Hash Cond: (o1.a1 = o2.a2)
+               ->  Seq Scan on o1  (cost=0.00..431.00 rows=1 width=8)
+               ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+                     ->  Seq Scan on o2  (cost=0.00..431.00 rows=1 width=8)
+   ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+               ->  Seq Scan on o3  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
+explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 is distinct from b3;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=3 width=24)
+   ->  Hash Left Join  (cost=0.00..1293.00 rows=1 width=24)
+         Hash Cond: (NOT (o2.a2 IS DISTINCT FROM o3.a3))
+         Join Filter: (o2.b2 IS DISTINCT FROM o3.b3)
+         ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=16)
+               Hash Cond: (o1.a1 = o2.a2)
+               ->  Seq Scan on o1  (cost=0.00..431.00 rows=1 width=8)
+               ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+                     ->  Seq Scan on o2  (cost=0.00..431.00 rows=1 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Seq Scan on o3  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+
+explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 = b3;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=3 width=24)
+   ->  Hash Left Join  (cost=0.00..1293.00 rows=1 width=24)
+         Hash Cond: ((NOT (o2.a2 IS DISTINCT FROM o3.a3)) AND (o2.b2 = o3.b3))
+         ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=16)
+               Hash Cond: (o1.a1 = o2.a2)
+               ->  Seq Scan on o1  (cost=0.00..431.00 rows=1 width=8)
+               ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+                     ->  Seq Scan on o2  (cost=0.00..431.00 rows=1 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Seq Scan on o3  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';

--- a/src/test/regress/sql/bfv_joins.sql
+++ b/src/test/regress/sql/bfv_joins.sql
@@ -358,6 +358,31 @@ EXPLAIN SELECT * FROM t1 JOIN t2 ON t1.a=t2.a;
 RESET optimizer_enable_hashjoin;
 RESET optimizer_enable_nljoin;
 
+-- Test hashed distribution spec derivation and -- 
+-- motion enforcement given INDF join condition --
+-- Outer joins' inner table yields false nulls  --
+-- colocation if join condition is null-aware   --
+drop table o1;
+drop table o2;
+drop table o3;
+
+create table o1 (a1 int, b1 int) distributed by (a1);
+create table o2 (a2 int, b2 int) distributed by (a2);
+create table o3 (a3 int, b3 int) distributed by (a3);
+
+insert into o1 select i, i from generate_series(1,20) i;
+insert into o2 select i, null from generate_series(11,30) i;
+insert into o3 values (NULL, 20);
+
+select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3;
+select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 is distinct from b3;
+select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 = b3;
+
+explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3;
+explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 is distinct from b3;
+explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 = b3;
+
+
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';


### PR DESCRIPTION
Issue: Community reports regression that post-fc662ea plans had redundant redistribution motion in inner joins

Root cause: Blanket change of Nulls Colocation to false in computing a matching hashed distribution spec

Solution: In matching a hashed distribution spec in inner join operations, set Nulls Colocation to true; and in matching a hashed distribution spec in outer join operations, set Nulls Colocation to false only if the join condition isn't null-aware. This reflects the Nulls Colocation property required for / delivered by the outer relation in hash join operations.

Implementation:
[CXformUtils] -- Check if the join condition is composed of equality predicates only. The output is passed to AddHashOrMergeJoinAlternative for determination of join condition null-awareness.
[CPhysical*Join] -- Add is_null_aware member to all the classes using the AddHashOrMergeJoinAlternative template. If the join is null-aware, nulls colocation has to be set true in deriving/requesting hash distribution specs. If the join isn't null-aware, nulls colocation can be set false.
[regression] -- Test hashed distribution spec derivation and motion enforcement in outer join with INDF join condition
[minidump] -- Space size change only. Added user's example to verify inner join matches the outer relation's Nulls Colocation.

(cherry picked from commit 817c41e9f2b60ac40644ca68a4ce5372b6fb99eb)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
